### PR TITLE
ci: add additional ci jobs for forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,8 @@ jobs:
       # required for forge commands that use git
       - name: setup git config
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "<>"
       - name: cargo test
         run: cargo test --locked --workspace -- --skip fork
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,26 @@ jobs:
   unit:
     name: unit tests
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: cargo test
+        run: cargo test --locked --workspace --all-features --lib --bins -- --skip fork
+
+  fork-unit:
+    name: fork unit tests
+    runs-on: ubuntu-latest
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
@@ -29,32 +49,34 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "$HOME/.foundry/cache"
-          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
+          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
 
       - name: cargo test
-        run: cargo test --locked --workspace --all-features --lib --bins
+        run: cargo test --locked --workspace --all-features --lib --bins fork
 
-  doc:
-    name: doc tests
+  integration:
+    name: integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
 
       - name: cargo test
-        run: cargo test --locked --workspace --all-features --doc
+        run: cargo test --locked --workspace -- --skip fork
 
-  integration:
-    name: integration tests
+  fork-integration:
+    name: fork integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -74,13 +96,36 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "$HOME/.foundry/cache"
-          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
+          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
 
       - name: cargo test
-        run: cargo test --locked --workspace --test '*'
+        run: cargo test --locked --workspace -- fork
 
   external-integration:
     name: external integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Force use of HTTPS for submodules
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - name: cargo test
+        run: cargo test --locked -p foundry-cli --features external-integration-tests -- --skip fork
+
+  external-fork-integration:
+    name: external fork integration tests
     runs-on: ubuntu-latest
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
@@ -101,13 +146,32 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "$HOME/.foundry/cache"
-          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
+          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
 
       - name: Force use of HTTPS for submodules
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
       - name: cargo test
-        run: cargo test --locked --workspace --features external-integration-tests --test '*'
+        run: cargo test --locked -p foundry-cli --features external-integration-tests fork_integration
+
+  doc:
+    name: doc tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: cargo test
+        run: cargo test --locked --workspace --all-features --doc
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,11 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-
+      # required for forge commands
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
       - name: cargo test
         run: cargo test --locked --workspace -- --skip fork
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-      # required for forge commands
+      # required for forge commands that use git
       - name: setup git config
         run: |
           git config user.name "GitHub Actions Bot"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,9 @@ Types of tests include:
 
 - **Unit tests**: Functions which have very specific tasks should be unit tested.
 - **Integration tests**: For general purpose, far reaching functionality, integration tests should be added.
-  The best way to add a new integration test is to look at existing ones and follow the style.
+  The best way to add a new integration test is to look at existing ones and follow the style. 
+
+Tests that use forking must contain "fork" in their name. 
 
 #### Commits
 

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -514,8 +514,15 @@ async fn call_past_state() {
     assert_eq!(value, "initial value");
 
     // make a call with `client`
-    let _tx_hash =
-        *contract.method::<_, H256>("setValue", "hi".to_owned()).unwrap().send().await.unwrap();
+    let _tx_hash = contract
+        .method::<_, H256>("setValue", "hi".to_owned())
+        .unwrap()
+        .send()
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap();
 
     // assert new value
     let value = contract.method::<_, String>("getValue", ()).unwrap().call().await.unwrap();

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -585,7 +585,7 @@ pub trait OutputExt {
 ///
 /// This should strip everything that can vary from run to run, like elapsed time, file paths
 static IGNORE_IN_FIXTURES: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(finished in (.*)?s|-->(.*).sol|Location(.*?)\.rs(.*)?Backtrace)").unwrap()
+    Regex::new(r"(finished in (.*)?s|-->(.*).sol|Location(.*?)\.rs(.*)?Backtrace|installing solc version(.*?)\n|Successfully installed solc(.*?)\n)").unwrap()
 });
 
 impl OutputExt for process::Output {

--- a/cli/tests/fixtures/can_check_snapshot.stdout
+++ b/cli/tests/fixtures/can_check_snapshot.stdout
@@ -1,11 +1,7 @@
-Compiling 3 files with 0.8.10
+Compiling 2 files with 0.8.10
 Solc 0.8.10 finished in 424.55ms
 Compiler run successful
 
 Running 1 test for src/ATest.t.sol:ATest
-[32m[PASS][0m testExample() (gas: 168)
-Test result: [32mok[0m. 1 passed; 0 failed; finished in 4.42ms
-
-Running 1 test for src/BTest.t.sol:BTest
 [32m[PASS][0m testExample() (gas: 168)
 Test result: [32mok[0m. 1 passed; 0 failed; finished in 4.42ms

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -538,21 +538,6 @@ contract ATest is DSTest {
    "#,
         )
         .unwrap();
-    prj.inner()
-        .add_source(
-            "BTest.t.sol",
-            r#"
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.10;
-import "./test.sol";
-contract BTest is DSTest {
-    function testExample() public {
-        assertTrue(true);
-    }
-}
-   "#,
-        )
-        .unwrap();
 
     cmd.arg("snapshot");
 

--- a/cli/tests/it/integration.rs
+++ b/cli/tests/it/integration.rs
@@ -4,12 +4,16 @@ forgetest_external!(solmate, "Rari-Capital/solmate");
 forgetest_external!(geb, "reflexer-labs/geb", &["--chain-id", "99"]);
 forgetest_external!(stringutils, "Arachnid/solidity-stringutils");
 // forgetest_external!(vaults, "Rari-Capital/vaults");
-forgetest_external!(multicall, "makerdao/multicall", &["--block-number", "1"]);
 forgetest_external!(lootloose, "gakonst/lootloose");
 forgetest_external!(lil_web3, "m1guelpf/lil-web3");
 forgetest_external!(maple_loan, "maple-labs/loan");
 
-// Forking tests
-forgetest_external!(drai, "mds1/drai", 13633752, &["--chain-id", "99"]);
-forgetest_external!(gunilev, "hexonaut/guni-lev", 13633752);
-forgetest_external!(convex, "mds1/convex-shutdown-simulation", 14445961);
+/// Forking tests
+mod fork_integration {
+    use foundry_cli_test_utils::forgetest_external;
+
+    forgetest_external!(multicall, "makerdao/multicall", &["--block-number", "1"]);
+    forgetest_external!(drai, "mds1/drai", 13633752, &["--chain-id", "99"]);
+    forgetest_external!(gunilev, "hexonaut/guni-lev", 13633752);
+    forgetest_external!(convex, "mds1/convex-shutdown-simulation", 14445961);
+}

--- a/cli/tests/rpc-cache-keyfile
+++ b/cli/tests/rpc-cache-keyfile
@@ -1,0 +1,5 @@
+This file serves as the key for the github actions/cache
+
+Any change in this file will invalidate the cache in CI that stores RPC data.
+
+Last updated: 05-26-2022


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1726
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adds 3 new fork only CI jobs to run

* all unit tests that contain `fork`
* integration tests that contain `fork`
* external integration tests that contain `fork`

the previous CI jobs now all skip `fork` tests

Adds a `rpc-cache-keyfile` that's supposed to work as a trigger to invalidate rpc cache in ci

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
