### PR TITLE
fix: anvil value_name

### DIFF
--- a/anvil/server/src/config.rs
+++ b/anvil/server/src/config.rs
@@ -9,7 +9,13 @@ pub struct ServerConfig {
     /// The cors `allow_origin` header
     #[cfg_attr(
         feature = "clap",
-        clap(long, help = "Set the CORS allow_origin", default_value = "*", name = "allow-origin")
+        clap(
+            long,
+            help = "Set the CORS allow_origin",
+            default_value = "*",
+            name = "allow-origin",
+            value_name = "ALLOW_ORIGIN"
+        )
     )]
     pub allow_origin: HeaderValueWrapper,
     /// Whether to enable CORS

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -23,26 +23,44 @@ pub struct NodeArgs {
     #[clap(flatten, next_help_heading = "EVM OPTIONS")]
     pub evm_opts: EvmArgs,
 
-    #[clap(long, short, help = "Port number to listen on.", default_value = "8545")]
+    #[clap(
+        long,
+        short,
+        help = "Port number to listen on.",
+        default_value = "8545",
+        value_name = "NUM"
+    )]
     pub port: u16,
 
     #[clap(
         long,
         short,
         help = "Number of dev accounts to generate and configure.",
-        default_value = "10"
+        default_value = "10",
+        value_name = "NUM"
     )]
     pub accounts: u64,
 
-    #[clap(long, help = "The balance of every dev account in Ether.", default_value = "10000")]
+    #[clap(
+        long,
+        help = "The balance of every dev account in Ether.",
+        default_value = "10000",
+        value_name = "NUM"
+    )]
     pub balance: u64,
 
-    #[clap(long, short, help = "BIP39 mnemonic phrase used for generating accounts")]
+    #[clap(
+        long,
+        short,
+        help = "BIP39 mnemonic phrase used for generating accounts",
+        value_name = "MNEMONIC"
+    )]
     pub mnemonic: Option<String>,
 
     #[clap(
         long,
-        help = "Sets the derivation path of the child key to be derived. [default: m/44'/60'/0'/0/]"
+        help = "Sets the derivation path of the child key to be derived. [default: m/44'/60'/0'/0/]",
+        value_name = "DERIVATION_PATH"
     )]
     pub derivation_path: Option<String>,
 
@@ -52,7 +70,12 @@ pub struct NodeArgs {
     #[clap(long, help = "Don't print anything on startup.")]
     pub silent: bool,
 
-    #[clap(long, help = "The EVM hardfork to use.", default_value = "latest")]
+    #[clap(
+        long,
+        help = "The EVM hardfork to use.",
+        default_value = "latest",
+        value_name = "HARDFORK"
+    )]
     pub hardfork: Hardfork,
 
     #[clap(
@@ -60,7 +83,8 @@ pub struct NodeArgs {
         long,
         alias = "blockTime",
         help = "Block time in seconds for interval mining.",
-        name = "block-time"
+        name = "block-time",
+        value_name = "SECONDS"
     )]
     pub block_time: Option<u64>,
 
@@ -72,12 +96,20 @@ pub struct NodeArgs {
     )]
     pub no_mining: bool,
 
-    #[cfg_attr(feature = "clap", clap(long, help = "The host the server will listen on"))]
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, help = "The host the server will listen on", value_name = "IP_ADDR")
+    )]
     pub host: Option<IpAddr>,
 
     #[cfg_attr(
         feature = "clap",
-        clap(long, help = "How transactions are sorted in the mempool", default_value = "fees")
+        clap(
+            long,
+            help = "How transactions are sorted in the mempool",
+            default_value = "fees",
+            value_name = "ORDER"
+        )
     )]
     pub order: TransactionOrder,
 }


### PR DESCRIPTION
closes: https://github.com/foundry-rs/foundry/issues/1742

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

add value_name for anvil for better context

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

```sh
anvil 0.1.0 (4fcd7e0 2022-05-26T14:13:22.92765Z)
A fast local Ethereum development node

USAGE:
    anvil [OPTIONS]

OPTIONS:
    -a, --accounts <NUM>                       Number of dev accounts to generate and configure. [default: 10]
    -b, --block-time <SECONDS>                 Block time in seconds for interval mining.
        --balance <NUM>                        The balance of every dev account in Ether. [default: 10000]
        --derivation-path <DERIVATION_PATH>    Sets the derivation path of the child key to be derived. [default: m/44'/60'/0'/0/]
    -h, --help                                 Print help information
        --hardfork <HARDFORK>                  The EVM hardfork to use. [default: latest]
        --host <IP_ADDR>                       The host the server will listen on
    -m, --mnemonic <MNEMONIC>                  BIP39 mnemonic phrase used for generating accounts
        --no-mining                            Disable auto and interval mining, and mine on demand instead.
        --order <ORDER>                        How transactions are sorted in the mempool [default: fees]
    -p, --port <NUM>                           Port number to listen on. [default: 8545]
        --silent                               Don't print anything on startup.
    -V, --version                              Print version information

EVM OPTIONS:
    -f, --fork-url <URL>               Fetch state over a remote endpoint instead of starting from an empty state
        --ffi                          Enables the FFI cheatcode.
        --fork-block-number <BLOCK>    Fetch state from a specific block number over a remote endpoint
        --initial-balance <BALANCE>    The initial balance of deployed test contracts
        --no-storage-caching           Explicitly disables the use of RPC caching
        --sender <ADDRESS>             The address which will be executing tests
    -v, --verbosity                    Verbosity of the EVM.

EXECUTOR ENVIRONMENT CONFIG:
        --block-base-fee-per-gas <FEE>     The base fee in a block
        --block-coinbase <ADDRESS>         The coinbase of the block
        --block-difficulty <DIFFICULTY>    The block difficulty
        --block-gas-limit <GAS_LIMIT>      The block gas limit
        --block-number <BLOCK>             The block number
        --block-timestamp <TIMESTAMP>      The timestamp of the block
        --chain-id <CHAIN_ID>              The chain ID
        --gas-limit <GAS_LIMIT>            The block gas limit
        --gas-price <GAS_PRICE>            The gas price
        --tx-origin <ADDRESS>              The transaction origin

SERVER OPTIONS:
        --allow-origin <ALLOW_ORIGIN>    Set the CORS allow_origin [default: *]
        --no-cors                        Disable CORS
```