### PR TITLE
fix(anvil): stop auto mining if pool is empty

### DIFF
--- a/anvil/src/eth/pool/transactions.rs
+++ b/anvil/src/eth/pool/transactions.rs
@@ -460,7 +460,7 @@ impl ReadyTransactions {
                 // (addr + nonce) then we check for gas price
                 if to_remove.provides() == tx.provides {
                     // check if underpriced
-                    if tx.pending_transaction.transaction.gas_price() < to_remove.gas_price() {
+                    if tx.pending_transaction.transaction.gas_price() <= to_remove.gas_price() {
                         warn!(target: "txpool", "ready replacement transaction underpriced [{:?}]", tx.hash());
                         return Err(PoolError::ReplacementUnderpriced(Box::new(tx.clone())))
                     } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fixes a bug that resulted in infinite block mining.

This happened if a tx with the same nonce was replaced, but was already fired via the new ready tx notification stream the auto miner listens on.

The transaction was replaced but the previous implementation of the `ReadyTransactionMiner` polled the pool until it all previously received `ready transactions` were taken from the pool. The miner polled the pool forever since the replaced tx was purged from the pool.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* clear the `ready` buffer of the `ReadyTransactionMiner` once the pool is empty. this gets rid of hashes that are no longer present in the pool.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
