### PR TITLE
fix(forge): handle case when there's no bytecode in the artifact

### DIFF
--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -169,14 +169,17 @@ pub fn unwrap_contracts(
 ) -> BTreeMap<ArtifactId, (Abi, Vec<u8>)> {
     contracts
         .iter()
-        .map(|(id, c)| {
+        .filter_map(|(id, c)| {
             let bytecode = if deployed_code {
-                c.deployed_bytecode.clone().into_bytes().expect("not bytecode").to_vec()
+                c.deployed_bytecode.clone().into_bytes()
             } else {
-                c.bytecode.clone().object.into_bytes().expect("not bytecode").to_vec()
+                c.bytecode.clone().object.into_bytes()
             };
 
-            (id.clone(), (c.abi.clone(), bytecode))
+            if let Some(bytecode) = bytecode {
+                return Some((id.clone(), (c.abi.clone(), bytecode.to_vec())))
+            }
+            None
         })
         .collect()
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If the artifact didn't have the requested bytecode (eg. interface), it would panic.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Just skip it instead.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
