### PR TITLE
[wip] feat(forge): script json flag 

### DIFF
--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -59,6 +59,7 @@ impl DebugArgs {
             resume: false,
             debug: true,
             slow: false,
+            json: false,
         };
         script.run_script().await
     }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -105,7 +105,7 @@ impl ScriptArgs {
                 }
 
                 if self.json {
-                    self.show_json(&script_config, &decoder, &mut result)?;
+                    self.show_json(&script_config, &mut result)?;
                 } else {
                     self.show_traces(&script_config, &decoder, &mut result)?;
                 }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -104,7 +104,11 @@ impl ScriptArgs {
                     }
                 }
 
-                self.show_traces(&script_config, &decoder, &mut result)?;
+                if self.json {
+                    self.show_json(&script_config, &decoder, &mut result)?;
+                } else {
+                    self.show_traces(&script_config, &decoder, &mut result)?;
+                }
 
                 self.handle_broadcastable_transactions(
                     &target,

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -40,6 +40,7 @@ use std::{
     time::Duration,
 };
 
+use serde::{Deserialize, Serialize};
 use yansi::Paint;
 
 // Loads project's figment and merges the build cli arguments into it
@@ -115,6 +116,12 @@ pub struct ScriptResult {
     pub labeled_addresses: BTreeMap<Address, String>,
     pub transactions: Option<VecDeque<TypedTransaction>>,
     pub returned: bytes::Bytes,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct JsonResult {
+    pub logs: Vec<String>,
+    pub gas_used: u64,
 }
 
 impl ScriptArgs {
@@ -221,15 +228,12 @@ impl ScriptArgs {
     pub fn show_json(
         &self,
         script_config: &ScriptConfig,
-        decoder: &CallTraceDecoder,
         result: &mut ScriptResult,
     ) -> eyre::Result<()> {
         let console_logs = decode_console_logs(&result.logs);
-        if !console_logs.is_empty() {
-            println!("\n== Logs ==");
-            let j = serde_json::to_string(&console_logs)?;
-            println!("{}", j);
-        }
+        let output = JsonResult { logs: console_logs, gas_used: result.gas };
+        let j = serde_json::to_string(&output)?;
+        println!("{}", j);
 
         Ok(())
     }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -40,7 +40,6 @@ use std::{
     time::Duration,
 };
 
-use cast::revm::Return;
 use serde::{Deserialize, Serialize};
 use yansi::Paint;
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -101,6 +101,9 @@ pub struct ScriptArgs {
         help = "Makes sure a transaction is sent, only after its previous one has been confirmed and succeeded."
     )]
     pub slow: bool,
+
+    #[clap(long, help = "Output results in JSON format.")]
+    pub json: bool,
 }
 
 pub struct ScriptResult {
@@ -212,6 +215,15 @@ impl ScriptArgs {
             eyre::bail!("{}", Paint::red("Script failed."));
         }
 
+        Ok(())
+    }
+
+    pub fn show_json(
+        &self,
+        script_config: &ScriptConfig,
+        decoder: &CallTraceDecoder,
+        result: &mut ScriptResult,
+    ) -> eyre::Result<()> {
         Ok(())
     }
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -224,6 +224,13 @@ impl ScriptArgs {
         decoder: &CallTraceDecoder,
         result: &mut ScriptResult,
     ) -> eyre::Result<()> {
+        let console_logs = decode_console_logs(&result.logs);
+        if !console_logs.is_empty() {
+            println!("\n== Logs ==");
+            let j = serde_json::to_string(&console_logs)?;
+            println!("{}", j);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
issue: https://github.com/foundry-rs/foundry/issues/1769

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Adding `forge script --json` 

I'm a bit unsure about the logic and so adding as draft for now.

using this to test json output
```bash
forge script ./test/Simple.t.sol --tc SimpleTest --fork-url $GOERLI_RPC_URL
[⠢] Compiling...
[⠰] Compiling 2 files with 0.8.13
[⠔] Solc 0.8.13 finished in 74.99ms
Compiler run successful
Script ran successfully.
Gas used: 9098

== Return ==
0: uint256 1234
1: bytes32 0x6100000000000000000000000000000000000000000000000000000000000000
2: string "asdf"

== Logs ==
  test
```
```solidity
contract SimpleTest is DSTest {
    uint256 a = 1234;
    bytes32 b = 'a';
    string c = "asdf";

    function run() public returns (uint, bytes32, string memory){
        emit log_string("test");
        return (a, b, c);
    }
}
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
