### PR TITLE
forge: fix Etherscan API key not being read from command line during script runs

### DIFF
--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -25,6 +25,7 @@ impl ScriptArgs {
         };
 
         self.maybe_load_private_key(&mut script_config)?;
+        self.maybe_load_etherscan_api_key(&mut script_config)?;
 
         if let Some(fork_url) = script_config.evm_opts.fork_url.as_ref() {
             // when forking, override the sender's nonce to the onchain value
@@ -202,6 +203,13 @@ impl ScriptArgs {
             if wallets.len() == 1 {
                 script_config.evm_opts.sender = wallets.get(0).unwrap().address()
             }
+        }
+        Ok(())
+    }
+
+    fn maybe_load_etherscan_api_key(&mut self, script_config: &mut ScriptConfig) -> eyre::Result<()> {
+        if let Some(ref etherscan_api_key) = self.etherscan_api_key {
+            script_config.config.etherscan_api_key = Some(etherscan_api_key.clone());
         }
         Ok(())
     }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -207,7 +207,10 @@ impl ScriptArgs {
         Ok(())
     }
 
-    fn maybe_load_etherscan_api_key(&mut self, script_config: &mut ScriptConfig) -> eyre::Result<()> {
+    fn maybe_load_etherscan_api_key(
+        &mut self,
+        script_config: &mut ScriptConfig,
+    ) -> eyre::Result<()> {
         if let Some(ref etherscan_api_key) = self.etherscan_api_key {
             script_config.config.etherscan_api_key = Some(etherscan_api_key.clone());
         }


### PR DESCRIPTION
When using `forge script`, the command line option `--etherscan-api-key` isn't passed into the script run.

Validation appears to work correctly, so if `--verify` is passed the script will terminate if `--etherscan-api-key` isn't provided. However, after providing this key, it is ignored and results in verification silently not occurring.

Setting the `ETHERSCAN_API_KEY` does work properly as it's captured in the Figment creation process. 

## Motivation

Passing the Etherscan key via command line is a documented option and enables easier parameterization than solely allowing environment variables.

## Solution

I tried to mirror this off of the private key loading process that also loads from the parsed command line arguments. I'm not sure if there is a more idiomatic way (seems like it could go in the Figment creation), but I didn't see any other patterns.
