### PR TITLE
chore(cast): add error message for unknown chains

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -178,7 +178,10 @@ async fn main() -> eyre::Result<()> {
             )?;
 
             let chain_id = Cast::new(&provider).chain_id().await?;
-            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
+            let chain = Chain::try_from(chain_id.as_u64()).wrap_err(format!(
+                "Unknown chain detected: chain-id={}\nPlease report this as a bug: https://github.com/foundry-rs/foundry/issues/new?assignees=&labels=T-bug&template=BUG-FORM.yml",
+                chain_id.as_u64()
+            ))?;
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, chain, false).await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/1866
treat unknown chains as hard error and show message so we can get them supported
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain)` is redundant and will always cause issues if `Chain::try_from(chain_id.as_u64())` fails because the tx's chain id won't match the network
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
