### PR TITLE
feat: recursive remappings

### DIFF
--- a/dapptools/src/utils.rs
+++ b/dapptools/src/utils.rs
@@ -101,7 +101,7 @@ impl Remapping {
 
             // get all the directories inside a file if it's a valid dir
             if let Ok(dir) = std::fs::read_dir(&path) {
-                for inner in dir.into_iter() {
+                for inner in dir {
                     let inner = inner?;
                     let path = inner.path().display().to_string();
                     let path = path.rsplit('/').next().unwrap().to_string();


### PR DESCRIPTION
now correctly identifies remappings in the following dir structure:
```
            "repo1/src/",
            "repo1/src/contract.sol",
            "repo1/lib/",
            "repo1/lib/ds-math/src/",
            "repo1/lib/ds-math/src/contract.sol",
            "repo1/lib/ds-math/lib/ds-test/src/",
            "repo1/lib/ds-math/lib/ds-test/src/test.sol",
```

When it detects the same module twice (eg. ds-test), it deduplicates by choosing the earliest path.