### PR TITLE
Return Index Value and Type printed in `forge run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ name = "foundry-cli"
 version = "0.2.0"
 dependencies = [
  "atty",
+ "bytes",
  "cast",
  "clap",
  "clap_complete",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,6 +70,7 @@ semver = "1.0.5"
 once_cell = "1.9.0"
 similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
+bytes = "1.1.0"
 
 
 [dev-dependencies]

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -258,7 +258,7 @@ impl Cmd for RunArgs {
 
             println!("Gas used: {}", result.gas);
 
-            println!("== Result ==");
+            println!("== Return ==");
             match func.decode_output(&result.returned) {
                 Ok(decoded) => {
                     for (index, token) in decoded.iter().enumerate() {
@@ -267,7 +267,7 @@ impl Cmd for RunArgs {
                             None => String::from("unknown"),
                         };
 
-                        println!("{}: {:<9} {}", index, internal_type, format_token(&token));
+                        println!("{}: {:<9} {}", index, internal_type, format_token(token));
                     }
                 }
                 Err(_) => {

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use clap::{Parser, ValueHint};
 use ethers::{
-    abi::{Abi, RawLog},
+    abi::{Abi, Function, RawLog},
     prelude::ArtifactId,
     solc::{
         artifacts::{CompactContractBytecode, ContractBytecode, ContractBytecodeSome},
@@ -24,7 +24,7 @@ use forge::{
 };
 use foundry_common::evm::EvmArgs;
 use foundry_config::{figment::Figment, Config};
-use foundry_utils::{encode_args, IntoFunction, PostLinkInput, RuntimeOrHandle};
+use foundry_utils::{encode_args, format_token, IntoFunction, PostLinkInput, RuntimeOrHandle};
 use std::{collections::BTreeMap, path::PathBuf};
 use ui::{TUIExitReason, Tui, Ui};
 use yansi::Paint;
@@ -129,6 +129,26 @@ impl Cmd for RunArgs {
             builder = builder.with_tracing().with_debugger();
         }
 
+        let (func, call): (&Function, Bytes) = match self.sig.strip_prefix("0x") {
+            Some(calldata) => (
+                abi.functions()
+                    .find(|&func| {
+                        func.short_signature().to_vec() == hex::decode(calldata).unwrap()[..4]
+                    })
+                    .expect("Function selector not found in the ABI"),
+                hex::decode(calldata).unwrap().into(),
+            ),
+            _ => {
+                let func = IntoFunction::into(self.sig);
+                (
+                    abi.functions()
+                        .find(|&abi_func| abi_func.short_signature() == func.short_signature())
+                        .expect("Function signature not found in the ABI"),
+                    encode_args(&func, &self.args)?.into(),
+                )
+            }
+        };
+
         let mut result = {
             let mut runner =
                 Runner::new(builder.build(db), evm_opts.initial_balance, evm_opts.sender);
@@ -136,19 +156,20 @@ impl Cmd for RunArgs {
                 runner.setup(&predeploy_libraries, bytecode, needs_setup)?;
 
             let RunResult {
-                success, gas, logs, traces, debug: run_debug, labeled_addresses, ..
-            } = runner.run(
-                address,
-                if let Some(calldata) = self.sig.strip_prefix("0x") {
-                    hex::decode(calldata)?.into()
-                } else {
-                    encode_args(&IntoFunction::into(self.sig), &self.args)?.into()
-                },
-            )?;
+                success,
+                gas,
+                returned,
+                logs,
+                traces,
+                debug: run_debug,
+                labeled_addresses,
+                ..
+            } = runner.run(address, call)?;
 
             result.success &= success;
 
             result.gas = gas;
+            result.returned = returned;
             result.logs.extend(logs);
             result.traces.extend(traces);
             result.debug = run_debug;
@@ -236,6 +257,24 @@ impl Cmd for RunArgs {
             }
 
             println!("Gas used: {}", result.gas);
+
+            println!("== Result ==");
+            match func.decode_output(&result.returned) {
+                Ok(decoded) => {
+                    for (index, token) in decoded.iter().enumerate() {
+                        let internal_type = match &func.outputs[index].internal_type {
+                            Some(t) => String::from(t),
+                            None => String::from("unknown"),
+                        };
+
+                        println!("{}: {:<9} {}", index, internal_type, format_token(&token));
+                    }
+                }
+                Err(_) => {
+                    println!("{:x?}", (&result.returned));
+                }
+            }
+
             println!("== Logs ==");
             let console_logs = decode_console_logs(&result.logs);
             if !console_logs.is_empty() {
@@ -353,6 +392,7 @@ impl RunArgs {
 
 struct RunResult {
     pub success: bool,
+    pub returned: bytes::Bytes,
     pub logs: Vec<RawLog>,
     pub traces: Vec<(TraceKind, CallTraceArena)>,
     pub debug: Option<Vec<DebugArena>>,
@@ -437,6 +477,7 @@ impl<DB: DatabaseRef> Runner<DB> {
                     (
                         address,
                         RunResult {
+                            returned: bytes::Bytes::new(),
                             logs,
                             traces,
                             labeled_addresses: labels,
@@ -452,6 +493,7 @@ impl<DB: DatabaseRef> Runner<DB> {
             (
                 address,
                 RunResult {
+                    returned: bytes::Bytes::new(),
                     logs,
                     traces,
                     success: true,
@@ -464,10 +506,11 @@ impl<DB: DatabaseRef> Runner<DB> {
     }
 
     pub fn run(&mut self, address: Address, calldata: Bytes) -> eyre::Result<RunResult> {
-        let RawCallResult { reverted, gas, stipend, logs, traces, labels, debug, .. } =
+        let RawCallResult { reverted, gas, stipend, result, logs, traces, labels, debug, .. } =
             self.executor.call_raw(self.sender, address, calldata.0, 0.into())?;
         Ok(RunResult {
             success: !reverted,
+            returned: result,
             gas: gas.overflowing_sub(stipend).0,
             logs,
             traces: traces.map(|traces| vec![(TraceKind::Execution, traces)]).unwrap_or_default(),

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -261,13 +261,15 @@ impl Cmd for RunArgs {
             println!("== Return ==");
             match func.decode_output(&result.returned) {
                 Ok(decoded) => {
-                    for (index, token) in decoded.iter().enumerate() {
-                        let internal_type = match &func.outputs[index].internal_type {
-                            Some(t) => String::from(t),
-                            None => String::from("unknown"),
-                        };
+                    for (index, (token, output)) in decoded.iter().zip(&func.outputs).enumerate() {
+                        let internal_type = output.internal_type.as_deref().unwrap_or("unknown");
 
-                        println!("{}: {:<9} {}", index, internal_type, format_token(token));
+                        let label = if !output.name.is_empty() {
+                            output.name.to_string()
+                        } else {
+                            index.to_string()
+                        };
+                        println!("{}: {} {}", label.trim_end(), internal_type, format_token(token));
                     }
                 }
                 Err(_) => {

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -424,9 +424,9 @@ forgetest!(can_execute_run_command_with_returned, |prj: TestProject, mut cmd: Te
 pragma solidity 0.8.10;
 contract Demo {
     event log_string(string);
-    function run() external returns (uint256) {
+    function run() external returns (uint256 result, uint8) {
         emit log_string("script ran");
-        return 255;
+        return (255, 3);
     }
 }"#,
         )
@@ -436,9 +436,10 @@ contract Demo {
     assert!(output.ends_with(&format!(
         "Compiler run successful
 {}
-Gas used: 1801
+Gas used: 1836
 == Return ==
-0: uint256   255
+result: uint256 255
+1: uint8 3
 == Logs ==
   script ran
 ",

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -334,6 +334,7 @@ contract Demo {
         "Compiler run successful
 {}
 Gas used: 1751
+== Return ==
 == Logs ==
   script ran
 ",
@@ -366,6 +367,7 @@ contract Demo {
         "Compiler run successful
 {}
 Gas used: 1751
+== Return ==
 == Logs ==
   script ran
 ",
@@ -401,6 +403,7 @@ contract Demo {
         "Compiler run successful
 {}
 Gas used: 3957
+== Return ==
 == Logs ==
   script ran
   1
@@ -408,6 +411,39 @@ Gas used: 3957
 ",
         Paint::green("Script ran successfully.")
     ),));
+});
+
+// Tests that the run command can run functions with return values
+forgetest!(can_execute_run_command_with_returned, |prj: TestProject, mut cmd: TestCommand| {
+    let script = prj
+        .inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+contract Demo {
+    event log_string(string);
+    function run() external returns (uint256) {
+        emit log_string("script ran");
+        return 255;
+    }
+}"#,
+        )
+        .unwrap();
+    cmd.arg("run").arg(script);
+    let output = cmd.stdout_lossy();
+    assert!(output.ends_with(&format!(
+        "Compiler run successful
+{}
+Gas used: 1801
+== Return ==
+0: uint256   255
+== Logs ==
+  script ran
+",
+        Paint::green("Script ran successfully.")
+    )));
 });
 
 // tests that the `inspect` command works correctly

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -443,7 +443,6 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
 // so that `dep/=lib/a/src` will take precedent over  `dep/=lib/a/lib/b/src`
 forgetest_init!(can_prioritise_closer_lib_remappings, |prj: TestProject, mut cmd: TestCommand| {
     let config = cmd.config();
-    let remappings = config.get_all_remappings();
 
     // create a new lib directly in the `lib` folder with conflicting remapping `forge-std/`
     let mut config = config.clone();


### PR DESCRIPTION
Issue #1475 requests that `forge run` prints the index, value, and type of each returned value from the function call. This Pull Request includes a change that prints data in the previously mentioned format.

## Motivation

The problem being solved is for developers that execute a function call against a Solidity file and want to see not only the event logs and stack traces, but also what value the function returned.

## Solution

The solution required an additional field, `returned`, on the `RunResult` defined in the source file for the `forge run` command. This gets the `result` from the `raw_call` being executed against the compiled contract.

Another change was to additionally extract the function to be called from the contract ABI. This allows for the extraction of the exact return types. If this is omitted, every `uintN` value would be labeled `Uint` with no indication of the integer's size.

Finally, the `returned` data is decoded into `Token`s and looped over to be printed to the stdout.

The following is an example of the printed output.

```
== Return ==
0: bool      true
1: int256    255
2: uint256   2
3: address   0x0000000000000000000000000000000000000003
4: bytes32   0x0000000000000000000000000000000000000000000000000000000000000004
5: bytes     0x
6: string    "test"
7: uint8[]   [21, 22]
```