### PR TITLE
Add `forge upload-selectors` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "proptest",
  "rayon",
  "regex",
+ "reqwest",
  "rpassword",
  "rustc-hex",
  "semver",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
 bytes = "1.1.0"
 strum = { version = "0.24", features = ["derive"] }
+reqwest = { version = "0.11.8", default-features = false, features = ["json"] } 
 
 [dev-dependencies]
 foundry-utils = { path = "./../utils", features = ["test"] }

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -61,7 +61,7 @@ impl<'a> From<&'a CoreBuildArgs> for Config {
     }
 }
 
-#[derive(Debug, Clone, Parser, Serialize)]
+#[derive(Debug, Clone, Parser, Serialize, Default)]
 pub struct CoreBuildArgs {
     #[clap(
         help_heading = "CACHE OPTIONS",
@@ -209,24 +209,6 @@ impl Provider for CoreBuildArgs {
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))
-    }
-}
-
-impl Default for CoreBuildArgs {
-    fn default() -> CoreBuildArgs {
-        CoreBuildArgs {
-            project_paths: Default::default(),
-            out_path: Default::default(),
-            compiler: Default::default(),
-            ignored_error_codes: vec![],
-            no_auto_detect: false,
-            use_solc: None,
-            offline: false,
-            force: false,
-            libraries: vec![],
-            via_ir: false,
-            revert_strings: None,
-        }
     }
 }
 

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -212,6 +212,24 @@ impl Provider for CoreBuildArgs {
     }
 }
 
+impl Default for CoreBuildArgs {
+    fn default() -> CoreBuildArgs {
+        CoreBuildArgs {
+            project_paths: Default::default(),
+            out_path: Default::default(),
+            compiler: Default::default(),
+            ignored_error_codes: vec![],
+            no_auto_detect: false,
+            use_solc: None,
+            offline: false,
+            force: false,
+            libraries: vec![],
+            via_ir: false,
+            revert_strings: None,
+        }
+    }
+}
+
 // All `forge build` related arguments
 //
 // CLI arguments take the highest precedence in the Config/Figment hierarchy.
