### PR TITLE
feat(config): auto update libs section on install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +1962,7 @@ dependencies = [
  "serde",
  "serde_regex",
  "toml",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -4893,6 +4904,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba98375fd631b83696f87c64e4ed8e29e6a1f3404d6aed95fa95163bad38e705"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
 ]
 
 [[package]]

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, str};
 
 use crate::{cmd::Cmd, opts::forge::Dependency, utils::p_println};
 use clap::{Parser, ValueHint};
-use foundry_config::find_project_root_path;
+use foundry_config::{find_project_root_path, Config};
 use yansi::Paint;
 
 use std::{
@@ -49,7 +49,14 @@ impl Cmd for InstallArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let InstallArgs { root, .. } = self;
         let root = root.unwrap_or_else(|| find_project_root_path().unwrap());
-        install(root, self.dependencies, self.opts)
+        install(&root, self.dependencies, self.opts)?;
+        let mut config = Config::load_with_root(root);
+        let lib = PathBuf::from("lib");
+        if !config.libs.contains(&lib) {
+            config.libs.push(lib);
+            config.update_libs()?;
+        }
+        Ok(())
     }
 }
 

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -400,6 +400,14 @@ impl TestCommand {
         config
     }
 
+    /// Runs `git init` inside the project's dir
+    pub fn git_init(&self) -> process::Output {
+        let mut cmd = Command::new("git");
+        cmd.arg("init").current_dir(self.project.root());
+        let output = cmd.output().unwrap();
+        self.expect_success(output)
+    }
+
     /// Runs and captures the stdout of the given command.
     pub fn stdout(&mut self) -> String {
         let o = self.output();

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -21,9 +21,9 @@ ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features =
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["async", "svm-solc"] }
 Inflector = "0.11.4"
 regex = "1.5.5"
-#globset = { version = "0.4.8", features = ["serde1"] }
 globset = "0.4.8"
 walkdir = "2.3.2"
+toml_edit = "0.14.3"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1508

if `libs` section of the config does not contain the default library folder `lib`, like : `libs = ["node_modules"]`, automatically add `lib` after `forge install`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `Config::update` functions that can be easily extended to additional entries.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
