### PR TITLE
forge(fix): refactor pending transactions from `script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "solang-parser",
  "strsim",
  "strum 0.24.0",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
 bytes = "1.1.0"
 strum = { version = "0.24", features = ["derive"] }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 anvil = { path = "../anvil" }

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -1,10 +1,10 @@
 use crate::{
     cmd::{
-        forge::script::receipts::{get_pending_txes, maybe_has_receipt, wait_for_receipts},
+        forge::script::receipts::{wait_for_pending, wait_for_receipts},
         ScriptSequence,
     },
     opts::WalletType,
-    utils::{get_http_provider, print_receipt},
+    utils::get_http_provider,
 };
 use ethers::{
     prelude::{SignerMiddleware, TxHash},
@@ -22,59 +22,53 @@ impl ScriptArgs {
     ) -> eyre::Result<()> {
         let provider = get_http_provider(fork_url);
 
-        let required_addresses = deployment_sequence
-            .transactions
-            .iter()
-            .map(|tx| *tx.from().expect("No sender for onchain transaction!"))
-            .collect();
+        wait_for_pending(&provider, deployment_sequence).await?;
 
-        let local_wallets = self.wallets.find_all(&provider, required_addresses).await?;
-        if local_wallets.is_empty() {
-            eyre::bail!("Error accessing local wallet when trying to send onchain transaction, did you set a private key, mnemonic or keystore?")
-        }
+        if deployment_sequence.receipts.len() < deployment_sequence.transactions.len() {
+            let required_addresses = deployment_sequence
+                .transactions
+                .iter()
+                .skip(deployment_sequence.receipts.len())
+                .map(|tx| *tx.from().expect("No sender for onchain transaction!"))
+                .collect();
 
-        let transactions = deployment_sequence.transactions.clone();
+            let local_wallets = self.wallets.find_all(&provider, required_addresses).await?;
+            if local_wallets.is_empty() {
+                eyre::bail!("Error accessing local wallet when trying to send onchain transaction, did you set a private key, mnemonic or keystore?")
+            }
 
-        // Iterate through transactions, matching the `from` field with the associated
-        // wallet. Then send the transaction. Panics if we find a unknown `from`
-        let sequence =
-            transactions.into_iter().skip(deployment_sequence.receipts.len()).map(|tx| {
+            // We only wait for a transaction receipt before sending the next transaction, if there
+            // is more than one signer. There would be no way of assuring their order
+            // otherwise.
+            let sequential_broadcast = local_wallets.len() != 1 || self.slow;
+
+            let transactions = deployment_sequence.transactions.clone();
+
+            // Iterate through transactions, matching the `from` field with the associated
+            // wallet. Then send the transaction. Panics if we find a unknown `from`
+            let sequence = transactions.into_iter().map(|tx| {
                 let from = *tx.from().expect("No sender for onchain transaction!");
                 let signer = local_wallets.get(&from).expect("`find_all` returned incomplete.");
                 (tx, signer)
             });
 
-        let pending_txes = get_pending_txes(&deployment_sequence.pending, fork_url).await;
-        let mut future_receipts = vec![];
+            let mut future_receipts = vec![];
 
-        // We only wait for a transaction receipt before sending the next transaction, if there is
-        // more than one signer. There would be no way of assuring their order otherwise.
-        let sequential_broadcast = local_wallets.len() != 1 || self.slow;
-        for payload in sequence {
-            let (tx, signer) = payload;
+            println!("##\nSending transactions.");
+            for payload in sequence {
+                let (tx, signer) = payload;
+                let receipt = self.send_transaction(tx, signer, sequential_broadcast, fork_url);
 
-            // pending transactions from a previous failed run can be retrieve when passing
-            // `--resume`
-            match maybe_has_receipt(&tx, &pending_txes, fork_url).await {
-                Some(receipt) => {
-                    print_receipt(&receipt, *tx.nonce().unwrap())?;
-                    deployment_sequence.remove_pending(receipt.transaction_hash);
-                    deployment_sequence.add_receipt(receipt);
-                }
-                None => {
-                    let receipt = self.send_transaction(tx, signer, sequential_broadcast, fork_url);
-
-                    if sequential_broadcast {
-                        wait_for_receipts(vec![receipt], deployment_sequence).await?;
-                    } else {
-                        future_receipts.push(receipt);
-                    }
+                if sequential_broadcast {
+                    wait_for_receipts(vec![receipt], deployment_sequence).await?;
+                } else {
+                    future_receipts.push(receipt);
                 }
             }
-        }
 
-        if !sequential_broadcast {
-            wait_for_receipts(future_receipts, deployment_sequence).await.unwrap();
+            if !sequential_broadcast {
+                wait_for_receipts(future_receipts, deployment_sequence).await?;
+            }
         }
 
         println!("\n\n==========================");
@@ -168,7 +162,7 @@ impl ScriptArgs {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BroadcastError {
     Simple(String),
     ErrorWithTxHash(String, TxHash),

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -256,7 +256,9 @@ impl ScriptSequence {
     }
 
     pub fn add_pending(&mut self, tx_hash: TxHash) {
-        self.pending.push(tx_hash);
+        if !self.pending.contains(&tx_hash) {
+            self.pending.push(tx_hash);
+        }
     }
 
     pub fn remove_pending(&mut self, tx_hash: TxHash) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
It didn't make much sense on how it was before. 
On top of that, there was an issue sometimes where `--resume` was starting off on a transaction which had been published already, because we didn't wait for all pending transactions.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
