### PR TITLE
feat: forge init improvements

### DIFF
--- a/assets/ContractTemplate.sol
+++ b/assets/ContractTemplate.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
+pragma solidity ^0.8.13;
 
 contract Contract {}

--- a/assets/ContractTemplate.t.sol
+++ b/assets/ContractTemplate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
+pragma solidity ^0.8.13;
 
 import "ds-test/test.sol";
 

--- a/assets/workflowTemplate.yml
+++ b/assets/workflowTemplate.yml
@@ -1,0 +1,23 @@
+on: workflow_dispatch
+
+name: test
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run tests
+        run: forge test -vvv

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -158,6 +158,7 @@ fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
         let gitignore_path = root.join(".gitignore");
         std::fs::write(gitignore_path, include_str!("../../../../assets/.gitignoreTemplate"))?;
 
+        // git init
         Command::new("git")
             .arg("init")
             .current_dir(&root)
@@ -165,6 +166,12 @@ fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
             .stderr(Stdio::piped())
             .spawn()?
             .wait()?;
+
+        // create github workflow
+        let gh = root.join(".github").join("workflows");
+        std::fs::create_dir_all(&gh)?;
+        let workflow_path = gh.join("test.yml");
+        std::fs::write(workflow_path, include_str!("../../../../assets/workflowTemplate.yml"))?;
 
         if !no_commit {
             Command::new("git").args(&["add", "."]).current_dir(&root).spawn()?.wait()?;

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -97,6 +97,8 @@ impl Cmd for InitArgs {
 
             // make the dirs
             let src = root.join("src");
+            std::fs::create_dir_all(&src)?;
+
             let test = root.join("test");
             std::fs::create_dir_all(&test)?;
 

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -97,7 +97,7 @@ impl Cmd for InitArgs {
 
             // make the dirs
             let src = root.join("src");
-            let test = src.join("test");
+            let test = root.join("test");
             std::fs::create_dir_all(&test)?;
 
             // write the contract file


### PR DESCRIPTION
Solves some things in #1132 
- Loosens the pragma (and updating it to 0.8.13)
- Moves the test directory out of `src`
- Adds a Github workflow that runs `forge test -vvv` with `FOUNDRY_PROFILE=ci`

The Github workflow does not run by default, see https://github.com/foundry-rs/foundry/issues/1132#issuecomment-1082640211

Stuff missing because it's not in Forge:
- `forge test --sweep` (or similar)
- `forge build --verify-sizes` (or similar)