### PR TITLE
fix: use provided gas price in env

### DIFF
--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -425,7 +425,7 @@ pub fn custom_run(args: TestArgs, include_fuzz_tests: bool) -> eyre::Result<Test
     }
 
     // Prepare the test builder
-    let evm_spec = crate::utils::evm_spec(&config.evm_version);
+    let evm_spec = utils::evm_spec(&config.evm_version);
     let mut runner = MultiContractRunnerBuilder::default()
         .fuzzer(fuzzer)
         .initial_balance(evm_opts.initial_balance)

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -219,6 +219,7 @@ forgetest_init!(can_set_config_values, |prj: TestProject, _cmd: TestCommand| {
     assert!(config.via_ir);
 });
 
+// tests that solc can be explicitly set
 forgetest!(can_set_solc_explicitly, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_current_dir(prj.root());
     prj.inner()
@@ -320,6 +321,7 @@ Compiler run successful
     ));
 });
 
+// tests that the lib triple can be parsed
 forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_current_dir(prj.root());
     cmd.set_env(
@@ -337,14 +339,28 @@ forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestComman
 forgetest!(can_set_optimizer_runs, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_current_dir(prj.root());
 
-    // explicitly set gas_price
+    // explicitly set optimizer runs
     let config = Config { optimizer_runs: 1337, ..Default::default() };
     prj.write_config(config);
 
     let config = cmd.config();
-
     assert_eq!(config.optimizer_runs, 1337);
 
     let config = prj.config_from_output(["--optimizer-runs", "300"]);
     assert_eq!(config.optimizer_runs, 300);
+});
+
+// test that gas_price can be set
+forgetest!(can_set_gas_price, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.set_current_dir(prj.root());
+
+    // explicitly set gas_price
+    let config = Config { gas_price: 1337, ..Default::default() };
+    prj.write_config(config);
+
+    let config = cmd.config();
+    assert_eq!(config.gas_price, 1337);
+
+    let config = prj.config_from_output(["--gas-price", "300"]);
+    assert_eq!(config.gas_price, 300);
 });

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -134,7 +134,7 @@ impl ExecutorBuilder {
     #[must_use]
     pub fn with_cheatcodes(mut self, ffi: bool) -> Self {
         self.inspector_config.cheatcodes =
-            Some(Cheatcodes::new(ffi, self.env.block.clone(), self.env.tx.gas_price.clone()));
+            Some(Cheatcodes::new(ffi, self.env.block.clone(), self.env.tx.gas_price));
         self
     }
 
@@ -172,7 +172,7 @@ impl ExecutorBuilder {
     #[must_use]
     pub fn with_config(mut self, env: Env) -> Self {
         self.inspector_config.block = env.block.clone();
-        self.inspector_config.gas_price = env.tx.gas_price.clone();
+        self.inspector_config.gas_price = env.tx.gas_price;
         self.env = env;
         self
     }

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -133,7 +133,8 @@ impl ExecutorBuilder {
     /// Enables cheatcodes on the executor.
     #[must_use]
     pub fn with_cheatcodes(mut self, ffi: bool) -> Self {
-        self.inspector_config.cheatcodes = Some(Cheatcodes::new(ffi, self.env.block.clone()));
+        self.inspector_config.cheatcodes =
+            Some(Cheatcodes::new(ffi, self.env.block.clone(), self.env.tx.gas_price.clone()));
         self
     }
 
@@ -171,6 +172,7 @@ impl ExecutorBuilder {
     #[must_use]
     pub fn with_config(mut self, env: Env) -> Self {
         self.inspector_config.block = env.block.clone();
+        self.inspector_config.gas_price = env.tx.gas_price.clone();
         self.env = env;
         self
     }

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -48,7 +48,7 @@ impl InspectorStackConfig {
         stack.cheatcodes = self.cheatcodes.clone();
         if let Some(ref mut cheatcodes) = stack.cheatcodes {
             cheatcodes.block = Some(self.block.clone());
-            cheatcodes.gas_price = Some(self.gas_price.clone());
+            cheatcodes.gas_price = Some(self.gas_price);
         }
 
         if self.tracing {

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -16,6 +16,7 @@ pub use stack::{InspectorData, InspectorStack};
 mod cheatcodes;
 pub use cheatcodes::Cheatcodes;
 
+use ethers::types::U256;
 use revm::BlockEnv;
 
 #[derive(Default, Clone, Debug)]
@@ -28,6 +29,11 @@ pub struct InspectorStackConfig {
     /// Used in the cheatcode handler to overwrite the block environment separately from the
     /// execution block environment.
     pub block: BlockEnv,
+    /// The gas price
+    ///
+    /// Used in the cheatcode handler to overwrite the gas price separately from the gas price
+    /// in the execution environment.
+    pub gas_price: U256,
     /// Whether or not tracing is enabled
     pub tracing: bool,
     /// Whether or not the debugger is enabled
@@ -42,6 +48,7 @@ impl InspectorStackConfig {
         stack.cheatcodes = self.cheatcodes.clone();
         if let Some(ref mut cheatcodes) = stack.cheatcodes {
             cheatcodes.block = Some(self.block.clone());
+            cheatcodes.gas_price = Some(self.gas_price.clone());
         }
 
         if self.tracing {

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -512,25 +512,16 @@ where
         should_fail ^ success
     }
 
+    /// Creates the environment to use when executing the transaction
     fn build_env(&self, caller: Address, transact_to: TransactTo, data: Bytes, value: U256) -> Env {
         Env {
             cfg: self.env.cfg.clone(),
-            // We always set the gas price to 0 so we can execute the transaction regardless of
-            // network conditions - the actual gas price is kept in `self.block` and is applied by
-            // the cheatcode handler if it is enabled
-            block: BlockEnv {
-                basefee: 0.into(),
-                gas_limit: self.gas_limit,
-                ..self.env.block.clone()
-            },
+            block: BlockEnv { gas_limit: self.gas_limit, ..self.env.block.clone() },
             tx: TxEnv {
                 caller,
                 transact_to,
                 data,
                 value,
-                // As above, we set the gas price to 0.
-                gas_price: 0.into(),
-                gas_priority_fee: None,
                 gas_limit: self.gas_limit.as_u64(),
                 ..self.env.tx.clone()
             },

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -516,12 +516,22 @@ where
     fn build_env(&self, caller: Address, transact_to: TransactTo, data: Bytes, value: U256) -> Env {
         Env {
             cfg: self.env.cfg.clone(),
-            block: BlockEnv { gas_limit: self.gas_limit, ..self.env.block.clone() },
+            // We always set the gas price to 0 so we can execute the transaction regardless of
+            // network conditions - the actual gas price is kept in `self.block` and is applied by
+            // the cheatcode handler if it is enabled
+            block: BlockEnv {
+                basefee: 0.into(),
+                gas_limit: self.gas_limit,
+                ..self.env.block.clone()
+            },
             tx: TxEnv {
                 caller,
                 transact_to,
                 data,
                 value,
+                // As above, we set the gas price to 0.
+                gas_price: 0.into(),
+                gas_priority_fee: None,
                 gas_limit: self.gas_limit.as_u64(),
                 ..self.env.tx.clone()
             },

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -78,6 +78,7 @@ impl EvmOpts {
         }
     }
 
+    /// Returns the gas limit to use
     pub fn gas_limit(&self) -> U256 {
         self.env.block_gas_limit.unwrap_or(self.env.gas_limit).into()
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1143
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
gas_price will be 0 by default, if it's manually set, then this will now also be set in the `Env` used when executing an transaction
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
