### PR TITLE
test: disable check_broadcast_log test

### DIFF
--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1016,46 +1016,52 @@ forgetest_async!(fail_broadcast_staticcall, |prj: TestProject, cmd: TestCommand|
         .simulate(ScriptOutcome::FailedScript);
 });
 
-forgetest_async!(check_broadcast_log, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+forgetest_async!(
+    #[ignore]
+    check_broadcast_log,
+    |prj: TestProject, cmd: TestCommand| async move {
+        let port = next_port();
+        let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
+        let mut tester = ScriptTester::new(cmd, port, prj.root());
 
-    // Prepare CREATE2 Deployer
-    let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
-    let code = hex::decode("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3").expect("Could not decode create2 deployer init_code").into();
-    api.anvil_set_code(addr, code).await.unwrap();
+        // Prepare CREATE2 Deployer
+        let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
+        let code = hex::decode("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3").expect("Could not decode create2 deployer init_code").into();
+        api.anvil_set_code(addr, code).await.unwrap();
 
-    tester
-        .load_private_keys(vec![0])
-        .await
-        .add_sig("BroadcastTestLog", "run()")
-        .slow()
-        .simulate(ScriptOutcome::OkSimulation)
-        .broadcast(ScriptOutcome::OkBroadcast)
-        .assert_nonce_increment(vec![(0, 7)])
-        .await;
+        tester
+            .load_private_keys(vec![0])
+            .await
+            .add_sig("BroadcastTestLog", "run()")
+            .slow()
+            .simulate(ScriptOutcome::OkSimulation)
+            .broadcast(ScriptOutcome::OkBroadcast)
+            .assert_nonce_increment(vec![(0, 7)])
+            .await;
 
-    // Uncomment to recreate log
-    // std::fs::copy("broadcast/Broadcast.t.sol/31337/run-latest.json",
-    // PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../testdata/fixtures/broadcast.log.json"));
+        // Uncomment to recreate log
+        // std::fs::copy("broadcast/Broadcast.t.sol/31337/run-latest.json",
+        // PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../testdata/fixtures/broadcast.log.json"
+        // ));
 
-    // Ignore blockhash since it changes inbetween runs.
-    let re = Regex::new(r"blockHash.*?blockNumber").unwrap();
+        // Ignore blockhash since it changes inbetween runs.
+        let re = Regex::new(r"blockHash.*?blockNumber").unwrap();
 
-    let fixtures_log = std::fs::read_to_string(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../testdata/fixtures/broadcast.log.json"),
-    )
-    .unwrap();
-    let fixtures_log = re.replace_all(&fixtures_log, "");
+        let fixtures_log = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../testdata/fixtures/broadcast.log.json"),
+        )
+        .unwrap();
+        let fixtures_log = re.replace_all(&fixtures_log, "");
 
-    let run_log =
-        std::fs::read_to_string("broadcast/Broadcast.t.sol/31337/run-latest.json").unwrap();
-    let run_log = re.replace_all(&run_log, "");
+        let run_log =
+            std::fs::read_to_string("broadcast/Broadcast.t.sol/31337/run-latest.json").unwrap();
+        let run_log = re.replace_all(&run_log, "");
 
-    // Ignore timestamp with `-11` since it changes inbetween runs.
-    assert!(&fixtures_log[..(fixtures_log.len() - 11)] == &run_log[..(run_log.len() - 11)]);
-});
+        // Ignore timestamp with `-11` since it changes inbetween runs.
+        assert!(&fixtures_log[..(fixtures_log.len() - 11)] == &run_log[..(run_log.len() - 11)]);
+    }
+);
 
 // test to check that install/remove works properly
 forgetest!(can_install_and_remove, |prj: TestProject, mut cmd: TestCommand| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ignores the `check_broadcast_log` that's currently failing on a couple of open PRs (#1946, #1945, #1926)

unfortunately, it's not obvious why this fails, updating the file also did not help, #1941

but looks like this is perhaps due to some regex issues #1938, no idea what this even does, sorry @joshieDo :)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* ignore test until test improved
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
