### PR TITLE
feat(fmt): variable declaration

### DIFF
--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -75,7 +75,9 @@ pub trait Visitor {
         Ok(())
     }
 
-    fn visit_expr(&mut self, _expr: &mut Expression) -> VResult {
+    fn visit_expr(&mut self, expr: &mut Expression) -> VResult {
+        self.visit_source(expr.loc())?;
+
         Ok(())
     }
 
@@ -278,6 +280,14 @@ impl Visitable for Statement {
 impl Visitable for VariableDeclaration {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
         v.visit_var_declaration(self)?;
+
+        Ok(())
+    }
+}
+
+impl Visitable for Expression {
+    fn visit(&mut self, v: &mut impl Visitor) -> VResult {
+        v.visit_expr(self)?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Formatter should format variable declarations. They occur in structs only now, but also will be in variable definitions where we should account for multiline case:
```bash
echo 'contract Contract { uint8 public str; }' | prettier --parser solidity-parse --print-width 1

contract Contract
{
    uint8
        public str;
}
```

## Solution

Format variable declarations
