### PR TITLE
Adds `forge test --list`

### DIFF
--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -539,8 +539,8 @@ fn list(runner: MultiContractRunner, filter: Filter, json: bool) -> eyre::Result
         for (file, contracts) in results.iter() {
             println!("{}", file);
             for (contract, tests) in contracts.iter() {
-                println!("\t{}", contract);
-                println!("\t{}\n", tests.join("\n\t\t"));
+                println!("  {}", contract);
+                println!("    {}\n", tests.join("\n    "));
             }
         }
     }

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -70,6 +70,9 @@ pub struct Filter {
         conflicts_with = "pattern"
     )]
     pub path_pattern_inverse: Option<globset::Glob>,
+
+    #[clap(long="list",alias="l")]
+    pub list: bool
 }
 
 impl Filter {

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -106,10 +106,10 @@ impl FileFilter for Filter {
     fn is_match(&self, file: &Path) -> bool {
         if let Some(file) = file.as_os_str().to_str() {
             if let Some(ref glob) = self.path_pattern {
-                return glob.compile_matcher().is_match(file);
+                return glob.compile_matcher().is_match(file)
             }
             if let Some(ref glob) = self.path_pattern_inverse {
-                return !glob.compile_matcher().is_match(file);
+                return !glob.compile_matcher().is_match(file)
             }
         }
         file.is_sol_test()

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -215,6 +215,7 @@ impl MultiContractRunner {
                 let tests = abi
                     .functions()
                     .filter(|func| func.name.starts_with("test"))
+                    .filter(|func| filter.matches_test(func.signature()))
                     .map(|func| func.name.clone())
                     .collect::<Vec<_>>();
 

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -81,13 +81,13 @@ impl MultiContractRunnerBuilder {
                     if let Some(b) = contract.bytecode.expect("No bytecode").object.into_bytes() {
                         b
                     } else {
-                        return Ok(())
+                        return Ok(());
                     };
 
                 let abi = contract.abi.expect("We should have an abi by now");
                 // if its a test, add it to deployable contracts
-                if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
-                    abi.functions().any(|func| func.name.starts_with("test"))
+                if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
+                    && abi.functions().any(|func| func.name.starts_with("test"))
                 {
                     deployable_contracts
                         .insert(id.clone(), (abi.clone(), bytecode, dependencies.to_vec()));
@@ -176,8 +176,8 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy()) &&
-                    filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy())
+                    && filter.matches_contract(&id.name)
             })
             .flat_map(|(_, (abi, _, _))| {
                 abi.functions().filter(|func| filter.matches_test(func.signature()))
@@ -190,12 +190,37 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy()) &&
-                    filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy())
+                    && filter.matches_contract(&id.name)
             })
             .flat_map(|(_, (abi, _, _))| abi.functions().map(|func| func.name.clone()))
             .filter(|sig| sig.starts_with("test"))
             .collect()
+    }
+
+    pub fn list(
+        &mut self,
+        filter: &(impl TestFilter + Send + Sync),
+    ) -> BTreeMap<String, (String, Vec<String>)> {
+        self.contracts
+            .par_iter()
+            .filter(|(id, _)| {
+                filter.matches_path(id.source.to_string_lossy())
+                    && filter.matches_contract(&id.name)
+            })
+            .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
+            .map(|(id, (abi, _, _))| {
+                let source = id.source.as_path().display().to_string();
+                let name = id.name.clone();
+                let tests = abi
+                    .functions()
+                    .filter(|func| func.name.starts_with("test"))
+                    .map(|func| func.name.clone())
+                    .collect::<Vec<_>>();
+
+                (source, (name, tests))
+            })
+            .collect::<BTreeMap<_, _>>()
     }
 
     pub fn test(
@@ -214,8 +239,8 @@ impl MultiContractRunner {
             .contracts
             .par_iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy()) &&
-                    filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy())
+                    && filter.matches_contract(&id.name)
             })
             .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
             .map(|(id, (abi, deploy_code, libs))| {
@@ -1070,7 +1095,7 @@ mod tests {
         let rpc_url = std::env::var("ETH_RPC_URL");
         if rpc_url.is_err() {
             eprintln!("Skipping test, ETH_RPC_URL is not set.");
-            return
+            return;
         }
         let mut runner = forked_runner(&(rpc_url.unwrap()));
         let suite_result = runner.test(&Filter::new(".*", ".*", ".*fork"), None, true).unwrap();

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -81,13 +81,13 @@ impl MultiContractRunnerBuilder {
                     if let Some(b) = contract.bytecode.expect("No bytecode").object.into_bytes() {
                         b
                     } else {
-                        return Ok(());
+                        return Ok(())
                     };
 
                 let abi = contract.abi.expect("We should have an abi by now");
                 // if its a test, add it to deployable contracts
-                if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
-                    && abi.functions().any(|func| func.name.starts_with("test"))
+                if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
+                    abi.functions().any(|func| func.name.starts_with("test"))
                 {
                     deployable_contracts
                         .insert(id.clone(), (abi.clone(), bytecode, dependencies.to_vec()));
@@ -176,8 +176,8 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy())
-                    && filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy()) &&
+                    filter.matches_contract(&id.name)
             })
             .flat_map(|(_, (abi, _, _))| {
                 abi.functions().filter(|func| filter.matches_test(func.signature()))
@@ -190,8 +190,8 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy())
-                    && filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy()) &&
+                    filter.matches_contract(&id.name)
             })
             .flat_map(|(_, (abi, _, _))| abi.functions().map(|func| func.name.clone()))
             .filter(|sig| sig.starts_with("test"))
