### PR TITLE
feat(fmt): user-defined value type definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f49c1bb28a8814fdac132b1ec1f2f65c656186d8dfbc411db8bcaba45cdc06"
+checksum = "e6b2ad9c159bd02219a59368133301e6195fdaa2b5d55c628ccdcd611d49235f"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ethereum", "web3", "solidity", "linter"]
 [dependencies]
 indent_write = "2.2.0"
 semver = "1.0.4"
-solang-parser = "0.1.11"
+solang-parser = "0.1.12"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 use indent_write::fmt::IndentWriter;
 use solang_parser::pt::{
     ContractDefinition, DocComment, EnumDefinition, Expression, Identifier, Loc, SourceUnit,
-    SourceUnitPart, StringLiteral, StructDefinition, Type, VariableDeclaration,
+    SourceUnitPart, StringLiteral, StructDefinition, Type, TypeDefinition, VariableDeclaration,
 };
 
 use crate::{
@@ -510,6 +510,19 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         Ok(())
     }
 
+    fn visit_type_definition(&mut self, def: &mut TypeDefinition) -> VResult {
+        if !def.doc.is_empty() {
+            def.doc.visit(self)?;
+            writeln!(self)?;
+        }
+
+        write!(self, "type {} is ", def.name.name)?;
+        def.ty.visit(self)?;
+        write!(self, ";")?;
+
+        Ok(())
+    }
+
     fn visit_stray_semicolon(&mut self) -> VResult {
         write!(self, ";")?;
 
@@ -648,5 +661,10 @@ struct Bar {
 }
 ",
         );
+    }
+
+    #[test]
+    fn type_definition() {
+        test_directory("TypeDefinition");
     }
 }

--- a/fmt/src/loc.rs
+++ b/fmt/src/loc.rs
@@ -25,6 +25,7 @@ impl LineOfCode for SourceUnitPart {
             SourceUnitPart::ErrorDefinition(error) => error.loc,
             SourceUnitPart::FunctionDefinition(function) => function.loc,
             SourceUnitPart::VariableDefinition(variable) => variable.loc,
+            SourceUnitPart::TypeDefinition(def) => def.loc,
         }
     }
 }
@@ -40,6 +41,7 @@ impl LineOfCode for ContractPart {
             ContractPart::FunctionDefinition(function) => function.loc(),
             ContractPart::StraySemicolon(loc) => *loc,
             ContractPart::Using(using) => using.loc,
+            ContractPart::TypeDefinition(def) => def.loc,
         }
     }
 }

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -175,6 +175,12 @@ pub trait Visitor {
         Ok(())
     }
 
+    fn visit_type_definition(&mut self, def: &mut TypeDefinition) -> VResult {
+        self.visit_source(def.loc)?;
+
+        Ok(())
+    }
+
     fn visit_stray_semicolon(&mut self) -> VResult;
 
     fn visit_newline(&mut self) -> VResult;
@@ -239,6 +245,7 @@ impl Visitable for SourceUnitPart {
             SourceUnitPart::ErrorDefinition(error) => v.visit_error(error),
             SourceUnitPart::FunctionDefinition(function) => v.visit_function(function),
             SourceUnitPart::VariableDefinition(variable) => v.visit_var_definition(variable),
+            SourceUnitPart::TypeDefinition(def) => v.visit_type_definition(def),
             SourceUnitPart::StraySemicolon(_) => v.visit_stray_semicolon(),
         }
     }
@@ -263,6 +270,7 @@ impl Visitable for ContractPart {
             ContractPart::EnumDefinition(enumeration) => v.visit_enum(enumeration),
             ContractPart::VariableDefinition(variable) => v.visit_var_definition(variable),
             ContractPart::FunctionDefinition(function) => v.visit_function(function),
+            ContractPart::TypeDefinition(def) => v.visit_type_definition(def),
             ContractPart::StraySemicolon(_) => v.visit_stray_semicolon(),
             ContractPart::Using(using) => v.visit_using(using),
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Recently, support for user-defined value types was added to Solang parser: https://github.com/hyperledger-labs/solang/pull/747. Let's start formatting it in Foundry.

## Solution

Format user-defined value type definitions.
