### PR TITLE
fix(forge): Better deploy errors

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -95,7 +95,9 @@ impl RunArgs {
                             .call_raw_committing(past_tx.from, to, past_tx.input.0, past_tx.value)
                             .unwrap();
                     } else {
-                        executor.deploy(past_tx.from, past_tx.input.0, past_tx.value).unwrap();
+                        executor
+                            .deploy(past_tx.from, past_tx.input.0, past_tx.value, None)
+                            .unwrap();
                     }
                 }
             }
@@ -120,7 +122,7 @@ impl RunArgs {
                     }
                 } else {
                     let DeployResult { gas, traces, debug: run_debug, .. }: DeployResult =
-                        executor.deploy(tx.from, tx.input.0, tx.value).unwrap();
+                        executor.deploy(tx.from, tx.input.0, tx.value, None).unwrap();
 
                     RunResult {
                         success: true,

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -390,7 +390,7 @@ impl<DB: DatabaseRef> Runner<DB> {
             .filter_map(|code| {
                 let DeployResult { traces, .. } = self
                     .executor
-                    .deploy(self.sender, code.0.clone(), 0u32.into())
+                    .deploy(self.sender, code.0.clone(), 0u32.into(), None)
                     .expect("couldn't deploy library");
 
                 traces
@@ -405,7 +405,7 @@ impl<DB: DatabaseRef> Runner<DB> {
             traces: constructor_traces,
             debug: constructor_debug,
             ..
-        } = self.executor.deploy(self.sender, code.0, 0u32.into()).expect("couldn't deploy");
+        } = self.executor.deploy(self.sender, code.0, 0u32.into(), None).expect("couldn't deploy");
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
         self.executor.set_balance(address, self.initial_balance);
 


### PR DESCRIPTION
## Motivation
Closes #1538

## Solution
Return `EvmError::Execution` from a failed `executor.deploy` when possible. Had to change to `for _ in x.iter()` to allow for early exiting

before:
```haskell
$ forge test -vvvvvv -m L2MessengerCorrectL1Messenger
[⠔] Compiling...
[⠔] Compiling 11 files with 0.8.10
[⠑] Solc 0.8.10 finished in 5.88s
Compiler run successful (with warnings)
The application panicked (crashed).
Message:  couldn't deploy:
   0: deployment failed: Revert

Location:
   /home/runner/work/foundry/foundry/evm/src/executor/mod.rs:465

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
Location: /home/runner/work/foundry/foundry/forge/src/runner.rs:232

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
Aborted (core dumped)
```

after:
```haskell
Running 1 test for contracts/test/L2CrossDomainMessenger.t.sol:L2CrossDomainMessenger_Test
[FAIL. Reason: Initializable: contract is already initialized] setUp() (gas: 0)
Logs:
  0x4200000000000000000000000000000000000007

Traces:
  [6434787] → new <Unknown>@0xb4c79dab8f259c7aee6e5b2aa729821864227e84
    ├─ [0] VM::deal(0x0000000000000000000000000000000000000080, 65536)
    │   └─ ← ()
    ├─ [0] VM::deal(0x0000000000000000000000000000000000000100, 65536)
    │   └─ ← ()
    ├─ [0] VM::warp(1000)
    │   └─ ← ()
    ├─ [775961] → new L2OutputOracle@0xce71065d4017f316ec606fe4422e11eb2c47c246
    │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    │   ├─ emit OwnershipTransferred(previousOwner: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84, newOwner: 0x000000000000000000000000000000000000abba)
    │   └─ ← 3413 bytes of code
    ├─ [1923853] → new OptimismPortal@0x185a4dc360ce69bdccee33b3784b0282f7961aea
    │   └─ ← 9497 bytes of code
    ├─ [1504168] → new L1CrossDomainMessenger@0xefc56627233b02ea95bae7e19f648d7dcd5bb132
    │   └─ ← 7513 bytes of code
    ├─ [160828] L1CrossDomainMessenger::initialize(OptimismPortal: [0x185a4dc360ce69bdccee33b3784b0282f7961aea])
    │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    │   └─ ← ()
    ├─ [1505368] → new L2CrossDomainMessenger@0xf5a2fe45f4f1308502b1c136b9ef8af136141382
    │   └─ ← 7519 bytes of code
    ├─ [0] VM::etch(/*snip*/)
    │   └─ ← ()
    ├─ [0] console::log(0x4200000000000000000000000000000000000007) [staticcall]
    │   └─ ← ()
    ├─ [23546] 0x4200…0007::initialize(L1CrossDomainMessenger: [0xefc56627233b02ea95bae7e19f648d7dcd5bb132])
    │   └─ ← "Initializable: contract is already initialized"
    └─ ← 0 bytes of code

Test result: FAILED. 0 passed; 1 failed; finished in 19.67ms