### PR TITLE
perf: remove redundant config usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit",
+ "tracing",
  "walkdir",
 ]
 
@@ -5084,9 +5085,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -5108,11 +5109,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -18,7 +18,7 @@ use ethers::{
     },
 };
 use eyre::{eyre, Context};
-use foundry_config::{Chain, Config, SolcReq};
+use foundry_config::{find_project_root_path, Chain, Config, SolcReq};
 use foundry_utils::Retry;
 use futures::FutureExt;
 use once_cell::sync::Lazy;
@@ -198,7 +198,7 @@ impl VerifyArgs {
         };
 
         let project = build_args.project()?;
-        let config = Config::load();
+        let config = Config::load_with_root(find_project_root_path().unwrap());
 
         if self.contract.path.is_none() && !config.cache {
             eyre::bail!(

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -132,7 +132,10 @@ pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
     runtime.command(cmd.clone());
     let wx = Watchexec::new(init, runtime.clone())?;
 
-    let filter = args.filter();
+    let config: Config = args.build_args().into();
+
+    let filter = args.filter(&config);
+
     // marker to check whether to override the command
     let no_reconfigure = filter.pattern.is_some() ||
         filter.test_pattern.is_some() ||
@@ -140,7 +143,6 @@ pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
         filter.contract_pattern.is_some() ||
         args.watch.run_all;
 
-    let config: Config = args.build_args().into();
     let state = WatchTestState {
         project_root: config.__root.0,
         no_reconfigure,

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -138,14 +138,15 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
         }
 
         let now = std::time::Instant::now();
-        tracing::trace!(target : "forge_compile", "start compiling project");
+        tracing::trace!(target : "forge::compile", "start compiling project");
 
         let output = term::with_spinner_reporter(|| f(project))?;
 
         let elapsed = now.elapsed();
-        tracing::trace!(target : "forge_compile", "finished compiling after {:?}", elapsed);
+        tracing::trace!(target : "forge::compile", "finished compiling after {:?}", elapsed);
 
         if output.has_compiler_errors() {
+            tracing::warn!(target: "forge::compile", "compiled with errors");
             eyre::bail!(output.to_string())
         } else if output.is_unchanged() {
             println!("No files changed, compilation skipped");

--- a/cli/tests/fixtures/can_set_yul_optimizer.stderr
+++ b/cli/tests/fixtures/can_set_yul_optimizer.stderr
@@ -10,7 +10,7 @@ Error:
    0: [0m
 
 Location:
-   [35mcli/src/compile.rs[0m:[35m149[0m
+   [35mcli/src/compile.rs[0m:[35m150[0m
 
 Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
 Run with RUST_BACKTRACE=full to include source snippets.

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.5.5"
 globset = "0.4.8"
 walkdir = "2.3.2"
 toml_edit = "0.14.3"
+tracing = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.1.4"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

it was reported that `forge test` hangs for projects that import https://github.com/mangrovedao/mangrove (very large)

I tracked this down to redundante+incorrect usage of `Config::load` in the `TestFilter`

So far, the "filter" loaded the config, which is redundant with the current usage, as a config is also loaded when the filter is used.

the Config -> Filter pipeline is a bit contrary to the intended use of Config, where everything should be merged _into_ Config.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* instead of loading the Config again, reuse it
* also adds some traces used to debug this
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
