### PR TITLE
test: use rotating alchemy api keys

### DIFF
--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -170,7 +170,7 @@ macro_rules! forgetest_external {
             ]);
             cmd.set_env("FOUNDRY_FUZZ_RUNS", "1");
 
-            let next_eth_rpc_url = foundry_utils::rpc::next_http_rpc_endpoint();
+            let next_eth_rpc_url = foundry_utils::rpc::next_http_archive_rpc_endpoint();
             if $fork_block > 0 {
                 cmd.set_env("FOUNDRY_ETH_RPC_URL", next_eth_rpc_url);
                 cmd.set_env("FOUNDRY_FORK_BLOCK_NUMBER", stringify!($fork_block));

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -9,7 +9,6 @@ use foundry_cli_test_utils::{
     util::{pretty_err, read_string, OutputExt, TestCommand, TestProject},
 };
 use foundry_config::{parse_with_profile, BasicConfig, Chain, Config, SolidityErrorCode};
-use foundry_utils::rpc::next_http_rpc_endpoint;
 use std::{fs, path::PathBuf};
 use yansi::Paint;
 
@@ -615,7 +614,7 @@ forgetest_ignore!(can_compile_local_spells, |_: TestProject, mut cmd: TestComman
         .to_string();
     println!("project root: \"{root}\"");
 
-    let eth_rpc_url = next_http_rpc_endpoint();
+    let eth_rpc_url = foundry_utils::rpc::next_http_archive_rpc_endpoint();
     let dss_exec_lib = "src/DssSpell.sol:DssExecLib:0xfD88CeE74f7D78697775aBDAE53f9Da1559728E4";
 
     cmd.args([

--- a/utils/src/rpc.rs
+++ b/utils/src/rpc.rs
@@ -47,7 +47,8 @@ pub fn next_http_rpc_endpoint() -> String {
 ///
 /// This will rotate all available rpc endpoints
 pub fn next_rinkeby_http_rpc_endpoint() -> String {
-    next_rpc_endpoint("rinkeby")
+    // infura keys don't have access to archive state
+    "https://eth-rinkeby.alchemyapi.io/v2/9VWGraLx0tMiSWx05WH-ywgSVmMxs66W".to_string()
 }
 
 pub fn next_rpc_endpoint(network: &str) -> String {

--- a/utils/src/rpc.rs
+++ b/utils/src/rpc.rs
@@ -22,6 +22,7 @@ const ALCHEMY_MAINNET_KEYS: &[&str] = &[
     "QC55XC151AgkS3FNtWvz9VZGeu9Xd9lb",
     "pwc5rmJhrdoaSEfimoKEmsvOjKSmPDrP",
     "A5sZ85MIr4SzCMkT0zXh2eeamGIq3vGL",
+    "9VWGraLx0tMiSWx05WH-ywgSVmMxs66W",
 ];
 
 /// counts how many times a rpc endpoint was requested for _mainnet_
@@ -47,8 +48,8 @@ pub fn next_http_rpc_endpoint() -> String {
 ///
 /// This will rotate all available rpc endpoints
 pub fn next_rinkeby_http_rpc_endpoint() -> String {
-    // infura keys don't have access to archive state
-    "https://eth-rinkeby.alchemyapi.io/v2/9VWGraLx0tMiSWx05WH-ywgSVmMxs66W".to_string()
+    let idx = next() % ALCHEMY_MAINNET_KEYS.len();
+    format!("https://eth-rinkeby.alchemyapi.io/v2/{}", ALCHEMY_MAINNET_KEYS[idx])
 }
 
 pub fn next_rpc_endpoint(network: &str) -> String {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the infura keys we're using don't have access to archive state.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
only use alchemy keys in rotation
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
