### PR TITLE
feat(bind): option to skip Cargo.toml from consistency checks

### DIFF
--- a/anvil/core/src/eth/subscription.rs
+++ b/anvil/core/src/eth/subscription.rs
@@ -10,7 +10,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 /// Result of a subscription
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum SubscriptionResult {
     /// New block header

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -67,6 +67,10 @@ pub struct BindArgs {
     #[clap(long = "single-file", help = "Generate bindings as a single file.")]
     #[serde(skip)]
     single_file: bool,
+
+    #[clap(long = "skip-cargo-toml", help = "Skip Cargo.toml from consistency checks.")]
+    #[serde(skip)]
+    skip_cargo_toml: bool,
 }
 
 impl BindArgs {
@@ -109,6 +113,7 @@ No contract artifacts found. Hint: Have you built your contracts yet? `forge bin
                 &self.crate_version,
                 self.bindings_root(),
                 self.single_file,
+                !self.skip_cargo_toml,
             )?;
         } else {
             bindings.ensure_consistent_module(self.bindings_root(), self.single_file)?;
@@ -141,7 +146,7 @@ impl Cmd for BindArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         if !self.overwrite && self.bindings_exist() {
             println!("Bindings found. Checking for consistency.");
-            return self.check_existing_bindings()
+            return self.check_existing_bindings();
         }
 
         if self.overwrite {

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -146,7 +146,7 @@ impl Cmd for BindArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         if !self.overwrite && self.bindings_exist() {
             println!("Bindings found. Checking for consistency.");
-            return self.check_existing_bindings();
+            return self.check_existing_bindings()
         }
 
         if self.overwrite {

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -68,7 +68,7 @@ pub struct BindArgs {
     #[serde(skip)]
     single_file: bool,
 
-    #[clap(long = "skip-cargo-toml", help = "Skip Cargo.toml from consistency checks.")]
+    #[clap(long = "skip-cargo-toml", help = "Skip Cargo.toml consistency checks.")]
     #[serde(skip)]
     skip_cargo_toml: bool,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Blocked by https://github.com/gakonst/ethers-rs/pull/1301

## Motivation

https://github.com/foundry-rs/foundry/issues/1701

## Solution

Add `--skip-cargo-toml` option.