### PR TITLE
Improve docstring for --repo foundryup option.

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -185,7 +185,7 @@ OPTIONS:
     -b, --branch    Install a specific branch
     -P, --pr        Install a specific Pull Request
     -C, --commit    Install a specific commit
-    -r, --repo      Install a forks main branch
+    -r, --repo      Install from a remote GitHib repo (uses default branch if no other options are set)
     -p, --path      Install a local repository
 EOF
 }


### PR DESCRIPTION
Title :point_up:

## Motivation

Existing docstring `Install a forks main branch` isn't completely correct.

## Solution

Improve the docstring.
