### PR TITLE
fix: decode events for 0-sized contracts

### DIFF
--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -20,7 +20,7 @@ use forge::{
         builder::Backend, opts::EvmOpts, CallResult, DatabaseRef, DeployResult, EvmError, Executor,
         ExecutorBuilder, RawCallResult,
     },
-    trace::{identifier::LocalTraceIdentifier, CallTraceArena, CallTraceDecoder, TraceKind},
+    trace::{identifier::LocalTraceIdentifier, CallTraceArena, CallTraceDecoderBuilder, TraceKind},
     CALLER,
 };
 use foundry_common::evm::EvmArgs;
@@ -162,7 +162,10 @@ impl Cmd for RunArgs {
         // bytecode. Might be better to wait for an interactive debugger where we can do this on
         // the fly while retaining access to the database?
         let local_identifier = LocalTraceIdentifier::new(&known_contracts);
-        let mut decoder = CallTraceDecoder::new_with_labels(result.labeled_addresses.clone());
+        let mut decoder = CallTraceDecoderBuilder::new()
+            .with_labels(result.labeled_addresses.clone())
+            .with_events(local_identifier.events())
+            .build();
         for (_, trace) in &mut result.traces {
             decoder.identify(trace, &local_identifier);
         }

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -17,7 +17,7 @@ use forge::{
     gas_report::GasReport,
     trace::{
         identifier::{EtherscanIdentifier, LocalTraceIdentifier},
-        CallTraceDecoder, TraceKind,
+        CallTraceDecoderBuilder, TraceKind,
     },
     MultiContractRunner, MultiContractRunnerBuilder, SuiteResult, TestFilter, TestKind,
 };
@@ -521,8 +521,10 @@ fn test(
 
                 if !result.traces.is_empty() {
                     // Identify addresses in each trace
-                    let mut decoder =
-                        CallTraceDecoder::new_with_labels(result.labeled_addresses.clone());
+                    let mut decoder = CallTraceDecoderBuilder::new()
+                        .with_labels(result.labeled_addresses.clone())
+                        .with_events(local_identifier.events())
+                        .build();
 
                     // Decode the traces
                     let mut decoded_traces = Vec::new();

--- a/evm/src/trace/identifier/local.rs
+++ b/evm/src/trace/identifier/local.rs
@@ -1,6 +1,6 @@
 use super::{AddressIdentity, TraceIdentifier};
 use ethers::{
-    abi::{Abi, Address},
+    abi::{Abi, Address, Event},
     prelude::ArtifactId,
 };
 use std::{borrow::Cow, collections::BTreeMap};
@@ -20,6 +20,11 @@ impl LocalTraceIdentifier {
                 })
                 .collect(),
         }
+    }
+
+    /// Get all the events of the local contracts.
+    pub fn events(&self) -> Vec<Event> {
+        self.local_contracts.iter().flat_map(|(_, (_, abi))| abi.events().cloned()).collect()
     }
 }
 

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -7,7 +7,7 @@ mod decoder;
 mod node;
 mod utils;
 
-pub use decoder::CallTraceDecoder;
+pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 
 use crate::{abi::CHEATCODE_ADDRESS, CallKind};
 use ansi_term::Colour;


### PR DESCRIPTION
Contracts and libraries with 0 runtime bytecode would not be decoded, and sometimes they are used as "event containers".

Fixes #1309 