### PR TITLE
forge: split sending and waiting for receipts + buffered 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "glob",
  "globset",
  "hex",
+ "indicatif 0.17.0-rc.11",
  "once_cell",
  "pretty_assertions",
  "proptest",
@@ -2637,6 +2638,17 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017d0ce94b8e91e29d2c78ed891e57e5ec3dc4371820a9d96abab4af09eb8ad"
+dependencies = [
+ "console 0.15.0",
+ "number_prefix",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4665,7 +4677,7 @@ dependencies = [
  "fs2",
  "hex",
  "home",
- "indicatif",
+ "indicatif 0.16.2",
  "itertools",
  "once_cell",
  "rand 0.8.5",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -73,6 +73,7 @@ strsim = "0.10.0"
 bytes = "1.1.0"
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0.30"
+indicatif = "0.17.0-rc.11"
 
 [dev-dependencies]
 anvil = { path = "../anvil" }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -7,6 +7,7 @@ mod utils;
 
 use cast::{Cast, SimpleCast, TxBuilder};
 use foundry_config::Config;
+use utils::get_http_provider;
 mod opts;
 use crate::{cmd::Cmd, utils::consume_config_rpc_url};
 use cast::InterfacePath;
@@ -262,9 +263,9 @@ async fn main() -> eyre::Result<()> {
             resend,
         } => {
             let config = Config::from(&eth);
-            let provider = Provider::try_from(
-                config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-            )?;
+            let provider = get_http_provider(
+                &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+            );
             let chain_id = Cast::new(&provider).chain_id().await?;
             let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
             let sig = sig.unwrap_or_default();

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -265,6 +265,7 @@ async fn main() -> eyre::Result<()> {
             let config = Config::from(&eth);
             let provider = get_http_provider(
                 &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+                false,
             );
             let chain_id = Cast::new(&provider).chain_id().await?;
             let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -166,6 +166,7 @@ impl CreateArgs {
         let config = Config::from(&self.eth);
         let provider = get_http_provider(
             &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+            false,
         );
         let params = match abi.constructor {
             Some(ref v) => {

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -4,12 +4,12 @@ use crate::{
     cmd::{forge::build::CoreBuildArgs, Cmd, RetryArgs},
     compile,
     opts::{forge::ContractInfo, EthereumOpts, WalletType},
-    utils::{parse_ether_value, parse_u256},
+    utils::{get_http_provider, parse_ether_value, parse_u256},
 };
 use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, Constructor, Token},
-    prelude::{artifacts::BytecodeObject, ContractFactory, Http, Middleware, Provider},
+    prelude::{artifacts::BytecodeObject, ContractFactory, Middleware},
     solc::utils::RuntimeOrHandle,
     types::{transaction::eip2718::TypedTransaction, Chain, U256},
 };
@@ -164,9 +164,9 @@ impl CreateArgs {
 
         // Add arguments to constructor
         let config = Config::from(&self.eth);
-        let provider = Provider::<Http>::try_from(
-            config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-        )?;
+        let provider = get_http_provider(
+            &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+        );
         let params = match abi.constructor {
             Some(ref v) => {
                 let constructor_args =

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -62,6 +62,7 @@ impl DebugArgs {
             etherscan_api_key: None,
             verify: false,
             json: false,
+            with_gas_price: None,
         };
         script.run_script().await
     }

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -101,6 +101,9 @@ impl ScriptArgs {
                     let tx_hash = self.send_transaction(tx, signer, sequential_broadcast, fork_url);
 
                     if sequential_broadcast {
+                        update_progress!(pb, (index + already_broadcasted));
+                        index += 1;
+
                         wait_for_receipts(
                             vec![tx_hash.await?],
                             deployment_sequence,
@@ -129,7 +132,7 @@ impl ScriptArgs {
                     deployment_sequence.save()?;
 
                     if !sequential_broadcast {
-                        println!("##\nCollecting Receipts.");
+                        println!("##\nWaiting for receipts.");
                         wait_for_receipts(tx_hashes, deployment_sequence, provider.clone()).await?;
                     }
                 }

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -77,7 +77,7 @@ impl ScriptArgs {
 
             //  We send transactions and wait for receipts in batches of 50, since some networks
             // cannot handle more than that.
-            let batch_size = 50;
+            let batch_size = 100;
             let batches = sequence.chunks(batch_size).map(|f| f.to_vec()).collect::<Vec<_>>();
             let mut index = 0;
 

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -58,7 +58,7 @@ impl ScriptArgs {
                 .expect("You must provide an RPC URL (see --fork-url).")
                 .clone();
 
-            let provider = get_http_provider(&fork_url);
+            let provider = get_http_provider(&fork_url, true);
             let chain = provider.get_chainid().await?.as_u64();
 
             let mut deployment_sequence =

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -64,7 +64,7 @@ impl ScriptArgs {
             let mut deployment_sequence =
                 ScriptSequence::load(&script_config.config, &self.sig, &target, chain)?;
 
-            receipts::wait_for_pending(&provider, &mut deployment_sequence).await?;
+            receipts::wait_for_pending(provider, &mut deployment_sequence).await?;
 
             if self.resume {
                 self.send_transactions(&mut deployment_sequence, &fork_url).await?;

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -13,7 +13,7 @@ mod executor;
 
 mod receipts;
 
-use crate::{cmd::forge::build::BuildArgs, opts::MultiWallet};
+use crate::{cmd::forge::build::BuildArgs, opts::MultiWallet, utils::parse_ether_value};
 use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, Function},
@@ -116,6 +116,15 @@ pub struct ScriptArgs {
 
     #[clap(long, help = "Output results in JSON format.")]
     pub json: bool,
+
+    #[clap(
+        long,
+        help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
+        env = "ETH_GAS_PRICE",
+        parse(try_from_str = parse_ether_value),
+        value_name = "PRICE"
+    )]
+    pub with_gas_price: Option<U256>,
 }
 
 pub struct ScriptResult {

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -161,8 +161,8 @@ impl ScriptArgs {
             CallTraceDecoderBuilder::new().with_labels(result.labeled_addresses.clone()).build();
 
         for (_, trace) in &mut result.traces {
-            decoder.identify(trace, &etherscan_identifier);
             decoder.identify(trace, &local_identifier);
+            decoder.identify(trace, &etherscan_identifier);
         }
         Ok(decoder)
     }

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -32,7 +32,7 @@ pub async fn wait_for_receipts(
 
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];
-    let pb = init_progress!(tx_hashes, "txes");
+    let pb = init_progress!(tx_hashes, "receipts");
 
     let total_txes = tx_hashes.len();
     for (index, tx_hash) in tx_hashes.into_iter().enumerate() {

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -48,8 +48,11 @@ pub async fn wait_for_receipts(
                     deployment_sequence.remove_pending(receipt.transaction_hash);
                     receipts.push(receipt)
                 }
-                Ok(None) | Err(_) => {
-                    errors.push(format!("Failure on receiving a receipt for {}", tx_hash));
+                Ok(None) => {
+                    errors.push(format!("Received an empty receipt for {}", tx_hash));
+                }
+                Err(err) => {
+                    errors.push(format!("Failure on receiving a receipt for {}:\n{err}", tx_hash));
                 }
             }
             if total_txes > 1 {

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -1,6 +1,6 @@
 use crate::{cmd::ScriptSequence, utils::print_receipt};
-use ethers::prelude::{Http, Middleware, Provider, TransactionReceipt, H256, U256};
-use futures::future::join_all;
+use ethers::prelude::{Http, PendingTransaction, Provider, TxHash};
+use futures::StreamExt;
 
 use super::broadcast::BroadcastError;
 
@@ -11,80 +11,62 @@ pub async fn wait_for_pending(
 ) -> eyre::Result<()> {
     if !deployment_sequence.pending.is_empty() {
         println!("##\nChecking previously pending transactions.");
-        let future_receipts = deployment_sequence
-            .pending
-            .iter()
-            .map(|tx_hash| pending_receipt(provider, *tx_hash))
-            .collect();
-        wait_for_receipts(future_receipts, deployment_sequence).await?;
+        wait_for_receipts(
+            &deployment_sequence.pending.iter().map(|tx_hash| Ok(*tx_hash)).collect::<Vec<_>>(),
+            deployment_sequence,
+            provider,
+        )
+        .await?;
     }
     Ok(())
-}
-
-/// Waits for a pending receipt, and gets its nonce to return (receipt, nonce).
-async fn pending_receipt(
-    provider: &Provider<Http>,
-    tx_hash: H256,
-) -> Result<(TransactionReceipt, U256), BroadcastError> {
-    let pending_err =
-        || BroadcastError::Simple(format!("Failed to get pending transaction {tx_hash:?}."));
-
-    let receipt = provider
-        .get_transaction_receipt(tx_hash)
-        .await
-        .map_err(|_| pending_err())?
-        .ok_or_else(pending_err)?;
-
-    let tx = provider
-        .get_transaction(tx_hash)
-        .await
-        .map_err(|_| pending_err())?
-        .ok_or_else(pending_err)?;
-
-    Ok((receipt, tx.nonce))
 }
 
 /// Waits for a list of receipts. If it fails, it tries to retrieve the transaction hash that can be
 /// used on a later run with `--resume`.
 pub async fn wait_for_receipts(
-    tasks: Vec<impl futures::Future<Output = Result<(TransactionReceipt, U256), BroadcastError>>>,
+    tx_hashes: &[Result<TxHash, BroadcastError>],
     deployment_sequence: &mut ScriptSequence,
+    provider: &Provider<Http>,
 ) -> eyre::Result<()> {
-    let res = join_all(tasks).await;
+    let mut tasks = vec![];
+    for tx_hash in tx_hashes {
+        tasks.push(PendingTransaction::new(tx_hash.clone()?, provider));
+    }
 
+    let tasks = futures::stream::iter(tasks).buffered(20);
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];
 
-    for receipt in res {
+    for (tx_hash, receipt) in tx_hashes.iter().zip(tasks.collect::<Vec<_>>().await) {
+        let tx_hash = tx_hash.clone()?;
+
         match receipt {
-            Ok(ret) => {
-                if let Some(status) = ret.0.status {
+            Ok(Some(receipt)) => {
+                if let Some(status) = receipt.status {
                     if status.is_zero() {
-                        errors.push(format!("Transaction Failure: {}", ret.0.transaction_hash));
+                        errors.push(format!("Transaction Failure: {}", receipt.transaction_hash));
                     }
                 }
-                deployment_sequence.remove_pending(ret.0.transaction_hash);
-                let _ = print_receipt(&ret.0, ret.1);
-                receipts.push(ret)
+                deployment_sequence.remove_pending(receipt.transaction_hash);
+                let _ = print_receipt(&receipt);
+                receipts.push(receipt)
             }
-            Err(e) => {
-                if let BroadcastError::ErrorWithTxHash(_, tx_hash) = e {
-                    deployment_sequence.add_pending(tx_hash);
-                }
-                errors.push(format!("{e}"));
+            Ok(None) | Err(_) => {
+                deployment_sequence.add_pending(tx_hash);
+                errors.push(format!("Failure on receiving a receipt for {}", tx_hash));
             }
-        };
+        }
     }
 
-    for (receipt, nonce) in receipts {
-        print_receipt(&receipt, nonce)?;
+    for receipt in receipts {
         deployment_sequence.add_receipt(receipt);
     }
 
     if !errors.is_empty() {
         let mut error_msg = format!("{:?}", errors);
         if !deployment_sequence.pending.is_empty() {
-            error_msg += "\n\n Add `--resume` to your command to try and continue broadcasting the transactions."
+            error_msg += "\n\n Add `--resume` to your command to try and continue broadcasting
+    the transactions."
         }
         eyre::bail!(error_msg);
     }

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -28,7 +28,7 @@ pub async fn wait_for_receipts(
     let mut tasks = futures::stream::iter(
         tx_hashes.iter().map(|tx| PendingTransaction::new(*tx, &provider)).collect::<Vec<_>>(),
     )
-    .buffered(20);
+    .buffered(10);
 
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -33,8 +33,8 @@ pub async fn wait_for_receipts(
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];
     let pb = init_progress!(tx_hashes, "receipts");
+    update_progress!(pb, -1);
 
-    let total_txes = tx_hashes.len();
     for (index, tx_hash) in tx_hashes.into_iter().enumerate() {
         if let Some(receipt) = tasks.next().await {
             match receipt {
@@ -55,9 +55,7 @@ pub async fn wait_for_receipts(
                     errors.push(format!("Failure on receiving a receipt for {}:\n{err}", tx_hash));
                 }
             }
-            if total_txes > 1 {
-                update_progress!(pb, index);
-            }
+            update_progress!(pb, index);
         } else {
             break
         }

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -28,7 +28,7 @@ pub async fn wait_for_receipts(
     let mut tasks = futures::stream::iter(
         tx_hashes.iter().map(|tx| PendingTransaction::new(*tx, &provider)).collect::<Vec<_>>(),
     )
-    .buffered(2);
+    .buffered(20);
 
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -62,7 +62,7 @@ pub async fn wait_for_receipts(
     }
 
     for receipt in receipts {
-        let _ = print_receipt(&receipt);
+        print_receipt(&receipt);
         deployment_sequence.add_receipt(receipt);
     }
 

--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -28,7 +28,7 @@ pub async fn wait_for_receipts(
     let mut tasks = futures::stream::iter(
         tx_hashes.iter().map(|tx| PendingTransaction::new(*tx, &provider)).collect::<Vec<_>>(),
     )
-    .buffered(10);
+    .buffer_unordered(10);
 
     let mut receipts = vec![];
     let mut errors: Vec<String> = vec![];

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -258,7 +258,7 @@ pub struct TestArgs {
         long,
         env = "ETHERSCAN_API_KEY",
         help = "Set etherscan api key to better decode traces",
-        value_name = "KEY"
+        value_name = "ETHERSCAN_KEY"
     )]
     etherscan_api_key: Option<String>,
 

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -478,7 +478,7 @@ macro_rules! update_progress {
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain: u64) -> bool {
     matches!(
-        Chain::try_from(chain).expect("Chain does not exist."),
+        Chain::try_from(chain).unwrap_or(Chain::Mainnet),
         Chain::Arbitrum | Chain::ArbitrumTestnet
     )
 }

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -443,6 +443,6 @@ macro_rules! init_progress {
 #[macro_export]
 macro_rules! update_progress {
     ($pb:ident, $index:expr) => {
-        $pb.set_position($index as u64 + 1);
+        $pb.set_position(($index + 1) as u64);
     };
 }

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -3,6 +3,7 @@ use cast::executor::inspector::DEFAULT_CREATE2_DEPLOYER;
 use clap::Parser;
 use ethers::{
     abi::{Abi, Address},
+    core::types::Chain,
     prelude::{ArtifactId, NameOrAddress, TransactionReceipt, TxHash},
     solc::{
         artifacts::{
@@ -445,4 +446,12 @@ macro_rules! update_progress {
     ($pb:ident, $index:expr) => {
         $pb.set_position(($index + 1) as u64);
     };
+}
+
+/// True if the network calculates gas costs differently.
+pub fn has_different_gas_calc(chain: u64) -> bool {
+    match Chain::try_from(chain).expect("Chain does not exist.") {
+        Chain::Arbitrum | Chain::ArbitrumTestnet => true,
+        _ => false,
+    }
 }

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -350,6 +350,9 @@ impl ScriptSequence {
             let mut future_verifications = vec![];
             let mut create2 = self.create2_contracts.clone().into_iter();
 
+            // Make sure the receipts have the right order first.
+            self.sort_receipts();
+
             for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
                 let mut create2_offset = 0;
 

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -418,3 +418,28 @@ impl Drop for ScriptSequence {
         self.save().expect("not able to save deployment sequence");
     }
 }
+
+#[macro_export]
+macro_rules! init_progress {
+    ($local:expr, $label:expr) => {{
+        let pb = ProgressBar::new($local.len() as u64);
+        let mut template =
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ".to_string();
+        template += $label;
+        template += " ({eta})";
+        pb.set_style(
+            ProgressStyle::with_template(&template)
+                .unwrap()
+                .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
+                .progress_chars("#>-"),
+        );
+        pb
+    }};
+}
+
+#[macro_export]
+macro_rules! update_progress {
+    ($pb:ident, $index:expr) => {
+        $pb.set_position($index as u64 + 1);
+    };
+}

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -4,14 +4,15 @@ pub mod forge;
 mod multi_wallet;
 mod wallet;
 
+use std::sync::Arc;
+
 pub use multi_wallet::*;
 pub use wallet::*;
-
-use std::convert::TryFrom;
 
 use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
+    prelude::RetryClient,
     providers::{Http, Provider},
     signers::{HDPath as LedgerHDPath, Ledger, Signer, Trezor, TrezorHDPath},
     types::{Address, Chain, U256},
@@ -86,7 +87,11 @@ impl EthereumOpts {
 
     #[allow(unused)]
     pub async fn signer(&self, chain_id: U256) -> eyre::Result<Option<WalletType>> {
-        self.signer_with(chain_id, Provider::try_from(self.rpc_url()?)?).await
+        self.signer_with(
+            chain_id,
+            Arc::new(Provider::<RetryClient<Http>>::new_client(self.rpc_url()?, 10, 1000)?),
+        )
+        .await
     }
 
     /// Returns a [`SignerMiddleware`] corresponding to the provided private key, mnemonic or hw
@@ -94,7 +99,7 @@ impl EthereumOpts {
     pub async fn signer_with(
         &self,
         chain_id: U256,
-        provider: Provider<Http>,
+        provider: Arc<Provider<RetryClient<Http>>>,
     ) -> eyre::Result<Option<WalletType>> {
         if self.wallet.ledger {
             let derivation = match &self.wallet.hd_path {

--- a/cli/src/opts/multi_wallet.rs
+++ b/cli/src/opts/multi_wallet.rs
@@ -1,9 +1,12 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
-    prelude::{Http, Middleware, Provider, Signer},
+    prelude::{Http, Middleware, Provider, RetryClient, Signer},
     signers::{HDPath as LedgerHDPath, Ledger, LocalWallet, Trezor, TrezorHDPath},
     types::Address,
 };
@@ -188,7 +191,7 @@ impl MultiWallet {
     /// error, if it can't find all.
     pub async fn find_all(
         &self,
-        provider: &Provider<Http>,
+        provider: Arc<Provider<RetryClient<Http>>>,
         mut addresses: HashSet<Address>,
     ) -> Result<HashMap<Address, WalletType>> {
         println!("\n###\nFinding wallets for all the necessary addresses...");

--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -11,27 +11,29 @@ use ethers::{
 use eyre::{eyre, Result};
 use serde::Serialize;
 
+type SignerClient<T> = SignerMiddleware<Arc<Provider<RetryClient<Http>>>, T>;
+
 #[derive(Debug)]
 pub enum WalletType {
-    Local(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>),
-    Ledger(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>),
-    Trezor(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>),
+    Local(SignerClient<LocalWallet>),
+    Ledger(SignerClient<Ledger>),
+    Trezor(SignerClient<Trezor>),
 }
 
-impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>> for WalletType {
-    fn from(hw: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>) -> WalletType {
+impl From<SignerClient<Ledger>> for WalletType {
+    fn from(hw: SignerClient<Ledger>) -> WalletType {
         WalletType::Ledger(hw)
     }
 }
 
-impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>> for WalletType {
-    fn from(hw: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>) -> WalletType {
+impl From<SignerClient<Trezor>> for WalletType {
+    fn from(hw: SignerClient<Trezor>) -> WalletType {
         WalletType::Trezor(hw)
     }
 }
 
-impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>> for WalletType {
-    fn from(wallet: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>) -> WalletType {
+impl From<SignerClient<LocalWallet>> for WalletType {
+    fn from(wallet: SignerClient<LocalWallet>) -> WalletType {
         WalletType::Local(wallet)
     }
 }

--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
-    prelude::RetryClient,
+    prelude::{RetryClient, Signer},
     providers::{Http, Provider},
     signers::{coins_bip39::English, Ledger, LocalWallet, MnemonicBuilder, Trezor},
     types::Address,
@@ -35,6 +35,16 @@ impl From<SignerClient<Trezor>> for WalletType {
 impl From<SignerClient<LocalWallet>> for WalletType {
     fn from(wallet: SignerClient<LocalWallet>) -> WalletType {
         WalletType::Local(wallet)
+    }
+}
+
+impl WalletType {
+    pub fn chain_id(&self) -> u64 {
+        match self {
+            WalletType::Local(inner) => inner.signer().chain_id(),
+            WalletType::Ledger(inner) => inner.signer().chain_id(),
+            WalletType::Trezor(inner) => inner.signer().chain_id(),
+        }
     }
 }
 

--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -1,8 +1,9 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
+    prelude::RetryClient,
     providers::{Http, Provider},
     signers::{coins_bip39::English, Ledger, LocalWallet, MnemonicBuilder, Trezor},
     types::Address,
@@ -12,25 +13,25 @@ use serde::Serialize;
 
 #[derive(Debug)]
 pub enum WalletType {
-    Local(SignerMiddleware<Provider<Http>, LocalWallet>),
-    Ledger(SignerMiddleware<Provider<Http>, Ledger>),
-    Trezor(SignerMiddleware<Provider<Http>, Trezor>),
+    Local(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>),
+    Ledger(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>),
+    Trezor(SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>),
 }
 
-impl From<SignerMiddleware<Provider<Http>, Ledger>> for WalletType {
-    fn from(hw: SignerMiddleware<Provider<Http>, Ledger>) -> WalletType {
+impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>> for WalletType {
+    fn from(hw: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Ledger>) -> WalletType {
         WalletType::Ledger(hw)
     }
 }
 
-impl From<SignerMiddleware<Provider<Http>, Trezor>> for WalletType {
-    fn from(hw: SignerMiddleware<Provider<Http>, Trezor>) -> WalletType {
+impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>> for WalletType {
+    fn from(hw: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, Trezor>) -> WalletType {
         WalletType::Trezor(hw)
     }
 }
 
-impl From<SignerMiddleware<Provider<Http>, LocalWallet>> for WalletType {
-    fn from(wallet: SignerMiddleware<Provider<Http>, LocalWallet>) -> WalletType {
+impl From<SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>> for WalletType {
+    fn from(wallet: SignerMiddleware<Arc<Provider<RetryClient<Http>>>, LocalWallet>) -> WalletType {
         WalletType::Local(wallet)
     }
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -255,9 +255,11 @@ pub fn enable_paint() {
 
 /// Gives out a provider with a `100ms` interval poll if it's a localhost URL (most likely an anvil
 /// node) and with the default, `7s` if otherwise.
-pub fn get_http_provider(url: &str) -> Arc<Provider<RetryClient<Http>>> {
-    let provider =
-        Provider::<RetryClient<Http>>::new_client(url, 10, 1000).expect("Bad fork provider.");
+pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClient<Http>>> {
+    let (max_retry, initial_backoff) = if aggressive { (1000, 1) } else { (10, 1000) };
+
+    let provider = Provider::<RetryClient<Http>>::new_client(url, max_retry, initial_backoff)
+        .expect("Bad fork provider.");
 
     Arc::new(if url.contains("127.0.0.1") || url.contains("localhost") {
         provider.interval(Duration::from_millis(100))

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -257,6 +257,7 @@ pub fn enable_paint() {
 /// node) and with the default, `7s` if otherwise.
 pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClient<Http>>> {
     let (max_retry, initial_backoff) = if aggressive { (1000, 1) } else { (10, 1000) };
+    let interval = if aggressive { Duration::from_secs(1) } else { Duration::from_secs(7) };
 
     let provider = Provider::<RetryClient<Http>>::new_client(url, max_retry, initial_backoff)
         .expect("Bad fork provider.");
@@ -264,7 +265,7 @@ pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClien
     Arc::new(if url.contains("127.0.0.1") || url.contains("localhost") {
         provider.interval(Duration::from_millis(100))
     } else {
-        provider
+        provider.interval(interval)
     })
 }
 
@@ -285,7 +286,7 @@ pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
     };
 
     println!(
-        "\n#####\n{}Hash: 0x{}{}\nBlock: {}\nPaid: {} ETH ({} gas * {} gwei)",
+        "\n#####\n{}Hash: 0x{}{}\nBlock: {}\nPaid: {} ETH ({} gas * {} gwei)\n",
         check,
         hex::encode(receipt.transaction_hash.as_bytes()),
         contract_address,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -264,7 +264,7 @@ pub fn get_http_provider(url: &str) -> Provider<Http> {
     }
 }
 
-pub fn print_receipt(receipt: &TransactionReceipt, nonce: U256) -> eyre::Result<()> {
+pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
     let mut contract_address = "".to_string();
     if let Some(addr) = receipt.contract_address {
         contract_address = format!("\nContract Address: 0x{}", hex::encode(addr.as_bytes()));
@@ -281,12 +281,11 @@ pub fn print_receipt(receipt: &TransactionReceipt, nonce: U256) -> eyre::Result<
     };
 
     println!(
-        "\n#####\n{}Hash: 0x{}{}\nBlock: {}\nNonce: {}\nPaid: {} ETH ({} gas * {} gwei)",
+        "\n#####\n{}Hash: 0x{}{}\nBlock: {}\nPaid: {} ETH ({} gas * {} gwei)",
         check,
         hex::encode(receipt.transaction_hash.as_bytes()),
         contract_address,
         receipt.block_number.expect("no block_number"),
-        nonce,
         paid.trim_end_matches('0'),
         gas_used,
         format_units(gas_price, 9)?.trim_end_matches('0').trim_end_matches('.')

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -323,31 +323,6 @@ impl CommandUtils for Command {
     }
 }
 
-#[macro_export]
-macro_rules! init_progress {
-    ($local:expr, $label:expr) => {{
-        let pb = ProgressBar::new($local.len() as u64);
-        let mut template =
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ".to_string();
-        template += $label;
-        template += " ({eta})";
-        pb.set_style(
-            ProgressStyle::with_template(&template)
-                .unwrap()
-                .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
-                .progress_chars("#>-"),
-        );
-        pb
-    }};
-}
-
-#[macro_export]
-macro_rules! update_progress {
-    ($pb:ident, $index:expr) => {
-        $pb.set_position($index as u64 + 1);
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -276,10 +276,10 @@ pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
     }
 
     let gas_used = receipt.gas_used.unwrap_or_default();
-    let gas_price = receipt.effective_gas_price.expect("no gas price");
+    let gas_price = receipt.effective_gas_price.unwrap_or_default();
     let paid = format_units(gas_used.mul(gas_price), 18)?;
 
-    let check = if receipt.status.unwrap().is_zero() {
+    let check = if receipt.status.unwrap_or_default().is_zero() {
         Emoji("❌ ", " [Failed] ")
     } else {
         Emoji("✅ ", " [Success] ")
@@ -290,7 +290,7 @@ pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
         check,
         hex::encode(receipt.transaction_hash.as_bytes()),
         contract_address,
-        receipt.block_number.expect("no block_number"),
+        receipt.block_number.unwrap_or_default(),
         paid.trim_end_matches('0'),
         gas_used,
         format_units(gas_price, 9)?.trim_end_matches('0').trim_end_matches('.')

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -325,16 +325,20 @@ impl CommandUtils for Command {
 
 #[macro_export]
 macro_rules! init_progress {
-    ($local:expr, $label:expr) => {
-        {
-            let pb = ProgressBar::new($local.len() as u64);
-            pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} $label ({eta})")
+    ($local:expr, $label:expr) => {{
+        let pb = ProgressBar::new($local.len() as u64);
+        let mut template =
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ".to_string();
+        template += $label;
+        template += " ({eta})";
+        pb.set_style(
+            ProgressStyle::with_template(&template)
                 .unwrap()
                 .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
-                .progress_chars("#>-"));
-            pb
-        }
-    }
+                .progress_chars("#>-"),
+        );
+        pb
+    }};
 }
 
 #[macro_export]

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -269,7 +269,7 @@ pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClien
     })
 }
 
-pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
+pub fn print_receipt(receipt: &TransactionReceipt) {
     let mut contract_address = "".to_string();
     if let Some(addr) = receipt.contract_address {
         contract_address = format!("\nContract Address: 0x{}", hex::encode(addr.as_bytes()));
@@ -277,7 +277,7 @@ pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
 
     let gas_used = receipt.gas_used.unwrap_or_default();
     let gas_price = receipt.effective_gas_price.unwrap_or_default();
-    let paid = format_units(gas_used.mul(gas_price), 18)?;
+    let paid = format_units(gas_used.mul(gas_price), 18).expect("");
 
     let check = if receipt.status.unwrap_or_default().is_zero() {
         Emoji("❌ ", " [Failed] ")
@@ -293,9 +293,8 @@ pub fn print_receipt(receipt: &TransactionReceipt) -> eyre::Result<()> {
         receipt.block_number.unwrap_or_default(),
         paid.trim_end_matches('0'),
         gas_used,
-        format_units(gas_price, 9)?.trim_end_matches('0').trim_end_matches('.')
+        format_units(gas_price, 9).expect("").trim_end_matches('0').trim_end_matches('.')
     );
-    Ok(())
 }
 
 /// Useful extensions to [`std::process::Command`].


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref #1817 #1816 #1826 #1829
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

At @mattsse suggestion, I tried separating into two different processes. ~~First send every transaction, and only then, wait for the receipts. Both with `buffered` set at 20.~~

~~1. Get `gas_price` or `eip1559_fees` estimation in the beginning.
2. Send every transaction. It only waits for a valid HTTP response before sending the next one. Collects all `transaction_hashes`.
3. Creates `PendingTransactions` from `transaction_hashes` and waits for the receipts to arrive. in a `.buffered(2)`.~~

--
1. Get `gas_price` or `eip1559_fees` estimation in the beginning.
2. Sign transactions "manually" to skip `eth_createAccessList`
3. Sends transactions in batches of 100. [`buffered(7)`]
4. Waits for the receipts of each batch [`buffer_unordered(10)`], before sending the next batch.

Currently, with rinkeby alchemy I'm able to send 100 transactions in around 30 seconds. 
I tried different parameters, and it was the best I could do without completely spam the endpoint. If we remove any kind of backoff period (so it keeps retrying until it works), it takes like 10 seconds for 100 txes. But I'm guessing that's asking to get banned with certain RPCs.

Why batches of 100? Avalanche testnet seems to either remove or lose transactions in the mempool if we do many more than that, leading to a messed up account. And even then, it takes quite a bit for them to be committed.
Why `.buffered(N)`? 

![image](https://user-images.githubusercontent.com/93316087/172011695-6e185a48-1e8b-4349-b7c4-50e114f5d638.png)





<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
