### PR TITLE
chore: use revm crates version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,8 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm#dd3f11fc997a7c9d0182e3544a6803ec687b91d4"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806e90d2a967e11e3d704fac1ccf39978756991c26cf1dcecc80d9a763d6b559"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3789,8 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "revm_precompiles"
-version = "0.4.0"
-source = "git+https://github.com/bluealloy/revm#dd3f11fc997a7c9d0182e3544a6803ec687b91d4"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6aae8f44783ef6ff39fc22c9c999dfa0e17b79d663b752730c02a025935185"
 dependencies = [
  "bytes",
  "k256",

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.9.0"
 # EVM
 bytes = "1.1.0"
 hashbrown = "0.12"
-revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
+revm = { version="1.3", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
 
 # Fuzzer
 proptest = "1.0.0"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -14,4 +14,4 @@ eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
 forge = { path = "../forge" }
-revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256", "with-serde"] }
+revm = { version="1.3", default-features = false, features = ["std", "k256", "with-serde"] }


### PR DESCRIPTION
Finaly published revm version to crates. This is small change switching github url to crates version.