### PR TITLE
feat(forge): allow install in config folder

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -472,6 +472,18 @@ impl Config {
         self.remappings.dedup();
     }
 
+    /// Returns the directory in which dependencies should be installed
+    ///
+    /// Returns the first dir from `libs` that is not `node_modules` or `lib` if `libs` is empty
+    pub fn install_lib_dir(&self) -> PathBuf {
+        self.libs
+            .iter()
+            .filter(|p| !p.ends_with("node_modules"))
+            .next()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("lib"))
+    }
+
     /// Serves as the entrypoint for obtaining the project.
     ///
     /// Returns the `Project` configured with all `solc` and path related values.
@@ -2013,6 +2025,35 @@ mod tests {
 
     use std::{fs::File, io::Write};
     use tempfile::tempdir;
+
+    #[test]
+    fn test_install_dir() {
+        figment::Jail::expect_with(|jail| {
+            let config = Config::load();
+            assert_eq!(config.install_lib_dir(), PathBuf::from("lib"));
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [default]
+                libs = ['node_modules', 'lib']
+            "#,
+            )?;
+            let config = Config::load();
+            assert_eq!(config.install_lib_dir(), PathBuf::from("lib"));
+
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [default]
+                libs = ['custom', 'node_modules', 'lib']
+            "#,
+            )?;
+            let config = Config::load();
+            assert_eq!(config.install_lib_dir(), PathBuf::from("custom"));
+
+            Ok(())
+        });
+    }
 
     #[test]
     fn test_figment_is_default() {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -478,8 +478,7 @@ impl Config {
     pub fn install_lib_dir(&self) -> PathBuf {
         self.libs
             .iter()
-            .filter(|p| !p.ends_with("node_modules"))
-            .next()
+            .find(|p| !p.ends_with("node_modules"))
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("lib"))
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1834 use lib folder in config as install target
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
select the first dir in `libs` that is not `node_modules`, by default this will be `lib` but allows other targets like

```toml
libs = ['contracts/solidity/src/lib']
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
