### PR TITLE
replace dapphub/ds-test with forge-std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 out/
 out.json
+.idea

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -124,8 +124,8 @@ impl Cmd for InitArgs {
             if !offline {
                 let opts = DependencyInstallOpts { no_git, no_commit, quiet };
 
-                if root.join("lib/ds-test").exists() {
-                    println!("\"lib/ds-test\" already exists, skipping install....");
+                if root.join("lib/forge-std").exists() {
+                    println!("\"lib/forge-std\" already exists, skipping install....");
                     install(&root, vec![], opts)?;
                 } else {
                     Dependency::from_str("https://github.com/foundry-rs/forge-std")

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -128,7 +128,7 @@ impl Cmd for InitArgs {
                     println!("\"lib/ds-test\" already exists, skipping install....");
                     install(&root, vec![], opts)?;
                 } else {
-                    Dependency::from_str("https://github.com/dapphub/ds-test")
+                    Dependency::from_str("https://github.com/foundry-rs/forge-std")
                         .and_then(|dependency| install(&root, vec![dependency], opts))?;
                 }
             }

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -83,8 +83,8 @@ forgetest!(can_init_no_git, |prj: TestProject, mut cmd: TestCommand| {
     prj.assert_config_exists();
 
     assert!(!prj.root().join(".git").exists());
-    assert!(prj.root().join("lib/ds-test").exists());
-    assert!(!prj.root().join("lib/ds-test/.git").exists());
+    assert!(prj.root().join("lib/forge-std").exists());
+    assert!(!prj.root().join("lib/forge-std/.git").exists());
 });
 
 // Checks that quiet mode does not print anything
@@ -104,7 +104,7 @@ forgetest!(can_init_non_empty, |prj: TestProject, mut cmd: TestCommand| {
     cmd.arg("--force");
     cmd.assert_non_empty_stdout();
     assert!(prj.root().join(".git").exists());
-    assert!(prj.root().join("lib/ds-test").exists());
+    assert!(prj.root().join("lib/forge-std").exists());
 });
 
 // Checks that remappings.txt and .vscode/settings.json is generated
@@ -128,7 +128,7 @@ forgetest!(can_init_vscode, |prj: TestProject, mut cmd: TestCommand| {
     let remappings = prj.root().join("remappings.txt");
     assert!(remappings.is_file());
     let content = std::fs::read_to_string(remappings).unwrap();
-    assert_eq!(content, "ds-test/=lib/ds-test/src/");
+    assert_eq!(content, "forge-std/=lib/forge-std/src/");
 });
 
 // checks that `clean` removes dapptools style paths

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -128,7 +128,7 @@ forgetest!(can_init_vscode, |prj: TestProject, mut cmd: TestCommand| {
     let remappings = prj.root().join("remappings.txt");
     assert!(remappings.is_file());
     let content = std::fs::read_to_string(remappings).unwrap();
-    assert_eq!(content, "forge-std/=lib/forge-std/src/\nds-test/=lib/forge-std/lib/ds-test/src/");
+    assert_eq!(content, "ds-test/=lib/forge-std/lib/ds-test/src/\nforge-std/=lib/forge-std/src/");
 });
 
 // checks that `clean` removes dapptools style paths

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -128,7 +128,7 @@ forgetest!(can_init_vscode, |prj: TestProject, mut cmd: TestCommand| {
     let remappings = prj.root().join("remappings.txt");
     assert!(remappings.is_file());
     let content = std::fs::read_to_string(remappings).unwrap();
-    assert_eq!(content, "forge-std/=lib/forge-std/src/");
+    assert_eq!(content, "forge-std/=lib/forge-std/src/\nds-test/=lib/forge-std/lib/ds-test/src/");
 });
 
 // checks that `clean` removes dapptools style paths

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -125,10 +125,13 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
     // ensure remappings contain test
     assert_eq!(profile.remappings.len(), 2);
-    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[0].to_string());
+    assert_eq!(
+        "ds-test/=lib/forge-std/lib/ds-test/src/".to_string(),
+        profile.remappings[0].to_string()
+    );
     // the loaded config has resolved, absolute paths
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/src").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/src").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
@@ -137,32 +140,34 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
-    let remappings_txt = prj.create_file("remappings.txt", "forge-std/=lib/forge-std/from-file/");
+    let remappings_txt =
+        prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-file").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-file").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     // env vars work
-    std::env::set_var("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/from-env/");
+    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-env").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-env").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
-    let config = prj.config_from_output(["--remappings", "forge-std/=lib/forge-std/from-cli"]);
+    let config =
+        prj.config_from_output(["--remappings", "ds-test/=lib/forge-std/lib/ds-test/from-cli"]);
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-cli").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-cli").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     let config = prj.config_from_output(["--remappings", "other-key/=lib/other/"]);
-    assert_eq!(config.remappings.len(), 2);
+    assert_eq!(config.remappings.len(), 3);
     assert_eq!(
         format!("other-key/={}/", prj.root().join("lib/other").display()),
-        Remapping::from(config.remappings[1].clone()).to_string()
+        Remapping::from(config.remappings[2].clone()).to_string()
     );
 
     std::env::remove_var("DAPP_REMAPPINGS");

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -124,7 +124,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(config, profile.clone().sanitized());
 
     // ensure remappings contain test
