### PR TITLE
feat(verify): Make chain flag consistent with forge create

### DIFF
--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -42,10 +42,12 @@ pub struct VerifyArgs {
 
     #[clap(
         long,
+        alias = "chain_id", // backward compatibility
+        env = "CHAIN",
         help = "the chain id of the network you are verifying for",
         default_value = "mainnet"
     )]
-    chain_id: Chain,
+    chain: Chain,
 
     #[clap(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
     etherscan_key: String,
@@ -77,7 +79,7 @@ impl VerifyArgs {
 
         let verify_args = self.create_verify_request()?;
 
-        let etherscan = Client::new(self.chain_id.try_into()?, &self.etherscan_key)
+        let etherscan = Client::new(self.chain.try_into()?, &self.etherscan_key)
             .wrap_err("Failed to create etherscan client")?;
 
         let resp = etherscan


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently `forge create` and `forge verify-contract` uses different flag to specify the chain id. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This changes enables `forge verify-contract` to use `--chain` flag, so it's consistent with `forge create`.