### PR TITLE
feat(forge): verify broadcasted contracts on `forge script`

### DIFF
--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -59,6 +59,8 @@ impl DebugArgs {
             resume: false,
             debug: true,
             slow: false,
+            etherscan_api_key: None,
+            verify: false,
         };
         script.run_script().await
     }

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -148,7 +148,7 @@ impl ScriptArgs {
         &mut self,
         script_config: &ScriptConfig,
     ) -> eyre::Result<(Project, ProjectCompileOutput)> {
-        let project = script_config.config.ephemeral_no_artifacts_project()?;
+        let project = script_config.config.project()?;
 
         let output = match dunce::canonicalize(&self.path) {
             // We got passed an existing path to the contract
@@ -162,7 +162,6 @@ impl ScriptArgs {
 
                     (path, output)
                 } else {
-                    let project = script_config.config.project()?;
                     let output = compile::compile(&project, false, false)?;
                     let cache = SolFilesCache::read_joined(&project.paths)?;
 

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -1,9 +1,9 @@
 use crate::{
-    cmd::{unwrap_contracts, ScriptSequence},
+    cmd::{unwrap_contracts, ScriptSequence, VerifyBundle},
     utils::get_http_provider,
 };
+
 use ethers::{
-    abi::Abi,
     prelude::{artifacts::CompactContractBytecode, ArtifactId, Middleware, Signer},
     types::{transaction::eip2718::TypedTransaction, U256},
 };
@@ -39,13 +39,18 @@ impl ScriptArgs {
             project,
             target,
             contract,
-            highlevel_known_contracts,
+            mut highlevel_known_contracts,
             predeploy_libraries,
             known_contracts: default_known_contracts,
             sources,
         } = self.build(&script_config)?;
 
-        if self.resume {
+        let mut verify = VerifyBundle::new(
+            &script_config.config,
+            unwrap_contracts(&highlevel_known_contracts, false),
+        );
+
+        if self.resume || (self.verify && !self.broadcast) {
             let fork_url = self
                 .evm_opts
                 .fork_url
@@ -58,9 +63,16 @@ impl ScriptArgs {
 
             let mut deployment_sequence =
                 ScriptSequence::load(&script_config.config, &self.sig, &target, chain)?;
-            self.send_transactions(&mut deployment_sequence, &fork_url).await?;
+
+            if self.resume {
+                self.send_transactions(&mut deployment_sequence, &fork_url).await?;
+            }
+
+            if self.verify {
+                deployment_sequence.verify_contracts(verify, chain).await?;
+            }
         } else {
-            let mut known_contracts = unwrap_contracts(&highlevel_known_contracts);
+            let known_contracts = unwrap_contracts(&highlevel_known_contracts, true);
 
             // execute once with default sender
             let sender = script_config.evm_opts.sender;
@@ -77,7 +89,7 @@ impl ScriptArgs {
                     result.transactions.as_ref(),
                     &predeploy_libraries,
                 )? {
-                    known_contracts = self
+                    highlevel_known_contracts = self
                         .rerun_with_new_deployer(
                             project,
                             &mut script_config,
@@ -87,7 +99,11 @@ impl ScriptArgs {
                         )
                         .await?;
                     // redo traces
-                    decoder = self.decode_traces(&script_config, &mut result, &known_contracts)?;
+                    decoder = self.decode_traces(
+                        &script_config,
+                        &mut result,
+                        &unwrap_contracts(&highlevel_known_contracts, true),
+                    )?;
                 } else {
                     // prepend predeploy libraries
                     let mut lib_deploy = self.create_deploy_transactions(
@@ -106,11 +122,13 @@ impl ScriptArgs {
 
                 self.show_traces(&script_config, &decoder, &mut result)?;
 
+                verify.known_contracts = unwrap_contracts(&highlevel_known_contracts, false);
                 self.handle_broadcastable_transactions(
                     &target,
                     result.transactions,
                     &mut decoder,
                     &script_config,
+                    verify,
                 )
                 .await?;
             }
@@ -127,7 +145,7 @@ impl ScriptArgs {
         new_sender: Address,
         first_run_result: &mut ScriptResult,
         default_known_contracts: BTreeMap<ArtifactId, CompactContractBytecode>,
-    ) -> eyre::Result<BTreeMap<ArtifactId, (Abi, Vec<u8>)>> {
+    ) -> eyre::Result<BTreeMap<ArtifactId, ContractBytecodeSome>> {
         // if we had a new sender that requires relinking, we need to
         // get the nonce mainnet for accurate addresses for predeploy libs
         let nonce = foundry_utils::next_nonce(
@@ -165,7 +183,7 @@ impl ScriptArgs {
         *first_run_result = result;
         first_run_result.transactions = Some(txs);
 
-        Ok(unwrap_contracts(&highlevel_known_contracts))
+        Ok(highlevel_known_contracts)
     }
 
     /// In case the user has loaded *only* one private-key, we can assume that he's using it as the

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -101,6 +101,16 @@ pub struct ScriptArgs {
         help = "Makes sure a transaction is sent, only after its previous one has been confirmed and succeeded."
     )]
     pub slow: bool,
+
+    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+    pub etherscan_api_key: Option<String>,
+
+    #[clap(
+        long,
+        help = "If it finds a matching broadcast log, it tries to verify every contract found in the receipts.",
+        requires = "etherscan-api-key"
+    )]
+    pub verify: bool,
 }
 
 pub struct ScriptResult {

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -1,8 +1,9 @@
 use crate::{opts::forge::ContractInfo, suggestions};
+use cast::executor::inspector::DEFAULT_CREATE2_DEPLOYER;
 use clap::Parser;
 use ethers::{
-    abi::Abi,
-    prelude::{ArtifactId, TransactionReceipt, TxHash},
+    abi::{Abi, Address},
+    prelude::{ArtifactId, NameOrAddress, TransactionReceipt, TxHash},
     solc::{
         artifacts::{
             CompactBytecode, CompactContractBytecode, CompactDeployedBytecode, ContractBytecodeSome,
@@ -22,6 +23,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use yansi::Paint;
+
+use super::forge::{
+    build::ProjectPathsArgs,
+    create::RETRY_VERIFY_ON_CREATE,
+    verify::{self},
+};
 
 /// Common trait for all cli commands
 pub trait Cmd: clap::Parser + Sized {
@@ -156,21 +163,58 @@ pub fn needs_setup(abi: &Abi) -> bool {
 
 pub fn unwrap_contracts(
     contracts: &BTreeMap<ArtifactId, ContractBytecodeSome>,
+    deployed_code: bool,
 ) -> BTreeMap<ArtifactId, (Abi, Vec<u8>)> {
     contracts
         .iter()
         .map(|(id, c)| {
-            (
-                id.clone(),
-                (
-                    c.abi.clone(),
-                    c.deployed_bytecode.clone().into_bytes().expect("not bytecode").to_vec(),
-                ),
-            )
+            let bytecode = if deployed_code {
+                c.deployed_bytecode.clone().into_bytes().expect("not bytecode").to_vec()
+            } else {
+                c.bytecode.clone().object.into_bytes().expect("not bytecode").to_vec()
+            };
+
+            (id.clone(), (c.abi.clone(), bytecode))
         })
         .collect()
 }
 
+/// Data struct to help `ScriptSequence` verify contracts on `etherscan`.
+pub struct VerifyBundle {
+    pub num_of_optimizations: Option<usize>,
+    pub known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)>,
+    pub etherscan_key: Option<String>,
+    pub project_paths: ProjectPathsArgs,
+}
+
+impl VerifyBundle {
+    pub fn new(config: &Config, known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)>) -> Self {
+        let num_of_optimizations =
+            if config.optimizer { Some(config.optimizer_runs) } else { None };
+
+        let project_paths = ProjectPathsArgs {
+            root: Some(config.__root.0.clone()),
+            contracts: Some(config.src.clone()),
+            remappings: config
+                .remappings
+                .iter()
+                .map(|remap| remap.clone().to_remapping(config.__root.0.clone()))
+                .collect(),
+            remappings_env: None,
+            cache_path: Some(config.cache_path.clone()),
+            lib_paths: config.libs.clone(),
+            hardhat: config.profile == Config::HARDHAT_PROFILE,
+            config_path: Some(config.get_config_path()),
+        };
+
+        VerifyBundle {
+            num_of_optimizations,
+            known_contracts,
+            etherscan_key: config.etherscan_api_key.clone(),
+            project_paths,
+        }
+    }
+}
 /// Helper that saves the transactions sequence and its state on which transactions have been
 /// broadcasted
 #[derive(Deserialize, Serialize, Clone)]
@@ -178,6 +222,7 @@ pub struct ScriptSequence {
     pub transactions: VecDeque<TypedTransaction>,
     pub receipts: Vec<TransactionReceipt>,
     pub pending: Vec<TxHash>,
+    pub create2_contracts: Option<Vec<Address>>,
     pub path: PathBuf,
     pub timestamp: u64,
 }
@@ -196,6 +241,7 @@ impl ScriptSequence {
             transactions,
             receipts: vec![],
             pending: vec![],
+            create2_contracts: None,
             path,
             timestamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -263,6 +309,14 @@ impl ScriptSequence {
         self.pending.retain(|element| element != &tx_hash);
     }
 
+    pub fn add_create2(&mut self, address: Address) {
+        if let Some(addresses) = &mut self.create2_contracts {
+            addresses.push(address);
+        } else {
+            self.create2_contracts = Some(vec![address]);
+        }
+    }
+
     /// Saves to ./broadcast/contract_filename/sig[-timestamp].json
     pub fn get_path(
         out: &Path,
@@ -281,6 +335,74 @@ impl ScriptSequence {
         let filename = sig.split_once('(').expect("Sig is invalid").0.to_owned();
         out.push(format!("{filename}-latest.json"));
         Ok(out)
+    }
+
+    /// Given the broadcast log, it matches transactions with receipts, and tries to verify any
+    /// created contract on etherscan.
+    pub async fn verify_contracts(&mut self, verify: VerifyBundle, chain: u64) -> eyre::Result<()> {
+        let mut future_verifications = vec![];
+        let mut create2 = self.create2_contracts.clone().unwrap_or_default().into_iter();
+
+        if let Some(etherscan_key) = &verify.etherscan_key {
+            for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
+                let mut create2_offset = 0;
+
+                // CREATE2 contract addresses do not come in the receipt.
+                if let Some(&NameOrAddress::Address(to)) = tx.to() {
+                    if to == DEFAULT_CREATE2_DEPLOYER {
+                        receipt.contract_address = create2.next();
+                        create2_offset = 32;
+                    }
+                }
+
+                if let (Some(contract_address), Some(data)) = (receipt.contract_address, tx.data())
+                {
+                    for (artifact, (_contract, bytecode)) in &verify.known_contracts {
+                        // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
+                        // of the transaction
+                        if data.0.split_at(create2_offset).1.starts_with(bytecode) {
+                            let constructor_args =
+                                data.0.split_at(create2_offset + bytecode.len()).1.to_vec();
+
+                            let contract = ContractInfo {
+                                path: Some(
+                                    artifact
+                                        .source
+                                        .to_str()
+                                        .expect("There should be an artifact.")
+                                        .to_string(),
+                                ),
+                                name: artifact.name.clone(),
+                            };
+
+                            let verify = verify::VerifyArgs {
+                                address: contract_address,
+                                contract,
+                                compiler_version: None,
+                                constructor_args: Some(hex::encode(&constructor_args)),
+                                num_of_optimizations: verify.num_of_optimizations,
+                                chain: chain.into(),
+                                etherscan_key: etherscan_key.clone(),
+                                project_paths: verify.project_paths.clone(),
+                                flatten: false,
+                                force: false,
+                                watch: true,
+                                retry: RETRY_VERIFY_ON_CREATE,
+                            };
+
+                            future_verifications.push(verify.run());
+                        }
+                    }
+                }
+            }
+
+            println!("##\nStart Contract Verification");
+            for verification in future_verifications {
+                verification.await?;
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Verify `CREATE` and `CREATE2` contracts broadcasted on `forge script`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
For `CREATE`, we just match `receipts` to `transactions`, extract the constructor arguments and pass that to `VerifyArgs`.
For `CREATE2`, we have to collect and store the created addresses from the on-chain simulation. After that, it's pretty much the same, apart from offsetting the transaction data.

### Behaviour:
`--broadcast --verify`: compiles, runs, broadcasts and verifies after submitting all transactions successfully.
`--resume --verify`: compiles, broadcasts and verifies after submitting all transactions successfully.
`--verify`: compiles and verifies existing contracts from receipts.

### Some pain points right now
* If it's a contract inside a standalone script and outside of a project, then `VerifyArgs` doesn't like it.
* Etherscan needs a `Retry` for rate limiting as well.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
