### PR TITLE
feat(forge): Use IndexedPathBuf

### DIFF
--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -10,7 +10,7 @@ use ethers::{
         Client,
     },
     solc::{
-        artifacts::{BytecodeHash, Source},
+        artifacts::{BytecodeHash, IndexedPathBuf, Source},
         AggregatedCompilerOutput, CompilerInput, Project, Solc,
     },
 };
@@ -211,7 +211,10 @@ impl VerifyArgs {
         };
         let input = CompilerInput {
             language: "Solidity".to_string(),
-            sources: BTreeMap::from([("constract.sol".into(), Source { content: content.into() })]),
+            sources: BTreeMap::from([(
+                IndexedPathBuf::new("constract.sol".into(), 0),
+                Source { content: content.into() },
+            )]),
             settings: Default::default(),
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes https://github.com/foundry-rs/foundry/issues/1283

Blocked by https://github.com/gakonst/ethers-rs/pull/1151

(See ethers-rs for more detail)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This changes propose `Sources` to be defined as `BTreeMap<IndexedPathBuf, Source>` instead of `BTreeMap<PathBuf, Source>`. `IndexedPathBuf` contains `index` field which we can use to determine how the key is sorted by just simply assign the `index` value.

In the case of verification, the `sources` key will be ordered by source code for main contract first then followed by the imported source codes.

Results:
- [Contract Verified without IndexedPathBuf](https://rinkeby.etherscan.io/address/0xcc544ecdc8b0f00fe8e4e7f796032c3919d3d83f#code)
- [Contract Verified with IndexedPathBuf](https://rinkeby.etherscan.io/address/0x356a7bb15a898e7265f377a71825d21072202123#code)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
