### PR TITLE
fix(cast): auto fetch chain id in cast call

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -196,7 +196,7 @@ async fn main() -> eyre::Result<()> {
             )?;
 
             let chain_id = provider.get_chainid().await?;
-            let chain = Chain::try_from(chain_id.as_u64())?;
+            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, chain, false).await?;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -195,8 +195,11 @@ async fn main() -> eyre::Result<()> {
                 config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
             )?;
 
+            let chain_id = provider.get_chainid().await?;
+            let chain = Chain::try_from(chain_id.as_u64())?;
+
             let mut builder =
-                TxBuilder::new(&provider, config.sender, address, eth.chain, false).await?;
+                TxBuilder::new(&provider, config.sender, address, chain, false).await?;
             builder.etherscan_api_key(config.etherscan_api_key).set_args(&sig, args).await?;
             let builder_output = builder.build();
             println!("{}", Cast::new(provider).call(builder_output, block).await?);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fixes #1522 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Automatically fetch the chain id in `cast call` instead of relying on an environment variable.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
