### PR TITLE
ci: add project workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,15 @@
+name: project
+on:
+  issues:
+    types: [opened, transferred]
+
+jobs:
+  add-to-project:
+    name: add issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/foundry-rs/projects/2
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+


### PR DESCRIPTION
## Motivation

I created a GitHub project to provide a better overview of the issues in the repository, similar to the one for Foundry Book.

It can be found [here](https://github.com/orgs/foundry-rs/projects/2).

I don't expect people to actively use it (it's not a requirement), but I use it myself and find it helpful. The only annoyance is that issues manually need to be added to the project.

## Solution

Add a workflow that automatically adds issues to the project.

I added my own PAT to the repository secrets with the correct scopes, so it should Just Work:tm: