### PR TITLE
fix(anvil): use correct timestamp from fork

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -187,11 +187,12 @@ impl Backend {
         if let Some(fork) = self.get_fork() {
             // reset the fork entirely and reapply the genesis config
             fork.reset(forking.json_rpc_url.clone(), forking.block_number).await?;
-            // update env settings
+            // update all settings related to the forked block
             {
                 let mut env = self.env.write();
                 env.cfg.chain_id = fork.chain_id().into();
                 env.block.number = fork.block_number().into();
+                self.time.set_start_timestamp(fork.timestamp());
             }
 
             // reset storage

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -36,6 +36,12 @@ impl TimeManager {
         *current = next;
     }
 
+    /// Sets the timestamp we should base further timestamps on
+    pub fn set_start_timestamp(&self, seconds: u64) {
+        let current = duration_since_unix_epoch().as_secs() as i128;
+        *self.offset.write() = (seconds as i128) - current;
+    }
+
     /// Jumps forward in time by the given seconds
     ///
     /// This will apply a permanent offset to the natural UNIX Epoch timestamp


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1630
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
In fork mode, set the current timestamp to the forked block timestamp by using it as offset
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
