### PR TITLE
bug "fix":  temporarily disable docker build on release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
 
   release-docker:
     name: Release Docker
+    if: false
     uses: ./.github/workflows/docker-publish.yml
 
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from alpine as build-environment
 WORKDIR /opt
-RUN apk add clang lld curl build-base linux-headers \
+RUN apk add clang lld curl build-base linux-headers openssl-dev \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x ./rustup.sh \
     && ./rustup.sh -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from alpine as build-environment
 WORKDIR /opt
-RUN apk add clang lld curl build-base linux-headers openssl-dev \
+RUN apk add clang lld curl build-base linux-headers \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x ./rustup.sh \
     && ./rustup.sh -y


### PR DESCRIPTION
## Motivation
Docker build is currently failing.

After [64087b59c0ac9abb4b5e04d8c84e8bab47f4c6c3](https://github.com/foundry-rs/foundry/commit/64087b59c0ac9abb4b5e04d8c84e8bab47f4c6c3), the docker build has been failing at compiling `group v0.11.0` due to missing openssl-dependency. Adding this dependency solves that issue, but reveals another problem with compiling `foundry-cli`: 

```sh
#13 808.6    Compiling foundry-cli v0.2.0 (/opt/foundry/cli)
#13 809.7 error: failed to run custom build command for `foundry-cli v0.2.0 (/opt/foundry/cli)`
#13 809.7 
#13 809.7 Caused by:
#13 809.7   process didn't exit successfully: `/opt/foundry/target/release/build/foundry-cli-f3551be4cc3b0164/build-script-build` (signal: 11, SIGSEGV: invalid memory reference)
#13 809.7 warning: build failed, waiting for other jobs to finish...
```

Example job with openssl fixed but foundry-cli failing [here](https://github.com/dmfxyz/foundry/runs/6032143566?check_suite_focus=true).
This is definitely some alpine library related issue.

## Solution
Temporarily disable the docker build so that releases do not fail. Restore once fixed (should be able to take a look in a few days).
Bug opened here: https://github.com/foundry-rs/foundry/issues/1314