### PR TITLE
feat(cast): pad bytes32 hex values if they are short

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -500,6 +500,7 @@ pub async fn get_func_etherscan(
 }
 
 /// Parses string input as Token against the expected ParamType
+#[allow(clippy::no_effect)]
 pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
     params: I,
     lenient: bool,
@@ -517,20 +518,17 @@ pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
                 match param {
                     ParamType::FixedBytes(32) => {
                         if value.len() < 66 {
-                            if let Ok(pad) = String::from_utf8(vec![b'0'; 66-value.len()]) {
-                                let padded_value: String = [value, &pad].concat();
-                                token = if lenient {
-                                    LenientTokenizer::tokenize(param, &padded_value)
-                                } else {
-                                    StrictTokenizer::tokenize(param, &padded_value)
-                                };
-                            }
+                            let padded_value = [value, &"0".repeat(66 - value.len())].concat();
+                            token = if lenient {
+                                LenientTokenizer::tokenize(param, &padded_value)
+                            } else {
+                                StrictTokenizer::tokenize(param, &padded_value)
+                            };
                         }
                     }
                     ParamType::Uint(_) => {
-                        println!("Not Bytes32");
                         if let ParamType::Uint(_) = param {
-                        // try again if value is hex
+                            // try again if value is hex
                             if let Ok(value) = U256::from_str(value).map(|v| v.to_string()) {
                                 token = if lenient {
                                     LenientTokenizer::tokenize(param, &value)
@@ -540,7 +538,11 @@ pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
                             }
                         }
                     }
-                    _ =>  {();}
+                    // TODO: Not sure what to do here. Put the no effect in for now, but that is not
+                    // ideal. We could attempt massage for every value type?
+                    _ => {
+                        ();
+                    }
                 }
             }
             token

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -538,9 +538,7 @@ pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
                     }
                     // TODO: Not sure what to do here. Put the no effect in for now, but that is not
                     // ideal. We could attempt massage for every value type?
-                    _ => {
-                        ();
-                    }
+                    _ => {}
                 }
             }
             token

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -527,15 +527,13 @@ pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
                         }
                     }
                     ParamType::Uint(_) => {
-                        if let ParamType::Uint(_) = param {
-                            // try again if value is hex
-                            if let Ok(value) = U256::from_str(value).map(|v| v.to_string()) {
-                                token = if lenient {
-                                    LenientTokenizer::tokenize(param, &value)
-                                } else {
-                                    StrictTokenizer::tokenize(param, &value)
-                                };
-                            }
+                        // try again if value is hex
+                        if let Ok(value) = U256::from_str(value).map(|v| v.to_string()) {
+                            token = if lenient {
+                                LenientTokenizer::tokenize(param, &value)
+                            } else {
+                                StrictTokenizer::tokenize(param, &value)
+                            };
                         }
                     }
                     // TODO: Not sure what to do here. Put the no effect in for now, but that is not


### PR DESCRIPTION
## Motivation
#1588 showed that `cast` will not pad bytes32 arguments in methods like `call`. 

## Solution
Currently, the solution adds an additional error massaging case to `parse_tokens` that right pads the value to 32 bytes if the param is type `FixedBytes(32)`. 

Some open questions:
- Should we massage other value types? E.g. if an address is not 20 bytes? Obviously a zero padding there makes less intuitive sense. I am not familiar with the intricacies of the `seth` spec but we could match that exactly? Can open a separate issue for this.

- Not sure I am doing to default match case correctly with the no-op.

## Example Behavior Changes:
Before:
```sh
$> cast call 0x5a464c28d19848f44199d003bef5ecc87d090f87 "name(bytes32)(string)" 0x5257413030312d4100000
Error:
   0: Failed to parse tokens
   1: Invalid data

Location:
   /home/finn/git/dmfxyz/foundry/utils/src/lib.rs:549
```
New:
```sh
$> cast call 0x5a464c28d19848f44199d003bef5ecc87d090f87 "name(bytes32)(string)" 0x5257413030312d4100000
RWA001-A: 6s Capital
```

