### PR TITLE
fix: cast find-block

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -53,7 +53,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -114,7 +114,7 @@ where
     /// Generates an access list for the specified transaction
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -1220,7 +1220,7 @@ impl SimpleCast {
         let code = meta.source_code();
 
         if code.is_empty() {
-            return Err(eyre::eyre!("unverified contract"));
+            return Err(eyre::eyre!("unverified contract"))
         }
 
         Ok(code)

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -53,7 +53,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -114,7 +114,7 @@ where
     /// Generates an access list for the specified transaction
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -340,8 +340,13 @@ where
             false,
         )
         .await?;
-        Ok(U256::from_str_radix(strip_0x(&block_field), 16)
-            .expect("Unable to convert hexadecimal to U256"))
+
+        let ret = if block_field.starts_with("0x") {
+            U256::from_str_radix(strip_0x(&block_field), 16).expect("Unable to convert hex to U256")
+        } else {
+            U256::from_str_radix(&block_field, 10).expect("Unable to convert decimal to U256")
+        };
+        Ok(ret)
     }
 
     pub async fn base_fee<T: Into<BlockId>>(&self, block: T) -> Result<U256> {
@@ -1215,7 +1220,7 @@ impl SimpleCast {
         let code = meta.source_code();
 
         if code.is_empty() {
-            return Err(eyre::eyre!("unverified contract"))
+            return Err(eyre::eyre!("unverified contract"));
         }
 
         Ok(code)

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -11,7 +11,7 @@ casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
     // Skip fork tests if the RPC url is not set.
     if std::env::var("ETH_RPC_URL").is_err() {
         eprintln!("Skipping test finds_block. ETH_RPC_URL is not set.");
-        return;
+        return
     };
 
     // Construct args

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -11,7 +11,7 @@ casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
     // Skip fork tests if the RPC url is not set.
     if std::env::var("ETH_RPC_URL").is_err() {
         eprintln!("Skipping test finds_block. ETH_RPC_URL is not set.");
-        return
+        return;
     };
 
     // Construct args
@@ -24,5 +24,8 @@ casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
     println!("{}", output);
 
     // Expect successful block query
-    assert!(output.contains("6574364"), "{}", output);
+    // Query: 1647843609, Mar 21 2022 06:20:09 UTC
+    // Output block: https://etherscan.io/block/14428082
+    // Output block time: Mar 21 2022 06:20:09 UTC
+    assert!(output.contains("14428082"), "{}", output);
 });


### PR DESCRIPTION
fixes #1286

## Motivation

Fixes `cast find-block`.

## Solution

Fixes broken `Cast::timestamp` function. See #1286 for an example.

## Test

There's already a unit test that could've caught this regression,`finds_block`. However, it requires `ETH_RPC_URL` and skips if that's missing.

Running `ETH_RPC_URL=<valid url> cargo test` fails before this PR, succeeds after.
