### PR TITLE
feat: improve contract size reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "color-eyre",
+ "comfy-table",
  "console 0.15.0",
  "dunce",
  "ethers",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,6 +43,7 @@ tracing = "0.1.26"
 console = "0.15.0"
 watchexec = "2.0.0-pre.11"
 atty = "0.2.14"
+comfy-table = "5.0.0"
 
 # async / parallel
 tokio = { version = "1.11.0", features = ["macros"] }

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -1,9 +1,9 @@
 //! Support for compiling [ethers::solc::Project]
 
 use crate::term;
+use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, *};
 use ethers::solc::{report::NoReporter, Artifact, FileFilter, Project, ProjectCompileOutput};
-use foundry_utils::to_table;
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, fmt::Display, path::PathBuf};
 
 /// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
 /// compilation was successful or if there was a cache hit.
@@ -13,6 +13,71 @@ pub fn compile(
     print_sizes: bool,
 ) -> eyre::Result<ProjectCompileOutput> {
     ProjectCompiler::new(print_names, print_sizes).compile(project)
+}
+
+// https://eips.ethereum.org/EIPS/eip-170
+const CONTRACT_SIZE_LIMIT: usize = 24576;
+
+pub struct SizeReport {
+    pub contracts: BTreeMap<String, ContractInfo>,
+}
+
+pub struct ContractInfo {
+    pub size: usize,
+    pub is_test_contract: bool,
+}
+
+impl SizeReport {
+    /// Returns the size of the largest contract, excluding test contracts.
+    pub fn max_size(&self) -> usize {
+        let mut max_size = 0;
+        for (_, contract) in &self.contracts {
+            if !contract.is_test_contract && contract.size > max_size {
+                max_size = contract.size;
+            }
+        }
+        max_size
+    }
+
+    /// Returns true if all contracts are within the size limit, excluding test contracts.
+    pub fn exceeds_size_limit(&self) -> bool {
+        self.max_size() > CONTRACT_SIZE_LIMIT
+    }
+}
+
+impl Display for SizeReport {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+        table.set_header(vec![
+            Cell::new("Contract").add_attribute(Attribute::Bold).fg(Color::Blue),
+            Cell::new("Size").add_attribute(Attribute::Bold).fg(Color::Blue),
+            Cell::new("Margin").add_attribute(Attribute::Bold).fg(Color::Blue),
+        ]);
+
+        for (name, contract) in &self.contracts {
+            if contract.is_test_contract || contract.size == 0 {
+                continue
+            }
+
+            let margin = isize::try_from(CONTRACT_SIZE_LIMIT).unwrap() -
+                isize::try_from(contract.size).unwrap();
+            let color = match contract.size {
+                0..=17999 => Color::Reset,
+                18000..=CONTRACT_SIZE_LIMIT => Color::Yellow,
+                _ => Color::Red,
+            };
+
+            table.add_row(vec![
+                Cell::new(name).fg(color),
+                Cell::new(contract.size).fg(color),
+                Cell::new(margin).fg(color),
+            ]);
+        }
+
+        println!("{}", table);
+        Ok(())
+    }
 }
 
 /// Helper type to configure how to compile a project
@@ -111,20 +176,34 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
                     println!();
                 }
                 let compiled_contracts = output.compiled_contracts_by_compiler_version();
-                let mut sizes = BTreeMap::new();
+                let mut size_report = SizeReport { contracts: BTreeMap::new() };
                 for (_, contracts) in compiled_contracts.into_iter() {
                     for (name, contract) in contracts {
                         let size = contract
                             .get_bytecode_bytes()
                             .map(|bytes| bytes.0.len())
                             .unwrap_or_default();
-                        sizes.insert(name, size);
+
+                        let test_functions: Vec<_> = contract
+                            .abi
+                            .as_ref()
+                            .unwrap()
+                            .abi
+                            .functions()
+                            .into_iter()
+                            .filter(|func| func.name.starts_with("test") || func.name.eq("IS_TEST"))
+                            .collect();
+
+                        let is_test_contract = test_functions.len() > 0;
+                        size_report.contracts.insert(name, ContractInfo { size, is_test_contract });
                     }
                 }
-                let json = serde_json::to_value(&sizes)?;
-                println!("name             size (bytes)");
-                println!("-----------------------------");
-                println!("{}", to_table(json));
+
+                println!("{}", size_report);
+
+                // exit with error if any contract exceeds the size limit, excluding test contracts.
+                let exit_status = if size_report.exceeds_size_limit() { 1 } else { 0 };
+                std::process::exit(exit_status);
             }
         }
 

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -55,13 +55,9 @@ impl Display for SizeReport {
             Cell::new("Margin").add_attribute(Attribute::Bold).fg(Color::Blue),
         ]);
 
-        for (name, contract) in &self.contracts {
-            if contract.is_test_contract || contract.size == 0 {
-                continue
-            }
-
-            let margin = isize::try_from(CONTRACT_SIZE_LIMIT).unwrap() -
-                isize::try_from(contract.size).unwrap();
+        let contracts = self.contracts.iter().filter(|(_, c)| !c.is_test_contract && c.size > 0);
+        for (name, contract) in contracts {
+            let margin = CONTRACT_SIZE_LIMIT as isize - contract.size as isize;
             let color = match contract.size {
                 0..=17999 => Color::Reset,
                 18000..=CONTRACT_SIZE_LIMIT => Color::Yellow,


### PR DESCRIPTION
Closes (most of) https://github.com/foundry-rs/foundry/issues/992, except for the last bullet point in the description.

`forge build --sizes` now behaves as follows:

- Only reports sizes for non-test contracts and contracts with non-zero size. Test contracts are identified by any contract that either has a method that starts with `test` or a method called `IS_TEST`.
- Uses same table style as gas reports.
- Tables cells are highlighted yellow if over 18kB, and red if over the size limit. A margin column displays the difference between the contract size limit and its current size.
- Exits with error if any contracts are above size limit. This is analogous to `forge test` exiting with an error when a test fails, which is a useful behavior for checking sizes in CI

<img width="353" alt="image" src="https://user-images.githubusercontent.com/17163988/163679813-90551270-a448-401c-be58-d3e2eaf8a470.png">

<img width="358" alt="image" src="https://user-images.githubusercontent.com/17163988/163679342-394f0cb3-d032-4b2f-96bf-5ba7be46f84c.png">

cc'ing @transmissions11 who opened #992 and @tynes who implemented this originally in https://github.com/foundry-rs/foundry/pull/682