### PR TITLE
chore: bump ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1327,7 +1327,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1458,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#02ad93a1cfb7b62eb051c77c61dc4c0218428e4a"
+source = "git+https://github.com/gakonst/ethers-rs#8dd553a5ebbc19846fcd2d5a037c4f044f51c430"
 dependencies = [
  "colored",
  "dunce",
@@ -4338,7 +4338,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.9"
-source = "git+https://github.com/roynalnaruto/svm-rs#9c86111689147842dd76f5fe8db7cf472e729118"
+source = "git+https://github.com/roynalnaruto/svm-rs#1eb7f4e2ccb549096885ded598f6c05b2d96dccf"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "svm-rs-builds"
 version = "0.1.0"
-source = "git+https://github.com/roynalnaruto/svm-rs#9c86111689147842dd76f5fe8db7cf472e729118"
+source = "git+https://github.com/roynalnaruto/svm-rs#1eb7f4e2ccb549096885ded598f6c05b2d96dccf"
 dependencies = [
  "build_const",
  "hex",


### PR DESCRIPTION
Contains some fixes for `console.logBytes` formatting and closes #796 because of https://github.com/gakonst/ethers-rs/pull/1149