### PR TITLE
Support constructor args for forge run

### DIFF
--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -27,7 +27,7 @@ use forge::{
 };
 use foundry_config::{figment::Figment, Config};
 use foundry_utils::{encode_args, parse_tokens, IntoFunction, PostLinkInput, RuntimeOrHandle};
-use std::{collections::BTreeMap, path::PathBuf, fs};
+use std::{collections::BTreeMap, fs, path::PathBuf};
 use ui::{TUIExitReason, Tui, Ui};
 
 // Loads project's figment and merges the build cli arguments into it
@@ -156,11 +156,9 @@ impl Cmd for RunArgs {
         let bytecode_enc_params = match (abi.constructor(), params.is_empty()) {
             (None, false) => {
                 eyre::bail!("Constructor error");
-            },
-            (None, true) => bytecode,
-            (Some(constructor), _) => {
-                constructor.encode_input(bytecode.to_vec(), &params)?.into()
             }
+            (None, true) => bytecode,
+            (Some(constructor), _) => constructor.encode_input(bytecode.to_vec(), &params)?.into(),
         };
 
         let mut result = {

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -410,6 +410,8 @@ pub fn custom_run(mut args: TestArgs, include_fuzz_tests: bool) -> eyre::Result<
                         target_contract: Some(utils::get_contract_name(&id).to_string()),
                         sig,
                         args: Vec::new(),
+                        constructor_args: Vec::new(),
+                        constructor_args_path: None,
                         debug: true,
                         opts: args.opts,
                         evm_opts: args.evm_opts,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I couldn't run "forge run" for contracts which took at least one constructor argument.

## Solution

I added new constructor arg options to this cli mode which are appended to the bytecode as constructor arguments according to the abi spec.

