### PR TITLE
fix(anvil): notify on promoted transactions

### DIFF
--- a/anvil/src/eth/pool/mod.rs
+++ b/anvil/src/eth/pool/mod.rs
@@ -116,7 +116,11 @@ impl Pool {
     pub fn add_transaction(&self, tx: PoolTransaction) -> Result<AddedTransaction, PoolError> {
         let added = self.inner.write().add_transaction(tx)?;
         if let AddedTransaction::Ready(ref ready) = added {
-            self.notify_listener(ready.hash)
+            self.notify_listener(ready.hash);
+            // also notify promoted transactions
+            for promoted in ready.promoted.iter().copied() {
+                self.notify_listener(promoted);
+            }
         }
         Ok(added)
     }

--- a/anvil/tests/it/geth.rs
+++ b/anvil/tests/it/geth.rs
@@ -1,0 +1,29 @@
+//! tests against local geth for local debug purposes
+
+use ethers::{
+    abi::Address,
+    prelude::{Middleware, TransactionRequest},
+    providers::Provider,
+};
+use futures::StreamExt;
+use tokio::time::timeout;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_geth_pending_transaction() {
+    let client = Provider::try_from("http://127.0.0.1:8545").unwrap();
+    let accounts = client.get_accounts().await.unwrap();
+    let tx = TransactionRequest::new()
+        .from(accounts[0])
+        .to(Address::random())
+        .value(1337u64)
+        .nonce(2u64);
+
+    let mut watch_tx_stream =
+        client.watch_pending_transactions().await.unwrap().transactions_unordered(1).fuse();
+
+    let _res = client.send_transaction(tx, None).await.unwrap();
+
+    let pending = timeout(std::time::Duration::from_secs(3), watch_tx_stream.next()).await;
+    assert!(pending.is_err());
+}

--- a/anvil/tests/it/main.rs
+++ b/anvil/tests/it/main.rs
@@ -6,6 +6,7 @@ mod anvil_api;
 mod api;
 mod fork;
 mod ganache;
+mod geth;
 mod logs;
 mod pubsub;
 mod traces;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the test `can_stream_pending_transactions` in `ethers-rs` led to jobs running forever:

https://github.com/gakonst/ethers-rs/runs/6801222172?check_suite_focus=true

 because not all transactions were emitted as "pending" by anvil
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* also notify promoted transactions 
* port over `can_stream_pending_transactions`

Ref https://github.com/gakonst/ethers-rs/pull/1365

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
