### PR TITLE
fix: maintain same dev accounts as on logged on output

### DIFF
--- a/anvil/src/eth/sign.rs
+++ b/anvil/src/eth/sign.rs
@@ -35,20 +35,24 @@ pub trait Signer: Send + Sync {
     ) -> Result<TypedTransaction, BlockchainError>;
 }
 
+/// Maintains developer keys
 pub struct DevSigner {
+    addresses: Vec<Address>,
     accounts: HashMap<Address, Wallet<SigningKey>>,
 }
 
 impl DevSigner {
-    pub fn new(accounts: HashMap<Address, Wallet<SigningKey>>) -> Self {
-        Self { accounts }
+    pub fn new(accounts: Vec<Wallet<SigningKey>>) -> Self {
+        let addresses = accounts.iter().map(|wallet| wallet.address()).collect::<Vec<_>>();
+        let accounts = addresses.iter().cloned().zip(accounts.into_iter()).collect();
+        Self { addresses, accounts }
     }
 }
 
 #[async_trait::async_trait]
 impl Signer for DevSigner {
     fn accounts(&self) -> Vec<Address> {
-        self.accounts.keys().copied().collect()
+        self.addresses.clone()
     }
 
     fn is_signer_for(&self, addr: Address) -> bool {

--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn spawn(mut config: NodeConfig) -> (EthApi, NodeHandle) {
 
     let fork = backend.get_fork().cloned();
 
-    let NodeConfig { accounts, block_time, port, max_transactions, server_config, .. } =
+    let NodeConfig { signer_accounts, block_time, port, max_transactions, server_config, .. } =
         config.clone();
 
     let pool = Arc::new(Pool::default());
@@ -92,7 +92,7 @@ pub async fn spawn(mut config: NodeConfig) -> (EthApi, NodeHandle) {
     };
     let miner = Miner::new(mode);
 
-    let dev_signer: Box<dyn EthSigner> = Box::new(DevSigner::new(accounts));
+    let dev_signer: Box<dyn EthSigner> = Box::new(DevSigner::new(signer_accounts));
     let fees = backend.fees().clone();
     let fee_history_cache = Arc::new(Mutex::new(Default::default()));
     let fee_history_service = FeeHistoryService::new(
@@ -198,12 +198,12 @@ impl NodeHandle {
 
     /// Signer accounts that can sign messages/transactions from the EVM node
     pub fn dev_accounts(&self) -> impl Iterator<Item = Address> + '_ {
-        self.config.accounts.keys().cloned()
+        self.config.signer_accounts.iter().map(|wallet| wallet.address())
     }
 
     /// Signer accounts that can sign messages/transactions from the EVM node
     pub fn dev_wallets(&self) -> impl Iterator<Item = Wallet<SigningKey>> + '_ {
-        self.config.accounts.values().cloned()
+        self.config.signer_accounts.iter().cloned()
     }
 
     /// Accounts that will be initialised with `genesis_balance` in the genesis block

--- a/anvil/tests/it/anvil.rs
+++ b/anvil/tests/it/anvil.rs
@@ -25,3 +25,13 @@ async fn test_can_change_mining_mode() {
     let num = provider.get_block_number().await.unwrap();
     assert_eq!(num.as_u64(), 2);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_default_dev_keys() {
+    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let provider = handle.http_provider();
+
+    let dev_accounts = handle.dev_accounts().collect::<Vec<_>>();
+    let accounts = provider.get_accounts().await.unwrap();
+    assert_eq!(dev_accounts, accounts);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
use same key order in `eth_accounts` as logged on output
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* dev signer maintains a Vec<Address> of the same addresses shown when `anvil` starts
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
