### PR TITLE
fix(anvil): use zero price if not set

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -594,7 +594,8 @@ impl EthApi {
             request.gas_price,
             request.max_fee_per_gas,
             request.max_priority_fee_per_gas,
-        )?;
+        )?
+        .or_zero_fees();
 
         let (exit, out, gas, _) = self.backend.call(request, fees);
 

--- a/anvil/src/eth/fees.rs
+++ b/anvil/src/eth/fees.rs
@@ -281,6 +281,17 @@ impl FeeDetails {
         }
     }
 
+    /// If neither `gas_price` nor `max_fee_per_gas` is `Some`, this will set both to `0`
+    pub fn or_zero_fees(self) -> Self {
+        let FeeDetails { gas_price, max_fee_per_gas, max_priority_fee_per_gas } = self;
+
+        let no_fees = gas_price.is_none() && max_fee_per_gas.is_none();
+        let gas_price = if no_fees { Some(U256::zero()) } else { gas_price };
+        let max_fee_per_gas = if no_fees { Some(U256::zero()) } else { max_fee_per_gas };
+
+        Self { gas_price, max_fee_per_gas, max_priority_fee_per_gas }
+    }
+
     /// Turns this type into a tuple
     pub fn split(self) -> (Option<U256>, Option<U256>, Option<U256>) {
         let Self { gas_price, max_fee_per_gas, max_priority_fee_per_gas } = self;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
If no gas_price or max fee per gas was set in eth_call, use 0 for both
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