@@ -205,8 +205,8 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy())
-                    && filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy()) &&
+                    filter.matches_contract(&id.name)
             })
             .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
             .map(|(id, (abi, _, _))| {
@@ -243,8 +243,8 @@ impl MultiContractRunner {
             .contracts
             .par_iter()
             .filter(|(id, _)| {
-                filter.matches_path(id.source.to_string_lossy())
-                    && filter.matches_contract(&id.name)
+                filter.matches_path(id.source.to_string_lossy()) &&
+                    filter.matches_contract(&id.name)
             })
             .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
             .map(|(id, (abi, deploy_code, libs))| {
@@ -1099,7 +1099,7 @@ mod tests {
         let rpc_url = std::env::var("ETH_RPC_URL");
         if rpc_url.is_err() {
             eprintln!("Skipping test, ETH_RPC_URL is not set.");
-            return;
+            return
         }
         let mut runner = forked_runner(&(rpc_url.unwrap()));
         let suite_result = runner.test(&Filter::new(".*", ".*", ".*fork"), None, true).unwrap();

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -235,7 +235,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                         labeled_addresses: labels,
                         setup_failed: true,
                         reason: Some(reason),
-                    });
+                    })
                 }
                 e => eyre::bail!("Unrecoverable error: {:?}", e),
             }
@@ -261,7 +261,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                     labeled_addresses: labels,
                     setup_failed: true,
                     reason: Some(reason),
-                });
+                })
             }
             e => eyre::bail!("Unrecoverable error: {:?}", e),
         };
@@ -345,7 +345,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                 )]
                 .into(),
                 warnings,
-            ));
+            ))
         }
 
         let setup = self.setup(needs_setup)?;
@@ -367,7 +367,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                 )]
                 .into(),
                 warnings,
-            ));
+            ))
         }
 
         // Collect valid test functions
@@ -376,9 +376,9 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             .functions()
             .into_iter()
             .filter(|func| {
-                func.name.starts_with("test")
-                    && filter.matches_test(func.signature())
-                    && (include_fuzz_tests || func.inputs.is_empty())
+                func.name.starts_with("test") &&
+                    filter.matches_test(func.signature()) &&
+                    (include_fuzz_tests || func.inputs.is_empty())
             })
             .map(|func| (func, func.name.starts_with("testFail")))
             .collect();
@@ -457,7 +457,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }
             Err(err) => {
                 tracing::error!(?err);
-                return Err(err.into());
+                return Err(err.into())
             }
         };
         traces.extend(execution_traces.map(|traces| (TraceKind::Execution, traces)).into_iter());

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -235,7 +235,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                         labeled_addresses: labels,
                         setup_failed: true,
                         reason: Some(reason),
-                    })
+                    });
                 }
                 e => eyre::bail!("Unrecoverable error: {:?}", e),
             }
@@ -261,7 +261,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                     labeled_addresses: labels,
                     setup_failed: true,
                     reason: Some(reason),
-                })
+                });
             }
             e => eyre::bail!("Unrecoverable error: {:?}", e),
         };
@@ -345,7 +345,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                 )]
                 .into(),
                 warnings,
-            ))
+            ));
         }
 
         let setup = self.setup(needs_setup)?;
@@ -367,7 +367,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                 )]
                 .into(),
                 warnings,
-            ))
+            ));
         }
 
         // Collect valid test functions
@@ -376,9 +376,9 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             .functions()
             .into_iter()
             .filter(|func| {
-                func.name.starts_with("test") &&
-                    filter.matches_test(func.signature()) &&
-                    (include_fuzz_tests || func.inputs.is_empty())
+                func.name.starts_with("test")
+                    && filter.matches_test(func.signature())
+                    && (include_fuzz_tests || func.inputs.is_empty())
             })
             .map(|func| (func, func.name.starts_with("testFail")))
             .collect();
@@ -457,7 +457,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }
             Err(err) => {
                 tracing::error!(?err);
-                return Err(err.into())
+                return Err(err.into());
             }
         };
         traces.extend(execution_traces.map(|traces| (TraceKind::Execution, traces)).into_iter());


### PR DESCRIPTION
## Motivation

Similarly to `cargo test -- --list`, it's useful to have a way for the tooling to list existing tests, preferably in a structured way.
The main use-case, and what led me down this, is to integrate a test runner into an IDE such as VC Code. The [rust test runner](https://github.com/swellaby/vscode-rust-test-adapter) itself uses the same approach, which is far cleaner and more efficient than other extensions that try to parse test files themselves.

My main motivation here is to build the actual VS Code extension. When getting started, I was following along how the rust equivalent was doing it, which led me writing this

## Solution

Adds the ability to run `forge test --list`, which simply lists tests instead of running them

Due to the existing code structure, it also became trivial to make this work alongside `--json` and `--match-test` flags. Particularly, `--json` can be useful to make it easier for outside extensions to parse structured content

#### Samples

**simple listing**
```bash
❯ ~/contrib/foundry/target/debug/forge test --list                                                    
[⠘] Compiling...
No files changed, compilation skipped
test/Contract.t.sol
        ContractTest
                testAnotherExample
                testExample
```

**json format**
```bash
❯ ~/contrib/foundry/target/debug/forge test --list --json                                             
[⠃] Compiling...
No files changed, compilation skipped
{"test/Contract.t.sol":{"ContractTest":["testAnotherExample","testExample"]}}
```

**filtered & formatted json**
```bash
❯ ~/contrib/foundry/target/debug/forge test --list --json --match-test "Another" | tail -n 1 | json_pp
{
   "test/Contract.t.sol" : {
      "ContractTest" : [
         "testAnotherExample"
      ]
   }
}
```