### PR TITLE
fix(forge/create): list unlinked library contracts in error message

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -119,7 +119,17 @@ impl Cmd for CreateArgs {
 
         let bin = match bin.object {
             BytecodeObject::Bytecode(_) => bin.object,
-            _ => eyre::bail!("Dynamic linking not supported in `create` command - deploy the library contract first, then provide the address to link at compile time")
+            _ => {
+                let link_refs = bin
+                    .link_references
+                    .iter()
+                    .flat_map(|(path, names)| {
+                        names.keys().map(move |name| format!("\t{}: {}", name, path))
+                    })
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                eyre::bail!("Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}", link_refs)
+            }
         };
 
         // Add arguments to constructor


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes https://github.com/foundry-rs/foundry/issues/1621.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
List link references in error message.

## Test
Tested with the repo in this [issue comment](https://github.com/foundry-rs/foundry/issues/1338#issuecomment-1113071366), and the following is the output of `forge create Contract`:
```
[⠢] Compiling...
[⠔] Compiling 9 files with 0.8.13
[⠑] Solc 0.8.13 finished in 233.18ms
Compiler run successful
Error:
   0: Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time
        ChainlinkTWAP: /home/USER/Repos/chainlink-test/src/libraries/ChainlinkTWAP.sol

Location:
   cli/src/cmd/forge/create.rs:125

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```
