### PR TITLE
fix: cast etherscan_source and interface -h value_name to "CHAIN"

### DIFF
--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -38,7 +38,8 @@ pub struct ClapChain {
         env = "CHAIN",
         default_value = "mainnet",
         // if Chain implemented ArgEnum, we'd get this for free
-        possible_values = Chain::VARIANTS
+        possible_values = Chain::VARIANTS,
+        value_name = "CHAIN"
     )]
     pub inner: Chain,
 }


### PR DESCRIPTION
Closes: https://github.com/foundry-rs/foundry/issues/1730

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

one liner to change value_name to "CHAIN"

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
