### PR TITLE
feat(anvil): add timestamp interval support

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -298,6 +298,12 @@ pub enum EthRequest {
     #[serde(rename = "evm_setNextBlockTimestamp", with = "sequence")]
     EvmSetNextBlockTimeStamp(u64),
 
+    /// Similar to `evm_increaseTime` but takes sets a block timestamp `interval`
+    ///
+    /// The timestamp of the next block will be computed as `lastBlock_timestamp + interval`
+    #[serde(rename = "evm_setBlockTimestampInterval", with = "sequence")]
+    EvmSetBlockTimeStampInterval(u64),
+
     /// Mine a single block
     #[serde(rename = "evm_mine")]
     EvmMine(#[serde(default)] Option<Params<EvmMineOptions>>),
@@ -785,6 +791,13 @@ mod tests {
     #[test]
     fn test_serde_custom_next_timestamp() {
         let s = r#"{"method": "evm_setNextBlockTimestamp", "params": [100]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_custom_timestamp_interval() {
+        let s = r#"{"method": "evm_setBlockTimestampInterval", "params": [100]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -298,9 +298,9 @@ pub enum EthRequest {
     #[serde(rename = "evm_setNextBlockTimestamp", with = "sequence")]
     EvmSetNextBlockTimeStamp(u64),
 
-    /// Similar to `evm_increaseTime` but takes sets a block timestamp `interval`
+    /// Similar to `evm_increaseTime` but takes sets a block timestamp `interval`.
     ///
-    /// The timestamp of the next block will be computed as `lastBlock_timestamp + interval`
+    /// The timestamp of the next block will be computed as `lastBlock_timestamp + interval`.
     #[serde(rename = "evm_setBlockTimestampInterval", with = "sequence")]
     EvmSetBlockTimeStampInterval(u64),
 

--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -304,6 +304,10 @@ pub enum EthRequest {
     #[serde(rename = "evm_setBlockTimestampInterval", with = "sequence")]
     EvmSetBlockTimeStampInterval(u64),
 
+    /// Removes a `evm_setBlockTimestampInterval` if it exists
+    #[serde(rename = "evm_removeBlockTimestampInterval", with = "empty_params")]
+    EvmRemoveBlockTimeStampInterval(()),
+
     /// Mine a single block
     #[serde(rename = "evm_mine")]
     EvmMine(#[serde(default)] Option<Params<EvmMineOptions>>),
@@ -798,6 +802,13 @@ mod tests {
     #[test]
     fn test_serde_custom_timestamp_interval() {
         let s = r#"{"method": "evm_setBlockTimestampInterval", "params": [100]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_custom_remove_timestamp_interval() {
+        let s = r#"{"method": "evm_removeBlockTimestampInterval", "params": []}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -301,11 +301,11 @@ pub enum EthRequest {
     /// Similar to `evm_increaseTime` but takes sets a block timestamp `interval`.
     ///
     /// The timestamp of the next block will be computed as `lastBlock_timestamp + interval`.
-    #[serde(rename = "evm_setBlockTimestampInterval", with = "sequence")]
+    #[serde(rename = "anvil_setBlockTimestampInterval", with = "sequence")]
     EvmSetBlockTimeStampInterval(u64),
 
-    /// Removes a `evm_setBlockTimestampInterval` if it exists
-    #[serde(rename = "evm_removeBlockTimestampInterval", with = "empty_params")]
+    /// Removes a `anvil_setBlockTimestampInterval` if it exists
+    #[serde(rename = "anvil_removeBlockTimestampInterval", with = "empty_params")]
     EvmRemoveBlockTimeStampInterval(()),
 
     /// Mine a single block
@@ -801,14 +801,14 @@ mod tests {
 
     #[test]
     fn test_serde_custom_timestamp_interval() {
-        let s = r#"{"method": "evm_setBlockTimestampInterval", "params": [100]}"#;
+        let s = r#"{"method": "anvil_setBlockTimestampInterval", "params": [100]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }
 
     #[test]
     fn test_serde_custom_remove_timestamp_interval() {
-        let s = r#"{"method": "evm_removeBlockTimestampInterval", "params": []}"#;
+        let s = r#"{"method": "anvil_removeBlockTimestampInterval", "params": []}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1414,7 +1414,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_setBlockTimestampInterval`
     pub fn evm_set_block_timestamp_interval(&self, seconds: u64) -> Result<()> {
-        node_info!("evm_setNextBlockTimestamp");
+        node_info!("evm_setBlockTimestampInterval");
         self.backend.time().set_block_timestamp_interval(seconds);
         Ok(())
     }
@@ -1423,7 +1423,7 @@ impl EthApi {
     ///
     /// Handler for RPC call: `evm_removeBlockTimestampInterval`
     pub fn evm_remove_block_timestamp_interval(&self) -> Result<bool> {
-        node_info!("evm_setNextBlockTimestamp");
+        node_info!("evm_removeBlockTimestampInterval");
         Ok(self.backend.time().remove_block_timestamp_interval())
     }
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -272,6 +272,9 @@ impl EthApi {
             EthRequest::EvmSetBlockTimeStampInterval(time) => {
                 self.evm_set_block_timestamp_interval(time).to_rpc_result()
             }
+            EthRequest::EvmRemoveBlockTimeStampInterval(()) => {
+                self.evm_remove_block_timestamp_interval().to_rpc_result()
+            }
             EthRequest::EvmMine(mine) => {
                 self.evm_mine(mine.map(|p| p.params)).await.to_rpc_result()
             }
@@ -1414,6 +1417,14 @@ impl EthApi {
         node_info!("evm_setNextBlockTimestamp");
         self.backend.time().set_block_timestamp_interval(seconds);
         Ok(())
+    }
+
+    /// Sets an interval for the block timestamp
+    ///
+    /// Handler for RPC call: `evm_removeBlockTimestampInterval`
+    pub fn evm_remove_block_timestamp_interval(&self) -> Result<bool> {
+        node_info!("evm_setNextBlockTimestamp");
+        Ok(self.backend.time().remove_block_timestamp_interval())
     }
 
     /// Mine blocks, instantly.

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -269,6 +269,9 @@ impl EthApi {
             EthRequest::EvmSetNextBlockTimeStamp(time) => {
                 self.evm_set_next_block_timestamp(time).to_rpc_result()
             }
+            EthRequest::EvmSetBlockTimeStampInterval(time) => {
+                self.evm_set_block_timestamp_interval(time).to_rpc_result()
+            }
             EthRequest::EvmMine(mine) => {
                 self.evm_mine(mine.map(|p| p.params)).await.to_rpc_result()
             }
@@ -1401,6 +1404,15 @@ impl EthApi {
     pub fn evm_set_next_block_timestamp(&self, seconds: u64) -> Result<()> {
         node_info!("evm_setNextBlockTimestamp");
         self.backend.time().set_next_block_timestamp(seconds);
+        Ok(())
+    }
+
+    /// Sets an interval for the block timestamp
+    ///
+    /// Handler for RPC call: `evm_setBlockTimestampInterval`
+    pub fn evm_set_block_timestamp_interval(&self, seconds: u64) -> Result<()> {
+        node_info!("evm_setNextBlockTimestamp");
+        self.backend.time().set_block_timestamp_interval(seconds);
         Ok(())
     }
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1412,18 +1412,18 @@ impl EthApi {
 
     /// Sets an interval for the block timestamp
     ///
-    /// Handler for RPC call: `evm_setBlockTimestampInterval`
+    /// Handler for RPC call: `anvil_setBlockTimestampInterval`
     pub fn evm_set_block_timestamp_interval(&self, seconds: u64) -> Result<()> {
-        node_info!("evm_setBlockTimestampInterval");
+        node_info!("anvil_setBlockTimestampInterval");
         self.backend.time().set_block_timestamp_interval(seconds);
         Ok(())
     }
 
     /// Sets an interval for the block timestamp
     ///
-    /// Handler for RPC call: `evm_removeBlockTimestampInterval`
+    /// Handler for RPC call: `anvil_removeBlockTimestampInterval`
     pub fn evm_remove_block_timestamp_interval(&self) -> Result<bool> {
-        node_info!("evm_removeBlockTimestampInterval");
+        node_info!("anvil_removeBlockTimestampInterval");
         Ok(self.backend.time().remove_block_timestamp_interval())
     }
 

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -20,7 +20,9 @@ pub struct TimeManager {
     /// will be taken and returned. After which the `offset` will be updated accordingly
     next_exact_timestamp: Arc<RwLock<Option<u64>>>,
     /// The interval to use when determining the next block's timestamp
-    interval: Arc<RwLock<Option<TimestampInterval>>>,
+    interval: Arc<RwLock<Option<u64>>>,
+    /// The last timestamp that was returned
+    last_timestamp: Arc<RwLock<Option<u64>>>,
 }
 
 // === impl TimeManager ===
@@ -59,23 +61,45 @@ impl TimeManager {
 
     /// Sets an interval to use when computing the next timestamp
     ///
-    /// If an interval already exists, this will update the interval, otherwise a new interval will be set starting with the current timestamp
+    /// If an interval already exists, this will update the interval, otherwise a new interval will
+    /// be set starting with the current timestamp.
     pub fn set_block_timestamp_interval(&self, interval: u64) {
         trace!(target: "time", "set interval {}", interval);
-        let mut current = self.interval.write();
-        if let Some(current) = current.as_mut() {
-            current.interval = interval;
+        self.interval.write().replace(interval);
+    }
+
+    /// Removes the interval if it exists
+    pub fn remove_block_timestamp_interval(&self) -> bool {
+        if self.interval.write().take().is_some() {
+            trace!(target: "time", "removed interval");
+            // interval mode disabled but need to update the offset accordingly
+            let last = self.last_timestamp();
+            let now = duration_since_unix_epoch().as_secs() as i128;
+            let offset = (last as i128) - now;
+            *self.offset.write() = offset.saturating_add(1);
+            true
         } else {
-            *current =
-                Some(TimestampInterval { interval, last_timestamp: self.current_call_timestamp() });
+            false
         }
     }
 
-    /// Returns the current timestamp and updates the underlying offset accordingly
+    fn set_last_timestamp(&self, last_timestamp: u64) {
+        self.last_timestamp.write().replace(last_timestamp);
+    }
+
+    /// Returns the last timestamp
+    fn last_timestamp(&self) -> u64 {
+        self.last_timestamp.read().unwrap_or_else(|| {
+            let current = duration_since_unix_epoch().as_secs() as i128;
+            current.saturating_add(self.offset()) as u64
+        })
+    }
+
+    /// Returns the current timestamp and updates the underlying offset and interval accordingly
     pub fn next_timestamp(&self) -> u64 {
         let current = duration_since_unix_epoch().as_secs() as i128;
 
-        if let Some(next) = self.next_exact_timestamp.write().take() {
+        let next = if let Some(next) = self.next_exact_timestamp.write().take() {
             // return the custom block timestamp and adjust the offset accordingly
             // the offset will be negative if the `next` timestamp is in the past
             let offset = (next as i128) - current;
@@ -83,34 +107,32 @@ impl TimeManager {
             // increase the offset by one second, so that we don't yield the same timestamp twice if
             // it's set manually
             *current_offset = offset.saturating_add(1);
-            return next
-        }
+            next
+        } else if let Some(interval) = *self.interval.read() {
+            self.last_timestamp().saturating_add(interval)
+        } else {
+            current.saturating_add(self.offset()) as u64
+        };
 
-        current.saturating_add(self.offset()) as u64
+        self.set_last_timestamp(next);
+        next
     }
 
-    /// Returns the current timestamp for a call that does not update the value
+    /// Returns the current timestamp for a call that does _not_ update the value
     pub fn current_call_timestamp(&self) -> u64 {
-        let mut current = duration_since_unix_epoch().as_secs() as i128;
+        let current = duration_since_unix_epoch().as_secs() as i128;
 
         if let Some(next) = *self.next_exact_timestamp.read() {
             // return the custom block timestamp and adjust the offset accordingly
             // the offset will be negative if the `next` timestamp is in the past
             let offset = (next as i128) - current;
-            current = current.saturating_add(offset)
+            current.saturating_add(offset) as u64
+        } else if let Some(interval) = *self.interval.read() {
+            self.last_timestamp().saturating_add(interval)
+        } else {
+            current.saturating_add(self.offset()) as u64
         }
-
-        current as u64
     }
-}
-
-/// Provides a tick rate for the time manager
-///
-/// While the timestamp is based on the unix epoch, it
-#[derive(Debug, Clone)]
-struct TimestampInterval {
-    interval: u64,
-    last_timestamp: u64,
 }
 
 /// Returns the current duration since unix epoch.

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -86,6 +86,15 @@ impl TimeManager {
     }
 }
 
+/// Provides a tick rate for the time manager
+///
+/// While the timestamp is based on the unix epoch, it
+#[derive(Debug, Clone)]
+struct TickRate {
+    tick: Arc<RwLock<u64>>,
+    last_timestamp:Arc<RwLock<u64>>,
+}
+
 /// Returns the current duration since unix epoch.
 pub fn duration_since_unix_epoch() -> Duration {
     use std::time::SystemTime;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1930
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* adds two new rpc calls
  * `anvil_setBlockTimestampInterval` to configure a interval for the block timestamps
  * `anvil_removeBlockTimestampInterval` to remove it (alternatively this could be replaced by `anvil_setBlockTimestampInterval(0)`, but perhaps a constant timestamp is useful)

`evm_setNextBlockTimestamp` still works if a interval is enabled 


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
