### PR TITLE
fix(anvil): only include historic logs if from field set

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1087,8 +1087,13 @@ impl EthApi {
     /// Handler for ETH RPC call: `eth_newFilter`
     pub async fn new_filter(&self, filter: Filter) -> Result<String> {
         node_info!("eth_newFilter");
-        // all logs that are already available that match the filter
-        let historic = self.backend.logs(filter.clone()).await?;
+        // all logs that are already available that match the filter if the filter's block range is
+        // in the past
+        let historic = if filter.from_block.is_some() {
+            self.backend.logs(filter.clone()).await?
+        } else {
+            vec![]
+        };
         let filter = EthFilter::Logs(Box::new(LogsFilter {
             blocks: self.new_block_notifications(),
             storage: self.storage_info(),

--- a/anvil/tests/it/logs.rs
+++ b/anvil/tests/it/logs.rs
@@ -7,6 +7,7 @@ use ethers::{
     prelude::{BlockNumber, Filter, FilterKind, Middleware, Signer, H256},
     types::Log,
 };
+use futures::StreamExt;
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -123,4 +124,52 @@ async fn can_install_filter() {
         .unwrap();
 
     assert_eq!(all_logs.len(), num_logs + 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watch_events() {
+    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let wallet = handle.dev_wallets().next().unwrap();
+    let client = Arc::new(SignerMiddleware::new(handle.http_provider(), wallet));
+
+    let contract = SimpleStorage::deploy(Arc::clone(&client), "initial value".to_string())
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    // We spawn the event listener:
+    let event = contract.event::<ValueChanged>();
+    let mut stream = event.stream().await.unwrap();
+
+    // Also set up a subscription for the same thing
+    let ws = Arc::new(handle.ws_provider().await);
+    let contract2 = SimpleStorage::new(contract.address(), ws);
+    let event2 = contract2.event::<ValueChanged>();
+    let mut subscription = event2.subscribe().await.unwrap();
+
+    let mut subscription_meta = event2.subscribe().await.unwrap().with_meta();
+
+    let num_calls = 3u64;
+
+    // and we make a few calls
+    let num = client.get_block_number().await.unwrap();
+    for i in 0..num_calls {
+        let call = contract.method::<_, H256>("setValue", i.to_string()).unwrap().legacy();
+        let pending_tx = call.send().await.unwrap();
+        let _receipt = pending_tx.await.unwrap();
+    }
+
+    for i in 0..num_calls {
+        // unwrap the option of the stream, then unwrap the decoding result
+        let log = stream.next().await.unwrap().unwrap();
+        let log2 = subscription.next().await.unwrap().unwrap();
+        let (log3, meta) = subscription_meta.next().await.unwrap().unwrap();
+        assert_eq!(log.new_value, log3.new_value);
+        assert_eq!(log.new_value, log2.new_value);
+        assert_eq!(log.new_value, i.to_string());
+        assert_eq!(meta.block_number, num + i + 1);
+        let hash = client.get_block(num + i + 1).await.unwrap().unwrap().hash.unwrap();
+        assert_eq!(meta.block_hash, hash);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
failing ethers-rs test highlighted an issue with `eth_newFilter` and historic logs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* port ethers-rs test
* only include historic logs if from_field set
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
