### PR TITLE
feat(evm): compile etherscan sources and use them on the debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,7 @@ dependencies = [
 name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
+ "dunce",
  "ethers",
  "ethers-addressbook",
  "ethers-core",
@@ -1830,12 +1831,15 @@ dependencies = [
  "ethers-providers",
  "ethers-solc",
  "eyre",
+ "foundry-config",
  "hex",
  "reqwest",
  "rlp",
  "rustc-hex",
+ "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing-subscriber",
 ]

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -513,16 +513,17 @@ fn test(
         Ok(TestOutcome::new(results, allow_failure))
     } else {
         // Set up identifiers
-        let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
+        let mut local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
         let remote_chain_id = runner.evm_opts.get_remote_chain_id();
         // Do not re-query etherscan for contracts that you've already queried today.
         // TODO: Make this configurable.
         let cache_ttl = Duration::from_secs(24 * 60 * 60);
-        let etherscan_identifier = EtherscanIdentifier::new(
+        let mut etherscan_identifier = EtherscanIdentifier::new(
             remote_chain_id,
             config.etherscan_api_key,
             remote_chain_id.and_then(Config::foundry_etherscan_cache_dir),
             cache_ttl,
+            false,
         );
 
         // Set up test reporter channel
@@ -570,8 +571,8 @@ fn test(
                     // Decode the traces
                     let mut decoded_traces = Vec::new();
                     for (kind, trace) in &mut result.traces {
-                        decoder.identify(trace, &local_identifier);
-                        decoder.identify(trace, &etherscan_identifier);
+                        decoder.identify(trace, &mut local_identifier);
+                        decoder.identify(trace, &mut etherscan_identifier);
 
                         let should_include = match kind {
                             // At verbosity level 3, we only display traces for failed tests

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -176,7 +176,7 @@ impl CallTraceDecoder {
     /// Identify unknown addresses in the specified call trace using the specified identifier.
     ///
     /// Unknown contracts are contracts that either lack a label or an ABI.
-    pub fn identify(&mut self, trace: &CallTraceArena, identifier: &impl TraceIdentifier) {
+    pub fn identify(&mut self, trace: &CallTraceArena, identifier: &mut impl TraceIdentifier) {
         let unidentified_addresses = trace
             .addresses()
             .into_iter()

--- a/evm/src/trace/identifier/local.rs
+++ b/evm/src/trace/identifier/local.rs
@@ -30,7 +30,7 @@ impl LocalTraceIdentifier {
 
 impl TraceIdentifier for LocalTraceIdentifier {
     fn identify_addresses(
-        &self,
+        &mut self,
         addresses: Vec<(&Address, Option<&Vec<u8>>)>,
     ) -> Vec<AddressIdentity> {
         addresses

--- a/evm/src/trace/identifier/mod.rs
+++ b/evm/src/trace/identifier/mod.rs
@@ -27,7 +27,7 @@ pub trait TraceIdentifier {
     /// Attempts to identify an address in one or more call traces.
     #[allow(clippy::type_complexity)]
     fn identify_addresses(
-        &self,
+        &mut self,
         addresses: Vec<(&Address, Option<&Vec<u8>>)>,
     ) -> Vec<AddressIdentity>;
 }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Tui {
     current_step: usize,
     identified_contracts: HashMap<Address, String>,
     known_contracts: HashMap<String, ContractBytecodeSome>,
-    source_code: BTreeMap<u32, String>,
+    known_contracts_sources: HashMap<String, BTreeMap<u32, String>>,
 }
 
 impl Tui {
@@ -67,7 +67,7 @@ impl Tui {
         current_step: usize,
         identified_contracts: HashMap<Address, String>,
         known_contracts: HashMap<String, ContractBytecodeSome>,
-        source_code: BTreeMap<u32, String>,
+        known_contracts_sources: HashMap<String, BTreeMap<u32, String>>,
     ) -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
@@ -82,7 +82,7 @@ impl Tui {
             current_step,
             identified_contracts,
             known_contracts,
-            source_code,
+            known_contracts_sources,
         })
     }
 
@@ -106,7 +106,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -122,7 +122,7 @@ impl Tui {
                 address,
                 identified_contracts,
                 known_contracts,
-                source_code,
+                known_contracts_sources,
                 debug_steps,
                 opcode_list,
                 current_step,
@@ -137,7 +137,7 @@ impl Tui {
                 address,
                 identified_contracts,
                 known_contracts,
-                source_code,
+                known_contracts_sources,
                 debug_steps,
                 opcode_list,
                 current_step,
@@ -155,7 +155,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -189,7 +189,7 @@ impl Tui {
                     address,
                     identified_contracts,
                     known_contracts,
-                    source_code,
+                    known_contracts_sources,
                     debug_steps[current_step].ic,
                     call_kind,
                     src_pane,
@@ -226,7 +226,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -266,7 +266,7 @@ impl Tui {
                             address,
                             identified_contracts,
                             known_contracts,
-                            source_code,
+                            known_contracts_sources,
                             debug_steps[current_step].ic,
                             call_kind,
                             src_pane,
@@ -328,7 +328,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         ic: usize,
         call_kind: CallKind,
         area: Rect,
@@ -346,7 +346,10 @@ impl Tui {
         let mut text_output: Text = Text::from("");
 
         if let Some(contract_name) = identified_contracts.get(&address) {
-            if let Some(known) = known_contracts.get(contract_name) {
+            // todo check
+            if let (Some(known), Some(source_code)) =
+                (known_contracts.get(contract_name), known_contracts_sources.get(contract_name))
+            {
                 // grab either the creation source map or runtime sourcemap
                 if let Some(sourcemap) = if matches!(call_kind, CallKind::Create) {
                     known.bytecode.source_map()
@@ -410,7 +413,8 @@ impl Tui {
                                     };
 
                                     let max_line_num = num_lines.to_string().len();
-                                    // We check if there is other text on the same line before the
+                                    // We check if there is other text on the same line before
+                                    // the
                                     // highlight starts
                                     if let Some(last) = before.pop() {
                                         if !last.ends_with('\n') {
@@ -1178,7 +1182,7 @@ impl Ui for Tui {
                     debug_call[draw_memory.inner_call_index].0,
                     &self.identified_contracts,
                     &self.known_contracts,
-                    &self.source_code,
+                    &self.known_contracts_sources,
                     &debug_call[draw_memory.inner_call_index].1[..],
                     &opcode_list,
                     current_step,

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 repository = "https://github.com/gakonst/foundry"
 
 [dependencies]
+foundry-config = { path = "../config" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
@@ -23,6 +24,9 @@ serde = "1.0.132"
 serde_json = { version = "1.0.67", default-features = false }
 tokio = { version = "1.12.0", features = ["rt-multi-thread", "macros"] }
 rlp = "0.5.1"
+dunce = "1.0.2"
+tempfile = "3.3.0"
+semver = "1.0.5"
 
 
 [dev-dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
**WIP**

Debugging with sources coming from etherscan is nice. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. When identifying addresses for traces, collect addresses & sources. 
2. Compile each contract address [and downloads the solc version required)
3. Provide them to the TUI debugger. Here I changed the TUI initialization. @brockelmore wdyt ?

Missing:
- [ ] etherscan multi-file support
- [ ] cache
- [ ] cleanup

It's working now with some limitations:

* flattened sources only
* no vyper
* [no v0.4.*](https://github.com/gakonst/ethers-rs/issues/1176)
* `--via-ir` isn't provided by etherscan (i think...).

Working example:
```
cargo run --bin cast -- run 0xe6288cf5bb88281801302d558e434b8fced0dbaa8edc007ef2f5b0ffec694f88 --rpc-url https://api.avax.network/ext/bc/C/rpc --debug
```

If there are many contracts, be ready to wait a while...

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
