### PR TITLE
Switch selector database to sig.eth.samczsun.com

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -344,8 +344,8 @@ async fn main() -> eyre::Result<()> {
                     }
                 } // Checking if signer isn't the default value
                   // 00a329c0648769A73afAc7F9381E08FB43dBEA72.
-            } else if config.sender !=
-                Address::from_str("00a329c0648769A73afAc7F9381E08FB43dBEA72").unwrap()
+            } else if config.sender
+                != Address::from_str("00a329c0648769A73afAc7F9381E08FB43dBEA72").unwrap()
             {
                 if resend {
                     nonce = Some(provider.get_transaction_count(config.sender, None).await?);
@@ -431,10 +431,10 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::FourByte { selector } => {
             let sigs = foundry_utils::fourbyte(&selector).await?;
-            sigs.iter().for_each(|sig| println!("{}", sig.0));
+            sigs.iter().for_each(|sig| println!("{}", sig));
         }
-        Subcommands::FourByteDecode { calldata, id } => {
-            let sigs = foundry_utils::fourbyte_possible_sigs(&calldata, id).await?;
+        Subcommands::FourByteDecode { calldata } => {
+            let sigs = foundry_utils::fourbyte_possible_sigs(&calldata).await?;
             sigs.iter().enumerate().for_each(|(i, sig)| println!("{}) \"{}\"", i + 1, sig));
 
             let sig = match sigs.len() {
@@ -457,7 +457,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::FourByteEvent { topic } => {
             let sigs = foundry_utils::fourbyte_event(&topic).await?;
-            sigs.iter().for_each(|sig| println!("{}", sig.0));
+            sigs.iter().for_each(|sig| println!("{}", sig));
         }
 
         Subcommands::PrettyCalldata { calldata, offline } => {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -344,8 +344,8 @@ async fn main() -> eyre::Result<()> {
                     }
                 } // Checking if signer isn't the default value
                   // 00a329c0648769A73afAc7F9381E08FB43dBEA72.
-            } else if config.sender
-                != Address::from_str("00a329c0648769A73afAc7F9381E08FB43dBEA72").unwrap()
+            } else if config.sender !=
+                Address::from_str("00a329c0648769A73afAc7F9381E08FB43dBEA72").unwrap()
             {
                 if resend {
                     nonce = Some(provider.get_transaction_count(config.sender, None).await?);
@@ -430,11 +430,11 @@ async fn main() -> eyre::Result<()> {
             println!("{encoded}");
         }
         Subcommands::FourByte { selector } => {
-            let sigs = foundry_utils::fourbyte(&selector).await?;
+            let sigs = foundry_utils::decode_function_selector(&selector).await?;
             sigs.iter().for_each(|sig| println!("{}", sig));
         }
         Subcommands::FourByteDecode { calldata } => {
-            let sigs = foundry_utils::fourbyte_possible_sigs(&calldata).await?;
+            let sigs = foundry_utils::decode_calldata(&calldata).await?;
             sigs.iter().enumerate().for_each(|(i, sig)| println!("{}) \"{}\"", i + 1, sig));
 
             let sig = match sigs.len() {
@@ -456,7 +456,7 @@ async fn main() -> eyre::Result<()> {
             tokens.for_each(|t| println!("{t}"));
         }
         Subcommands::FourByteEvent { topic } => {
-            let sigs = foundry_utils::fourbyte_event(&topic).await?;
+            let sigs = foundry_utils::decode_event_topic(&topic).await?;
             sigs.iter().for_each(|sig| println!("{}", sig));
         }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -435,16 +435,6 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     FourByteDecode {
         #[clap(help = "The ABI-encoded calldata.")]
         calldata: String,
-        #[clap(
-            long,
-            help = "The index of the resolved signature to use.",
-            long_help = r#"The index of the resolved signature to use.
-
-4byte.directory can have multiple possible signatures for a given selector.
-
-The index can also be earliest or latest."#
-        )]
-        id: Option<String>,
     },
     #[clap(name = "4byte-event")]
     #[clap(aliases = &["4e", "4be"])]


### PR DESCRIPTION
This PR switches the selector database for `4byte`, `4byte-decode`, and `4byte-event` cast commands to use samczsun's [new database](https://sig.eth.samczsun.com) rather than 4byte.directory. See https://github.com/foundry-rs/foundry/issues/1672 for details


## Solution

- Updated the 4byte bindings utils to use samczsun's service instead
- added few tests ensuring selectors work w/ and w/o 0x prefix