### PR TITLE
chore: use exact git error

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -186,7 +186,7 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
             &target_dir
         )
     } else if stderr.contains("not a git repository") {
-        eyre::bail!("\"{}\" is not a git repository", url)
+        eyre::bail!("{stderr}")
     } else if stderr.contains("paths are ignored by one of your .gitignore files") {
         let error =
             stderr.lines().filter(|l| !l.starts_with("hint:")).collect::<Vec<&str>>().join("\n");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
current check also matched: `"fatal: not a git repository (or any of the parent directories): .git` on non git repo.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
propagate exact git error
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
