### PR TITLE
fix: rename optimize-runs to optimizer-runs

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -153,7 +153,7 @@ pub struct CompilerArgs {
 
     #[clap(help = "The number of optimizer runs.", long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub optimize_runs: Option<usize>,
+    pub optimizer_runs: Option<usize>,
 
     /// Extra output to include in the contract's artifact.
     ///

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -164,7 +164,7 @@ macro_rules! forgetest_external {
             // Run the tests
             cmd.arg("test").args($forge_opts).args([
                 "--optimize",
-                "--optimize-runs",
+                "--optimizer-runs",
                 "20000",
                 "--ffi",
             ]);

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -328,3 +328,19 @@ forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestComman
         vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6".to_string(),]
     );
 });
+
+// test that optimizer runs works
+forgetest!(can_set_optimizer_runs, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.set_current_dir(prj.root());
+
+    // explicitly set gas_price
+    let config = Config { optimizer_runs: 1337, ..Default::default() };
+    prj.write_config(config);
+
+    let config = cmd.config();
+
+    assert_eq!(config.optimizer_runs, 1337);
+
+    let config = prj.config_from_output(["--optimizer-runs", "300"]);
+    assert_eq!(config.optimizer_runs, 300);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
use `optimizer-runs` consistently so it gets picked up by the config
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
