### PR TITLE
feat: cast ls + cast accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "futures",
  "hex",
  "rustc-hex",
+ "serde",
  "serde_json",
 ]
 
@@ -1677,10 +1678,13 @@ name = "foundry-utils"
 version = "0.1.0"
 dependencies = [
  "ethers",
+ "coins-bip32",
+ "dirs-next",
  "ethers-addressbook",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",
+ "ethers-signers",
  "ethers-solc",
  "eyre",
  "hex",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -8,13 +8,14 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 foundry-utils = { path = "../utils" }
-futures = "0.3.17"
+futures = "0.3.19"
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
+serde = "1.0.132"
 serde_json = "1.0.67"
 chrono = "0.2"
 hex = "0.4.3"

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -56,7 +56,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::Cast;
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -149,6 +149,13 @@ async fn main() -> eyre::Result<()> {
                 )?
             );
         }
+        Subcommands::Accounts { rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            let accounts = Cast::new(provider).accounts().await?;
+            for account in accounts {
+                println!("{}", account);
+            }
+        }
         Subcommands::Block { rpc_url, block, full, field, to_json } => {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);
@@ -482,6 +489,14 @@ async fn main() -> eyre::Result<()> {
                 );
             }
             println!("{}", name);
+        }
+        Subcommands::Ls { rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            let (accounts, balances) = Cast::new(provider).ls().await?;
+
+            for (account, balance) in accounts.iter().zip(balances.iter()) {
+                println!("{:?}\t{}", account.address, balance)
+            }
         }
         Subcommands::Storage { address, slot, rpc_url, block } => {
             let provider = Provider::try_from(rpc_url)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -101,9 +101,7 @@ pub enum Subcommands {
         unit: Option<String>,
     },
     #[clap(name = "accounts")]
-    #[clap(
-        about = "Print information about accounts"
-    )]
+    #[clap(about = "Print information about accounts")]
     Accounts {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -100,6 +100,14 @@ pub enum Subcommands {
         value: Option<String>,
         unit: Option<String>,
     },
+    #[clap(name = "accounts")]
+    #[clap(
+        about = "Print information about accounts"
+    )]
+    Accounts {
+        #[clap(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[clap(name = "block")]
     #[clap(
         about = "Prints information about <block>. If <field> is given, print only the value of that field"
@@ -399,6 +407,12 @@ pub enum Subcommands {
         rpc_url: String,
         #[clap(long, short, help = "do a forward resolution to ensure the address is correct")]
         verify: bool,
+    },
+    #[clap(name = "ls")]
+    #[clap(about = "Display a list of your local accounts and balances (in wei)")]
+    Ls {
+        #[clap(short, long, env = "ETH_RPC_URL")]
+        rpc_url: String,
     },
     #[clap(name = "storage", about = "Show the raw value of a contract's storage slot")]
     Storage {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,10 +12,12 @@ ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features =
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"], optional = true }
 
-
+dirs-next = "2.0.0"
+coins-bip32 = "0.6.0"
 eyre = { version = "0.6.5", default-features = false }
 hex = "0.4.3"
 reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls"] }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,14 +1,13 @@
 #![doc = include_str!("../README.md")]
 use coins_bip32::path::DerivationPath;
 use ethers_addressbook::contract;
-use ethers_core::types::Address;
 use ethers_core::{
     abi::{
         self, parse_abi,
         token::{LenientTokenizer, StrictTokenizer, Tokenizer},
         Abi, AbiParser, Event, EventParam, Function, Param, ParamType, Token,
     },
-    types::*,
+    types::{Address, *},
 };
 use ethers_etherscan::Client;
 use ethers_signers::{HDPath, Ledger};


### PR DESCRIPTION
## Motivation

I'd like to use `cast` for sending transactions with a key on my hardware wallet.
Implementing `cast ls` helps with making sure that the correct hardware wallet
is plugged in.

`cast ls` should list off the available wallets that can be used for signing. This
includes the local keystore (`geth account list`), plugged in ledgers and plugged
in trezors. `seth` can also support the RPC endpoint `eth_accounts`
when the env var `ETH_RPC_ACCOUNTS` is [set](https://github.com/dapphub/dapptools/blob/1be7d796a468f52a5eb5b6830591d76a3b4b1c49/src/seth/libexec/seth/seth-accounts#L3). I don't see an ethers remote signer
that uses RPC for signing so its probably early for that
functionality.

This PR doesn't yet support trezor as I don't have a trezor wallet to test out, but it
should be easy to add. It also needs sane default keystore locations based on the
OS.

- Should the config options for `ethsign ls` be made available to `cast ls`? They aren't with `seth ls`,
  unless you use env vars
- I was looking into using https://github.com/roynalnaruto/eth-keystore-rs for parsing the keystores
  but it doesn't support pulling the `address` field out of the keystore JSON. This field was removed
  from the keystore spec as to preserve privacy

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `cast ls` which prints out a list of
addresses and their balances. The `seth` implementation
is based on `ethsign`, see:

- https://github.com/dapphub/dapptools/blob/1be7d796a468f52a5eb5b6830591d76a3b4b1c49/src/seth/libexec/seth/seth-accounts#L4
- https://github.com/dapphub/dapptools/blob/1be7d796a468f52a5eb5b6830591d76a3b4b1c49/src/ethsign/ethsign.go#L210

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


