### PR TITLE
chore(deps): bump tracing-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,9 +4648,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.29"
 
 # Logging
 tracing = "0.1.26"
-tracing-subscriber = "=0.3.9"
+tracing-subscriber = "0.3.11"
 tracing-error = "0.2.0"
 
 # Threading/futures

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -20,7 +20,7 @@ glob = "0.3.0"
 # TODO: Trim down
 tokio = { version = "1.10.1" }
 tracing = "0.1.26"
-tracing-subscriber = "=0.3.9"
+tracing-subscriber = "0.3.11"
 proptest = "1.0.0"
 rayon = "1.5"
 rlp = "0.5.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
removes the pin to `0.3.9` which was required because there was a parser issue in tracing's env filter
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
