### PR TITLE
feat(fmt): support base in function attributes

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -37,6 +37,7 @@ struct FormatBuffer {
     w: String,
 }
 
+// TODO: store context entities as references without copying
 #[derive(Default)]
 struct Context {
     contract: Option<ContractDefinition>,

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -37,6 +37,12 @@ struct FormatBuffer {
     w: String,
 }
 
+#[derive(Default)]
+struct Context {
+    contract: Option<ContractDefinition>,
+    function: Option<FunctionDefinition>,
+}
+
 /// A Solidity formatter
 pub struct Formatter<'a, W> {
     w: &'a mut W,
@@ -46,6 +52,7 @@ pub struct Formatter<'a, W> {
     pending_indent: bool,
     current_line: usize,
     bufs: Vec<FormatBuffer>,
+    context: Context,
 }
 
 impl<'a, W: Write> Formatter<'a, W> {
@@ -58,6 +65,7 @@ impl<'a, W: Write> Formatter<'a, W> {
             pending_indent: true,
             bufs: Vec::new(),
             current_line: 0,
+            context: Context::default(),
         }
     }
 
@@ -286,6 +294,8 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_contract(&mut self, contract: &mut ContractDefinition) -> VResult {
+        self.context.contract = Some(contract.clone());
+
         if !contract.doc.is_empty() {
             contract.doc.visit(self)?;
             writeln!(self)?;
@@ -299,10 +309,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             let bases = contract
                 .base
                 .iter_mut()
-                .map(|base| {
-                    // TODO
-                    self.visit_to_string(&mut base.loc)
-                })
+                .map(|base| self.visit_to_string(base))
                 .collect::<Result<Vec<_>, _>>()?;
 
             let multiline = self.is_separated_multiline(&bases, ", ");
@@ -364,6 +371,8 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
 
             write!(self, "}}")?;
         }
+
+        self.context.contract = None;
 
         Ok(())
     }
@@ -535,6 +544,8 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_function(&mut self, func: &mut FunctionDefinition) -> VResult {
+        self.context.function = Some(func.clone());
+
         if !func.doc.is_empty() {
             func.doc.visit(self)?;
             writeln!(self)?;
@@ -589,7 +600,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             if !attributes.is_empty() {
                 writeln!(self)?;
                 self.indent(1);
-                self.write_items(&attributes, true)?;
+                func.attributes.visit(self)?;
                 self.dedent(1);
             }
 
@@ -624,6 +635,8 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             None => write!(self, ";")?,
         }
 
+        self.context.function = None;
+
         Ok(())
     }
 
@@ -631,7 +644,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     /// visit function regarding one line/multiline cases. We can transform it into one line later
     /// by `.split("\n").join(" ")`.
     fn visit_function_attribute_list(&mut self, list: &mut Vec<FunctionAttribute>) -> VResult {
-        let attributes = list
+        let mut attributes = list
             .iter_mut()
             .sorted_by_key(|attribute| match attribute {
                 FunctionAttribute::Visibility(_) => 0,
@@ -640,10 +653,14 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 FunctionAttribute::Override(_, _) => 3,
                 FunctionAttribute::BaseOrModifier(_, _) => 4,
             })
-            .map(|attribute| self.visit_to_string(attribute))
-            .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
+            .peekable();
 
-        self.write_items(&attributes, true)?;
+        while let Some(attribute) = attributes.next() {
+            attribute.visit(self)?;
+            if attributes.peek().is_some() {
+                writeln!(self)?;
+            }
+        }
 
         Ok(())
     }
@@ -654,18 +671,63 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             FunctionAttribute::Visibility(visibility) => write!(self, "{visibility}")?,
             FunctionAttribute::Virtual(_) => write!(self, "virtual")?,
             FunctionAttribute::Override(loc, _) => loc.visit(self)?,
