### PR TITLE
feat(forge/debugger): Gas lines

### DIFF
--- a/evm/src/debug.rs
+++ b/evm/src/debug.rs
@@ -122,6 +122,8 @@ pub struct DebugStep {
     pub ic: usize,
     /// Cumulative gas usage
     pub total_gas_used: u64,
+    /// Step gas
+    pub step_gas: u64,
 }
 
 impl Default for DebugStep {
@@ -134,6 +136,7 @@ impl Default for DebugStep {
             push_bytes: None,
             ic: 0,
             total_gas_used: 0,
+            step_gas: 0,
         }
     }
 }

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -175,6 +175,8 @@ where
                 .get(&pc)
                 .expect("unknown ic for pc"),
             total_gas_used: gas_used(data.env.cfg.spec_id, total_gas_spent, gas.refunded() as u64),
+            // TODO: fix this to be accurate
+            step_gas: self.current_gas_block,
         });
 
         Return::Continue

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1028,20 +1028,20 @@ impl Tui {
         known_contracts: &BTreeMap<String, ContractBytecodeSome>,
         source_code: &BTreeMap<u32, String>,
         draw_memory: &mut DrawMemory,
-        debug_calls: &[(Address, Vec<DebugStep>, bool)],
+        debug_calls: &[(Address, Vec<DebugStep>, CallKind)],
     ) {
         // builds a mapping of:
         // src_idx => call_index => current_step => line_num => gas_cost
         //
         // step thru each debug_call
-        debug_calls.iter().enumerate().for_each(|(call_index, (address, steps, creation))| {
+        debug_calls.iter().enumerate().for_each(|(call_index, (address, steps, call_kind))| {
             // iterate thru the debug_steps for an index
             steps.iter().enumerate().for_each(|(current_step, step)| {
                 // grab the sourcemap
                 if let Some(contract_name) = identified_contracts.get(address) {
                     if let Some(known) = known_contracts.get(contract_name) {
                         // grab either the creation source map or runtime sourcemap
-                        if let Some(Ok(sourcemap)) = if *creation {
+                        if let Some(Ok(sourcemap)) = if matches!(call_kind, CallKind::Create) {
                             known.bytecode.source_map()
                         } else {
                             known
@@ -1158,7 +1158,7 @@ impl Ui for Tui {
             &self.known_contracts,
             &self.source_code,
             &mut draw_memory,
-            &debug_call,
+            &debug_call[..],
         );
 
         let mut stack_labels = false;


### PR DESCRIPTION
## Motivation
People want to know hotspots in their contract. 

## Solution
In the debugger, we add the ability to press `l` which toggles the "gas lines" - this shows the cumulative gas consumed by the line.

Caveats:
1. I don't know how to get accurate `step_gas` from `revm`. Currently uses `current_gas_block` but this is an incorrect placeholder.
2. Cannot use compiler setting `generatedSources`, which would allow us to get the yul code the compiler generated. This gas is currently just not included.
3.  Sourcemaps where multiple lines are highlighted are just added to the top line. Less of a caveat and more of an implementation detail
4. Doesn't sum jump_into's to parent

Note: some of this code can likely be reused for coverage reports if we don't go the "missed jump blocks" route

![image](https://user-images.githubusercontent.com/31553173/160298145-1cafbd79-59ea-45ac-8097-8c99faa8caf0.png)

