### PR TITLE
Clarify error message when RPC fails

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -470,7 +470,7 @@ Chain ID:       {}
                 .get_block(BlockNumber::Number(fork_block_number.into()))
                 .await
                 .expect("Failed to get fork block")
-                .unwrap();
+                .unwrap_or_else(|| panic!("Failed to get fork block"));
 
             env.block.number = fork_block_number.into();
             fork_timestamp = Some(block.timestamp);


### PR DESCRIPTION
Optimism public RPC is currently getting hammered from the airdrop, so right now starting an anvil node from an optimism fork sometimes fails with

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /Users/runner/work/foundry/foundry/anvil/src/config.rs:473:18
```

This is a bit confusing since it seems like an anvil bug, so this just clarifies the error.