### PR TITLE
anvil(fix): include target index in cumulative_gas_used

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1116,7 +1116,7 @@ impl Backend {
         let receipts = self.get_receipts(block.transactions.iter().map(|tx| tx.hash()));
 
         let mut cumulative_gas_used = U256::zero();
-        for receipt in receipts.iter().take(index) {
+        for receipt in receipts.iter().take(index + 1) {
             cumulative_gas_used = cumulative_gas_used.saturating_add(receipt.gas_used());
         }
 


### PR DESCRIPTION
## Motivation

When comparing results from `anvil` with `geth` the `cumulative_gas_used` differs. 

## Solution

The gas of the queried transaction should be included in `cumulative_gas_used`. 

