### PR TITLE
test(fmt): introduce our own test cases

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Clone testdata for fmt tests
-        run: make fmt-testdata
-
       - name: Apple M1 setup
         if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Clone testdata for fmt tests
-        run: make fmt-testdata
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -57,8 +54,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Clone testdata for fmt tests
-        run: make fmt-testdata
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -81,8 +77,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Clone testdata for fmt tests
-        run: make fmt-testdata
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /target
 out/
 out.json
-
-fmt/testdata/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ name = "forge-fmt"
 version = "0.2.0"
 dependencies = [
  "indent_write",
+ "itertools",
  "pretty_assertions",
  "semver",
  "solang-parser",

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-.PHONY: fmt-testdata
-
-fmt-testdata:
-	@FOLDER=$(shell dirname "$0")/fmt/testdata/prettier-plugin-solidity;\
-	if [ ! -d $$FOLDER/.git ] ; then git clone --depth 1 --recursive https://github.com/prettier-solidity/prettier-plugin-solidity $$FOLDER;\
-	else cd $$FOLDER; git pull --recurse-submodules; fi

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -17,3 +17,4 @@ solang-parser = "0.1.12"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
+itertools = "0.10.3"

--- a/fmt/testdata/ContractDefinitions/bracket-spacing.fmt.sol
+++ b/fmt/testdata/ContractDefinitions/bracket-spacing.fmt.sol
@@ -1,0 +1,3 @@
+// config: line-length=160
+// config: bracket-spacing=true
+contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 { }

--- a/fmt/testdata/ContractDefinitions/fmt.sol
+++ b/fmt/testdata/ContractDefinitions/fmt.sol
@@ -1,0 +1,7 @@
+contract ContractDefinition is
+    Contract1,
+    Contract2,
+    Contract3,
+    Contract4,
+    Contract5
+{}

--- a/fmt/testdata/ContractDefinitions/original.sol
+++ b/fmt/testdata/ContractDefinitions/original.sol
@@ -1,0 +1,2 @@
+contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 {
+}

--- a/fmt/testdata/EnumDefinitions/bracket-spacing.fmt.sol
+++ b/fmt/testdata/EnumDefinitions/bracket-spacing.fmt.sol
@@ -1,0 +1,21 @@
+// config: bracket-spacing=true
+contract EnumDefinitions {
+    enum Empty { }
+    enum ActionChoices {
+        GoLeft,
+        GoRight,
+        GoStraight,
+        SitStill
+    }
+    enum States {
+        State1,
+        State2,
+        State3,
+        State4,
+        State5,
+        State6,
+        State7,
+        State8,
+        State9
+    }
+}

--- a/fmt/testdata/EnumDefinitions/fmt.sol
+++ b/fmt/testdata/EnumDefinitions/fmt.sol
@@ -1,0 +1,20 @@
+contract EnumDefinitions {
+    enum Empty {}
+    enum ActionChoices {
+        GoLeft,
+        GoRight,
+        GoStraight,
+        SitStill
+    }
+    enum States {
+        State1,
+        State2,
+        State3,
+        State4,
+        State5,
+        State6,
+        State7,
+        State8,
+        State9
+    }
+}

--- a/fmt/testdata/EnumDefinitions/original.sol
+++ b/fmt/testdata/EnumDefinitions/original.sol
@@ -1,0 +1,7 @@
+contract EnumDefinitions {
+    enum Empty {
+
+    }
+    enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+}

--- a/fmt/testdata/ImportDirective/bracket-spacing.fmt.sol
+++ b/fmt/testdata/ImportDirective/bracket-spacing.fmt.sol
@@ -1,0 +1,6 @@
+// config: bracket-spacing=true
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import "AnotherFile.sol" as SomeSymbol;
+import { symbol1 as alias, symbol2 } from "File.sol";
+import { symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4 } from "File2.sol";

--- a/fmt/testdata/ImportDirective/fmt.sol
+++ b/fmt/testdata/ImportDirective/fmt.sol
@@ -1,0 +1,5 @@
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import "AnotherFile.sol" as SomeSymbol;
+import {symbol1 as alias, symbol2} from "File.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";

--- a/fmt/testdata/ImportDirective/original.sol
+++ b/fmt/testdata/ImportDirective/original.sol
@@ -1,0 +1,5 @@
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import * as SomeSymbol from "AnotherFile.sol";
+import {symbol1 as alias, symbol2} from "File.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";

--- a/fmt/testdata/StatementBlock/bracket-spacing.fmt.sol
+++ b/fmt/testdata/StatementBlock/bracket-spacing.fmt.sol
@@ -1,0 +1,18 @@
+// config: bracket-spacing=true
+contract Contract {
+    function test() {
+        unchecked { a += 1; }
+
+        unchecked {
+            a += 1;
+        }
+        2 + 2;
+
+        unchecked {
+            a += 1;
+        }
+        unchecked { }
+
+        1 + 1;
+    }
+}

--- a/fmt/testdata/StatementBlock/fmt.sol
+++ b/fmt/testdata/StatementBlock/fmt.sol
@@ -1,0 +1,17 @@
+contract Contract {
+    function test() {
+        unchecked {a += 1;}
+
+        unchecked {
+            a += 1;
+        }
+        2 + 2;
+
+        unchecked {
+            a += 1;
+        }
+        unchecked {}
+
+        1 + 1;
+    }
+}

--- a/fmt/testdata/StatementBlock/original.sol
+++ b/fmt/testdata/StatementBlock/original.sol
@@ -1,0 +1,17 @@
+contract Contract {
+    function test() { unchecked { a += 1; }
+
+        unchecked {
+        a += 1;
+        }
+    2 + 2;
+
+unchecked { a += 1;
+        }
+    unchecked {}
+
+    1 + 1;
+
+
+    }
+}

--- a/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
+++ b/fmt/testdata/StructDefinition/bracket-spacing.fmt.sol
@@ -1,0 +1,7 @@
+// config: bracket-spacing=true
+struct Foo { }
+
+struct Bar {
+    uint256 foo;
+    string bar;
+}

--- a/fmt/testdata/StructDefinition/fmt.sol
+++ b/fmt/testdata/StructDefinition/fmt.sol
@@ -1,0 +1,6 @@
+struct Foo {}
+
+struct Bar {
+    uint256 foo;
+    string bar;
+}

--- a/fmt/testdata/StructDefinition/original.sol
+++ b/fmt/testdata/StructDefinition/original.sol
@@ -1,0 +1,2 @@
+struct   Foo  {
+} struct   Bar  {    uint foo ;string bar ;  }

--- a/fmt/testdata/TypeDefinition/fmt.sol
+++ b/fmt/testdata/TypeDefinition/fmt.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.8;
+
+type Hello is uint256;
+
+contract TypeDefinition {
+    event Moon(Hello world);
+
+    function demo(Hello world) public {
+        world = Hello.wrap(Hello.unwrap(world) + 1337);
+        emit Moon(world);
+    }
+}

--- a/fmt/testdata/TypeDefinition/original.sol
+++ b/fmt/testdata/TypeDefinition/original.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.8;
+
+    type Hello is uint;
+
+contract TypeDefinition {
+    event Moon(Hello world);
+
+        function demo(Hello world) public {
+        world = Hello.wrap(Hello.unwrap(world) + 1337);
+        emit Moon(world);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Previously, we had test cases for formatter borrowed 🦀  from https://github.com/prettier-solidity/prettier-plugin-solidity. While it was a good starting point, there are several issues with that approach:
1. Parsing their snapshots is not obvious since its from JavaScript testing library.
2. We might wanna have our own test cases to cover some aspects of formatter and preserving that JS snapshots style is a pain.

## Solution

Introduce our own test cases for the nodes that we know how to format continuing borrowing good ones from prettier-plugin-solidity.
