### PR TITLE
feat(forge): add expectEmit(...,address) for specifying emitting contract

### DIFF
--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -35,6 +35,7 @@ ethers::contract::abigen!(
             record()
             accesses(address)(bytes32[],bytes32[])
             expectEmit(bool,bool,bool,bool)
+            expectEmit(bool,bool,bool,bool,address)
             mockCall(address,bytes,bytes)
             clearMockedCalls()
             expectCall(address,bytes)

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -200,7 +200,11 @@ where
     fn log(&mut self, _: &mut EVMData<'_, DB>, address: &Address, topics: &[H256], data: &Bytes) {
         // Match logs if `expectEmit` has been called
         if !self.expected_emits.is_empty() {
-            handle_expect_emit(self, RawLog { topics: topics.to_vec(), data: data.to_vec() }, address);
+            handle_expect_emit(
+                self,
+                RawLog { topics: topics.to_vec(), data: data.to_vec() },
+                address,
+            );
         }
     }
 

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -197,10 +197,10 @@ where
         Return::Continue
     }
 
-    fn log(&mut self, _: &mut EVMData<'_, DB>, _: &Address, topics: &[H256], data: &Bytes) {
+    fn log(&mut self, _: &mut EVMData<'_, DB>, address: &Address, topics: &[H256], data: &Bytes) {
         // Match logs if `expectEmit` has been called
         if !self.expected_emits.is_empty() {
-            handle_expect_emit(self, RawLog { topics: topics.to_vec(), data: data.to_vec() });
+            handle_expect_emit(self, RawLog { topics: topics.to_vec(), data: data.to_vec() }, address);
         }
     }
 

--- a/forge/README.md
+++ b/forge/README.md
@@ -164,6 +164,8 @@ which implements the following methods:
   
 - `function expectEmit(bool,bool,bool,bool) external`: Expects the next emitted event. Params check topic 1, topic 2, topic 3 and data are the same.
 
+- `function expectEmit(bool,bool,bool,bool,address) external`: Expects the next emitted event. Params check topic 1, topic 2, topic 3 and data are the same. Also checks supplied address against address of originating contract.
+
 - `function getCode(string calldata) external returns (bytes memory)`: Fetches bytecode from a contract artifact. The parameter can either be in the form `ContractFile.sol` (if the filename and contract name are the same), `ContractFile.sol:ContractName`, or `./path/to/artifact.json`.
 
 - `function label(address addr, string calldata label) external`: Label an address in test traces.
@@ -218,6 +220,7 @@ Below is another example using the `expectEmit` cheatcode to check events:
 ```solidity
 interface Vm {
     function expectEmit(bool,bool,bool,bool) external;
+    function expectEmit(bool,bool,bool,bool,address) external;
 }
 
 contract T is DSTest {
@@ -227,6 +230,14 @@ contract T is DSTest {
         ExpectEmit emitter = new ExpectEmit();
         // check topic 1, topic 2, and data are the same as the following emitted event
         vm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1337), 1337);
+        emitter.t();
+    }
+  
+    function testExpectEmitWithAddress() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // do the same as above and check emitting address
+        vm.expectEmit(true,true,false,true,address(emitter));
         emit Transfer(address(this), address(1337), 1337);
         emitter.t();
     }

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -42,8 +42,10 @@ interface Cheats {
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
-    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans).
+    // Second form also checks supplied address against emitting contract.
     function expectEmit(bool,bool,bool,bool) external;
+    function expectEmit(bool,bool,bool,bool,address) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -210,6 +210,13 @@ contract ExpectEmitTest is DSTest {
         );
     }
 
+    function testExpectEmitAddress() public {
+        cheats.expectEmit(true, true, true, true, address(emitter));
+        emit Something(1, 2, 3, 4);
+
+        emitter.emitEvent(1, 2, 3, 4);
+    }
+
     /// Ref: issue #760
     function testFailLowLevelWithoutEmit() public {
         LowLevelCaller caller = new LowLevelCaller();

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -217,6 +217,13 @@ contract ExpectEmitTest is DSTest {
         emitter.emitEvent(1, 2, 3, 4);
     }
 
+    function testFailExpectEmitAddress() public {
+        cheats.expectEmit(true, true, true, true, address(0));
+        emit Something(1, 2, 3, 4);
+
+        emitter.emitEvent(1, 2, 3, 4);
+    }
+
     /// Ref: issue #760
     function testFailLowLevelWithoutEmit() public {
         LowLevelCaller caller = new LowLevelCaller();


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/1264

A second form of `expectEmit(...)` that takes an address to check against the emitting contract in case nested contracts can emit the same event.

## Solution

Add a second form of `expectEmit(...)` with an address parameter. Internally, the emitting contract's address is forwarded to the log handler and checked against the supplied address.

Also, update docs and tests.