-    assert_eq!(profile.remappings.len(), 1);
+    assert_eq!(profile.remappings.len(), 2);
     assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[0].to_string());
     // the loaded config has resolved, absolute paths
     assert_eq!(

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -78,7 +78,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         eth_rpc_url: Some("localhost".to_string()),
         etherscan_api_key: None,
         verbosity: 4,
-        remappings: vec![Remapping::from_str("ds-test=lib/ds-test/").unwrap().into()],
+        remappings: vec![Remapping::from_str("forge-std=lib/forge-std/").unwrap().into()],
         libraries: vec![
             "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6".to_string()
         ],
@@ -125,10 +125,10 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
     // ensure remappings contain test
     assert_eq!(profile.remappings.len(), 1);
-    assert_eq!("ds-test/=lib/ds-test/src/".to_string(), profile.remappings[0].to_string());
+    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[0].to_string());
     // the loaded config has resolved, absolute paths
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/ds-test/src").display()),
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/src").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
@@ -137,24 +137,24 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
-    let remappings_txt = prj.create_file("remappings.txt", "ds-test/=lib/ds-test/from-file/");
+    let remappings_txt = prj.create_file("remappings.txt", "forge-std/=lib/forge-std/from-file/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-file").display()),
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-file").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     // env vars work
-    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/from-env/");
+    std::env::set_var("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-env").display()),
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-env").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
-    let config = prj.config_from_output(["--remappings", "ds-test/=lib/ds-test/from-cli"]);
+    let config = prj.config_from_output(["--remappings", "forge-std/=lib/forge-std/from-cli"]);
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-cli").display()),
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-cli").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -142,11 +142,15 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
-    let remappings_txt = prj.create_file("remappings.txt", "forge-std/=lib/forge-std/from-file/");
+    let remappings_txt = prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file\nforge-std/=lib/forge-std/from-file/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-file").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-file").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
+    );
+    assert_eq!(
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-file").display()),
+        Remapping::from(config.remappings[1].clone()).to_string()
     );
 
     // env vars work

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -125,11 +125,16 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
     // ensure remappings contain test
     assert_eq!(profile.remappings.len(), 2);
-    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[0].to_string());
+    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/".to_string(), profile.remappings[0].to_string());
+    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[1].to_string());
     // the loaded config has resolved, absolute paths
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/src").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/src").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
+    );
+    assert_eq!(
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/src").display()),
+        Remapping::from(config.remappings[1].clone()).to_string()
     );
 
     cmd.arg("config");

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -154,11 +154,15 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     );
 
     // env vars work
-    std::env::set_var("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/from-env/");
+    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env\nforge-std/=lib/forge-std/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-env").display()),
+        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-env").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
+    );
+    assert_eq!(
+        format!("forge-std/={}/", prj.root().join("lib/forge-std/from-env").display()),
+        Remapping::from(config.remappings[1].clone()).to_string()
     );
 
     let config = prj.config_from_output(["--remappings", "forge-std/=lib/forge-std/from-cli"]);

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -125,16 +125,11 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
     // ensure remappings contain test
     assert_eq!(profile.remappings.len(), 2);
