### PR TITLE
feat: add anvil to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /opt/foundry
 COPY . .
 RUN source $HOME/.profile && cargo build --release \
     && strip /opt/foundry/target/release/forge \
-    && strip /opt/foundry/target/release/cast
+    && strip /opt/foundry/target/release/cast \
+    && strip /opt/foundry/target/release/anvil
 
 from alpine as foundry-client
 ENV GLIBC_KEY=https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
@@ -21,4 +22,5 @@ RUN wget -q -O ${GLIBC_KEY_FILE} ${GLIBC_KEY} \
     && apk add glibc.apk --force
 COPY --from=build-environment /opt/foundry/target/release/forge /usr/local/bin/forge
 COPY --from=build-environment /opt/foundry/target/release/cast /usr/local/bin/cast
+COPY --from=build-environment /opt/foundry/target/release/anvil /usr/local/bin/anvil
 ENTRYPOINT ["/bin/sh", "-c"]


### PR DESCRIPTION
Was trying to use anvil via docker and found out it's not there yet.

This change adds anvil to PATH of the docker container.

⚠️ I was able to build locally, but had issues when building on docker. I saw the same issue in the CI [here](https://github.com/foundry-rs/foundry/runs/6031912323?check_suite_focus=true). It takes over an hour to build on docker on my machine so I figured someone here (@gakonst?) might already be familiar with the issue and know what to do. Maybe it's just flakiness?