### PR TITLE
fix(anvil): handle earliest block number in filter

### DIFF
--- a/anvil/core/src/eth/filter.rs
+++ b/anvil/core/src/eth/filter.rs
@@ -49,6 +49,7 @@ impl Filter {
     pub fn get_from_block_number(&self) -> Option<u64> {
         self.from_block.and_then(|block| match block {
             BlockNumber::Number(num) => Some(num.as_u64()),
+            BlockNumber::Earliest => Some(0),
             _ => None,
         })
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
fixes an error where "earliest" in the "from" field went undetected and only logs for the last block were returned
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
