### PR TITLE
feat(anvil): support impersonated accounts in eth_sendTransaction

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -476,7 +476,7 @@ impl TypedTransaction {
     /// Returns the Signature of the transaction
     pub fn signature(&self) -> Signature {
         match self {
-            TypedTransaction::Legacy(tx) => tx.signature.clone(),
+            TypedTransaction::Legacy(tx) => tx.signature,
             TypedTransaction::EIP2930(tx) => {
                 let v = tx.odd_y_parity as u8;
                 let r = U256::from_big_endian(&tx.r[..]);

--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -472,6 +472,25 @@ impl TypedTransaction {
     pub fn to(&self) -> Option<&Address> {
         self.kind().as_call()
     }
+
+    /// Returns the Signature of the transaction
+    pub fn signature(&self) -> Signature {
+        match self {
+            TypedTransaction::Legacy(tx) => tx.signature.clone(),
+            TypedTransaction::EIP2930(tx) => {
+                let v = tx.odd_y_parity as u8;
+                let r = U256::from_big_endian(&tx.r[..]);
+                let s = U256::from_big_endian(&tx.s[..]);
+                Signature { r, s, v: v.into() }
+            }
+            TypedTransaction::EIP1559(tx) => {
+                let v = tx.odd_y_parity as u8;
+                let r = U256::from_big_endian(&tx.r[..]);
+                let s = U256::from_big_endian(&tx.s[..]);
+                Signature { r, s, v: v.into() }
+            }
+        }
+    }
 }
 
 impl Encodable for TypedTransaction {

--- a/anvil/src/eth/backend/cheats.rs
+++ b/anvil/src/eth/backend/cheats.rs
@@ -1,5 +1,6 @@
 //! Support for "cheat codes" / bypass functions
 
+use anvil_core::eth::transaction::TypedTransaction;
 use ethers::types::{Address, Signature, U256};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -8,6 +9,11 @@ use tracing::trace;
 /// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
 const BYPASS_SIGNATURE: Signature =
     Signature { r: U256([0, 0, 0, 0]), s: U256([0, 0, 0, 0]), v: 0 };
+
+/// Returns `true` if the signature of the `transaction` is the `BYPASS_SIGNATURE`
+pub fn is_bypassed(transaction: &TypedTransaction) -> bool {
+    transaction.signature() == BYPASS_SIGNATURE
+}
 
 /// Manages user modifications that may affect the node's behavior
 ///
@@ -40,6 +46,11 @@ impl CheatsManager {
     /// Returns the account that's currently being impersonated
     pub fn impersonated_account(&self) -> Option<Address> {
         self.state.read().impersonated_account
+    }
+
+    /// Returns true if the `addr` is currently impersonated
+    pub fn is_impersonated(&self, addr: Address) -> bool {
+        self.state.read().impersonated_account == Some(addr)
     }
 
     /// Returns the signature to use to bypass transaction signing

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -2,7 +2,11 @@
 
 use crate::next_port;
 use anvil::{spawn, NodeConfig};
-use ethers::prelude::Middleware;
+use ethers::{
+    prelude::Middleware,
+    types::{Address, TransactionRequest},
+    utils::WEI_IN_ETHER,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_set_gas_price() {
@@ -12,4 +16,27 @@ async fn can_set_gas_price() {
     let gas_price = 1337u64.into();
     api.anvil_set_min_gas_price(gas_price).await.unwrap();
     assert_eq!(gas_price, provider.get_gas_price().await.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_impersonate() {
+    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let provider = handle.http_provider();
+
+    let impersonated = Address::random();
+    let to = Address::random();
+
+    let balance = WEI_IN_ETHER.saturating_mul(10u64.into());
+    api.anvil_set_balance(impersonated, balance).await.unwrap();
+    assert_eq!(balance, provider.get_balance(impersonated, None).await.unwrap());
+
+    let tx = TransactionRequest::new().to(to).value(balance / 2);
+
+    let res = provider.send_transaction(tx.clone().from(impersonated), None).await;
+    assert!(res.is_err());
+
+    api.anvil_impersonate_account(impersonated).await.unwrap();
+    let tx = provider.send_transaction(tx.clone(), None).await.unwrap().await.unwrap().unwrap();
+
+    assert_eq!(tx.from, impersonated);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
allow `eth_sendTransaction` with impersonated account
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* bypass address recovery if sender is impersonated account
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
