### PR TITLE
docs: update forge readme github actions ci

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -368,7 +368,7 @@ For example, if you have `@openzeppelin` imports, you would
 
 ## Github Actions CI
 
-We recommend using the [Github Actions CI setup](https://github.com/FrankieIsLost/forge-template/blob/2ff5ae4ea40d77d4aa4e8353e0a878478ec9df24/.github/workflows/CI.yml) from @FrankieIsLost's [forge-template](https://github.com/FrankieIsLost/forge-template).
+We recommend using the [Github Actions CI setup](https://book.getfoundry.sh/config/continous-integration.html) from the [📖 Foundry Book](https://book.getfoundry.sh/index.html).
 
 ## Future Features
 


### PR DESCRIPTION
Issue: https://github.com/foundry-rs/foundry/issues/1496

Simple forge readme update to point to foundry book CI page: https://book.getfoundry.sh/config/continous-integration.html


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
