### PR TITLE
refactor(evm): move cache flushing to SharedBackend

### DIFF
--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -375,3 +375,18 @@ impl<'de> Deserialize<'de> for JsonBlockCacheData {
         })
     }
 }
+
+/// A type that flushes a `JsonBlockCacheDB` on drop
+///
+/// This type intentionally does not implement `Clone` since it's intendent that there's only once
+/// instance that will flush the cache.
+#[derive(Debug)]
+pub struct FlushJsonBlockCacheDB(pub Arc<JsonBlockCacheDB>);
+
+impl Drop for FlushJsonBlockCacheDB {
+    fn drop(&mut self) {
+        trace!(target: "fork::cache", "flushing cache");
+        self.0.flush();
+        trace!(target: "fork::cache", "flushed cache");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #1688

Moves the flushing behaviour to the sender half, making the `BackendHandler` completely independent.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
see docs
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
