### PR TITLE
feat: add additional logs to DSTest abi

### DIFF
--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -44,6 +44,8 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
             format!("{}: 0x{}", inner.key, hex::encode(inner.val))
         }
         LogNamedStringFilter(inner) => format!("{}: {}", inner.key, inner.val),
+        LogNamedArray1Filter(inner) => format!("{}: {:?}", inner.key, inner.val),
+        LogNamedArray2Filter(inner) => format!("{}: {:?}", inner.key, inner.val),
 
         e => e.to_string(),
     };

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -80,7 +80,8 @@ pub static HARDHAT_CONSOLE_ADDRESS: Address = H160([
     0x2e, 0x6c, 0x6f, 0x67,
 ]);
 
-// Bindings for DS-style event logs
+// Bindings for DS-style event logs. Note that the array logs below are not actually part of DSTest,
+// but are part of forge-std, so are included here to ensure they are decoded in output logs.
 ethers::contract::abigen!(
     Console,
     r#"[
@@ -92,6 +93,8 @@ ethers::contract::abigen!(
             event log_uint               (uint)
             event log_bytes              (bytes)
             event log_string             (string)
+            event log_array              (uint256[] val)
+            event log_array              (int256[] val)
             event log_named_address      (string key, address val)
             event log_named_bytes32      (string key, bytes32 val)
             event log_named_decimal_int  (string key, int val, uint decimals)
@@ -100,6 +103,8 @@ ethers::contract::abigen!(
             event log_named_uint         (string key, uint val)
             event log_named_bytes        (string key, bytes val)
             event log_named_string       (string key, string val)
+            event log_named_array        (string key, uint256[] val)
+            event log_named_array        (string key, int256[] val)
     ]"#
 );
 pub use console_mod::{ConsoleEvents, CONSOLE_ABI};


### PR DESCRIPTION
In https://github.com/foundry-rs/forge-std/pull/86, `assertEq` overloads were added for testing array equality. They work by hashing the two arrays, and like other assertion helpers they emit an event with the expected vs. actual values if they don't match.

DSTest's `test.sol` does not have any events for arrays, therefore right now these new logs in forge-std only show up in traces. This PR adds these events to the DSTest ABI so they now show up in the `Logs:` section when running tests.

cc @ZeroEkkusu / ref https://github.com/foundry-rs/book/issues/372