### PR TITLE
chore: make std::fs read/open errors more informative

### DIFF
--- a/dapp/src/artifacts.rs
+++ b/dapp/src/artifacts.rs
@@ -1,5 +1,5 @@
 use ethers::core::utils::{solc::Contract, CompiledContract};
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -14,7 +14,9 @@ pub struct DapptoolsArtifact {
 impl DapptoolsArtifact {
     /// Convenience function to read from a file
     pub fn read(file: impl AsRef<Path>) -> Result<Self> {
-        let file = std::fs::File::open(file)?;
+        let file = std::fs::File::open(file.as_ref()).wrap_err_with(|| {
+            format!("Failed to open artifacts file `{}`", file.as_ref().display())
+        })?;
         Ok(serde_json::from_reader::<_, _>(file)?)
     }
 

--- a/dapptools/src/utils.rs
+++ b/dapptools/src/utils.rs
@@ -84,7 +84,9 @@ impl Remapping {
     /// Gets all the remappings detected
     pub fn find_many(path: &str) -> eyre::Result<Vec<Self>> {
         let path = std::path::Path::new(path);
-        let paths = std::fs::read_dir(path)?;
+        let paths = std::fs::read_dir(path).wrap_err_with(|| {
+            format!("Failed to read directory `{}` for remappings", path.display())
+        })?;
         let remappings = paths
             .into_iter()
             // TODO: Surely there must be a better way to convert to str


### PR DESCRIPTION
Now, if you don't have one of the folders from your remappings (or `lib` by default), you get an error message like `error=Failed to read directory 'lib' for remappings` rather than ` error=No such file or directory (os error 2)`. Something similar was done for the case where dapptools tries to read a non-existent artifacts file.


Potentially resolves #107 