### PR TITLE
fix(forge): revert provider interval to default 7s on `script`

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -258,7 +258,6 @@ pub fn enable_paint() {
 /// node) and with the default, `7s` if otherwise.
 pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClient<Http>>> {
     let (max_retry, initial_backoff) = if aggressive { (1000, 1) } else { (10, 1000) };
-    let interval = if aggressive { Duration::from_secs(1) } else { Duration::from_secs(7) };
 
     let provider = Provider::<RetryClient<Http>>::new_client(url, max_retry, initial_backoff)
         .expect("Bad fork provider.");
@@ -266,7 +265,7 @@ pub fn get_http_provider(url: &str, aggressive: bool) -> Arc<Provider<RetryClien
     Arc::new(if url.contains("127.0.0.1") || url.contains("localhost") {
         provider.interval(Duration::from_millis(100))
     } else {
-        provider.interval(interval)
+        provider
     })
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I have seen user reports that they have to call `--resume` too many times on `forge script`. This comes from `PendingTransaction` trying too many times on a low interval.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

For now, I would like to revert this to 7 seconds as it was before.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
