### PR TITLE
feat(cast) Signed Integer decoding in `cast call`

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -102,7 +102,8 @@ where
                         Token::Bytes(inner) => format!("0x{}", hex::encode(inner)),
                         Token::FixedBytes(inner) => format!("0x{}", hex::encode(inner)),
                         // print as decimal
-                        Token::Uint(inner) | Token::Int(inner) => inner.to_string(),
+                        Token::Uint(inner) => inner.to_string(),
+                        Token::Int(inner) => format!("{}", I256::from_raw(*inner)),
                         _ => format!("{item}"),
                     }
                 })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1719.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Split up the formatting for uints and ints, because the `ethereum_types` crate does not decode signed integers correctly. I assume there are some other places where this may need to be fixed? 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
