### PR TITLE
feat(anvil): check tx pool when determining next nonce

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,4 +1,4 @@
-use crate::{cmd::Cmd, utils};
+use crate::{cmd::Cmd, utils, utils::consume_config_rpc_url};
 use cast::trace::CallTraceDecoder;
 use clap::Parser;
 use ethers::{
@@ -20,7 +20,6 @@ use std::{
 };
 use ui::{TUIExitReason, Tui, Ui};
 use yansi::Paint;
-use crate::utils::consume_config_rpc_url;
 
 #[derive(Debug, Clone, Parser)]
 pub struct RunArgs {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1656
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
check pending transactions from the sender:
* when determining the highest nonce for a transaction
* `eth_getTransactionCount` for pending block number

iterate over all pending tx, if there's a tx from the sender (starting at on-chain nonce), increment the `current nonce`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
