### PR TITLE
[wip] feat(fmt): intermediate chunk struct

### DIFF
--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -156,18 +156,6 @@ impl Comments {
         Self { prefixes, postfixes }
     }
 
-    pub(crate) fn get_comments_before(&self, byte: usize) -> Vec<&CommentWithMetadata> {
-        let mut out = self
-            .prefixes
-            .iter()
-            .rev()
-            .take_while(|comment| comment.is_before(byte))
-            .chain(self.prefixes.iter().rev().take_while(|comment| comment.is_before(byte)))
-            .collect::<Vec<_>>();
-        out.sort_by_key(|comment| comment.loc.start());
-        out
-    }
-
     pub(crate) fn remove_prefixes_before(&mut self, byte: usize) -> Vec<CommentWithMetadata> {
         let mut prefixes = self.prefixes.split_off(
             self.prefixes

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -8,8 +8,6 @@ pub type VError = Box<dyn std::error::Error>;
 /// The result type a [Visitor] may return
 pub type VResult = Result<(), VError>;
 
-pub type ParameterList = Vec<(Loc, Option<Parameter>)>;
-
 /// A trait that is invoked while traversing the Solidity Parse Tree.
 /// Each method of the [Visitor] trait is a hook that can be potentially overridden.
 ///
@@ -24,10 +22,6 @@ pub trait Visitor {
     }
 
     fn visit_doc_comment(&mut self, _doc_comment: &mut DocComment) -> VResult {
-        Ok(())
-    }
-
-    fn visit_doc_comments(&mut self, _doc_comments: &mut [DocComment]) -> VResult {
         Ok(())
     }
 
@@ -414,7 +408,6 @@ macro_rules! impl_visitable {
 }
 
 impl_visitable!(DocComment, visit_doc_comment);
-impl_visitable!(Vec<DocComment>, visit_doc_comments);
 impl_visitable!(SourceUnit, visit_source_unit);
 impl_visitable!(VariableDeclaration, visit_var_declaration);
 impl_visitable!(FunctionAttribute, visit_function_attribute);

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -221,6 +221,11 @@ pub trait Visitor {
         Ok(())
     }
 
+    fn visit_var_attribute(&mut self, attribute: &mut VariableAttribute) -> VResult {
+        self.visit_source(attribute.loc())?;
+        Ok(())
+    }
+
     fn visit_base(&mut self, base: &mut Base) -> VResult {
         self.visit_source(base.loc)
     }
@@ -415,6 +420,7 @@ impl_visitable!(DocComment, visit_doc_comment);
 impl_visitable!(SourceUnit, visit_source_unit);
 impl_visitable!(VariableDeclaration, visit_var_declaration);
 impl_visitable!(FunctionAttribute, visit_function_attribute);
+impl_visitable!(VariableAttribute, visit_var_attribute);
 impl_visitable!(Parameter, visit_parameter);
 impl_visitable!(Base, visit_base);
 impl_visitable!(EventParameter, visit_event_parameter);

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -221,10 +221,7 @@ pub trait Visitor {
     }
 
     fn visit_function_attribute(&mut self, attribute: &mut FunctionAttribute) -> VResult {
-        if let Some(loc) = attribute.loc() {
-            self.visit_source(loc)?;
-        }
-
+        self.visit_source(attribute.loc())?;
         Ok(())
     }
 
@@ -234,18 +231,6 @@ pub trait Visitor {
 
     fn visit_parameter(&mut self, parameter: &mut Parameter) -> VResult {
         self.visit_source(parameter.loc)
-    }
-
-    /// Write parameter list used in function/constructor/fallback/modifier arguments, return
-    /// arguments and try return arguments including opening and closing parenthesis.
-    fn visit_parameter_list(&mut self, list: &mut ParameterList) -> VResult {
-        self.visit_opening_paren()?;
-        if let (Some((first_loc, _)), Some((last_loc, _))) = (list.first(), list.last()) {
-            self.visit_source(Loc::File(first_loc.file_no(), first_loc.start(), last_loc.end()))?;
-        }
-        self.visit_closing_paren()?;
-
-        Ok(())
     }
 
     fn visit_struct(&mut self, structure: &mut StructDefinition) -> VResult {
@@ -434,7 +419,6 @@ impl_visitable!(SourceUnit, visit_source_unit);
 impl_visitable!(VariableDeclaration, visit_var_declaration);
 impl_visitable!(FunctionAttribute, visit_function_attribute);
 impl_visitable!(Parameter, visit_parameter);
-impl_visitable!(ParameterList, visit_parameter_list);
 impl_visitable!(Base, visit_base);
 impl_visitable!(EventParameter, visit_event_parameter);
 impl_visitable!(ErrorParameter, visit_error_parameter);

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -33,12 +33,13 @@ pub trait Visitor {
         Ok(())
     }
 
-    fn visit_import_plain(&mut self, _import: &mut StringLiteral) -> VResult {
+    fn visit_import_plain(&mut self, _loc: Loc, _import: &mut StringLiteral) -> VResult {
         Ok(())
     }
 
     fn visit_import_global(
         &mut self,
+        _loc: Loc,
         _global: &mut StringLiteral,
         _alias: &mut Identifier,
     ) -> VResult {
@@ -47,6 +48,7 @@ pub trait Visitor {
 
     fn visit_import_renames(
         &mut self,
+        _loc: Loc,
         _imports: &mut [(Identifier, Option<Identifier>)],
         _from: &mut StringLiteral,
     ) -> VResult {
@@ -316,9 +318,11 @@ impl Visitable for SourceUnitPart {
 impl Visitable for Import {
     fn visit(&mut self, v: &mut impl Visitor) -> VResult {
         match self {
-            Import::Plain(import, _) => v.visit_import_plain(import),
-            Import::GlobalSymbol(global, import_as, _) => v.visit_import_global(global, import_as),
-            Import::Rename(from, imports, _) => v.visit_import_renames(imports, from),
+            Import::Plain(import, loc) => v.visit_import_plain(*loc, import),
+            Import::GlobalSymbol(global, import_as, loc) => {
+                v.visit_import_global(*loc, global, import_as)
+            }
+            Import::Rename(from, imports, loc) => v.visit_import_renames(*loc, imports, from),
         }
     }
 }

--- a/fmt/testdata/DocComments/fmt.sol
+++ b/fmt/testdata/DocComments/fmt.sol
@@ -15,12 +15,7 @@ contract HelloWorld {
 
     /// Constructs the dude
     /// @param age The dude's age
-    constructor(uint256 age) {
-        theDude = Person({
-            age: age,
-            wallet: msg.sender
-        });
-    }
+    constructor(uint256 age) {}
 
     /**
      * @dev Calculates a rectangle's surface and perimeter.
@@ -33,8 +28,5 @@ contract HelloWorld {
         public
         pure
         returns (uint256 s, uint256 p)
-    {
-        s = w * h;
-        p = 2 * (w + h);
-    }
+    {}
 }

--- a/fmt/testdata/DocComments/original.sol
+++ b/fmt/testdata/DocComments/original.sol
@@ -16,12 +16,7 @@ contract HelloWorld {
 
     /// Constructs the dude
         /// @param age The dude's age
-    constructor(uint256 age) {
-        theDude = Person({
-            age: age,
-            wallet: msg.sender
-        });
-    }
+    constructor(uint256 age) {}
 
     /** @dev Calculates a rectangle's surface and perimeter.
       * @param w Width of the rectangle.
@@ -29,8 +24,5 @@ contract HelloWorld {
                 * @return s The calculated surface.
 * @return p The calculated perimeter.
       */
-    function rectangle(uint256 w, uint256 h) public pure returns (uint256 s, uint256 p) {
-        s = w * h;
-        p = 2 * (w + h);
-    }
+    function rectangle(uint256 w, uint256 h) public pure returns (uint256 s, uint256 p) {}
 }

--- a/fmt/testdata/FunctionDefinition/fmt.sol
+++ b/fmt/testdata/FunctionDefinition/fmt.sol
@@ -51,28 +51,23 @@ interface FunctionInterfaces {
         uint256 x1,
         uint256 x2,
         uint256 x3
-    ) modifier1 modifier2 modifier3;
+    )
+        modifier1
+        modifier2
+        modifier3;
 
     function someParamsSomeReturns(
         uint256 x1,
         uint256 x2,
         uint256 x3
     )
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        );
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
     function someModifiersSomeReturns()
         modifier1
         modifier2
         modifier3
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        );
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
     function someParamSomeModifiersSomeReturns(
         uint256 x1,
@@ -82,11 +77,7 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         modifier3
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        );
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
     function someParamsManyModifiers(
         uint256 x1,
@@ -133,7 +124,10 @@ interface FunctionInterfaces {
         uint256 x8,
         uint256 x9,
         uint256 x10
-    ) modifier1 modifier2 modifier3;
+    )
+        modifier1
+        modifier2
+        modifier3;
 
     function manyParamssomeReturns(
         uint256 x1,
@@ -147,11 +141,7 @@ interface FunctionInterfaces {
         uint256 x9,
         uint256 x10
     )
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        );
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
     function manyParamsManyModifiers(
         uint256 x1,
@@ -381,7 +371,11 @@ contract FunctionDefinitions {
         uint256 x1,
         uint256 x2,
         uint256 x3
-    ) modifier1 modifier2 modifier3 {
+    )
+        modifier1
+        modifier2
+        modifier3
+    {
         a = 1;
     }
 
@@ -390,11 +384,7 @@ contract FunctionDefinitions {
         uint256 x2,
         uint256 x3
     )
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        )
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
@@ -403,11 +393,7 @@ contract FunctionDefinitions {
         modifier1
         modifier2
         modifier3
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        )
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
@@ -420,11 +406,7 @@ contract FunctionDefinitions {
         modifier1
         modifier2
         modifier3
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        )
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
@@ -480,7 +462,11 @@ contract FunctionDefinitions {
         uint256 x8,
         uint256 x9,
         uint256 x10
-    ) modifier1 modifier2 modifier3 {
+    )
+        modifier1
+        modifier2
+        modifier3
+    {
         a = 1;
     }
 
@@ -496,11 +482,7 @@ contract FunctionDefinitions {
         uint256 x9,
         uint256 x10
     )
-        returns (
-            uint256 y1,
-            uint256 y2,
-            uint256 y3
-        )
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }

--- a/fmt/testdata/FunctionDefinitionWithComments/fmt.sol
+++ b/fmt/testdata/FunctionDefinitionWithComments/fmt.sol
@@ -1,0 +1,29 @@
+// function prefix
+function someParamSomeModifiersSomeReturns( // function name postfix
+    // x1 prefix
+    uint256 x1, // x1 postfix
+    // x2 prefix
+    uint256 x2, // x2 postfix
+        // x2 postfix2
+    // x3 prefix
+    uint256 x3 // x3 postfix
+)
+    // public prefix
+    public // public postfix
+    // pure prefix
+    pure // pure postfix
+    // modifier1 prefix
+    modifier1 // modifier1 postfix
+    // modifier2 prefix
+    modifier2 // modifier2 postfix
+    // modifier3 prefix
+    modifier3 // modifier3 postfix
+    returns (
+        // y1 prefix
+        uint256 y1, // y1 postfix
+        // y2 prefix
+        uint256 y2, // y2 postfix
+        // y3 prefix
+        uint256 y3
+    ); // y3 postfix
+    // function postfix

--- a/fmt/testdata/FunctionDefinitionWithComments/original.sol
+++ b/fmt/testdata/FunctionDefinitionWithComments/original.sol
@@ -1,0 +1,28 @@
+// function prefix
+function someParamSomeModifiersSomeReturns( // function name postfix
+    // x1 prefix
+    uint256 x1, // x1 postfix
+    // x2 prefix
+    uint256 x2, // x2 postfix
+        // x2 postfix2
+    // x3 prefix
+    uint256 x3 // x3 postfix
+)
+    // pure prefix
+    pure // pure postfix
+    // modifier1 prefix
+    modifier1 // modifier1 postfix
+    // public prefix
+    public // public postfix
+    // modifier2 prefix
+    modifier2 // modifier2 postfix
+    // modifier3 prefix
+    modifier3 // modifier3 postfix
+    returns (
+        // y1 prefix
+        uint256 y1, // y1 postfix
+        // y2 prefix
+        uint256 y2, // y2 postfix
+        // y3 prefix
+        uint256 y3 // y3 postfix
+    ); // function postfix

--- a/fmt/testdata/FunctionType/fmt.sol
+++ b/fmt/testdata/FunctionType/fmt.sol
@@ -4,28 +4,13 @@ library ArrayUtils {
         internal
         pure
         returns (uint256[] memory r)
-    {
-        r = new uint[](self.length);
-        for (uint i = 0; i < self.length; i++) {
-            r[i] = f(self[i]);
-        }
-    }
+    {}
 
     function reduce(uint256[] memory self, function (uint, uint) pure returns (uint) f)
         internal
         pure
         returns (uint256 r)
-    {
-        r = self[0];
-        for (uint i = 1; i < self.length; i++) {
-            r = f(r, self[i]);
-        }
-    }
+    {}
 
-    function range(uint256 length) internal pure returns (uint256[] memory r) {
-        r = new uint[](length);
-        for (uint i = 0; i < r.length; i++) {
-            r[i] = i;
-        }
-    }
+    function range(uint256 length) internal pure returns (uint256[] memory r) {}
 }

--- a/fmt/testdata/FunctionType/original.sol
+++ b/fmt/testdata/FunctionType/original.sol
@@ -4,28 +4,12 @@ library ArrayUtils {
         pure
         returns (
             uint[] memory r
-        )
-    {
-        r = new uint[](self.length);
-        for (uint i = 0; i < self.length; i++) {
-            r[i] = f(self[i]);
-        }
-    }
+        ) {}
 
     function reduce(
         uint[] memory self,
         function (uint, uint) pure returns (uint) f
-    ) internal pure returns (uint256 r) {
-        r = self[0];
-        for (uint i = 1; i < self.length; i++) {
-            r = f(r, self[i]);
-        }
-    }
+    ) internal pure returns (uint256 r) {}
 
-    function range(uint256 length) internal pure returns (uint[] memory r) {
-        r = new uint[](length);
-        for (uint i = 0; i < r.length; i++) {
-            r[i] = i;
-        }
-    }
+    function range(uint256 length) internal pure returns (uint[] memory r) {}
 }

--- a/fmt/testdata/ImportDirective/bracket-spacing.fmt.sol
+++ b/fmt/testdata/ImportDirective/bracket-spacing.fmt.sol
@@ -3,4 +3,9 @@ import "SomeFile.sol";
 import "SomeFile.sol" as SomeOtherFile;
 import "AnotherFile.sol" as SomeSymbol;
 import { symbol1 as alias, symbol2 } from "File.sol";
-import { symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4 } from "File2.sol";
+import {
+    symbol1 as alias1,
+    symbol2 as alias2,
+    symbol3 as alias3,
+    symbol4
+} from "File2.sol";

--- a/fmt/testdata/ImportDirective/fmt.sol
+++ b/fmt/testdata/ImportDirective/fmt.sol
@@ -2,4 +2,9 @@ import "SomeFile.sol";
 import "SomeFile.sol" as SomeOtherFile;
 import "AnotherFile.sol" as SomeSymbol;
 import {symbol1 as alias, symbol2} from "File.sol";
-import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";
+import {
+    symbol1 as alias1,
+    symbol2 as alias2,
+    symbol3 as alias3,
+    symbol4
+} from "File2.sol";

--- a/fmt/testdata/ModifierDefinition/fmt.sol
+++ b/fmt/testdata/ModifierDefinition/fmt.sol
@@ -3,9 +3,11 @@ contract ModifierDefinitions {
     modifier noParams() {}
     modifier oneParam(uint256 a) {}
     modifier twoParams(uint256 a, uint256 b) {}
-    modifier threeParams(
+    modifier threeParams(uint256 a, uint256 b, uint256 c) {}
+    modifier fourParams(
         uint256 a,
         uint256 b,
-        uint256 c
+        uint256 c,
+        uint256 d
     ) {}
 }

--- a/fmt/testdata/ModifierDefinition/original.sol
+++ b/fmt/testdata/ModifierDefinition/original.sol
@@ -3,4 +3,5 @@ contract ModifierDefinitions {
     modifier oneParam(uint a) {}
     modifier twoParams(uint a,uint b) {}
     modifier threeParams(uint a,uint b   ,uint c) {}
+    modifier fourParams(uint a,uint b   ,uint c, uint d) {}
 }

--- a/fmt/testdata/SimpleComments/fmt.sol
+++ b/fmt/testdata/SimpleComments/fmt.sol
@@ -13,11 +13,15 @@ contract SampleContract {
     constructor() { /* comment 9 */ } // comment 10
 
     // comment 11
-    function max(/* comment 13 */ uint256 arg1, uint256 /* comment 14 */ arg2, uint256 /* comment 15 */)
-    // comment 16
-    external /* comment 17 */
-    pure
-    returns(uint256) 
+    function max( /* comment 13 */
+        uint256 arg1,
+        uint256 /* comment 14 */ arg2,
+        uint256 /* comment 15 */
+    )
+        // comment 16
+        external /* comment 17 */
+        pure
+        returns(uint256)
     // comment 18
     { // comment 19
         return arg1 > arg2 ? arg1 : arg2;
@@ -25,5 +29,5 @@ contract SampleContract {
 }
 
 // comment 20
-contract /* comment 21 */ ExampleContract /* comment 22 */ is SampleContract {}
+contract /* comment 21 */ ExampleContract is /* comment 22 */ SampleContract {}
 

--- a/fmt/testdata/SimpleComments/original.sol
+++ b/fmt/testdata/SimpleComments/original.sol
@@ -22,5 +22,5 @@ contract SampleContract {
     }
 }
 
-// comment 
-contract /* comment */ ExampleContract /* comment 9 */ is SampleContract {}
+// comment 20
+contract /* comment 21 */ ExampleContract /* comment 22 */ is SampleContract {}

--- a/fmt/testdata/UsingDirective/fmt.sol
+++ b/fmt/testdata/UsingDirective/fmt.sol
@@ -4,4 +4,24 @@ contract UsingExampleContract {
     using Example.UsingExampleLibrary for uint256;
     using {M.g, M.f} for uint256;
     using UsingExampleLibrary for uint256 global;
+    using {
+        Theses,
+        Are,
+        MultipleLibraries,
+        ThatNeedToBePut,
+        OnSeparateLines
+    } for uint256;
+    using {
+        This
+            .isareally
+            .longmember
+            .access
+            .expression
+            .that
+            .needs
+            .to
+            .besplit
+            .into
+            .lines
+    } for uint256;
 }

--- a/fmt/testdata/UsingDirective/original.sol
+++ b/fmt/testdata/UsingDirective/original.sol
@@ -4,4 +4,6 @@ contract UsingExampleContract {
    using Example.UsingExampleLibrary  for  uint;
         using { M.g, M.f} for uint;
 using UsingExampleLibrary for   uint  global;
+using { Theses, Are, MultipleLibraries, ThatNeedToBePut, OnSeparateLines } for uint;
+using { This.isareally.longmember.access.expression.that.needs.to.besplit.into.lines } for uint;
 }


### PR DESCRIPTION
So I went a little crazy trying to get comments to work in the scope of function declarations and otherwise... The main crux of this PR (still WIP) is to add a `Chunk` struct that holds the context of comments. You can then format this Chunk or rearrange it or manage its comments in special cases.

This is especially useful in lists for example. We can essentially extract the chunk information first, sort if necessary, use that chunk information to check if it fits, and then rewrite the chunks with commas correctly placed before the postfix comments

The other big change here, this chunk on writing handles its own whitespace. This is just kind of a side effect that it has to handle its own whitespace because its potentially surrounded by comments. 

There's a bunch of minor stuff in here about handling of temp buffers as well as some helpers for dealing with surrounding things with parentheses and such and handling comments and spacing there as well. Its still very much a work in progress and a complete mess, but I wanted to get it posted here for feedback and collaboration