### PR TITLE
Solidity's model checker basic options

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -47,6 +47,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
             yul_details: Some(YulDetails { stack_allocation: Some(true), ..Default::default() }),
             ..Default::default()
         }),
+        model_checker: None,
         extra_output: Default::default(),
         extra_output_files: Default::default(),
         names: true,

--- a/config/README.md
+++ b/config/README.md
@@ -138,6 +138,42 @@ stackAllocation = true
 optimizerSteps = 'dhfoDgvulfnTUtnIf'
 ```
 
+##### Additional Model Checker settings
+
+[Solidity's built-in model checker](https://docs.soliditylang.org/en/latest/smtchecker.html#tutorial)
+is an opt-in module that can be enabled via the `ModelChecker` object.
+
+See [Compiler Input Description `settings.modelChecker`](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description)
+and [the model checker's options](https://docs.soliditylang.org/en/latest/smtchecker.html#smtchecker-options-and-tuning).
+
+The module is available in `solc` release binaries for OSX and Linux.
+The latter requires the z3 library version [4.8.8, 4.8.14] to be installed
+in the system (SO version 4.8).
+
+Similarly to the optimizer settings above, the `model_checker` settings must be
+prefixed with the profile they correspond to: `[default.model_checker]` belongs
+to the `[default]` profile.
+
+```toml
+[default.model_checker]
+contracts = { '/path/to/project/src/Contract.sol' = [ 'Contract' ] }
+engine = 'chc'
+timeout = 10000
+targets = [ 'assert' ]
+```
+
+The fields above are recommended when using the model checker.
+Setting which contract should be verified is extremely important, otherwise all
+available contracts will be verified which can consume a lot of time.
+The recommended engine is `chc`, but `bmc` and `all` (runs both) are also
+accepted.
+It is also important to set a proper timeout (given in milliseconds), since the
+default time given to the underlying solvers may not be enough.
+If no verification targets are given, only assertions will be checked.
+
+The model checker will run when `forge build` is invoked, and will show
+findings as warnings if any.
+
 ## Environment Variables
 
 Foundry's tools read all environment variable names prefixed with `FOUNDRY_` using the string after the `_` as the name


### PR DESCRIPTION
Not sure if this is wanted, but I think it would be cool to have direct access to Solidity's model checker via the Foundry options. This is basically what I'm running locally.
The options are opt-in and not there by default, so it shouldn't bother the default case and Foundry users who don't explicitly add it.

## Description

This PR adds the minimum required options to `foundry.toml` (as opt-in) that enable [Soldity's model checker](https://docs.soliditylang.org/en/latest/smtchecker.html).

## Motivation

Solidity has a built-in model checker that can be easy to use on OSX and Linux (the latter needs z3 <=4.8.14 installed system-wide) via compiler options.

## Solution

The options were added based on a subset of the [tools options](https://docs.soliditylang.org/en/latest/smtchecker.html#smtchecker-options-and-tuning). For now only the essential options were added, but the rest (such as `divModNoSlack` and `invariants`) can easily be added afterwards.

This PR depends on its corresponding `ethers-rs` PR (https://github.com/gakonst/ethers-rs/pull/1258), and the first commit here points to that PR's branch to show how the integration works, and would be removed if/when that PR is merged.

## Example

The feature this PR enables is represented below.

Let `src/Contract.sol` be the following code, which you want to verify:

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

contract Contract {
	uint x;

	function inc() public {
		++x;
	}

	function inv(uint y) public view {
		require(y > 2);
		assert(x <= y);
	}
}
```

This is added to `foundry.toml`:

```toml
[default.model_checker]
contracts = { '/path/to/project/src/Contract.sol' = [ 'Contract' ] }
engine = 'chc'
timeout = 10000
```

Result of `forge build`:

```bash
[⠆] Compiling...
[⠑] Compiling 2 files with 0.8.13
[⠘] Solc 0.8.13 finished in 332.19ms
Compiler run successful (with warnings)
warning[6328]: Warning: CHC: Assertion violation happens here.
Counterexample:
x = 4
y = 3

Transaction trace:
Contract.constructor()
State: x = 0
Contract.inc()
State: x = 1
Contract.inc()
State: x = 2
Contract.inc()
State: x = 3
Contract.inc()
State: x = 4
Contract.inv(3)
  --> /path/to/project/src/Contract.sol:13:3:
   |
13 | 		assert(x <= y);
   | 		^^^^^^^^^^^^^^
```