### PR TITLE
feat(forge): create add  scale-gas-limit

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -90,6 +90,14 @@ This is automatically enabled for common networks without EIP1559."#
     gas_limit: Option<U256>,
 
     #[clap(
+        long = "scale-gas-limit",
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Scale the gas limit by the given percentage.",
+        value_name = "NUM"
+    )]
+    scale_gas_limit: Option<U256>,
+
+    #[clap(
         long = "priority-fee", 
         help_heading = "TRANSACTION OPTIONS",
         help = "Gas priority fee for EIP1559 transactions.",
@@ -97,6 +105,7 @@ This is automatically enabled for common networks without EIP1559."#
         value_name = "PRICE"
     )]
     priority_fee: Option<U256>,
+
     #[clap(
         long,
         help_heading = "TRANSACTION OPTIONS",
@@ -241,7 +250,13 @@ impl CreateArgs {
 
         // set gas limit if specified
         if let Some(gas_limit) = self.gas_limit {
-            deployer.tx.set_gas(gas_limit);
+            if let Some(scale_gas_limit) = self.scale_gas_limit {
+                // let new_gas_limit = gas_limit * (1f64 + (scale_gas_limit / 100f64));
+                // deployer.tx.set_gas(new_gas_limit);
+                deployer.tx.set_gas(gas_limit * scale_gas_limit);
+            } else {
+                deployer.tx.set_gas(gas_limit);
+            }
         }
 
         // set nonce if specified


### PR DESCRIPTION
closes: https://github.com/foundry-rs/foundry/issues/1803

Opened as draft to get some guidance, if you wouldn't mind pointing me in the right direction.

1. Trying to figure out how to multiply the `gas_limit` to get a scaled 10% or 20%, etc

```rust
#[clap(
    long = "scale-gas-limit",
    help_heading = "TRANSACTION OPTIONS",
    help = "Scale the gas limit by the given percentage.",
    value_name = "NUM"
)]
scale_gas_limit: Option<U256>,

if let Some(gas_limit) = self.gas_limit {
    if let Some(scale_gas_limit) = self.scale_gas_limit {
        // let new_gas_limit = gas_limit * (1f64 + (scale_gas_limit / 100f64));
        // deployer.tx.set_gas(new_gas_limit);
        deployer.tx.set_gas(gas_limit * scale_gas_limit);
    } else {
        deployer.tx.set_gas(gas_limit);
    }
}
```





Currently it works as full number multiplier -ex: `--gas-limit 2000000 --scale-gas-limit 2`
```bash
➜  playground git:(main) ~/CLionProjects/foundry/target/debug/forge create --rpc-url $MUMBAI_RPC_URL --constructor-args "Zech" "ZCH" --private-key $PRIVATE_KEY src/NFT.sol:Zech --gas-limit 2000000 --scale-gas-limit 2
[⠑] Compiling...
No files changed, compilation skipped
Deployer: 0x28a435d0fe95e127e6b95babf232d5739217b3f0
Deployed to: 0x29ba3e20fa76aff8bb5a2a19ac4e4b5a2febbd95
Transaction hash: 0x118474b9e53720e351c546d6aadee29c882d0c541eab21c298862dd39399c7cf
```

Gives a 4 million gas limit



<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
