### PR TITLE
refactor(fmt): visit functions for statements

### DIFF
--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -158,6 +158,7 @@ pub trait Visitor {
         Ok(())
     }
 
+    #[allow(clippy::type_complexity)]
     fn visit_try(
         &mut self,
         loc: Loc,

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -57,31 +57,46 @@ pub trait Visitor {
         Ok(())
     }
 
-    fn visit_statement(&mut self, stmt: &mut Statement) -> VResult {
-        self.visit_source(stmt.loc())?;
+    fn visit_assembly(
+        &mut self,
+        loc: Loc,
+        _dialect: &mut Option<StringLiteral>,
+        _block: &mut YulBlock,
+    ) -> VResult {
+        self.visit_source(loc)?;
 
         Ok(())
     }
 
-    fn visit_assembly(&mut self, stmt: &mut YulStatement) -> VResult {
-        self.visit_source(stmt.loc())?;
+    fn visit_block(
+        &mut self,
+        loc: Loc,
+        _unchecked: bool,
+        _statements: &mut Vec<Statement>,
+    ) -> VResult {
+        self.visit_source(loc)?;
 
         Ok(())
     }
 
-    fn visit_arg(&mut self, arg: &mut NamedArgument) -> VResult {
-        self.visit_source(arg.loc)?;
+    fn visit_args(&mut self, loc: Loc, _args: &mut Vec<NamedArgument>) -> VResult {
+        self.visit_source(loc)?;
 
         Ok(())
     }
 
-    fn visit_expr(&mut self, expr: &mut Expression) -> VResult {
-        self.visit_source(expr.loc())?;
+    /// Doesn't write semicolon at the end because expressions can appear as both
+    /// part of other node and a statement in the function body
+    fn visit_expr(&mut self, loc: Loc, _expr: &mut Expression) -> VResult {
+        self.visit_source(loc)?;
 
         Ok(())
     }
 
-    fn visit_emit(&mut self, _expr: &mut Expression) -> VResult {
+    fn visit_emit(&mut self, loc: Loc, _event: &mut Expression) -> VResult {
+        self.visit_source(loc)?;
+        self.visit_stray_semicolon()?;
+
         Ok(())
     }
 
@@ -96,15 +111,42 @@ pub trait Visitor {
         Ok(())
     }
 
-    /// Doesn't write semicolon at the end because variable declaration can be in both
-    /// struct definition and function body
+    fn visit_var_definition_stmt(
+        &mut self,
+        loc: Loc,
+        _declaration: &mut VariableDeclaration,
+        _expr: &mut Option<Expression>,
+    ) -> VResult {
+        self.visit_source(loc)?;
+        self.visit_stray_semicolon()?;
+
+        Ok(())
+    }
+
+    /// Doesn't write semicolon at the end because variable declarations can appear in both
+    /// struct definition and function body as a statement
     fn visit_var_declaration(&mut self, var: &mut VariableDeclaration) -> VResult {
         self.visit_source(var.loc)?;
 
         Ok(())
     }
 
-    fn visit_return(&mut self, _expr: &mut Option<Expression>) -> VResult {
+    fn visit_return(&mut self, loc: Loc, _expr: &mut Option<Expression>) -> VResult {
+        self.visit_source(loc)?;
+        self.visit_stray_semicolon()?;
+
+        Ok(())
+    }
+
+    fn visit_revert(
+        &mut self,
+        loc: Loc,
+        _error: &mut Option<Identifier>,
+        _args: &mut Vec<Expression>,
+    ) -> VResult {
+        self.visit_source(loc)?;
+        self.visit_stray_semicolon()?;
+
         Ok(())
     }
 
@@ -116,11 +158,57 @@ pub trait Visitor {
         Ok(())
     }
 
-    fn visit_do_while(&mut self, _stmt: &mut Statement, _expr: &mut Expression) -> VResult {
+    fn visit_try(
+        &mut self,
+        loc: Loc,
+        _expr: &mut Expression,
+        _returns: &mut Option<(Vec<(Loc, Option<Parameter>)>, Box<Statement>)>,
+        _clauses: &mut Vec<CatchClause>,
+    ) -> VResult {
+        self.visit_source(loc)?;
+
         Ok(())
     }
 
-    fn visit_while(&mut self, _expr: &mut Expression, _stmt: &mut Statement) -> VResult {
+    fn visit_if(
+        &mut self,
+        loc: Loc,
+        _cond: &mut Expression,
+        _if_branch: &mut Box<Statement>,
+        _else_branch: &mut Option<Box<Statement>>,
+    ) -> VResult {
+        self.visit_source(loc)?;
+
+        Ok(())
+    }
+
+    fn visit_do_while(
+        &mut self,
+        loc: Loc,
+        _cond: &mut Statement,
+        _body: &mut Expression,
+    ) -> VResult {
+        self.visit_source(loc)?;
+
+        Ok(())
+    }
+
+    fn visit_while(&mut self, loc: Loc, _cond: &mut Expression, _body: &mut Statement) -> VResult {
+        self.visit_source(loc)?;
+
+        Ok(())
+    }
+
+    fn visit_for(
+        &mut self,
+        loc: Loc,
+        _init: &mut Option<Box<Statement>>,
+        _cond: &mut Option<Box<Expression>>,
+        _update: &mut Option<Box<Statement>>,
+        _body: &mut Option<Box<Statement>>,
+    ) -> VResult {
+        self.visit_source(loc)?;
+
         Ok(())
     }
 
@@ -279,9 +367,39 @@ impl Visitable for ContractPart {
 
 impl Visitable for Statement {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
-        v.visit_statement(self)?;
-
-        Ok(())
+        match self {
+            Statement::Block { loc, unchecked, statements } => {
+                v.visit_block(*loc, *unchecked, statements)
+            }
+            Statement::Assembly { loc, dialect, block } => v.visit_assembly(*loc, dialect, block),
+            Statement::Args(loc, args) => v.visit_args(*loc, args),
+            Statement::If(loc, cond, if_branch, else_branch) => {
+                v.visit_if(*loc, cond, if_branch, else_branch)
+            }
+            Statement::While(loc, cond, body) => v.visit_while(*loc, cond, body),
+            Statement::Expression(loc, expr) => {
+                v.visit_expr(*loc, expr)?;
+                v.visit_stray_semicolon()
+            }
+            Statement::VariableDefinition(loc, declaration, expr) => {
+                v.visit_var_definition_stmt(*loc, declaration, expr)
+            }
+            Statement::For(loc, init, cond, update, body) => {
+                v.visit_for(*loc, init, cond, update, body)
+            }
+            Statement::DoWhile(loc, cond, body) => v.visit_do_while(*loc, cond, body),
+            Statement::Continue(_) => v.visit_continue(),
+            Statement::Break(_) => v.visit_break(),
+            Statement::Return(loc, expr) => v.visit_return(*loc, expr),
+            Statement::Revert(loc, error, args) => v.visit_revert(*loc, error, args),
+            Statement::Emit(loc, event) => v.visit_emit(*loc, event),
+            Statement::Try(loc, expr, returns, clauses) => {
+                v.visit_try(*loc, expr, returns, clauses)
+            }
+            // TODO: statement doc comments are parsed differently than doc comments attached to
+            //  another node. Ideally, Solang should parse them into `solang::pt::DocComment` enum.
+            Statement::DocComment(..) => Ok(()),
+        }
     }
 }
 
@@ -295,7 +413,7 @@ impl Visitable for VariableDeclaration {
 
 impl Visitable for Expression {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
-        v.visit_expr(self)?;
+        v.visit_expr(self.loc(), self)?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`solang::pt::Statement` is a enum, so we better match in in the `visit.rs` and call corresponding hooks for each of the variants.

## Solution

Create visit function hooks for `solang::pt::Statement` variants, move logic there from one broad `visit_statement` that we've previously had.
