### PR TITLE
fix: properly display negative numbers in traces

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -753,14 +753,7 @@ pub fn format_token(param: &Token) -> String {
         Token::Address(addr) => format!("{:?}", addr),
         Token::FixedBytes(bytes) => format!("0x{}", hex::encode(&bytes)),
         Token::Bytes(bytes) => format!("0x{}", hex::encode(&bytes)),
-        Token::Int(mut num) => {
-            if num.bit(255) {
-                num = num - 1;
-                format!("-{}", num.overflowing_neg().0)
-            } else {
-                num.to_string()
-            }
-        }
+        Token::Int(num) => format!("{}", I256::from_raw(*num)),
         Token::Uint(num) => num.to_string(),
         Token::Bool(b) => format!("{b}"),
         Token::String(s) => format!("{:?}", s),


### PR DESCRIPTION
## Motivation

The logic to display negative numbers in traces was off by 1.

## Solution

Just use `I256` from ethers where this logic is already present instead of duplicating it here.

Closes #1427
