### PR TITLE
fix exceeds_size_limit annotation error

### DIFF
--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -39,7 +39,7 @@ impl SizeReport {
         max_size
     }
 
-    /// Returns true if all contracts are within the size limit, excluding test contracts.
+    /// Returns true if any contract exceeds the size limit, excluding test contracts.
     pub fn exceeds_size_limit(&self) -> bool {
         self.max_size() > CONTRACT_SIZE_LIMIT
     }


### PR DESCRIPTION
fix exceeds_size_limit annotation error, modify exceeds_size_limit function annotation from `Returns true if all contracts are within the size limit, excluding test contracts.` to `Returns true if any contract exceeds the size limit, excluding test contracts.`