### PR TITLE
fix(anvil): use base fee of fork by default

### DIFF
--- a/anvil/src/eth/fees.rs
+++ b/anvil/src/eth/fees.rs
@@ -22,6 +22,9 @@ pub const MAX_FEE_HISTORY_CACHE_SIZE: u64 = 2048u64;
 /// Initial base fee for EIP-1559 blocks.
 pub const INITIAL_BASE_FEE: u64 = 1_000_000_000;
 
+/// Initial default gas price for the first block
+pub const INITIAL_GAS_PRICE: u64 = 1_875_000_000;
+
 /// Bounds the amount the base fee can change between blocks.
 pub const BASE_FEE_CHANGE_DENOMINATOR: u64 = 8;
 

--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -229,7 +229,7 @@ impl NodeHandle {
 
     /// Default gas price for all txs
     pub fn gas_price(&self) -> U256 {
-        self.config.gas_price
+        self.config.get_gas_price()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1863

* use last base fee and current gas price retrieved from the endpoint
* adjust default gas price settings to match hh instead of ganache

needs follow-up to change the `eth_gasPrice` endpoint to match: https://github.com/ethereum/pm/issues/328#issuecomment-853612573

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use the base fee of the last fork block by default if not provided via cli
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
