### PR TITLE
fix: add safety check for auto-detected remappings

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1771,6 +1771,10 @@ impl<'a> RemappingsProvider<'a> {
         // use auto detection for all libs
         for r in self.lib_paths.iter().map(|lib| self.root.join(lib)).flat_map(Remapping::find_many)
         {
+            // this is an additional safety check for weird auto-detected remappings
+            if ["lib/", "src/", "contracts/"].contains(&r.name.as_str()) {
+                continue
+            }
             insert_closest(&mut lib_remappings, r.name, r.path.into());
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1797
Ref https://github.com/gakonst/ethers-rs/pull/1335
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
prevents weird autodetected remappings named `lib` or `src`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
