### PR TITLE
fix: unify names of supported chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "similar",
  "solang-parser",
  "strsim",
+ "strum 0.24.0",
  "tokio",
  "toml",
  "tracing",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,7 +71,7 @@ once_cell = "1.9.0"
 similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
 bytes = "1.1.0"
-
+strum = { version = "0.24", features = ["derive"] }
 
 [dev-dependencies]
 foundry-utils = { path = "./../utils", features = ["test"] }

--- a/cli/src/cmd/forge/cache.rs
+++ b/cli/src/cmd/forge/cache.rs
@@ -2,6 +2,7 @@
 
 use clap::{Parser, Subcommand};
 use std::str::FromStr;
+use strum::VariantNames;
 
 use crate::cmd::Cmd;
 use cache::{Cache, ChainCache};
@@ -41,25 +42,9 @@ pub struct CleanArgs {
     #[clap(
         env = "CHAIN",
         default_value = "all",
-        possible_values = [
-            "all",
-            "mainnet",
-            "ropsten",
-            "rinkeby",
-            "goerli",
-            "kovan",
-            "xdai",
-            "polygon",
-            "polygon_mumbai",
-            "avalanche",
-            "avalanche_fuji",
-            "sepolia",
-            "moonbeam",
-            "moonbeam_dev",
-            "moonriver",
-            "optimism",
-            "optimism-kovan"
-    ])]
+        possible_value = "all",
+        possible_values = Chain::VARIANTS
+    )]
     chains: Vec<ChainOrAll>,
 
     #[clap(
@@ -78,25 +63,9 @@ pub struct LsArgs {
     #[clap(
         env = "CHAIN",
         default_value = "all",
-        possible_values = [
-            "all",
-            "mainnet",
-            "ropsten",
-            "rinkeby",
-            "goerli",
-            "kovan",
-            "xdai",
-            "polygon",
-            "polygon_mumbai",
-            "avalanche",
-            "avalanche_fuji",
-            "sepolia",
-            "moonbeam",
-            "moonbeam_dev",
-            "moonriver",
-            "optimism",
-            "optimism-kovan"
-    ])]
+        possible_value = "all",
+        possible_values = Chain::VARIANTS
+    )]
     chains: Vec<ChainOrAll>,
 }
 


### PR DESCRIPTION
fixes: https://github.com/foundry-rs/foundry/issues/1564

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I previously tried using ArgEnum but ran into problems documented on previous pr: https://github.com/foundry-rs/foundry/pull/1581


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This fix uses strum on ethers-rs
https://github.com/gakonst/ethers-rs/blob/1271308e06bd4c1b6db271488838e011505fcdfa/ethers-core/src/types/chain.rs#L14-L47

like so:
```rust
#[repr(u64)]
#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Deserialize, EnumVariantNames)]
#[serde(rename_all = "snake_case")]
#[strum(serialize_all = "kebab-case")]
pub enum Chain {
    Mainnet = 1,
    #[strum(serialize = "xdai")]
    XDai = 100,
    #[strum(serialize = "bsc")]
    BinanceSmartChain = 56,
    #[strum(serialize = "bsc-testnet")]
    BinanceSmartChainTestnet = 97,
}
```

and we can use `Chain::VARIANTS`
```rust
pub struct CleanArgs {
    // TODO refactor to dedup shared logic with ClapChain in opts/mod
    #[clap(
        env = "CHAIN",
        default_value = "all",
        possible_value = "all",
        possible_values = Chain::VARIANTS
    )]
    chains: Vec<ChainOrAll>,

```


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
