### PR TITLE
feat: forge coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "proptest",
  "revm",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ debug = 0
 
 ## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 #[patch."https://github.com/gakonst/ethers-rs"]
-#ethers = { path = "../../gakonst/ethers-rs" }
-#ethers-core = { path = "../../gakonst/ethers-rs/ethers-core" }
-#ethers-providers = { path = "../../gakonst/ethers-rs/ethers-providers" }
-#ethers-signers = { path = "../../gakonst/ethers-rs/ethers-signers" }
-#ethers-etherscan = { path = "../../gakonst/ethers-rs/ethers-etherscan" }
-#ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc" }
+#ethers = { path = "../ethers-rs" }
+#ethers-core = { path = "../ethers-rs/ethers-core" }
+#ethers-providers = { path = "../ethers-rs/ethers-providers" }
+#ethers-signers = { path = "../ethers-rs/ethers-signers" }
+#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
+#ethers-solc = { path = "../ethers-rs/ethers-solc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ debug = 0
 
 ## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 #[patch."https://github.com/gakonst/ethers-rs"]
-#ethers = { path = "../ethers-rs" }
-#ethers-core = { path = "../ethers-rs/ethers-core" }
-#ethers-providers = { path = "../ethers-rs/ethers-providers" }
-#ethers-signers = { path = "../ethers-rs/ethers-signers" }
-#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
-#ethers-solc = { path = "../ethers-rs/ethers-solc" }
+#ethers = { path = "../../gakonst/ethers-rs" }
+#ethers-core = { path = "../../gakonst/ethers-rs/ethers-core" }
+#ethers-providers = { path = "../../gakonst/ethers-rs/ethers-providers" }
+#ethers-signers = { path = "../../gakonst/ethers-rs/ethers-signers" }
+#ethers-etherscan = { path = "../../gakonst/ethers-rs/ethers-etherscan" }
+#ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc" }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -24,7 +24,7 @@ use forge::{
 };
 use foundry_common::evm::EvmArgs;
 use foundry_config::{figment::Figment, Config};
