### PR TITLE
chore(config): try converting to named chain first

### DIFF
--- a/config/src/chain.rs
+++ b/config/src/chain.rs
@@ -46,7 +46,7 @@ impl From<ethers_core::types::Chain> for Chain {
 
 impl From<u64> for Chain {
     fn from(id: u64) -> Self {
-        Chain::Id(id)
+        ethers_core::types::Chain::try_from(id).map(Chain::Named).unwrap_or_else(|_| Chain::Id(id))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #1886 try converting to a known chain first for `From<u64>`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
