### PR TITLE
fix(forge): Fixes AccountInfo code in forked mode

### DIFF
--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -278,7 +278,7 @@ where
                             let (code, code_hash) = if !code.0.is_empty() {
                                 (Some(code.0.clone()), keccak256(&code).into())
                             } else {
-                                (None, KECCAK_EMPTY)
+                                (Some(bytes::Bytes::default()), KECCAK_EMPTY)
                             };
 
                             // update the cache


### PR DESCRIPTION
## Motivation
#1513

## Solution
We should never have `account_info.code == None` if we have loaded an account already. This fixes that 
