### PR TITLE
feat(forge): overload `expectCall` and `mockCall` with `msg.value`

### DIFF
--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -40,6 +40,7 @@ ethers::contract::abigen!(
             mockCall(address,bytes,bytes)
             clearMockedCalls()
             expectCall(address,bytes)
+            expectCall(address,uint256,bytes)
             getCode(string)
             label(address,string)
             assume(bool)
@@ -90,7 +91,7 @@ pub use hardhatconsole_mod::HARDHATCONSOLE_ABI as HARDHAT_CONSOLE_ABI;
 /// it with the selector `abigen!` bindings expect.
 pub fn patch_hardhat_console_selector(mut input: Vec<u8>) -> Vec<u8> {
     if input.len() < 4 {
-        return input
+        return input;
     }
 
     let selector = Selector::try_from(&input[..4]).unwrap();

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -92,7 +92,7 @@ pub use hardhatconsole_mod::HARDHATCONSOLE_ABI as HARDHAT_CONSOLE_ABI;
 /// it with the selector `abigen!` bindings expect.
 pub fn patch_hardhat_console_selector(mut input: Vec<u8>) -> Vec<u8> {
     if input.len() < 4 {
-        return input;
+        return input
     }
 
     let selector = Selector::try_from(&input[..4]).unwrap();

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -38,6 +38,7 @@ ethers::contract::abigen!(
             expectEmit(bool,bool,bool,bool)
             expectEmit(bool,bool,bool,bool,address)
             mockCall(address,bytes,bytes)
+            mockCall(address,uint256,bytes,bytes)
             clearMockedCalls()
             expectCall(address,bytes)
             expectCall(address,uint256,bytes)

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -48,11 +48,11 @@ pub fn handle_expect_revert(
     retdata: Bytes,
 ) -> Result<(Option<Address>, Bytes), Bytes> {
     if matches!(status, return_ok!()) {
-        return Err("Call did not revert as expected".to_string().encode().into());
+        return Err("Call did not revert as expected".to_string().encode().into())
     }
 
     if !expected_revert.is_empty() && retdata.is_empty() {
-        return Err("Call reverted as expected, but without data".to_string().encode().into());
+        return Err("Call reverted as expected, but without data".to_string().encode().into())
     }
 
     let (err, actual_revert): (_, Bytes) = match retdata {
@@ -180,13 +180,18 @@ pub struct MockCallDataContext {
 
 impl Ord for MockCallDataContext {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Calldata matching is reversed to ensure that a tighter match is
+        // returned if an exact match is not found. In case, there is
+        // a partial match to calldata that is more specific than
+        // a match to a msg.value, then the more specific calldata takes
+        // precedence.
         self.calldata.cmp(&other.calldata).reverse().then(self.value.cmp(&other.value).reverse())
     }
 }
 
 impl PartialOrd for MockCallDataContext {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -3,7 +3,7 @@ mod env;
 pub use env::{Prank, RecordAccess};
 /// Assertion helpers (such as `expectEmit`)
 mod expect;
-pub use expect::{ExpectedCallData, ExpectedEmit, ExpectedRevert};
+pub use expect::{ExpectedCallData, ExpectedEmit, ExpectedRevert, MockCallDataContext};
 /// Cheatcodes that interact with the external environment (FFI etc.)
 mod ext;
 /// Cheatcodes that configure the fuzzer
@@ -61,7 +61,7 @@ pub struct Cheatcodes {
     pub accesses: Option<RecordAccess>,
 
     /// Mocked calls
-    pub mocked_calls: BTreeMap<Address, BTreeMap<Bytes, Bytes>>,
+    pub mocked_calls: BTreeMap<Address, BTreeMap<MockCallDataContext, Bytes>>,
 
     /// Expected calls
     pub expected_calls: BTreeMap<Address, Vec<ExpectedCallData>>,
@@ -123,11 +123,16 @@ where
 
             // Handle mocked calls
             if let Some(mocks) = self.mocked_calls.get(&call.contract) {
-                if let Some(mock_retdata) = mocks.get(&call.input) {
+                let ctx = MockCallDataContext {
+                    calldata: call.input.clone(),
+                    value: Some(call.transfer.value),
+                };
+                if let Some(mock_retdata) = mocks.get(&ctx) {
                     return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone());
-                } else if let Some((_, mock_retdata)) =
-                    mocks.iter().find(|(mock, _)| *mock == &call.input[..mock.len()])
-                {
+                } else if let Some((_, mock_retdata)) = mocks.iter().find(|(mock, _)| {
+                    &*mock.calldata == &call.input[..mock.calldata.len()]
+                        && mock.value.map(|value| value == call.transfer.value).unwrap_or(true)
+                }) {
                     return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone());
                 }
             }

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -113,9 +113,9 @@ where
             // Handle expected calls
             if let Some(expecteds) = self.expected_calls.get_mut(&call.contract) {
                 if let Some(found_match) = expecteds.iter().position(|expected| {
-                    expected.calldata.len() <= call.input.len()
-                        && expected.calldata == &call.input[..expected.calldata.len()]
-                        && expected.value.map(|value| value == call.transfer.value).unwrap_or(true)
+                    expected.calldata.len() <= call.input.len() &&
+                        expected.calldata == call.input[..expected.calldata.len()] &&
+                        expected.value.map(|value| value == call.transfer.value).unwrap_or(true)
                 }) {
                     expecteds.remove(found_match);
                 }
@@ -128,19 +128,19 @@ where
                     value: Some(call.transfer.value),
                 };
                 if let Some(mock_retdata) = mocks.get(&ctx) {
-                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone());
+                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone())
                 } else if let Some((_, mock_retdata)) = mocks.iter().find(|(mock, _)| {
-                    &*mock.calldata == &call.input[..mock.calldata.len()]
-                        && mock.value.map(|value| value == call.transfer.value).unwrap_or(true)
+                    *mock.calldata == call.input[..mock.calldata.len()] &&
+                        mock.value.map(|value| value == call.transfer.value).unwrap_or(true)
                 }) {
-                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone());
+                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone())
                 }
             }
 
             // Apply our prank
             if let Some(prank) = &self.prank {
-                if data.subroutine.depth() >= prank.depth
-                    && call.context.caller == prank.prank_caller
+                if data.subroutine.depth() >= prank.depth &&
+                    call.context.caller == prank.prank_caller
                 {
                     // At the target depth we set `msg.sender`
                     if data.subroutine.depth() == prank.depth {
@@ -234,7 +234,7 @@ where
         _: bool,
     ) -> (Return, Gas, Bytes) {
         if call.contract == CHEATCODE_ADDRESS || call.contract == HARDHAT_CONSOLE_ADDRESS {
-            return (status, remaining_gas, retdata);
+            return (status, remaining_gas, retdata)
         }
 
         // Clean up pranks
@@ -254,7 +254,7 @@ where
                 return match handle_expect_revert(false, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, remaining_gas, retdata),
                     Ok((_, retdata)) => (Return::Return, remaining_gas, retdata),
-                };
+                }
             }
         }
 
@@ -269,7 +269,7 @@ where
                 Return::Revert,
                 remaining_gas,
                 "Log != expected log".to_string().encode().into(),
-            );
+            )
         } else {
             // Clear the emits we expected at this depth that have been found
             self.expected_emits.retain(|expected| !expected.found)
@@ -291,11 +291,11 @@ where
                         expecteds[0]
                             .value
                             .map(|v| format!(" and value {}", v))
-                            .unwrap_or("".to_string())
+                            .unwrap_or_else(|| "".to_string())
                     )
                     .encode()
                     .into(),
