### PR TITLE
use `Test` instead of `DSTest` in `ContractTemplate.t.sol`

### DIFF
--- a/cli/assets/ContractTemplate.t.sol
+++ b/cli/assets/ContractTemplate.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract ContractTest is DSTest {
+contract ContractTest is Test {
     function setUp() public {}
 
     function testExample() public {


### PR DESCRIPTION
Gm,

`forge init` installs Forge Std, but the template still uses DSTest.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Get more users to switch to Forge Std.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
```solidity
import "forge-std/Test.sol";

contract ContractTest is Test {
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
