### PR TITLE
fix: show full addresses in debugger

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -618,10 +618,10 @@ impl Tui {
                     text_output.extend(Text::from("No sourcemap for contract"));
                 }
             } else {
-                text_output.extend(Text::from(format!("Unknown contract at address {address}")));
+                text_output.extend(Text::from(format!("Unknown contract at address {address:?}")));
             }
         } else {
-            text_output.extend(Text::from(format!("Unknown contract at address {address}")));
+            text_output.extend(Text::from(format!("Unknown contract at address {address:?}")));
         }
 
         let paragraph =
@@ -641,7 +641,7 @@ impl Tui {
     ) {
         let block_source_code = Block::default()
             .title(format!(
-                "Address: {} | PC: {} | Gas used in call: {}",
+                "Address: {:?} | PC: {} | Gas used in call: {}",
                 address,
                 if let Some(step) = debug_steps.get(current_step) {
                     step.pc.to_string()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
it is hard to look up shortened addresses referenced in debugger
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
show full addresses
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
