### PR TITLE
chore: add convex shutdown integration test

### DIFF
--- a/cli/tests/it/integration.rs
+++ b/cli/tests/it/integration.rs
@@ -12,3 +12,4 @@ forgetest_external!(maple_loan, "maple-labs/loan");
 // Forking tests
 forgetest_external!(drai, "mds1/drai", 13633752, &["--chain-id", "99"]);
 forgetest_external!(gunilev, "hexonaut/guni-lev", 13633752);
+forgetest_external!(convex, "mds1/convex-shutdown-simulation", 14445961);


### PR DESCRIPTION
Added new integration tests as my first task, as suggested in the issue #958.

The first run is painfully long but once cached it's all good as expected. Although i don't know if the github actions will benefit from caching.

## Motivation

I just wanted to start contributing and i found this among the older good first issues.

