### PR TITLE
fix(install): use origin refs only

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -105,8 +105,10 @@ pub(crate) fn install(
 /// make sure tag exists on the remote repository
 fn check_tag(dep: &Dependency) -> eyre::Result<()> {
     if let (Some(ref url), Some(ref tag)) = (&dep.url, &dep.tag) {
-        let output =
-            Command::new("git").args(&["ls-remote", "-t", "--refs", url, tag]).stdout(Stdio::piped()).output()?;
+        let output = Command::new("git")
+            .args(&["ls-remote", "-t", "--refs", url, tag])
+            .stdout(Stdio::piped())
+            .output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         if !stdout.contains(tag) {
             eyre::bail!("tag/branch/commit \"{}\" does not exists", tag)

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -106,7 +106,7 @@ pub(crate) fn install(
 fn check_tag(dep: &Dependency) -> eyre::Result<()> {
     if let (Some(ref url), Some(ref tag)) = (&dep.url, &dep.tag) {
         let output =
-            Command::new("git").args(&["ls-remote", url, tag]).stdout(Stdio::piped()).output()?;
+            Command::new("git").args(&["ls-remote", "-t", "--refs", url, tag]).stdout(Stdio::piped()).output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         if !stdout.contains(tag) {
             eyre::bail!("tag/branch/commit \"{}\" does not exists", tag)


### PR DESCRIPTION
Limit to only refs/tags  and do not show peeled tags or pseudorefs like HEAD in the output.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