-            FunctionAttribute::BaseOrModifier(loc, _) => {
-                let base_or_modifier = self.visit_to_string(loc)?;
-                write!(
-                    self,
-                    "{}",
-                    // TODO: strip empty parentheses only for modifiers. Currently, we can't detect
-                    //  whether it's a base constructor or modifier. We probably need to keep track
-                    //  of the current contract definition that's in processing?
-                    base_or_modifier.strip_suffix("()").unwrap_or(&base_or_modifier)
-                )?;
+            FunctionAttribute::BaseOrModifier(_, base) => {
+                let is_contract_base = self.context.contract.as_ref().map_or(false, |contract| {
+                    contract
+                        .base
+                        .iter()
+                        .any(|contract_base| contract_base.name.name == base.name.name)
+                });
+
+                if is_contract_base {
+                    base.visit(self)?;
+                } else {
+                    let base_or_modifier = self.visit_to_string(base)?;
+                    write!(
+                        self,
+                        "{}",
+                        base_or_modifier.strip_suffix("()").unwrap_or(&base_or_modifier)
+                    )?;
+                }
             }
         };
+
+        Ok(())
+    }
+
+    fn visit_base(&mut self, base: &mut Base) -> VResult {
+        let need_parents = self.context.function.is_some() || base.args.is_some();
+
+        write!(self, "{}", base.name.name)?;
+
+        if need_parents {
+            self.visit_opening_paren()?;
+        }
+
+        if let Some(args) = &mut base.args {
+            let args = args
+                .iter_mut()
+                .map(|arg| self.visit_to_string(arg))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let multiline = self.is_separated_multiline(&args, ", ");
+
+            if multiline {
+                writeln!(self)?;
+                self.indent(1);
+            }
+
+            self.write_items_separated(&args, ", ", multiline)?;
+
+            if multiline {
+                self.dedent(1);
+                writeln!(self)?;
+            }
+        }
+
+        if need_parents {
+            self.visit_closing_paren()?;
+        }
 
         Ok(())
     }
@@ -925,11 +987,10 @@ mod tests {
         );
     }
 
-    // TODO: see in `visit_function_attribute`
-    // #[test]
-    // fn constructor_definition() {
-    //     test_directory("ConstructorDefinition");
-    // }
+    #[test]
+    fn constructor_definition() {
+        test_directory("ConstructorDefinition");
+    }
 
     #[test]
     fn contract_definition() {

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -250,6 +250,12 @@ pub trait Visitor {
         Ok(())
     }
 
+    fn visit_base(&mut self, base: &mut Base) -> VResult {
+        self.visit_source(base.loc)?;
+
+        Ok(())
+    }
+
     fn visit_parameter(&mut self, parameter: &mut Parameter) -> VResult {
         self.visit_source(parameter.loc)?;
 
@@ -493,6 +499,14 @@ impl Visitable for Parameter {
 impl Visitable for ParameterList {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
         v.visit_parameter_list(self)?;
+
+        Ok(())
+    }
+}
+
+impl Visitable for Base {
+    fn visit(&mut self, v: &mut impl Visitor) -> VResult {
+        v.visit_base(self)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

Previously, we've been restoring function attributes from the original source code due to this issue:
https://github.com/foundry-rs/foundry/blob/37452a3644e6a7e356204096232345f8aede53b6/fmt/src/formatter.rs#L662-L665

## Solution

Let's introduce `Context` which tracks current nodes we're visiting. In this case, we need to know whether we're visiting a contract base or usual modifier.

Current solution isn't perfect because we're copying values instead of storing references to them:
https://github.com/foundry-rs/foundry/blob/f3485c4a703ce9dc4ff6cffb67559e88d2161aee/fmt/src/formatter.rs#L297
https://github.com/foundry-rs/foundry/blob/f3485c4a703ce9dc4ff6cffb67559e88d2161aee/fmt/src/formatter.rs#L547
It's not obvious how to solve it in a zero-copy manner because we can't have both mutable and immutable shared references. One way is to pass a `RefCell` everywhere and take a mutable reference only when we need it, but it quickly becomes ugly because we need to pass it everywhere from the top.

I think we can merge it as-is now and solve this TODO later.