### PR TITLE
Style: Remove redundant 0x prefix

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -269,7 +269,7 @@ where
                     Return::Revert,
                     remaining_gas,
                     format!(
-                        "Expected a call to 0x{} with data {}, but got none",
+                        "Expected a call to {} with data {}, but got none",
                         address,
                         ethers::types::Bytes::from(expecteds[0].clone())
                     )

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -269,7 +269,7 @@ where
                     Return::Revert,
                     remaining_gas,
                     format!(
-                        "Expected a call to {} with data {}, but got none",
+                        "Expected a call to {:?} with data {}, but got none",
                         address,
                         ethers::types::Bytes::from(expecteds[0].clone())
                     )


### PR DESCRIPTION
Signed-off-by: Daniel Ivanov <daniel.k.ivanov95@gmail.com>

## Motivation

There is a redundant `0x` prefix in the `expectCall` cheatcode. 
Example:
```
[FAIL. Reason: Expected a call to 0x0xefc5…b132 with data 0x01ffc9a70000000000000000000000000000000000000000000000000000000001ffc9a7, but got none] testCreateWorks() (gas: 1668618)
``` 

## Solution

removed the prefix 🤯 