### PR TITLE
Fix `cast call` etherscan bug

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -195,7 +195,7 @@ async fn main() -> eyre::Result<()> {
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, eth.chain, false).await?;
-            builder.set_args(&sig, args).await?.etherscan_api_key(eth.etherscan_api_key);
+            builder.etherscan_api_key(eth.etherscan_api_key).set_args(&sig, args).await?;
             let builder_output = builder.build();
             println!("{}", Cast::new(provider).call(builder_output, block).await?);
         }


### PR DESCRIPTION
Fixes the following bug

```
> cast call dai balanceOf vitalik.eth
The application panicked (crashed).
Message:  Must set ETHERSCAN_API_KEY
Location: /Users/runner/work/foundry/foundry/cast/src/tx.rs:162

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
[1]    52218 abort      cast call dai balanceOf vitalik.eth

> cast -V
cast 0.2.0 (92427e7 2022-04-23T00:08:21.719627+00:00)
```