-                );
+                )
             }
 
             // Check if we have any leftover expected emits
@@ -307,7 +307,7 @@ where
                         .to_string()
                         .encode()
                         .into(),
-                );
+                )
             }
         }
 
@@ -363,7 +363,7 @@ where
                 return match handle_expect_revert(true, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, None, remaining_gas, retdata),
                     Ok((address, retdata)) => (Return::Return, address, remaining_gas, retdata),
-                };
+                }
             }
         }
 

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -288,10 +288,7 @@ where
                         "Expected a call to {:?} with data {}{}, but got none",
                         address,
                         ethers::types::Bytes::from(expecteds[0].calldata.clone()),
-                        expecteds[0]
-                            .value
-                            .map(|v| format!(" and value {}", v))
-                            .unwrap_or_else(|| "".to_string())
+                        expecteds[0].value.map(|v| format!(" and value {}", v)).unwrap_or_default()
                     )
                     .encode()
                     .into(),

--- a/forge/README.md
+++ b/forge/README.md
@@ -310,6 +310,8 @@ interface Hevm {
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
+    // Expect to be called with particular msg.value
+    function expectCall(address,uint256,bytes calldata) external;
     // Fetches the contract bytecode from its artifact file
     function getCode(string calldata) external returns (bytes memory);
     // Label an address in test traces

--- a/forge/README.md
+++ b/forge/README.md
@@ -305,12 +305,15 @@ interface Hevm {
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
     function mockCall(address,bytes calldata,bytes calldata) external;
+    // Mocks a call to an address with a specific msg.value, returning specified data.
+    // Calldata match takes precedence over msg.value in case of ambiguity.
+    function mockCall(address,uint256,bytes calldata,bytes calldata) external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
-    // Expect to be called with particular msg.value
+    // Expect a call to an address with the specified msg.value and calldata
     function expectCall(address,uint256,bytes calldata) external;
     // Fetches the contract bytecode from its artifact file
     function getCode(string calldata) external returns (bytes memory);

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -58,6 +58,8 @@ interface Cheats {
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
+    // Expect a call to an address with the specified msg.value and calldata
+    function expectCall(address,uint256,bytes calldata) external;
     // Gets the code from an artifact file. Takes in the relative path to the json file
     function getCode(string calldata) external returns (bytes memory);
     // Labels an address in call traces

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -53,6 +53,9 @@ interface Cheats {
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
     function mockCall(address,bytes calldata,bytes calldata) external;
+    // Mocks a call to an address with a specific msg.value, returning specified data.
+    // Calldata match takes precedence over msg.value in case of ambiguity.
+    function mockCall(address,uint256,bytes calldata,bytes calldata) external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expect a call to an address with the specified calldata.

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -16,6 +16,14 @@ contract Contract {
     function add(uint256 a, uint256 b) public pure returns (uint256) {
         return a + b;
     }
+
+    function pay(uint256 a) public payable returns (uint256) {
+      return a;
+    }
+
+    function silentPay() public payable returns (uint256) {
+      return 3;
+    }
 }
 
 contract NestedContract {
@@ -103,5 +111,34 @@ contract ExpectCallTest is DSTest {
             abi.encodeWithSelector(target.add.selector, 3, 3, 3)
         );
         target.add(3, 3);
+    }
+
+    function testExpectCallWithValue() public {
+        Contract target = new Contract();
+        cheats.expectCall(
+            address(target),
+            1,
+            abi.encodeWithSelector(target.pay.selector, 2)
+        );
+        target.pay{ value: 1 }(2);
+    }
+
+    function testFailExpectCallValue() public {
+        Contract target = new Contract();
+        cheats.expectCall(
+            address(target),
+            1,
+            abi.encodeWithSelector(target.pay.selector, 2)
+        );
+    }
+
+    function testExpectCallWithValueWithoutParameters() public {
+        Contract target = new Contract();
+        cheats.expectCall(
+            address(target),
+            3,
+            abi.encodeWithSelector(target.silentPay.selector)
+        );
+        target.silentPay{ value: 3 }();
     }
 }

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -21,9 +21,6 @@ contract Contract {
       return a;
     }
 
-    function silentPay() public payable returns (uint256) {
-      return 3;
-    }
 }
 
 contract NestedContract {
@@ -120,7 +117,7 @@ contract ExpectCallTest is DSTest {
             1,
             abi.encodeWithSelector(target.pay.selector, 2)
         );
-        target.pay{ value: 1 }(2);
+        target.pay{value: 1}(2);
     }
 
     function testFailExpectCallValue() public {
@@ -137,8 +134,8 @@ contract ExpectCallTest is DSTest {
         cheats.expectCall(
             address(target),
             3,
-            abi.encodeWithSelector(target.silentPay.selector)
+            abi.encodeWithSelector(target.pay.selector)
         );
-        target.silentPay{ value: 3 }();
+        target.pay{value: 3}(100);
     }
 }

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -20,7 +20,6 @@ contract Contract {
     function pay(uint256 a) public payable returns (uint256) {
       return a;
     }
-
 }
 
 contract NestedContract {

--- a/testdata/cheats/MockCall.t.sol
+++ b/testdata/cheats/MockCall.t.sol
@@ -188,5 +188,4 @@ contract MockCallTest is DSTest {
         assertEq(mock.pay{value: 10}(2), 2);
         assertEq(mock.pay(2), 2);
     }
-
 }

--- a/testdata/cheats/MockCall.t.sol
+++ b/testdata/cheats/MockCall.t.sol
@@ -16,6 +16,10 @@ contract Mock {
     function add(uint256 a, uint256 b) public pure returns (uint256) {
         return a + b;
     }
+
+    function pay(uint256 a) public payable returns (uint256) {
+        return a;
+    }
 }
 
 contract NestedMock {
@@ -113,4 +117,76 @@ contract MockCallTest is DSTest {
         assertEq(target.numberA(), 1);
         assertEq(target.numberB(), 2);
     }
+
+    function testMockCallMultiplePartialMatch() public {
+        Mock mock = new Mock();
+
+        cheats.mockCall(
+            address(mock),
+            abi.encodeWithSelector(mock.add.selector),
+            abi.encode(10)
+        );
+        cheats.mockCall(
+            address(mock),
+            abi.encodeWithSelector(mock.add.selector, 2),
+            abi.encode(20)
+        );
+        cheats.mockCall(
+            address(mock),
+            abi.encodeWithSelector(mock.add.selector, 2, 3),
+            abi.encode(30)
+        );
+
+        assertEq(mock.add(1, 2), 10);
+        assertEq(mock.add(2, 2), 20);
+        assertEq(mock.add(2, 3), 30);
+    }
+
+    function testMockCallWithValue() public {
+        Mock mock = new Mock();
+
+        cheats.mockCall(
+            address(mock),
+            10,
+            abi.encodeWithSelector(mock.pay.selector),
+            abi.encode(10)
+        );
+
+        assertEq(mock.pay{value: 10}(1), 10);
+        assertEq(mock.pay(1), 1);
+
+        for (uint i = 0; i < 100; i++) {
+            cheats.mockCall(
+                address(mock),
+                i,
+                abi.encodeWithSelector(mock.pay.selector),
+                abi.encode(i * 2)
+            );
+        }
+
+        assertEq(mock.pay(1), 0);
+        assertEq(mock.pay{value: 10}(1), 20);
+        assertEq(mock.pay{value: 50}(1), 100);
+    }
+
+    function testMockCallWithValueCalldataPrecedence() public {
+        Mock mock = new Mock();
+
+        cheats.mockCall(
+            address(mock),
+            10,
+            abi.encodeWithSelector(mock.pay.selector),
+            abi.encode(10)
+        );
+        cheats.mockCall(
+            address(mock),
+            abi.encodeWithSelector(mock.pay.selector, 2),
+            abi.encode(2)
+        );
+
+        assertEq(mock.pay{value: 10}(1), 10);
+        assertEq(mock.pay{value: 10}(2), 2);
+        assertEq(mock.pay(2), 2);
+    }
+
 }


### PR DESCRIPTION
Closes #1568 
Closes #1604 

- Added overloaded `expectCall` with `msg.value`
- Added overloaded `mockCall` with `msg.value
- Fixed `mockCall` partial calldata matching

## Solution
Implementation for the overloading of `expectCall` was straightforward with a new `struct` that contains the `calldata` and `msg.value`.

For the `mockCall`, `Ord` trait was implemented for `MockCallDataContext` to ensure that partial matching is consistent.
The partial match now allows for the longest prefix in the calldata to be matched if there is no exact match.

There is also a new precedence order, and a more specific calldata precedes a `msg.value` match with a shorter prefix calldata match.