### PR TITLE
feat(fmt): Expression multiline formatting

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -787,22 +787,17 @@ impl<'a, W: Write> Formatter<'a, W> {
         let comments = self.comments.clone();
 
         let mut should_commit = false;
-        let res = self.with_temp_buf(|fmt| {
+        let buf = self.with_temp_buf(|fmt| {
             should_commit = fun(fmt)?;
             Ok(())
-        });
+        })?;
 
-        match res {
-            Ok(buf) => {
-                if should_commit {
-                    write_chunk!(self, "{}", buf.w)?;
-                    Ok(true)
-                } else {
-                    self.comments = comments;
-                    Ok(false)
-                }
-            }
-            Err(err) => Err(err),
+        if should_commit {
+            write_chunk!(self, "{}", buf.w)?;
+            Ok(true)
+        } else {
+            self.comments = comments;
+            Ok(false)
         }
     }
 

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -110,7 +110,7 @@ impl<W: Sized> FormatBuffer<W> {
 
     fn create_temp_buf(&self) -> FormatBuffer<String> {
         let mut new = FormatBuffer::new(String::new(), self.tab_width);
-        new.base_indent_len = self.level() * self.tab_width;
+        new.base_indent_len = self.current_indent_len();
         new.last_indent = " ".repeat(self.last_indent_len().saturating_sub(new.base_indent_len));
         new.current_line_len = self.current_line_len();
         new.restrict_to_single_line = self.restrict_to_single_line;
@@ -147,6 +147,10 @@ impl<W: Sized> FormatBuffer<W> {
         self.last_indent.len() + self.base_indent_len
     }
 
+    fn current_indent_len(&self) -> usize {
+        self.level() + self.tab_width
+    }
+
     fn set_current_line_len(&mut self, len: usize) {
         self.current_line_len = len
     }
@@ -181,7 +185,7 @@ impl<W: Write> FormatBuffer<W> {
             // later on
             let line_start = line
                 .char_indices()
-                .take(self.base_indent_len + 1)
+                .take(self.base_indent_len)
                 .take_while(|(_, ch)| ch.is_whitespace())
                 .last()
                 .map(|(idx, _)| idx)
@@ -524,13 +528,18 @@ impl<'a, W: Write> Formatter<'a, W> {
 
     /// Is length of the `text` with respect to already written line <= `config.line_length`
     fn will_it_fit(&self, text: impl AsRef<str>) -> bool {
-        if text.as_ref().contains('\n') {
+        let text = text.as_ref();
+        if text.is_empty() {
+            return true
+        }
+        if text.contains('\n') {
             return false
         }
-        self.config.line_length >
+        let space = if self.next_chunk_needs_space(text.chars().next().unwrap()) { 1 } else { 0 };
+        self.config.line_length >=
             self.last_indent_len()
                 .saturating_add(self.current_line_len())
-                .saturating_add(text.as_ref().len())
+                .saturating_add(text.len() + space)
     }
 
     fn write_chunks_separated<'b>(
@@ -689,7 +698,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         if !content.is_empty() {
             // add whitespace if necessary
             if self.next_chunk_needs_space(content.chars().next().unwrap()) {
-                if self.will_it_fit(format!(" {content}")) {
+                if self.will_it_fit(&content) {
                     write!(self.buf(), " ")?;
                 } else {
                     writeln!(self.buf())?;
@@ -738,7 +747,13 @@ impl<'a, W: Write> Formatter<'a, W> {
                 Ok(None)
             }
             Err(err) => Err(err),
-            Ok(buf) => Ok(Some(buf.w)),
+            Ok(buf) => {
+                if self.will_it_fit(&buf.w) {
+                    Ok(Some(buf.w))
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 
@@ -763,9 +778,37 @@ impl<'a, W: Write> Formatter<'a, W> {
                 }
             }
             Ok(buf) => {
-                write_chunk!(self, "{}", buf.w)?;
-                Ok(true)
+                if self.will_it_fit(&buf.w) {
+                    write_chunk!(self, "{}", buf.w)?;
+                    Ok(true)
+                } else {
+                    self.comments = comments;
+                    Ok(false)
+                }
             }
+        }
+    }
+
+    fn revertible(&mut self, mut fun: impl FnMut(&mut Self) -> Result<bool>) -> Result<bool> {
+        let comments = self.comments.clone();
+
+        let mut should_commit = false;
+        let res = self.with_temp_buf(|fmt| {
+            should_commit = fun(fmt)?;
+            Ok(())
+        });
+
+        match res {
+            Ok(buf) => {
+                if should_commit {
+                    write_chunk!(self, "{}", buf.w)?;
+                    Ok(true)
+                } else {
+                    self.comments = comments;
+                    Ok(false)
+                }
+            }
+            Err(err) => Err(err),
         }
     }
 
@@ -817,15 +860,8 @@ impl<'a, W: Write> Formatter<'a, W> {
     where
         E: Visitable + LineOfCode,
     {
-        let simulated = self.simulate_to_string(|fmt| {
-            fmt.visit_flattened_expr_multiline(flattened, false)?;
-            Ok(())
-        })?;
-        if !self.will_it_fit(simulated) {
-            self.visit_flattened_expr_multiline(flattened, true)?;
-        } else {
-            // TODO we can probably reuse simulated here
-            self.visit_flattened_expr_multiline(flattened, false)?;
+        if !self.try_on_single_line(|fmt| fmt.visit_flattened_expr_multiline(flattened, false))? {
+            self.grouped(|fmt| fmt.visit_flattened_expr_multiline(flattened, true))?;
         }
         Ok(())
     }
@@ -885,8 +921,56 @@ impl<'a, W: Write> Formatter<'a, W> {
         Ok(())
     }
 
-    fn visit_operator_expr(&mut self, expr: &mut Expression) -> Result<()> {
-        self.visit_flattened_expr(&mut expr.flatten())
+    fn visit_assignment(&mut self, expr: &mut Expression) -> Result<()> {
+        use Expression::*;
+
+        if self.try_on_single_line(|fmt| expr.visit(fmt))? {
+            return Ok(())
+        }
+
+        self.write_postfix_comments_before(expr.loc().start())?;
+        self.write_prefix_comments_before(expr.loc().start())?;
+
+        if self.is_beginning_of_line() &&
+            self.try_on_single_line(|fmt| fmt.indented(1, |fmt| expr.visit(fmt)))?
+        {
+            return Ok(())
+        } else {
+            let mut fit_on_next_line = false;
+            self.indented(1, |fmt| {
+                fmt.revertible(|fmt| {
+                    writeln!(fmt.buf())?;
+                    fit_on_next_line = fmt.try_on_single_line(|fmt| expr.visit(fmt))?;
+                    Ok(fit_on_next_line)
+                })?;
+                Ok(())
+            })?;
+            if fit_on_next_line {
+                return Ok(())
+            }
+        }
+
+        let unsplittable = matches!(
+            expr,
+            BoolLiteral(..) |
+                NumberLiteral(..) |
+                RationalNumberLiteral(..) |
+                HexNumberLiteral(..) |
+                StringLiteral(..) |
+                HexLiteral(..) |
+                AddressLiteral(..) |
+                Variable(..) |
+                Unit(..) |
+                This(..)
+        );
+        if unsplittable {
+            self.indented(1, |fmt| expr.visit(fmt))?;
+            return Ok(())
+        }
+
+        expr.visit(self)?;
+
+        Ok(())
     }
 
     fn grouped(&mut self, mut fun: impl FnMut(&mut Self) -> Result<()>) -> Result<()> {
@@ -1328,7 +1412,9 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             Expression::And(..) |
             Expression::Or(..) |
             Expression::Equal(..) |
-            Expression::NotEqual(..) => self.visit_operator_expr(expr)?,
+            Expression::NotEqual(..) => {
+                self.visit_flattened_expr(&mut expr.flatten())?;
+            }
             Expression::Variable(ident) => {
                 ident.visit(self)?;
             }
@@ -1960,20 +2046,21 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             name.content.push_str(" =");
         }
 
+        let mut multiline = false;
         self.indented(1, |fmt| {
-            let multiline = fmt.are_chunks_separated_multiline("{}", &attrs, "")?;
-            fmt.write_chunks_separated(&attrs, "", multiline)?;
-            fmt.write_chunk(&name)?;
+            if !fmt.try_on_single_line(|fmt| fmt.write_chunks_separated(&attrs, "", false))? {
+                multiline = true;
+                fmt.write_chunks_separated(&attrs, "", true)?;
+            }
+            if !fmt.try_on_single_line(|fmt| fmt.write_chunk(&name))? {
+                multiline = true;
+                fmt.write_chunk(&name)?;
+            }
             Ok(())
         })?;
 
         if let Some(init) = &mut var.initializer {
-            // TODO check if this should actually be indented or not. Function calls, member access
-            // and things may not need to be indented
-            self.indented(1, |fmt| {
-                init.visit(fmt)?;
-                Ok(())
-            })?;
+            self.indented_if(multiline, 1, |fmt| fmt.visit_assignment(init))?;
         }
 
         self.write_semicolon()?;

--- a/fmt/src/solang_ext/operator.rs
+++ b/fmt/src/solang_ext/operator.rs
@@ -5,7 +5,7 @@ use super::{LineOfCode, OptionalLineOfCode};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum Precedence {
-    Literal,
+    P00,
     P01,
     P02,
     P03,
@@ -131,7 +131,7 @@ impl Operator for &mut Expression {
             List(..) |
             ArrayLiteral(..) |
             Unit(..) |
-            This(..) => Literal,
+            This(..) => P00,
             ArraySubscript(..) |
             ArraySlice(..) |
             FunctionCall(..) |

--- a/fmt/src/solang_ext/operator.rs
+++ b/fmt/src/solang_ext/operator.rs
@@ -1,5 +1,7 @@
 use solang_parser::pt::*;
 
+use super::{LineOfCode, OptionalLineOfCode};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum Precedence {
@@ -35,15 +37,84 @@ impl Precedence {
     }
 }
 
-pub trait Operator {
+pub enum FlatExpression<Expr> {
+    Expression(Expr),
+    SpacedOp(&'static str),
+    UnspacedOp(&'static str),
+    Group(Vec<FlatExpression<Expr>>),
+}
+
+impl<Expr> OptionalLineOfCode for FlatExpression<Expr>
+where
+    Expr: LineOfCode,
+{
+    fn loc(&self) -> Option<Loc> {
+        match self {
+            Self::Expression(expr) => Some(expr.loc()),
+            Self::SpacedOp(_) | Self::UnspacedOp(_) => None,
+            Self::Group(group) => {
+                let mut locs = group.iter().filter_map(|item| item.loc());
+                let mut first = locs.next()?;
+                let last = locs.last().unwrap_or(first);
+                first.use_end_from(&last);
+                Some(first)
+            }
+        }
+    }
+}
+
+pub trait Operator: Sized {
     fn precedence(&self) -> Precedence;
     fn operator(&self) -> Option<&'static str>;
     fn has_space_around(&self) -> bool;
-    fn left_mut(&mut self) -> Option<&mut Self>;
-    fn right_mut(&mut self) -> Option<&mut Self>;
+    fn into_components(self) -> (Option<Self>, Option<Self>);
+    fn flatten(self) -> Vec<FlatExpression<Self>> {
+        let op = if let Some(op) = self.operator() {
+            op
+        } else {
+            return vec![FlatExpression::Expression(self)]
+        };
+        let mut out = Vec::new();
+        let has_space_around = self.has_space_around();
+        let precedence = self.precedence();
+        let (left, right) = self.into_components();
+
+        if let Some(left) = left {
+            if left.precedence().is_evaluated_first(precedence) {
+                out.append(&mut left.flatten());
+            } else {
+                out.push(FlatExpression::Group(left.flatten()))
+            }
+            out.push(if has_space_around {
+                FlatExpression::SpacedOp(op)
+            } else {
+                FlatExpression::UnspacedOp(op)
+            });
+            if let Some(right) = right {
+                if precedence.is_evaluated_first(right.precedence()) {
+                    out.push(FlatExpression::Group(right.flatten()))
+                } else {
+                    out.append(&mut right.flatten());
+                }
+            }
+        } else if let Some(right) = right {
+            out.push(if has_space_around {
+                FlatExpression::SpacedOp(op)
+            } else {
+                FlatExpression::UnspacedOp(op)
+            });
+            if precedence.is_evaluated_first(right.precedence()) {
+                out.push(FlatExpression::Group(right.flatten()))
+            } else {
+                out.append(&mut right.flatten());
+            }
+        }
+
+        out
+    }
 }
 
-impl Operator for Expression {
+impl Operator for &mut Expression {
     fn precedence(&self) -> Precedence {
         use Expression::*;
         use Precedence::*;
@@ -164,74 +235,10 @@ impl Operator for Expression {
                 UnaryMinus(..)
         )
     }
-    fn left_mut(&mut self) -> Option<&mut Self> {
+    fn into_components(self) -> (Option<Self>, Option<Self>) {
         use Expression::*;
         match self {
-            PostDecrement(_, expr) |
-            PostIncrement(_, expr) |
-            Power(_, expr, _) |
-            Multiply(_, expr, _) |
-            Divide(_, expr, _) |
-            Modulo(_, expr, _) |
-            Add(_, expr, _) |
-            Subtract(_, expr, _) |
-            ShiftLeft(_, expr, _) |
-            ShiftRight(_, expr, _) |
-            BitwiseAnd(_, expr, _) |
-            BitwiseXor(_, expr, _) |
-            BitwiseOr(_, expr, _) |
-            Less(_, expr, _) |
-            More(_, expr, _) |
-            LessEqual(_, expr, _) |
-            MoreEqual(_, expr, _) |
-            Equal(_, expr, _) |
-            NotEqual(_, expr, _) |
-            And(_, expr, _) |
-            Or(_, expr, _) |
-            Assign(_, expr, _) |
-            AssignOr(_, expr, _) |
-            AssignAnd(_, expr, _) |
-            AssignXor(_, expr, _) |
-            AssignShiftLeft(_, expr, _) |
-            AssignShiftRight(_, expr, _) |
-            AssignAdd(_, expr, _) |
-            AssignSubtract(_, expr, _) |
-            AssignMultiply(_, expr, _) |
-            AssignDivide(_, expr, _) |
-            AssignModulo(_, expr, _) => Some(expr.as_mut()),
-            MemberAccess(..) |
-            Not(..) |
-            Complement(..) |
-            Delete(..) |
-            UnaryPlus(..) |
-            UnaryMinus(..) |
-            PreDecrement(..) |
-            New(..) |
-            PreIncrement(..) |
-            Ternary(..) |
-            ArraySubscript(..) |
-            ArraySlice(..) |
-            FunctionCall(..) |
-            FunctionCallBlock(..) |
-            NamedFunctionCall(..) |
-            BoolLiteral(..) |
-            NumberLiteral(..) |
-            RationalNumberLiteral(..) |
-            HexNumberLiteral(..) |
-            StringLiteral(..) |
-            Type(..) |
-            HexLiteral(..) |
-            AddressLiteral(..) |
-            Variable(..) |
-            List(..) |
-            ArrayLiteral(..) |
-            Unit(..) |
-            This(..) => None,
-        }
-    }
-    fn right_mut(&mut self) -> Option<&mut Self> {
-        use Expression::*;
-        match self {
+            PostDecrement(_, expr) | PostIncrement(_, expr) => (Some(expr.as_mut()), None),
             Not(_, expr) |
             Complement(_, expr) |
             New(_, expr) |
@@ -239,40 +246,38 @@ impl Operator for Expression {
             UnaryPlus(_, expr) |
             UnaryMinus(_, expr) |
             PreDecrement(_, expr) |
-            PreIncrement(_, expr) |
-            Power(_, _, expr) |
-            Multiply(_, _, expr) |
-            Divide(_, _, expr) |
-            Modulo(_, _, expr) |
-            Add(_, _, expr) |
-            Subtract(_, _, expr) |
-            ShiftLeft(_, _, expr) |
-            ShiftRight(_, _, expr) |
-            BitwiseAnd(_, _, expr) |
-            BitwiseXor(_, _, expr) |
-            BitwiseOr(_, _, expr) |
-            Less(_, _, expr) |
-            More(_, _, expr) |
-            LessEqual(_, _, expr) |
-            MoreEqual(_, _, expr) |
-            Equal(_, _, expr) |
-            NotEqual(_, _, expr) |
-            And(_, _, expr) |
-            Or(_, _, expr) |
-            Assign(_, _, expr) |
-            AssignOr(_, _, expr) |
-            AssignAnd(_, _, expr) |
-            AssignXor(_, _, expr) |
-            AssignShiftLeft(_, _, expr) |
-            AssignShiftRight(_, _, expr) |
-            AssignAdd(_, _, expr) |
-            AssignSubtract(_, _, expr) |
-            AssignMultiply(_, _, expr) |
-            AssignDivide(_, _, expr) |
-            AssignModulo(_, _, expr) => Some(expr.as_mut()),
+            PreIncrement(_, expr) => (None, Some(expr.as_mut())),
+            Power(_, left, right) |
+            Multiply(_, left, right) |
+            Divide(_, left, right) |
+            Modulo(_, left, right) |
+            Add(_, left, right) |
+            Subtract(_, left, right) |
+            ShiftLeft(_, left, right) |
+            ShiftRight(_, left, right) |
+            BitwiseAnd(_, left, right) |
+            BitwiseXor(_, left, right) |
+            BitwiseOr(_, left, right) |
+            Less(_, left, right) |
+            More(_, left, right) |
+            LessEqual(_, left, right) |
+            MoreEqual(_, left, right) |
+            Equal(_, left, right) |
+            NotEqual(_, left, right) |
+            And(_, left, right) |
+            Or(_, left, right) |
+            Assign(_, left, right) |
+            AssignOr(_, left, right) |
+            AssignAnd(_, left, right) |
+            AssignXor(_, left, right) |
+            AssignShiftLeft(_, left, right) |
+            AssignShiftRight(_, left, right) |
+            AssignAdd(_, left, right) |
+            AssignSubtract(_, left, right) |
+            AssignMultiply(_, left, right) |
+            AssignDivide(_, left, right) |
+            AssignModulo(_, left, right) => (Some(left.as_mut()), Some(right.as_mut())),
             MemberAccess(..) |
-            PostDecrement(..) |
-            PostIncrement(..) |
             Ternary(..) |
             ArraySubscript(..) |
             ArraySlice(..) |
@@ -291,7 +296,7 @@ impl Operator for Expression {
             List(..) |
             ArrayLiteral(..) |
             Unit(..) |
-            This(..) => None,
+            This(..) => (None, None),
         }
     }
 }

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -322,6 +322,18 @@ pub trait Visitable {
         V: Visitor;
 }
 
+impl<T> Visitable for &mut T
+where
+    T: Visitable,
+{
+    fn visit<V>(&mut self, v: &mut V) -> Result<(), V::Error>
+    where
+        V: Visitor,
+    {
+        T::visit(self, v)
+    }
+}
+
 impl Visitable for SourceUnitPart {
     fn visit<V>(&mut self, v: &mut V) -> Result<(), V::Error>
     where

--- a/fmt/testdata/DoWhileStatement/fmt.sol
+++ b/fmt/testdata/DoWhileStatement/fmt.sol
@@ -13,8 +13,10 @@ contract DoWhileStatement {
         do {
             "test";
         } while (
-            someVeryVeryLongCondition && !someVeryVeryLongCondition &&
-            !someVeryVeryLongCondition && someVeryVeryLongCondition
+            someVeryVeryLongCondition
+                && !someVeryVeryLongCondition
+                && !someVeryVeryLongCondition
+                && someVeryVeryLongCondition
         );
     }
 }

--- a/fmt/testdata/ExpressionPrecedence/fmt.sol
+++ b/fmt/testdata/ExpressionPrecedence/fmt.sol
@@ -1,21 +1,13 @@
-uint256 expression = 1 + 2 + 3;
-
-uint256 expression = 1 + (2 + 3);
-
-uint256 expression = 1 * 2 + 3;
-
-uint256 expression = 1 * 2 + 3;
-
-uint256 expression = 1 * (2 + 3);
-
-uint256 expression = 1 + 2 * 3;
-
-uint256 expression = (1 + 2) * 3;
-
-uint256 expression = 1 + 2 * 3;
-
-uint256 expression = 1 ** 2 ** 3;
-
-uint256 expression = 1 ** 2 ** 3;
-
-uint256 expression = (1 ** 2) ** 3;
+function test() {
+    uint256 expr001 = 1 + 2 + 3;
+    uint256 expr002 = 1 + (2 + 3);
+    uint256 expr003 = 1 * 2 + 3;
+    uint256 expr004 = 1 * 2 + 3;
+    uint256 expr005 = 1 * (2 + 3);
+    uint256 expr006 = 1 + 2 * 3;
+    uint256 expr007 = (1 + 2) * 3;
+    uint256 expr008 = 1 + 2 * 3;
+    uint256 expr009 = 1 ** 2 ** 3;
+    uint256 expr010 = 1 ** 2 ** 3;
+    uint256 expr011 = (1 ** 2) ** 3;
+}

--- a/fmt/testdata/ExpressionPrecedence/original.sol
+++ b/fmt/testdata/ExpressionPrecedence/original.sol
@@ -1,11 +1,13 @@
-uint256 expression = (1 + 2) + 3;
-uint256 expression = 1 + (2 + 3);
-uint256 expression = 1 * 2 + 3;
-uint256 expression = (1 * 2) + 3;
-uint256 expression = 1 * (2 + 3);
-uint256 expression = 1 + 2 * 3;
-uint256 expression = (1 + 2) * 3;
-uint256 expression = 1 + (2 * 3);
-uint256 expression = 1 ** 2 ** 3;
-uint256 expression = 1 ** (2 ** 3);
-uint256 expression = (1 ** 2) ** 3;
+function test() {
+    uint256 expr001 = (1 + 2) + 3;
+    uint256 expr002 = 1 + (2 + 3);
+    uint256 expr003 = 1 * 2 + 3;
+    uint256 expr004 = (1 * 2) + 3;
+    uint256 expr005 = 1 * (2 + 3);
+    uint256 expr006 = 1 + 2 * 3;
+    uint256 expr007 = (1 + 2) * 3;
+    uint256 expr008 = 1 + (2 * 3);
+    uint256 expr009 = 1 ** 2 ** 3;
+    uint256 expr010 = 1 ** (2 ** 3);
+    uint256 expr011 = (1 ** 2) ** 3;
+}

--- a/fmt/testdata/VariableDefinition/fmt.sol
+++ b/fmt/testdata/VariableDefinition/fmt.sol
@@ -20,17 +20,17 @@ contract Contract {
         constant
         immutable
         override BYTES =
-        0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+            0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
     bytes32
         private
         constant
         immutable
         override
         BYTES_VERY_VERY_VERY_LONG =
-        0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+            0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
     bytes32 private constant
         BYTES_VERY_VERY_LONG =
-        0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+            0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
 
     uint256 constant POWER_EXPRESSION =
         10 ** 27;

--- a/fmt/testdata/WhileStatement/fmt.sol
+++ b/fmt/testdata/WhileStatement/fmt.sol
@@ -24,8 +24,12 @@ contract WhileStatement {
 
         uint256 someLongVariableName;
         while (
-            someLongVariableName < 10 && someLongVariableName < 11 &&
-            someLongVariableName < 12
+            someLongVariableName
+                < 10
+                && someLongVariableName
+                < 11
+                && someLongVariableName
+                < 12
         ) {
             someLongVariableName++;
         }


### PR DESCRIPTION
## Motivation

We want long same precedence operators to be formatted on separate lines like this

```
epxression1
  + expression2
  + expression3
  + expression4
```

## Solution

Flatten expressions into lists to figure out how to separate lines