-use std::{collections::HashMap, sync::mpsc::channel, thread};
+use std::{collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
@@ -158,14 +158,14 @@ impl CoverageArgs {
             for mut versioned_source in versioned_sources {
                 let source = &mut versioned_source.source_file;
                 if let Some(ast) = source.ast.take() {
-                    let mut visitor = Visitor::new();
-                    visitor.visit_ast(ast)?;
+                    let items = Visitor::new(std::fs::read_to_string(PathBuf::from(&path))?)
+                        .visit_ast(ast)?;
 
-                    if visitor.items.is_empty() {
+                    if items.is_empty() {
                         continue
                     }
 
-                    map.add_source(path.clone(), versioned_source, visitor.items);
+                    map.add_source(path.clone(), versioned_source, items);
                 }
             }
         }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -7,21 +7,17 @@ use crate::{
     compile::ProjectCompiler,
     utils,
 };
-use cast::coverage::{BranchKind, CoverageItem, CoverageMap, CoverageSummary};
 use clap::{AppSettings, ArgEnum, Parser};
-use comfy_table::{Cell, Color, Row, Table};
 use ethers::{
-    prelude::{artifacts::Node, Artifact, Project, ProjectCompileOutput},
+    prelude::{Artifact, Project, ProjectCompileOutput},
     solc::{
-        artifacts::{
-            ast::{Ast, NodeType},
-            contract::CompactContractBytecode,
-        },
+        artifacts::contract::CompactContractBytecode,
         sourcemap::{self, SourceMap},
         ArtifactId,
     },
 };
 use forge::{
+    coverage::{CoverageMap, CoverageReporter, LcovReporter, SummaryReporter, Visitor},
     executor::opts::EvmOpts,
     result::SuiteResult,
     trace::{identifier::LocalTraceIdentifier, CallTraceDecoder, CallTraceDecoderBuilder},
@@ -29,8 +25,7 @@ use forge::{
 };
 use foundry_common::evm::EvmArgs;
 use foundry_config::{figment::Figment, Config};
-use std::{collections::BTreeMap, io::Write, sync::mpsc::channel, thread};
-use tracing::warn;
+use std::{collections::BTreeMap, sync::mpsc::channel, thread};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
@@ -176,7 +171,7 @@ impl CoverageArgs {
         self,
         project: Project,
         output: ProjectCompileOutput,
-        source_maps: BTreeMap<ArtifactId, SourceMap>,
+        _source_maps: BTreeMap<ArtifactId, SourceMap>,
         map: CoverageMap,
         config: Config,
         evm_opts: EvmOpts,
@@ -211,14 +206,14 @@ impl CoverageArgs {
         // TODO: Coverage for fuzz tests
         let handle = thread::spawn(move || runner.test(&self.filter, Some(tx), false).unwrap());
         for mut result in rx.into_iter().flat_map(|(_, suite)| suite.test_results.into_values()) {
-            if let Some(hit_data) = result.coverage.take() {
+            if let Some(_hit_data) = result.coverage.take() {
                 let mut decoder =
                     CallTraceDecoderBuilder::new().with_events(local_identifier.events()).build();
                 for (_, trace) in &mut result.traces {
                     decoder.identify(trace, &local_identifier);
                 }
                 // TODO: We need an ArtifactId here for the addresses
-                let CallTraceDecoder { contracts, .. } = decoder;
+                let CallTraceDecoder { contracts: _, .. } = decoder;
 
                 // ..
             }
@@ -251,384 +246,4 @@ pub enum CoverageReportKind {
     Lcov,
 }
 
-// TODO: Move to other module
-#[derive(Debug, Default, Clone)]
-struct Visitor {
-    /// Coverage items
-    pub items: Vec<CoverageItem>,
-    /// The current branch ID
-    // TODO: Does this need to be unique across files?
-    pub branch_id: usize,
-}
-
-impl Visitor {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn visit_ast(&mut self, ast: Ast) -> eyre::Result<()> {
-        for node in ast.nodes.into_iter() {
-            if !matches!(node.node_type, NodeType::ContractDefinition) {
-                continue
-            }
-
-            self.visit_contract(node)?;
-        }
-
-        Ok(())
-    }
-
-    pub fn visit_contract(&mut self, node: Node) -> eyre::Result<()> {
-        let is_contract =
-            node.attribute("contractKind").map_or(false, |kind: String| kind == "contract");
-        let is_abstract: bool = node.attribute("abstract").unwrap_or_default();
-
-        // Skip interfaces, libraries and abstract contracts
-        if !is_contract || is_abstract {
-            return Ok(())
-        }
-
-        for node in node.nodes {
-            if node.node_type == NodeType::FunctionDefinition {
-                self.visit_function_definition(node)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn visit_function_definition(&mut self, mut node: Node) -> eyre::Result<()> {
-        let name: String =
-            node.attribute("name").ok_or_else(|| eyre::eyre!("function has no name"))?;
-        let is_virtual: bool = node.attribute("virtual").unwrap_or_default();
-
-        // Skip virtual functions
-        if is_virtual {
-            return Ok(())
-        }
-
-        match node.body.take() {
-            // Skip virtual functions
-            Some(body) if !is_virtual => {
-                self.items.push(CoverageItem::Function { name, offset: node.src.start, hits: 0 });
-                self.visit_block(*body)
-            }
-            _ => Ok(()),
-        }
-    }
-
-    pub fn visit_block(&mut self, node: Node) -> eyre::Result<()> {
-        let statements: Vec<Node> = node.attribute("statements").unwrap_or_default();
-
-        for statement in statements {
-            self.visit_statement(statement)?;
-        }
-
-        Ok(())
-    }
-    pub fn visit_statement(&mut self, node: Node) -> eyre::Result<()> {
-        // TODO: inlineassembly
-        match node.node_type {
-            // Blocks
-            NodeType::Block | NodeType::UncheckedBlock => self.visit_block(node),
-            // Simple statements
-            NodeType::Break |
-            NodeType::Continue |
-            NodeType::EmitStatement |
-            NodeType::PlaceholderStatement |
-            NodeType::Return |
-            NodeType::RevertStatement => {
-                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
-                Ok(())
-            }
-            // Variable declaration
-            NodeType::VariableDeclarationStatement => {
-                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
-                if let Some(expr) = node.attribute("initialValue") {
-                    self.visit_expression(expr)?;
-                }
-                Ok(())
-            }
-            // While loops
-            NodeType::DoWhileStatement | NodeType::WhileStatement => {
-                self.visit_expression(
-                    node.attribute("condition")
-                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
-                )?;
-
-                let body =
-                    node.body.ok_or_else(|| eyre::eyre!("while statement had no body node"))?;
-                self.visit_block_or_statement(*body)
-            }
-            // For loops
-            NodeType::ForStatement => {
-                if let Some(stmt) = node.attribute("initializationExpression") {
-                    self.visit_statement(stmt)?;
-                }
-                if let Some(expr) = node.attribute("condition") {
-                    self.visit_expression(expr)?;
-                }
-                if let Some(stmt) = node.attribute("loopExpression") {
-                    self.visit_statement(stmt)?;
-                }
-
-                let body =
-                    node.body.ok_or_else(|| eyre::eyre!("for statement had no body node"))?;
-                self.visit_block_or_statement(*body)
-            }
-            // Expression statement
-            NodeType::ExpressionStatement => self.visit_expression(
-                node.attribute("expression")
-                    .ok_or_else(|| eyre::eyre!("expression statement had no expression"))?,
-            ),
-            // If statement
-            NodeType::IfStatement => {
-                // TODO: create branch
-                self.visit_expression(
-                    node.attribute("condition")
-                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
-                )?;
-
-                let true_body: Node = node
-                    .attribute("trueBody")
-                    .ok_or_else(|| eyre::eyre!("if statement had no true body"))?;
-
-                // We need to store the current branch ID here since visiting the body of either of
-                // the if blocks may increase `self.branch_id` in the case of nested if statements.
-                let branch_id = self.branch_id;
-
-                // We increase the branch ID here such that nested branches do not use the same
-                // branch ID as we do
-                self.branch_id += 1;
-
-                self.items.push(CoverageItem::Branch {
-                    id: branch_id,
-                    kind: BranchKind::True,
-                    offset: true_body.src.start,
-                    hits: 0,
-                });
-                self.visit_block_or_statement(true_body)?;
-
-                let false_body: Option<Node> = node.attribute("falseBody");
-                if let Some(false_body) = false_body {
-                    self.items.push(CoverageItem::Branch {
-                        id: branch_id,
-                        kind: BranchKind::False,
-                        offset: false_body.src.start,
-                        hits: 0,
-                    });
-                    self.visit_block_or_statement(false_body)?;
-                }
-
-                Ok(())
-            }
-            // Try-catch statement
-            NodeType::TryStatement => {
-                // TODO: Clauses
-                // TODO: This is branching, right?
-                self.visit_expression(
-                    node.attribute("externalCall")
-                        .ok_or_else(|| eyre::eyre!("try statement had no call"))?,
-                )
-            }
-            _ => {
-                warn!("unexpected node type, expected a statement: {:?}", node.node_type);
-                Ok(())
-            }
-        }
-    }
-
-    pub fn visit_expression(&mut self, node: Node) -> eyre::Result<()> {
-        // TODO
-        // elementarytypenameexpression
-        //  memberaccess
-        //  newexpression
-        //  tupleexpression
-        match node.node_type {
-            NodeType::Assignment | NodeType::UnaryOperation | NodeType::BinaryOperation => {
-                // TODO: Should we explore the subexpressions?
-                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
-                Ok(())
-            }
-            NodeType::FunctionCall => {
-                // TODO: Handle assert and require
-                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
-                Ok(())
-            }
-            NodeType::Conditional => {
-                // TODO: Do we count these as branches?
-                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
-                Ok(())
-            }
-            // Does not count towards coverage
-            NodeType::FunctionCallOptions |
-            NodeType::Identifier |
-            NodeType::IndexAccess |
-            NodeType::IndexRangeAccess |
-            NodeType::Literal => Ok(()),
-            _ => {
-                warn!("unexpected node type, expected an expression: {:?}", node.node_type);
-                Ok(())
-            }
-        }
-    }
-
-    pub fn visit_block_or_statement(&mut self, node: Node) -> eyre::Result<()> {
-        match node.node_type {
-            NodeType::Block => self.visit_block(node),
-            NodeType::Break |
-            NodeType::Continue |
-            NodeType::DoWhileStatement |
-            NodeType::EmitStatement |
-            NodeType::ExpressionStatement |
-            NodeType::ForStatement |
-            NodeType::IfStatement |
-            NodeType::InlineAssembly |
-            NodeType::PlaceholderStatement |
-            NodeType::Return |
-            NodeType::RevertStatement |
-            NodeType::TryStatement |
-            NodeType::VariableDeclarationStatement |
-            NodeType::WhileStatement => self.visit_statement(node),
-            _ => {
-                warn!("unexpected node type, expected block or statement: {:?}", node.node_type);
-                Ok(())
-            }
-        }
-    }
-}
-
 // TODO: Move reporters to own module
-/// A coverage reporter.
-pub trait CoverageReporter {
-    fn build(&mut self, map: CoverageMap);
-    fn finalize(self) -> eyre::Result<()>;
-}
-
-/// A simple summary reporter that prints the coverage results in a table.
-struct SummaryReporter {
-    /// The summary table.
-    table: Table,
-    /// The total coverage of the entire project.
-    total: CoverageSummary,
-}
-
-impl SummaryReporter {
-    pub fn new() -> Self {
-        let mut table = Table::new();
-        table.set_header(&["File", "% Lines", "% Statements", "% Branches", "% Funcs"]);
-
-        Self { table, total: CoverageSummary::default() }
-    }
-
-    fn add_row(&mut self, name: impl Into<Cell>, summary: CoverageSummary) {
-        let mut row = Row::new();
-        row.add_cell(name.into())
-            .add_cell(format_cell(summary.line_hits, summary.line_count))
-            .add_cell(format_cell(summary.statement_hits, summary.statement_count))
-            .add_cell(format_cell(summary.branch_hits, summary.branch_count))
-            .add_cell(format_cell(summary.function_hits, summary.function_count));
-        self.table.add_row(row);
-    }
-}
-
-impl CoverageReporter for SummaryReporter {
-    fn build(&mut self, map: CoverageMap) {
-        for file in map {
-            let summary = file.summary();
-
-            self.total.add(&summary);
-            self.add_row(file.path.to_string_lossy(), summary);
-        }
-    }
-
-    fn finalize(mut self) -> eyre::Result<()> {
-        self.add_row("Total", self.total.clone());
-        println!("{}", self.table);
-        Ok(())
-    }
-}
-
-fn format_cell(hits: usize, total: usize) -> Cell {
-    let percentage = if total == 0 { 1. } else { hits as f64 / total as f64 };
-
-    Cell::new(format!("{}% ({hits}/{total})", percentage * 100.)).fg(match percentage {
-        _ if percentage < 0.5 => Color::Red,
-        _ if percentage < 0.75 => Color::Yellow,
-        _ => Color::Green,
-    })
-}
-
-struct LcovReporter<W> {
-    /// Destination buffer
-    destination: W,
-    /// The coverage map to write
-    map: Option<CoverageMap>,
-}
-
-impl<W> LcovReporter<W> {
-    pub fn new(destination: W) -> Self {
-        Self { destination, map: None }
-    }
-}
-
-impl<W> CoverageReporter for LcovReporter<W>
-where
-    W: Write,
-{
-    fn build(&mut self, map: CoverageMap) {
-        self.map = Some(map);
-    }
-
-    fn finalize(mut self) -> eyre::Result<()> {
-        let map = self.map.ok_or_else(|| eyre::eyre!("no coverage map given to reporter"))?;
-
-        for file in map {
-            let summary = file.summary();
-
-            writeln!(self.destination, "TN:")?;
-            writeln!(self.destination, "SF:{}", file.path.to_string_lossy())?;
-
-            // TODO: Line numbers instead of byte offsets
-            for item in file.items {
-                match item {
-                    CoverageItem::Function { name, offset, hits } => {
-                        writeln!(self.destination, "FN:{offset},{name}")?;
-                        writeln!(self.destination, "FNDA:{hits},{name}")?;
-                    }
-                    CoverageItem::Line { offset, hits } => {
-                        writeln!(self.destination, "DA:{offset},{hits}")?;
-                    }
-                    CoverageItem::Branch { id, offset, hits, .. } => {
-                        // TODO: Block ID
-                        writeln!(
-                            self.destination,
-                            "BRDA:{offset},{id},{id},{}",
-                            if hits == 0 { "-".to_string() } else { hits.to_string() }
-                        )?;
-                    }
-                    // Statements are not in the LCOV format
-                    CoverageItem::Statement { .. } => (),
-                }
-            }
-
-            // Function summary
-            writeln!(self.destination, "FNF:{}", summary.function_count)?;
-            writeln!(self.destination, "FNH:{}", summary.function_hits)?;
-
-            // Line summary
-            writeln!(self.destination, "LF:{}", summary.line_count)?;
-            writeln!(self.destination, "LH:{}", summary.line_hits)?;
-
-            // Branch summary
-            writeln!(self.destination, "BRF:{}", summary.branch_count)?;
-            writeln!(self.destination, "BRH:{}", summary.branch_hits)?;
-
-            writeln!(self.destination, "end_of_record")?;
-        }
-
-        println!("Wrote LCOV report.");
-
-        Ok(())
-    }
-}

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -142,7 +142,7 @@ impl CoverageArgs {
             })
             .collect();
 
-        let mut map = CoverageMap::new();
+        let mut map = CoverageMap::default();
         for (path, versioned_sources) in sources.0.into_iter() {
             // TODO: Make these checks robust
             // NOTE: We should actually filter out test contracts in the AST

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -82,6 +82,9 @@ impl Cmd for CoverageArgs {
     }
 }
 
+/// A map, keyed by artifact ID, to a tuple of the deployment source map and the runtime source map.
+type SourceMaps = HashMap<ArtifactId, (SourceMap, SourceMap)>;
+
 // The main flow of the command itself
 impl CoverageArgs {
     /// Collects and adjusts configuration.
@@ -115,14 +118,11 @@ impl CoverageArgs {
     }
 
     /// Builds the coverage map.
-    fn prepare(
-        &self,
-        output: ProjectCompileOutput,
-    ) -> eyre::Result<(CoverageMap, HashMap<ArtifactId, (SourceMap, SourceMap)>)> {
+    fn prepare(&self, output: ProjectCompileOutput) -> eyre::Result<(CoverageMap, SourceMaps)> {
         // Get sources and source maps
         let (artifacts, sources) = output.into_artifacts_with_sources();
 
-        let source_maps: HashMap<ArtifactId, (SourceMap, SourceMap)> = artifacts
+        let source_maps: SourceMaps = artifacts
             .into_iter()
             .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
             .filter_map(|(id, artifact): (ArtifactId, CompactContractBytecode)| {
@@ -194,7 +194,7 @@ impl CoverageArgs {
         self,
         project: Project,
         output: ProjectCompileOutput,
-        source_maps: HashMap<ArtifactId, (SourceMap, SourceMap)>,
+        source_maps: SourceMaps,
         mut map: CoverageMap,
         config: Config,
         evm_opts: EvmOpts,

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -145,6 +145,10 @@ impl CoverageArgs {
         let mut map = CoverageMap::new();
         for (path, versioned_sources) in sources.0.into_iter() {
             // TODO: Make these checks robust
+            // NOTE: We should actually filter out test contracts in the AST
+            // instead of on a source file level. Repositories like Solmate
+            // have a lot of abstract contracts that are being tested, and these
+            // are usually defined in the test files themselves.
             let is_test = path.ends_with(".t.sol");
             let is_dependency = path.starts_with("lib");
             if is_test || is_dependency {

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -123,9 +123,8 @@ impl CoverageArgs {
         let (artifacts, sources) = output.into_artifacts_with_sources();
 
         let source_maps: HashMap<ArtifactId, (SourceMap, SourceMap)> = artifacts
-            .iter()
-            // TODO: Filter out dependencies
-            .map(|(id, artifact)| (id.clone(), CompactContractBytecode::from(artifact.clone())))
+            .into_iter()
+            .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
             .filter_map(|(id, artifact): (ArtifactId, CompactContractBytecode)| {
                 Some((
                     id,
@@ -145,6 +144,13 @@ impl CoverageArgs {
 
         let mut map = CoverageMap::new();
         for (path, versioned_sources) in sources.0.into_iter() {
+            // TODO: Make these checks robust
+            let is_test = path.ends_with(".t.sol");
+            let is_dependency = path.starts_with("lib");
+            if is_test || is_dependency {
+                continue
+            }
+
             for mut versioned_source in versioned_sources {
                 let source = &mut versioned_source.source_file;
                 if let Some(ast) = source.ast.take() {

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -1,0 +1,626 @@
+//! Coverage command
+use crate::{
+    cmd::{
+        forge::{build::CoreBuildArgs, test::Filter},
+        Cmd,
+    },
+    compile::ProjectCompiler,
+    utils,
+};
+use cast::coverage::{BranchKind, CoverageItem, CoverageMap, CoverageSummary};
+use clap::{AppSettings, ArgEnum, Parser};
+use comfy_table::{Cell, Color, Row, Table};
+use ethers::{
+    prelude::{artifacts::Node, Artifact, Project, ProjectCompileOutput},
+    solc::{
+        artifacts::{
+            ast::{Ast, NodeType},
+            contract::CompactContractBytecode,
+        },
+        sourcemap::{self, SourceMap},
+        ArtifactId,
+    },
+};
+use forge::{
+    executor::opts::EvmOpts,
+    result::SuiteResult,
+    trace::{identifier::LocalTraceIdentifier, CallTraceDecoder, CallTraceDecoderBuilder},
+    MultiContractRunnerBuilder,
+};
+use foundry_common::evm::EvmArgs;
+use foundry_config::{figment::Figment, Config};
+use std::{collections::BTreeMap, io::Write, sync::mpsc::channel, thread};
+use tracing::warn;
+
+// Loads project's figment and merges the build cli arguments into it
+foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
+
+/// Generate coverage reports for your tests.
+#[derive(Debug, Clone, Parser)]
+#[clap(global_setting = AppSettings::DeriveDisplayOrder)]
+pub struct CoverageArgs {
+    #[clap(
+        long,
+        arg_enum,
+        default_value = "summary",
+        help = "The report type to use for coverage."
+    )]
+    report: CoverageReportKind,
+
+    #[clap(flatten, next_help_heading = "TEST FILTERING")]
+    filter: Filter,
+
+    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    evm_opts: EvmArgs,
+
+    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    opts: CoreBuildArgs,
+}
+
+impl CoverageArgs {
+    /// Returns the flattened [`CoreBuildArgs`]
+    pub fn build_args(&self) -> &CoreBuildArgs {
+        &self.opts
+    }
+
+    /// Returns the currently configured [Config] and the extracted [EvmOpts] from that config
+    pub fn config_and_evm_opts(&self) -> eyre::Result<(Config, EvmOpts)> {
+        // merge all configs
+        let figment: Figment = self.into();
+        let evm_opts = figment.extract()?;
+        let config = Config::from_provider(figment).sanitized();
+
+        Ok((config, evm_opts))
+    }
+}
+
+impl Cmd for CoverageArgs {
+    type Output = ();
+
+    fn run(self) -> eyre::Result<Self::Output> {
+        let (config, evm_opts) = self.configure()?;
+        let (project, output) = self.build(&config)?;
+        println!("Analysing contracts...");
+        let (map, source_maps) = self.prepare(output.clone())?;
+
+        println!("Running tests...");
+        self.collect(project, output, source_maps, map, config, evm_opts)
+    }
+}
+
+impl CoverageArgs {
+    /// Collects and adjusts configuration.
+    fn configure(&self) -> eyre::Result<(Config, EvmOpts)> {
+        // Merge all configs
+        let (config, mut evm_opts) = self.config_and_evm_opts()?;
+
+        // We always want traces
+        evm_opts.verbosity = 3;
+
+        Ok((config, evm_opts))
+    }
+
+    /// Builds the project.
+    fn build(&self, config: &Config) -> eyre::Result<(Project, ProjectCompileOutput)> {
+        // Set up the project
+        let project = {
+            let mut project = config.ephemeral_no_artifacts_project()?;
+
+            // Disable the optimizer for more accurate source maps
+            project.solc_config.settings.optimizer.disable();
+
+            project
+        };
+
+        // TODO: This does not strip file prefixes for `SourceFiles`...
+        let output = ProjectCompiler::default()
+            .compile(&project)?
+            .with_stripped_file_prefixes(project.root());
+
+        Ok((project, output))
+    }
+
+    /// Builds the coverage map.
+    fn prepare(
+        &self,
+        output: ProjectCompileOutput,
+    ) -> eyre::Result<(CoverageMap, BTreeMap<ArtifactId, SourceMap>)> {
+        // Get sources and source maps
+        let (artifacts, sources) = output.into_artifacts_with_sources();
+
+        let source_maps: BTreeMap<ArtifactId, SourceMap> = artifacts
+            .into_iter()
+            .filter(|(_, artifact)| {
+                // TODO: Filter out dependencies
+                // Filter out tests
+                !artifact
+                    .get_abi()
+                    .map(|abi| abi.functions().any(|f| f.name.starts_with("test")))
+                    .unwrap_or_default()
+            })
+            .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
+            .filter_map(|(id, artifact): (ArtifactId, CompactContractBytecode)| {
+                let source_map = artifact
+                    .deployed_bytecode
+                    .as_ref()
+                    .and_then(|bytecode| bytecode.bytecode.as_ref())
+                    .and_then(|bytecode| bytecode.source_map.as_ref())
+                    .and_then(|source_map| sourcemap::parse(source_map).ok())?;
+
+                Some((id, source_map))
+            })
+            .collect();
+
+        let mut map = CoverageMap::new();
+        for (path, versioned_sources) in sources.0.into_iter() {
+            for mut versioned_source in versioned_sources {
+                let source = &mut versioned_source.source_file;
+                if let Some(ast) = source.ast.take() {
+                    let mut visitor = Visitor::new();
+                    visitor.visit_ast(ast)?;
+
+                    if visitor.items.is_empty() {
+                        continue
+                    }
+
+                    map.add_source(path.clone(), versioned_source, visitor.items);
+                }
+            }
+        }
+
+        Ok((map, source_maps))
+    }
+
+    /// Runs tests, collects coverage data and generates the final report.
+    fn collect(
+        self,
+        project: Project,
+        output: ProjectCompileOutput,
+        source_maps: BTreeMap<ArtifactId, SourceMap>,
+        map: CoverageMap,
+        config: Config,
+        evm_opts: EvmOpts,
+    ) -> eyre::Result<()> {
+        // Setup the fuzzer
+        // TODO: Add CLI Options to modify the persistence
+        let cfg = proptest::test_runner::Config {
+            failure_persistence: None,
+            cases: config.fuzz_runs,
+            max_local_rejects: config.fuzz_max_local_rejects,
+            max_global_rejects: config.fuzz_max_global_rejects,
+            ..Default::default()
+        };
+        let fuzzer = proptest::test_runner::TestRunner::new(cfg);
+        let root = project.paths.root;
+
+        // Build the contract runner
+        let evm_spec = crate::utils::evm_spec(&config.evm_version);
+        let mut runner = MultiContractRunnerBuilder::default()
+            .fuzzer(fuzzer)
+            .initial_balance(evm_opts.initial_balance)
+            .evm_spec(evm_spec)
+            .sender(evm_opts.sender)
+            .with_fork(utils::get_fork(&evm_opts, &config.rpc_storage_caching))
+            .with_coverage()
+            .build(root.clone(), output, evm_opts)?;
+        let (tx, rx) = channel::<(String, SuiteResult)>();
+
+        // Set up identifier
+        let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
+
+        // TODO: Coverage for fuzz tests
+        let handle = thread::spawn(move || runner.test(&self.filter, Some(tx), false).unwrap());
+        for mut result in rx.into_iter().flat_map(|(_, suite)| suite.test_results.into_values()) {
+            if let Some(hit_data) = result.coverage.take() {
+                let mut decoder =
+                    CallTraceDecoderBuilder::new().with_events(local_identifier.events()).build();
+                for (_, trace) in &mut result.traces {
+                    decoder.identify(trace, &local_identifier);
+                }
+                // TODO: We need an ArtifactId here for the addresses
+                let CallTraceDecoder { contracts, .. } = decoder;
+
+                // ..
+            }
+        }
+
+        // Reattach the thread
+        let _ = handle.join();
+
+        match self.report {
+            CoverageReportKind::Summary => {
+                let mut reporter = SummaryReporter::new();
+                reporter.build(map);
+                reporter.finalize()
+            }
+            // TODO: Sensible place to put the LCOV file
+            CoverageReportKind::Lcov => {
+                let mut reporter =
+                    LcovReporter::new(std::fs::File::create(root.join("lcov.info"))?);
+                reporter.build(map);
+                reporter.finalize()
+            }
+        }
+    }
+}
+
+// TODO: HTML
+#[derive(Debug, Clone, ArgEnum)]
+pub enum CoverageReportKind {
+    Summary,
+    Lcov,
+}
+
+// TODO: Move to other module
+#[derive(Debug, Default, Clone)]
+struct Visitor {
+    /// Coverage items
+    pub items: Vec<CoverageItem>,
+    /// The current branch ID
+    // TODO: Does this need to be unique across files?
+    pub branch_id: usize,
+}
+
+impl Visitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn visit_ast(&mut self, ast: Ast) -> eyre::Result<()> {
+        for node in ast.nodes.into_iter() {
+            if !matches!(node.node_type, NodeType::ContractDefinition) {
+                continue
+            }
+
+            self.visit_contract(node)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn visit_contract(&mut self, node: Node) -> eyre::Result<()> {
+        let is_contract =
+            node.attribute("contractKind").map_or(false, |kind: String| kind == "contract");
+        let is_abstract: bool = node.attribute("abstract").unwrap_or_default();
+
+        // Skip interfaces, libraries and abstract contracts
+        if !is_contract || is_abstract {
+            return Ok(())
+        }
+
+        for node in node.nodes {
+            if node.node_type == NodeType::FunctionDefinition {
+                self.visit_function_definition(node)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn visit_function_definition(&mut self, mut node: Node) -> eyre::Result<()> {
+        let name: String =
+            node.attribute("name").ok_or_else(|| eyre::eyre!("function has no name"))?;
+        let is_virtual: bool = node.attribute("virtual").unwrap_or_default();
+
+        // Skip virtual functions
+        if is_virtual {
+            return Ok(())
+        }
+
+        match node.body.take() {
+            // Skip virtual functions
+            Some(body) if !is_virtual => {
+                self.items.push(CoverageItem::Function { name, offset: node.src.start, hits: 0 });
+                self.visit_block(*body)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    pub fn visit_block(&mut self, node: Node) -> eyre::Result<()> {
+        let statements: Vec<Node> = node.attribute("statements").unwrap_or_default();
+
+        for statement in statements {
+            self.visit_statement(statement)?;
+        }
+
+        Ok(())
+    }
+    pub fn visit_statement(&mut self, node: Node) -> eyre::Result<()> {
+        // TODO: inlineassembly
+        match node.node_type {
+            // Blocks
+            NodeType::Block | NodeType::UncheckedBlock => self.visit_block(node),
+            // Simple statements
+            NodeType::Break |
+            NodeType::Continue |
+            NodeType::EmitStatement |
+            NodeType::PlaceholderStatement |
+            NodeType::Return |
+            NodeType::RevertStatement => {
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            // Variable declaration
+            NodeType::VariableDeclarationStatement => {
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                if let Some(expr) = node.attribute("initialValue") {
+                    self.visit_expression(expr)?;
+                }
+                Ok(())
+            }
+            // While loops
+            NodeType::DoWhileStatement | NodeType::WhileStatement => {
+                self.visit_expression(
+                    node.attribute("condition")
+                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
+                )?;
+
+                let body =
+                    node.body.ok_or_else(|| eyre::eyre!("while statement had no body node"))?;
+                self.visit_block_or_statement(*body)
+            }
+            // For loops
+            NodeType::ForStatement => {
+                if let Some(stmt) = node.attribute("initializationExpression") {
+                    self.visit_statement(stmt)?;
+                }
+                if let Some(expr) = node.attribute("condition") {
+                    self.visit_expression(expr)?;
+                }
+                if let Some(stmt) = node.attribute("loopExpression") {
+                    self.visit_statement(stmt)?;
+                }
+
+                let body =
+                    node.body.ok_or_else(|| eyre::eyre!("for statement had no body node"))?;
+                self.visit_block_or_statement(*body)
+            }
+            // Expression statement
+            NodeType::ExpressionStatement => self.visit_expression(
+                node.attribute("expression")
+                    .ok_or_else(|| eyre::eyre!("expression statement had no expression"))?,
+            ),
+            // If statement
+            NodeType::IfStatement => {
+                // TODO: create branch
+                self.visit_expression(
+                    node.attribute("condition")
+                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
+                )?;
+
+                let true_body: Node = node
+                    .attribute("trueBody")
+                    .ok_or_else(|| eyre::eyre!("if statement had no true body"))?;
+                self.items.push(CoverageItem::Branch {
+                    id: self.branch_id,
+                    kind: BranchKind::True,
+                    offset: true_body.src.start,
+                    hits: 0,
+                });
+                self.visit_block_or_statement(true_body)?;
+
+                let false_body: Option<Node> = node.attribute("falseBody");
+                if let Some(false_body) = false_body {
+                    self.items.push(CoverageItem::Branch {
+                        id: self.branch_id,
+                        kind: BranchKind::False,
+                        offset: false_body.src.start,
+                        hits: 0,
+                    });
+                    self.visit_block_or_statement(false_body)?;
+                }
+
+                self.branch_id += 1;
+                Ok(())
+            }
+            // Try-catch statement
+            NodeType::TryStatement => {
+                // TODO: Clauses
+                // TODO: This is branching, right?
+                self.visit_expression(
+                    node.attribute("externalCall")
+                        .ok_or_else(|| eyre::eyre!("try statement had no call"))?,
+                )
+            }
+            _ => {
+                warn!("unexpected node type, expected a statement: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn visit_expression(&mut self, node: Node) -> eyre::Result<()> {
+        // TODO
+        // elementarytypenameexpression
+        //  memberaccess
+        //  newexpression
+        //  tupleexpression
+        match node.node_type {
+            NodeType::Assignment | NodeType::UnaryOperation | NodeType::BinaryOperation => {
+                // TODO: Should we explore the subexpressions?
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            NodeType::FunctionCall => {
+                // TODO: Handle assert and require
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            NodeType::Conditional => {
+                // TODO: Do we count these as branches?
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            // Does not count towards coverage
+            NodeType::FunctionCallOptions |
+            NodeType::Identifier |
+            NodeType::IndexAccess |
+            NodeType::IndexRangeAccess |
+            NodeType::Literal => Ok(()),
+            _ => {
+                warn!("unexpected node type, expected an expression: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn visit_block_or_statement(&mut self, node: Node) -> eyre::Result<()> {
+        match node.node_type {
+            NodeType::Block => self.visit_block(node),
+            NodeType::Break |
+            NodeType::Continue |
+            NodeType::DoWhileStatement |
+            NodeType::EmitStatement |
+            NodeType::ExpressionStatement |
+            NodeType::ForStatement |
+            NodeType::IfStatement |
+            NodeType::InlineAssembly |
+            NodeType::PlaceholderStatement |
+            NodeType::Return |
+            NodeType::RevertStatement |
+            NodeType::TryStatement |
+            NodeType::VariableDeclarationStatement |
+            NodeType::WhileStatement => self.visit_statement(node),
+            _ => {
+                warn!("unexpected node type, expected block or statement: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+}
+
+// TODO: Move reporters to own module
+/// A coverage reporter.
+pub trait CoverageReporter {
+    fn build(&mut self, map: CoverageMap);
+    fn finalize(self) -> eyre::Result<()>;
+}
+
+/// A simple summary reporter that prints the coverage results in a table.
+struct SummaryReporter {
+    /// The summary table.
+    table: Table,
+    /// The total coverage of the entire project.
+    total: CoverageSummary,
+}
+
+impl SummaryReporter {
+    pub fn new() -> Self {
+        let mut table = Table::new();
+        table.set_header(&["File", "% Lines", "% Statements", "% Branches", "% Funcs"]);
+
+        Self { table, total: CoverageSummary::default() }
+    }
+
+    fn add_row(&mut self, name: impl Into<Cell>, summary: CoverageSummary) {
+        let mut row = Row::new();
+        row.add_cell(name.into())
+            .add_cell(format_cell(summary.line_hits, summary.line_count))
+            .add_cell(format_cell(summary.statement_hits, summary.statement_count))
+            .add_cell(format_cell(summary.branch_hits, summary.branch_count))
+            .add_cell(format_cell(summary.function_hits, summary.function_count));
+        self.table.add_row(row);
+    }
+}
+
+impl CoverageReporter for SummaryReporter {
+    fn build(&mut self, map: CoverageMap) {
+        for file in map {
+            let summary = file.summary();
+
+            self.total.add(&summary);
+            self.add_row(file.path.to_string_lossy(), summary);
+        }
+    }
+
+    fn finalize(mut self) -> eyre::Result<()> {
+        self.add_row("Total", self.total.clone());
+        println!("{}", self.table);
+        Ok(())
+    }
+}
+
+fn format_cell(hits: usize, total: usize) -> Cell {
+    let percentage = if total == 0 { 1. } else { hits as f64 / total as f64 };
+
+    Cell::new(format!("{}% ({hits}/{total})", percentage * 100.)).fg(match percentage {
+        _ if percentage < 0.5 => Color::Red,
+        _ if percentage < 0.75 => Color::Yellow,
+        _ => Color::Green,
+    })
+}
+
+struct LcovReporter<W> {
+    /// Destination buffer
+    destination: W,
+    /// The coverage map to write
+    map: Option<CoverageMap>,
+}
+
+impl<W> LcovReporter<W> {
+    pub fn new(destination: W) -> Self {
+        Self { destination, map: None }
+    }
+}
+
+impl<W> CoverageReporter for LcovReporter<W>
+where
+    W: Write,
+{
+    fn build(&mut self, map: CoverageMap) {
+        self.map = Some(map);
+    }
+
+    fn finalize(mut self) -> eyre::Result<()> {
+        let map = self.map.ok_or_else(|| eyre::eyre!("no coverage map given to reporter"))?;
+
+        for file in map {
+            let summary = file.summary();
+
+            writeln!(self.destination, "TN:")?;
+            writeln!(self.destination, "SF:{}", file.path.to_string_lossy())?;
+
+            // TODO: Line numbers instead of byte offsets
+            for item in file.items {
+                match item {
+                    CoverageItem::Function { name, offset, hits } => {
+                        writeln!(self.destination, "FN:{offset},{name}")?;
+                        writeln!(self.destination, "FNDA:{hits},{name}")?;
+                    }
+                    CoverageItem::Line { offset, hits } => {
+                        writeln!(self.destination, "DA:{offset},{hits}")?;
+                    }
+                    CoverageItem::Branch { id, offset, hits, .. } => {
+                        // TODO: Block ID
+                        writeln!(
+                            self.destination,
+                            "BRDA:{offset},{id},{id},{}",
+                            if hits == 0 { "-".to_string() } else { hits.to_string() }
+                        )?;
+                    }
+                    // Statements are not in the LCOV format
+                    CoverageItem::Statement { .. } => (),
+                }
+            }
+
+            // Function summary
+            writeln!(self.destination, "FNF:{}", summary.function_count)?;
+            writeln!(self.destination, "FNH:{}", summary.function_hits)?;
+
+            // Line summary
+            writeln!(self.destination, "LF:{}", summary.line_count)?;
+            writeln!(self.destination, "LH:{}", summary.line_hits)?;
+
+            // Branch summary
+            writeln!(self.destination, "BRF:{}", summary.branch_count)?;
+            writeln!(self.destination, "BRH:{}", summary.branch_hits)?;
+
+            writeln!(self.destination, "end_of_record")?;
+        }
+
+        println!("Wrote LCOV report.");
+
+        Ok(())
+    }
+}

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -12,11 +12,7 @@ use clap::{AppSettings, ArgEnum, Parser};
 use ethers::{
     abi::Address,
     prelude::{Artifact, Project, ProjectCompileOutput},
-    solc::{
-        artifacts::contract::CompactContractBytecode,
-        sourcemap::{self, SourceMap},
-        ArtifactId,
-    },
+    solc::{artifacts::contract::CompactContractBytecode, sourcemap::SourceMap, ArtifactId},
 };
 use forge::{
     coverage::{CoverageMap, CoverageReporter, LcovReporter, SummaryReporter, Visitor},
@@ -137,14 +133,7 @@ impl CoverageArgs {
             })
             .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
             .filter_map(|(id, artifact): (ArtifactId, CompactContractBytecode)| {
-                let source_map = artifact
-                    .deployed_bytecode
-                    .as_ref()
-                    .and_then(|bytecode| bytecode.bytecode.as_ref())
-                    .and_then(|bytecode| bytecode.source_map.as_ref())
-                    .and_then(|source_map| sourcemap::parse(source_map).ok())?;
-
-                Some((id, source_map))
+                artifact.get_source_map().and_then(|source_map| Some((id, source_map.ok()?)))
             })
             .collect();
 

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -11,7 +11,7 @@ use cast::trace::identifier::TraceIdentifier;
 use clap::{AppSettings, ArgEnum, Parser};
 use ethers::{
     abi::Address,
-    prelude::{artifacts, Artifact, Project, ProjectCompileOutput},
+    prelude::{Artifact, Project, ProjectCompileOutput},
     solc::{
         artifacts::contract::CompactContractBytecode,
         sourcemap::{self, SourceMap},
@@ -232,11 +232,7 @@ impl CoverageArgs {
                                 source_map,
                                 hit_map.clone(),
                             );
-                        } else {
-                            println!("Found no hit map: {:?}", artifact_id);
                         }
-                    } else {
-                        println!("Found no source map: {:?}", artifact_id);
                     }
                 }
             }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -14,7 +14,9 @@ use ethers::{
     solc::{artifacts::contract::CompactContractBytecode, sourcemap::SourceMap, ArtifactId},
 };
 use forge::{
-    coverage::{CoverageMap, CoverageReporter, LcovReporter, SummaryReporter, Visitor},
+    coverage::{
+        CoverageMap, CoverageReporter, DebugReporter, LcovReporter, SummaryReporter, Visitor,
+    },
     executor::opts::EvmOpts,
     result::SuiteResult,
     trace::identifier::LocalTraceIdentifier,
@@ -237,6 +239,11 @@ impl CoverageArgs {
                 reporter.build(map);
                 reporter.finalize()
             }
+            CoverageReportKind::Debug => {
+                let mut reporter = DebugReporter::new();
+                reporter.build(map);
+                reporter.finalize()
+            }
         }
     }
 }
@@ -246,4 +253,5 @@ impl CoverageArgs {
 pub enum CoverageReportKind {
     Summary,
     Lcov,
+    Debug,
 }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -5,7 +5,7 @@ use crate::{
         Cmd,
     },
     compile::ProjectCompiler,
-    utils::{self, p_println},
+    utils::{self, p_println, FoundryPathExt},
 };
 use cast::trace::identifier::TraceIdentifier;
 use clap::{AppSettings, ArgEnum, Parser};
@@ -149,7 +149,7 @@ impl CoverageArgs {
             // instead of on a source file level. Repositories like Solmate
             // have a lot of abstract contracts that are being tested, and these
             // are usually defined in the test files themselves.
-            let is_test = path.ends_with(".t.sol");
+            let is_test = path.is_sol_test();
             let is_dependency = path.starts_with("lib");
             if is_test || is_dependency {
                 continue

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -5,7 +5,7 @@ use crate::{
         Cmd,
     },
     compile::ProjectCompiler,
-    utils,
+    utils::{self, p_println},
 };
 use cast::trace::identifier::TraceIdentifier;
 use clap::{AppSettings, ArgEnum, Parser};
@@ -74,10 +74,10 @@ impl Cmd for CoverageArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let (config, evm_opts) = self.configure()?;
         let (project, output) = self.build(&config)?;
-        println!("Analysing contracts...");
+        p_println!(!self.opts.silent => "Analysing contracts...");
         let (map, source_maps) = self.prepare(output.clone())?;
 
-        println!("Running tests...");
+        p_println!(!self.opts.silent => "Running tests...");
         self.collect(project, output, source_maps, map, config, evm_opts)
     }
 }
@@ -212,7 +212,7 @@ impl CoverageArgs {
         let root = project.paths.root;
 
         // Build the contract runner
-        let evm_spec = crate::utils::evm_spec(&config.evm_version);
+        let evm_spec = utils::evm_spec(&config.evm_version);
         let mut runner = MultiContractRunnerBuilder::default()
             .fuzzer(fuzzer)
             .initial_balance(evm_opts.initial_balance)

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -170,12 +170,9 @@ impl CoverageArgs {
                         })
                         .collect();
 
-                    let items = Visitor::new(
-                        source.id,
-                        std::fs::read_to_string(PathBuf::from(&path))?,
-                        source_maps,
-                    )
-                    .visit_ast(ast)?;
+                    let items =
+                        Visitor::new(source.id, std::fs::read_to_string(&path)?, source_maps)
+                            .visit_ast(ast)?;
 
                     if items.is_empty() {
                         continue

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -250,23 +250,12 @@ impl CoverageArgs {
         let _ = handle.join();
 
         match self.report {
-            CoverageReportKind::Summary => {
-                let mut reporter = SummaryReporter::new();
-                reporter.build(map);
-                reporter.finalize()
-            }
+            CoverageReportKind::Summary => SummaryReporter::default().report(map),
             // TODO: Sensible place to put the LCOV file
             CoverageReportKind::Lcov => {
-                let mut reporter =
-                    LcovReporter::new(std::fs::File::create(root.join("lcov.info"))?);
-                reporter.build(map);
-                reporter.finalize()
+                LcovReporter::new(std::fs::File::create(root.join("lcov.info"))?).report(map)
             }
-            CoverageReportKind::Debug => {
-                let mut reporter = DebugReporter::new();
-                reporter.build(map);
-                reporter.finalize()
-            }
+            CoverageReportKind::Debug => DebugReporter::default().report(map),
         }
     }
 }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -253,7 +253,7 @@ impl CoverageArgs {
             CoverageReportKind::Summary => SummaryReporter::default().report(map),
             // TODO: Sensible place to put the LCOV file
             CoverageReportKind::Lcov => {
-                LcovReporter::new(std::fs::File::create(root.join("lcov.info"))?).report(map)
+                LcovReporter::new(&mut std::fs::File::create(root.join("lcov.info"))?).report(map)
             }
             CoverageReportKind::Debug => DebugReporter::default().report(map),
         }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -216,7 +216,7 @@ impl CoverageArgs {
             .evm_spec(evm_spec)
             .sender(evm_opts.sender)
             .with_fork(utils::get_fork(&evm_opts, &config.rpc_storage_caching))
-            .with_coverage()
+            .set_coverage(true)
             .build(root.clone(), output, evm_opts)?;
         let (tx, rx) = channel::<(String, SuiteResult)>();
 

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -22,7 +22,7 @@ use forge::{
     trace::identifier::LocalTraceIdentifier,
     MultiContractRunnerBuilder,
 };
-use foundry_common::evm::EvmArgs;
+use foundry_common::{evm::EvmArgs, fs};
 use foundry_config::{figment::Figment, Config};
 use std::{collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
 
@@ -170,9 +170,8 @@ impl CoverageArgs {
                         })
                         .collect();
 
-                    let items =
-                        Visitor::new(source.id, std::fs::read_to_string(&path)?, source_maps)
-                            .visit_ast(ast)?;
+                    let items = Visitor::new(source.id, fs::read_to_string(&path)?, source_maps)
+                        .visit_ast(ast)?;
 
                     if items.is_empty() {
                         continue
@@ -253,7 +252,7 @@ impl CoverageArgs {
             CoverageReportKind::Summary => SummaryReporter::default().report(map),
             // TODO: Sensible place to put the LCOV file
             CoverageReportKind::Lcov => {
-                LcovReporter::new(&mut std::fs::File::create(root.join("lcov.info"))?).report(map)
+                LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(map)
             }
             CoverageReportKind::Debug => DebugReporter::default().report(map),
         }

--- a/cli/src/cmd/forge/mod.rs
+++ b/cli/src/cmd/forge/mod.rs
@@ -41,6 +41,7 @@ pub mod bind;
 pub mod build;
 pub mod cache;
 pub mod config;
+pub mod coverage;
 pub mod create;
 pub mod debug;
 pub mod flatten;

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -159,20 +159,15 @@ impl ScriptArgs {
         )
         .await;
 
-        let mut builder = ExecutorBuilder::default()
+        let executor = ExecutorBuilder::default()
             .with_cheatcodes(CheatsConfig::new(&script_config.config, &script_config.evm_opts))
             .with_config(env)
             .with_spec(crate::utils::evm_spec(&script_config.config.evm_version))
-            .with_gas_limit(script_config.evm_opts.gas_limit());
+            .with_gas_limit(script_config.evm_opts.gas_limit())
+            .set_tracing(script_config.evm_opts.verbosity >= 3 || self.debug)
+            .set_debugger(self.debug)
+            .build(db);
 
-        if script_config.evm_opts.verbosity >= 3 {
-            builder = builder.with_tracing();
-        }
-
-        if self.debug {
-            builder = builder.with_tracing().with_debugger();
-        }
-
-        ScriptRunner::new(builder.build(db), script_config.evm_opts.initial_balance, sender)
+        ScriptRunner::new(executor, script_config.evm_opts.initial_balance, sender)
     }
 }

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -35,6 +35,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Script(cmd) => {
             utils::block_on(cmd.run_script())?;
         }
+        Subcommands::Coverage(cmd) => {
+            cmd.run()?;
+        }
         Subcommands::Bind(cmd) => {
             cmd.run()?;
         }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -7,7 +7,7 @@ use crate::cmd::forge::{
     bind::BindArgs,
     build::BuildArgs,
     cache::CacheArgs,
-    config,
+    config, coverage,
     create::CreateArgs,
     debug::DebugArgs,
     flatten,
@@ -59,7 +59,10 @@ pub enum Subcommands {
     #[clap(visible_alias = "s")]
     Script(ScriptArgs),
 
-    #[clap(visible_alias = "bi")]
+    #[clap(about = "Generate coverage reports.")]
+    Coverage(coverage::CoverageArgs),
+
+    #[clap(alias = "bi")]
     #[clap(about = "Generate Rust bindings for smart contracts.")]
     Bind(BindArgs),
 

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -46,5 +46,8 @@ proptest = "1.0.0"
 yansi = "0.5.1"
 url = "2.2.2"
 
+# Coverage
+semver = "1.0.5"
+
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/evm/src/coverage.rs
+++ b/evm/src/coverage.rs
@@ -1,0 +1,257 @@
+use ethers::{
+    prelude::{sourcemap::SourceMap, sources::VersionedSourceFile},
+    types::Address,
+};
+use semver::Version;
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+    usize,
+};
+
+/// A coverage map.
+///
+/// The coverage map collects coverage items for sources. It also converts hit data from
+/// [HitMap]s into their appropriate coverage items.
+///
+/// You **MUST** add all the sources before you start adding hit data.
+#[derive(Default, Debug, Clone)]
+pub struct CoverageMap {
+    /// A map of `(version, source id)` -> `source file`
+    sources: BTreeMap<(Version, u32), SourceFile>,
+}
+
+impl CoverageMap {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Adds coverage items and a source map for the given source.
+    ///
+    /// Sources are identified by path, and then by source ID and version.
+    ///
+    /// We need both the version and the source ID in case the project has distinct file
+    /// hierarchies that use different compiler versions, as that will result in multiple compile
+    /// jobs, and source IDs are only guaranteed to be stable across a single compile job.
+    pub fn add_source(
+        &mut self,
+        path: String,
+        source: VersionedSourceFile,
+        items: Vec<CoverageItem>,
+    ) {
+        let VersionedSourceFile { version, source_file: source } = source;
+
+        self.sources.insert((version, source.id), SourceFile { path: PathBuf::from(path), items });
+    }
+
+    pub fn add_hit_map(
+        &mut self,
+        source_version: Version,
+        source_map: &SourceMap,
+        hit_map: HitMap,
+    ) {
+        // NOTE(onbjerg): I've made an assumption here that the coverage items are laid out in
+        // sorted order, ordered by their offset in the source code.
+        //
+        // This assumption is based on the way we process the AST - we start at the root node,
+        // and work our way down. If we change up how we process the AST, we *have* to either
+        // change this logic to work with unsorted data, or sort the data prior to calling
+        // this function.
+        for (ic, instruction_hits) in hit_map.hits.into_iter() {
+            if instruction_hits == 0 {
+                continue
+            }
+
+            // Get the instruction offset and the source ID in the source map.
+            let (instruction_offset, source_id) = if let Some((instruction_offset, source_id)) =
+                source_map
+                    .get(ic)
+                    .and_then(|source_element| Some((source_element.offset, source_element.index?)))
+            {
+                (instruction_offset, source_id)
+            } else {
+                continue
+            };
+
+            // Get the coverage items corresponding to the source ID in the source map.
+            if let Some(source) = self.sources.get_mut(&(source_version.clone(), source_id)) {
+                for item in source.items.iter_mut() {
+                    match item {
+                        CoverageItem::Line { offset, hits } |
+                        CoverageItem::Statement { offset, hits } |
+                        CoverageItem::Branch { offset, hits, .. } |
+                        CoverageItem::Function { offset, hits, .. } => {
+                            // We've reached a point where we will no longer be able to map this
+                            // instruction to coverage items
+                            if instruction_offset < *offset {
+                                break
+                            }
+
+                            // We found a matching coverage item, but there may be more
+                            if instruction_offset == *offset {
+                                *hits += instruction_hits;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl IntoIterator for CoverageMap {
+    type Item = SourceFile;
+    type IntoIter = std::collections::btree_map::IntoValues<(Version, u32), Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.sources.into_values()
+    }
+}
+
+/// A collection of [HitMap]s
+pub type HitMaps = HashMap<Address, HitMap>;
+
+/// Hit data for an address.
+///
+/// Contains low-level data about hit counters for the instructions in the bytecode of a contract.
+#[derive(Debug, Clone, Default)]
+pub struct HitMap {
+    hits: BTreeMap<usize, u64>,
+}
+
+impl HitMap {
+    /// Increase the hit counter for the given instruction counter.
+    pub fn hit(&mut self, ic: usize) {
+        *self.hits.entry(ic).or_default() += 1;
+    }
+}
+
+/// A source file.
+#[derive(Default, Debug, Clone)]
+pub struct SourceFile {
+    pub path: PathBuf,
+    pub items: Vec<CoverageItem>,
+}
+
+impl SourceFile {
+    /// Get a simple summary of the coverage for the file.
+    pub fn summary(&self) -> CoverageSummary {
+        self.items.iter().fold(CoverageSummary::default(), |mut summary, item| match item {
+            CoverageItem::Line { hits, .. } => {
+                summary.line_count += 1;
+                if *hits > 0 {
+                    summary.line_hits += 1;
+                }
+                summary
+            }
+            CoverageItem::Statement { hits, .. } => {
+                summary.statement_count += 1;
+                if *hits > 0 {
+                    summary.statement_hits += 1;
+                }
+                summary
+            }
+            CoverageItem::Branch { hits, .. } => {
+                summary.branch_count += 1;
+                if *hits > 0 {
+                    summary.branch_hits += 1;
+                }
+                summary
+            }
+            CoverageItem::Function { hits, .. } => {
+                summary.function_count += 1;
+                if *hits > 0 {
+                    summary.function_hits += 1;
+                }
+                summary
+            }
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CoverageItem {
+    /// An executable line in the code.
+    Line {
+        /// The byte offset in the source file for the start of the line.
+        offset: usize,
+        /// The number of times this item was hit.
+        hits: u64,
+    },
+
+    /// A statement in the code.
+    Statement {
+        /// The byte offset in the source file for the start of the statement.
+        offset: usize,
+        /// The number of times this statement was hit.
+        hits: u64,
+    },
+
+    /// A branch in the code.
+    Branch {
+        /// The ID that identifies the branch.
+        ///
+        /// There are two branches with the same ID,
+        /// one for each outcome (true and false).
+        id: usize,
+        /// The branch kind.
+        kind: BranchKind,
+        /// The byte offset which the branch is on in the source file.
+        offset: usize,
+        /// The number of times this item was hit.
+        hits: u64,
+    },
+
+    /// A function in the code.
+    Function {
+        /// The name of the function.
+        name: String,
+        /// The byte offset which the function is on in the source file.
+        offset: usize,
+        /// The number of times this item was hit.
+        hits: u64,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum BranchKind {
+    /// A false branch
+    True,
+    /// A true branch
+    False,
+}
+
+/// Coverage summary for a source file.
+#[derive(Default, Debug, Clone)]
+pub struct CoverageSummary {
+    /// The number of executable lines in the source file.
+    pub line_count: usize,
+    /// The number of lines that were hit.
+    pub line_hits: usize,
+    /// The number of statements in the source file.
+    pub statement_count: usize,
+    /// The number of statements that were hit.
+    pub statement_hits: usize,
+    /// The number of branches in the source file.
+    pub branch_count: usize,
+    /// The number of branches that were hit.
+    pub branch_hits: usize,
+    /// The number of functions in the source file.
+    pub function_count: usize,
+    /// The number of functions hit.
+    pub function_hits: usize,
+}
+
+impl CoverageSummary {
+    /// Add the data of another [CoverageSummary] to this one.
+    pub fn add(&mut self, other: &CoverageSummary) {
+        self.line_count += other.line_count;
+        self.line_hits += other.line_hits;
+        self.statement_count += other.statement_count;
+        self.statement_hits += other.statement_hits;
+        self.branch_count += other.branch_count;
+        self.branch_hits += other.branch_hits;
+        self.function_count += other.function_count;
+        self.function_hits += other.function_hits;
+    }
+}

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -1,3 +1,6 @@
+mod visitor;
+pub use visitor::Visitor;
+
 use ethers::{
     prelude::{sourcemap::SourceMap, sources::VersionedSourceFile},
     types::Address,

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -194,9 +194,13 @@ pub enum CoverageItem {
     Branch {
         /// The ID that identifies the branch.
         ///
-        /// There are two branches with the same ID,
-        /// one for each outcome (true and false).
-        id: usize,
+        /// There may be multiple items with the same branch ID - they belong to the same branch,
+        /// but represent different paths.
+        branch_id: usize,
+        /// The path ID for this branch.
+        ///
+        /// The first path has ID 0, the next ID 1, and so on.
+        path_id: usize,
         /// The branch kind.
         kind: BranchKind,
         /// The byte offset which the branch is on in the source file.

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -79,16 +79,14 @@ impl CoverageMap {
             // Get the coverage items corresponding to the source ID in the source map.
             if let Some(source) = self.sources.get_mut(&(source_version.clone(), source_id)) {
                 for item in source.items.iter_mut() {
-                    let loc = item.source_location();
-
                     // We've reached a point where we will no longer be able to map this
                     // instruction to coverage items
-                    if instruction_offset < loc.start {
+                    if instruction_offset < item.anchor() {
                         break
                     }
 
                     // We found a matching coverage item, but there may be more
-                    if instruction_offset == loc.start {
+                    if instruction_offset == item.anchor() {
                         item.increment_hits(instruction_hits);
                     }
                 }
@@ -173,6 +171,8 @@ pub enum CoverageItem {
     Line {
         /// The location of the line in the source code.
         loc: SourceLocation,
+        /// The instruction counter that covers this line.
+        anchor: usize,
         /// The number of times this item was hit.
         hits: u64,
     },
@@ -181,6 +181,8 @@ pub enum CoverageItem {
     Statement {
         /// The location of the statement in the source code.
         loc: SourceLocation,
+        /// The instruction counter that covers this statement.
+        anchor: usize,
         /// The number of times this statement was hit.
         hits: u64,
     },
@@ -189,6 +191,8 @@ pub enum CoverageItem {
     Branch {
         /// The location of the branch in the source code.
         loc: SourceLocation,
+        /// The instruction counter that covers this branch.
+        anchor: usize,
         /// The ID that identifies the branch.
         ///
         /// There may be multiple items with the same branch ID - they belong to the same branch,
@@ -208,6 +212,8 @@ pub enum CoverageItem {
     Function {
         /// The location of the function in the source code.
         loc: SourceLocation,
+        /// The instruction counter that covers this function.
+        anchor: usize,
         /// The name of the function.
         name: String,
         /// The number of times this item was hit.
@@ -222,6 +228,15 @@ impl CoverageItem {
             Self::Statement { loc, .. } |
             Self::Branch { loc, .. } |
             Self::Function { loc, .. } => loc,
+        }
+    }
+
+    pub fn anchor(&self) -> usize {
+        match self {
+            Self::Line { anchor, .. } |
+            Self::Statement { anchor, .. } |
+            Self::Branch { anchor, .. } |
+            Self::Function { anchor, .. } => *anchor,
         }
     }
 

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -8,6 +8,7 @@ use ethers::{
 use semver::Version;
 use std::{
     collections::{BTreeMap, HashMap},
+    fmt::Display,
     path::PathBuf,
     usize,
 };
@@ -259,6 +260,28 @@ impl CoverageItem {
     }
 }
 
+impl Display for CoverageItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            CoverageItem::Line { loc, anchor, hits } => {
+                write!(f, "Line (location: {loc}, anchor: {anchor}, hits: {hits})")
+            }
+            CoverageItem::Statement { loc, anchor, hits } => {
+                write!(f, "Statement (location: {loc}, anchor: {anchor}, hits: {hits})")
+            }
+            CoverageItem::Branch { loc, anchor, hits, branch_id, path_id, kind } => {
+                write!(f, "{} Branch (branch: {branch_id}, path: {path_id}) (location: {loc}, anchor: {anchor}, hits: {hits})", match kind {
+                    BranchKind::True => "True",
+                    BranchKind::False => "False",
+                })
+            }
+            CoverageItem::Function { loc, anchor, hits, name } => {
+                write!(f, r#"Function "{name}" (location: {loc}, anchor: {anchor}, hits: {hits})"#)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SourceLocation {
     /// Start byte in the source code.
@@ -267,6 +290,18 @@ pub struct SourceLocation {
     pub length: Option<usize>,
     /// The line in the source code.
     pub line: usize,
+}
+
+impl Display for SourceLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "L{}, C{}-{}",
+            self.line,
+            self.start,
+            self.length.map_or(self.start, |length| self.start + length)
+        )
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -134,6 +134,13 @@ pub struct SourceFile {
 impl SourceFile {
     /// Get a simple summary of the coverage for the file.
     pub fn summary(&self) -> CoverageSummary {
+        println!("Uncovered for {:?}:", self.path);
+        self.items.iter().for_each(|item| {
+            if item.hits() == 0 {
+                println!("- {:?}", item);
+            }
+        });
+
         self.items.iter().fold(CoverageSummary::default(), |mut summary, item| match item {
             CoverageItem::Line { hits, .. } => {
                 summary.line_count += 1;
@@ -231,6 +238,15 @@ impl CoverageItem {
             Self::Statement { hits, .. } |
             Self::Branch { hits, .. } |
             Self::Function { hits, .. } => *hits += delta,
+        }
+    }
+
+    pub fn hits(&self) -> u64 {
+        match self {
+            Self::Line { hits, .. } |
+            Self::Statement { hits, .. } |
+            Self::Branch { hits, .. } |
+            Self::Function { hits, .. } => *hits,
         }
     }
 }

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -134,13 +134,6 @@ pub struct SourceFile {
 impl SourceFile {
     /// Get a simple summary of the coverage for the file.
     pub fn summary(&self) -> CoverageSummary {
-        println!("Uncovered for {:?}:", self.path);
-        self.items.iter().for_each(|item| {
-            if item.hits() == 0 {
-                println!("- {:?}", item);
-            }
-        });
-
         self.items.iter().fold(CoverageSummary::default(), |mut summary, item| match item {
             CoverageItem::Line { hits, .. } => {
                 summary.line_count += 1;

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -26,10 +26,6 @@ pub struct CoverageMap {
 }
 
 impl CoverageMap {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
     /// Adds coverage items and a source map for the given source.
     ///
     /// Sources are identified by path, and then by source ID and version.

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -66,28 +66,25 @@ impl CoverageMap {
                 continue
             }
 
-            // Get the instruction offset and the source ID in the source map.
-            let (instruction_offset, source_id) = if let Some((instruction_offset, source_id)) =
-                source_map
-                    .get(ic)
-                    .and_then(|source_element| Some((source_element.offset, source_element.index?)))
-            {
-                (instruction_offset, source_id)
-            } else {
-                continue
-            };
+            // Get the source ID in the source map.
+            let source_id =
+                if let Some(source_id) = source_map.get(ic).and_then(|element| element.index) {
+                    source_id
+                } else {
+                    continue
+                };
 
             // Get the coverage items corresponding to the source ID in the source map.
             if let Some(source) = self.sources.get_mut(&(source_version.clone(), source_id)) {
                 for item in source.items.iter_mut() {
                     // We've reached a point where we will no longer be able to map this
                     // instruction to coverage items
-                    if instruction_offset < item.anchor() {
-                        break
-                    }
+                    /*if ic > item.anchor() {
+                        break;
+                    }*/
 
                     // We found a matching coverage item, but there may be more
-                    if instruction_offset == item.anchor() {
+                    if ic == item.anchor() {
                         item.increment_hits(instruction_hits);
                     }
                 }

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -44,19 +44,24 @@ impl CoverageMap {
         self.sources.insert((version, source.id), SourceFile { path: path.into(), items });
     }
 
+    /// Processes data from a [HitMap] and sets hit counts for coverage items in this coverage map.
+    ///
+    /// This function should only be called *after* all the relevant sources have been processed and
+    /// added to the map (see [add_source]).
+    ///
+    /// NOTE(onbjerg): I've made an assumption here that the coverage items are laid out in
+    /// sorted order, ordered by their anchors.
+    ///
+    /// This assumption is based on the way we process the AST - we start at the root node,
+    /// and work our way down. If we change up how we process the AST, we *have* to either
+    /// change this logic to work with unsorted data, or sort the data prior to calling
+    /// this function.
     pub fn add_hit_map(
         &mut self,
         source_version: Version,
         source_map: &SourceMap,
         hit_map: HitMap,
     ) {
-        // NOTE(onbjerg): I've made an assumption here that the coverage items are laid out in
-        // sorted order, ordered by their offset in the source code.
-        //
-        // This assumption is based on the way we process the AST - we start at the root node,
-        // and work our way down. If we change up how we process the AST, we *have* to either
-        // change this logic to work with unsorted data, or sort the data prior to calling
-        // this function.
         for (ic, instruction_hits) in hit_map.hits.into_iter() {
             if instruction_hits == 0 {
                 continue

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -23,7 +23,7 @@ use std::{
 #[derive(Default, Debug, Clone)]
 pub struct CoverageMap {
     /// A map of `(version, source id)` -> `source file`
-    sources: BTreeMap<(Version, u32), SourceFile>,
+    sources: HashMap<(Version, u32), SourceFile>,
 }
 
 impl CoverageMap {
@@ -97,7 +97,7 @@ impl CoverageMap {
 
 impl IntoIterator for CoverageMap {
     type Item = SourceFile;
-    type IntoIter = std::collections::btree_map::IntoValues<(Version, u32), Self::Item>;
+    type IntoIter = std::collections::hash_map::IntoValues<(Version, u32), Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.sources.into_values()

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -35,13 +35,13 @@ impl CoverageMap {
     /// jobs, and source IDs are only guaranteed to be stable across a single compile job.
     pub fn add_source(
         &mut self,
-        path: String,
+        path: impl Into<PathBuf>,
         source: VersionedSourceFile,
         items: Vec<CoverageItem>,
     ) {
         let VersionedSourceFile { version, source_file: source } = source;
 
-        self.sources.insert((version, source.id), SourceFile { path: PathBuf::from(path), items });
+        self.sources.insert((version, source.id), SourceFile { path: path.into(), items });
     }
 
     pub fn add_hit_map(

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -9,6 +9,7 @@ use semver::Version;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Display,
+    ops::AddAssign,
     path::PathBuf,
     usize,
 };
@@ -331,9 +332,8 @@ pub struct CoverageSummary {
     pub function_hits: usize,
 }
 
-impl CoverageSummary {
-    /// Add the data of another [CoverageSummary] to this one.
-    pub fn add(&mut self, other: &CoverageSummary) {
+impl AddAssign<&Self> for CoverageSummary {
+    fn add_assign(&mut self, other: &Self) {
         self.line_count += other.line_count;
         self.line_hits += other.line_hits;
         self.statement_count += other.statement_count;

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -1,0 +1,249 @@
+use super::{BranchKind, CoverageItem};
+use ethers::solc::artifacts::ast::{Ast, Node, NodeType};
+use tracing::warn;
+
+#[derive(Debug, Default, Clone)]
+pub struct Visitor {
+    /// Coverage items
+    pub items: Vec<CoverageItem>,
+    /// The current branch ID
+    // TODO: Does this need to be unique across files?
+    pub branch_id: usize,
+}
+
+impl Visitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn visit_ast(&mut self, ast: Ast) -> eyre::Result<()> {
+        for node in ast.nodes.into_iter() {
+            if !matches!(node.node_type, NodeType::ContractDefinition) {
+                continue
+            }
+
+            self.visit_contract(node)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn visit_contract(&mut self, node: Node) -> eyre::Result<()> {
+        let is_contract =
+            node.attribute("contractKind").map_or(false, |kind: String| kind == "contract");
+        let is_abstract: bool = node.attribute("abstract").unwrap_or_default();
+
+        // Skip interfaces, libraries and abstract contracts
+        if !is_contract || is_abstract {
+            return Ok(())
+        }
+
+        for node in node.nodes {
+            if node.node_type == NodeType::FunctionDefinition {
+                self.visit_function_definition(node)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn visit_function_definition(&mut self, mut node: Node) -> eyre::Result<()> {
+        let name: String =
+            node.attribute("name").ok_or_else(|| eyre::eyre!("function has no name"))?;
+        let is_virtual: bool = node.attribute("virtual").unwrap_or_default();
+
+        // Skip virtual functions
+        if is_virtual {
+            return Ok(())
+        }
+
+        match node.body.take() {
+            // Skip virtual functions
+            Some(body) if !is_virtual => {
+                self.items.push(CoverageItem::Function { name, offset: node.src.start, hits: 0 });
+                self.visit_block(*body)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    pub fn visit_block(&mut self, node: Node) -> eyre::Result<()> {
+        let statements: Vec<Node> = node.attribute("statements").unwrap_or_default();
+
+        for statement in statements {
+            self.visit_statement(statement)?;
+        }
+
+        Ok(())
+    }
+    pub fn visit_statement(&mut self, node: Node) -> eyre::Result<()> {
+        // TODO: inlineassembly
+        match node.node_type {
+            // Blocks
+            NodeType::Block | NodeType::UncheckedBlock => self.visit_block(node),
+            // Simple statements
+            NodeType::Break |
+            NodeType::Continue |
+            NodeType::EmitStatement |
+            NodeType::PlaceholderStatement |
+            NodeType::Return |
+            NodeType::RevertStatement => {
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            // Variable declaration
+            NodeType::VariableDeclarationStatement => {
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                if let Some(expr) = node.attribute("initialValue") {
+                    self.visit_expression(expr)?;
+                }
+                Ok(())
+            }
+            // While loops
+            NodeType::DoWhileStatement | NodeType::WhileStatement => {
+                self.visit_expression(
+                    node.attribute("condition")
+                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
+                )?;
+
+                let body =
+                    node.body.ok_or_else(|| eyre::eyre!("while statement had no body node"))?;
+                self.visit_block_or_statement(*body)
+            }
+            // For loops
+            NodeType::ForStatement => {
+                if let Some(stmt) = node.attribute("initializationExpression") {
+                    self.visit_statement(stmt)?;
+                }
+                if let Some(expr) = node.attribute("condition") {
+                    self.visit_expression(expr)?;
+                }
+                if let Some(stmt) = node.attribute("loopExpression") {
+                    self.visit_statement(stmt)?;
+                }
+
+                let body =
+                    node.body.ok_or_else(|| eyre::eyre!("for statement had no body node"))?;
+                self.visit_block_or_statement(*body)
+            }
+            // Expression statement
+            NodeType::ExpressionStatement => self.visit_expression(
+                node.attribute("expression")
+                    .ok_or_else(|| eyre::eyre!("expression statement had no expression"))?,
+            ),
+            // If statement
+            NodeType::IfStatement => {
+                // TODO: create branch
+                self.visit_expression(
+                    node.attribute("condition")
+                        .ok_or_else(|| eyre::eyre!("while statement had no condition"))?,
+                )?;
+
+                let true_body: Node = node
+                    .attribute("trueBody")
+                    .ok_or_else(|| eyre::eyre!("if statement had no true body"))?;
+
+                // We need to store the current branch ID here since visiting the body of either of
+                // the if blocks may increase `self.branch_id` in the case of nested if statements.
+                let branch_id = self.branch_id;
+
+                // We increase the branch ID here such that nested branches do not use the same
+                // branch ID as we do
+                self.branch_id += 1;
+
+                self.items.push(CoverageItem::Branch {
+                    id: branch_id,
+                    kind: BranchKind::True,
+                    offset: true_body.src.start,
+                    hits: 0,
+                });
+                self.visit_block_or_statement(true_body)?;
+
+                let false_body: Option<Node> = node.attribute("falseBody");
+                if let Some(false_body) = false_body {
+                    self.items.push(CoverageItem::Branch {
+                        id: branch_id,
+                        kind: BranchKind::False,
+                        offset: false_body.src.start,
+                        hits: 0,
+                    });
+                    self.visit_block_or_statement(false_body)?;
+                }
+
+                Ok(())
+            }
+            // Try-catch statement
+            NodeType::TryStatement => {
+                // TODO: Clauses
+                // TODO: This is branching, right?
+                self.visit_expression(
+                    node.attribute("externalCall")
+                        .ok_or_else(|| eyre::eyre!("try statement had no call"))?,
+                )
+            }
+            _ => {
+                warn!("unexpected node type, expected a statement: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn visit_expression(&mut self, node: Node) -> eyre::Result<()> {
+        // TODO
+        // elementarytypenameexpression
+        //  memberaccess
+        //  newexpression
+        //  tupleexpression
+        match node.node_type {
+            NodeType::Assignment | NodeType::UnaryOperation | NodeType::BinaryOperation => {
+                // TODO: Should we explore the subexpressions?
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            NodeType::FunctionCall => {
+                // TODO: Handle assert and require
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            NodeType::Conditional => {
+                // TODO: Do we count these as branches?
+                self.items.push(CoverageItem::Statement { offset: node.src.start, hits: 0 });
+                Ok(())
+            }
+            // Does not count towards coverage
+            NodeType::FunctionCallOptions |
+            NodeType::Identifier |
+            NodeType::IndexAccess |
+            NodeType::IndexRangeAccess |
+            NodeType::Literal => Ok(()),
+            _ => {
+                warn!("unexpected node type, expected an expression: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn visit_block_or_statement(&mut self, node: Node) -> eyre::Result<()> {
+        match node.node_type {
+            NodeType::Block => self.visit_block(node),
+            NodeType::Break |
+            NodeType::Continue |
+            NodeType::DoWhileStatement |
+            NodeType::EmitStatement |
+            NodeType::ExpressionStatement |
+            NodeType::ForStatement |
+            NodeType::IfStatement |
+            NodeType::InlineAssembly |
+            NodeType::PlaceholderStatement |
+            NodeType::Return |
+            NodeType::RevertStatement |
+            NodeType::TryStatement |
+            NodeType::VariableDeclarationStatement |
+            NodeType::WhileStatement => self.visit_statement(node),
+            _ => {
+                warn!("unexpected node type, expected block or statement: {:?}", node.node_type);
+                Ok(())
+            }
+        }
+    }
+}

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -163,7 +163,8 @@ impl Visitor {
                 self.branch_id += 1;
 
                 self.items.push(CoverageItem::Branch {
-                    id: branch_id,
+                    branch_id,
+                    path_id: 0,
                     kind: BranchKind::True,
                     offset: true_body.src.start,
                     hits: 0,
@@ -173,7 +174,8 @@ impl Visitor {
                 let false_body: Option<Node> = node.attribute("falseBody");
                 if let Some(false_body) = false_body {
                     self.items.push(CoverageItem::Branch {
-                        id: branch_id,
+                        branch_id,
+                        path_id: 1,
                         kind: BranchKind::False,
                         offset: false_body.src.start,
                         hits: 0,
@@ -202,7 +204,8 @@ impl Visitor {
                 self.branch_id += 1;
 
                 self.items.push(CoverageItem::Branch {
-                    id: branch_id,
+                    branch_id,
+                    path_id: 0,
                     kind: BranchKind::True,
                     offset: body.src.start,
                     hits: 0,

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -378,9 +378,17 @@ impl Visitor {
                     .iter()
                     .enumerate()
                     .find(|(_, element)| {
-                        element.index.map_or(false, |source_id| {
-                            source_id == self.source_id && element.offset >= loc.start
-                        })
+                        element
+                            .index
+                            .and_then(|source_id| {
+                                Some(
+                                    source_id == self.source_id &&
+                                        element.offset >= loc.start &&
+                                        element.offset + element.length <=
+                                            loc.start + loc.length?,
+                                )
+                            })
+                            .unwrap_or_default()
                     })
                     .map(|(ic, _)| ic)
             })

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -328,7 +328,11 @@ impl Visitor {
     /// Pushes a coverage item to the internal collection, and might push a line item as well.
     fn push_item(&mut self, item: CoverageItem) {
         let source_location = item.source_location();
-        if self.last_line < source_location.line {
+
+        // Push a line item if we haven't already
+        if matches!(item, CoverageItem::Statement { .. } | CoverageItem::Branch { .. }) &&
+            self.last_line < source_location.line
+        {
             self.items.push(CoverageItem::Line {
                 loc: source_location.clone(),
                 anchor: item.anchor(),

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -366,7 +366,7 @@ impl Visitor {
         SourceLocation {
             start: loc.start,
             length: loc.length,
-            line: self.source[..loc.start].as_bytes().iter().filter(|&&c| c == b'\n').count() + 1,
+            line: self.source[..loc.start].lines().count() + 1,
         }
     }
 

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -152,6 +152,13 @@ impl ExecutorBuilder {
         self
     }
 
+    /// Enables coverage collection
+    #[must_use]
+    pub fn with_coverage(mut self) -> Self {
+        self.inspector_config.coverage = true;
+        self
+    }
+
     /// Sets the EVM spec to use
     #[must_use]
     pub fn with_spec(mut self, spec: SpecId) -> Self {

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -138,24 +138,24 @@ impl ExecutorBuilder {
         self
     }
 
-    /// Enables tracing
+    /// Enables or disables tracing
     #[must_use]
-    pub fn with_tracing(mut self) -> Self {
-        self.inspector_config.tracing = true;
+    pub fn set_tracing(mut self, enable: bool) -> Self {
+        self.inspector_config.tracing = enable;
         self
     }
 
-    /// Enables the debugger
+    /// Enables or disables the debugger
     #[must_use]
-    pub fn with_debugger(mut self) -> Self {
-        self.inspector_config.debugger = true;
+    pub fn set_debugger(mut self, enable: bool) -> Self {
+        self.inspector_config.debugger = enable;
         self
     }
 
-    /// Enables coverage collection
+    /// Enables or disables coverage collection
     #[must_use]
-    pub fn with_coverage(mut self) -> Self {
-        self.inspector_config.coverage = true;
+    pub fn set_coverage(mut self, enable: bool) -> Self {
+        self.inspector_config.coverage = enable;
         self
     }
 

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -1,0 +1,139 @@
+use crate::{coverage::HitMaps, executor::inspector::utils::get_create_address};
+use bytes::Bytes;
+use ethers::types::Address;
+use revm::{
+    opcode, spec_opcode_gas, CallInputs, CreateInputs, Database, EVMData, Gas, Inspector,
+    Interpreter, Return, SpecId,
+};
+use std::collections::BTreeMap;
+
+#[derive(Default, Debug)]
+pub struct CoverageCollector {
+    /// Maps that track instruction hit data.
+    pub maps: HitMaps,
+
+    /// The execution addresses, with the topmost one being the current address.
+    context: Vec<Address>,
+
+    /// A mapping of program counters to instruction counters.
+    ///
+    /// The program counter keeps track of where we are in the contract bytecode as a whole,
+    /// including push bytes, while the instruction counter ignores push bytes.
+    ///
+    /// The instruction counter is used in Solidity source maps.
+    pub ic_map: BTreeMap<Address, BTreeMap<usize, usize>>,
+}
+
+impl CoverageCollector {
+    /// Builds the instruction counter map for the given bytecode.
+    // TODO: Some of the same logic is performed in REVM, but then later discarded. We should
+    // investigate if we can reuse it
+    // TODO: Duplicate code of the debugger inspector
+    pub fn build_ic_map(&mut self, spec: SpecId, code: &Bytes) {
+        if let Some(context) = self.context.last() {
+            let opcode_infos = spec_opcode_gas(spec);
+            let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
+
+            let mut i = 0;
+            let mut cumulative_push_size = 0;
+            while i < code.len() {
+                let op = code[i];
+                ic_map.insert(i, i - cumulative_push_size);
+                if opcode_infos[op as usize].is_push {
+                    // Skip the push bytes.
+                    //
+                    // For more context on the math, see: https://github.com/bluealloy/revm/blob/007b8807b5ad7705d3cacce4d92b89d880a83301/crates/revm/src/interpreter/contract.rs#L114-L115
+                    i += (op - opcode::PUSH1 + 1) as usize;
+                    cumulative_push_size += (op - opcode::PUSH1 + 1) as usize;
+                }
+                i += 1;
+            }
+
+            self.ic_map.insert(*context, ic_map);
+        }
+    }
+
+    pub fn enter(&mut self, address: Address) {
+        self.context.push(address);
+    }
+
+    pub fn exit(&mut self) {
+        self.context.pop();
+    }
+}
+
+impl<DB> Inspector<DB> for CoverageCollector
+where
+    DB: Database,
+{
+    fn call(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        call: &mut CallInputs,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.enter(call.context.code_address);
+
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    // TODO: Don't collect coverage for test contract if possible
+    fn step(
+        &mut self,
+        interpreter: &mut Interpreter,
+        _: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        let pc = interpreter.program_counter();
+        if let Some(context) = self.context.last() {
+            if let Some(ic) = self.ic_map.get(context).and_then(|ic_map| ic_map.get(&pc)) {
+                let map = self.maps.entry(*context).or_default();
+
+                map.hit(*ic);
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn call_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CallInputs,
+        gas: Gas,
+        status: Return,
+        retdata: Bytes,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.exit();
+
+        (status, gas, retdata)
+    }
+
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &mut CreateInputs,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        // TODO: Does this increase gas cost?
+        data.subroutine.load_account(call.caller, data.db);
+        let nonce = data.subroutine.account(call.caller).info.nonce;
+        self.enter(get_create_address(call, nonce));
+
+        (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    fn create_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CreateInputs,
+        status: Return,
+        address: Option<Address>,
+        gas: Gas,
+        retdata: Bytes,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        self.exit();
+
+        (status, address, gas, retdata)
+    }
+}

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -77,6 +77,20 @@ where
         (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
 
+    // TODO: Duplicate code of the debugger inspector
+    fn initialize_interp(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        _: bool,
+    ) -> Return {
+        // TODO: This is rebuilt for all contracts every time. We should only run this if the IC
+        // map for a given address does not exist, *but* we need to account for the fact that the
+        // code given by the interpreter may either be the contract init code, or the runtime code.
+        self.build_ic_map(data.env.cfg.spec_id, &interp.contract().code);
+        Return::Continue
+    }
+
     // TODO: Don't collect coverage for test contract if possible
     fn step(
         &mut self,

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -10,6 +10,9 @@ pub use tracer::Tracer;
 mod debugger;
 pub use debugger::Debugger;
 
+mod coverage;
+pub use coverage::CoverageCollector;
+
 mod stack;
 pub use stack::{InspectorData, InspectorStack};
 
@@ -38,6 +41,8 @@ pub struct InspectorStackConfig {
     pub tracing: bool,
     /// Whether or not the debugger is enabled
     pub debugger: bool,
+    /// Whether or not coverage info should be collected
+    pub coverage: bool,
 }
 
 impl InspectorStackConfig {
@@ -56,6 +61,9 @@ impl InspectorStackConfig {
         }
         if self.debugger {
             stack.debugger = Some(Debugger::default());
+        }
+        if self.coverage {
+            stack.coverage = Some(CoverageCollector::default());
         }
         stack
     }

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -1,5 +1,5 @@
-use super::{Cheatcodes, Debugger, LogCollector, Tracer};
-use crate::{debug::DebugArena, trace::CallTraceArena};
+use super::{Cheatcodes, CoverageCollector, Debugger, LogCollector, Tracer};
+use crate::{coverage::HitMaps, debug::DebugArena, trace::CallTraceArena};
 use bytes::Bytes;
 use ethers::types::{Address, Log, H256};
 use revm::{db::Database, CallInputs, CreateInputs, EVMData, Gas, Inspector, Interpreter, Return};
@@ -22,6 +22,7 @@ pub struct InspectorData {
     pub labels: BTreeMap<Address, String>,
     pub traces: Option<CallTraceArena>,
     pub debug: Option<DebugArena>,
+    pub coverage: Option<HitMaps>,
     pub cheatcodes: Option<Cheatcodes>,
 }
 
@@ -35,6 +36,7 @@ pub struct InspectorStack {
     pub logs: Option<LogCollector>,
     pub cheatcodes: Option<Cheatcodes>,
     pub debugger: Option<Debugger>,
+    pub coverage: Option<CoverageCollector>,
 }
 
 impl InspectorStack {
@@ -48,6 +50,7 @@ impl InspectorStack {
                 .unwrap_or_default(),
             traces: self.tracer.map(|tracer| tracer.traces),
             debug: self.debugger.map(|debugger| debugger.arena),
+            coverage: self.coverage.map(|coverage| coverage.maps),
             cheatcodes: self.cheatcodes,
         }
     }
@@ -87,7 +90,13 @@ where
     ) -> Return {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.tracer,
+                &mut self.coverage,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let status = inspector.step(interpreter, data, is_static);
 
@@ -144,7 +153,13 @@ where
     ) -> (Return, Gas, Bytes) {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.tracer,
+                &mut self.coverage,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let (status, gas, retdata) = inspector.call(data, call, is_static);
 
@@ -169,7 +184,13 @@ where
     ) -> (Return, Gas, Bytes) {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.tracer,
+                &mut self.coverage,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let (new_status, new_gas, new_retdata) = inspector.call_end(
                     data,
@@ -198,7 +219,13 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.tracer,
+                &mut self.coverage,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let (status, addr, gas, retdata) = inspector.create(data, call);
 
@@ -223,7 +250,13 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.tracer,
+                &mut self.coverage,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let (new_status, new_address, new_gas, new_retdata) = inspector.create_end(
                     data,

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -68,7 +68,13 @@ where
     ) -> Return {
         call_inspectors!(
             inspector,
-            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            [
+                &mut self.debugger,
+                &mut self.coverage,
+                &mut self.tracer,
+                &mut self.logs,
+                &mut self.cheatcodes
+            ],
             {
                 let status = inspector.initialize_interp(interpreter, data, is_static);
 

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -28,7 +28,8 @@ pub use revm::Env;
 
 use self::inspector::{InspectorData, InspectorStackConfig};
 use crate::{
-    debug::DebugArena, executor::inspector::DEFAULT_CREATE2_DEPLOYER, trace::CallTraceArena, CALLER,
+    coverage::HitMaps, debug::DebugArena, executor::inspector::DEFAULT_CREATE2_DEPLOYER,
+    trace::CallTraceArena, CALLER,
 };
 use bytes::Bytes;
 use ethers::{
@@ -108,6 +109,8 @@ pub struct CallResult<D: Detokenize> {
     pub labels: BTreeMap<Address, String>,
     /// The traces of the call
     pub traces: Option<CallTraceArena>,
+    /// The coverage info collected during the call
+    pub coverage: Option<HitMaps>,
     /// The debug nodes of the call
     pub debug: Option<DebugArena>,
     /// Scripted transactions generated from this call
@@ -138,6 +141,8 @@ pub struct RawCallResult {
     pub labels: BTreeMap<Address, String>,
     /// The traces of the call
     pub traces: Option<CallTraceArena>,
+    /// The coverage info collected during the call
+    pub coverage: Option<HitMaps>,
     /// The debug nodes of the call
     pub debug: Option<DebugArena>,
     /// Scripted transactions generated from this call
@@ -160,6 +165,7 @@ impl Default for RawCallResult {
             logs: Vec::new(),
             labels: BTreeMap::new(),
             traces: None,
+            coverage: None,
             debug: None,
             transactions: None,
             state_changeset: None,
@@ -297,6 +303,7 @@ where
             logs,
             labels,
             traces,
+            coverage,
             debug,
             transactions,
             state_changeset,
@@ -312,6 +319,7 @@ where
                     logs,
                     labels,
                     traces,
+                    coverage,
                     debug,
                     transactions,
                     state_changeset,
@@ -361,7 +369,7 @@ where
             _ => Bytes::default(),
         };
 
-        let InspectorData { logs, labels, traces, debug, mut cheatcodes } =
+        let InspectorData { logs, labels, traces, coverage, debug, mut cheatcodes } =
             inspector.collect_inspector_states();
 
         // Persist the changed block environment
@@ -394,6 +402,7 @@ where
             stipend,
             logs,
             labels,
+            coverage,
             traces,
             debug,
             transactions,
@@ -424,6 +433,7 @@ where
             logs,
             labels,
             traces,
+            coverage,
             debug,
             transactions,
             state_changeset,
@@ -439,6 +449,7 @@ where
                     logs,
                     labels,
                     traces,
+                    coverage,
                     debug,
                     transactions,
                     state_changeset,
@@ -488,7 +499,7 @@ where
             _ => Bytes::default(),
         };
 
-        let InspectorData { logs, labels, traces, debug, cheatcodes, .. } =
+        let InspectorData { logs, labels, traces, debug, coverage, cheatcodes, .. } =
             inspector.collect_inspector_states();
 
         let transactions = if let Some(cheats) = cheatcodes {
@@ -510,6 +521,7 @@ where
             logs: logs.to_vec(),
             labels,
             traces,
+            coverage,
             debug,
             transactions,
             state_changeset: Some(state_changeset),

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -1,11 +1,15 @@
 /// Decoding helpers
 pub mod decode;
 
-/// Call trace arena, decoding and formatting
+/// Call tracing
+/// Contains a call trace arena, decoding and formatting utilities
 pub mod trace;
 
 /// Debugger data structures
 pub mod debug;
+
+/// Coverage data structures
+pub mod coverage;
 
 /// Forge test execution backends
 pub mod executor;

--- a/evm/src/trace/identifier/etherscan.rs
+++ b/evm/src/trace/identifier/etherscan.rs
@@ -65,6 +65,7 @@ impl TraceIdentifier for EtherscanIdentifier {
                     label: Some(label.clone()),
                     contract: Some(label),
                     abi: Some(Cow::Owned(abi)),
+                    artifact_id: None,
                 })
                 .collect();
 

--- a/evm/src/trace/identifier/local.rs
+++ b/evm/src/trace/identifier/local.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 /// A trace identifier that tries to identify addresses using local contracts.
 pub struct LocalTraceIdentifier {
-    local_contracts: BTreeMap<Vec<u8>, (String, Abi)>,
+    local_contracts: BTreeMap<Vec<u8>, (ArtifactId, Abi)>,
 }
 
 impl LocalTraceIdentifier {
@@ -16,9 +16,7 @@ impl LocalTraceIdentifier {
         Self {
             local_contracts: known_contracts
                 .iter()
-                .map(|(id, (abi, runtime_code))| {
-                    (runtime_code.clone(), (id.name.clone(), abi.clone()))
-                })
+                .map(|(id, (abi, runtime_code))| (runtime_code.clone(), (id.clone(), abi.clone())))
                 .collect(),
         }
     }
@@ -38,15 +36,15 @@ impl TraceIdentifier for LocalTraceIdentifier {
             .into_iter()
             .filter_map(|(address, code)| {
                 let code = code?;
-                let (_, (name, abi)) = self
+                let (_, (id, abi)) = self
                     .local_contracts
                     .iter()
                     .find(|(known_code, _)| diff_score(known_code, code) < 0.1)?;
 
                 Some(AddressIdentity {
                     address: *address,
-                    contract: Some(name.clone()),
-                    label: Some(name.clone()),
+                    contract: Some(id.identifier()),
+                    label: Some(id.name.clone()),
                     abi: Some(Cow::Borrowed(abi)),
                 })
             })

--- a/evm/src/trace/identifier/local.rs
+++ b/evm/src/trace/identifier/local.rs
@@ -46,6 +46,7 @@ impl TraceIdentifier for LocalTraceIdentifier {
                     contract: Some(id.identifier()),
                     label: Some(id.name.clone()),
                     abi: Some(Cow::Borrowed(abi)),
+                    artifact_id: Some(id.clone()),
                 })
             })
             .collect()

--- a/evm/src/trace/identifier/mod.rs
+++ b/evm/src/trace/identifier/mod.rs
@@ -7,7 +7,10 @@ pub use etherscan::EtherscanIdentifier;
 mod signatures;
 pub use signatures::SignaturesIdentifier;
 
-use ethers::abi::{Abi, Address};
+use ethers::{
+    abi::{Abi, Address},
+    prelude::ArtifactId,
+};
 use std::borrow::Cow;
 
 /// An address identity
@@ -22,6 +25,8 @@ pub struct AddressIdentity<'a> {
     pub contract: Option<String>,
     /// The ABI of the contract at this address
     pub abi: Option<Cow<'a, Abi>>,
+    /// The artifact ID of the contract, if any.
+    pub artifact_id: Option<ArtifactId>,
 }
 
 /// Trace identifiers figure out what ABIs and labels belong to all the addresses of the trace.

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -108,11 +108,10 @@ where
                     CoverageItem::Line { offset, hits } => {
                         writeln!(self.destination, "DA:{offset},{hits}")?;
                     }
-                    CoverageItem::Branch { id, offset, hits, .. } => {
-                        // TODO: Block ID
+                    CoverageItem::Branch { branch_id, path_id, offset, hits, .. } => {
                         writeln!(
                             self.destination,
-                            "BRDA:{offset},{id},{id},{}",
+                            "BRDA:{offset},{branch_id},{path_id},{}",
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -98,20 +98,27 @@ where
             writeln!(self.destination, "TN:")?;
             writeln!(self.destination, "SF:{}", file.path.to_string_lossy())?;
 
-            // TODO: Line numbers instead of byte offsets
             for item in file.items {
                 match item {
-                    CoverageItem::Function { name, offset, hits } => {
-                        writeln!(self.destination, "FN:{offset},{name}")?;
+                    CoverageItem::Function {
+                        loc: SourceLocation { line, .. }, name, hits, ..
+                    } => {
+                        writeln!(self.destination, "FN:{line},{name}")?;
                         writeln!(self.destination, "FNDA:{hits},{name}")?;
                     }
-                    CoverageItem::Line { offset, hits } => {
-                        writeln!(self.destination, "DA:{offset},{hits}")?;
+                    CoverageItem::Line { loc: SourceLocation { line, .. }, hits, .. } => {
+                        writeln!(self.destination, "DA:{line},{hits}")?;
                     }
-                    CoverageItem::Branch { branch_id, path_id, offset, hits, .. } => {
+                    CoverageItem::Branch {
+                        loc: SourceLocation { line, .. },
+                        branch_id,
+                        path_id,
+                        hits,
+                        ..
+                    } => {
                         writeln!(
                             self.destination,
-                            "BRDA:{offset},{branch_id},{path_id},{}",
+                            "BRDA:{line},{branch_id},{path_id},{}",
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -1,0 +1,143 @@
+use comfy_table::{Cell, Color, Row, Table};
+pub use foundry_evm::coverage::*;
+use std::io::Write;
+
+/// A coverage reporter.
+pub trait CoverageReporter {
+    fn build(&mut self, map: CoverageMap);
+    fn finalize(self) -> eyre::Result<()>;
+}
+
+/// A simple summary reporter that prints the coverage results in a table.
+pub struct SummaryReporter {
+    /// The summary table.
+    table: Table,
+    /// The total coverage of the entire project.
+    total: CoverageSummary,
+}
+
+impl Default for SummaryReporter {
+    fn default() -> Self {
+        let mut table = Table::new();
+        table.set_header(&["File", "% Lines", "% Statements", "% Branches", "% Funcs"]);
+
+        Self { table, total: CoverageSummary::default() }
+    }
+}
+
+impl SummaryReporter {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    fn add_row(&mut self, name: impl Into<Cell>, summary: CoverageSummary) {
+        let mut row = Row::new();
+        row.add_cell(name.into())
+            .add_cell(format_cell(summary.line_hits, summary.line_count))
+            .add_cell(format_cell(summary.statement_hits, summary.statement_count))
+            .add_cell(format_cell(summary.branch_hits, summary.branch_count))
+            .add_cell(format_cell(summary.function_hits, summary.function_count));
+        self.table.add_row(row);
+    }
+}
+
+impl CoverageReporter for SummaryReporter {
+    fn build(&mut self, map: CoverageMap) {
+        for file in map {
+            let summary = file.summary();
+
+            self.total.add(&summary);
+            self.add_row(file.path.to_string_lossy(), summary);
+        }
+    }
+
+    fn finalize(mut self) -> eyre::Result<()> {
+        self.add_row("Total", self.total.clone());
+        println!("{}", self.table);
+        Ok(())
+    }
+}
+
+fn format_cell(hits: usize, total: usize) -> Cell {
+    let percentage = if total == 0 { 1. } else { hits as f64 / total as f64 };
+
+    Cell::new(format!("{}% ({hits}/{total})", percentage * 100.)).fg(match percentage {
+        _ if percentage < 0.5 => Color::Red,
+        _ if percentage < 0.75 => Color::Yellow,
+        _ => Color::Green,
+    })
+}
+
+pub struct LcovReporter<W> {
+    /// Destination buffer
+    destination: W,
+    /// The coverage map to write
+    map: Option<CoverageMap>,
+}
+
+impl<W> LcovReporter<W> {
+    pub fn new(destination: W) -> Self {
+        Self { destination, map: None }
+    }
+}
+
+impl<W> CoverageReporter for LcovReporter<W>
+where
+    W: Write,
+{
+    fn build(&mut self, map: CoverageMap) {
+        self.map = Some(map);
+    }
+
+    fn finalize(mut self) -> eyre::Result<()> {
+        let map = self.map.ok_or_else(|| eyre::eyre!("no coverage map given to reporter"))?;
+
+        for file in map {
+            let summary = file.summary();
+
+            writeln!(self.destination, "TN:")?;
+            writeln!(self.destination, "SF:{}", file.path.to_string_lossy())?;
+
+            // TODO: Line numbers instead of byte offsets
+            for item in file.items {
+                match item {
+                    CoverageItem::Function { name, offset, hits } => {
+                        writeln!(self.destination, "FN:{offset},{name}")?;
+                        writeln!(self.destination, "FNDA:{hits},{name}")?;
+                    }
+                    CoverageItem::Line { offset, hits } => {
+                        writeln!(self.destination, "DA:{offset},{hits}")?;
+                    }
+                    CoverageItem::Branch { id, offset, hits, .. } => {
+                        // TODO: Block ID
+                        writeln!(
+                            self.destination,
+                            "BRDA:{offset},{id},{id},{}",
+                            if hits == 0 { "-".to_string() } else { hits.to_string() }
+                        )?;
+                    }
+                    // Statements are not in the LCOV format
+                    CoverageItem::Statement { .. } => (),
+                }
+            }
+
+            // Function summary
+            writeln!(self.destination, "FNF:{}", summary.function_count)?;
+            writeln!(self.destination, "FNH:{}", summary.function_hits)?;
+
+            // Line summary
+            writeln!(self.destination, "LF:{}", summary.line_count)?;
+            writeln!(self.destination, "LH:{}", summary.line_hits)?;
+
+            // Branch summary
+            writeln!(self.destination, "BRF:{}", summary.branch_count)?;
+            writeln!(self.destination, "BRH:{}", summary.branch_hits)?;
+
+            writeln!(self.destination, "end_of_record")?;
+        }
+
+        println!("Wrote LCOV report.");
+
+        Ok(())
+    }
+}

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -61,7 +61,7 @@ impl CoverageReporter for SummaryReporter {
 fn format_cell(hits: usize, total: usize) -> Cell {
     let percentage = if total == 0 { 1. } else { hits as f64 / total as f64 };
 
-    Cell::new(format!("{}% ({hits}/{total})", percentage * 100.)).fg(match percentage {
+    Cell::new(format!("{:.2}% ({hits}/{total})", percentage * 100.)).fg(match percentage {
         _ if percentage < 0.5 => Color::Red,
         _ if percentage < 0.75 => Color::Yellow,
         _ => Color::Green,

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -41,7 +41,7 @@ impl CoverageReporter for SummaryReporter {
         for file in map {
             let summary = file.summary();
 
-            self.total.add(&summary);
+            self.total += &summary;
             self.add_row(file.path.to_string_lossy(), summary);
         }
 
@@ -176,7 +176,7 @@ impl CoverageReporter for DebugReporter {
         for file in map {
             let summary = file.summary();
 
-            self.total.add(&summary);
+            self.total += &summary;
             self.add_row(file.path.to_string_lossy(), summary);
 
             file.items.iter().for_each(|item| {

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -68,22 +68,19 @@ fn format_cell(hits: usize, total: usize) -> Cell {
     cell
 }
 
-pub struct LcovReporter<W> {
+pub struct LcovReporter<'a> {
     /// Destination buffer
-    destination: W,
+    destination: &'a mut (dyn Write + 'a),
 }
 
-impl<W> LcovReporter<W> {
-    pub fn new(destination: W) -> Self {
+impl<'a> LcovReporter<'a> {
+    pub fn new(destination: &'a mut (dyn Write + 'a)) -> LcovReporter<'a> {
         Self { destination }
     }
 }
 
-impl<W> CoverageReporter for LcovReporter<W>
-where
-    W: Write,
-{
-    fn report(mut self, map: CoverageMap) -> eyre::Result<()> {
+impl<'a> CoverageReporter for LcovReporter<'a> {
+    fn report(self, map: CoverageMap) -> eyre::Result<()> {
         for file in map {
             let summary = file.summary();
 

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,6 +1,9 @@
 /// Gas reports
 pub mod gas_report;
 
+/// Coverage reports
+pub mod coverage;
+
 /// The Forge test runner
 mod runner;
 pub use runner::ContractRunner;

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -31,6 +31,8 @@ pub struct MultiContractRunnerBuilder {
     pub fork: Option<Fork>,
     /// Additional cheatcode inspector related settings derived from the `Config`
     pub cheats_config: Option<CheatsConfig>,
+    /// Whether or not to collect coverage info
+    pub coverage: bool,
 }
 
 pub type DeployableContracts = BTreeMap<ArtifactId, (Abi, Bytes, Vec<Bytes>)>;
@@ -128,6 +130,7 @@ impl MultiContractRunnerBuilder {
             source_paths,
             fork: self.fork,
             cheats_config: self.cheats_config.unwrap_or_default(),
+            coverage: self.coverage,
         })
     }
 
@@ -166,6 +169,12 @@ impl MultiContractRunnerBuilder {
         self.cheats_config = Some(cheats_config);
         self
     }
+
+    #[must_use]
+    pub fn with_coverage(mut self) -> Self {
+        self.coverage = true;
+        self
+    }
 }
 
 /// A multi contract runner receives a set of contracts deployed in an EVM instance and proceeds
@@ -192,6 +201,8 @@ pub struct MultiContractRunner {
     pub fork: Option<Fork>,
     /// Additional cheatcode inspector related settings derived from the `Config`
     pub cheats_config: CheatsConfig,
+    /// Whether or not to collect coverage info
+    pub coverage: bool,
 }
 
 impl MultiContractRunner {
@@ -279,6 +290,10 @@ impl MultiContractRunner {
 
                 if self.evm_opts.verbosity >= 3 {
                     builder = builder.with_tracing();
+                }
+
+                if self.coverage {
+                    builder = builder.with_coverage();
                 }
 
                 let executor = builder.build(db.clone());

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -282,21 +282,15 @@ impl MultiContractRunner {
             })
             .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
             .map(|(id, (abi, deploy_code, libs))| {
-                let mut builder = ExecutorBuilder::default()
+                let executor = ExecutorBuilder::default()
                     .with_cheatcodes(self.cheats_config.clone())
                     .with_config(env.clone())
                     .with_spec(self.evm_spec)
-                    .with_gas_limit(self.evm_opts.gas_limit());
+                    .with_gas_limit(self.evm_opts.gas_limit())
+                    .set_tracing(self.evm_opts.verbosity >= 3)
+                    .set_coverage(self.coverage)
+                    .build(db.clone());
 
-                if self.evm_opts.verbosity >= 3 {
-                    builder = builder.with_tracing();
-                }
-
-                if self.coverage {
-                    builder = builder.with_coverage();
-                }
-
-                let executor = builder.build(db.clone());
                 let result = self.run_tests(
                     &id.identifier(),
                     abi,

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -171,8 +171,8 @@ impl MultiContractRunnerBuilder {
     }
 
     #[must_use]
-    pub fn with_coverage(mut self) -> Self {
-        self.coverage = true;
+    pub fn set_coverage(mut self, enable: bool) -> Self {
+        self.coverage = enable;
         self
     }
 }

--- a/forge/src/result.rs
+++ b/forge/src/result.rs
@@ -3,6 +3,7 @@
 use crate::Address;
 use ethers::prelude::Log;
 use foundry_evm::{
+    coverage::HitMaps,
     fuzz::{CounterExample, FuzzedCases},
     trace::{CallTraceArena, TraceKind},
 };
@@ -62,6 +63,10 @@ pub struct TestResult {
 
     /// Traces
     pub traces: Vec<(TraceKind, CallTraceArena)>,
+
+    /// Raw coverage info
+    #[serde(skip)]
+    pub coverage: Option<HitMaps>,
 
     /// Labeled addresses
     pub labeled_addresses: BTreeMap<Address, String>,


### PR DESCRIPTION
Adds test coverage support to Forge.

### Usage

> **You cannot currently run this locally easily**
>
> This PR depends on https://github.com/gakonst/ethers-rs/pull/1201, so to run locally you must clone `ethers-rs` from that branch
> and update the patch section in `Cargo.toml` to point to your patched ethers. Then, run `foundryup -p .`.

Simply run `forge coverage` to get a coverage summary.

An LCOV reporter is also included: `forge coverage --report lcov`. Currently the LCOV file is written to `./lcov.info` but this is going to move.

### Background

I've had to rewrite this feature many times.. I wrote what I thought would be a good structure, only to find out later that something would not work and/or fit into the current structure, so I scrapped most of it and tried again.

Initially, the thought was to analyse `JUMPI` and `JUMPDEST`s to find branches (i.e. `require`, `assert`, `if` etc.), however it would not get us all the way in terms of the information we want - we want functions, branches, executable lines and statements.

The primary mode of operation for the coverage tool will be to collect the following pieces of information:

- **Functions** (done)
- **Executable lines**: lines, excluding lines that do nothing (whitespace, comments, brackets on single lines etc.)
- **Branches**: If statements, calls to require and asserts (wip)
- **Statements**: executable statements, which differ from lines in that you can have multiple statements per executable line (sort of done)

This information will be collected from the AST of the Solidity files. Then the tests are run with a special coverage collector that marks opcodes as hit as they are executed, which we later use (along with source maps) to map back to the coverage items.

Currently, I am working off of a combination of [`solidity-coverage`](https://github.com/sc-forks/solidity-coverage/) and [this Brownie blog post](https://medium.com/coinmonks/brownie-evaluating-solidity-code-coverage-via-opcode-tracing-a7cf5a92d28c) to figure out what to include in the reports and relevant data structures.

### Report types

The above information will be output either to stdout as a simple report, or as an LCOV file that you can upload to services like CodeCov. A stretch goal would be to add a HTML report as well, but since tools already exist for converting LCOV to HTML, it isn't a deal breaker if it is not in the first version.

### Compared to other coverage tools

- DappTools's coverage tool is not super great (see comments above) as it does not support outputting to standard reporting formats like LCOV, and it does not treat `require` and `assert` as branches.
- Hardhat Coverage is closer to what we want, but it's slow and it distorts gas since it instruments the code of the contracts

### Current status

Good 

- **All functions are detected**
- **Most statements are detected**, however there are some TODOs in the source code itself with questions about how deep in the AST we want to go, specifically around subexpressions.
- **I am collecting hit data** for individual instructions

Missing

- **Executable lines are not detected**: I left this for last because (fingers crossed) this would be the easiest item type to detect
- **Not all branches are detected**: I am detecting if-statements, however, I do wonder if it works as intended (e.g. should we mark chained `elseif`'s with the same branch ID?). I also do not currently detect `assert` and `require` type branches.
- **HTML reporter**: There is no HTML reporter and I consider it a stretch goal.
- **Hit data is NOT hooked up yet** so every item shows up as uncovered. My current thinking is that I want good detection, and then I'll start hooking up the hit data, but it is possible to hook it up first.

Needs change

- **LCOV reports do not have a fixed place yet**: I need to figure out where to put report data in general: I've thought about `out/coverage` (e.g. `out/coverage/lcov.info`, `out/coverage/html/index.html`), but I'm not sure yet.
- **Dependencies and test contracts are not filtered out**: We don't want to generate coverage for dependencies or the test contracts themselves
- **The summary reporter is verbose**: Currently the full path for files is displayed, but it should work more like what @mds1 had in mind in #99 

Needs clarification

- **Subexpression clarifications**: I'm not sure how deep to go for statement coverage in terms of subexpressions. See the relevant TODOs in the source code. I am also not sure if try/catch counts as a branch, or whether `Conditional` nodes count as branches (e.g. ternary statements).
- **Probably only works for Solidity >= 0.8.0** but I'm not sure yet. There have been some breaking changes in how the AST is structured (specifically, `name` used to be `nodeType` and function names etc. were in `node.attributes.name`)
- **LCOV block IDs**: LCOV branches (specifically the `BRDA` item) have a branch ID and a block ID. I'm not sure what the block ID is supposed to mean.

### Task list

**Branches**

- [ ] Detect `assert` as a branch
- [ ] Detect `require` as a branch
- [ ] Figure out if try/catch is a branch
- [ ] Figure out if `Conditional` nodes are branches

**Lines**

- [x] Detect executable lines

**Statements**

- [ ] Figure out what subexpressions to include as statement items

**Reporters**

- [ ] Add a HTML reporter like [`solidity-coverage`](https://github.com/sc-forks/solidity-coverage/)
- [ ] Bring summary reporter more in line with @mds1's idea in #99 
- [ ] Figure out if the LCOV reporter is broken or not
       I've tried running the LCOV report through `genhtml` but it complained that the file was malformed. I'm not sure if this is to be expected, or if it is just because we don't map the relevant items to source lines and that is why it is complaining

**Misc**

- [x] Hook up hit data
- [ ] Figure out what Solidity versions are supported and what versions we *should* support
- [x] Filter out dependency contracts
- [x] Filter out test contracts
- [ ] Try to break it and fix or handle those breakages

### Other

Companion PR: https://github.com/gakonst/ethers-rs/pull/1201

Closes #99