### PR TITLE
fix(anvil): increase timestamp offset by 1 sec if manually set

### DIFF
--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -64,8 +64,8 @@ impl TimeManager {
             // the offset will be negative if the `next` timestamp is in the past
             let offset = (next as i128) - current;
             let mut current_offset = self.offset.write();
-            // increase the offset by one second, so that we don't yield the same timestamp twice if it's
-            // set manually
+            // increase the offset by one second, so that we don't yield the same timestamp twice if
+            // it's set manually
             *current_offset = offset.saturating_add(1);
             return next
         }

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -64,7 +64,7 @@ impl TimeManager {
             // the offset will be negative if the `next` timestamp is in the past
             let offset = (next as i128) - current;
             let mut current_offset = self.offset.write();
-            // increase the by one second, so that we don't yield the same timestamp twice if it's
+            // increase the offset by one second, so that we don't yield the same timestamp twice if it's
             // set manually
             *current_offset = offset.saturating_add(1);
             return next

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -64,7 +64,9 @@ impl TimeManager {
             // the offset will be negative if the `next` timestamp is in the past
             let offset = (next as i128) - current;
             let mut current_offset = self.offset.write();
-            *current_offset = offset;
+            // increase the by one second, so that we don't yield the same timestamp twice if it's
+            // set manually
+            *current_offset = offset.saturating_add(1);
             return next
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the timestamp's resolution is seconds, if manually set (`evm_setNextBlockTimestamp`), followed by an immediate `evm_mine` both blocks can have the timestamp.
since this is manually set, it would make sense to make sure that the next block will definitely have a newer timestamp.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
