### PR TITLE
fix: make memory limit configurable

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -67,6 +67,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         block_timestamp: 10,
         block_difficulty: 10,
         block_gas_limit: Some(100.into()),
+        memory_limit: 2u64.pow(24),
         eth_rpc_url: Some("localhost".to_string()),
         etherscan_api_key: None,
         verbosity: 4,

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -67,7 +67,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         block_timestamp: 10,
         block_difficulty: 10,
         block_gas_limit: Some(100.into()),
-        memory_limit: 2u64.pow(24),
+        memory_limit: 2u64.pow(25),
         eth_rpc_url: Some("localhost".to_string()),
         etherscan_api_key: None,
         verbosity: 4,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -168,6 +168,8 @@ pub struct Config {
     pub block_difficulty: u64,
     /// the `block.gaslimit` value during EVM execution
     pub block_gas_limit: Option<GasLimit>,
+    /// The memory limit of the EVM (16 MiB by default)
+    pub memory_limit: u64,
     /// Additional output selection for all contracts
     /// such as "ir", "devodc", "storageLayout", etc.
     /// See [Solc Compiler Api](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-api)
@@ -925,6 +927,7 @@ impl Default for Config {
             block_timestamp: 0,
             block_difficulty: 0,
             block_gas_limit: None,
+            memory_limit: 2u64.pow(24),
             eth_rpc_url: None,
             etherscan_api_key: None,
             verbosity: 0,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -168,7 +168,7 @@ pub struct Config {
     pub block_difficulty: u64,
     /// the `block.gaslimit` value during EVM execution
     pub block_gas_limit: Option<GasLimit>,
-    /// The memory limit of the EVM (16 MiB by default)
+    /// The memory limit of the EVM (32 MB by default)
     pub memory_limit: u64,
     /// Additional output selection for all contracts
     /// such as "ir", "devodc", "storageLayout", etc.
@@ -927,7 +927,7 @@ impl Default for Config {
             block_timestamp: 0,
             block_difficulty: 0,
             block_gas_limit: None,
-            memory_limit: 2u64.pow(24),
+            memory_limit: 2u64.pow(25),
             eth_rpc_url: None,
             etherscan_api_key: None,
             verbosity: 0,

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -5,6 +5,7 @@ use revm::{BlockEnv, CfgEnv, Env, TxEnv};
 /// ethereum provider.
 pub async fn environment<M: Middleware>(
     provider: &M,
+    memory_limit: u64,
     override_chain_id: Option<u64>,
     pin_block: Option<u64>,
     origin: Address,
@@ -24,8 +25,7 @@ pub async fn environment<M: Middleware>(
     Ok(Env {
         cfg: CfgEnv {
             chain_id: override_chain_id.unwrap_or(rpc_chain_id.as_u64()).into(),
-            // 16 MiB
-            memory_limit: 2u64.pow(24),
+            memory_limit,
             ..Default::default()
         },
         block: BlockEnv {

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -86,6 +86,7 @@ pub mod test_helpers {
         sender: Address::from_str("00a329c0648769a73afac7f9381e08fb43dbea72").unwrap(),
         initial_balance: U256::MAX,
         ffi: true,
+        memory_limit: 2u64.pow(24),
         ..Default::default()
     });
 


### PR DESCRIPTION
I think 16 MiB is a sane default for most tests, but the symbolic project in #1310 in Solidity broke it.

We could raise the default memory limit, but I think a saner choice is just to make it configurable. Raising the default could slow down fuzz tests in e.g. Solmate that "accidentally"/randomly do `mload`/`mstore` in high memory regions

Closes #1310