@@ -310,7 +328,7 @@ impl Provider for BuildArgs {
 
 impl_figment_convert!(BuildArgs, args);
 
-#[derive(Debug, Clone, Parser, Serialize)]
+#[derive(Debug, Clone, Parser, Serialize, Default)]
 pub struct ProjectPathsArgs {
     #[clap(
         help = "The project's root path.",

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -1,0 +1,119 @@
+use crate::{
+    cmd::forge::build::{CoreBuildArgs, ProjectPathsArgs},
+    compile,
+    opts::forge::CompilerArgs,
+};
+use clap::Parser;
+use ethers::prelude::artifacts::{output_selection::ContractOutputSelection, LosslessAbi};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::trace;
+
+#[derive(Serialize, Debug)]
+struct ImportRequest {
+    #[serde(rename = "type")]
+    import_type: String,
+    data: Vec<LosslessAbi>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImportTypeData {
+    imported: HashMap<String, String>,
+    duplicated: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImportData {
+    function: ImportTypeData,
+    event: ImportTypeData,
+}
+
+#[derive(Deserialize, Debug)]
+struct ImportResponse {
+    result: ImportData,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UploadSelectorsArgs {
+    #[clap(help = "The name of the contract to upload selectors for.")]
+    pub contract: String,
+
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    pub project_paths: ProjectPathsArgs,
+}
+
+impl UploadSelectorsArgs {
+    /// Builds a contract and uploads the ABI to selector database
+    pub async fn run(self) -> eyre::Result<()> {
+        let UploadSelectorsArgs { contract, project_paths } = self;
+
+        let build_args = CoreBuildArgs {
+            project_paths: project_paths.clone(),
+            out_path: Default::default(),
+            ignored_error_codes: vec![],
+            no_auto_detect: false,
+            use_solc: None,
+            offline: false,
+            force: false,
+            libraries: vec![],
+            via_ir: false,
+            revert_strings: None,
+            compiler: CompilerArgs {
+                extra_output: vec![ContractOutputSelection::Abi],
+                ..Default::default()
+            },
+        };
+
+        trace!("Building project");
+        let project = build_args.project()?;
+        let outcome = compile::suppress_compile(&project)?;
+        let found_artifact = outcome.find(&contract);
+        let artifact = found_artifact.ok_or_else(|| {
+            eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
+        })?;
+
+        let body = ImportRequest {
+            import_type: "abi".to_string(),
+            data: vec![artifact.abi.clone().ok_or(eyre::eyre!("Unable to fetch abi"))?],
+        };
+
+        // upload abi to selector database
+        trace!("Uploading selector args {:?}", body);
+        let res: ImportResponse = reqwest::Client::new()
+            .post("https://sig.eth.samczsun.com/api/v1/import")
+            .json(&body)
+            .send()
+            .await?
+            .json()
+            .await?;
+        trace!("Got response: {:?}", res);
+        describe_upload(res);
+
+        Ok(())
+    }
+}
+
+/// Print info about the functions which were uploaded or already known
+fn describe_upload(response: ImportResponse) {
+    response
+        .result
+        .function
+        .imported
+        .iter()
+        .for_each(|(k, v)| println!("Imported: Function {k}: {v}"));
+    response.result.event.imported.iter().for_each(|(k, v)| println!("Imported: Event {k}: {v}"));
+    response
+        .result
+        .function
+        .duplicated
+        .iter()
+        .for_each(|(k, v)| println!("Duplicated: Function {k}: {v}"));
+    response
+        .result
+        .event
+        .duplicated
+        .iter()
+        .for_each(|(k, v)| println!("Duplicated: Event {k}: {v}"));
+
+    println!("Selectors successfully uploaded to https://sig.eth.samczsun.com");
+}

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -9,6 +9,60 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::trace;
 
+static SELECTOR_DATABASE_URL: &str = "https://sig.eth.samczsun.com/api/v1/import";
+
+#[derive(Debug, Clone, Parser)]
+pub struct UploadSelectorsArgs {
+    #[clap(help = "The name of the contract to upload selectors for.")]
+    pub contract: String,
+
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    pub project_paths: ProjectPathsArgs,
+}
+
+impl UploadSelectorsArgs {
+    /// Builds a contract and uploads the ABI to selector database
+    pub async fn run(self) -> eyre::Result<()> {
+        let UploadSelectorsArgs { contract, project_paths } = self;
+
+        let build_args = CoreBuildArgs {
+            project_paths: project_paths.clone(),
+            compiler: CompilerArgs {
+                extra_output: vec![ContractOutputSelection::Abi],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        trace!("Building project");
+        let project = build_args.project()?;
+        let outcome = compile::suppress_compile(&project)?;
+        let found_artifact = outcome.find(&contract);
+        let artifact = found_artifact.ok_or_else(|| {
+            eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
+        })?;
+
+        let body = ImportRequest {
+            import_type: "abi".to_string(),
+            data: vec![artifact.abi.clone().ok_or(eyre::eyre!("Unable to fetch abi"))?],
+        };
+
+        // upload abi to selector database
+        trace!("Uploading selector args {:?}", body);
+        let res: ImportResponse = reqwest::Client::new()
+            .post(SELECTOR_DATABASE_URL)
+            .json(&body)
+            .send()
+            .await?
+            .json()
+            .await?;
+        trace!("Got response: {:?}", res);
+        res.describe_upload();
+
+        Ok(())
+    }
+}
+
 #[derive(Serialize, Debug)]
 struct ImportRequest {
     #[serde(rename = "type")]
@@ -33,87 +87,26 @@ struct ImportResponse {
     result: ImportData,
 }
 
-#[derive(Debug, Clone, Parser)]
-pub struct UploadSelectorsArgs {
-    #[clap(help = "The name of the contract to upload selectors for.")]
-    pub contract: String,
+impl ImportResponse {
+    /// Print info about the functions which were uploaded or already known
+    pub fn describe_upload(&self) {
+        self.result
+            .function
+            .imported
+            .iter()
+            .for_each(|(k, v)| println!("Imported: Function {k}: {v}"));
+        self.result.event.imported.iter().for_each(|(k, v)| println!("Imported: Event {k}: {v}"));
+        self.result
+            .function
+            .duplicated
+            .iter()
+            .for_each(|(k, v)| println!("Duplicated: Function {k}: {v}"));
+        self.result
+            .event
+            .duplicated
+            .iter()
+            .for_each(|(k, v)| println!("Duplicated: Event {k}: {v}"));
 
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
-    pub project_paths: ProjectPathsArgs,
-}
-
-impl UploadSelectorsArgs {
-    /// Builds a contract and uploads the ABI to selector database
-    pub async fn run(self) -> eyre::Result<()> {
-        let UploadSelectorsArgs { contract, project_paths } = self;
-
-        let build_args = CoreBuildArgs {
-            project_paths: project_paths.clone(),
-            out_path: Default::default(),
-            ignored_error_codes: vec![],
-            no_auto_detect: false,
-            use_solc: None,
-            offline: false,
-            force: false,
-            libraries: vec![],
-            via_ir: false,
-            revert_strings: None,
-            compiler: CompilerArgs {
-                extra_output: vec![ContractOutputSelection::Abi],
-                ..Default::default()
-            },
-        };
-
-        trace!("Building project");
-        let project = build_args.project()?;
-        let outcome = compile::suppress_compile(&project)?;
-        let found_artifact = outcome.find(&contract);
-        let artifact = found_artifact.ok_or_else(|| {
-            eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
-        })?;
-
-        let body = ImportRequest {
-            import_type: "abi".to_string(),
-            data: vec![artifact.abi.clone().ok_or(eyre::eyre!("Unable to fetch abi"))?],
-        };
-
-        // upload abi to selector database
-        trace!("Uploading selector args {:?}", body);
-        let res: ImportResponse = reqwest::Client::new()
-            .post("https://sig.eth.samczsun.com/api/v1/import")
-            .json(&body)
-            .send()
-            .await?
-            .json()
-            .await?;
-        trace!("Got response: {:?}", res);
-        describe_upload(res);
-
-        Ok(())
+        println!("Selectors successfully uploaded to https://sig.eth.samczsun.com");
     }
-}
-
-/// Print info about the functions which were uploaded or already known
-fn describe_upload(response: ImportResponse) {
-    response
-        .result
-        .function
-        .imported
-        .iter()
-        .for_each(|(k, v)| println!("Imported: Function {k}: {v}"));
-    response.result.event.imported.iter().for_each(|(k, v)| println!("Imported: Event {k}: {v}"));
-    response
-        .result
-        .function
-        .duplicated
-        .iter()
-        .for_each(|(k, v)| println!("Duplicated: Function {k}: {v}"));
-    response
-        .result
-        .event
-        .duplicated
-        .iter()
-        .for_each(|(k, v)| println!("Duplicated: Event {k}: {v}"));
-
-    println!("Selectors successfully uploaded to https://sig.eth.samczsun.com");
 }

--- a/cli/src/cmd/forge/mod.rs
+++ b/cli/src/cmd/forge/mod.rs
@@ -44,6 +44,7 @@ pub mod config;
 pub mod create;
 pub mod flatten;
 pub mod fmt;
+pub mod fourbyte;
 pub mod init;
 pub mod inspect;
 pub mod install;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -111,6 +111,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Inspect(cmd) => {
             cmd.run()?;
         }
+        Subcommands::UploadSelectors(args) => {
+            utils::block_on(args.run())?;
+        }
         Subcommands::Tree(cmd) => {
             cmd.run()?;
         }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -146,7 +146,10 @@ pub enum Subcommands {
     #[clap(alias = "in", about = "Get specialized information about a smart contract")]
     Inspect(inspect::InspectArgs),
 
-    #[clap(alias = "up", about = "Uploads abi to sig.eth.samczsun.com function selector database")]
+    #[clap(
+        alias = "up",
+        about = "Uploads abi of given contract to https://sig.eth.samczsun.com function selector database"
+    )]
     UploadSelectors(UploadSelectorsArgs),
 
     #[clap(

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -11,6 +11,7 @@ use crate::cmd::forge::{
     create::CreateArgs,
     flatten,
     fmt::FmtArgs,
+    fourbyte::UploadSelectorsArgs,
     init::InitArgs,
     inspect,
     install::InstallArgs,
@@ -144,6 +145,9 @@ pub enum Subcommands {
 
     #[clap(alias = "in", about = "Get specialized information about a smart contract")]
     Inspect(inspect::InspectArgs),
+
+    #[clap(alias = "up", about = "Uploads abi to sig.eth.samczsun.com function selector database")]
+    UploadSelectors(UploadSelectorsArgs),
 
     #[clap(
         alias = "tr",


### PR DESCRIPTION
This PR adds a new command to forge `forge upload-selectors` which builds a given contract and uploads the fresh ABI to sig.eth.samczsun.com 4byte selector database. See https://github.com/foundry-rs/foundry/issues/1672
