### PR TITLE
fix(anvil): use interval_at to mine after first elapsed interval

### DIFF
--- a/anvil/src/eth/miner.rs
+++ b/anvil/src/eth/miner.rs
@@ -168,7 +168,8 @@ pub struct FixedBlockTimeMiner {
 impl FixedBlockTimeMiner {
     /// Creates a new instance with an interval of `duration`
     pub fn new(duration: Duration) -> Self {
-        Self { interval: tokio::time::interval(duration) }
+        let start = tokio::time::Instant::now() + duration;
+        Self { interval: tokio::time::interval_at(start, duration) }
     }
 
     fn poll(&mut self, pool: &Arc<Pool>, cx: &mut Context<'_>) -> Poll<Vec<Arc<PoolTransaction>>> {

--- a/anvil/src/service.rs
+++ b/anvil/src/service.rs
@@ -1,6 +1,9 @@
 //! background service
 
-use crate::eth::{backend, fees::FeeHistoryService, miner::Miner, pool::Pool};
+use crate::{
+    eth::{backend, fees::FeeHistoryService, miner::Miner, pool::Pool},
+    filter::Filters,
+};
 use futures::FutureExt;
 use std::{
     future::Future,
@@ -9,8 +12,6 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::time::Interval;
-
-use crate::filter::Filters;
 use tracing::trace;
 
 /// The type that drives the blockchain's state

--- a/anvil/tests/it/anvil.rs
+++ b/anvil/tests/it/anvil.rs
@@ -19,11 +19,11 @@ async fn test_can_change_mining_mode() {
     // changing the mining mode will instantly mine a new block
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     let num = provider.get_block_number().await.unwrap();
-    assert_eq!(num.as_u64(), 1);
+    assert_eq!(num.as_u64(), 0);
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     let num = provider.get_block_number().await.unwrap();
-    assert_eq!(num.as_u64(), 2);
+    assert_eq!(num.as_u64(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
only start mining after first interval elapsed
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use `interval_at(now+blocktime)` instead of `interval`, which is ready instantly.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
