### PR TITLE
fix(cast): use config value for `cast call` etherscan key

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -196,7 +196,7 @@ async fn main() -> eyre::Result<()> {
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, eth.chain, false).await?;
-            builder.etherscan_api_key(eth.etherscan_api_key).set_args(&sig, args).await?;
+            builder.etherscan_api_key(config.etherscan_api_key).set_args(&sig, args).await?;
             let builder_output = builder.build();
             println!("{}", Cast::new(provider).call(builder_output, block).await?);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`cast call` is currently not pulling `ETHERSCAN_API_KEY` from a users config file.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
In `cli/src/cast.rs`, use `config.etherscan_api_key` instead of `eth.etherscan_api_key`
