### PR TITLE
feat(anvil): add support for historic state

### DIFF
--- a/anvil/core/src/eth/call.rs
+++ b/anvil/core/src/eth/call.rs
@@ -1,41 +1,42 @@
 use ethers_core::types::{transaction::eip2930::AccessList, Address, Bytes, U256};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Call request
-#[derive(Debug, Default, PartialEq, Deserialize, Clone)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct CallRequest {
     /// From
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<Address>,
     /// To
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to: Option<Address>,
     /// Gas Price
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gas_price: Option<U256>,
     /// EIP-1559 Max base fee the caller is willing to pay
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_fee_per_gas: Option<U256>,
     /// EIP-1559 Priority fee the caller is paying to the block author
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_priority_fee_per_gas: Option<U256>,
     /// Gas
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gas: Option<U256>,
     /// Value
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<U256>,
     /// Data
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<Bytes>,
     /// Nonce
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<U256>,
     /// AccessList
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub access_list: Option<AccessList>,
     /// EIP-2718 type
-    #[serde(default, rename = "type")]
+    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<U256>,
 }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -641,7 +641,7 @@ impl EthApi {
         )?
         .or_zero_fees();
 
-        let (exit, out, gas, _) = self.backend.call(request, fees, block_number);
+        let (exit, out, gas, _) = self.backend.call(request, fees, block_number)?;
 
         trace!(target = "node", "Call status {:?}, gas {}", exit, gas);
 
@@ -679,7 +679,8 @@ impl EthApi {
         }
 
         let from = request.from;
