### PR TITLE
Add option to clear etherscan cache

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -138,7 +138,7 @@ impl RunArgs {
             let etherscan_identifier = EtherscanIdentifier::new(
                 evm_opts.get_remote_chain_id(),
                 config.etherscan_api_key,
-                Config::foundry_etherscan_cache_dir(evm_opts.get_chain_id()),
+                Config::foundry_etherscan_chain_cache_dir(evm_opts.get_chain_id()),
                 Duration::from_secs(24 * 60 * 60),
             );
 

--- a/cli/src/cmd/forge/cache.rs
+++ b/cli/src/cmd/forge/cache.rs
@@ -37,6 +37,7 @@ impl FromStr for ChainOrAll {
 }
 
 #[derive(Debug, Parser)]
+#[clap(group = clap::ArgGroup::new("etherscan-blocks").multiple(false))]
 pub struct CleanArgs {
     // TODO refactor to dedup shared logic with ClapChain in opts/mod
     #[clap(
@@ -54,11 +55,12 @@ pub struct CleanArgs {
         multiple_values(true),
         use_value_delimiter(true),
         require_value_delimiter(true),
-        value_name = "BLOCKS"
+        value_name = "BLOCKS",
+        group = "etherscan-blocks"
     )]
     blocks: Vec<u64>,
 
-    #[clap(long)]
+    #[clap(long, group = "etherscan-blocks")]
     etherscan: bool,
 }
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -124,7 +124,7 @@ impl ScriptArgs {
         let etherscan_identifier = EtherscanIdentifier::new(
             script_config.evm_opts.get_remote_chain_id(),
             script_config.config.etherscan_api_key.clone(),
-            Config::foundry_etherscan_cache_dir(script_config.evm_opts.get_chain_id()),
+            Config::foundry_etherscan_chain_cache_dir(script_config.evm_opts.get_chain_id()),
             Duration::from_secs(24 * 60 * 60),
         );
 

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -620,7 +620,7 @@ fn test(
         let etherscan_identifier = EtherscanIdentifier::new(
             remote_chain_id,
             config.etherscan_api_key,
-            remote_chain_id.and_then(Config::foundry_etherscan_cache_dir),
+            remote_chain_id.and_then(Config::foundry_etherscan_chain_cache_dir),
             cache_ttl,
         );
 

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -49,17 +49,58 @@ forgetest_ignore!(can_cache_clean, |_: TestProject, mut cmd: TestCommand| {
     assert!(!path.exists());
 });
 
+// checks that `cache clean --etherscan` can be invoked and only cleans the foundry etherscan cache
+// this test is not isolated and modifies ~ so it is ignored
+forgetest_ignore!(can_cache_clean_etherscan, |_: TestProject, mut cmd: TestCommand| {
+    let cache_dir = Config::foundry_cache_dir().unwrap();
+    let etherscan_cache_dir = Config::foundry_etherscan_cache_dir().unwrap();
+    let path = cache_dir.as_path();
+    let etherscan_path = etherscan_cache_dir.as_path();
+    fs::create_dir_all(etherscan_path).unwrap();
+    cmd.args(["cache", "clean", "--etherscan"]);
+    cmd.assert_empty_stdout();
+
+    assert!(path.exists());
+    assert!(!etherscan_path.exists());
+
+    Config::clean_foundry_cache().unwrap();
+});
+
+// checks that `cache clean all --etherscan` can be invoked and only cleans the foundry etherscan
+// cache. This test is not isolated and modifies ~ so it is ignored
+forgetest_ignore!(can_cache_clean_all_etherscan, |_: TestProject, mut cmd: TestCommand| {
+    let rpc_cache_dir = Config::foundry_rpc_cache_dir().unwrap();
+    let etherscan_cache_dir = Config::foundry_etherscan_cache_dir().unwrap();
+    let rpc_path = rpc_cache_dir.as_path();
+    let etherscan_path = etherscan_cache_dir.as_path();
+    fs::create_dir_all(rpc_path).unwrap();
+    fs::create_dir_all(etherscan_path).unwrap();
+    cmd.args(["cache", "clean", "all", "--etherscan"]);
+    cmd.assert_empty_stdout();
+
+    assert!(rpc_path.exists());
+    assert!(!etherscan_path.exists());
+
+    Config::clean_foundry_cache().unwrap();
+});
+
 // checks that `cache clean <chain>` can be invoked and cleans the chain cache
 // this test is not isolated and modifies ~ so it is ignored
 forgetest_ignore!(can_cache_clean_chain, |_: TestProject, mut cmd: TestCommand| {
-    let cache_dir =
-        Config::foundry_chain_cache_dir(Chain::Named(ethers::prelude::Chain::Mainnet)).unwrap();
+    let chain = Chain::Named(ethers::prelude::Chain::Mainnet);
+    let cache_dir = Config::foundry_chain_cache_dir(chain).unwrap();
+    let etherscan_cache_dir = Config::foundry_etherscan_chain_cache_dir(chain).unwrap();
     let path = cache_dir.as_path();
+    let etherscan_path = etherscan_cache_dir.as_path();
     fs::create_dir_all(path).unwrap();
+    fs::create_dir_all(etherscan_path).unwrap();
     cmd.args(["cache", "clean", "mainnet"]);
     cmd.assert_empty_stdout();
 
     assert!(!path.exists());
+    assert!(!etherscan_path.exists());
+
+    Config::clean_foundry_cache().unwrap();
 });
 
 // checks that `cache clean <chain> --blocks 100,101` can be invoked and cleans the chain block
@@ -67,18 +108,50 @@ forgetest_ignore!(can_cache_clean_chain, |_: TestProject, mut cmd: TestCommand| 
 forgetest_ignore!(can_cache_clean_blocks, |_: TestProject, mut cmd: TestCommand| {
     let chain = Chain::Named(ethers::prelude::Chain::Mainnet);
     let block1 = 100;
-    let block2 = 102;
+    let block2 = 101;
+    let block3 = 102;
     let block1_cache_dir = Config::foundry_block_cache_dir(chain, block1).unwrap();
     let block2_cache_dir = Config::foundry_block_cache_dir(chain, block2).unwrap();
+    let block3_cache_dir = Config::foundry_block_cache_dir(chain, block3).unwrap();
+    let etherscan_cache_dir = Config::foundry_etherscan_chain_cache_dir(chain).unwrap();
     let block1_path = block1_cache_dir.as_path();
     let block2_path = block2_cache_dir.as_path();
+    let block3_path = block3_cache_dir.as_path();
+    let etherscan_path = etherscan_cache_dir.as_path();
     fs::create_dir_all(block1_path).unwrap();
     fs::create_dir_all(block2_path).unwrap();
+    fs::create_dir_all(block3_path).unwrap();
+    fs::create_dir_all(etherscan_path).unwrap();
     cmd.args(["cache", "clean", "mainnet", "--blocks", "100,101"]);
     cmd.assert_empty_stdout();
 
     assert!(!block1_path.exists());
     assert!(!block2_path.exists());
+    assert!(block3_path.exists());
+    assert!(etherscan_path.exists());
+
+    Config::clean_foundry_cache().unwrap();
+});
+
+// checks that `cache clean <chain> --etherscan` can be invoked and cleans the etherscan chain cache
+// this test is not isolated and modifies ~ so it is ignored
+forgetest_ignore!(can_cache_clean_chain_etherscan, |_: TestProject, mut cmd: TestCommand| {
+    let cache_dir =
+        Config::foundry_chain_cache_dir(Chain::Named(ethers::prelude::Chain::Mainnet)).unwrap();
+    let etherscan_cache_dir =
+        Config::foundry_etherscan_chain_cache_dir(Chain::Named(ethers::prelude::Chain::Mainnet))
+            .unwrap();
+    let path = cache_dir.as_path();
+    let etherscan_path = etherscan_cache_dir.as_path();
+    fs::create_dir_all(path).unwrap();
+    fs::create_dir_all(etherscan_path).unwrap();
+    cmd.args(["cache", "clean", "mainnet", "--etherscan"]);
+    cmd.assert_empty_stdout();
+
+    assert!(path.exists());
+    assert!(!etherscan_path.exists());
+
+    Config::clean_foundry_cache().unwrap();
 });
 
 // checks that init works

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1016,6 +1016,30 @@ impl Config {
         Ok(())
     }
 
+    /// Clears the foundry etherscan cache
+    pub fn clean_foundry_etherscan_cache() -> eyre::Result<()> {
+        if let Some(cache_dir) = Config::foundry_etherscan_cache_dir() {
+            let path = cache_dir.as_path();
+            let _ = fs::remove_dir_all(path);
+        } else {
+            eyre::bail!("failed to get foundry_etherscan_cache_dir");
+        }
+
+        Ok(())
+    }
+
+    /// Clears the foundry etherscan cache for `chain`
+    pub fn clean_foundry_etherscan_chain_cache(chain: Chain) -> eyre::Result<()> {
+        if let Some(cache_dir) = Config::foundry_etherscan_chain_cache_dir(chain) {
+            let path = cache_dir.as_path();
+            let _ = fs::remove_dir_all(path);
+        } else {
+            eyre::bail!("failed to get foundry_etherscan_cache_dir for chain: {}", chain);
+        }
+
+        Ok(())
+    }
+
     /// List the data in the foundry cache
     pub fn list_foundry_cache() -> eyre::Result<Cache> {
         if let Some(cache_dir) = Config::foundry_rpc_cache_dir() {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -907,24 +907,34 @@ impl Config {
         Self::foundry_dir().map(|p| p.join("cache"))
     }
 
-    /// Returns the path to foundry chain's cache dir `~/.foundry/cache/<chain>`
+    /// Returns the path to foundry rpc cache dir `~/.foundry/cache/rpc`
+    pub fn foundry_rpc_cache_dir() -> Option<PathBuf> {
+        Some(Self::foundry_cache_dir()?.join("rpc"))
+    }
+    /// Returns the path to foundry chain's cache dir `~/.foundry/cache/rpc/<chain>`
     pub fn foundry_chain_cache_dir(chain_id: impl Into<Chain>) -> Option<PathBuf> {
-        Some(Self::foundry_cache_dir()?.join(chain_id.into().to_string()))
+        Some(Self::foundry_rpc_cache_dir()?.join(chain_id.into().to_string()))
     }
 
-    /// Returns the path to foundry's etherscan cache dir `~/.foundry/cache/<chain>/etherscan`
-    pub fn foundry_etherscan_cache_dir(chain_id: impl Into<Chain>) -> Option<PathBuf> {
-        Some(Self::foundry_chain_cache_dir(chain_id)?.join("etherscan"))
+    /// Returns the path to foundry's etherscan cache dir `~/.foundry/cache/etherscan`
+    pub fn foundry_etherscan_cache_dir() -> Option<PathBuf> {
+        Some(Self::foundry_cache_dir()?.join("etherscan"))
+    }
+
+    /// Returns the path to foundry's etherscan cache dir for `chain_id`
+    /// `~/.foundry/cache/etherscan/<chain>`
+    pub fn foundry_etherscan_chain_cache_dir(chain_id: impl Into<Chain>) -> Option<PathBuf> {
+        Some(Self::foundry_etherscan_cache_dir()?.join(chain_id.into().to_string()))
     }
 
     /// Returns the path to the cache dir of the `block` on the `chain`
-    /// `~/.foundry/cache/<chain>/<block>
+    /// `~/.foundry/cache/rpc/<chain>/<block>
     pub fn foundry_block_cache_dir(chain_id: impl Into<Chain>, block: u64) -> Option<PathBuf> {
         Some(Self::foundry_chain_cache_dir(chain_id)?.join(format!("{block}")))
     }
 
     /// Returns the path to the cache file of the `block` on the `chain`
-    /// `~/.foundry/cache/<chain>/<block>/storage.json`
+    /// `~/.foundry/cache/rpc/<chain>/<block>/storage.json`
     pub fn foundry_block_cache_file(chain_id: impl Into<Chain>, block: u64) -> Option<PathBuf> {
         Some(Self::foundry_block_cache_dir(chain_id, block)?.join("storage.json"))
     }
@@ -1008,7 +1018,7 @@ impl Config {
 
     /// List the data in the foundry cache
     pub fn list_foundry_cache() -> eyre::Result<Cache> {
-        if let Some(cache_dir) = Config::foundry_cache_dir() {
+        if let Some(cache_dir) = Config::foundry_rpc_cache_dir() {
             let mut cache = Cache { chains: vec![] };
             if !cache_dir.exists() {
                 return Ok(cache)


### PR DESCRIPTION
## Motivation
Currently forge cache clean only clears RPC cache, but it would be beneficial to also be able to clear the Etherscan verification status cache.

Solves #1477

## Solution
This PR:
* Adds the `--etherscan` flag to `forge cache clean`

* Displays the etherscan cache storage with `forge cache ls`:
```
-️ mainnet (6.7 kB)
        -️ Block Explorer (0.0 B)

        -️ Block 14880985 (3.4 kB)
        -️ Block 14881100 (3.3 kB)
```

* Restructures the cache directory structure:
```
cache/
    - rpc/{mainnet,...}
    - etherscan/{mainnet,...}
```