### PR TITLE
chore: Captured identifiers + minor panic-removal

### DIFF
--- a/binder/src/lib.rs
+++ b/binder/src/lib.rs
@@ -175,7 +175,7 @@ impl Binder {
 
         let compiled = project.compile()?;
         if compiled.has_compiler_errors() {
-            eyre::bail!("Compiled with errors:\n{}", compiled);
+            eyre::bail!("Compiled with errors:\n{compiled}");
         }
 
         trace!("Generating bindings");

--- a/binder/src/utils.rs
+++ b/binder/src/utils.rs
@@ -305,22 +305,20 @@ impl GitReference {
         let id = match self {
             GitReference::Tag(s) => {
                 let resolve_tag = move || -> eyre::Result<git2::Oid> {
-                    let refname = format!("refs/remotes/origin/tags/{}", s);
+                    let refname = format!("refs/remotes/origin/tags/{s}");
                     let id = repo.refname_to_id(&refname)?;
                     let obj = repo.find_object(id, None)?;
                     let obj = obj.peel(ObjectType::Commit)?;
                     Ok(obj.id())
                 };
-                resolve_tag().with_context(|| format!("failed to find tag `{}`", s))?
+                resolve_tag().with_context(|| format!("failed to find tag `{s}`"))?
             }
             GitReference::Branch(s) => {
-                let name = format!("origin/{}", s);
+                let name = format!("origin/{s}");
                 let b = repo
                     .find_branch(&name, git2::BranchType::Remote)
-                    .with_context(|| format!("failed to find branch `{}`", s))?;
-                b.get()
-                    .target()
-                    .ok_or_else(|| eyre::eyre!("branch `{}` did not have a target", s))?
+                    .with_context(|| format!("failed to find branch `{s}`"))?;
+                b.get().target().ok_or_else(|| eyre::eyre!("branch `{s}` did not have a target"))?
             }
 
             // use the HEAD commit
@@ -647,11 +645,8 @@ where
         }
         msg.push('\n');
         if !ssh_agent_attempts.is_empty() {
-            let names = ssh_agent_attempts
-                .iter()
-                .map(|s| format!("`{}`", s))
-                .collect::<Vec<_>>()
-                .join(", ");
+            let names =
+                ssh_agent_attempts.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ");
             msg.push_str(&format!(
                 "\n* attempted ssh-agent authentication, but \
                  no usernames succeeded: {}",
@@ -746,7 +741,7 @@ pub fn fetch(
         return fetch_with_cli(repo, url, &refspecs, tags)
     }
 
-    debug!("doing a fetch for {}", url);
+    debug!("doing a fetch for {url}");
     let git_config = git2::Config::open_default()?;
 
     with_retry(|| {
@@ -774,7 +769,7 @@ pub fn fetch(
                     Ok(()) => break,
                     Err(e) => e,
                 };
-                debug!("fetch failed: {}", err);
+                debug!("fetch failed: {err}");
 
                 if !repo_reinitialized &&
                     matches!(err.class(), ErrorClass::Reference | ErrorClass::Odb)

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -89,7 +89,7 @@ where
         )?;
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {
-            format!("{}\n", res)
+            format!("{res}\n")
         } else {
             // seth compatible user-friendly return type conversions
             let out = decoded
@@ -102,7 +102,7 @@ where
                         Token::FixedBytes(inner) => format!("0x{}", hex::encode(inner)),
                         // print as decimal
                         Token::Uint(inner) | Token::Int(inner) => inner.to_string(),
-                        _ => format!("{}", item),
+                        _ => format!("{item}"),
                     }
                 })
                 .collect::<Vec<_>>();
@@ -299,7 +299,7 @@ where
                 .ok_or_else(|| eyre::eyre!("block {:?} not found", block))?;
             if let Some(ref field) = field {
                 get_pretty_block_attr(block, field.to_string())
-                    .unwrap_or_else(|| format!("{} is not a valid block field", field))
+                    .unwrap_or_else(|| format!("{field} is not a valid block field"))
             } else if to_json {
                 serde_json::to_value(&block).unwrap().to_string()
             } else {
@@ -317,7 +317,7 @@ where
                     "use --full to view transactions".to_string()
                 } else {
                     get_pretty_block_attr(block, field.to_string())
-                        .unwrap_or_else(|| format!("{} is not a valid block field", field))
+                        .unwrap_or_else(|| format!("{field} is not a valid block field"))
                 }
             } else if to_json {
                 serde_json::to_value(&block).unwrap().to_string()
@@ -539,14 +539,14 @@ where
             serde_json::to_value(&transaction_result)?
                 .get(field)
                 .cloned()
-                .ok_or_else(|| eyre::eyre!("field {} not found", field))?
+                .ok_or_else(|| eyre::eyre!("field {field} not found"))?
         } else {
             serde_json::to_value(&transaction_result)?
         };
 
         let transaction = if let Some(ref field) = field {
             get_pretty_tx_attr(transaction_result, field.to_string())
-                .unwrap_or_else(|| format!("{} is not a valid tx field", field))
+                .unwrap_or_else(|| format!("{field} is not a valid tx field"))
         } else if to_json {
             serde_json::to_string(&transaction)?
         } else {
@@ -606,7 +606,7 @@ where
             serde_json::to_value(&receipt)?
                 .get(field)
                 .cloned()
-                .ok_or_else(|| eyre::eyre!("field {} not found", field))?
+                .ok_or_else(|| eyre::eyre!("field {field} not found"))?
         } else {
             serde_json::to_value(&receipt)?
         };
@@ -638,7 +638,7 @@ impl SimpleCast {
     /// ```
     pub fn from_utf8(s: &str) -> String {
         let s: String = s.as_bytes().to_hex();
-        format!("0x{}", s)
+        format!("0x{s}")
     }
     /// Generates an interface in solidity from either a local file ABI or a verified contract on
     /// Etherscan. It returns a vector of [`InterfaceSource`] structs that contain the source of the
@@ -886,7 +886,7 @@ impl SimpleCast {
         let func = AbiParser::default().parse_function(sig.as_ref())?;
         let calldata = encode_args(&func, args)?.to_hex::<String>();
         let encoded = &calldata[8..];
-        Ok(format!("0x{}", encoded))
+        Ok(format!("0x{encoded}"))
     }
 
     /// Converts decimal input to hex
@@ -1135,7 +1135,7 @@ impl SimpleCast {
             _ => keccak256(data).to_hex(),
         };
 
-        Ok(format!("0x{}", hash))
+        Ok(format!("0x{hash}"))
     }
 
     /// Converts ENS names to their namehash representation
@@ -1172,7 +1172,7 @@ impl SimpleCast {
         }
 
         let namehash: String = node.to_hex();
-        Ok(format!("0x{}", namehash))
+        Ok(format!("0x{namehash}"))
     }
 
     /// Performs ABI encoding to produce the hexadecimal calldata with the given arguments.
@@ -1271,7 +1271,7 @@ impl SimpleCast {
         from_value: &str,
         slot_number: &str,
     ) -> Result<String> {
-        let sig = format!("x({},{})", from_type, to_type);
+        let sig = format!("x({from_type},{to_type})");
         let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
         let location: String = Self::keccak(&encoded)?;
         Ok(location)

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -202,7 +202,7 @@ async fn resolve_ens<M: Middleware, T: Into<NameOrAddress>>(provider: &M, addr: 
         NameOrAddress::Name(ref ens_name) => provider.resolve_name(ens_name).await,
         NameOrAddress::Address(addr) => Ok(addr),
     }
-    .map_err(|x| eyre!("Failed to resolve ENS name: {}", x))?;
+    .map_err(|x| eyre!("Failed to resolve ENS name: {x}"))?;
     Ok(from_addr)
 }
 
@@ -270,7 +270,7 @@ mod tests {
             match ens_name {
                 "a.eth" => Ok(H160::from_str(ADDR_1).unwrap()),
                 "b.eth" => Ok(H160::from_str(ADDR_2).unwrap()),
-                _ => unreachable!("don't know how to resolve {}", ens_name),
+                _ => unreachable!("don't know how to resolve {ens_name}"),
             }
         }
     }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -5,5 +5,5 @@ fn main() {
     // Change the SHA output to the short variant
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
     vergen::vergen(config)
-        .unwrap_or_else(|e| panic!("vergen crate failed to generate version information! {}", e));
+        .unwrap_or_else(|e| panic!("vergen crate failed to generate version information! {e}"));
 }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -75,7 +75,7 @@ async fn main() -> eyre::Result<()> {
                 .bytes()
                 .map(|x| format!("{:02x}", x.expect("invalid binary data")))
                 .collect();
-            println!("0x{}", hex);
+            println!("0x{hex}");
         }
 
         Subcommands::ToHexdata { input } => {
@@ -97,7 +97,7 @@ async fn main() -> eyre::Result<()> {
                     output
                 }
             };
-            println!("0x{}", output);
+            println!("0x{output}");
         }
         Subcommands::ToCheckSumAddress { address } => {
             let val = unwrap_or_stdin(address)?;
@@ -369,7 +369,7 @@ async fn main() -> eyre::Result<()> {
                 println!("{:?}", pending_tx);
             } else {
                 let receipt =
-                    pending_tx.await?.ok_or_else(|| eyre::eyre!("tx {} not found", tx_hash))?;
+                    pending_tx.await?.ok_or_else(|| eyre::eyre!("tx {tx_hash} not found"))?;
                 println!("{}", serde_json::json!(receipt));
             }
         }
