### PR TITLE
feat: show hardhat console.logs in traces

### DIFF
--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -1,8 +1,5 @@
 use crate::{
-    executor::{
-        inspector::utils::{gas_used, get_create_address},
-        HARDHAT_CONSOLE_ADDRESS,
-    },
+    executor::inspector::utils::{gas_used, get_create_address},
     trace::{
         CallTrace, CallTraceArena, LogCallOrder, RawOrDecodedCall, RawOrDecodedLog,
         RawOrDecodedReturnData,
@@ -75,15 +72,13 @@ where
         call: &mut CallInputs,
         _: bool,
     ) -> (Return, Gas, Bytes) {
-        if call.contract != HARDHAT_CONSOLE_ADDRESS {
-            self.start_trace(
-                data.subroutine.depth() as usize,
-                call.context.code_address,
-                call.input.to_vec(),
-                call.transfer.value,
-                call.context.scheme.into(),
-            );
-        }
+        self.start_trace(
+            data.subroutine.depth() as usize,
+            call.context.code_address,
+            call.input.to_vec(),
+            call.transfer.value,
+            call.context.scheme.into(),
+        );
 
         (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
@@ -98,20 +93,18 @@ where
     fn call_end(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CallInputs,
+        _call: &CallInputs,
         gas: Gas,
         status: Return,
         retdata: Bytes,
         _: bool,
     ) -> (Return, Gas, Bytes) {
-        if call.contract != HARDHAT_CONSOLE_ADDRESS {
-            self.fill_trace(
-                matches!(status, return_ok!()),
-                gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
-                retdata.to_vec(),
-                None,
-            );
-        }
+        self.fill_trace(
+            matches!(status, return_ok!()),
+            gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
+            retdata.to_vec(),
+            None,
+        );
 
         (status, gas, retdata)
     }

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -3,7 +3,7 @@ use super::{
     RawOrDecodedReturnData,
 };
 use crate::{
-    abi::{CHEATCODE_ADDRESS, CONSOLE_ABI, HEVM_ABI},
+    abi::{CHEATCODE_ADDRESS, CONSOLE_ABI, HARDHAT_CONSOLE_ABI, HARDHAT_CONSOLE_ADDRESS, HEVM_ABI},
     trace::{node::CallTraceNode, utils},
 };
 use ethers::{
@@ -79,6 +79,21 @@ impl CallTraceDecoder {
     /// The call trace decoder always knows how to decode calls to the cheatcode address, as well
     /// as DSTest-style logs.
     pub fn new() -> Self {
+        let hevm_abi = HARDHAT_CONSOLE_ABI
+            .functions()
+            .map(|func| (func.short_signature(), vec![func.clone()]))
+            .collect::<BTreeMap<[u8; 4], Vec<Function>>>();
+
+        let hardhat_console_abi = HEVM_ABI
+            .functions()
+            .map(|func| (func.short_signature(), vec![func.clone()]))
+            .collect::<BTreeMap<[u8; 4], Vec<Function>>>();
+
+        let functions = hevm_abi
+            .into_iter()
+            .chain(hardhat_console_abi)
+            .collect::<BTreeMap<[u8; 4], Vec<Function>>>();
+
         Self {
             // TODO: These are the Ethereum precompiles. We should add a way to support precompiles
             // for other networks, too.
@@ -153,11 +168,12 @@ impl CallTraceDecoder {
             ]
             .into(),
             contracts: Default::default(),
-            labels: [(CHEATCODE_ADDRESS, "VM".to_string())].into(),
-            functions: HEVM_ABI
-                .functions()
-                .map(|func| (func.short_signature(), vec![func.clone()]))
-                .collect::<BTreeMap<[u8; 4], Vec<Function>>>(),
+            labels: [
+                (CHEATCODE_ADDRESS, "VM".to_string()),
+                (HARDHAT_CONSOLE_ADDRESS, "console".to_string()),
+            ]
+            .into(),
+            functions,
             events: CONSOLE_ABI
                 .events()
                 .map(|event| ((event.signature(), indexed_inputs(event)), vec![event.clone()]))


### PR DESCRIPTION
## Motivation

Using Hardhat's `console.log` is a common pattern for seeing values during execution. Due to a bug in the library, function selectors for log calls using `int256` and `uint256` types are not computed directly. Therefore foundry decided not to show hardhat logs in traces, since they would not be decoded properly unless function selectors were patched..

## Solution

In forge-std <link to PR> we add `console2.sol`, which fixes the function selectors in `console.sol`. Users now have a choice:
- Use `console2.log()` to have all logs properly decoded in traces
- Use `console.log()` for backwards compatibility with Hardhat, but logs using int256 and uint256 types will not be decoded in traces
