### PR TITLE
fix: return early if chain dir does not exist

### DIFF
--- a/cli/src/cmd/forge/cache.rs
+++ b/cli/src/cmd/forge/cache.rs
@@ -130,7 +130,7 @@ impl Cmd for LsArgs {
 
     fn run(self) -> Result<Self::Output> {
         let LsArgs { chains } = self;
-        let mut cache = Cache { chains: vec![] };
+        let mut cache = Cache::default();
         for chain_or_all in chains {
             match chain_or_all {
                 ChainOrAll::Chain(chain) => cache.chains.push(list_chain_cache(chain)?),
@@ -162,6 +162,6 @@ fn list_chain_cache(chain: Chain) -> Result<ChainCache> {
     if let Ok(foundry_chain) = FoundryConfigChain::try_from(chain) {
         Config::list_foundry_chain_cache(foundry_chain)
     } else {
-        eyre::bail!("failed to map chain");
+        eyre::bail!("failed to recognise chain: {}", chain);
     }
 }

--- a/config/src/cache.rs
+++ b/config/src/cache.rs
@@ -184,14 +184,14 @@ impl Serialize for CachedEndpoints {
 }
 
 /// Content of the foundry cache folder
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Cache {
     /// The list of chains in the cache
     pub chains: Vec<ChainCache>,
 }
 
-impl std::fmt::Display for Cache {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Cache {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for chain in &self.chains {
             match NumberPrefix::decimal(chain.blocks.iter().map(|x| x.1).sum::<u64>() as f32) {
                 NumberPrefix::Standalone(size) => {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -992,6 +992,9 @@ impl Config {
     //The path provided to this function should point to a cached chain folder
     fn get_cached_blocks(chain_path: &Path) -> eyre::Result<Vec<(String, u64)>> {
         let mut blocks = vec![];
+        if !chain_path.exists() {
+            return Ok(blocks)
+        }
         for block in chain_path
             .read_dir()?
             .flatten()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As discovered here https://github.com/gakonst/ethers-rs/pull/1249 `forge cache ls <chain>` can fail if the chain dir does not exist
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
return early if dir does not exist
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
