### PR TITLE
feat(forge): flag to manually set nonce in `forge create`

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -71,7 +71,16 @@ This is automatically enabled for common networks without EIP1559."#
     gas_price: Option<U256>,
 
     #[clap(
-        long = "gas-limit",
+        long,
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Nonce for the transaction.",
+        parse(try_from_str = parse_u256),
+        value_name = "NONCE"
+    )]
+    nonce: Option<U256>,
+
+    #[clap(
+    long = "gas-limit",
         help_heading = "TRANSACTION OPTIONS",
         help = "Gas limit for the transaction.",
         env = "ETH_GAS_LIMIT",
@@ -232,6 +241,11 @@ impl CreateArgs {
         // set gas limit if specified
         if let Some(gas_limit) = self.gas_limit {
             deployer.tx.set_gas(gas_limit);
+        }
+
+        // set nonce if specified
+        if let Some(nonce) = self.nonce {
+            deployer.tx.set_nonce(nonce);
         }
 
         // set priority fee if specified


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1051
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adds a flag to manually set the nonce. Does this need to be added to any other commands?

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
