### PR TITLE
anvil: add `net_listening` call for usage with `Remix`

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -38,6 +38,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_networkId", alias = "net_version", with = "empty_params")]
     EthNetworkId(()),
 
+    #[serde(rename = "net_listening", with = "empty_params")]
+    NetListening(()),
+
     #[serde(rename = "eth_gasPrice", with = "empty_params")]
     EthGasPrice(()),
 
@@ -494,6 +497,13 @@ mod tests {
     #[test]
     fn test_eth_chain_id() {
         let s = r#"{"method": "eth_chainId", "params":[]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_net_listening() {
+        let s = r#"{"method": "net_listening", "params":[]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -70,7 +70,7 @@ pub struct EthApi {
     pool: Arc<Pool>,
     /// Holds all blockchain related data
     /// In-Memory only for now
-    backend: Arc<backend::mem::Backend>, 
+    backend: Arc<backend::mem::Backend>,
     /// Whether this node is mining
     is_mining: bool,
     /// available signers
@@ -375,7 +375,7 @@ impl EthApi {
         node_info!("eth_networkId");
         Ok(Some(self.backend.chain_id().as_u64().into()))
     }
-    
+
     /// Returns true if client is actively listening for network connections.
     ///
     /// Handler for ETH RPC call: `net_listening`

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -70,7 +70,7 @@ pub struct EthApi {
     pool: Arc<Pool>,
     /// Holds all blockchain related data
     /// In-Memory only for now
-    backend: Arc<backend::mem::Backend>,
+    backend: Arc<backend::mem::Backend>, 
     /// Whether this node is mining
     is_mining: bool,
     /// available signers
@@ -90,6 +90,8 @@ pub struct EthApi {
     filters: Filters,
     /// How transactions are ordered in the pool
     transaction_order: Arc<RwLock<TransactionOrder>>,
+    /// Whether we're listening for RPC calls
+    net_listening: bool,
 }
 
 // === impl Eth RPC API ===
@@ -118,6 +120,7 @@ impl EthApi {
             miner,
             logger,
             filters,
+            net_listening: true,
             transaction_order: Arc::new(RwLock::new(transactions_order)),
         }
     }
@@ -139,6 +142,7 @@ impl EthApi {
             }
             EthRequest::EthChainId(_) => self.eth_chain_id().to_rpc_result(),
             EthRequest::EthNetworkId(_) => self.network_id().to_rpc_result(),
+            EthRequest::NetListening(_) => self.net_listening().to_rpc_result(),
             EthRequest::EthGasPrice(_) => self.gas_price().to_rpc_result(),
             EthRequest::EthAccounts(_) => self.accounts().to_rpc_result(),
             EthRequest::EthBlockNumber(_) => self.block_number().to_rpc_result(),
@@ -370,6 +374,14 @@ impl EthApi {
     pub fn network_id(&self) -> Result<Option<U64>> {
         node_info!("eth_networkId");
         Ok(Some(self.backend.chain_id().as_u64().into()))
+    }
+    
+    /// Returns true if client is actively listening for network connections.
+    ///
+    /// Handler for ETH RPC call: `net_listening`
+    pub fn net_listening(&self) -> Result<bool> {
+        node_info!("net_listening");
+        Ok(self.net_listening)
     }
 
     /// Returns the current gas price


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Anvil is unable to handle`net_listening` calls, which is used by Remix, hence why Anvil is currently not compatible with Remix. 
```
{"method":"net_listening","params":[],"id":43,"jsonrpc":"2.0"}
```

Returns:

```
{"jsonrpc":"2.0","id":43,"error":{"code":-32601,"message":"Method not found"}}

```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR adds a `net_listening` method, which returns true if Anvil is listening, and false if not.  


```
net_listening

Returns true if client is actively listening for network connections.
Returns

Promise<boolean> : true when listening, otherwise false.
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
I've used a similar implementation to `is_mining`, aka return True, else False, so this lacks tokio tests. 

Remix now works when selecting Ganache/Hardhat as Environment for Remix.
 
P.S: I'll also push a PR to Remix in a bit to add Anvil properly on their end 