### PR TITLE
feat(fmt): format struct (restoring fields from source for now)

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -598,19 +598,13 @@ mod tests {
         test_formatter(
             FormatterConfig::default(),
             "struct   Foo  {   
-              }",
+              } struct   Bar  {    uint256 foo ;string bar ;  }",
             "
 struct Foo {}
-",
-        );
 
-        test_formatter(
-            FormatterConfig::default(),
-            "struct   Foo  {    uint256 bar ;string baz ;  }",
-            "
-struct Foo {
-    uint256 bar;
-    string baz;
+struct Bar {
+    uint256 foo;
+    string bar;
 }
 ",
         );

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -412,6 +412,11 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_enum(&mut self, enumeration: &mut EnumDefinition) -> VResult {
+        if !enumeration.doc.is_empty() {
+            enumeration.doc.visit(self)?;
+            writeln!(self)?;
+        }
+
         write!(self, "enum {} ", &enumeration.name.name)?;
 
         if enumeration.values.is_empty() {
@@ -438,6 +443,11 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_struct(&mut self, structure: &mut StructDefinition) -> VResult {
+        if !structure.doc.is_empty() {
+            structure.doc.visit(self)?;
+            writeln!(self)?;
+        }
+
         write!(self, "struct {} ", &structure.name.name)?;
 
         if structure.fields.is_empty() {

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 use indent_write::fmt::IndentWriter;
 use solang_parser::pt::{
     ContractDefinition, DocComment, EnumDefinition, Identifier, Loc, SourceUnit, SourceUnitPart,
-    StringLiteral,
+    StringLiteral, StructDefinition,
 };
 
 use crate::{
@@ -413,6 +413,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
 
     fn visit_enum(&mut self, enumeration: &mut EnumDefinition) -> VResult {
         write!(self, "enum {} ", &enumeration.name.name)?;
+
         if enumeration.values.is_empty() {
             self.write_empty_brackets()?;
         } else {
@@ -425,6 +426,29 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 if i != enumeration.values.len() - 1 {
                     write!(self, ",")?;
                 }
+
+                writeln!(self)?;
+            }
+            self.dedent(1);
+
+            write!(self, "}}")?;
+        }
+
+        Ok(())
+    }
+
+    fn visit_struct(&mut self, structure: &mut StructDefinition) -> VResult {
+        write!(self, "struct {} ", &structure.name.name)?;
+
+        if structure.fields.is_empty() {
+            self.write_empty_brackets()?;
+        } else {
+            writeln!(self, "{{")?;
+
+            self.indent(1);
+            for field in structure.fields.iter_mut() {
+                field.visit(self)?;
+                self.visit_stray_semicolon()?;
 
                 writeln!(self)?;
             }
@@ -557,5 +581,28 @@ mod tests {
     #[test]
     fn import_directive() {
         test_directory("ImportDirective");
+    }
+
+    #[test]
+    fn struct_definition() {
+        test_formatter(
+            FormatterConfig::default(),
+            "struct   Foo  {   
+              }",
+            "
+struct Foo {}
+",
+        );
+
+        test_formatter(
+            FormatterConfig::default(),
+            "struct   Foo  {    uint256 bar ;string baz ;  }",
+            "
+struct Foo {
+    uint256 bar;
+    string baz;
+}
+",
+        );
     }
 }

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -83,13 +83,21 @@ pub trait Visitor {
         Ok(())
     }
 
-    fn visit_var_def(&mut self, var: &mut VariableDefinition) -> VResult {
+    fn visit_var_definition(&mut self, var: &mut VariableDefinition) -> VResult {
         if !var.doc.is_empty() {
             self.visit_doc_comments(&mut var.doc)?;
             self.visit_newline()?;
         }
         self.visit_source(var.loc)?;
         self.visit_stray_semicolon()?;
+
+        Ok(())
+    }
+
+    /// Doesn't write semicolon at the end because variable declaration can be in both
+    /// struct definition and function body
+    fn visit_var_declaration(&mut self, var: &mut VariableDeclaration) -> VResult {
+        self.visit_source(var.loc)?;
 
         Ok(())
     }
@@ -228,7 +236,7 @@ impl Visitable for SourceUnitPart {
             SourceUnitPart::EventDefinition(event) => v.visit_event(event),
             SourceUnitPart::ErrorDefinition(error) => v.visit_error(error),
             SourceUnitPart::FunctionDefinition(function) => v.visit_function(function),
-            SourceUnitPart::VariableDefinition(variable) => v.visit_var_def(variable),
+            SourceUnitPart::VariableDefinition(variable) => v.visit_var_definition(variable),
             SourceUnitPart::StraySemicolon(_) => v.visit_stray_semicolon(),
         }
     }
@@ -251,7 +259,7 @@ impl Visitable for ContractPart {
             ContractPart::EventDefinition(event) => v.visit_event(event),
             ContractPart::ErrorDefinition(error) => v.visit_error(error),
             ContractPart::EnumDefinition(enumeration) => v.visit_enum(enumeration),
-            ContractPart::VariableDefinition(variable) => v.visit_var_def(variable),
+            ContractPart::VariableDefinition(variable) => v.visit_var_definition(variable),
             ContractPart::FunctionDefinition(function) => v.visit_function(function),
             ContractPart::StraySemicolon(_) => v.visit_stray_semicolon(),
             ContractPart::Using(using) => v.visit_using(using),
@@ -262,6 +270,14 @@ impl Visitable for ContractPart {
 impl Visitable for Statement {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
         v.visit_statement(self)?;
+
+        Ok(())
+    }
+}
+
+impl Visitable for VariableDeclaration {
+    fn visit(&mut self, v: &mut impl Visitor) -> VResult {
+        v.visit_var_declaration(self)?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Baby steps

## Solution

Implement `struct` formatting with copying fields from source code (for now)