@@ -391,24 +391,24 @@ async fn main() -> eyre::Result<()> {
             let builder_output = builder.peek();
 
             let gas = Cast::new(&provider).estimate(builder_output).await?;
-            println!("{}", gas);
+            println!("{gas}");
         }
         Subcommands::CalldataDecode { sig, calldata } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, true)?;
             let tokens = foundry_utils::format_tokens(&tokens);
-            tokens.for_each(|t| println!("{}", t));
+            tokens.for_each(|t| println!("{t}"));
         }
         Subcommands::AbiDecode { sig, calldata, input } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
             let tokens = foundry_utils::format_tokens(&tokens);
-            tokens.for_each(|t| println!("{}", t));
+            tokens.for_each(|t| println!("{t}"));
         }
         Subcommands::AbiEncode { sig, args } => {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
         Subcommands::Index { key_type, value_type, key, slot_number } => {
             let encoded = SimpleCast::index(&key_type, &value_type, &key, &slot_number)?;
-            println!("{}", encoded);
+            println!("{encoded}");
         }
         Subcommands::FourByte { selector } => {
             let sigs = foundry_utils::fourbyte(&selector).await?;
@@ -434,7 +434,7 @@ async fn main() -> eyre::Result<()> {
             let tokens = SimpleCast::abi_decode(sig, &calldata, true)?;
             let tokens = foundry_utils::format_tokens(&tokens);
 
-            tokens.for_each(|t| println!("{}", t));
+            tokens.for_each(|t| println!("{t}"));
         }
         Subcommands::FourByteEvent { topic } => {
             let sigs = foundry_utils::fourbyte_event(&topic).await?;
@@ -443,11 +443,11 @@ async fn main() -> eyre::Result<()> {
 
         Subcommands::PrettyCalldata { calldata, offline } => {
             if !calldata.starts_with("0x") {
-                eprintln!("Expected calldata hex string, received \"{}\"", calldata);
+                eprintln!("Expected calldata hex string, received \"{calldata}\"");
                 std::process::exit(0)
             }
             let pretty_data = foundry_utils::pretty_calldata(&calldata, offline).await?;
-            println!("{}", pretty_data);
+            println!("{pretty_data}");
         }
         Subcommands::Age { block, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
@@ -511,13 +511,13 @@ async fn main() -> eyre::Result<()> {
             };
 
             // put it all together
-            let pragma = format!("pragma solidity {};", pragma);
+            let pragma = format!("pragma solidity {pragma};");
             let interfaces = interfaces
                 .iter()
                 .map(|iface| iface.source.to_string())
                 .collect::<Vec<_>>()
                 .join("\n");
-            let res = format!("{}\n\n{}", pragma, interfaces);
+            let res = format!("{pragma}\n\n{interfaces}");
 
             // print or write to file
             match output_location {
@@ -527,7 +527,7 @@ async fn main() -> eyre::Result<()> {
                     println!("Saved interface at {}", loc.display());
                 }
                 None => {
-                    println!("{}", res);
+                    println!("{res}");
                 }
             }
         }
@@ -559,7 +559,7 @@ async fn main() -> eyre::Result<()> {
                     name, who
                 );
             }
-            println!("{}", name);
+            println!("{name}");
         }
         Subcommands::Storage { address, slot, rpc_url, block } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
@@ -747,14 +747,14 @@ async fn main() -> eyre::Result<()> {
                     WalletType::Local(wallet) => wallet.signer().sign_message(&message).await?,
                     WalletType::Trezor(wallet) => wallet.signer().sign_message(&message).await?,
                 };
-                println!("Signature: 0x{}", sig);
+                println!("Signature: 0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
                 let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
                 let signature = Signature::from_str(&signature)?;
                 match signature.verify(message, pubkey) {
                     Ok(_) => {
-                        println!("Validation success. Address {} signed this message.", address)
+                        println!("Validation success. Address {address} signed this message.")
                     }
                     Err(_) => println!(
                         "Validation failed. Address {} did not sign this message.",
@@ -829,7 +829,7 @@ where
         println!("{:#x}", tx_hash);
     } else {
         let receipt = cast.receipt(format!("{:#x}", tx_hash), None, confs, false, to_json).await?;
-        println!("{}", receipt);
+        println!("{receipt}");
     }
 
     Ok(())

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -34,8 +34,8 @@ impl FindBlockArgs {
         let cast_provider = Cast::new(provider);
 
         let res = join!(cast_provider.timestamp(last_block_num), cast_provider.timestamp(1));
-        let ts_block_latest = res.0.unwrap();
-        let ts_block_1 = res.1.unwrap();
+        let ts_block_latest = res.0?;
+        let ts_block_1 = res.1?;
 
         let block_num = if ts_block_latest.lt(&ts_target) {
             // If the most recent block's timestamp is below the target, return it

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -83,7 +83,7 @@ impl FindBlockArgs {
             }
             matching_block.unwrap_or(low_block)
         };
-        println!("{}", block_num);
+        println!("{block_num}");
 
         Ok(())
     }

--- a/cli/src/cmd/forge/config.rs
+++ b/cli/src/cmd/forge/config.rs
@@ -40,7 +40,7 @@ impl Cmd for ConfigArgs {
             config.to_string_pretty()?
         };
 
-        println!("{}", s);
+        println!("{s}");
         Ok(())
     }
 }

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -48,7 +48,7 @@ impl Cmd for FlattenArgs {
         let target_path = dunce::canonicalize(target_path)?;
         let flattened = paths
             .flatten(&target_path)
-            .map_err(|err| eyre::Error::msg(format!("Failed to flatten the file: {}", err)))?;
+            .map_err(|err| eyre::Error::msg(format!("Failed to flatten the file: {err}")))?;
 
         match output {
             Some(output) => {
@@ -56,7 +56,7 @@ impl Cmd for FlattenArgs {
                 std::fs::write(&output, flattened)?;
                 println!("Flattened file written at {}", output.display());
             }
-            None => println!("{}", flattened),
+            None => println!("{flattened}"),
         };
 
         Ok(())

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -132,7 +132,7 @@ impl Cmd for FmtArgs {
                     if diff.ratio() < 1.0 {
                         let mut diff_summary = String::new();
 
-                        writeln!(diff_summary, "Diff in {}:", input)?;
+                        writeln!(diff_summary, "Diff in {input}:")?;
                         for (j, group) in diff.grouped_ops(3).iter().enumerate() {
                             if j > 0 {
                                 writeln!(diff_summary, "{:-^1$}", "-", 80)?;
@@ -184,7 +184,7 @@ impl Cmd for FmtArgs {
                     if i > 0 {
                         println!();
                     }
-                    print!("{}", diff);
+                    print!("{diff}");
                 }
             }
 

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -82,7 +82,7 @@ impl FromStr for ContractArtifactFields {
             "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
             "userdoc" | "userDoc" | "user-doc" => Ok(ContractArtifactFields::UserDoc),
             "ewasm" | "e-wasm" => Ok(ContractArtifactFields::Ewasm),
-            _ => Err(format!("Unknown field: {}", s)),
+            _ => Err(format!("Unknown field: {s}")),
         }
     }
 }
@@ -163,7 +163,7 @@ impl Cmd for InspectArgs {
 
         // Unwrap the inner artifact
         let artifact = found_artifact.ok_or_else(|| {
-            eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract)
+            eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
         })?;
 
         // Match on ContractArtifactFields and Pretty Print

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -164,7 +164,7 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
     } else if stderr.contains("paths are ignored by one of your .gitignore files") {
         let error =
             stderr.lines().filter(|l| !l.starts_with("hint:")).collect::<Vec<&str>>().join("\n");
-        eyre::bail!("{}", error)
+        eyre::bail!("{error}")
     } else if !&output.status.success() {
         eyre::bail!("{}", stderr.trim())
     }
@@ -191,9 +191,9 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
         if !no_commit {
             Command::new("git").args(&["add", &libs.display().to_string()]).spawn()?.wait()?;
         }
-        format!("forge install: {}\n\n{}", target_dir, tag)
+        format!("forge install: {target_dir}\n\n{tag}")
     } else {
-        format!("forge install: {}", target_dir)
+        format!("forge install: {target_dir}")
     };
 
     if !no_commit {

--- a/cli/src/cmd/forge/remappings.rs
+++ b/cli/src/cmd/forge/remappings.rs
@@ -36,7 +36,7 @@ impl Cmd for RemappingArgs {
         };
         let remappings: Vec<_> =
             lib_path.iter().flat_map(|lib| relative_remappings(lib, &root)).collect();
-        remappings.iter().for_each(|x| println!("{}", x));
+        remappings.iter().for_each(|x| println!("{x}"));
         Ok(())
     }
 }

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -222,7 +222,7 @@ impl Cmd for RunArgs {
 
                         if should_include {
                             decoder.decode(trace);
-                            println!("{}", trace);
+                            println!("{trace}");
                         }
                     }
                     println!();
@@ -240,7 +240,7 @@ impl Cmd for RunArgs {
             let console_logs = decode_console_logs(&result.logs);
             if !console_logs.is_empty() {
                 for log in console_logs {
-                    println!("  {}", log);
+                    println!("  {log}");
                 }
             }
         }
@@ -304,7 +304,7 @@ impl RunArgs {
                 dependencies: &mut run_dependencies,
                 matched: false,
             },
-            |file, key| (format!("{}:{}", file, key), file, key),
+            |file, key| (format!("{file}:{key}"), file, key),
             |post_link_input| {
                 let PostLinkInput {
                     contract,

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -138,7 +138,7 @@ impl FromStr for Format {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "t" | "table" => Ok(Format::Table),
-            _ => Err(format!("Unrecognized format `{}`", s)),
+            _ => Err(format!("Unrecognized format `{s}`")),
         }
     }
 }
@@ -231,7 +231,7 @@ impl FromStr for SnapshotEntry {
                     })
                 })
             })
