### PR TITLE
Disable coloured logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,6 @@ dependencies = [
 name = "foundry-cli"
 version = "0.2.0"
 dependencies = [
- "ansi_term",
  "atty",
  "cast",
  "clap",
@@ -1757,6 +1756,7 @@ dependencies = [
  "vergen",
  "walkdir",
  "watchexec",
+ "yansi",
 ]
 
 [[package]]
@@ -1809,7 +1809,6 @@ dependencies = [
 name = "foundry-evm"
 version = "0.2.0"
 dependencies = [
- "ansi_term",
  "bytes",
  "ethers",
  "eyre",
@@ -1830,6 +1829,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "url",
+ "yansi",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ clap = { version = "3.0.10", features = [
     "wrap_help",
 ] }
 clap_complete = "3.0.4"
-ansi_term = "0.12.1"
+yansi = "0.5.1"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
 tracing = "0.1.26"

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -48,6 +48,7 @@ use eyre::WrapErr;
 async fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     utils::subscriber();
+    utils::enable_paint();
 
     let opts = Opts::parse();
     match opts.sub {

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,5 +1,4 @@
 use crate::{cmd::Cmd, utils};
-use ansi_term::Colour;
 use cast::trace::CallTraceDecoder;
 use clap::Parser;
 use ethers::{
@@ -20,6 +19,7 @@ use std::{
     time::Duration,
 };
 use ui::{TUIExitReason, Tui, Ui};
+use yansi::Paint;
 
 #[derive(Debug, Clone, Parser)]
 pub struct RunArgs {
@@ -193,9 +193,9 @@ fn print_traces(result: &mut RunResult, decoder: CallTraceDecoder) -> eyre::Resu
     println!();
 
     if result.success {
-        println!("{}", Colour::Green.paint("Script ran successfully."));
+        println!("{}", Paint::green("Script ran successfully."));
     } else {
-        println!("{}", Colour::Red.paint("Script failed."));
+        println!("{}", Paint::red("Script failed."));
     }
 
     println!("Gas used: {}", result.gas);

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -9,7 +9,7 @@ use clap::{Parser, ValueHint};
 use foundry_config::Config;
 
 use crate::cmd::forge::{install::DependencyInstallOpts, remappings};
-use ansi_term::Colour;
+use yansi::Paint;
 
 use std::{
     path::{Path, PathBuf},
@@ -88,7 +88,7 @@ impl Cmd for InitArgs {
                     r#"{}: `forge init` cannot be run on a non-empty directory.
 
         run `forge init --force` to initialize regardless."#,
-                    Colour::Red.paint("error")
+                    Paint::red("error")
                 );
                 std::process::exit(1);
             }
@@ -138,7 +138,7 @@ impl Cmd for InitArgs {
             }
         }
 
-        p_println!(!quiet => "    {} forge project.",   Colour::Green.paint("Initialized"));
+        p_println!(!quiet => "    {} forge project.",   Paint::green("Initialized"));
         Ok(())
     }
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -2,9 +2,9 @@
 use std::{path::PathBuf, str};
 
 use crate::{cmd::Cmd, opts::forge::Dependency, utils::p_println};
-use ansi_term::Colour;
 use clap::{Parser, ValueHint};
 use foundry_config::find_project_root_path;
+use yansi::Paint;
 
 use std::{
     path::Path,
@@ -97,7 +97,7 @@ pub(crate) fn install(
             install_as_submodule(&dep, &libs, no_commit)?;
         }
 
-        p_println!(!quiet => "    {} {}",    Colour::Green.paint("Installed"), dep.name);
+        p_println!(!quiet => "    {} {}",    Paint::green("Installed"), dep.name);
     }
     Ok(())
 }

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -2,7 +2,6 @@ use crate::{
     cmd::{forge::build::CoreBuildArgs, Cmd},
     compile, utils,
 };
-use ansi_term::Colour;
 use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, RawLog},
@@ -28,6 +27,7 @@ use foundry_config::{figment::Figment, Config};
 use foundry_utils::{encode_args, IntoFunction, PostLinkInput, RuntimeOrHandle};
 use std::{collections::BTreeMap, path::PathBuf};
 use ui::{TUIExitReason, Tui, Ui};
+use yansi::Paint;
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(RunArgs, opts, evm_opts);
@@ -104,7 +104,7 @@ impl Cmd for RunArgs {
             if setup_fn.name != "setUp" {
                 println!(
                     "{} Found invalid setup function \"{}\" did you mean \"setUp()\"?",
-                    Colour::Yellow.bold().paint("Warning:"),
+                    Paint::yellow("Warning:").bold(),
                     setup_fn.signature()
                 );
             }
@@ -230,9 +230,9 @@ impl Cmd for RunArgs {
             }
 
             if result.success {
-                println!("{}", Colour::Green.paint("Script ran successfully."));
+                println!("{}", Paint::green("Script ran successfully."));
             } else {
-                println!("{}", Colour::Red.paint("Script failed."));
+                println!("{}", Paint::red("Script failed."));
             }
 
             println!("Gas used: {}", result.gas);

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -7,7 +7,6 @@ use crate::cmd::{
     },
     Cmd,
 };
-use ansi_term::Colour;
 use clap::{Parser, ValueHint};
 use eyre::Context;
 use forge::TestKindGas;
@@ -23,6 +22,7 @@ use std::{
     str::FromStr,
 };
 use watchexec::config::{InitConfig, RuntimeConfig};
+use yansi::Paint;
 
 /// A regex that matches a basic snapshot entry like
 /// `Test:testDeposit() (gas: 58804)`
@@ -382,21 +382,21 @@ fn diff(tests: Vec<Test>, snaps: Vec<SnapshotEntry>) -> eyre::Result<()> {
 
 fn fmt_pct_change(change: f64) -> String {
     match change.partial_cmp(&0.0).unwrap_or(Ordering::Equal) {
-        Ordering::Less => Colour::Green.paint(format!("{:.3}%", change)).to_string(),
+        Ordering::Less => Paint::green(format!("{:.3}%", change)).to_string(),
         Ordering::Equal => {
             format!("{:.3}%", change)
         }
-        Ordering::Greater => Colour::Red.paint(format!("{:.3}%", change)).to_string(),
+        Ordering::Greater => Paint::red(format!("{:.3}%", change)).to_string(),
     }
 }
 
 fn fmt_change(change: i128) -> String {
     match change.cmp(&0) {
-        Ordering::Less => Colour::Green.paint(format!("{change}")).to_string(),
+        Ordering::Less => Paint::green(format!("{change}")).to_string(),
         Ordering::Equal => {
             format!("{change}")
         }
-        Ordering::Greater => Colour::Red.paint(format!("{change}")).to_string(),
+        Ordering::Greater => Paint::red(format!("{change}")).to_string(),
     }
 }
 

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -8,7 +8,6 @@ use crate::{
     utils,
     utils::FoundryPathExt,
 };
-use ansi_term::Colour;
 use clap::{AppSettings, Parser};
 use ethers::solc::FileFilter;
 use forge::{
@@ -32,6 +31,7 @@ use std::{
     time::Duration,
 };
 use watchexec::config::{InitConfig, RuntimeConfig};
+use yansi::Paint;
 
 #[derive(Debug, Clone, Parser)]
 pub struct Filter {
@@ -342,8 +342,8 @@ impl TestOutcome {
                 let successes = self.successes().count();
                 println!(
                     "Encountered a total of {} failing tests, {} tests succeeded",
-                    Colour::Red.paint(failures.to_string()),
-                    Colour::Green.paint(successes.to_string())
+                    Paint::red(failures.to_string()),
+                    Paint::green(successes.to_string())
                 );
                 std::process::exit(1);
             }
@@ -359,8 +359,7 @@ impl TestOutcome {
 
     pub fn summary(&self) -> String {
         let failed = self.failures().count();
-        let result =
-            if failed == 0 { Colour::Green.paint("ok") } else { Colour::Red.paint("FAILED") };
+        let result = if failed == 0 { Paint::green("ok") } else { Paint::red("FAILED") };
         format!(
             "Test result: {}. {} passed; {} failed; finished in {:.2?}",
             result,
@@ -373,7 +372,7 @@ impl TestOutcome {
 
 fn short_test_result(name: &str, result: &forge::TestResult) {
     let status = if result.success {
-        Colour::Green.paint("[PASS]")
+        Paint::green("[PASS]".to_string())
     } else {
         let txt = match (&result.reason, &result.counterexample) {
             (Some(ref reason), Some(ref counterexample)) => {
@@ -388,7 +387,7 @@ fn short_test_result(name: &str, result: &forge::TestResult) {
             (None, None) => "[FAIL]".to_string(),
         };
 
-        Colour::Red.paint(txt)
+        Paint::red(txt)
     };
 
     println!("{} {} {}", status, name, result.kind.gas_used());
@@ -538,7 +537,7 @@ fn test(
             let mut tests = suite_result.test_results.clone();
             println!();
             for warning in suite_result.warnings.iter() {
-                eprintln!("{} {}", Colour::Yellow.bold().paint("Warning:"), warning);
+                eprintln!("{} {}", Paint::yellow("Warning:").bold(), warning);
             }
             if !tests.is_empty() {
                 let term = if tests.len() > 1 { "tests" } else { "test" };

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -14,6 +14,7 @@ use clap_complete::generate;
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     utils::subscriber();
+    utils::enable_paint();
 
     let opts = Opts::parse();
     match opts.sub {

--- a/cli/src/term.rs
+++ b/cli/src/term.rs
@@ -1,6 +1,5 @@
 //! terminal utils
 
-use ansi_term::Colour;
 use atty::{self, Stream};
 use ethers::solc::{
     remappings::Remapping,
@@ -19,6 +18,7 @@ use std::{
     },
     time::Duration,
 };
+use yansi::Paint;
 
 /// Some spinners
 // https://github.com/gernest/wow/blob/master/spin/spinners.go
@@ -251,9 +251,7 @@ impl Reporter for SpinnerReporter {
     }
 
     fn on_solc_installation_error(&self, version: &Version, error: &str) {
-        self.send_msg(
-            Colour::Red.paint(format!("Failed to install solc {version}: {error}")).to_string(),
-        );
+        self.send_msg(Paint::red(format!("Failed to install solc {version}: {error}")).to_string());
     }
 
     fn on_unresolved_import(&self, import: &Path, remappings: &[Remapping]) {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
+use yansi::Paint;
 
 // reexport all `foundry_config::utils`
 #[doc(hidden)]
@@ -247,6 +248,17 @@ macro_rules! p_println {
     }}
 }
 pub(crate) use p_println;
+
+/// Disables terminal colours if either:
+/// - Running windows and the terminal does not support colour codes.
+/// - Colour has been disabled by some environment variable.
+pub fn enable_paint() {
+    let is_windows = cfg!(windows) && !Paint::enable_windows_ascii();
+    let env_colour_disabled = std::env::var("NO_COLOR").map(|_| true).unwrap_or(false);
+    if is_windows || env_colour_disabled {
+        Paint::disable();
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -254,7 +254,7 @@ pub(crate) use p_println;
 /// - Colour has been disabled by some environment variable.
 pub fn enable_paint() {
     let is_windows = cfg!(windows) && !Paint::enable_windows_ascii();
-    let env_colour_disabled = std::env::var("NO_COLOR").map(|_| true).unwrap_or(false);
+    let env_colour_disabled = std::env::var("NO_COLOR").is_ok();
     if is_windows || env_colour_disabled {
         Paint::disable();
     }

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1,5 +1,4 @@
 //! Contains various tests for checking forge's commands
-use ansi_term::Colour;
 use ethers::solc::{
     artifacts::{BytecodeHash, Metadata},
     ConfigurableContractArtifact,
@@ -11,6 +10,7 @@ use foundry_cli_test_utils::{
 };
 use foundry_config::{parse_with_profile, BasicConfig, Config, SolidityErrorCode};
 use std::{env, fs};
+use yansi::Paint;
 
 // import forge utils as mod
 #[allow(unused)]
@@ -293,7 +293,7 @@ Gas used: 1751
 == Logs ==
   script ran
 ",
-        Colour::Green.paint("Script ran successfully.")
+        Paint::green("Script ran successfully.")
     ),));
 });
 
@@ -325,7 +325,7 @@ Gas used: 1751
 == Logs ==
   script ran
 ",
-        Colour::Green.paint("Script ran successfully.")
+        Paint::green("Script ran successfully.")
     ),));
 });
 
@@ -362,7 +362,7 @@ Gas used: 3957
   1
   2
 ",
-        Colour::Green.paint("Script ran successfully.")
+        Paint::green("Script ran successfully.")
     ),));
 });
 

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -41,7 +41,7 @@ revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-fe
 proptest = "1.0.0"
 
 # Display
-ansi_term = "0.12.1"
+yansi = "0.5.1"
 url = "2.2.2"
 
 [dev-dependencies]

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -10,7 +10,6 @@ mod utils;
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 
 use crate::{abi::CHEATCODE_ADDRESS, CallKind};
-use ansi_term::Colour;
 use ethers::{
     abi::{Address, RawLog},
     types::U256,
@@ -21,6 +20,7 @@ use std::{
     collections::HashSet,
     fmt::{self, Write},
 };
+use yansi::{Color, Paint};
 
 /// An arena of [CallTraceNode]s
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -169,14 +169,14 @@ impl fmt::Display for RawOrDecodedLog {
                         f,
                         "{:>13}: {}",
                         if i == 0 { "emit topic 0".to_string() } else { format!("topic {i}") },
-                        Colour::Cyan.paint(format!("0x{}", hex::encode(&topic)))
+                        Paint::cyan(format!("0x{}", hex::encode(&topic)))
                     )?;
                 }
 
                 write!(
                     f,
                     "          data: {}",
-                    Colour::Cyan.paint(format!("0x{}", hex::encode(&log.data)))
+                    Paint::cyan(format!("0x{}", hex::encode(&log.data)))
                 )
             }
             RawOrDecodedLog::Decoded(name, params) => {
@@ -186,7 +186,7 @@ impl fmt::Display for RawOrDecodedLog {
                     .collect::<Vec<String>>()
                     .join(", ");
 
-                write!(f, "emit {}({})", Colour::Cyan.paint(name.clone()), params)
+                write!(f, "emit {}({})", Paint::cyan(name.clone()), params)
             }
         }
     }
@@ -309,8 +309,8 @@ impl fmt::Display for CallTrace {
                 f,
                 "[{}] {}{} {}@{:?}",
                 self.gas_cost,
-                Colour::Yellow.paint(CALL),
-                Colour::Yellow.paint("new"),
+                Paint::yellow(CALL),
+                Paint::yellow("new"),
                 self.label.as_ref().unwrap_or(&"<Unknown>".to_string()),
                 self.address
             )?;
@@ -347,7 +347,7 @@ impl fmt::Display for CallTrace {
                     "".to_string()
                 },
                 inputs,
-                Colour::Yellow.paint(action),
+                Paint::yellow(action),
             )?;
         }
 
@@ -364,12 +364,12 @@ pub enum TraceKind {
 }
 
 /// Chooses the color of the trace depending on the destination address and status of the call.
-fn trace_color(trace: &CallTrace) -> Colour {
+fn trace_color(trace: &CallTrace) -> Color {
     if trace.address == CHEATCODE_ADDRESS {
-        Colour::Blue
+        Color::Blue
     } else if trace.success {
-        Colour::Green
+        Color::Green
     } else {
-        Colour::Red
+        Color::Red
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
A couple issues (#1295,#1029) raise the concern of wanting an option to disable colours in the terminal output.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added a check when `forge` or `cast` is invoked that turns off colours if the terminal is a basic windows terminal, or if `NO_COLOR` is set in env. 

In order to do this I swapped out the `ansi_term` dependency across the whole crate for `yansi`
It has some very simple built in support for the exact feature wanted: [disabling colour on unsupporting windows terminals](https://docs.rs/yansi/latest/yansi/#windows).
It also seems like `ansi-term` is  [not being maintained ](https://github.com/ogham/rust-ansi-term/issues/72) so its not a bad idea to change to a more recently updated crate.

Didn't add any tests but I can confirm  running: 
```
$ NO_COLOR=1 forge test
```
now outputs  logs with no colours.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
