### PR TITLE
Fix anvil manpage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
           sudo apt-get -y install help2man
           help2man -N ./target/${TARGET}/release/forge > forge.1
           help2man -N ./target/${TARGET}/release/cast > cast.1
-          help2man -N ./target/${TARGET}/release/cast > anvil.1
+          help2man -N ./target/${TARGET}/release/anvil > anvil.1
           gzip forge.1
           gzip cast.1
           gzip anvil.1


### PR DESCRIPTION
In the release workflow the wrong manpage is generated for anvil.

P.S: GG on anvil!