### PR TITLE
fix(forge init): making sure ds-test is pulled while using --no-git flag

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -83,7 +83,6 @@ pub(crate) fn install(
         ]);
         cmd.spawn()?.wait()?;
     }
-
     std::fs::create_dir_all(&libs)?;
 
     for dep in dependencies {
@@ -121,7 +120,7 @@ fn check_tag(dep: &Dependency) -> eyre::Result<()> {
 fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
     let target_dir = if let Some(alias) = &dep.alias { alias } else { &dep.name };
     let output = Command::new("git")
-        .args(&["clone", &dep.url, target_dir])
+        .args(&["clone", "--recursive", &dep.url, target_dir])
         .current_dir(&libs)
         .stdout(Stdio::piped())
         .output()?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ds-test wasn't being pulled as a submodule of forge-std while using `forge init project --no-git`

To reproduce: `forge init project --no-git`  and `forge build`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

While installing `forge-std` as a dependency, adding a command to pull it's submodules.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
