### PR TITLE
ci: let clippy and fmt annotate prs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           args: --all --all-features -- -D warnings
-          token: ${{ secrets.GTIHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   cross-platform:
     name: Cross-platform tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,10 +196,16 @@ jobs:
           cache-on-failure: true
 
       - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
 
       - name: cargo clippy
-        run: cargo +nightly clippy --all --all-features -- -D warnings
+        uses: actions-rs/clippy-check@v1
+        with:
+          args: --all --all-features -- -D warnings
+          token: ${{ secrets.GTIHUB_TOKEN }}
 
   cross-platform:
     name: Cross-platform tests


### PR DESCRIPTION
Clippy and Rustfmt warnings will now show up as annotations in the PR file view, which I think is helpful for newcomers. I didn't let `cargo test` and `cargo build` annotate the PR because it might clutter the view a lot, but it is a possibility as well