### PR TITLE
fix(forge): provide default impls for remaining visitor methods in fmt

### DIFF
--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -13,7 +13,9 @@ pub type ParameterList = Vec<(Loc, Option<Parameter>)>;
 ///
 /// Currently the main implementor of this trait is the [`Formatter`](crate::Formatter) struct.
 pub trait Visitor {
-    fn visit_source(&mut self, _loc: Loc) -> VResult;
+    fn visit_source(&mut self, _loc: Loc) -> VResult {
+        Ok(())
+    }
 
     fn visit_source_unit(&mut self, _source_unit: &mut SourceUnit) -> VResult {
         Ok(())
@@ -286,13 +288,21 @@ pub trait Visitor {
         self.visit_source(def.loc)
     }
 
-    fn visit_stray_semicolon(&mut self) -> VResult;
+    fn visit_stray_semicolon(&mut self) -> VResult {
+        Ok(())
+    }
 
-    fn visit_opening_paren(&mut self) -> VResult;
+    fn visit_opening_paren(&mut self) -> VResult {
+        Ok(())
+    }
 
-    fn visit_closing_paren(&mut self) -> VResult;
+    fn visit_closing_paren(&mut self) -> VResult {
+        Ok(())
+    }
 
-    fn visit_newline(&mut self) -> VResult;
+    fn visit_newline(&mut self) -> VResult {
+        Ok(())
+    }
 
     fn visit_using(&mut self, using: &mut Using) -> VResult {
         self.visit_source(using.loc)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
allow fmt's `Visitor` to be reused in other packages 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

added default implementations

cc @mattsse @jpopesculian 