### PR TITLE
fix(verify): only include optimize infos when single file

### DIFF
--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -163,11 +163,13 @@ impl VerifyArgs {
                 .constructor_arguments(self.constructor_args.clone())
                 .code_format(code_format);
 
-        verify_args = if let Some(optimizations) = self.num_of_optimizations {
-            verify_args.optimization(true).runs(optimizations)
-        } else {
-            verify_args.optimization(false)
-        };
+        if code_format == CodeFormat::SingleFile {
+            verify_args = if let Some(optimizations) = self.num_of_optimizations {
+                verify_args.optimization(true).runs(optimizations)
+            } else {
+                verify_args.optimization(false)
+            };
+        }
 
         Ok(verify_args)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/gakonst/ethers-rs/pull/1212

`optimization` and `runs` are only applicable in single file mode and not for std json compiler input, because that info is already included in the compiler input object.

Ref https://docs.etherscan.io/api-endpoints/contracts#source-code-submission-gist
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
