### PR TITLE
feat(fmt): Add support for comments

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -12,7 +12,7 @@ use ethers::solc::ProjectPathsConfig;
 use rayon::prelude::*;
 use similar::{ChangeTag, TextDiff};
 
-use forge_fmt::{Formatter, FormatterConfig, Visitable};
+use forge_fmt::{Comments, Formatter, FormatterConfig, Visitable};
 
 use crate::cmd::Cmd;
 
@@ -74,7 +74,7 @@ impl Cmd for FmtArgs {
                 std::env::current_dir().expect("failed to get current directory")
             });
             if !root.is_dir() {
-                return Err(eyre::eyre!("Root path should be a directory"))
+                return Err(eyre::eyre!("Root path should be a directory"));
             }
 
             ProjectPathsConfig::find_source_dir(&root)
@@ -101,16 +101,17 @@ impl Cmd for FmtArgs {
                     Input::Stdin(source) => source.to_string()
                 };
 
-                let (mut source_unit, _comments) = solang_parser::parse(&source, i)
+                let (mut source_unit, comments) = solang_parser::parse(&source, i)
                     .map_err(|diags| eyre::eyre!(
                             "Failed to parse Solidity code for {}. Leaving source unchanged.\nDebug info: {:?}",
                             input,
                             diags
                         ))?;
+                let comments = Comments::new(comments, &source);
 
                 let mut output = String::new();
                 let mut formatter =
-                    Formatter::new(&mut output, &source, FormatterConfig::default());
+                    Formatter::new(&mut output, &source, comments, FormatterConfig::default());
 
                 source_unit.visit(&mut formatter).unwrap();
 

