### PR TITLE
test: add support for forge debug testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,19 +788,47 @@ checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
 name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+dependencies = [
+ "core-foundation-sys 0.6.2",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core-graphics"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15b3cb55687886a6b66953123621e5a1529a91a01666d646fb64baa13f900f0"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.6.4",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1150,6 +1178,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enigo"
+version = "0.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce8d7672e87b3155fd5e8a9226276da5c833e15bc879c7b98a78f743b67814"
+dependencies = [
+ "core-graphics",
+ "libc",
+ "objc",
+ "pkg-config",
+ "unicode-segmentation",
+ "winapi",
 ]
 
 [[package]]
@@ -1666,6 +1708,7 @@ dependencies = [
 name = "foundry-cli-test-utils"
 version = "0.1.0"
 dependencies = [
+ "enigo",
  "ethers-solc",
  "foundry-config",
  "once_cell",
@@ -2423,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -2479,6 +2522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2821,6 +2873,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"
@@ -3844,8 +3905,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
 ]
@@ -3856,7 +3917,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -14,3 +14,4 @@ once_cell = "1.9.0"
 foundry-config = { path = "../../config" }
 serde_json = "1.0.67"
 parking_lot = "0.12.0"
+enigo = "0.0.14"

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -14,4 +14,7 @@ once_cell = "1.9.0"
 foundry-config = { path = "../../config" }
 serde_json = "1.0.67"
 parking_lot = "0.12.0"
-enigo = "0.0.14"
+enigo = {version = "0.0.14" , optional = true }
+
+[features]
+tui-tests = ["enigo"]

--- a/cli/test-utils/src/lib.rs
+++ b/cli/test-utils/src/lib.rs
@@ -4,8 +4,8 @@ extern crate core;
 mod macros;
 
 // Utilities for making it easier to handle tests.
-pub mod util;
 pub mod stdin;
+pub mod util;
 
 pub use util::{TestCommand, TestProject};
 

--- a/cli/test-utils/src/lib.rs
+++ b/cli/test-utils/src/lib.rs
@@ -5,6 +5,8 @@ mod macros;
 
 // Utilities for making it easier to handle tests.
 pub mod util;
+pub mod stdin;
+
 pub use util::{TestCommand, TestProject};
 
 pub use ethers_solc;

--- a/cli/test-utils/src/stdin.rs
+++ b/cli/test-utils/src/stdin.rs
@@ -3,28 +3,25 @@ use std::time::Duration;
 /// TUI's default tick rate is 200ms, this should be fine for debug profile
 pub const SAFE_TICK_RATE: Duration = Duration::from_millis(300);
 
+/// Duration to wait until tui is booted up
+pub const SAFE_TUI_WARMUP: Duration = Duration::from_secs(2);
+
 #[derive(Debug, Clone)]
-pub struct StdInCommand {
-    /// The command to write to stdin
-    command: Vec<u8>,
+pub struct StdInKeyCommand {
+    /// The key command to fire
+    pub key: char,
     /// time to wait afterwards
-    wait: Duration
+    pub wait: Duration,
 }
 
-impl<T: AsRef<[u8]>> From<T> for StdInCommand {
-    fn from(command: T) -> Self {
-       Self {
-          command: command.as_ref().to_vec(),
-           wait: SAFE_TICK_RATE
-       }
+impl From<char> for StdInKeyCommand {
+    fn from(key: char) -> Self {
+        Self { key, wait: SAFE_TICK_RATE }
     }
 }
 
-impl<T: AsRef<[u8]>> From<(T, Duration)> for StdInCommand {
-    fn from(s: (T, Duration)) -> Self {
-        Self {
-            command: s.0.as_ref().to_vec(),
-            wait: s.1
-        }
+impl From<(char, Duration)> for StdInKeyCommand {
+    fn from(s: (char, Duration)) -> Self {
+        Self { key: s.0, wait: s.1 }
     }
 }

--- a/cli/test-utils/src/stdin.rs
+++ b/cli/test-utils/src/stdin.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+/// TUI's default tick rate is 200ms, this should be fine for debug profile
+pub const SAFE_TICK_RATE: Duration = Duration::from_millis(300);
+
+#[derive(Debug, Clone)]
+pub struct StdInCommand {
+    /// The command to write to stdin
+    command: Vec<u8>,
+    /// time to wait afterwards
+    wait: Duration
+}
+
+impl<T: AsRef<[u8]>> From<T> for StdInCommand {
+    fn from(command: T) -> Self {
+       Self {
+          command: command.as_ref().to_vec(),
+           wait: SAFE_TICK_RATE
+       }
+    }
+}
+
+impl<T: AsRef<[u8]>> From<(T, Duration)> for StdInCommand {
+    fn from(s: (T, Duration)) -> Self {
+        Self {
+            command: s.0.as_ref().to_vec(),
+            wait: s.1
+        }
+    }
+}

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -1,4 +1,4 @@
-use crate::stdin::{StdInKeyCommand, SAFE_TUI_WARMUP};
+use crate::stdin::{StdInKeyCommand};
 use ethers_solc::{
     cache::SolFilesCache,
     project_util::{copy_dir, TempProject},
@@ -446,18 +446,19 @@ impl TestCommand {
     ///
     /// *NOTE*: it's expected that the instructions will terminate the command at some time,
     /// otherwise this will wait indefinitely
-    pub fn spawn_and_send_stdin<I, A>(&mut self, commands: I) -> Output
+    pub fn spawn_and_send_stdin<I, A>(&mut self, _commands: I) -> Output
     where
         I: IntoIterator<Item = A> + Send + 'static,
         A: Into<StdInKeyCommand>,
     {
-        use enigo::{Enigo, Key, KeyboardControllable};
         let child = self.spawn();
 
+        #[cfg(feature = "tui-tests")]
         std::thread::spawn(move || {
-            std::thread::sleep(SAFE_TUI_WARMUP);
+            use enigo::{Enigo, Key, KeyboardControllable};
+            std::thread::sleep(crate::stdin::SAFE_TUI_WARMUP);
             let mut enigo = Enigo::new();
-            for cmd in commands.into_iter().map(Into::into) {
+            for cmd in _commands.into_iter().map(Into::into) {
                 let StdInKeyCommand { key, wait } = cmd;
                 enigo.key_click(Key::Layout(key));
                 std::thread::sleep(wait)

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -1,4 +1,4 @@
-use crate::stdin::{StdInKeyCommand};
+use crate::stdin::StdInKeyCommand;
 use ethers_solc::{
     cache::SolFilesCache,
     project_util::{copy_dir, TempProject},

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1,4 +1,5 @@
 //! Contains various tests for checking forge's commands
+use super::forge_utils;
 use ansi_term::Colour;
 use ethers::solc::{artifacts::Metadata, ConfigurableContractArtifact};
 use foundry_cli_test_utils::{
@@ -8,11 +9,6 @@ use foundry_cli_test_utils::{
 };
 use foundry_config::{parse_with_profile, BasicConfig, Config, SolidityErrorCode};
 use std::{env, fs};
-
-// import forge utils as mod
-#[allow(unused)]
-#[path = "../../src/utils.rs"]
-mod forge_utils;
 
 // tests `--help` is printed to std out
 forgetest!(print_help, |_: TestProject, mut cmd: TestCommand| {

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -1,4 +1,5 @@
 //! Contains various tests for checking forge commands related to config values
+use super::forge_utils;
 use ethers::{
     prelude::artifacts::YulDetails,
     types::{Address, U256},
@@ -14,11 +15,6 @@ use foundry_config::{
     Config, OptimizerDetails, SolcReq,
 };
 use std::{fs, path::PathBuf, str::FromStr};
-
-// import forge utils as mod
-#[allow(unused)]
-#[path = "../../src/utils.rs"]
-mod forge_utils;
 
 // tests all config values that are in use
 forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {

--- a/cli/tests/it/debug.rs
+++ b/cli/tests/it/debug.rs
@@ -1,45 +1,48 @@
 //! Contains various tests for checking the debugger
 use commands::*;
 use foundry_cli_test_utils::{
-    forgetest, forgetest_init,
-    stdin::StdInCommand,
+    forgetest, forgetest_ignore, forgetest_init,
     util::{TestCommand, TestProject},
 };
 
 const TEST_EXAMPLE_SIG: &str = "testExample()";
 
 /// Contains various keybinding for interacting with the debugger via stdin
+#[allow(unused)]
 mod commands {
-    fn quit() -> StdInCommand {
-        "q".into()
+    use foundry_cli_test_utils::stdin::StdInKeyCommand;
+
+    pub fn quit() -> StdInKeyCommand {
+        'q'.into()
     }
-    fn down() -> StdInCommand {
-        "j".into()
+    pub fn down() -> StdInKeyCommand {
+        'j'.into()
     }
-    fn up() -> StdInCommand {
-        "k".into()
+    pub fn up() -> StdInKeyCommand {
+        'k'.into()
     }
-    fn top_of_file() -> StdInCommand {
-        "g".into()
+    pub fn top_of_file() -> StdInKeyCommand {
+        'g'.into()
     }
-    fn bottom_of_file() -> StdInCommand {
-        "G".into()
+    pub fn bottom_of_file() -> StdInKeyCommand {
+        'G'.into()
     }
-    fn next_call() -> StdInCommand {
-        "C".into()
+    pub fn next_call() -> StdInKeyCommand {
+        'C'.into()
     }
-    fn forward() -> StdInCommand {
-        "s".into()
+    pub fn forward() -> StdInKeyCommand {
+        's'.into()
     }
-    fn backwards() -> StdInCommand {
-        "a".into()
+    pub fn backwards() -> StdInKeyCommand {
+        'a'.into()
     }
 }
 
 // tests that we can run the debugger for the template function
-forgetest_init!(can_start_debugger_for_function, |_prj: TestProject, mut cmd: TestCommand| {
-    cmd.args(["test", "--debug", TEST_EXAMPLE_SIG]);
+forgetest_ignore!(can_start_debugger_for_function, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.arg("build");
+    cmd.assert_non_empty_stdout();
+    cmd.forge_fuse().args(["test", "--debug", TEST_EXAMPLE_SIG]).root_arg();
 
-    let out = cmd.spawn_and_send_stdin([quit()]);
-    println!("{}", out);
+    let _out = cmd.spawn_and_send_stdin([quit()]);
 });

--- a/cli/tests/it/debug.rs
+++ b/cli/tests/it/debug.rs
@@ -1,0 +1,45 @@
+//! Contains various tests for checking the debugger
+use commands::*;
+use foundry_cli_test_utils::{
+    forgetest, forgetest_init,
+    stdin::StdInCommand,
+    util::{TestCommand, TestProject},
+};
+
+const TEST_EXAMPLE_SIG: &str = "testExample()";
+
+/// Contains various keybinding for interacting with the debugger via stdin
+mod commands {
+    fn quit() -> StdInCommand {
+        "q".into()
+    }
+    fn down() -> StdInCommand {
+        "j".into()
+    }
+    fn up() -> StdInCommand {
+        "k".into()
+    }
+    fn top_of_file() -> StdInCommand {
+        "g".into()
+    }
+    fn bottom_of_file() -> StdInCommand {
+        "G".into()
+    }
+    fn next_call() -> StdInCommand {
+        "C".into()
+    }
+    fn forward() -> StdInCommand {
+        "s".into()
+    }
+    fn backwards() -> StdInCommand {
+        "a".into()
+    }
+}
+
+// tests that we can run the debugger for the template function
+forgetest_init!(can_start_debugger_for_function, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.args(["test", "--debug", TEST_EXAMPLE_SIG]);
+
+    let out = cmd.spawn_and_send_stdin([quit()]);
+    println!("{}", out);
+});

--- a/cli/tests/it/debug.rs
+++ b/cli/tests/it/debug.rs
@@ -1,7 +1,7 @@
 //! Contains various tests for checking the debugger
 use commands::*;
 use foundry_cli_test_utils::{
-    forgetest, forgetest_ignore, forgetest_init,
+    forgetest_ignore,
     util::{TestCommand, TestProject},
 };
 

--- a/cli/tests/it/main.rs
+++ b/cli/tests/it/main.rs
@@ -5,7 +5,14 @@ mod cmd;
 #[cfg(not(feature = "external-integration-tests"))]
 mod config;
 #[cfg(not(feature = "external-integration-tests"))]
+mod debug;
+#[cfg(not(feature = "external-integration-tests"))]
 mod test;
+
+// import forge utils as mod
+#[allow(unused)]
+#[path = "../../src/utils.rs"]
+mod forge_utils;
 
 #[cfg(feature = "external-integration-tests")]
 mod integration;

--- a/cli/tests/it/test.rs
+++ b/cli/tests/it/test.rs
@@ -4,11 +4,6 @@ use foundry_cli_test_utils::{
     util::{TestCommand, TestProject},
 };
 
-// import forge utils as mod
-#[allow(unused)]
-#[path = "../../src/utils.rs"]
-mod forge_utils;
-
 // tests that direct import paths are handled correctly
 forgetest!(can_fuzz_array_params, |prj: TestProject, mut cmd: TestCommand| {
     prj.insert_ds_test();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the debugger is a widely used feature but we're lacking proper integration tests.
turns out testing TUI apps is not that straight forward because it requires a terminal so we need to run with `Stdio::inherit` but then we can't write to the child process stdin...

I tried to directly write to the stdin filedescriptor, which gets displayed in the debugger tui but for some reason it's not interpreted as an input event... maybe I'm missing something how crossterm parses Events, it uses the StdIn FD though...

Ref https://github.com/crossterm-rs/crossterm/issues/644

what works is sending keys via native libs, there are definitely some quirks and I'm not sure this will work in CI but it's definitely worth having it to test locally.

~~TUI tests are not quite ready, but this touches a bit of existing test code and I'd recommend merging as is and followup with getting `forge test --debug` integration tests working on ci~~
needs some additional tinkering and perhaps rethink how to make this work

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add support for sending key events
* feature gated for now 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
