### PR TITLE
forge(fix): verification on contracts with predeployed libraries + minor fixes

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -317,6 +317,7 @@ impl CreateArgs {
             force: false,
             watch: true,
             retry: RETRY_VERIFY_ON_CREATE,
+            libraries: vec![],
         };
         println!("Waiting for etherscan to detect contract deployment...");
         verify.run().await

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -110,6 +110,7 @@ impl ScriptArgs {
         &self,
         target: &ArtifactId,
         transactions: Option<VecDeque<TypedTransaction>>,
+        libraries: Libraries,
         decoder: &mut CallTraceDecoder,
         script_config: &ScriptConfig,
         verify: VerifyBundle,
@@ -142,6 +143,8 @@ impl ScriptArgs {
 
                 let mut deployment_sequence =
                     ScriptSequence::new(txes, &self.sig, target, &script_config.config, chain)?;
+
+                deployment_sequence.add_libraries(libraries);
 
                 create2_contracts
                     .into_iter()

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -91,7 +91,7 @@ impl ScriptArgs {
         foundry_utils::link_with_nonce_or_address(
             contracts.clone(),
             &mut highlevel_known_contracts,
-            libs,
+            &mut libs,
             sender,
             nonce,
             &mut extra_info,
@@ -142,6 +142,7 @@ impl ScriptArgs {
             predeploy_libraries: run_dependencies,
             sources: BTreeMap::new(),
             project,
+            libraries: libs,
         })
     }
 
@@ -218,6 +219,7 @@ pub struct BuildOutput {
     pub contract: CompactContractBytecode,
     pub known_contracts: BTreeMap<ArtifactId, CompactContractBytecode>,
     pub highlevel_known_contracts: BTreeMap<ArtifactId, ContractBytecodeSome>,
+    pub libraries: Libraries,
     pub predeploy_libraries: Vec<ethers::types::Bytes>,
     pub sources: BTreeMap<u32, String>,
 }

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -111,7 +111,7 @@ impl ScriptArgs {
         foundry_utils::link_with_nonce_or_address(
             contracts.clone(),
             &mut highlevel_known_contracts,
-            &mut libs,
+            libs,
             sender,
             nonce,
             &mut extra_info,
@@ -156,11 +156,17 @@ impl ScriptArgs {
 
         let target = extra_info.target_id.expect("Target not found?");
         let mut predeploy_libraries = vec![];
-        let mut libraries = vec![];
+        let mut new_libraries = vec![];
 
         for (library, bytecode) in run_dependencies.into_iter() {
             predeploy_libraries.push(bytecode);
-            libraries.push(library);
+            new_libraries.push(library);
+        }
+        let mut new_libraries = Libraries::parse(&new_libraries)?;
+
+        // Merge with user provided libraries
+        for (file, libraries) in libraries_addresses.libs.into_iter() {
+            new_libraries.libs.entry(file).or_insert(BTreeMap::new()).extend(libraries.into_iter())
         }
 
         Ok(BuildOutput {
@@ -171,7 +177,7 @@ impl ScriptArgs {
             predeploy_libraries,
             sources: BTreeMap::new(),
             project,
-            libraries: Libraries::parse(&libraries)?,
+            libraries: new_libraries,
         })
     }
 

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -155,16 +155,12 @@ impl ScriptArgs {
         )?;
 
         let target = extra_info.target_id.expect("Target not found?");
-        let mut predeploy_libraries = vec![];
-        let mut new_libraries = vec![];
 
-        for (library, bytecode) in run_dependencies.into_iter() {
-            predeploy_libraries.push(bytecode);
-            new_libraries.push(library);
-        }
-        let mut new_libraries = Libraries::parse(&new_libraries)?;
+        let (new_libraries, predeploy_libraries): (Vec<_>, Vec<_>) =
+            run_dependencies.into_iter().unzip();
 
         // Merge with user provided libraries
+        let mut new_libraries = Libraries::parse(&new_libraries)?;
         for (file, libraries) in libraries_addresses.libs.into_iter() {
             new_libraries.libs.entry(file).or_insert(BTreeMap::new()).extend(libraries.into_iter())
         }
@@ -213,7 +209,7 @@ impl ScriptArgs {
                     (res.0, output)
                 };
 
-                self.path = path.to_str().ok_or(eyre::eyre!("Invalid path string."))?.to_string();
+                self.path = path.to_string_lossy().to_string();
                 self.target_contract = Some(contract.name);
                 output
             }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -46,6 +46,7 @@ impl ScriptArgs {
         } = self.build(&script_config)?;
 
         let mut verify = VerifyBundle::new(
+            &project,
             &script_config.config,
             unwrap_contracts(&highlevel_known_contracts, false),
         );

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -17,7 +17,10 @@ use crate::{cmd::forge::build::BuildArgs, opts::MultiWallet};
 use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, Function},
-    prelude::{artifacts::ContractBytecodeSome, ArtifactId, Bytes, Project},
+    prelude::{
+        artifacts::{ContractBytecodeSome, Libraries},
+        ArtifactId, Bytes, Project,
+    },
     types::{transaction::eip2718::TypedTransaction, Address, Log, TransactionRequest, U256},
 };
 use forge::{

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -10,6 +10,7 @@ use ethers::{
         utils::lookup_compiler_version,
         Client,
     },
+    prelude::artifacts::StandardJsonCompilerInput,
     solc::{
         artifacts::{BytecodeHash, Source},
         cache::CacheEntry,
@@ -99,6 +100,15 @@ pub struct VerifyArgs {
 
     #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
     pub project_paths: ProjectPathsArgs,
+
+    #[clap(
+        help_heading = "LINKER OPTIONS",
+        help = "Set pre-linked libraries.",
+        long,
+        env = "DAPP_LIBRARIES",
+        value_name = "LIBRARIES"
+    )]
+    pub libraries: Vec<String>,
 }
 
 impl VerifyArgs {
@@ -181,7 +191,7 @@ impl VerifyArgs {
             use_solc: None,
             offline: false,
             force: false,
-            libraries: vec![],
+            libraries: self.libraries.clone(),
             via_ir: false,
             revert_strings: None,
         };
@@ -388,10 +398,24 @@ To skip this solc dry, pass `--force`.
         target: &Path,
         version: &Version,
     ) -> eyre::Result<(String, String, CodeFormat)> {
-        let input = project
+        let mut input: StandardJsonCompilerInput = project
             .standard_json_input(target)
             .wrap_err("Failed to get standard json input")?
             .normalize_evm_version(version);
+
+        input.settings.libraries.libs = input
+            .settings
+            .libraries
+            .libs
+            .into_iter()
+            .map(|(f, libs)| {
+                if f.is_absolute() {
+                    (f.strip_prefix(&project.root()).unwrap().to_path_buf(), libs)
+                } else {
+                    (f, libs)
+                }
+            })
+            .collect();
 
         let source =
             serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -408,13 +408,7 @@ To skip this solc dry, pass `--force`.
             .libraries
             .libs
             .into_iter()
-            .map(|(f, libs)| {
-                if f.is_absolute() {
-                    (f.strip_prefix(&project.root()).unwrap().to_path_buf(), libs)
-                } else {
-                    (f, libs)
-                }
-            })
+            .map(|(f, libs)| (f.strip_prefix(&project.root()).unwrap_or(&f).to_path_buf(), libs))
             .collect();
 
         let source =

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -189,21 +189,21 @@ pub struct VerifyBundle {
 }
 
 impl VerifyBundle {
-    pub fn new(config: &Config, known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)>) -> Self {
+    pub fn new(
+        project: &Project,
+        config: &Config,
+        known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)>,
+    ) -> Self {
         let num_of_optimizations =
             if config.optimizer { Some(config.optimizer_runs) } else { None };
 
         let project_paths = ProjectPathsArgs {
-            root: Some(config.__root.0.clone()),
-            contracts: Some(config.src.clone()),
-            remappings: config
-                .remappings
-                .iter()
-                .map(|remap| remap.clone().to_remapping(config.__root.0.clone()))
-                .collect(),
+            root: Some(project.paths.root.clone()),
+            contracts: Some(project.paths.sources.clone()),
+            remappings: project.paths.remappings.clone(),
             remappings_env: None,
-            cache_path: Some(config.cache_path.clone()),
-            lib_paths: config.libs.clone(),
+            cache_path: Some(project.paths.cache.clone()),
+            lib_paths: project.paths.libraries.clone(),
             hardhat: config.profile == Config::HARDHAT_PROFILE,
             config_path: Some(config.get_config_path()),
         };

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -330,12 +330,10 @@ impl ScriptSequence {
         self.libraries = {
             let mut str_libs = vec![];
             for (file, libs) in libraries.libs {
-                let file = file.to_str().expect("wrong path");
-
                 for (name, address) in libs {
                     str_libs.push(format!(
                         "{}:{}:{}",
-                        file.strip_prefix("__").unwrap_or(file),
+                        file.to_str().expect("wrong path"),
                         name,
                         address
                     ));
@@ -427,7 +425,7 @@ impl ScriptSequence {
                                 retry: RETRY_VERIFY_ON_CREATE,
                                 libraries: self.libraries.clone(),
                             };
-                            dbg!(&verify.libraries);
+
                             future_verifications.push(verify.run());
                         }
                     }

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -197,6 +197,8 @@ impl VerifyBundle {
         let num_of_optimizations =
             if config.optimizer { Some(config.optimizer_runs) } else { None };
 
+        let config_path = config.get_config_path();
+
         let project_paths = ProjectPathsArgs {
             root: Some(project.paths.root.clone()),
             contracts: Some(project.paths.sources.clone()),
@@ -205,7 +207,7 @@ impl VerifyBundle {
             cache_path: Some(project.paths.cache.clone()),
             lib_paths: project.paths.libraries.clone(),
             hardhat: config.profile == Config::HARDHAT_PROFILE,
-            config_path: Some(config.get_config_path()),
+            config_path: if config_path.exists() { Some(config_path) } else { None },
         };
 
         VerifyBundle {

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -331,12 +331,7 @@ impl ScriptSequence {
             let mut str_libs = vec![];
             for (file, libs) in libraries.libs {
                 for (name, address) in libs {
-                    str_libs.push(format!(
-                        "{}:{}:{}",
-                        file.to_str().expect("wrong path"),
-                        name,
-                        address
-                    ));
+                    str_libs.push(format!("{}:{}:{}", file.to_string_lossy(), name, address));
                 }
             }
             str_libs

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -15,6 +15,7 @@ use ethers::{
 };
 use foundry_config::Config;
 use foundry_utils::Retry;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -381,10 +382,19 @@ impl ScriptSequence {
                                 name: artifact.name.clone(),
                             };
 
+                            // We strip the build metadadata information, since it can lead to
+                            // etherscan not identifying it correctly. eg:
+                            // `v0.8.10+commit.fc410830.Linux.gcc` != `v0.8.10+commit.fc410830`
+                            let version = Version::new(
+                                artifact.version.major,
+                                artifact.version.minor,
+                                artifact.version.patch,
+                            );
+
                             let verify = verify::VerifyArgs {
                                 address: contract_address,
                                 contract,
-                                compiler_version: None,
+                                compiler_version: Some(version.to_string()),
                                 constructor_args: Some(hex::encode(&constructor_args)),
                                 num_of_optimizations: verify.num_of_optimizations,
                                 chain: chain.into(),

--- a/cli/tests/it/utils.rs
+++ b/cli/tests/it/utils.rs
@@ -28,7 +28,7 @@ pub fn network_rpc_key(chain: &str) -> Option<String> {
 
 pub fn network_private_key(chain: &str) -> Option<String> {
     let key = format!("{}_PRIVATE_KEY", chain.to_uppercase());
-    std::env::var(&key).ok()
+    std::env::var(&key).or_else(|_| std::env::var("TEST_PRIVATE_KEY")).ok()
 }
 
 /// Represents external input required for executing verification requests

--- a/cli/tests/it/utils.rs
+++ b/cli/tests/it/utils.rs
@@ -17,6 +17,7 @@ pub fn etherscan_key(chain: Chain) -> Option<String> {
         Chain::Fantom | Chain::FantomTestnet => {
             std::env::var("FTMSCAN_API_KEY").or_else(|_| std::env::var("FANTOMSCAN_API_KEY")).ok()
         }
+        Chain::OptimismKovan => std::env::var("OP_KOVAN_API_KEY").ok(),
         _ => std::env::var("ETHERSCAN_API_KEY").ok(),
     }
 }

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -230,3 +230,64 @@ forgetest!(
         }
     }
 );
+
+// tests `script --verify` on goerli with contract + predeployed libraries
+forgetest!(
+    can_verify_on_script_random_contract_with_libs_goerli,
+    |prj: TestProject, mut cmd: TestCommand| {
+        if let Some(info) = EnvExternalities::goerli() {
+            add_unique(&prj);
+            prj.inner()
+                .add_source(
+                    "ScriptVerify.sol",
+                    r#"
+    // SPDX-License-Identifier: UNLICENSED
+    pragma solidity =0.8.10;
+    import {Unique} from "./unique.sol";
+    library F {
+        function f() public pure returns (uint256) {
+            return 1;
+        }
+    }
+    library C {
+        function c() public pure returns (uint256) {
+            return 2;
+        }
+    }
+    interface HEVM {
+        function startBroadcast() external;
+    }
+
+    contract Hello is Unique {
+        function world() public {
+            F.f();
+            C.c();
+        }
+    }
+    contract ScriptVerify {
+        function run() public {
+            address vm = address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
+            HEVM(vm).startBroadcast();
+            new Hello();
+        }
+    }
+    "#,
+                )
+                .unwrap();
+
+            let contract_path = "src/ScriptVerify.sol:ScriptVerify";
+            cmd.arg("script")
+                .args(vec![
+                    "--rpc-url".to_string(),
+                    info.rpc.clone(),
+                    "--private-key".to_string(),
+                    info.pk.clone(),
+                ])
+                .arg("--broadcast")
+                .arg("--verify")
+                .arg(contract_path);
+
+            parse_verification_result(&mut cmd, 1).expect("Failed to verify check")
+        }
+    }
+);

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -92,8 +92,17 @@ impl MultiContractRunnerBuilder {
                 if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                     abi.functions().any(|func| func.name.starts_with("test"))
                 {
-                    deployable_contracts
-                        .insert(id.clone(), (abi.clone(), bytecode, dependencies.to_vec()));
+                    deployable_contracts.insert(
+                        id.clone(),
+                        (
+                            abi.clone(),
+                            bytecode,
+                            dependencies
+                                .into_iter()
+                                .map(|(_, bytecode)| bytecode)
+                                .collect::<Vec<_>>(),
+                        ),
+                    );
                 }
 
                 contract

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -60,11 +60,12 @@ impl MultiContractRunnerBuilder {
 
         // create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
+        let mut libraries = Default::default();
 
         foundry_utils::link_with_nonce_or_address(
             BTreeMap::from_iter(contracts),
             &mut known_contracts,
-            Default::default(),
+            &mut libraries,
             evm_opts.sender,
             U256::one(),
             &mut deployable_contracts,

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -60,12 +60,11 @@ impl MultiContractRunnerBuilder {
 
         // create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
-        let mut libraries = Default::default();
 
         foundry_utils::link_with_nonce_or_address(
             BTreeMap::from_iter(contracts),
             &mut known_contracts,
-            &mut libraries,
+            Default::default(),
             evm_opts.sender,
             U256::one(),
             &mut deployable_contracts,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -61,7 +61,7 @@ pub struct PostLinkInput<'a, T, U> {
 pub fn link_with_nonce_or_address<T, U>(
     contracts: BTreeMap<ArtifactId, CompactContractBytecode>,
     known_contracts: &mut BTreeMap<ArtifactId, T>,
-    deployed_library_addresses: &mut Libraries,
+    deployed_library_addresses: Libraries,
     sender: Address,
     nonce: U256,
     extra: &mut U,
@@ -119,7 +119,7 @@ pub fn link_with_nonce_or_address<T, U>(
                         &contracts_by_slug,
                         &link_tree,
                         &mut dependencies,
-                        deployed_library_addresses,
+                        &deployed_library_addresses,
                         nonce,
                         sender,
                     );
@@ -164,7 +164,7 @@ pub fn recurse_link<'a>(
     // library deployment vector (file:contract:address, bytecode)
     deployment: &'a mut Vec<(String, ethers_core::types::Bytes)>,
     // deployed library addresses fname => adddress
-    deployed_library_addresses: &'a mut Libraries,
+    deployed_library_addresses: &'a Libraries,
     // nonce to start at
     init_nonce: U256,
     // sender


### PR DESCRIPTION
There were a couple cases where verifying was not working properly or not giving enough information to the user on `forge script`

* Standalone scripts with `--verify` flag now throw an error, instead of finishing silently. `--verify` flag should only be used with contracts belonging to projects.
* Add `--libraries` to `forge verify-contract`
* Fixed verification of contracts with predeployed libraries. It was just failing silently. Now we properly store the library information on `ScriptSequence` and provide it to `forge verify-contract` through the `--libraries` field.
* Relink contracts on `--resume --script` or `--script` with libraries stored in `ScriptSequence`, before asking for contract verification.
* Strip the build metadata. If a compiler version has too much build data eg. `0.8.12+commit.f00d7308.**.Linux.gcc**`, etherscan fails.

Tested a few different scenarios, and seems more solid now.

--

I reckon that some past issues (related to `forge verify-contract` and `forge create --verify`) might be related to:
* compiler build metadata
* library linking