-    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/".to_string(), profile.remappings[0].to_string());
-    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[1].to_string());
+    assert_eq!("forge-std/=lib/forge-std/src/".to_string(), profile.remappings[0].to_string());
     // the loaded config has resolved, absolute paths
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/src").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
-    assert_eq!(
         format!("forge-std/={}/", prj.root().join("lib/forge-std/src").display()),
-        Remapping::from(config.remappings[1].clone()).to_string()
+        Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     cmd.arg("config");
@@ -142,27 +137,19 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
-    let remappings_txt = prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file\nforge-std/=lib/forge-std/from-file/");
+    let remappings_txt = prj.create_file("remappings.txt", "forge-std/=lib/forge-std/from-file/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-file").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
-    assert_eq!(
         format!("forge-std/={}/", prj.root().join("lib/forge-std/from-file").display()),
-        Remapping::from(config.remappings[1].clone()).to_string()
+        Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     // env vars work
-    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env\nforge-std/=lib/forge-std/from-env/");
+    std::env::set_var("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-env").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
-    assert_eq!(
         format!("forge-std/={}/", prj.root().join("lib/forge-std/from-env").display()),
-        Remapping::from(config.remappings[1].clone()).to_string()
+        Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     let config = prj.config_from_output(["--remappings", "forge-std/=lib/forge-std/from-cli"]);

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1608,7 +1608,7 @@ mod tests {
             jail.create_file(
                 "remappings.txt",
                 r#"
-                file-ds-test/=lib/ds-test/
+                file-forge-std/=lib/forge-std/
                 file-other/=lib/other/
             "#,
             )?;
@@ -1617,21 +1617,21 @@ mod tests {
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
+                    Remapping::from_str("file-forge-std/=lib/forge-std/").unwrap().into(),
                     Remapping::from_str("file-other/=lib/other/").unwrap().into(),
                 ],
             );
 
-            jail.set_env("DAPP_REMAPPINGS", "ds-test=lib/ds-test/\nother/=lib/other/");
+            jail.set_env("DAPP_REMAPPINGS", "forge-std=lib/forge-std/\nother/=lib/other/");
             let config = Config::load();
 
             assert_eq!(
                 config.remappings,
                 vec![
                     // From environment
-                    Remapping::from_str("ds-test=lib/ds-test/").unwrap().into(),
+                    Remapping::from_str("forge-std=lib/forge-std/").unwrap().into(),
                     // From remapping.txt
-                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
+                    Remapping::from_str("file-forge-std/=lib/forge-std/").unwrap().into(),
                     Remapping::from_str("file-other/=lib/other/").unwrap().into(),
                     // From environment
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
@@ -1660,7 +1660,7 @@ mod tests {
             jail.create_file(
                 "remappings.txt",
                 r#"
-                ds-test/=lib/ds-test/
+                forge-std/=lib/forge-std/
                 other/=lib/other/
             "#,
             )?;
@@ -1669,22 +1669,22 @@ mod tests {
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("ds-test/=lib/ds-test/").unwrap().into(),
+                    Remapping::from_str("forge-std/=lib/forge-std/").unwrap().into(),
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],
             );
 
-            jail.set_env("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/src/\nenv-lib/=lib/env-lib/");
+            jail.set_env("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/src/\nenv-lib/=lib/env-lib/");
             let config = Config::load();
 
             // Remappings should now be:
-            // - ds-test from environment (lib/ds-test/src/)
+            // - forge-std from environment (lib/forge-std/src/)
             // - other from remappings.txt (lib/other/)
             // - env-lib from environment (lib/env-lib/)
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap().into(),
+                    Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap().into(),
                     Remapping::from_str("env-lib/=lib/env-lib/").unwrap().into(),
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],
@@ -1694,7 +1694,7 @@ mod tests {
             assert_eq!(
                 config.get_all_remappings(),
                 vec![
-                    Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap(),
+                    Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap(),
                     Remapping::from_str("env-lib/=lib/env-lib/").unwrap(),
                     Remapping::from_str("other/=lib/other/").unwrap(),
                     Remapping::from_str("some-source/=some-source").unwrap(),
@@ -1739,7 +1739,7 @@ mod tests {
                 cache = true
                 eth_rpc_url = "https://example.com/"
                 verbosity = 3
-                remappings = ["ds-test=lib/ds-test/"]
+                remappings = ["forge-std=lib/forge-std/"]
                 via_ir = true
                 rpc_storage_caching = { chains = [1, "optimism", 999999], endpoints = "all"}
                 bytecode_hash = "ipfs"
@@ -1755,7 +1755,7 @@ mod tests {
                     out: "some-out".into(),
                     cache: true,
                     eth_rpc_url: Some("https://example.com/".to_string()),
-                    remappings: vec![Remapping::from_str("ds-test=lib/ds-test/").unwrap().into()],
+                    remappings: vec![Remapping::from_str("forge-std=lib/forge-std/").unwrap().into()],
                     verbosity: 3,
                     via_ir: true,
                     rpc_storage_caching: StorageCachingConfig {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1608,7 +1608,7 @@ mod tests {
             jail.create_file(
                 "remappings.txt",
                 r#"
-                file-forge-std/=lib/forge-std/
+                file-ds-test/=lib/ds-test/
                 file-other/=lib/other/
             "#,
             )?;
@@ -1617,21 +1617,21 @@ mod tests {
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("file-forge-std/=lib/forge-std/").unwrap().into(),
+                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
                     Remapping::from_str("file-other/=lib/other/").unwrap().into(),
                 ],
             );
 
-            jail.set_env("DAPP_REMAPPINGS", "forge-std=lib/forge-std/\nother/=lib/other/");
+            jail.set_env("DAPP_REMAPPINGS", "ds-test=lib/ds-test/\nother/=lib/other/");
             let config = Config::load();
 
             assert_eq!(
                 config.remappings,
                 vec![
                     // From environment
-                    Remapping::from_str("forge-std=lib/forge-std/").unwrap().into(),
+                    Remapping::from_str("ds-test=lib/ds-test/").unwrap().into(),
                     // From remapping.txt
-                    Remapping::from_str("file-forge-std/=lib/forge-std/").unwrap().into(),
+                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
                     Remapping::from_str("file-other/=lib/other/").unwrap().into(),
                     // From environment
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
@@ -1660,7 +1660,7 @@ mod tests {
             jail.create_file(
                 "remappings.txt",
                 r#"
-                forge-std/=lib/forge-std/
+                ds-test/=lib/ds-test/
                 other/=lib/other/
             "#,
             )?;
@@ -1669,22 +1669,22 @@ mod tests {
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("forge-std/=lib/forge-std/").unwrap().into(),
+                    Remapping::from_str("ds-test/=lib/ds-test/").unwrap().into(),
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],
             );
 
-            jail.set_env("DAPP_REMAPPINGS", "forge-std/=lib/forge-std/src/\nenv-lib/=lib/env-lib/");
+            jail.set_env("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/src/\nenv-lib/=lib/env-lib/");
             let config = Config::load();
 
             // Remappings should now be:
-            // - forge-std from environment (lib/forge-std/src/)
+            // - ds-test from environment (lib/ds-test/src/)
             // - other from remappings.txt (lib/other/)
             // - env-lib from environment (lib/env-lib/)
             assert_eq!(
                 config.remappings,
                 vec![
-                    Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap().into(),
+                    Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap().into(),
                     Remapping::from_str("env-lib/=lib/env-lib/").unwrap().into(),
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],
@@ -1694,7 +1694,7 @@ mod tests {
             assert_eq!(
                 config.get_all_remappings(),
                 vec![
-                    Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap(),
+                    Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap(),
                     Remapping::from_str("env-lib/=lib/env-lib/").unwrap(),
                     Remapping::from_str("other/=lib/other/").unwrap(),
                     Remapping::from_str("some-source/=some-source").unwrap(),
@@ -1739,7 +1739,7 @@ mod tests {
                 cache = true
                 eth_rpc_url = "https://example.com/"
                 verbosity = 3
-                remappings = ["forge-std=lib/forge-std/"]
+                remappings = ["ds-test=lib/ds-test/"]
                 via_ir = true
                 rpc_storage_caching = { chains = [1, "optimism", 999999], endpoints = "all"}
                 bytecode_hash = "ipfs"
@@ -1755,7 +1755,7 @@ mod tests {
                     out: "some-out".into(),
                     cache: true,
                     eth_rpc_url: Some("https://example.com/".to_string()),
-                    remappings: vec![Remapping::from_str("forge-std=lib/forge-std/").unwrap().into()],
+                    remappings: vec![Remapping::from_str("ds-test=lib/ds-test/").unwrap().into()],
                     verbosity: 3,
                     via_ir: true,
                     rpc_storage_caching: StorageCachingConfig {


### PR DESCRIPTION
First time contributor starting with the simplest issues.

Replace dapphub/ds-test library with forge-std

Issue: [#1409](https://github.com/foundry-rs/foundry/issues/1364)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Install and see lib
```bash
➜  foundry git:(master) ✗ cargo install --path ./cli --bins --locked --force

➜  test tree            
.
└── hello_foundry
    ├── foundry.toml
    ├── lib
    │   └── forge-std
    │       ├── LICENSE-APACHE
    │       ├── LICENSE-MIT
    │       ├── README.md
    │       ├── lib
    │       │   └── ds-test
    │       │       ├── LICENSE
    │       │       ├── Makefile
    │       │       ├── default.nix
    │       │       ├── demo
    │       │       │   └── demo.sol
    │       │       └── src
    │       │           └── test.sol
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Test results

```bash
➜  foundry git:(master) cargo check --all
   Finished dev [unoptimized] target(s) in 1m 09s

➜  foundry git:(master) cargo test --all --all-features
failures:
    integration::maple_loan

test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.76s



```