### PR TITLE
Chore: Add `etherscan_api_key` to config README

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -116,6 +116,8 @@ bytecode_hash = "ipfs"
 # If this option is enabled, Solc is instructed to generate output (bytecode) only for the required contracts
 # this can reduce compile time for `forge test` a bit but is considered experimental at this point.
 sparse_mode = false
+# Setting this option enables decoding of error traces from mainnet deployed / verfied contracts via etherscan
+etherscan_api_key="YOURETHERSCANAPIKEY"
 ```
 
 ##### Additional Optimizer settings


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The "All Options" section in the config readme does not mention the `etherscan_api_key` option that enables improved error traces, which renders the example incomplete.

## Solution

Add the `etherscan_api_key` option to the "All Options" config example.
