### PR TITLE
feat(cheatcode): chainId() - modify block.chainid

### DIFF
--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -43,7 +43,7 @@ ethers::contract::abigen!(
             assume(bool)
             setNonce(address,uint64)
             getNonce(address)
-            travel(uint256)
+            chainId(uint256)
     ]"#,
 );
 pub use hevm_mod::{HEVMCalls, HEVM_ABI};

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -43,6 +43,7 @@ ethers::contract::abigen!(
             assume(bool)
             setNonce(address,uint64)
             getNonce(address)
+            travel(uint256)
     ]"#,
 );
 pub use hevm_mod::{HEVMCalls, HEVM_ABI};

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -180,6 +180,10 @@ pub fn apply<DB: Database>(
             let account = data.subroutine.state().get(&inner.0).unwrap();
             Ok(abi::encode(&[Token::Uint(account.info.nonce.into())]).into())
         }
+        HEVMCalls::Travel(inner) => {
+            data.env.cfg.chain_id = inner.0;
+            Ok(Bytes::new())
+        }
         _ => return None,
     })
 }

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -180,7 +180,7 @@ pub fn apply<DB: Database>(
             let account = data.subroutine.state().get(&inner.0).unwrap();
             Ok(abi::encode(&[Token::Uint(account.info.nonce.into())]).into())
         }
-        HEVMCalls::Travel(inner) => {
+        HEVMCalls::ChainId(inner) => {
             data.env.cfg.chain_id = inner.0;
             Ok(Bytes::new())
         }

--- a/forge/README.md
+++ b/forge/README.md
@@ -174,7 +174,7 @@ which implements the following methods:
 
 - `function getNonce(address account)`: Get nonce for an account.
 
-- `function travel(uint x) public` Sets the block chainid to `x`.
+- `function chainId(uint x) public` Sets the block chainid to `x`.
 
 The below example uses the `warp` cheatcode to override the timestamp & `expectRevert` to expect a specific revert string:
 

--- a/forge/README.md
+++ b/forge/README.md
@@ -174,6 +174,8 @@ which implements the following methods:
 
 - `function getNonce(address account)`: Get nonce for an account.
 
+- `function travel(uint x) public` Sets the block chainid to `x`.
+
 The below example uses the `warp` cheatcode to override the timestamp & `expectRevert` to expect a specific revert string:
 
 ```solidity

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -64,4 +64,6 @@ interface Cheats {
     function setNonce(address,uint64) external;
     // Get nonce for an account
     function getNonce(address) external returns(uint64);
+    // Set block.chainid (newChainid)
+    function travel(uint256) external;
 }

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -65,5 +65,5 @@ interface Cheats {
     // Get nonce for an account
     function getNonce(address) external returns(uint64);
     // Set block.chainid (newChainId)
-    function travel(uint256) external;
+    function chainId(uint256) external;
 }

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -64,6 +64,6 @@ interface Cheats {
     function setNonce(address,uint64) external;
     // Get nonce for an account
     function getNonce(address) external returns(uint64);
-    // Set block.chainid (newChainid)
+    // Set block.chainid (newChainId)
     function travel(uint256) external;
 }

--- a/testdata/cheats/Travel.t.sol
+++ b/testdata/cheats/Travel.t.sol
@@ -4,17 +4,17 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 import "./Cheats.sol";
 
-contract TravelTest is DSTest {
+contract ChainIdTest is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
-    function testTravel() public {
-        cheats.travel(10);
-        assertEq(block.chainid, 10, "travel failed");
+    function testChainId() public {
+        cheats.chainId(10);
+        assertEq(block.chainid, 10, "chainId switch failed");
     }
 
-    function testTravelFuzzed(uint128 jump) public {
+    function testChainIdFuzzed(uint128 jump) public {
         uint pre = block.chainid;
-        cheats.travel(block.chainid + jump);
-        assertEq(block.chainid, pre + jump, "travel failed");
+        cheats.chainId(block.chainid + jump);
+        assertEq(block.chainid, pre + jump, "chainId switch failed");
     }
 }

--- a/testdata/cheats/Travel.t.sol
+++ b/testdata/cheats/Travel.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "./Cheats.sol";
+
+contract TravelTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function testTravel() public {
+        cheats.travel(10);
+        assertEq(block.chainid, 10, "travel failed");
+    }
+
+    function testTravelFuzzed(uint128 jump) public {
+        uint pre = block.chainid;
+        cheats.travel(block.chainid + jump);
+        assertEq(block.chainid, pre + jump, "travel failed");
+    }
+}


### PR DESCRIPTION
Many contracts I test involve using chain ID so being able to modify it via a cheatcode to simulate e2e tests in foundry is useful.

This PR adds `travel(uint256)` which modifies `block.chainid` to the cheatcodes by modifying `data.env.cfg.chain_id`. Tests pass, though this could interfere with `permit`s and `Sign()` in testing.

Unike #997 #1103, this cheatcode does not persist in `setUp` since it modifies `CfgEnv` & not `BlockEnv`, which would require a much deeper change.

