### PR TITLE
forge(fix): dont give out error if artifact has no source on `script`

### DIFF
--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -44,12 +44,15 @@ impl ScriptArgs {
         let mut sources: BTreeMap<u32, String> = BTreeMap::new();
 
         for (id, artifact) in output.into_artifacts() {
-            let source = artifact.source_file().ok_or(eyre::eyre!("Artifact has no source."))?;
-            sources.insert(
-                source.id,
-                source.ast.ok_or(eyre::eyre!("Source from artifact has no AST."))?.absolute_path,
-            );
-
+            if let Some(source) = artifact.source_file() {
+                sources.insert(
+                    source.id,
+                    source
+                        .ast
+                        .ok_or(eyre::eyre!("Source from artifact has no AST."))?
+                        .absolute_path,
+                );
+            }
             contracts.insert(id, artifact.into());
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If the artifact for whatever reason has no source (it should), we don't want to exit, because they're only necessary for the `debugger`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