--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -1,0 +1,147 @@
+use crate::solang_ext::*;
+use itertools::Itertools;
+use solang_parser::pt::*;
+
+#[derive(Debug, Clone, Copy)]
+pub enum CommentType {
+    Line,
+    Block,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CommentPosition {
+    Prefix,
+    Postfix,
+}
+
+#[derive(Debug, Clone)]
+pub struct DestructuredComment {
+    pub ty: CommentType,
+    pub loc: Loc,
+    pub comment: String,
+    pub position: CommentPosition,
+}
+
+impl DestructuredComment {
+    fn new(comment: Comment, position: CommentPosition) -> Self {
+        let (ty, loc, comment) = match comment {
+            Comment::Line(loc, comment) => (CommentType::Line, loc, comment),
+            Comment::Block(loc, comment) => (CommentType::Block, loc, comment),
+        };
+        Self { ty, loc, comment, position }
+    }
+    pub fn is_line(&self) -> bool {
+        matches!(self.ty, CommentType::Line)
+    }
+    pub fn is_prefix(&self) -> bool {
+        matches!(self.position, CommentPosition::Prefix)
+    }
+    pub fn needs_newline(&self) -> bool {
+        self.is_line() || self.is_prefix()
+    }
+    pub fn is_before(&self, byte: usize) -> bool {
+        self.loc.start() < byte
+    }
+}
+
+/// Comments are stored in reverse order for easy removal
+#[derive(Debug, Clone)]
+pub struct Comments {
+    prefixes: Vec<DestructuredComment>,
+    postfixes: Vec<DestructuredComment>,
+}
+
+impl Comments {
+    pub fn new(comments: Vec<Comment>, src: &str) -> Self {
+        let mut prefixes = Vec::new();
+        let mut postfixes = Vec::new();
+
+        for comment in comments.into_iter().rev() {
+            if Self::is_newline_comment(&comment, src) {
+                prefixes.push(DestructuredComment::new(comment, CommentPosition::Prefix))
+            } else {
+                postfixes.push(DestructuredComment::new(comment, CommentPosition::Postfix))
+            }
+        }
+        Self { prefixes, postfixes }
+    }
+
+    fn is_newline_comment(comment: &Comment, src: &str) -> bool {
+        for ch in src[..comment.loc().start()].chars().rev() {
+            if ch == '\n' {
+                return true
+            } else if !ch.is_whitespace() {
+                return false
+            }
+        }
+        true
+    }
+
+    pub(crate) fn pop_prefix(&mut self, byte: usize) -> Option<DestructuredComment> {
+        if self.prefixes.last()?.is_before(byte) {
+            Some(self.prefixes.pop().unwrap())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn peek_prefix(&mut self, byte: usize) -> Option<&DestructuredComment> {
+        self.prefixes.last().and_then(
+            |comment| {
+                if comment.is_before(byte) {
+                    Some(comment)
+                } else {
+                    None
+                }
+            },
+        )
+    }
+
+    pub(crate) fn pop_postfix(&mut self, byte: usize) -> Option<DestructuredComment> {
+        if self.postfixes.last()?.is_before(byte) {
+            Some(self.postfixes.pop().unwrap())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn get_comments_before(&self, byte: usize) -> Vec<&DestructuredComment> {
+        let mut out = self
+            .prefixes
+            .iter()
+            .rev()
+            .take_while(|comment| comment.is_before(byte))
+            .chain(self.prefixes.iter().rev().take_while(|comment| comment.is_before(byte)))
+            .collect::<Vec<_>>();
+        out.sort_by_key(|comment| comment.loc.start());
+        out
+    }
+
+    pub(crate) fn remove_comments_before(&mut self, byte: usize) -> Vec<DestructuredComment> {
+        let mut out = self.prefixes.split_off(
+            self.prefixes
+                .iter()
+                .find_position(|comment| comment.is_before(byte))
+                .map(|(idx, _)| idx)
+                .unwrap_or_else(|| self.prefixes.len()),
+        );
+        out.append(
+            &mut self.postfixes.split_off(
+                self.postfixes
+                    .iter()
+                    .find_position(|comment| comment.is_before(byte))
+                    .map(|(idx, _)| idx)
+                    .unwrap_or_else(|| self.postfixes.len()),
+            ),
+        );
+        out.sort_by_key(|comment| comment.loc.start());
+        out
+    }
+
+    pub(crate) fn drain(&mut self) -> Vec<DestructuredComment> {
+        let mut out = std::mem::take(&mut self.prefixes);
+        out.append(&mut self.postfixes);
+        out.sort_by_key(|comment| comment.loc.start());
+        out
+    }
+}

--- a/fmt/src/lib.rs
+++ b/fmt/src/lib.rs
@@ -1,9 +1,11 @@
 #![doc = include_str!("../README.md")]
 
+mod comments;
 mod formatter;
 mod helpers;
 pub mod solang_ext;
 mod visit;
 
+pub use comments::Comments;
 pub use formatter::{Formatter, FormatterConfig};
 pub use visit::{Visitable, Visitor};

--- a/fmt/src/solang_ext/ast_eq.rs
+++ b/fmt/src/solang_ext/ast_eq.rs
@@ -1,4 +1,4 @@
-use itertools::Itertools;
+use super::AttrSortKeyIteratorExt;
 use solang_parser::pt::*;
 
 pub trait AstEq {
@@ -19,18 +19,8 @@ impl AstEq for SourceUnit {
 
 impl AstEq for VariableDefinition {
     fn ast_eq(&self, other: &Self) -> bool {
-        let sort_attrs = |def: &Self| {
-            def.attrs
-                .iter()
-                .sorted_by_key(|attribute| match attribute {
-                    VariableAttribute::Visibility(_) => 0,
-                    VariableAttribute::Constant(_) => 1,
-                    VariableAttribute::Immutable(_) => 2,
-                    VariableAttribute::Override(_) => 3,
-                })
-                .cloned()
-                .collect::<Vec<_>>()
-        };
+        let sort_attrs =
+            |def: &Self| def.attrs.clone().into_iter().attr_sorted().collect::<Vec<_>>();
         let left_sorted_attrs = sort_attrs(self);
         let right_sorted_attrs = sort_attrs(other);
         self.ty.ast_eq(&other.ty) &&
@@ -42,20 +32,8 @@ impl AstEq for VariableDefinition {
 
 impl AstEq for FunctionDefinition {
     fn ast_eq(&self, other: &Self) -> bool {
-        let sort_attrs = |def: &Self| {
-            def.attributes
-                .iter()
-                .sorted_by_key(|attribute| match attribute {
-                    FunctionAttribute::Visibility(_) => 0,
-                    FunctionAttribute::Mutability(_) => 1,
-                    FunctionAttribute::Virtual(_) => 2,
-                    FunctionAttribute::Immutable(_) => 3,
-                    FunctionAttribute::Override(_, _) => 4,
-                    FunctionAttribute::BaseOrModifier(_, _) => 5,
-                })
-                .cloned()
-                .collect::<Vec<_>>()
-        };
+        let sort_attrs =
+            |def: &Self| def.attributes.clone().into_iter().attr_sorted().collect::<Vec<_>>();
         let left_sorted_attrs = sort_attrs(self);
         let right_sorted_attrs = sort_attrs(other);
         self.ty.ast_eq(&other.ty) &&

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -377,6 +377,15 @@ impl LineOfCode for Expression {
     }
 }
 
+impl LineOfCode for Comment {
+    fn loc(&self) -> Loc {
+        match self {
+            Comment::Line(loc, _) => *loc,
+            Comment::Block(loc, _) => *loc,
+        }
+    }
+}
+
 impl OptionalLineOfCode for FunctionAttribute {
     fn loc(&self) -> Option<Loc> {
         match self {

--- a/fmt/src/solang_ext/mod.rs
+++ b/fmt/src/solang_ext/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod ast_eq;
 mod loc;
+mod optional_sort_key;
 
 #[cfg(test)]
 pub use ast_eq::*;
 pub use loc::*;
+pub use optional_sort_key::*;

--- a/fmt/src/solang_ext/optional_sort_key.rs
+++ b/fmt/src/solang_ext/optional_sort_key.rs
@@ -1,0 +1,62 @@
+use itertools::Itertools;
+use solang_parser::pt::*;
+
+pub trait AttrSortKey {
+    fn attr_sort_key(&self) -> usize;
+}
+
+impl AttrSortKey for VariableAttribute {
+    fn attr_sort_key(&self) -> usize {
+        match self {
+            VariableAttribute::Visibility(..) => 0,
+            VariableAttribute::Constant(..) => 1,
+            VariableAttribute::Immutable(..) => 2,
+            VariableAttribute::Override(..) => 3,
+        }
+    }
+}
+
+impl AttrSortKey for FunctionAttribute {
+    fn attr_sort_key(&self) -> usize {
+        match self {
+            FunctionAttribute::Visibility(..) => 0,
+            FunctionAttribute::Mutability(..) => 1,
+            FunctionAttribute::Virtual(..) => 2,
+            FunctionAttribute::Immutable(..) => 3,
+            FunctionAttribute::Override(..) => 4,
+            FunctionAttribute::BaseOrModifier(..) => 5,
+        }
+    }
+}
+
+impl<T> AttrSortKey for &T
+where
+    T: AttrSortKey,
+{
+    fn attr_sort_key(&self) -> usize {
+        T::attr_sort_key(self)
+    }
+}
+
+impl<T> AttrSortKey for &mut T
+where
+    T: AttrSortKey,
+{
+    fn attr_sort_key(&self) -> usize {
+        T::attr_sort_key(self)
+    }
+}
+
+pub trait AttrSortKeyIteratorExt: Iterator {
+    fn attr_sorted(self) -> std::vec::IntoIter<Self::Item>;
+}
+
+impl<I> AttrSortKeyIteratorExt for I
+where
+    I: Iterator,
+    I::Item: AttrSortKey,
+{
+    fn attr_sorted(self) -> std::vec::IntoIter<Self::Item> {
+        self.sorted_by_key(|item| item.attr_sort_key())
+    }
+}

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -4,7 +4,9 @@ use crate::solang_ext::*;
 use solang_parser::pt::*;
 
 /// The error type a [Visitor] may return
-pub type VResult = Result<(), Box<dyn std::error::Error>>;
+pub type VError = Box<dyn std::error::Error>;
+/// The result type a [Visitor] may return
+pub type VResult = Result<(), VError>;
 
 pub type ParameterList = Vec<(Loc, Option<Parameter>)>;
 
@@ -84,6 +86,10 @@ pub trait Visitor {
     /// Don't write semicolon at the end because expressions can appear as both
     /// part of other node and a statement in the function body
     fn visit_expr(&mut self, loc: Loc, _expr: &mut Expression) -> VResult {
+        self.visit_source(loc)
+    }
+
+    fn visit_ident(&mut self, loc: Loc, _ident: &mut Identifier) -> VResult {
         self.visit_source(loc)
     }
 
@@ -407,6 +413,12 @@ impl Visitable for Loc {
 impl Visitable for Expression {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
         v.visit_expr(LineOfCode::loc(self), self)
+    }
+}
+
+impl Visitable for Identifier {
+    fn visit(&mut self, v: &mut impl Visitor) -> VResult {
+        v.visit_ident(self.loc, self)
     }
 }
 

--- a/fmt/testdata/FunctionType/fmt.sol
+++ b/fmt/testdata/FunctionType/fmt.sol
@@ -2,9 +2,7 @@ library ArrayUtils {
     function map(uint256[] memory self, function (uint) pure returns (uint) f)
         internal
         pure
-        returns (
-            uint256[] memory r
-        )
+        returns (uint256[] memory r)
     {
         r = new uint[](self.length);
         for (uint i = 0; i < self.length; i++) {
@@ -12,10 +10,11 @@ library ArrayUtils {
         }
     }
 
-    function reduce(
-        uint256[] memory self,
-        function (uint, uint) pure returns (uint) f
-    ) internal pure returns (uint256 r) {
+    function reduce(uint256[] memory self, function (uint, uint) pure returns (uint) f)
+        internal
+        pure
+        returns (uint256 r)
+    {
         r = self[0];
         for (uint i = 1; i < self.length; i++) {
             r = f(r, self[i]);

--- a/fmt/testdata/SimpleComments/fmt.sol
+++ b/fmt/testdata/SimpleComments/fmt.sol
@@ -1,0 +1,11 @@
+// comment 1
+uint256 example1 = 1;
+
+// comment 2
+// comment 3
+uint256 example2 = 2; // comment 4
+
+uint256 example3 = /* comment 5 */ 3; // comment 6
+
+// comment 7
+contract /* comment 8 */ ExampleContract /* comment 9 */ is Contract1 {}

--- a/fmt/testdata/SimpleComments/original.sol
+++ b/fmt/testdata/SimpleComments/original.sol
@@ -1,0 +1,9 @@
+// comment 1
+uint256 example1 = 1;
+// comment 2
+// comment 3
+uint256 example2 = 2;// comment 4
+uint256 example3 /* comment 5 */= 3; // comment 6
+
+// comment 7
+contract /* comment 8 */ ExampleContract /* comment 9 */ is Contract1 {}


### PR DESCRIPTION
Opening a draft to get some feedback on comments. Essentially the way comments are handled is by splitting them into two categories, prefixes and postfixes and types line and block comments

```rust
/* this is a prefix block comment */
let var = 1; // this is a postfix line comment
```

and trying to appropriately insert them where necessary, where prefixes need to start on a new line and line comments can't have anything follow them. As comments aren't in the parse tree the challenge is to try to figure out when to insert them appropriately and how to deal with the whitespace that they may or may not create.

This is essentially done by the adding a Comments context to the formatter and popping off comments as chunks get written via the `write_chunk` function and sometimes manually where more control is needed.

What I start doing here as well is to use the IndentWriter more by allowing the writing of multiple lines at a time as chunks can now be multiline given they contain line or prefix comments, and foregoing some of the assumptions of item size / line count before

The next steps are probably

* [ ] Replace all `write!` functions where necessary with `write_chunk!`
* [ ] Replace all `write_items_separated` with `write_chunks_separated`
* [ ] Lots and lots of tests
* [ ] Cleanup / refactor to find more patterns like `write_chunks_separated` (this will most likely be important when starting to really implement expressions and handling nesting / operator grouping)