-        let (_, _, _gas, mut state) = self.backend.call(request, FeeDetails::zero(), block_number);
+        let (_, _, _gas, mut state) =
+            self.backend.call(request, FeeDetails::zero(), block_number)?;
 
         // cleanup state map
         if let Some(from) = from {
@@ -770,7 +771,7 @@ impl EthApi {
         call_to_estimate.gas = Some(gas_limit);
 
         // execute the call without writing to db
-        let (exit, _, gas, _) = self.backend.call(call_to_estimate, fees.clone(), block_number);
+        let (exit, _, gas, _) = self.backend.call(call_to_estimate, fees.clone(), block_number)?;
         match exit {
             Return::Return | Return::Continue | Return::SelfDestruct | Return::Stop => {
                 // succeeded
@@ -784,7 +785,8 @@ impl EthApi {
                 // again with the max gas limit to check if revert is gas related or not
                 return if request.gas.is_some() || request.gas_price.is_some() {
                     request.gas = Some(self.backend.gas_limit());
-                    let (exit, _, _gas, _) = self.backend.call(request.clone(), fees, block_number);
+                    let (exit, _, _gas, _) =
+                        self.backend.call(request.clone(), fees, block_number)?;
                     match exit {
                         return_ok!() => {
                             // transaction succeeded by manually increasing the gas limit to highest
@@ -818,7 +820,8 @@ impl EthApi {
 
         while (highest_gas_limit - lowest_gas_limit) > U256::one() {
             request.gas = Some(mid_gas_limit);
-            let (exit, _, _gas, _) = self.backend.call(request.clone(), fees.clone(), block_number);
+            let (exit, _, _gas, _) =
+                self.backend.call(request.clone(), fees.clone(), block_number)?;
             match exit {
                 return_ok!() => {
                     highest_gas_limit = mid_gas_limit;

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -38,7 +38,7 @@ use ethers::{
     abi::ethereum_types::H64,
     providers::ProviderError,
     types::{
-        transaction::eip2930::{AccessList, AccessListItem},
+        transaction::eip2930::{AccessList, AccessListItem, AccessListWithGasUsed},
         Address, Block, BlockNumber, Bytes, Log, Trace, Transaction, TransactionReceipt, TxHash,
         H256, U256, U64,
     },
@@ -169,9 +169,9 @@ impl EthApi {
             }
             EthRequest::EthSign(addr, content) => self.sign(addr, content).await.to_rpc_result(),
             EthRequest::EthSendRawTransaction(tx) => self.send_raw_transaction(tx).to_rpc_result(),
-            EthRequest::EthCall(call, block) => self.call(call, block).to_rpc_result(),
+            EthRequest::EthCall(call, block) => self.call(call, block).await.to_rpc_result(),
             EthRequest::EthCreateAccessList(call, block) => {
-                self.create_access_list(call, block).to_rpc_result()
+                self.create_access_list(call, block).await.to_rpc_result()
             }
             EthRequest::EthEstimateGas(call, block) => {
                 self.estimate_gas(call, block).await.to_rpc_result()
@@ -607,8 +607,18 @@ impl EthApi {
     /// Call contract, returning the output data.
     ///
     /// Handler for ETH RPC call: `eth_call`
-    pub fn call(&self, request: CallRequest, _number: Option<BlockNumber>) -> Result<Bytes> {
+    pub async fn call(&self, request: CallRequest, number: Option<BlockNumber>) -> Result<Bytes> {
         node_info!("eth_call");
+        let number = self.backend.convert_block_number(number);
+        // check if the number predates the fork, if in fork mode
+        if let Some(fork) = self.get_fork() {
+            if fork.predates_fork(number) {
+                return Ok(fork
+                    .call(&request, Some(BlockNumber::Number(number.into()).into()))
+                    .await?)
+            }
+        }
+
         let fees = FeeDetails::new(
             request.gas_price,
             request.max_fee_per_gas,
@@ -616,7 +626,7 @@ impl EthApi {
         )?
         .or_zero_fees();
 
-        let (exit, out, gas, _) = self.backend.call(request, fees);
+        let (exit, out, gas, _) = self.backend.call(request, fees, Some(number.into()));
 
         trace!(target = "node", "Call status {:?}, gas {}", exit, gas);
 
@@ -638,14 +648,29 @@ impl EthApi {
     /// sender account and the precompiles.
     ///
     /// Handler for ETH RPC call: `eth_createAccessList`
-    pub fn create_access_list(
+    pub async fn create_access_list(
         &self,
         request: CallRequest,
-        _number: Option<BlockNumber>,
-    ) -> Result<AccessList> {
+        number: Option<BlockNumber>,
+    ) -> Result<AccessListWithGasUsed> {
         node_info!("eth_createAccessList");
+
+        let number = self.backend.convert_block_number(number);
+        // check if the number predates the fork, if in fork mode
+        if let Some(fork) = self.get_fork() {
+            if fork.predates_fork(number) {
+                return Ok(fork
+                    .create_access_list(&request, Some(BlockNumber::Number(number.into()).into()))
+                    .await?)
+            }
+        }
+
         let from = request.from;
-        let mut state = self.backend.call(request, FeeDetails::zero()).3;
+        let (_, _, gas, mut state) = self.backend.call(
+            request,
+            FeeDetails::zero(),
+            Some(BlockNumber::Number(number.into())),
+        );
 
         // cleanup state map
         if let Some(from) = from {
@@ -661,7 +686,7 @@ impl EthApi {
             })
             .collect();
 
-        Ok(AccessList(items))
+        Ok(AccessListWithGasUsed { access_list: AccessList(items), gas_used: gas.into() })
     }
 
     /// Estimate gas needed for execution of given contract.
@@ -670,9 +695,17 @@ impl EthApi {
     pub async fn estimate_gas(
         &self,
         mut request: CallRequest,
-        block: Option<BlockNumber>,
+        block_number: Option<BlockNumber>,
     ) -> Result<U256> {
         node_info!("eth_estimateGas");
+
+        let number = self.backend.convert_block_number(block_number);
+        // check if the number predates the fork, if in fork mode
+        if let Some(fork) = self.get_fork() {
+            if fork.predates_fork(number) {
+                return Ok(fork.estimate_gas(&request, block_number.map(Into::into)).await?)
+            }
+        }
 
         // call takes at least this amount
         const MIN_GAS: U256 = U256([21_000, 0, 0, 0]);
@@ -682,7 +715,7 @@ impl EthApi {
             request.data.as_ref().map(|data| data.as_ref().is_empty()).unwrap_or(true);
         if likely_transfer {
             if let Some(to) = request.to {
-                if let Ok(target_code) = self.backend.get_code(to, block).await {
+                if let Ok(target_code) = self.backend.get_code(to, block_number).await {
                     if target_code.as_ref().is_empty() {
                         return Ok(MIN_GAS)
                     }
@@ -705,7 +738,7 @@ impl EthApi {
         if let Some(from) = request.from {
             let gas_price = fees.gas_price.unwrap_or_default();
             if gas_price > U256::zero() {
-                let mut available_funds = self.backend.get_balance(from, block).await?;
+                let mut available_funds = self.backend.get_balance(from, block_number).await?;
                 if let Some(value) = request.value {
                     if value > available_funds {
                         return Err(InvalidTransactionError::Payment.into())
@@ -728,7 +761,7 @@ impl EthApi {
         call_to_estimate.gas = Some(gas_limit);
 
         // execute the call without writing to db
-        let (exit, _, gas, _) = self.backend.call(call_to_estimate, fees.clone());
+        let (exit, _, gas, _) = self.backend.call(call_to_estimate, fees.clone(), block_number);
         match exit {
             Return::Return | Return::Continue | Return::SelfDestruct | Return::Stop => {
                 // succeeded
@@ -742,7 +775,7 @@ impl EthApi {
                 // again with the max gas limit to check if revert is gas related or not
                 return if request.gas.is_some() || request.gas_price.is_some() {
                     request.gas = Some(self.backend.gas_limit());
-                    let (exit, _, _gas, _) = self.backend.call(request.clone(), fees);
+                    let (exit, _, _gas, _) = self.backend.call(request.clone(), fees, block_number);
                     match exit {
                         return_ok!() => {
                             // transaction succeeded by manually increasing the gas limit to highest
@@ -776,7 +809,7 @@ impl EthApi {
 
         while (highest_gas_limit - lowest_gas_limit) > U256::one() {
             request.gas = Some(mid_gas_limit);
-            let (exit, _, _gas, _) = self.backend.call(request.clone(), fees.clone());
+            let (exit, _, _gas, _) = self.backend.call(request.clone(), fees.clone(), block_number);
             match exit {
                 return_ok!() => {
                     highest_gas_limit = mid_gas_limit;

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -38,7 +38,7 @@ use ethers::{
     abi::ethereum_types::H64,
     providers::ProviderError,
     types::{
-        transaction::eip2930::{AccessList, AccessListItem, AccessListWithGasUsed},
+        transaction::eip2930::{AccessList, AccessListItem},
         Address, Block, BlockNumber, Bytes, Log, Trace, Transaction, TransactionReceipt, TxHash,
         H256, U256, U64,
     },
@@ -667,7 +667,7 @@ impl EthApi {
         &self,
         request: CallRequest,
         block_number: Option<BlockNumber>,
-    ) -> Result<AccessListWithGasUsed> {
+    ) -> Result<AccessList> {
         node_info!("eth_createAccessList");
         let number = self.backend.ensure_block_number(block_number)?;
         let block_number = Some(number.into());
@@ -679,7 +679,7 @@ impl EthApi {
         }
 
         let from = request.from;
-        let (_, _, gas, mut state) = self.backend.call(request, FeeDetails::zero(), block_number);
+        let (_, _, _gas, mut state) = self.backend.call(request, FeeDetails::zero(), block_number);
 
         // cleanup state map
         if let Some(from) = from {
@@ -695,7 +695,7 @@ impl EthApi {
             })
             .collect();
 
-        Ok(AccessListWithGasUsed { access_list: AccessList(items), gas_used: gas.into() })
+        Ok(AccessList(items))
     }
 
     /// Estimate gas needed for execution of given contract.

--- a/anvil/src/eth/backend/db.rs
+++ b/anvil/src/eth/backend/db.rs
@@ -2,7 +2,7 @@
 
 use crate::{revm::AccountInfo, U256};
 use ethers::{
-    prelude::{Address, Bytes},
+    prelude::{Address, Bytes, H160},
     types::H256,
 };
 use foundry_evm::{
@@ -91,8 +91,22 @@ impl StateDb {
     pub fn new(db: impl DatabaseRef + Send + Sync + 'static) -> Self {
         Self(Box::new(db))
     }
+}
 
-    pub fn as_db(&self) -> impl DatabaseRef + '_ {
-        &*self.0
+impl DatabaseRef for StateDb {
+    fn basic(&self, address: H160) -> AccountInfo {
+        self.0.basic(address)
+    }
+
+    fn code_by_hash(&self, code_hash: H256) -> bytes::Bytes {
+        self.0.code_by_hash(code_hash)
+    }
+
+    fn storage(&self, address: H160, index: U256) -> U256 {
+        self.0.storage(address, index)
+    }
+
+    fn block_hash(&self, number: U256) -> H256 {
+        self.0.block_hash(number)
     }
 }

--- a/anvil/src/eth/backend/fork.rs
+++ b/anvil/src/eth/backend/fork.rs
@@ -98,10 +98,10 @@ impl ClientFork {
     pub async fn call(
         &self,
         request: &CallRequest,
-        block: Option<BlockId>,
+        block: Option<BlockNumber>,
     ) -> Result<Bytes, ProviderError> {
         let tx = ethers::utils::serialize(request);
-        let block = ethers::utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
+        let block = ethers::utils::serialize(&block.unwrap_or(BlockNumber::Latest));
         self.provider().request("eth_call", [tx, block]).await
     }
 
@@ -109,10 +109,10 @@ impl ClientFork {
     pub async fn estimate_gas(
         &self,
         request: &CallRequest,
-        block: Option<BlockId>,
+        block: Option<BlockNumber>,
     ) -> Result<U256, ProviderError> {
         let tx = ethers::utils::serialize(request);
-        let block = ethers::utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
+        let block = ethers::utils::serialize(&block.unwrap_or(BlockNumber::Latest));
         self.provider().request("eth_estimateGas", [tx, block]).await
     }
 
@@ -120,10 +120,10 @@ impl ClientFork {
     pub async fn create_access_list(
         &self,
         request: &CallRequest,
-        block: Option<BlockId>,
+        block: Option<BlockNumber>,
     ) -> Result<AccessListWithGasUsed, ProviderError> {
         let tx = ethers::utils::serialize(request);
-        let block = ethers::utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
+        let block = ethers::utils::serialize(&block.unwrap_or(BlockNumber::Latest));
         self.provider().request("eth_createAccessList", [tx, block]).await
     }
 

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -1,7 +1,7 @@
 //! The in memory DB
 
 use crate::{
-    eth::backend::db::Db,
+    eth::backend::db::{Db, StateDb},
     mem::{snapshot::Snapshots, state::state_merkle_trie_root},
     revm::{db::DatabaseRef, Account, AccountInfo, Database, DatabaseCommit},
     Address, U256,
@@ -97,5 +97,9 @@ impl Db for MemDb {
 
     fn maybe_state_root(&self) -> Option<H256> {
         Some(state_merkle_trie_root(self.inner.cache(), self.inner.storage()))
+    }
+
+    fn current_state(&self) -> StateDb {
+        StateDb::new(self.inner.clone())
     }
 }

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -454,6 +454,7 @@ impl Backend {
         &self,
         request: CallRequest,
         fee_details: FeeDetails,
+        _number: Option<BlockNumber>,
     ) -> (Return, TransactOut, u64, State) {
         trace!(target: "backend", "calling from [{:?}] fees={:?}", request.from, fee_details);
         let CallRequest { from, to, gas, value, data, nonce, access_list, .. } = request;

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -1,15 +1,80 @@
 //! In-memory blockchain storage
-use crate::eth::backend::time::duration_since_unix_epoch;
+use crate::eth::{
+    backend::{db::StateDb, time::duration_since_unix_epoch},
+    pool::transactions::PoolTransaction,
+};
 use anvil_core::eth::{
     block::{Block, PartialHeader},
     receipt::TypedReceipt,
     transaction::TransactionInfo,
 };
 use ethers::prelude::{BlockId, BlockNumber, Trace, H256, H256 as TxHash, U64};
-
-use crate::eth::pool::transactions::PoolTransaction;
+use foundry_evm::executor::DatabaseRef;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt,
+    sync::Arc,
+};
+
+/// Represents the complete state of single block
+pub struct InMemoryBlockStates {
+    /// The states at a certain block
+    states: HashMap<H256, StateDb>,
+    /// How many states to store at most
+    limit: usize,
+    /// all states present, used to enforce `limit`
+    present: VecDeque<H256>,
+}
+
+// === impl InMemoryBlockStates ===
+
+impl InMemoryBlockStates {
+    /// Creates a new instance with limited slots
+    pub fn new(limit: usize) -> Self {
+        Self { states: Default::default(), limit, present: Default::default() }
+    }
+
+    /// Inserts a new (hash -> state) pair
+    ///
+    /// When the configured limit for the number of states that can be stored in memory is reached,
+    /// the oldest state is removed.
+    pub fn insert(&mut self, hash: H256, state: StateDb) {
+        if self.present.len() > self.limit {
+            // evict the oldest block
+            self.present.pop_front().and_then(|hash| self.states.remove(&hash));
+        }
+        self.states.insert(hash, state);
+        self.present.push_back(hash);
+    }
+
+    /// Returns the state for the given `hash` if present
+    pub fn get(&self, hash: &H256) -> Option<&StateDb> {
+        self.states.get(hash)
+    }
+
+    /// Clears all entries
+    pub fn clear(&mut self) {
+        self.states.clear();
+        self.present.clear();
+    }
+}
+
+impl fmt::Debug for InMemoryBlockStates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InMemoryBlockStates")
+            .field("limit", &self.limit)
+            .field("present", &self.present)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for InMemoryBlockStates {
+    fn default() -> Self {
+        // unlimited
+        Self::new(usize::MAX)
+    }
+}
 
 /// Stores the blockchain data (blocks, transactions)
 #[derive(Clone)]

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -9,7 +9,6 @@ use anvil_core::eth::{
     transaction::TransactionInfo,
 };
 use ethers::prelude::{BlockId, BlockNumber, Trace, H256, H256 as TxHash, U64};
-use foundry_evm::executor::DatabaseRef;
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, VecDeque},

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -52,6 +52,8 @@ pub enum BlockchainError {
     InvalidUrl(String),
     #[error("Internal error: {0:?}")]
     Internal(String),
+    #[error("BlockOutOfRangeError: block height is {0} but requested was {1}")]
+    BlockOutOfRange(u64, u64),
 }
 
 impl From<RpcError> for BlockchainError {
@@ -194,6 +196,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 }
                 err @ BlockchainError::InvalidUrl(_) => RpcError::invalid_params(err.to_string()),
                 BlockchainError::Internal(err) => RpcError::internal_error_with(err),
+                err @ BlockchainError::BlockOutOfRange(_, _) => {
+                    RpcError::invalid_params(err.to_string())
+                }
             }
             .into(),
         }

--- a/anvil/tests/it/ganache.rs
+++ b/anvil/tests/it/ganache.rs
@@ -2,18 +2,20 @@
 #![allow(unused)]
 use crate::init_tracing;
 use ethers::{
+    abi::Address,
     contract::ContractFactory,
     core::k256::SecretKey,
     prelude::{abigen, Middleware, Signer, SignerMiddleware, TransactionRequest, Ws},
     providers::{Http, Provider},
     signers::LocalWallet,
+    types::BlockNumber,
     utils::hex,
 };
 use ethers_solc::{project_util::TempProject, Artifact};
 use std::sync::Arc;
 
 fn ganache_wallet() -> LocalWallet {
-    let key_str = "3cb6fcd4261b21b2398fdbdc2b589d3b9aca4a63a6a40c8ab28773c1406b842b";
+    let key_str = "200fd426f5dc07b57c645007e8947253c0cde02050f0fafcf54c7cb81e05e3f9";
     let key_hex = hex::decode(key_str).expect("could not parse as hex");
     let key = SecretKey::from_be_bytes(&key_hex).expect("did not get private key");
     key.into()
@@ -27,6 +29,15 @@ fn http_client() -> Arc<SignerMiddleware<Provider<Http>, LocalWallet>> {
 async fn ws_client() -> Arc<SignerMiddleware<Provider<Ws>, LocalWallet>> {
     let provider = Provider::<Ws>::connect("ws://127.0.0.1:8545").await.unwrap();
     Arc::new(SignerMiddleware::new(provider, ganache_wallet()))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_ganache_block_number() {
+    let client = http_client();
+    let balance = client
+        .get_balance(Address::random(), Some(BlockNumber::Number(100u64.into()).into()))
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
previously all block number args were ignored, so eth_call was always executed on head state regardless of the paramaeter
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* keep previous states in memory, similar to snapshots, and transact_ref on a cached state if the block < head
* also adds range checks for block number args

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
