### PR TITLE
fix(anvil): load code if not yet loaded

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -807,8 +807,13 @@ impl Backend {
         _block: Option<BlockNumber>,
     ) -> Result<Bytes, BlockchainError> {
         trace!(target: "backend", "get code for {:?}", address);
-        let code = self.db.read().basic(address).code;
-        Ok(code.unwrap_or_default().into())
+        let account = self.db.read().basic(address);
+        let code = if let Some(code) = account.code {
+            code.into()
+        } else {
+            self.db.read().code_by_hash(account.code_hash).into()
+        };
+        Ok(code)
     }
 
     /// Returns the balance of the address


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1514
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
revm's memdb does store the code separately and if it's None it needs to be loaded via `code_by_hash`.
`code_by_hash` was also made safe for forked db in #1516 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
