### PR TITLE
Fix wrong install script link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First run the command below to get `foundryup`, the Foundry toolchain installer:
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-If you do not want to use the redirect, feel free to manually download the foundryup installation script from [here](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup).
+If you do not want to use the redirect, feel free to manually download the foundryup installation script from [here](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/install).
 
 Then, run `foundryup` in a new terminal session or after reloading your `PATH`.
 


### PR DESCRIPTION
The README linked to 
`https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup` 
instead of 
`https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/install` 
in the installation without redirect instruction.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
