### PR TITLE
fix: forge script debug flag description

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -93,7 +93,7 @@ pub struct ScriptArgs {
     #[clap(long)]
     pub resume: bool,
 
-    #[clap(long, help = "Takes precedence over broadcast")]
+    #[clap(long, help = "Open the script in the debugger. Takes precedence over broadcast.")]
     pub debug: bool,
 
     #[clap(


### PR DESCRIPTION
closes: https://github.com/foundry-rs/foundry/issues/1783

while documenting `forge script` found that `--debug` help text needs more info
book pr: https://github.com/foundry-rs/book/pull/335


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Current help text for `--debug`

```bash
➜  ~ forge script -h
forge-script
Run a smart contract as a script, building transactions that can be sent onchain.

USAGE:
    forge script [OPTIONS] <PATH> [--] [ARGS]...

ARGS:
    <PATH>       The contract you want to run. Either the file path or contract name
    <ARGS>...    Arguments to pass to the script function

OPTIONS:
        --broadcast                          Broadcasts the transactions.
        --debug                              Takes precedence over broadcast
    -h, --help                               Print help information
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
