### PR TITLE
fix: use consitent slashes in remappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "figment",
  "globset",
  "number_prefix",
+ "path-slash",
  "pretty_assertions",
  "regex",
  "semver",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -26,6 +26,9 @@ globset = "0.4.8"
 walkdir = "2.3.2"
 toml_edit = "0.14.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+path-slash = "0.1.4"
+
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 figment = { version = "0.10", features = ["test"] }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -445,6 +445,14 @@ impl Config {
     pub fn sanitized(self) -> Self {
         let mut config = self.canonic();
 
+        #[cfg(target_os = "windows")]
+        {
+            // force `/` in remappings on windows
+            use path_slash::PathBufExt;
+            config.remappings.iter_mut().for_each(|r| {
+                r.path.path = r.path.path.to_slash_lossy().into();
+            });
+        }
         // remove any potential duplicates
         config.remappings.sort_unstable();
         config.remappings.dedup();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1777
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
transform non `/` separators in remappings paths to `/` on windows.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
