### PR TITLE
chore: simplify cast sig command + fix a typo

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -10,9 +10,8 @@ use foundry_config::Config;
 mod opts;
 use cast::InterfacePath;
 use ethers::{
-    contract::BaseContract,
     core::{
-        abi::parse_abi,
+        abi::AbiParser,
         rand::thread_rng,
         types::{BlockId, BlockNumber::Latest, H256},
     },
@@ -630,8 +629,7 @@ async fn main() -> eyre::Result<()> {
             }
         }
         Subcommands::Sig { sig } => {
-            let contract = BaseContract::from(parse_abi(&[&sig]).unwrap());
-            let selector = contract.abi().functions().last().unwrap().short_signature();
+            let selector = AbiParser::default().parse_function(&sig).unwrap().short_signature();
             println!("0x{}", hex::encode(selector));
         }
         Subcommands::FindBlock(cmd) => cmd.run()?.await?,

--- a/evm/src/debug.rs
+++ b/evm/src/debug.rs
@@ -87,7 +87,7 @@ pub struct DebugNode {
     pub location: usize,
     /// Execution context.
     ///
-    /// Note that this is the address of the *code*, not necessarily the adddress of the storage.
+    /// Note that this is the address of the *code*, not necessarily the address of the storage.
     pub address: Address,
     /// The kind of call this is
     pub kind: CallKind,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`cast sig` is only parsing a single function, so it should use `parse_function()` rather than `parse_abi()`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

