### PR TITLE
feat(cheatcode): coinbase(address) - modify block.coinbase

### DIFF
--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -17,6 +17,7 @@ ethers::contract::abigen!(
             roll(uint256)
             warp(uint256)
             fee(uint256)
+            bank(address)
             store(address,bytes32,bytes32)
             load(address,bytes32)(bytes32)
             ffi(string[])(bytes)

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -17,7 +17,7 @@ ethers::contract::abigen!(
             roll(uint256)
             warp(uint256)
             fee(uint256)
-            bank(address)
+            coinbase(address)
             store(address,bytes32,bytes32)
             load(address,bytes32)(bytes32)
             ffi(string[])(bytes)

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -86,7 +86,7 @@ pub fn apply<DB: Database>(
             data.env.block.basefee = inner.0;
             Ok(Bytes::new())
         }
-        HEVMCalls::Bank(inner) => {
+        HEVMCalls::Coinbase(inner) => {
             data.env.block.coinbase = inner.0;
             Ok(Bytes::new())
         }

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -86,6 +86,10 @@ pub fn apply<DB: Database>(
             data.env.block.basefee = inner.0;
             Ok(Bytes::new())
         }
+        HEVMCalls::Bank(inner) => {
+            data.env.block.coinbase = inner.0;
+            Ok(Bytes::new())
+        }
         HEVMCalls::Store(inner) => {
             // TODO: Does this increase gas usage?
             data.subroutine.load_account(inner.0, data.db);

--- a/forge/README.md
+++ b/forge/README.md
@@ -124,7 +124,7 @@ which implements the following methods:
 
 - `function roll(uint x) public` Sets the block number to `x`.
 
-- `function bank(address c) public` Sets the block coinbase to `x`.
+- `function bank(address c) public` Sets the block coinbase to `c`.
 
 - `function store(address c, bytes32 loc, bytes32 val) public` Sets the slot
   `loc` of contract `c` to `val`.

--- a/forge/README.md
+++ b/forge/README.md
@@ -124,6 +124,8 @@ which implements the following methods:
 
 - `function roll(uint x) public` Sets the block number to `x`.
 
+- `function bank(address c) public` Sets the block coinbase to `x`.
+
 - `function store(address c, bytes32 loc, bytes32 val) public` Sets the slot
   `loc` of contract `c` to `val`.
 
@@ -260,6 +262,8 @@ interface Hevm {
     function roll(uint256) external;
     // Set block.basefee (newBasefee)
     function fee(uint256) external;
+    // Set block.coinbase (who)
+    function bank(address) external;
     // Loads a storage slot from an address (who, slot)
     function load(address,bytes32) external returns (bytes32);
     // Stores a value to an address' storage slot, (who, slot, value)

--- a/forge/README.md
+++ b/forge/README.md
@@ -124,7 +124,7 @@ which implements the following methods:
 
 - `function roll(uint x) public` Sets the block number to `x`.
 
-- `function bank(address c) public` Sets the block coinbase to `c`.
+- `function coinbase(address c) public` Sets the block coinbase to `c`.
 
 - `function store(address c, bytes32 loc, bytes32 val) public` Sets the slot
   `loc` of contract `c` to `val`.
@@ -263,7 +263,7 @@ interface Hevm {
     // Set block.basefee (newBasefee)
     function fee(uint256) external;
     // Set block.coinbase (who)
-    function bank(address) external;
+    function coinbase(address) external;
     // Loads a storage slot from an address (who, slot)
     function load(address,bytes32) external returns (bytes32);
     // Stores a value to an address' storage slot, (who, slot, value)

--- a/testdata/cheats/Bank.t.sol
+++ b/testdata/cheats/Bank.t.sol
@@ -4,16 +4,16 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 import "./Cheats.sol";
 
-contract BankTest is DSTest {
+contract CoinbaseTest is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
-    function testBank() public {
-        cheats.bank(0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8);
-        assertEq(block.coinbase, 0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8, "bank failed");
+    function testCoinbase() public {
+        cheats.coinbase(0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8);
+        assertEq(block.coinbase, 0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8, "coinbase failed");
     }
 
-    function testBankFuzzed(address who) public {
-        cheats.bank(who);
-        assertEq(block.coinbase, who, "bank failed");
+    function testCoinbaseFuzzed(address who) public {
+        cheats.coinbase(who);
+        assertEq(block.coinbase, who, "coinbase failed");
     }
 }

--- a/testdata/cheats/Bank.t.sol
+++ b/testdata/cheats/Bank.t.sol
@@ -13,7 +13,6 @@ contract BankTest is DSTest {
     }
 
     function testBankFuzzed(address who) public {
-        address pre = block.coinbase;
         cheats.bank(who);
         assertEq(block.coinbase, who, "bank failed");
     }

--- a/testdata/cheats/Bank.t.sol
+++ b/testdata/cheats/Bank.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "./Cheats.sol";
+
+contract BankTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function testBank() public {
+        cheats.bank(0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8);
+        assertEq(block.coinbase, 0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8, "bank failed");
+    }
+
+    function testBankFuzzed(address who) public {
+        address pre = block.coinbase;
+        cheats.bank(who);
+        assertEq(block.coinbase, who, "bank failed");
+    }
+}

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -9,7 +9,7 @@ interface Cheats {
     // Set block.basefee (newBasefee)
     function fee(uint256) external;
     // Set block.coinbase (who)
-    function bank(address) external;
+    function coinbase(address) external;
     // Loads a storage slot from an address (who, slot)
     function load(address,bytes32) external returns (bytes32);
     // Stores a value to an address' storage slot, (who, slot, value)

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -8,6 +8,8 @@ interface Cheats {
     function roll(uint256) external;
     // Set block.basefee (newBasefee)
     function fee(uint256) external;
+    // Set block.coinbase (who)
+    function bank(address) external;
     // Loads a storage slot from an address (who, slot)
     function load(address,bytes32) external returns (bytes32);
     // Stores a value to an address' storage slot, (who, slot, value)


### PR DESCRIPTION
This PR adds the cheat code `bank(address)` which sets `block.coinbase` by internally modifying `data.env.block.coinbase`. 

I'm not too familiar with foundry's internals, so I'm not highly confident that this doesn't break something unexpected. But it is a pretty small change and all tests pass.

## Motivation

This is useful for testing contracts that depend on the value of `block.coinbase`.