### PR TITLE
feat: added support for git ssh urls

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -289,6 +289,11 @@ mod tests {
                 "https://github.com/gakonst/lootloose",
                 None,
             ),
+            (
+                "git@github.com:gakonst/lootloose@v1",
+                "https://github.com/gakonst/lootloose",
+                Some("v1"),
+            ),
             ("git@github.com:gakonst/lootloose", "https://github.com/gakonst/lootloose", None),
             ("https://gitlab.com/gakonst/lootloose", "https://gitlab.com/gakonst/lootloose", None),
             ("https://github.xyz/gakonst/lootloose", "https://github.xyz/gakonst/lootloose", None),


### PR DESCRIPTION
## Motivation

- Adds the ability to run `forge install` with git ssh urls (`git@github:`) and `git+` prefixed urls for copy paste reasons as described in this issue (https://github.com/foundry-rs/foundry/issues/924)

## Solution

- Regex to match the string and pull out the brand name ie "github", "gitlab" and covert it to the `https://` repo url.
- Added tests for the additional cases.

