### PR TITLE
fix: add missing macOS(Intel) option in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -44,8 +44,8 @@ body:
       description: What operating system are you on?
       options:
         - Windows
-        - macOS (amd)
-        - macOS (M1)
+        - macOS (Intel)
+        - macOS (Apple Silicon)
         - Linux
   - type: textarea
     attributes:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

In the Operating System section of bug report issue template, both macOS(amd) and macOS(M1) are listed, but macOS(Intel) option is absent.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Change options 

- macOS(amd)
- macOS(M1)

to

- macOS(Intel)
- macOS(Apple Silicon)