### PR TITLE
#1718 - adds option to write anvil config to json file

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -90,7 +90,7 @@ pub struct NodeArgs {
 
     #[clap(
     long,
-    help = "Writes output of `anvil` as json to user-specified file. [Default anvil_out.json]",
+    help = "Writes output of `anvil` as json to user-specified file",
     value_name = "OUT_FILE"
     )]
     pub config_out: Option<String>,

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -89,9 +89,9 @@ pub struct NodeArgs {
     pub block_time: Option<u64>,
 
     #[clap(
-    long,
-    help = "Writes output of `anvil` as json to user-specified file",
-    value_name = "OUT_FILE"
+        long,
+        help = "Writes output of `anvil` as json to user-specified file",
+        value_name = "OUT_FILE"
     )]
     pub config_out: Option<String>,
 

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -89,6 +89,13 @@ pub struct NodeArgs {
     pub block_time: Option<u64>,
 
     #[clap(
+    long,
+    help = "Writes output of `anvil` as json to user-specified file. [Default anvil_out.json]",
+    value_name = "OUT_FILE"
+    )]
+    pub config_out: Option<String>,
+
+    #[clap(
         long,
         visible_alias = "no-mine",
         help = "Disable auto and interval mining, and mine on demand instead.",
@@ -139,6 +146,7 @@ impl NodeArgs {
             .with_server_config(self.server_config)
             .with_host(self.host)
             .set_silent(self.silent)
+            .set_config_out(self.config_out)
             .with_chain_id(self.evm_opts.env.chain_id.unwrap_or(CHAIN_ID))
             .with_transaction_order(self.order)
     }

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -231,11 +231,10 @@ Chain ID:       {}
         let mut wallet_description = HashMap::new();
         let mut available_accounts = Vec::with_capacity(self.genesis_accounts.len());
         let mut private_keys = Vec::with_capacity(self.genesis_accounts.len());
-        let balance = format_ether(self.genesis_balance);
 
-        for (idx, wallet) in self.genesis_accounts.iter().enumerate() {
-            available_accounts.push(format!("({}) {:?} ({} ETH)", idx, wallet.address(), balance));
-            private_keys.push(format!("({}) 0x{}", idx, hex::encode(wallet.signer().to_bytes())));
+        for (_, wallet) in self.genesis_accounts.iter().enumerate() {
+            available_accounts.push(format!("{:?}", wallet.address()));
+            private_keys.push(format!("0x{}", hex::encode(wallet.signer().to_bytes())));
         }
 
         if let Some(ref gen) = self.account_generator {
@@ -501,10 +500,12 @@ impl NodeConfig {
     /// Prints the config info
     pub fn print(&self, fork: Option<&ClientFork>) {
         if self.config_out.is_some() {
-            let f = File::create(self.config_out.as_deref().unwrap())
-                .expect("Unable to create anvil config description file");
+            let config_out = self.config_out.as_deref().unwrap();
+            let f =
+                File::create(config_out).expect("Unable to create anvil config description file");
             let mut f = BufWriter::new(f);
-            f.write_all(self.as_json(fork).as_bytes()).expect("Unable to write data");
+            f.write_all(self.as_json(fork).as_bytes())
+                .expect(&format!("Unable to write to anvil config file at {}", config_out));
         }
         if self.silent {
             return

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -106,6 +106,8 @@ pub struct NodeConfig {
     pub host: Option<IpAddr>,
     /// How transactions are sorted in the mempool
     pub transaction_order: TransactionOrder,
+    /// Filename to write anvil output as json
+    pub config_out: Option<String>,
 }
 
 // === impl NodeConfig ===
@@ -146,6 +148,7 @@ impl Default for NodeConfig {
             server_config: Default::default(),
             host: None,
             transaction_order: Default::default(),
+            config_out: None,
         }
     }
 }
@@ -272,6 +275,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets file to write config info to
+    #[must_use]
+    pub fn set_config_out(mut self, config_out: String) -> Self {
+        self.config_out = Option::from(config_out);
+        self
+    }
+
     /// Makes the node silent to not emit anything on stdout
     #[must_use]
     pub fn no_storage_caching(self) -> Self {
@@ -326,6 +336,9 @@ impl NodeConfig {
 
     /// Prints the config info
     pub fn print(&self, fork: Option<&ClientFork>) {
+        if self.config_out {
+            // TODO write to json
+        }
         if self.silent {
             return
         }


### PR DESCRIPTION
Adds the `--config-out <out_file>` option to anvil. This writes the same info that anvil writes to stdout, in a more machine-friendly format, as json to the file specified by the user.

## Motivation
https://github.com/foundry-rs/foundry/issues/1718

## Solution
pretty straightforward, if you include `--config-out <out_file>` it writes the relevant config info to <out_file>. note: it will still write the file it `silent` and `--config-out` are provided since i assumed silent is really referring to stdout/err
