### PR TITLE
style: change contract size output table to kB for readability

### DIFF
--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -51,8 +51,8 @@ impl Display for SizeReport {
         table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
         table.set_header(vec![
             Cell::new("Contract").add_attribute(Attribute::Bold).fg(Color::Blue),
-            Cell::new("Size").add_attribute(Attribute::Bold).fg(Color::Blue),
-            Cell::new("Margin").add_attribute(Attribute::Bold).fg(Color::Blue),
+            Cell::new("Size (kB)").add_attribute(Attribute::Bold).fg(Color::Blue),
+            Cell::new("Margin (kB)").add_attribute(Attribute::Bold).fg(Color::Blue),
         ]);
 
         let contracts = self.contracts.iter().filter(|(_, c)| !c.is_test_contract && c.size > 0);
@@ -66,8 +66,8 @@ impl Display for SizeReport {
 
             table.add_row(vec![
                 Cell::new(name).fg(color),
-                Cell::new(contract.size).fg(color),
-                Cell::new(margin).fg(color),
+                Cell::new(contract.size as f64 / 1000.0).fg(color),
+                Cell::new(margin as f64 / 1000.0).fg(color),
             ]);
         }
 


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/1331

Went with kB instead of bytes with a comma separator because it was easier to implement and more in line with how I think about contract sizes

<img width=350 src="https://user-images.githubusercontent.com/17163988/163719756-32c172fe-c9c1-475f-997b-9c2b87d082f3.png" />
