### PR TITLE
test: use serial_test instead of current dir locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "similar",
  "solang-parser",
  "strsim",
@@ -4397,6 +4398,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19dbfb999a147cedbfe82f042eb9555f5b0fa4ef95ee4570b74349103d9c9f4"
+dependencies = [
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.0",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9e2050b2be1d681f8f1c1a528bcfe4e00afa2d8995f713974f5333288659f2"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,6 +81,7 @@ foundry-utils = { path = "./../utils", features = ["test"] }
 foundry-cli-test-utils = { path = "./test-utils" }
 pretty_assertions = "1.0.0"
 toml = "0.5"
+serial_test = "0.7.0"
 
 [features]
 default = ["rustls"]

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -33,10 +33,10 @@
 /// });
 #[macro_export]
 macro_rules! forgetest {
-    ($test:ident, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $fun:expr) => {
         $crate::forgetest!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
-    ($test:ident, $style:expr, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
         fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
@@ -47,10 +47,10 @@ macro_rules! forgetest {
 
 #[macro_export]
 macro_rules! forgetest_async {
-    ($test:ident, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $fun:expr) => {
         $crate::forgetest_async!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
-    ($test:ident, $style:expr, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[tokio::test(flavor = "multi_thread")]
         async fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
@@ -61,10 +61,10 @@ macro_rules! forgetest_async {
 
 #[macro_export]
 macro_rules! casttest {
-    ($test:ident, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $fun:expr) => {
         $crate::casttest!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
-    ($test:ident, $style:expr, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
         fn $test() {
             let (prj, cmd) = $crate::util::setup_cast(stringify!($test), $style);
@@ -76,10 +76,10 @@ macro_rules! casttest {
 /// A helper macro to ignore `forgetest!` that should not run on CI
 #[macro_export]
 macro_rules! forgetest_ignore {
-    ($test:ident, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $fun:expr) => {
         $crate::forgetest_ignore!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
-    ($test:ident, $style:expr, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
         #[ignore]
         fn $test() {
@@ -92,10 +92,10 @@ macro_rules! forgetest_ignore {
 /// Same as `forgetest` but returns an already initialized project workspace (`forge init`)
 #[macro_export]
 macro_rules! forgetest_init {
-    ($test:ident, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $fun:expr) => {
         $crate::forgetest_init!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
-    ($test:ident, $style:expr, $fun:expr) => {
+    ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
         fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
@@ -111,11 +111,11 @@ macro_rules! forgetest_init {
 #[macro_export]
 macro_rules! forgetest_external {
     // forgetest_external!(test_name, "owner/repo");
-    ($test:ident, $repo:literal) => {
+    ($(#[$meta:meta])* $test:ident, $repo:literal) => {
         $crate::forgetest_external!($test, $repo, 0, Vec::<String>::new());
     };
     // forgetest_external!(test_name, "owner/repo", 1234);
-    ($test:ident, $repo:literal, $fork_block:literal) => {
+    ($(#[$meta:meta])* $test:ident, $repo:literal, $fork_block:literal) => {
         $crate::forgetest_external!(
             $test,
             $repo,
@@ -125,11 +125,11 @@ macro_rules! forgetest_external {
         );
     };
     // forgetest_external!(test_name, "owner/repo", &["--extra-opt", "val"]);
-    ($test:ident, $repo:literal, $forge_opts:expr) => {
+    ($(#[$meta:meta])* $test:ident, $repo:literal, $forge_opts:expr) => {
         $crate::forgetest_external!($test, $repo, 0, $forge_opts);
     };
     // forgetest_external!(test_name, "owner/repo", 1234, &["--extra-opt", "val"]);
-    ($test:ident, $repo:literal, $fork_block:literal, $forge_opts:expr) => {
+    ($(#[$meta:meta])* $test:ident, $repo:literal, $fork_block:literal, $forge_opts:expr) => {
         $crate::forgetest_external!(
             $test,
             $repo,
@@ -139,7 +139,7 @@ macro_rules! forgetest_external {
         );
     };
     // forgetest_external!(test_name, "owner/repo", PathStyle::Dapptools, 123);
-    ($test:ident, $repo:literal, $style:expr, $fork_block:literal, $forge_opts:expr) => {
+    ($(#[$meta:meta])* $test:ident, $repo:literal, $style:expr, $fork_block:literal, $forge_opts:expr) => {
         #[test]
         fn $test() {
             use std::process::{Command, Stdio};

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -34,13 +34,15 @@
 #[macro_export]
 macro_rules! forgetest {
     ($(#[$meta:meta])* $test:ident, $fun:expr) => {
-        $crate::forgetest!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+        $crate::forgetest!($(#[$meta])* $test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
     ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
+        $(#[$meta])*
         fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
-            $fun(prj, cmd);
+            let f = $fun;
+            f(prj, cmd);
         }
     };
 }
@@ -48,13 +50,15 @@ macro_rules! forgetest {
 #[macro_export]
 macro_rules! forgetest_async {
     ($(#[$meta:meta])* $test:ident, $fun:expr) => {
-        $crate::forgetest_async!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+        $crate::forgetest_async!($(#[$meta])* $test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
     ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[tokio::test(flavor = "multi_thread")]
+        $(#[$meta])*
         async fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
-            $fun(prj, cmd).await;
+            let f = $fun;
+            f(prj, cmd).await;
         }
     };
 }
@@ -62,13 +66,15 @@ macro_rules! forgetest_async {
 #[macro_export]
 macro_rules! casttest {
     ($(#[$meta:meta])* $test:ident, $fun:expr) => {
-        $crate::casttest!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+        $crate::casttest!($(#[$meta])* $test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
     ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
+        $(#[$meta])*
         fn $test() {
             let (prj, cmd) = $crate::util::setup_cast(stringify!($test), $style);
-            $fun(prj, cmd);
+            let f = $fun;
+            f(prj, cmd);
         }
     };
 }
@@ -77,14 +83,16 @@ macro_rules! casttest {
 #[macro_export]
 macro_rules! forgetest_ignore {
     ($(#[$meta:meta])* $test:ident, $fun:expr) => {
-        $crate::forgetest_ignore!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+        $crate::forgetest_ignore!($(#[$meta])* $test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
     ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
         #[ignore]
+        $(#[$meta])*
         fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
-            $fun(prj, cmd);
+            let f = $fun;
+            f(prj, cmd);
         }
     };
 }
@@ -93,14 +101,16 @@ macro_rules! forgetest_ignore {
 #[macro_export]
 macro_rules! forgetest_init {
     ($(#[$meta:meta])* $test:ident, $fun:expr) => {
-        $crate::forgetest_init!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+        $crate::forgetest_init!($(#[$meta])* $test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
     };
     ($(#[$meta:meta])* $test:ident, $style:expr, $fun:expr) => {
         #[test]
+        $(#[$meta])*
         fn $test() {
             let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $crate::util::initialize(prj.root());
-            $fun(prj, cmd);
+            let f = $fun;
+            f(prj, cmd);
         }
     };
 }
@@ -112,11 +122,12 @@ macro_rules! forgetest_init {
 macro_rules! forgetest_external {
     // forgetest_external!(test_name, "owner/repo");
     ($(#[$meta:meta])* $test:ident, $repo:literal) => {
-        $crate::forgetest_external!($test, $repo, 0, Vec::<String>::new());
+        $crate::forgetest_external!($(#[$meta])* $test, $repo, 0, Vec::<String>::new());
     };
     // forgetest_external!(test_name, "owner/repo", 1234);
     ($(#[$meta:meta])* $test:ident, $repo:literal, $fork_block:literal) => {
         $crate::forgetest_external!(
+            $(#[$meta])*
             $test,
             $repo,
             $crate::ethers_solc::PathStyle::Dapptools,
@@ -126,11 +137,12 @@ macro_rules! forgetest_external {
     };
     // forgetest_external!(test_name, "owner/repo", &["--extra-opt", "val"]);
     ($(#[$meta:meta])* $test:ident, $repo:literal, $forge_opts:expr) => {
-        $crate::forgetest_external!($test, $repo, 0, $forge_opts);
+        $crate::forgetest_external!($(#[$meta])* $test, $repo, 0, $forge_opts);
     };
     // forgetest_external!(test_name, "owner/repo", 1234, &["--extra-opt", "val"]);
     ($(#[$meta:meta])* $test:ident, $repo:literal, $fork_block:literal, $forge_opts:expr) => {
         $crate::forgetest_external!(
+            $(#[$meta])*
             $test,
             $repo,
             $crate::ethers_solc::PathStyle::Dapptools,
@@ -141,6 +153,7 @@ macro_rules! forgetest_external {
     // forgetest_external!(test_name, "owner/repo", PathStyle::Dapptools, 123);
     ($(#[$meta:meta])* $test:ident, $repo:literal, $style:expr, $fork_block:literal, $forge_opts:expr) => {
         #[test]
+        $(#[$meta])*
         fn $test() {
             use std::process::{Command, Stdio};
 

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -217,6 +217,7 @@ impl TestProject {
     }
 
     /// Creates a new command that is set to use the forge executable for this project
+    #[track_caller]
     pub fn forge_command(&self) -> TestCommand {
         let cmd = self.forge_bin();
         let _lock = CURRENT_DIR_LOCK.lock();
@@ -279,7 +280,9 @@ impl TestProject {
 impl Drop for TestCommand {
     fn drop(&mut self) {
         let _lock = self.current_dir_lock.take().unwrap_or_else(|| CURRENT_DIR_LOCK.lock());
-        let _ = std::env::set_current_dir(&self.saved_cwd);
+        if self.saved_cwd.exists() {
+            let _ = std::env::set_current_dir(&self.saved_cwd);
+        }
     }
 }
 

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -187,29 +187,20 @@ forgetest_ignore!(can_cache_clean_chain_etherscan, |_: TestProject, mut cmd: Tes
 });
 
 // checks that init works
-forgetest!(can_init_repo_with_config, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    let foundry_toml = prj.root().join(Config::FILE_NAME);
-    assert!(!foundry_toml.exists());
+forgetest!(
+    #[serial_test::serial]
+    can_init_repo_with_config,
+    |prj: TestProject, mut cmd: TestCommand| {
+        let foundry_toml = prj.root().join(Config::FILE_NAME);
+        assert!(!foundry_toml.exists());
 
-    cmd.args(["init", "--force"]).arg(prj.root());
-    cmd.assert_non_empty_stdout();
+        cmd.args(["init", "--force"]).arg(prj.root());
+        cmd.assert_non_empty_stdout();
 
-    let file = Config::find_config_file().unwrap();
-    assert_eq!(foundry_toml, file);
-
-    let s = read_string(&file);
-    let _config: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
-
-    // can detect root
-    assert_eq!(prj.root(), forge_utils::find_project_root_path().unwrap());
-    let nested = prj.root().join("nested/nested");
-    pretty_err(&nested, std::fs::create_dir_all(&nested));
-
-    // even if nested
-    cmd.set_current_dir(&nested);
-    assert_eq!(prj.root(), forge_utils::find_project_root_path().unwrap());
-});
+        let s = read_string(&foundry_toml);
+        let _config: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
+    }
+);
 
 // checks that init works repeatedly
 forgetest!(can_init_repo_repeatedly_with_force, |prj: TestProject, mut cmd: TestCommand| {
@@ -325,74 +316,83 @@ forgetest!(can_clean_hardhat, PathStyle::HardHat, |prj: TestProject, mut cmd: Te
 });
 
 // checks that `clean` also works with the "out" value set in Config
-forgetest_init!(can_clean_config, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    let config = Config { out: "custom-out".into(), ..Default::default() };
-    prj.write_config(config);
-    cmd.arg("build");
-    cmd.assert_non_empty_stdout();
+forgetest_init!(
+    #[serial_test::serial]
+    can_clean_config,
+    |prj: TestProject, mut cmd: TestCommand| {
+        let config = Config { out: "custom-out".into(), ..Default::default() };
+        prj.write_config(config);
+        cmd.arg("build");
+        cmd.assert_non_empty_stdout();
 
-    // default test contract is written in custom out directory
-    let artifact = prj.root().join("custom-out/Contract.t.sol/ContractTest.json");
-    assert!(artifact.exists());
+        // default test contract is written in custom out directory
+        let artifact = prj.root().join("custom-out/Contract.t.sol/ContractTest.json");
+        assert!(artifact.exists());
 
-    cmd.forge_fuse().arg("clean");
-    cmd.output();
-    assert!(!artifact.exists());
-});
-
-// checks that extra output works
-forgetest_init!(can_emit_extra_output, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    cmd.args(["build", "--extra-output", "metadata"]);
-    cmd.assert_non_empty_stdout();
-
-    let artifact_path = prj.paths().artifacts.join("Contract.sol/Contract.json");
-    let artifact: ConfigurableContractArtifact =
-        ethers::solc::utils::read_json_file(artifact_path).unwrap();
-    assert!(artifact.metadata.is_some());
-
-    cmd.forge_fuse().args(["build", "--extra-output-files", "metadata", "--force"]).root_arg();
-    cmd.assert_non_empty_stdout();
-
-    let metadata_path = prj.paths().artifacts.join("Contract.sol/Contract.metadata.json");
-    let _artifact: Metadata = ethers::solc::utils::read_json_file(metadata_path).unwrap();
-});
+        cmd.forge_fuse().arg("clean");
+        cmd.output();
+        assert!(!artifact.exists());
+    }
+);
 
 // checks that extra output works
-forgetest_init!(can_emit_multiple_extra_output, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    cmd.args(["build", "--extra-output", "metadata", "ir-optimized", "--extra-output", "ir"]);
-    cmd.assert_non_empty_stdout();
+forgetest_init!(
+    #[serial_test::serial]
+    can_emit_extra_output,
+    |prj: TestProject, mut cmd: TestCommand| {
+        cmd.args(["build", "--extra-output", "metadata"]);
+        cmd.assert_non_empty_stdout();
 
-    let artifact_path = prj.paths().artifacts.join("Contract.sol/Contract.json");
-    let artifact: ConfigurableContractArtifact =
-        ethers::solc::utils::read_json_file(artifact_path).unwrap();
-    assert!(artifact.metadata.is_some());
-    assert!(artifact.ir.is_some());
-    assert!(artifact.ir_optimized.is_some());
+        let artifact_path = prj.paths().artifacts.join("Contract.sol/Contract.json");
+        let artifact: ConfigurableContractArtifact =
+            ethers::solc::utils::read_json_file(artifact_path).unwrap();
+        assert!(artifact.metadata.is_some());
 
-    cmd.forge_fuse()
-        .args([
-            "build",
-            "--extra-output-files",
-            "metadata",
-            "ir-optimized",
-            "evm.bytecode.sourceMap",
-            "--force",
-        ])
-        .root_arg();
-    cmd.assert_non_empty_stdout();
+        cmd.forge_fuse().args(["build", "--extra-output-files", "metadata", "--force"]).root_arg();
+        cmd.assert_non_empty_stdout();
 
-    let metadata_path = prj.paths().artifacts.join("Contract.sol/Contract.metadata.json");
-    let _artifact: Metadata = ethers::solc::utils::read_json_file(metadata_path).unwrap();
+        let metadata_path = prj.paths().artifacts.join("Contract.sol/Contract.metadata.json");
+        let _artifact: Metadata = ethers::solc::utils::read_json_file(metadata_path).unwrap();
+    }
+);
 
-    let iropt = prj.paths().artifacts.join("Contract.sol/Contract.iropt");
-    std::fs::read_to_string(iropt).unwrap();
+// checks that extra output works
+forgetest_init!(
+    #[serial_test::serial]
+    can_emit_multiple_extra_output,
+    |prj: TestProject, mut cmd: TestCommand| {
+        cmd.args(["build", "--extra-output", "metadata", "ir-optimized", "--extra-output", "ir"]);
+        cmd.assert_non_empty_stdout();
 
-    let sourcemap = prj.paths().artifacts.join("Contract.sol/Contract.sourcemap");
-    std::fs::read_to_string(sourcemap).unwrap();
-});
+        let artifact_path = prj.paths().artifacts.join("Contract.sol/Contract.json");
+        let artifact: ConfigurableContractArtifact =
+            ethers::solc::utils::read_json_file(artifact_path).unwrap();
+        assert!(artifact.metadata.is_some());
+        assert!(artifact.ir.is_some());
+        assert!(artifact.ir_optimized.is_some());
+
+        cmd.forge_fuse()
+            .args([
+                "build",
+                "--extra-output-files",
+                "metadata",
+                "ir-optimized",
+                "evm.bytecode.sourceMap",
+                "--force",
+            ])
+            .root_arg();
+        cmd.assert_non_empty_stdout();
+
+        let metadata_path = prj.paths().artifacts.join("Contract.sol/Contract.metadata.json");
+        let _artifact: Metadata = ethers::solc::utils::read_json_file(metadata_path).unwrap();
+
+        let iropt = prj.paths().artifacts.join("Contract.sol/Contract.iropt");
+        std::fs::read_to_string(iropt).unwrap();
+
+        let sourcemap = prj.paths().artifacts.join("Contract.sol/Contract.sourcemap");
+        std::fs::read_to_string(sourcemap).unwrap();
+    }
+);
 
 forgetest!(can_print_warnings, |prj: TestProject, mut cmd: TestCommand| {
     prj.inner()
@@ -652,14 +652,16 @@ contract Foo {
 });
 
 // test that `forge snapshot` commands work
-forgetest!(can_check_snapshot, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    prj.insert_ds_test();
+forgetest!(
+    #[serial_test::serial]
+    can_check_snapshot,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.insert_ds_test();
 
-    prj.inner()
-        .add_source(
-            "ATest.t.sol",
-            r#"
+        prj.inner()
+            .add_source(
+                "ATest.t.sol",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 import "./test.sol";
@@ -669,18 +671,20 @@ contract ATest is DSTest {
     }
 }
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    cmd.arg("snapshot");
+        cmd.arg("snapshot");
 
-    cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/can_check_snapshot.stdout"),
-    );
+        cmd.unchecked_output().stdout_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/can_check_snapshot.stdout"),
+        );
 
-    cmd.arg("--check");
-    let _ = cmd.output();
-});
+        cmd.arg("--check");
+        let _ = cmd.output();
+    }
+);
 
 // test that `forge build` does not print `(with warnings)` if there arent any
 forgetest!(can_compile_without_warnings, |prj: TestProject, mut cmd: TestCommand| {
@@ -846,147 +850,126 @@ contract CTest is DSTest {
     assert_eq!(cache, cache_after);
 });
 
-forgetest_async!(
-    can_deploy_script_without_lib,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_deploy_script_without_lib, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0, 1])
-            .await
-            .add_sig("BroadcastTestNoLinking", "deployDoesntPanic()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 1), (1, 2)])
-            .await;
-    })
-);
+    tester
+        .load_private_keys(vec![0, 1])
+        .await
+        .add_sig("BroadcastTestNoLinking", "deployDoesntPanic()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 1), (1, 2)])
+        .await;
+});
 
-forgetest_async!(
-    can_deploy_script_with_lib,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0, 1])
-            .await
-            .add_sig("BroadcastTest", "deploy()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 2), (1, 1)])
-            .await;
-    })
-);
+    tester
+        .load_private_keys(vec![0, 1])
+        .await
+        .add_sig("BroadcastTest", "deploy()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 2), (1, 1)])
+        .await;
+});
 
-forgetest_async!(
-    can_resume_script,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_resume_script, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0])
-            .await
-            .add_sig("BroadcastTest", "deploy()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .resume(ScriptOutcome::MissingWallet)
-            // load missing wallet
-            .load_private_keys(vec![1])
-            .await
-            .run(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 2), (1, 1)])
-            .await;
-    })
-);
+    tester
+        .load_private_keys(vec![0])
+        .await
+        .add_sig("BroadcastTest", "deploy()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .resume(ScriptOutcome::MissingWallet)
+        // load missing wallet
+        .load_private_keys(vec![1])
+        .await
+        .run(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 2), (1, 1)])
+        .await;
+});
 
-forgetest_async!(
-    can_deploy_broadcast_wrap,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_deploy_broadcast_wrap, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .add_deployer(2)
-            .load_private_keys(vec![0, 1, 2])
-            .await
-            .add_sig("BroadcastTest", "deployOther()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 4), (1, 4), (2, 1)])
-            .await;
-    })
-);
+    tester
+        .add_deployer(2)
+        .load_private_keys(vec![0, 1, 2])
+        .await
+        .add_sig("BroadcastTest", "deployOther()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 4), (1, 4), (2, 1)])
+        .await;
+});
 
-forgetest_async!(
-    panic_no_deployer_set,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(panic_no_deployer_set, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0, 1])
-            .await
-            .add_sig("BroadcastTest", "deployOther()")
-            .simulate(ScriptOutcome::WarnSpecifyDeployer)
-            .broadcast(ScriptOutcome::MissingSender);
-    })
-);
+    tester
+        .load_private_keys(vec![0, 1])
+        .await
+        .add_sig("BroadcastTest", "deployOther()")
+        .simulate(ScriptOutcome::WarnSpecifyDeployer)
+        .broadcast(ScriptOutcome::MissingSender);
+});
 
-forgetest_async!(
-    can_deploy_no_arg_broadcast,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_deploy_no_arg_broadcast, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .add_deployer(0)
-            .load_private_keys(vec![0])
-            .await
-            .add_sig("BroadcastTest", "deployNoArgs()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 3)])
-            .await;
-    })
-);
+    tester
+        .add_deployer(0)
+        .load_private_keys(vec![0])
+        .await
+        .add_sig("BroadcastTest", "deployNoArgs()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 3)])
+        .await;
+});
 
-forgetest_async!(
-    can_deploy_with_create2,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(can_deploy_with_create2, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        // Prepare CREATE2 Deployer
-        let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
-        let code = hex::decode("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3").expect("Could not decode create2 deployer init_code").into();
-        api.anvil_set_code(addr, code).await.unwrap();
+    // Prepare CREATE2 Deployer
+    let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
+    let code = hex::decode("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3").expect("Could not decode create2 deployer init_code").into();
+    api.anvil_set_code(addr, code).await.unwrap();
 
-        tester
-            .add_deployer(0)
-            .load_private_keys(vec![0])
-            .await
-            .add_sig("BroadcastTestNoLinking", "deployCreate2()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 2)])
-            .await
-            // Running again results in error, since we're repeating the salt passed to CREATE2
-            .run(ScriptOutcome::FailedScript);
-    })
-);
+    tester
+        .add_deployer(0)
+        .load_private_keys(vec![0])
+        .await
+        .add_sig("BroadcastTestNoLinking", "deployCreate2()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 2)])
+        .await
+        // Running again results in error, since we're repeating the salt passed to CREATE2
+        .run(ScriptOutcome::FailedScript);
+});
 
 forgetest_async!(
     can_deploy_100_txes_concurrently,
-    (|prj: TestProject, cmd: TestCommand| async move {
+    |prj: TestProject, cmd: TestCommand| async move {
         let port = next_port();
         spawn(NodeConfig::test().with_port(port)).await;
         let mut tester = ScriptTester::new(cmd, port, prj.root());
@@ -999,12 +982,12 @@ forgetest_async!(
             .broadcast(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment(vec![(0, 100)])
             .await;
-    })
+    }
 );
 
 forgetest_async!(
     can_deploy_mixed_broadcast_modes,
-    (|prj: TestProject, cmd: TestCommand| async move {
+    |prj: TestProject, cmd: TestCommand| async move {
         let port = next_port();
         spawn(NodeConfig::test().with_port(port)).await;
         let mut tester = ScriptTester::new(cmd, port, prj.root());
@@ -1017,38 +1000,32 @@ forgetest_async!(
             .broadcast(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment(vec![(0, 15)])
             .await;
-    })
+    }
 );
 
-forgetest_async!(
-    deploy_with_setup,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(deploy_with_setup, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0])
-            .await
-            .add_sig("BroadcastTestSetup", "run()")
-            .simulate(ScriptOutcome::OkSimulation)
-            .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 6)])
-            .await;
-    })
-);
+    tester
+        .load_private_keys(vec![0])
+        .await
+        .add_sig("BroadcastTestSetup", "run()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(vec![(0, 6)])
+        .await;
+});
 
-forgetest_async!(
-    fail_broadcast_staticcall,
-    (|prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(fail_broadcast_staticcall, |prj: TestProject, cmd: TestCommand| async move {
+    let port = next_port();
+    spawn(NodeConfig::test().with_port(port)).await;
+    let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-        tester
-            .load_private_keys(vec![0])
-            .await
-            .add_sig("BroadcastTestNoLinking", "errorStaticCall()")
-            .simulate(ScriptOutcome::FailedScript);
-    })
-);
+    tester
+        .load_private_keys(vec![0])
+        .await
+        .add_sig("BroadcastTestNoLinking", "errorStaticCall()")
+        .simulate(ScriptOutcome::FailedScript);
+});

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -22,200 +22,224 @@ use std::{fs, path::PathBuf, str::FromStr};
 mod forge_utils;
 
 // tests all config values that are in use
-forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    // explicitly set all values
-    let input = Config {
-        profile: Config::DEFAULT_PROFILE,
-        __root: Default::default(),
-        src: "test-src".into(),
-        test: "test-test".into(),
-        script: "test-script".into(),
-        out: "out-test".into(),
-        libs: vec!["lib-test".into()],
-        cache: true,
-        cache_path: "test-cache".into(),
-        broadcast: "broadcast".into(),
-        force: true,
-        evm_version: EvmVersion::Byzantium,
-        gas_reports: vec!["Contract".to_string()],
-        solc: Some(SolcReq::Local(PathBuf::from("custom-solc"))),
-        auto_detect_solc: false,
-        offline: true,
-        optimizer: false,
-        optimizer_runs: 1000,
-        optimizer_details: Some(OptimizerDetails {
-            yul: Some(false),
-            yul_details: Some(YulDetails { stack_allocation: Some(true), ..Default::default() }),
-            ..Default::default()
-        }),
-        model_checker: None,
-        extra_output: Default::default(),
-        extra_output_files: Default::default(),
-        names: true,
-        sizes: true,
-        test_pattern: None,
-        test_pattern_inverse: None,
-        contract_pattern: None,
-        contract_pattern_inverse: None,
-        path_pattern: None,
-        path_pattern_inverse: None,
-        fuzz_runs: 1000,
-        fuzz_max_local_rejects: 2000,
-        fuzz_max_global_rejects: 100203,
-        ffi: true,
-        sender: "00a329c0648769A73afAc7F9381D08FB43dBEA72".parse().unwrap(),
-        tx_origin: "00a329c0648769A73afAc7F9F81E08FB43dBEA72".parse().unwrap(),
-        initial_balance: U256::from(0xffffffffffffffffffffffffu128),
-        block_number: 10,
-        fork_block_number: Some(200),
-        chain_id: Some(9999.into()),
-        gas_limit: 99_000_000u64.into(),
-        gas_price: Some(999),
-        block_base_fee_per_gas: 10,
-        block_coinbase: Address::random(),
-        block_timestamp: 10,
-        block_difficulty: 10,
-        block_gas_limit: Some(100u64.into()),
-        memory_limit: 2u64.pow(25),
-        eth_rpc_url: Some("localhost".to_string()),
-        etherscan_api_key: None,
-        verbosity: 4,
-        remappings: vec![Remapping::from_str("forge-std=lib/forge-std/").unwrap().into()],
-        libraries: vec![
-            "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6".to_string()
-        ],
-        ignored_error_codes: vec![],
-        via_ir: true,
-        rpc_storage_caching: StorageCachingConfig {
-            chains: CachedChains::None,
-            endpoints: CachedEndpoints::Remote,
-        },
-        no_storage_caching: true,
-        bytecode_hash: Default::default(),
-        revert_strings: Some(RevertStrings::Strip),
-        sparse_mode: true,
-        allow_paths: vec![],
-        __non_exhaustive: (),
-    };
-    prj.write_config(input.clone());
-    let config = cmd.config();
-    assert_eq!(input, config);
-});
+forgetest!(
+    #[serial_test::serial]
+    can_extract_config_values,
+    |prj: TestProject, mut cmd: TestCommand| {
+        // explicitly set all values
+        let input = Config {
+            profile: Config::DEFAULT_PROFILE,
+            __root: Default::default(),
+            src: "test-src".into(),
+            test: "test-test".into(),
+            script: "test-script".into(),
+            out: "out-test".into(),
+            libs: vec!["lib-test".into()],
+            cache: true,
+            cache_path: "test-cache".into(),
+            broadcast: "broadcast".into(),
+            force: true,
+            evm_version: EvmVersion::Byzantium,
+            gas_reports: vec!["Contract".to_string()],
+            solc: Some(SolcReq::Local(PathBuf::from("custom-solc"))),
+            auto_detect_solc: false,
+            offline: true,
+            optimizer: false,
+            optimizer_runs: 1000,
+            optimizer_details: Some(OptimizerDetails {
+                yul: Some(false),
+                yul_details: Some(YulDetails {
+                    stack_allocation: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            model_checker: None,
+            extra_output: Default::default(),
+            extra_output_files: Default::default(),
+            names: true,
+            sizes: true,
+            test_pattern: None,
+            test_pattern_inverse: None,
+            contract_pattern: None,
+            contract_pattern_inverse: None,
+            path_pattern: None,
+            path_pattern_inverse: None,
+            fuzz_runs: 1000,
+            fuzz_max_local_rejects: 2000,
+            fuzz_max_global_rejects: 100203,
+            ffi: true,
+            sender: "00a329c0648769A73afAc7F9381D08FB43dBEA72".parse().unwrap(),
+            tx_origin: "00a329c0648769A73afAc7F9F81E08FB43dBEA72".parse().unwrap(),
+            initial_balance: U256::from(0xffffffffffffffffffffffffu128),
+            block_number: 10,
+            fork_block_number: Some(200),
+            chain_id: Some(9999.into()),
+            gas_limit: 99_000_000u64.into(),
+            gas_price: Some(999),
+            block_base_fee_per_gas: 10,
+            block_coinbase: Address::random(),
+            block_timestamp: 10,
+            block_difficulty: 10,
+            block_gas_limit: Some(100u64.into()),
+            memory_limit: 2u64.pow(25),
+            eth_rpc_url: Some("localhost".to_string()),
+            etherscan_api_key: None,
+            verbosity: 4,
+            remappings: vec![Remapping::from_str("forge-std=lib/forge-std/").unwrap().into()],
+            libraries: vec![
+                "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
+                    .to_string(),
+            ],
+            ignored_error_codes: vec![],
+            via_ir: true,
+            rpc_storage_caching: StorageCachingConfig {
+                chains: CachedChains::None,
+                endpoints: CachedEndpoints::Remote,
+            },
+            no_storage_caching: true,
+            bytecode_hash: Default::default(),
+            revert_strings: Some(RevertStrings::Strip),
+            sparse_mode: true,
+            allow_paths: vec![],
+            __non_exhaustive: (),
+        };
+        prj.write_config(input.clone());
+        let config = cmd.config();
+        assert_eq!(input, config);
+    }
+);
 
 // tests config gets printed to std out
-forgetest!(can_show_config, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.arg("config");
-    cmd.set_current_dir(prj.root());
-    let expected = Config::load().to_string_pretty().unwrap().trim().to_string();
-    assert_eq!(expected, cmd.stdout().trim().to_string());
-});
+forgetest!(
+    #[serial_test::serial]
+    can_show_config,
+    |_prj: TestProject, mut cmd: TestCommand| {
+        cmd.arg("config");
+        let expected = Config::load().to_string_pretty().unwrap().trim().to_string();
+        assert_eq!(expected, cmd.stdout().trim().to_string());
+    }
+);
 
 // checks that config works
 // - foundry.toml is properly generated
 // - paths are resolved properly
 // - config supports overrides from env, and cli
-forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
+forgetest_init!(
+    #[serial_test::serial]
+    can_override_config,
+    |prj: TestProject, mut cmd: TestCommand| {
+        cmd.set_current_dir(prj.root());
+        let foundry_toml = prj.root().join(Config::FILE_NAME);
+        assert!(foundry_toml.exists());
 
-    let foundry_toml = prj.root().join(Config::FILE_NAME);
-    assert!(foundry_toml.exists());
-    let file = Config::find_config_file().unwrap();
-    assert_eq!(foundry_toml, file);
+        let profile = Config::load_with_root(prj.root());
 
-    let config = forge_utils::load_config();
-    let profile = Config::load_with_root(prj.root());
-    assert_eq!(config, profile.clone().sanitized());
+        // ensure remappings contain test
+        assert_eq!(profile.remappings.len(), 2);
+        assert_eq!(
+            "ds-test/=lib/forge-std/lib/ds-test/src/".to_string(),
+            profile.remappings[0].to_string()
+        );
+        // the loaded config has resolved, absolute paths
+        assert_eq!(
+            "ds-test/=lib/forge-std/lib/ds-test/src/",
+            Remapping::from(profile.remappings[0].clone()).to_string()
+        );
 
-    // ensure remappings contain test
-    assert_eq!(profile.remappings.len(), 2);
-    assert_eq!(
-        "ds-test/=lib/forge-std/lib/ds-test/src/".to_string(),
-        profile.remappings[0].to_string()
-    );
-    // the loaded config has resolved, absolute paths
-    assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/src").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
+        cmd.arg("config");
+        let expected = profile.to_string_pretty().unwrap();
+        assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
-    cmd.arg("config");
-    let expected = profile.to_string_pretty().unwrap();
-    assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
+        // remappings work
+        let remappings_txt =
+            prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
+        let config = forge_utils::load_config_with_root(Some(prj.root().into()));
+        assert_eq!(
+            format!(
+                "ds-test/={}/",
+                prj.root().join("lib/forge-std/lib/ds-test/from-file").display()
+            ),
+            Remapping::from(config.remappings[0].clone()).to_string()
+        );
 
-    // remappings work
-    let remappings_txt =
-        prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
-    let config = forge_utils::load_config();
-    assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-file").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
+        // env vars work
+        std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
+        let config = forge_utils::load_config_with_root(Some(prj.root().into()));
+        assert_eq!(
+            format!(
+                "ds-test/={}/",
+                prj.root().join("lib/forge-std/lib/ds-test/from-env").display()
+            ),
+            Remapping::from(config.remappings[0].clone()).to_string()
+        );
 
-    // env vars work
-    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
-    let config = forge_utils::load_config();
-    assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-env").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
+        let config =
+            prj.config_from_output(["--remappings", "ds-test/=lib/forge-std/lib/ds-test/from-cli"]);
+        assert_eq!(
+            format!(
+                "ds-test/={}/",
+                prj.root().join("lib/forge-std/lib/ds-test/from-cli").display()
+            ),
+            Remapping::from(config.remappings[0].clone()).to_string()
+        );
 
-    let config =
-        prj.config_from_output(["--remappings", "ds-test/=lib/forge-std/lib/ds-test/from-cli"]);
-    assert_eq!(
-        format!("ds-test/={}/", prj.root().join("lib/forge-std/lib/ds-test/from-cli").display()),
-        Remapping::from(config.remappings[0].clone()).to_string()
-    );
+        let config = prj.config_from_output(["--remappings", "other-key/=lib/other/"]);
+        assert_eq!(config.remappings.len(), 3);
+        assert_eq!(
+            format!("other-key/={}/", prj.root().join("lib/other").display()),
+            Remapping::from(config.remappings[2].clone()).to_string()
+        );
 
-    let config = prj.config_from_output(["--remappings", "other-key/=lib/other/"]);
-    assert_eq!(config.remappings.len(), 3);
-    assert_eq!(
-        format!("other-key/={}/", prj.root().join("lib/other").display()),
-        Remapping::from(config.remappings[2].clone()).to_string()
-    );
+        std::env::remove_var("DAPP_REMAPPINGS");
+        pretty_err(&remappings_txt, fs::remove_file(&remappings_txt));
 
-    std::env::remove_var("DAPP_REMAPPINGS");
-    pretty_err(&remappings_txt, fs::remove_file(&remappings_txt));
+        cmd.set_cmd(prj.forge_bin()).args(["config", "--basic"]);
+        let expected = profile.into_basic().to_string_pretty().unwrap();
+        pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
+    }
+);
 
-    cmd.set_cmd(prj.forge_bin()).args(["config", "--basic"]);
-    let expected = profile.into_basic().to_string_pretty().unwrap();
-    pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
-});
+forgetest_init!(
+    #[serial_test::serial]
+    can_detect_config_vals,
+    |prj: TestProject, _cmd: TestCommand| {
+        let url = "http://127.0.0.1:8545";
+        let config = prj.config_from_output(["--no-auto-detect", "--rpc-url", url]);
+        assert!(!config.auto_detect_solc);
+        assert_eq!(config.eth_rpc_url, Some(url.to_string()));
 
-forgetest_init!(can_detect_config_vals, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    let url = "http://127.0.0.1:8545";
-    let config = prj.config_from_output(["--no-auto-detect", "--rpc-url", url]);
-    assert!(!config.auto_detect_solc);
-    assert_eq!(config.eth_rpc_url, Some(url.to_string()));
-
-    let mut config = Config::load_with_root(prj.root());
-    config.eth_rpc_url = Some("http://127.0.0.1:8545".to_string());
-    config.auto_detect_solc = false;
-    // write to `foundry.toml`
-    prj.create_file(
-        Config::FILE_NAME,
-        &config.to_string_pretty().unwrap().replace("eth_rpc_url", "eth-rpc-url"),
-    );
-    let config = prj.config_from_output(["--force"]);
-    assert!(!config.auto_detect_solc);
-    assert_eq!(config.eth_rpc_url, Some(url.to_string()));
-});
+        let mut config = Config::load_with_root(prj.root());
+        config.eth_rpc_url = Some("http://127.0.0.1:8545".to_string());
+        config.auto_detect_solc = false;
+        // write to `foundry.toml`
+        prj.create_file(
+            Config::FILE_NAME,
+            &config.to_string_pretty().unwrap().replace("eth_rpc_url", "eth-rpc-url"),
+        );
+        let config = prj.config_from_output(["--force"]);
+        assert!(!config.auto_detect_solc);
+        assert_eq!(config.eth_rpc_url, Some(url.to_string()));
+    }
+);
 
 // checks that `clean` removes dapptools style paths
-forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    let url = "http://127.0.0.1:8545";
-    let config = prj.config_from_output(["--rpc-url", url, "--ffi"]);
-    assert_eq!(config.eth_rpc_url, Some(url.to_string()));
-    assert!(config.ffi);
+forgetest_init!(
+    #[serial_test::serial]
+    can_get_evm_opts,
+    |prj: TestProject, _cmd: TestCommand| {
+        let url = "http://127.0.0.1:8545";
+        let config = prj.config_from_output(["--rpc-url", url, "--ffi"]);
+        assert_eq!(config.eth_rpc_url, Some(url.to_string()));
+        assert!(config.ffi);
 
-    std::env::set_var("FOUNDRY_ETH_RPC_URL", url);
-    let figment = Config::figment_with_root(prj.root()).merge(("debug", false));
-    let evm_opts: EvmOpts = figment.extract().unwrap();
-    assert_eq!(evm_opts.fork_url, Some(url.to_string()));
-    std::env::remove_var("FOUNDRY_ETH_RPC_URL");
-});
+        std::env::set_var("FOUNDRY_ETH_RPC_URL", url);
+        let figment = Config::figment_with_root(prj.root()).merge(("debug", false));
+        let evm_opts: EvmOpts = figment.extract().unwrap();
+        assert_eq!(evm_opts.fork_url, Some(url.to_string()));
+        std::env::remove_var("FOUNDRY_ETH_RPC_URL");
+    }
+);
 
 // checks that we can set various config values
 forgetest_init!(can_set_config_values, |prj: TestProject, _cmd: TestCommand| {
@@ -224,74 +248,82 @@ forgetest_init!(can_set_config_values, |prj: TestProject, _cmd: TestCommand| {
 });
 
 // tests that solc can be explicitly set
-forgetest!(can_set_solc_explicitly, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    prj.inner()
-        .add_source(
-            "Foo",
-            r#"
+forgetest!(
+    #[serial_test::serial]
+    can_set_solc_explicitly,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.inner()
+            .add_source(
+                "Foo",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >0.8.9;
 contract Greeter {}
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    // explicitly set to run with 0.8.10
-    let config = Config { solc: Some("0.8.10".into()), ..Default::default() };
-    prj.write_config(config);
+        // explicitly set to run with 0.8.10
+        let config = Config { solc: Some("0.8.10".into()), ..Default::default() };
+        prj.write_config(config);
 
-    cmd.arg("build");
+        cmd.arg("build");
 
-    assert!(cmd.stdout_lossy().ends_with(
-        "
+        assert!(cmd.stdout_lossy().ends_with(
+            "
 Compiler run successful
 ",
-    ));
-});
+        ));
+    }
+);
 
 // tests that `--use <solc>` works
-forgetest!(can_use_solc, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    prj.inner()
-        .add_source(
-            "Foo",
-            r#"
+forgetest!(
+    #[serial_test::serial]
+    can_use_solc,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.inner()
+            .add_source(
+                "Foo",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.7.0;
 contract Foo {}
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    cmd.args(["build", "--use", "0.7.1"]);
+        cmd.args(["build", "--use", "0.7.1"]);
 
-    let stdout = cmd.stdout_lossy();
-    assert!(stdout.contains("Compiler run successful"));
+        let stdout = cmd.stdout_lossy();
+        assert!(stdout.contains("Compiler run successful"));
 
-    cmd.forge_fuse().args(["build", "--force", "--use", "solc:0.7.1"]).root_arg();
+        cmd.forge_fuse().args(["build", "--force", "--use", "solc:0.7.1"]).root_arg();
 
-    assert!(stdout.contains("Compiler run successful"));
+        assert!(stdout.contains("Compiler run successful"));
 
-    // fails to use solc that does not exist
-    cmd.forge_fuse().args(["build", "--use", "this/solc/does/not/exist"]);
-    assert!(cmd.stderr_lossy().contains("this/solc/does/not/exist does not exist"));
+        // fails to use solc that does not exist
+        cmd.forge_fuse().args(["build", "--use", "this/solc/does/not/exist"]);
+        assert!(cmd.stderr_lossy().contains("this/solc/does/not/exist does not exist"));
 
-    // 0.7.1 was installed in previous step, so we can use the path to this directly
-    let local_solc = ethers::solc::Solc::find_svm_installed_version("0.7.1")
-        .unwrap()
-        .expect("solc 0.7.1 is installed");
-    cmd.forge_fuse().args(["build", "--force", "--use"]).arg(local_solc.solc).root_arg();
-    assert!(stdout.contains("Compiler run successful"));
-});
+        // 0.7.1 was installed in previous step, so we can use the path to this directly
+        let local_solc = ethers::solc::Solc::find_svm_installed_version("0.7.1")
+            .unwrap()
+            .expect("solc 0.7.1 is installed");
+        cmd.forge_fuse().args(["build", "--force", "--use"]).arg(local_solc.solc).root_arg();
+        assert!(stdout.contains("Compiler run successful"));
+    }
+);
 
 // test to ensure yul optimizer can be set as intended
-forgetest!(can_set_yul_optimizer, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    prj.inner()
-        .add_source(
-            "Foo",
-            r#"
+forgetest!(
+    #[serial_test::serial]
+    can_set_yul_optimizer,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.inner()
+            .add_source(
+                "Foo",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 contract Foo {
@@ -302,72 +334,81 @@ contract Foo {
     }
 }
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    cmd.arg("build");
-    cmd.unchecked_output().stderr_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/can_set_yul_optimizer.stderr"),
-    );
+        cmd.arg("build");
+        cmd.unchecked_output().stderr_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/can_set_yul_optimizer.stderr"),
+        );
 
-    // disable yul optimizer explicitly
-    let config = Config {
-        optimizer_details: Some(OptimizerDetails { yul: Some(false), ..Default::default() }),
-        ..Default::default()
-    };
-    prj.write_config(config);
+        // disable yul optimizer explicitly
+        let config = Config {
+            optimizer_details: Some(OptimizerDetails { yul: Some(false), ..Default::default() }),
+            ..Default::default()
+        };
+        prj.write_config(config);
 
-    assert!(cmd.stdout_lossy().ends_with(
-        "
+        assert!(cmd.stdout_lossy().ends_with(
+            "
 Compiler run successful
 ",
-    ));
-});
+        ));
+    }
+);
 
 // tests that the lib triple can be parsed
-forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    cmd.set_env(
-        "DAPP_LIBRARIES",
-        "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
-    );
-    let config = cmd.config();
-    assert_eq!(
-        config.libraries,
-        vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6".to_string(),]
-    );
-});
+forgetest_init!(
+    #[serial_test::serial]
+    can_parse_dapp_libraries,
+    |_prj: TestProject, mut cmd: TestCommand| {
+        cmd.set_env(
+            "DAPP_LIBRARIES",
+            "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
+        );
+        let config = cmd.config();
+        assert_eq!(
+            config.libraries,
+            vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
+                .to_string(),]
+        );
+    }
+);
 
 // test that optimizer runs works
-forgetest!(can_set_optimizer_runs, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
+forgetest!(
+    #[serial_test::serial]
+    can_set_optimizer_runs,
+    |prj: TestProject, mut cmd: TestCommand| {
+        // explicitly set optimizer runs
+        let config = Config { optimizer_runs: 1337, ..Default::default() };
+        prj.write_config(config);
 
-    // explicitly set optimizer runs
-    let config = Config { optimizer_runs: 1337, ..Default::default() };
-    prj.write_config(config);
+        let config = cmd.config();
+        assert_eq!(config.optimizer_runs, 1337);
 
-    let config = cmd.config();
-    assert_eq!(config.optimizer_runs, 1337);
-
-    let config = prj.config_from_output(["--optimizer-runs", "300"]);
-    assert_eq!(config.optimizer_runs, 300);
-});
+        let config = prj.config_from_output(["--optimizer-runs", "300"]);
+        assert_eq!(config.optimizer_runs, 300);
+    }
+);
 
 // test that gas_price can be set
-forgetest!(can_set_gas_price, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
+forgetest!(
+    #[serial_test::serial]
+    can_set_gas_price,
+    |prj: TestProject, mut cmd: TestCommand| {
+        // explicitly set gas_price
+        let config = Config { gas_price: Some(1337), ..Default::default() };
+        prj.write_config(config);
 
-    // explicitly set gas_price
-    let config = Config { gas_price: Some(1337), ..Default::default() };
-    prj.write_config(config);
+        let config = cmd.config();
+        assert_eq!(config.gas_price, Some(1337));
 
-    let config = cmd.config();
-    assert_eq!(config.gas_price, Some(1337));
-
-    let config = prj.config_from_output(["--gas-price", "300"]);
-    assert_eq!(config.gas_price, Some(300));
-});
+        let config = prj.config_from_output(["--gas-price", "300"]);
+        assert_eq!(config.gas_price, Some(300));
+    }
+);
 
 // test that optimizer runs works
 forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCommand| {
@@ -442,51 +483,59 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
 
 // test remappings with closer paths are prioritised
 // so that `dep/=lib/a/src` will take precedent over  `dep/=lib/a/lib/b/src`
-forgetest_init!(can_prioritise_closer_lib_remappings, |prj: TestProject, mut cmd: TestCommand| {
-    let config = cmd.config();
+forgetest_init!(
+    #[serial_test::serial]
+    can_prioritise_closer_lib_remappings,
+    |prj: TestProject, mut cmd: TestCommand| {
+        let config = cmd.config();
 
-    // create a new lib directly in the `lib` folder with conflicting remapping `forge-std/`
-    let mut config = config.clone();
-    config.remappings = vec![Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap().into()];
-    let nested = prj.paths().libraries[0].join("dep1");
-    pretty_err(&nested, fs::create_dir_all(&nested));
-    let toml_file = nested.join("foundry.toml");
-    pretty_err(&toml_file, fs::write(&toml_file, config.to_string_pretty().unwrap()));
+        // create a new lib directly in the `lib` folder with conflicting remapping `forge-std/`
+        let mut config = config.clone();
+        config.remappings =
+            vec![Remapping::from_str("forge-std/=lib/forge-std/src/").unwrap().into()];
+        let nested = prj.paths().libraries[0].join("dep1");
+        pretty_err(&nested, fs::create_dir_all(&nested));
+        let toml_file = nested.join("foundry.toml");
+        pretty_err(&toml_file, fs::write(&toml_file, config.to_string_pretty().unwrap()));
 
-    let config = cmd.config();
-    let remappings = config.get_all_remappings();
-    pretty_assertions::assert_eq!(
-        remappings,
-        vec![
-            "dep1/=lib/dep1/src/".parse().unwrap(),
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-            "forge-std/=lib/forge-std/src/".parse().unwrap(),
-            "src/=src/".parse().unwrap()
-        ]
-    );
-});
+        let config = cmd.config();
+        let remappings = config.get_all_remappings();
+        pretty_assertions::assert_eq!(
+            remappings,
+            vec![
+                "dep1/=lib/dep1/src/".parse().unwrap(),
+                "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
+                "forge-std/=lib/forge-std/src/".parse().unwrap(),
+                "src/=src/".parse().unwrap()
+            ]
+        );
+    }
+);
 
 // test to check that foundry.toml libs section updates on install
-forgetest!(can_update_libs_section, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    cmd.git_init();
+forgetest!(
+    #[serial_test::serial]
+    can_update_libs_section,
+    |prj: TestProject, mut cmd: TestCommand| {
+        cmd.git_init();
 
-    // explicitly set gas_price
-    let init = Config { libs: vec!["node_modules".into()], ..Default::default() };
-    prj.write_config(init.clone());
+        // explicitly set gas_price
+        let init = Config { libs: vec!["node_modules".into()], ..Default::default() };
+        prj.write_config(init.clone());
 
-    cmd.args(["install", "foundry-rs/forge-std", "--no-commit"]);
-    cmd.assert_non_empty_stdout();
+        cmd.args(["install", "foundry-rs/forge-std", "--no-commit"]);
+        cmd.assert_non_empty_stdout();
 
-    let config = cmd.forge_fuse().config();
-    // `lib` was added automatically
-    let expected = vec![PathBuf::from("node_modules"), PathBuf::from("lib")];
-    assert_eq!(config.libs, expected);
+        let config = cmd.forge_fuse().config();
+        // `lib` was added automatically
+        let expected = vec![PathBuf::from("node_modules"), PathBuf::from("lib")];
+        assert_eq!(config.libs, expected);
 
-    // additional install don't edit `libs`
-    cmd.forge_fuse().args(["install", "dapphub/ds-test", "--no-commit"]);
-    cmd.assert_non_empty_stdout();
+        // additional install don't edit `libs`
+        cmd.forge_fuse().args(["install", "dapphub/ds-test", "--no-commit"]);
+        cmd.assert_non_empty_stdout();
 
-    let config = cmd.forge_fuse().config();
-    assert_eq!(config.libs, expected);
-});
+        let config = cmd.forge_fuse().config();
+        assert_eq!(config.libs, expected);
+    }
+);

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -12,67 +12,79 @@ use std::{path::PathBuf, str::FromStr};
 mod forge_utils;
 
 // tests that test filters are handled correctly
-forgetest!(can_set_filter_values, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
+forgetest!(
+    #[serial_test::serial]
+    can_set_filter_values,
+    |prj: TestProject, mut cmd: TestCommand| {
+        let patt = regex::Regex::new("test*").unwrap();
+        let glob = globset::Glob::from_str("foo/bar/baz*").unwrap();
 
-    let patt = regex::Regex::new("test*").unwrap();
-    let glob = globset::Glob::from_str("foo/bar/baz*").unwrap();
+        // explicitly set patterns
+        let config = Config {
+            test_pattern: Some(patt.clone().into()),
+            test_pattern_inverse: None,
+            contract_pattern: Some(patt.clone().into()),
+            contract_pattern_inverse: None,
+            path_pattern: Some(glob.clone()),
+            path_pattern_inverse: None,
+            ..Default::default()
+        };
+        prj.write_config(config);
 
-    // explicitly set patterns
-    let config = Config {
-        test_pattern: Some(patt.clone().into()),
-        test_pattern_inverse: None,
-        contract_pattern: Some(patt.clone().into()),
-        contract_pattern_inverse: None,
-        path_pattern: Some(glob.clone()),
-        path_pattern_inverse: None,
-        ..Default::default()
-    };
-    prj.write_config(config);
+        let config = cmd.config();
 
-    let config = cmd.config();
-
-    assert_eq!(config.test_pattern.unwrap().as_str(), patt.as_str());
-    assert_eq!(config.test_pattern_inverse, None);
-    assert_eq!(config.contract_pattern.unwrap().as_str(), patt.as_str());
-    assert_eq!(config.contract_pattern_inverse, None);
-    assert_eq!(config.path_pattern.unwrap(), glob);
-    assert_eq!(config.path_pattern_inverse, None);
-});
+        assert_eq!(config.test_pattern.unwrap().as_str(), patt.as_str());
+        assert_eq!(config.test_pattern_inverse, None);
+        assert_eq!(config.contract_pattern.unwrap().as_str(), patt.as_str());
+        assert_eq!(config.contract_pattern_inverse, None);
+        assert_eq!(config.path_pattern.unwrap(), glob);
+        assert_eq!(config.path_pattern_inverse, None);
+    }
+);
 
 // tests that warning is displayed when there are no tests in project
-forgetest!(warn_no_tests, |prj: TestProject, mut cmd: TestCommand| {
-    // set up command
-    cmd.set_current_dir(prj.root());
-    cmd.args(["test"]);
+forgetest!(
+    #[serial_test::serial]
+    warn_no_tests,
+    |_prj: TestProject, mut cmd: TestCommand| {
+        // set up command
+        cmd.args(["test"]);
 
-    // run command and assert
-    cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/warn_no_tests.stdout"),
-    );
-});
+        // run command and assert
+        cmd.unchecked_output().stdout_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/warn_no_tests.stdout"),
+        );
+    }
+);
 
 // tests that warning is displayed with pattern when no tests match
-forgetest!(warn_no_tests_match, |prj: TestProject, mut cmd: TestCommand| {
-    // set up command
-    cmd.set_current_dir(prj.root());
-    cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
-    cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
-    cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
+forgetest!(
+    #[serial_test::serial]
+    warn_no_tests_match,
+    |_prj: TestProject, mut cmd: TestCommand| {
+        // set up command
+        cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
+        cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
+        cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
-    // run command and assert
-    cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/warn_no_tests_match.stdout"),
-    );
-});
+        // run command and assert
+        cmd.unchecked_output().stdout_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/warn_no_tests_match.stdout"),
+        );
+    }
+);
 
 // tests that suggestion is provided with pattern when no tests match
-forgetest!(suggest_when_no_tests_match, |prj: TestProject, mut cmd: TestCommand| {
-    // set up project
-    prj.inner()
-        .add_source(
-            "TestE.t.sol",
-            r#"
+forgetest!(
+    #[serial_test::serial]
+    suggest_when_no_tests_match,
+    |prj: TestProject, mut cmd: TestCommand| {
+        // set up project
+        prj.inner()
+            .add_source(
+                "TestE.t.sol",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 
@@ -81,21 +93,21 @@ contract TestC {
     }
 }
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    // set up command
-    cmd.set_current_dir(prj.root());
-    cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
-    cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
-    cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
+        // set up command
+        cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
+        cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
+        cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
-    // run command and assert
-    cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/suggest_when_no_tests_match.stdout"),
-    );
-});
+        // run command and assert
+        cmd.unchecked_output().stdout_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/suggest_when_no_tests_match.stdout"),
+        );
+    }
+);
 
 // tests that direct import paths are handled correctly
 forgetest!(can_fuzz_array_params, |prj: TestProject, mut cmd: TestCommand| {
@@ -187,20 +199,22 @@ contract FailTest is DSTest {
 });
 
 // tests that `forge test` will pick up tests that are stored in the `test = <path>` config value
-forgetest!(can_run_test_in_custom_test_folder, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.set_current_dir(prj.root());
-    prj.insert_ds_test();
+forgetest!(
+    #[serial_test::serial]
+    can_run_test_in_custom_test_folder,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.insert_ds_test();
 
-    // explicitly set the test folder
-    let config = Config { test: "nested/forge-tests".into(), ..Default::default() };
-    prj.write_config(config);
-    let config = cmd.config();
-    assert_eq!(config.test, PathBuf::from("nested/forge-tests"));
+        // explicitly set the test folder
+        let config = Config { test: "nested/forge-tests".into(), ..Default::default() };
+        prj.write_config(config);
+        let config = cmd.config();
+        assert_eq!(config.test, PathBuf::from("nested/forge-tests"));
 
-    prj.inner()
-        .add_source(
-            "nested/forge-tests/MyTest.t.sol",
-            r#"
+        prj.inner()
+            .add_source(
+                "nested/forge-tests/MyTest.t.sol",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 import "../../test.sol";
@@ -210,15 +224,16 @@ contract MyTest is DSTest {
     }
 }
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    cmd.arg("test");
-    cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/can_run_test_in_custom_test_folder.stdout"),
-    );
-});
+        cmd.arg("test");
+        cmd.unchecked_output().stdout_matches_path(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/can_run_test_in_custom_test_folder.stdout"),
+        );
+    }
+);
 
 // checks that forge test repeatedly produces the same output
 forgetest_init!(can_test_repeatedly, |_prj: TestProject, mut cmd: TestCommand| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
prevent flakes related to Config/current dir manipulation 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use `serial_test` instead of locking current dir by extending all `test!` macros

if this turns out to be stable we can try to phase out more tests that are currently run with `serial_test`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
