### PR TITLE
forge: add script/ to project paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.3"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.3"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.3"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1560,10 +1560,9 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "ethers-core",
- "ethers-solc",
  "reqwest",
  "semver",
  "serde",
@@ -1576,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1600,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1635,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.2"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1658,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#00b38c437a7cae6fbe9f846ffbb12a03fbed0df5"
+source = "git+https://github.com/gakonst/ethers-rs#c7a8a1ea5a896d0f93f2693cc13d64262549951c"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -4719,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/assets/ContractTemplate.s.sol
+++ b/cli/assets/ContractTemplate.s.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+import {Contract} from "src/Contract.sol";
+
+contract ContractScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        vm.broadcast();
+        new Contract();
+    }
+}

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -296,7 +296,7 @@ impl BuildArgs {
         // use the path arguments or if none where provided the `src` dir
         self.watch.watchexec_config(|| {
             let config = Config::from(self);
-            vec![config.src, config.test]
+            vec![config.src, config.test, config.script]
         })
     }
 }

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -102,12 +102,18 @@ impl Cmd for InitArgs {
             let test = root.join("test");
             std::fs::create_dir_all(&test)?;
 
+            let script = root.join("script");
+            std::fs::create_dir_all(&script)?;
+
             // write the contract file
             let contract_path = src.join("Contract.sol");
             std::fs::write(contract_path, include_str!("../../../assets/ContractTemplate.sol"))?;
             // write the tests
             let contract_path = test.join("Contract.t.sol");
             std::fs::write(contract_path, include_str!("../../../assets/ContractTemplate.t.sol"))?;
+            // write the script
+            let contract_path = script.join("Contract.s.sol");
+            std::fs::write(contract_path, include_str!("../../../assets/ContractTemplate.s.sol"))?;
 
             let dest = root.join(Config::FILE_NAME);
             if !dest.exists() {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -583,6 +583,7 @@ impl Config {
             .cache(&self.cache_path.join(SOLIDITY_FILES_CACHE_FILENAME))
             .sources(&self.src)
             .tests(&self.test)
+            .scripts(&self.script)
             .artifacts(&self.out)
             .libs(self.libs.clone())
             .remappings(self.get_all_remappings())

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -416,6 +416,7 @@ impl Config {
 
         self.src = p(&root, &self.src);
         self.test = p(&root, &self.test);
+        self.script = p(&root, &self.script);
         self.out = p(&root, &self.out);
 
         self.libs = self.libs.into_iter().map(|lib| p(&root, &lib)).collect();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Pending / Ref: https://github.com/gakonst/ethers-rs/pull/1359
```
Currently, our convention on foundry is to have scripts in the script/ folder. 
However, the folder does not actually belong to the project. It may lead to weird issues, 
if there's contracts declared inside when verifying contracts.

Alternatively, we could also add a more generic additional_sources where by default we add the script/ folder.
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