-            .ok_or_else(|| format!("Could not extract Snapshot Entry for {}", s))
+            .ok_or_else(|| format!("Could not extract Snapshot Entry for {s}"))
     }
 }
 
@@ -245,8 +245,7 @@ fn read_snapshot(path: impl AsRef<Path>) -> eyre::Result<Vec<SnapshotEntry>> {
     )
     .lines()
     {
-        entries
-            .push(SnapshotEntry::from_str(line?.as_str()).map_err(|err| eyre::eyre!("{}", err))?);
+        entries.push(SnapshotEntry::from_str(line?.as_str()).map_err(|err| eyre::eyre!("{err}"))?);
     }
     Ok(entries)
 }
@@ -393,11 +392,11 @@ fn fmt_pct_change(change: f64) -> String {
 
 fn fmt_change(change: i128) -> String {
     match change.cmp(&0) {
-        Ordering::Less => Colour::Green.paint(format!("{}", change)).to_string(),
+        Ordering::Less => Colour::Green.paint(format!("{change}")).to_string(),
         Ordering::Equal => {
-            format!("{}", change)
+            format!("{change}")
         }
-        Ordering::Greater => Colour::Red.paint(format!("{}", change)).to_string(),
+        Ordering::Greater => Colour::Red.paint(format!("{change}")).to_string(),
     }
 }
 

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -348,13 +348,13 @@ fn short_test_result(name: &str, result: &forge::TestResult) {
     } else {
         let txt = match (&result.reason, &result.counterexample) {
             (Some(ref reason), Some(ref counterexample)) => {
-                format!("[FAIL. Reason: {}. Counterexample: {}]", reason, counterexample)
+                format!("[FAIL. Reason: {reason}. Counterexample: {counterexample}]")
             }
             (None, Some(ref counterexample)) => {
-                format!("[FAIL. Counterexample: {}]", counterexample)
+                format!("[FAIL. Counterexample: {counterexample}]")
             }
             (Some(ref reason), None) => {
-                format!("[FAIL. Reason: {}]", reason)
+                format!("[FAIL. Reason: {reason}]")
             }
             (None, None) => "[FAIL]".to_string(),
         };
@@ -447,9 +447,9 @@ pub fn custom_run(mut args: TestArgs, include_fuzz_tests: bool) -> eyre::Result<
                 }
                 n =>
                     Err(
-                    eyre::eyre!("{} tests matched your criteria, but exactly 1 test must match in order to run the debugger.\n
+                    eyre::eyre!("{n} tests matched your criteria, but exactly 1 test must match in order to run the debugger.\n
                         \n
-                        Use --match-contract and --match-path to further limit the search.", n))
+                        Use --match-contract and --match-path to further limit the search."))
             }
     } else {
         let TestArgs { filter, .. } = args;
@@ -525,7 +525,7 @@ fn test(
                     if !console_logs.is_empty() {
                         println!("Logs:");
                         for log in console_logs {
-                            println!("  {}", log);
+                            println!("  {log}");
                         }
                         println!();
                     }
@@ -571,7 +571,7 @@ fn test(
 
                     if !decoded_traces.is_empty() {
                         println!("Traces:");
-                        decoded_traces.into_iter().for_each(|trace| println!("{}", trace));
+                        decoded_traces.into_iter().for_each(|trace| println!("{trace}"));
                     }
 
                     if gas_reporting {

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -328,7 +328,7 @@ fn on_action<F, T>(
             if let Some(status) = completion {
                 match status {
                     Some(ProcessEnd::ExitError(code)) => {
-                        tracing::trace!("Command exited with {}", code)
+                        tracing::trace!("Command exited with {code}")
                     }
                     Some(ProcessEnd::ExitSignal(sig)) => {
                         tracing::trace!("Command killed by {:?}", sig)
@@ -396,7 +396,7 @@ pub fn runtime(args: &WatchArgs) -> eyre::Result<RuntimeConfig> {
         let envs = summarise_events_to_env(prespawn.events.iter());
         if let Some(mut command) = prespawn.command().await {
             for (k, v) in envs {
-                command.env(format!("CARGO_WATCH_{}_PATH", k), v);
+                command.env(format!("CARGO_WATCH_{k}_PATH"), v);
             }
         }
 

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -83,12 +83,12 @@ fn get_artifact_from_path(
     Ok((
         artifact
             .abi
-            .ok_or_else(|| eyre::Error::msg(format!("abi not found for {}", contract_name)))?,
+            .ok_or_else(|| eyre::Error::msg(format!("abi not found for {contract_name}")))?,
         artifact
             .bytecode
-            .ok_or_else(|| eyre::Error::msg(format!("bytecode not found for {}", contract_name)))?,
+            .ok_or_else(|| eyre::Error::msg(format!("bytecode not found for {contract_name}")))?,
         artifact
             .deployed_bytecode
-            .ok_or_else(|| eyre::Error::msg(format!("bytecode not found for {}", contract_name)))?,
+            .ok_or_else(|| eyre::Error::msg(format!("bytecode not found for {contract_name}")))?,
     ))
 }

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -151,7 +151,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             println!("No files changed, compilation skipped");
         } else {
             // print the compiler output / warnings
-            println!("{}", output);
+            println!("{output}");
 
             // print any sizes or names
             if print_names {
@@ -162,7 +162,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
                         version.major, version.minor, version.patch
                     );
                     for (name, _) in contracts {
-                        println!("    - {}", name);
+                        println!("    - {name}");
                     }
                 }
             }
@@ -190,7 +190,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
                     }
                 }
 
-                println!("{}", size_report);
+                println!("{size_report}");
 
                 // exit with error if any contract exceeds the size limit, excluding test contracts.
                 let exit_status = if size_report.exceeds_size_limit() { 1 } else { 0 };
@@ -236,6 +236,6 @@ pub fn compile_files(project: &Project, files: Vec<PathBuf>) -> eyre::Result<Pro
     if output.has_compiler_errors() {
         eyre::bail!(output.to_string())
     }
-    println!("{}", output);
+    println!("{output}");
     Ok(output)
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -214,7 +214,7 @@ impl FromStr for FullContractInfo {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (path, name) = s
             .split_once(':')
-            .ok_or_else(|| eyre::eyre!("Expected `<path>:<contractname>`, got `{}`", s))?;
+            .ok_or_else(|| eyre::eyre!("Expected `<path>:<contractname>`, got `{s}`"))?;
         Ok(Self { path: path.to_string(), name: name.trim().to_string() })
     }
 }
@@ -264,9 +264,9 @@ impl FromStr for Dependency {
             format!("https://{}.{}/{}", brand, tld, project)
         } else {
             if !GH_REPO_REGEX.is_match(dependency) {
-                eyre::bail!("invalid github repository name `{}`", dependency);
+                eyre::bail!("invalid github repository name `{dependency}`");
             }
-            format!("https://{}/{}", GITHUB, dependency)
+            format!("https://{GITHUB}/{dependency}")
         };
 
         // everything after the "@" should be considered the version

--- a/cli/src/term.rs
+++ b/cli/src/term.rs
@@ -133,7 +133,7 @@ impl Spinner {
         if self.no_progress {
             return
         }
-        println!("\r\x1b[2K\x1b[1m[\x1b[31m-\x1b[0;1m]\x1b[0m {}", line);
+        println!("\r\x1b[2K\x1b[1m[\x1b[31m-\x1b[0;1m]\x1b[0m {line}");
     }
 }
 
@@ -242,17 +242,17 @@ impl Reporter for SpinnerReporter {
 
     /// Invoked before a new [`Solc`] bin is installed
     fn on_solc_installation_start(&self, version: &Version) {
-        self.send_msg(format!("installing solc version \"{}\"", version));
+        self.send_msg(format!("installing solc version \"{version}\""));
     }
 
     /// Invoked before a new [`Solc`] bin was successfully installed
     fn on_solc_installation_success(&self, version: &Version) {
-        self.send_msg(format!("Successfully installed solc {}", version));
+        self.send_msg(format!("Successfully installed solc {version}"));
     }
 
     fn on_solc_installation_error(&self, version: &Version, error: &str) {
         self.send_msg(
-            Colour::Red.paint(format!("Failed to install solc {}: {}", version, error)).to_string(),
+            Colour::Red.paint(format!("Failed to install solc {version}: {error}")).to_string(),
         );
     }
 

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -97,7 +97,7 @@ impl TestProject {
     /// to a logical grouping of tests.
     pub fn new(name: &str, style: PathStyle) -> Self {
         let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
-        let project = pretty_err(name, TempProject::with_style(&format!("{}-{}", name, id), style));
+        let project = pretty_err(name, TempProject::with_style(&format!("{name}-{id}"), style));
         Self::with_project(project)
     }
 

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -21,7 +21,7 @@ casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
     // Call `cast find-block`
     cmd.args(["find-block", "--rpc-url", eth_rpc_url.as_str(), &timestamp]);
     let output = cmd.stdout_lossy();
-    println!("{}", output);
+    println!("{output}");
 
     // Expect successful block query
     // Query: 1647843609, Mar 21 2022 06:20:09 UTC

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -500,7 +500,7 @@ forgetest_ignore!(can_compile_local_spells, |_: TestProject, mut cmd: TestComman
         .join("../../foundry-integration-tests/testdata/spells-mainnet")
         .to_string_lossy()
         .to_string();
-    println!("project root: \"{}\"", root);
+    println!("project root: \"{root}\"");
 
     let eth_rpc_url = env::var("ETH_RPC_URL").unwrap();
     let dss_exec_lib = "src/DssSpell.sol:DssExecLib:0xfD88CeE74f7D78697775aBDAE53f9Da1559728E4";

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -112,7 +112,7 @@ forgetest!(can_verify_random_contract, |prj: TestProject, mut cmd: TestCommand| 
 
         let out = cmd.stdout_lossy();
         let address = parse_deployed_address(out.as_str())
-            .unwrap_or_else(|| panic!("Failed to parse deployer {}", out));
+            .unwrap_or_else(|| panic!("Failed to parse deployer {out}"));
 
         cmd.forge_fuse().arg("verify-contract").root_arg().args([
             "--chain-id".to_string(),

--- a/config/src/chain.rs
+++ b/config/src/chain.rs
@@ -79,7 +79,7 @@ impl FromStr for Chain {
         } else {
             s.parse::<u64>()
                 .map(Chain::Id)
-                .map_err(|_| format!("Expected known chain or integer, found: {}", s))
+                .map_err(|_| format!("Expected known chain or integer, found: {s}"))
         }
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -532,7 +532,7 @@ impl Config {
             self.src.file_name().and_then(|s| s.to_str()).filter(|s| !s.is_empty())
         {
             remappings.push(Remapping {
-                name: format!("{}/", src_dir_name),
+                name: format!("{src_dir_name}/"),
                 path: format!("{}", self.src.display()),
             });
         }
@@ -744,7 +744,7 @@ impl Config {
         Some(
             Config::foundry_cache_dir()?
                 .join(chain_id.into().to_string())
-                .join(format!("{}", block))
+                .join(format!("{block}"))
                 .join("storage.json"),
         )
     }

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -116,15 +116,15 @@ pub fn parse_libraries(
         let mut items = lib.split(':');
         let file = items
             .next()
-            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {}", lib)))?;
+            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {lib}")))?;
         let lib = items
             .next()
-            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {}", lib)))?;
+            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {lib}")))?;
         let addr = items
             .next()
-            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {}", lib)))?;
+            .ok_or_else(|| SolcError::msg(format!("failed to parse invalid library: {lib}")))?;
         if items.next().is_some() {
-            return Err(SolcError::msg(format!("failed to parse invalid library: {}", lib)))
+            return Err(SolcError::msg(format!("failed to parse invalid library: {lib}")))
         }
         libraries
             .entry(file.to_string())
@@ -148,7 +148,7 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
             .into(),
         Value::Empty(_, _) => Vec::<Value>::new().into(),
         val @ Value::Array(_, _) => val,
-        _ => return Err(format!("Invalid value `{}`, expected an array", val).into()),
+        _ => return Err(format!("Invalid value `{val}`, expected an array").into()),
     };
     Ok(value)
 }

--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -214,7 +214,7 @@ where
                         Some(block) => Ok(block
                             .hash
                             .expect("empty block hash on mined block, this should never happen")),
-                        None => Err(eyre::eyre!("block {} not found", number)),
+                        None => Err(eyre::eyre!("block {number} not found")),
                     };
                     (block_hash, number)
                 });

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -57,7 +57,7 @@ fn get_code(path: &str) -> Result<Bytes, Bytes> {
         let contract_name =
             if parts.len() == 1 { parts[0].replace(".sol", "") } else { parts[1].to_string() };
         let out_dir = ProjectPathsConfig::find_artifacts_dir(Path::new("./"));
-        out_dir.join(format!("{}/{}.json", file, contract_name))
+        out_dir.join(format!("{file}/{contract_name}.json"))
     };
 
     let mut buffer = String::new();

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -98,11 +98,11 @@ impl EvmOpts {
     pub fn get_remote_chain_id(&self) -> Option<Chain> {
         if let Some(ref url) = self.fork_url {
             if url.contains("mainnet") {
-                tracing::trace!("auto detected mainnet chain from url {}", url);
+                tracing::trace!("auto detected mainnet chain from url {url}");
                 return Some(Chain::Mainnet)
             }
             let provider = Provider::try_from(url.as_str())
-                .unwrap_or_else(|_| panic!("Failed to establish provider to {}", url));
+                .unwrap_or_else(|_| panic!("Failed to establish provider to {url}"));
 
             if let Ok(id) = foundry_utils::RuntimeOrHandle::new().block_on(provider.get_chainid()) {
                 return Chain::try_from(id.as_u64()).ok()

--- a/evm/src/fuzz/strategies/param.rs
+++ b/evm/src/fuzz/strategies/param.rs
@@ -39,7 +39,7 @@ pub fn fuzz_param(param: &ParamType) -> impl Strategy<Value = Token> {
                     num.into_token()
                 })
                 .boxed(),
-            _ => panic!("unsupported solidity type int{}", n),
+            _ => panic!("unsupported solidity type int{n}"),
         },
         ParamType::Uint(n) => {
             super::UintStrategy::new(*n, vec![]).prop_map(|x| x.into_token()).boxed()
@@ -103,7 +103,7 @@ pub fn fuzz_param_from_state(param: &ParamType, state: EvmFuzzState) -> BoxedStr
                     num.into_token()
                 })
                 .boxed(),
-            _ => panic!("unsupported solidity type int{}", n),
+            _ => panic!("unsupported solidity type int{n}"),
         },
         ParamType::Uint(n) => match n / 8 {
             32 => value.prop_map(move |value| U256::from(value).into_token()).boxed(),
@@ -112,7 +112,7 @@ pub fn fuzz_param_from_state(param: &ParamType, state: EvmFuzzState) -> BoxedStr
                     (U256::from(value) % (U256::from(2usize).pow(U256::from(y * 8)))).into_token()
                 })
                 .boxed(),
-            _ => panic!("unsupported solidity type uint{}", n),
+            _ => panic!("unsupported solidity type uint{n}"),
         },
         ParamType::Bool => value.prop_map(move |value| Token::Bool(value[31] == 1)).boxed(),
         ParamType::String => value

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -103,8 +103,8 @@ impl fmt::Display for CallTraceArena {
             writeln!(writer, "{}{}", left, node.trace)?;
 
             // Display logs and subcalls
-            let left_prefix = format!("{}{}", child, BRANCH);
-            let right_prefix = format!("{}{}", child, PIPE);
+            let left_prefix = format!("{child}{BRANCH}");
+            let right_prefix = format!("{child}{PIPE}");
             for child in &node.ordering {
                 match child {
                     LogCallOrder::Log(index) => {
@@ -168,7 +168,7 @@ impl fmt::Display for RawOrDecodedLog {
                     writeln!(
                         f,
                         "{:>13}: {}",
-                        if i == 0 { "emit topic 0".to_string() } else { format!("topic {}", i) },
+                        if i == 0 { "emit topic 0".to_string() } else { format!("topic {i}") },
                         Colour::Cyan.paint(format!("0x{}", hex::encode(&topic)))
                     )?;
                 }
@@ -182,7 +182,7 @@ impl fmt::Display for RawOrDecodedLog {
             RawOrDecodedLog::Decoded(name, params) => {
                 let params = params
                     .iter()
-                    .map(|(name, value)| format!("{}: {}", name, value))
+                    .map(|(name, value)| format!("{name}: {value}"))
                     .collect::<Vec<String>>()
                     .join(", ");
 

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -190,7 +190,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         if let Some(remainder) = lines.next() {
             // Call with `self.write_str` and not `write!`, so we can have `\n` at the beginning
             // without triggering an indentation
-            self.write_str(&format!("\n{}", remainder))?;
+            self.write_str(&format!("\n{remainder}"))?;
         }
 
         Ok(())

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -119,7 +119,7 @@ impl Display for GasReport {
 
             let mut table = Table::new();
             table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
-            table.set_header(vec![Cell::new(format!("{} contract", name))
+            table.set_header(vec![Cell::new(format!("{name} contract"))
                 .add_attribute(Attribute::Bold)
                 .fg(Color::Green)]);
             table.add_row(vec![

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -66,7 +66,7 @@ impl MultiContractRunnerBuilder {
             &mut known_contracts,
             evm_opts.sender,
             &mut deployable_contracts,
-            |file, key| (format!("{}.json:{}", key, key), file, key),
+            |file, key| (format!("{key}.json:{key}"), file, key),
             |post_link_input| {
                 let PostLinkInput {
                     contract,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -246,7 +246,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             {
                 Ok(CallResult { traces, labels, logs, .. }) => (false, logs, traces, labels, None),
                 Err(EvmError::Execution { traces, labels, logs, reason, .. }) => {
-                    (true, logs, traces, labels, Some(format!("Setup failed: {}", reason)))
+                    (true, logs, traces, labels, Some(format!("Setup failed: {reason}")))
                 }
                 Err(e) => (
                     true,

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -618,10 +618,10 @@ impl Tui {
                     text_output.extend(Text::from("No sourcemap for contract"));
                 }
             } else {
-                text_output.extend(Text::from(format!("Unknown contract at address {}", address)));
+                text_output.extend(Text::from(format!("Unknown contract at address {address}")));
             }
         } else {
-            text_output.extend(Text::from(format!("Unknown contract at address {}", address)));
+            text_output.extend(Text::from(format!("Unknown contract at address {address}")));
         }
 
         let paragraph =
@@ -707,7 +707,7 @@ impl Tui {
 
             if let Some(op) = opcode_list.get(line_number) {
                 text_output.push(Spans::from(Span::styled(
-                    format!("{}{}", line_number_format, op),
+                    format!("{line_number_format}{op}"),
                     Style::default().fg(Color::White).bg(bg_color),
                 )));
             } else {
@@ -779,7 +779,7 @@ impl Tui {
 
                 if stack_labels {
                     if let Some((_, name)) = affected {
-                        words.push(Span::raw(format!("| {}", name)));
+                        words.push(Span::raw(format!("| {name}")));
                     } else {
                         words.push(Span::raw("| ".to_string()));
                     }
@@ -917,7 +917,7 @@ impl Ui for Tui {
             disable_raw_mode().expect("Unable to disable raw mode");
             execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)
                 .expect("unable to execute disable mouse capture");
-            println!("{}", e);
+            println!("{e}");
         }));
         // This is the recommend tick rate from tui-rs, based on their examples
         let tick_rate = Duration::from_millis(200);

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -281,7 +281,7 @@ impl<'a> IntoFunction for &'a str {
     fn into(self) -> Function {
         AbiParser::default()
             .parse_function(self)
-            .unwrap_or_else(|_| panic!("could not convert {} to function", self))
+            .unwrap_or_else(|_| panic!("could not convert {self} to function"))
     }
 }
 
@@ -548,13 +548,13 @@ pub async fn fourbyte(selector: &str) -> Result<Vec<(String, i32)>> {
     }
     let selector = &selector[..8];
 
-    let url = format!("https://www.4byte.directory/api/v1/signatures/?hex_signature={}", selector);
+    let url = format!("https://www.4byte.directory/api/v1/signatures/?hex_signature={selector}");
     let res = reqwest::get(url).await?;
     let res = res.text().await?;
     let api_response = match serde_json::from_str::<ApiResponse>(&res) {
         Ok(inner) => inner,
         Err(err) => {
-            eyre::bail!("Could not decode response:\n {}.\nError: {}", res, err)
+            eyre::bail!("Could not decode response:\n {res}.\nError: {err}")
         }
     };
 
@@ -631,8 +631,7 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
     }
     let topic = &topic[..8];
 
-    let url =
-        format!("https://www.4byte.directory/api/v1/event-signatures/?hex_signature={}", topic);
+    let url = format!("https://www.4byte.directory/api/v1/event-signatures/?hex_signature={topic}");
     let res = reqwest::get(url).await?;
     let api_response = res.json::<ApiResponse>().await?;
 
@@ -748,19 +747,19 @@ pub fn format_token(param: &Token) -> String {
             }
         }
         Token::Uint(num) => num.to_string(),
-        Token::Bool(b) => format!("{}", b),
+        Token::Bool(b) => format!("{b}"),
         Token::String(s) => format!("{:?}", s),
         Token::FixedArray(tokens) => {
             let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
-            format!("[{}]", string)
+            format!("[{string}]")
         }
         Token::Array(tokens) => {
             let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
-            format!("[{}]", string)
+            format!("[{string}]")
         }
         Token::Tuple(tokens) => {
             let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
-            format!("({})", string)
+            format!("({string})")
         }
     }
 }
@@ -809,7 +808,7 @@ fn format_param(param: &Param, structs: &mut HashSet<String>) -> String {
             ParamType::FixedArray(_, _) |
             ParamType::Tuple(_),
     );
-    let kind = if is_memory { format!("{} memory", kind) } else { kind };
+    let kind = if is_memory { format!("{kind} memory") } else { kind };
 
     if param.name.is_empty() {
         kind
@@ -857,7 +856,7 @@ fn get_param_type(
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            let v2_struct = format!("struct {} {{ {} }}", name, args);
+            let v2_struct = format!("struct {name} {{ {args} }}");
             (name, Some(v2_struct))
         }
         // If not, just get the string of the param kind.
@@ -902,7 +901,7 @@ pub fn abi_to_solidity(contract_abi: &Abi, mut contract_name: &str) -> Result<St
                 .join(", ");
 
             let event_final = format!("event {}({})", event.name, inputs);
-            format!("{};", event_final)
+            format!("{event_final};")
         })
         .collect::<Vec<_>>()
         .join("\n    ");
@@ -931,13 +930,13 @@ pub fn abi_to_solidity(contract_abi: &Abi, mut contract_name: &str) -> Result<St
 
             let mut func = format!("function {}({})", function.name, inputs);
             if !mutability.is_empty() {
-                func = format!("{} {}", func, mutability);
+                func = format!("{func} {mutability}");
             }
-            func = format!("{} external", func);
+            func = format!("{func} external");
             if !outputs.is_empty() {
-                func = format!("{} returns ({})", func, outputs);
+                func = format!("{func} returns ({outputs})");
             }
-            format!("{};", func)
+            format!("{func};")
         })
         .collect::<Vec<_>>()
         .join("\n    ");
@@ -1071,7 +1070,7 @@ mod tests {
             &mut known_contracts,
             Address::default(),
             &mut deployable_contracts,
-            |file, key| (format!("{}.json:{}", key, key), file, key),
+            |file, key| (format!("{key}.json:{key}"), file, key),
             |post_link_input| {
                 match post_link_input.id.slug().as_str() {
                     "DSTest.json:DSTest" => {
@@ -1102,7 +1101,7 @@ mod tests {
                             *nested_lib_unlinked
                         );
                     }
-                    s => panic!("unexpected slug {}", s),
+                    s => panic!("unexpected slug {s}"),
                 }
                 Ok(())
             },


### PR DESCRIPTION
Brings the code base to the bright new world of [captured identifiers](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings). Removes a pair of unneeded unwraps.

Tool-aided by [comby-rust](https://github.com/huitseeker/comby-rust)