### PR TITLE
ci: enable rpc caching in integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+      - name: Forge RPC cache
+        uses: actions/cache@v3
+        with:
+          path: "$HOME/.foundry/cache"
+          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
       - name: cargo test
         run: cargo test --locked --workspace --all-features --lib --bins
@@ -65,6 +70,11 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+      - name: Forge RPC cache
+        uses: actions/cache@v3
+        with:
+          path: "$HOME/.foundry/cache"
+          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
       - name: cargo test
         run: cargo test --locked --workspace --test '*'
@@ -90,7 +100,7 @@ jobs:
       - name: Forge RPC cache
         uses: actions/cache@v3
         with:
-          path: ~/.foundry/cache
+          path: "$HOME/.foundry/cache"
           key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
       - name: Force use of HTTPS for submodules
@@ -126,6 +136,6 @@ jobs:
   cross-platform:
     name: Cross-platform tests
     if: github.event_name != 'pull_request'
-    needs: [integration, lint, doc, unit]
+    needs: [ integration, lint, doc, unit ]
     uses: ./.github/workflows/cross-platform.yml
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
enable caching in `integration` and standard tests as well (for anvil).

it appears that for whatever reason the rpc cache files are not cached for CI...

the `foundry home dir` is "$HOME/.foundry" 

https://github.com/xdg-rs/dirs/blob/master/dirs/src/lib.rs#L38-L39

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
