### PR TITLE
fix: ignore `DAPP_TEST_CACHE`

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -806,7 +806,7 @@ impl From<Config> for Figment {
                 Toml::file(Env::var_or("FOUNDRY_CONFIG", Config::FILE_NAME)).nested(),
             )))
             .merge(Env::prefixed("DAPP_").ignore(&["REMAPPINGS", "LIBRARIES"]).global())
-            .merge(Env::prefixed("DAPP_TEST_").global())
+            .merge(Env::prefixed("DAPP_TEST_").ignore(&["CACHE"]).global())
             .merge(DappEnvCompatProvider)
             .merge(Env::raw().only(&["ETHERSCAN_API_KEY"]))
             .merge(


### PR DESCRIPTION
`DAPP_TEST_CACHE` is a path to the RPC cache for DappTools, but for us it tries to write it to `cache` which is a boolean

Closes #1187