### PR TITLE
fix: follow symlinks to libs

### DIFF
--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -141,7 +141,7 @@ pub fn foundry_toml_dirs(root: impl AsRef<Path>) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_dir())
-        .filter_map(|e| std::fs::canonicalize(e.path()).ok())
+        .filter_map(|e| ethers_solc::utils::canonicalize(e.path()).ok())
         .filter(|p| p.join(Config::FILE_NAME).exists())
         .collect()
 }

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -116,6 +116,8 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
 
 /// Returns a list of _unique_ paths to all folders under `root` that contain a `foundry.toml` file
 ///
+/// This will also resolve symlinks
+///
 /// # Example
 ///
 /// ```no_run
@@ -135,12 +137,11 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
 /// ```
 pub fn foundry_toml_dirs(root: impl AsRef<Path>) -> Vec<PathBuf> {
     walkdir::WalkDir::new(root)
-        .min_depth(1)
         .max_depth(1)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_dir())
-        .filter(|e| e.path().join(Config::FILE_NAME).exists())
-        .map(|e| e.path().to_path_buf())
+        .filter_map(|e| std::fs::canonicalize(e.path()).ok())
+        .filter(|p| p.join(Config::FILE_NAME).exists())
         .collect()
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #1498

resolves symlinks (`std::fs::canonicalize`) when scanning nested foundry.toml libs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
