### PR TITLE
feat(forge): Check tag in forge install

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -90,6 +90,7 @@ pub(crate) fn install(
         let target_dir = if let Some(alias) = &dep.alias { alias } else { &dep.name };
         let DependencyInstallOpts { no_git, no_commit, quiet } = opts;
         p_println!(!quiet => "Installing {} in {:?}, (url: {}, tag: {:?})", dep.name, &libs.join(&target_dir), dep.url, dep.tag);
+        check_tag(&dep)?;
         if no_git {
             install_as_folder(&dep, &libs)?;
         } else {
@@ -97,6 +98,21 @@ pub(crate) fn install(
         }
 
         p_println!(!quiet => "    {} {}",    Colour::Green.paint("Installed"), dep.name);
+    }
+    Ok(())
+}
+
+/// make sure tag is exists on the remote repository
+fn check_tag(dep: &Dependency) -> eyre::Result<()> {
+    if let Some(ref tag) = dep.tag {
+        let output = Command::new("git")
+            .args(&["ls-remote", &dep.url, tag])
+            .stdout(Stdio::piped())
+            .output()?;
+        let stdout = str::from_utf8(&output.stdout).unwrap();
+        if !stdout.contains(tag) {
+            eyre::bail!("tag/branch/commit \"{}\" is not exists", tag)
+        }
     }
     Ok(())
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -102,16 +102,16 @@ pub(crate) fn install(
     Ok(())
 }
 
-/// make sure tag is exists on the remote repository
+/// make sure tag exists on the remote repository
 fn check_tag(dep: &Dependency) -> eyre::Result<()> {
     if let Some(ref tag) = dep.tag {
         let output = Command::new("git")
             .args(&["ls-remote", &dep.url, tag])
             .stdout(Stdio::piped())
             .output()?;
-        let stdout = str::from_utf8(&output.stdout).unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
         if !stdout.contains(tag) {
-            eyre::bail!("tag/branch/commit \"{}\" is not exists", tag)
+            eyre::bail!("tag/branch/commit \"{}\" does not exists", tag)
         }
     }
     Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fix #1248 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

It checks the reference on remote repository via `git ls-remote` before running the installation

```
✦ forgedev install Rari-Capital/solmate@v7
Installing solmate in "/Users/pyk/github/pyk/foundry-install/lib/solmate", (url: https://github.com/Rari-Capital/solmate, tag: Some("v7"))
Error:
   0: tag/branch/commit "v7" is not exists

Location:
   cli/src/cmd/forge/install.rs:114

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
