### PR TITLE
fix: allow any chain id in cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "eyre",
+ "foundry-config",
  "foundry-evm",
  "foundry-utils",
  "futures",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["ethereum", "web3"]
 [dependencies]
 foundry-utils = { path = "../utils" }
 foundry-evm = { path = "./../evm" }
+foundry-config = { path = "./../config" }
+
 futures = "0.3.17"
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -1,13 +1,13 @@
 use ethers_core::{
     abi::Function,
     types::{
-        transaction::eip2718::TypedTransaction, Chain, Eip1559TransactionRequest, NameOrAddress,
+        transaction::eip2718::TypedTransaction, Eip1559TransactionRequest, NameOrAddress,
         TransactionRequest, H160, U256,
     },
 };
 use ethers_providers::Middleware;
-
-use eyre::{eyre, Result};
+use eyre::{eyre, Result, WrapErr};
+use foundry_config::Chain;
 use foundry_utils::{encode_args, get_func, get_func_etherscan};
 use futures::future::join_all;
 
@@ -49,20 +49,18 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
         provider: &'a M,
         from: F,
         to: T,
-        chain: Chain,
+        chain: impl Into<Chain>,
         legacy: bool,
     ) -> Result<TxBuilder<'a, M>> {
+        let chain = chain.into();
         let from_addr = resolve_ens(provider, from).await?;
-        let to_addr = resolve_ens(provider, foundry_utils::resolve_addr(to, chain)?).await?;
+        let to_addr =
+            resolve_ens(provider, foundry_utils::resolve_addr(to, chain.try_into().ok())?).await?;
 
         let tx: TypedTransaction = if chain.is_legacy() || legacy {
-            TransactionRequest::new().from(from_addr).to(to_addr).chain_id(chain as u64).into()
+            TransactionRequest::new().from(from_addr).to(to_addr).chain_id(chain.id()).into()
         } else {
-            Eip1559TransactionRequest::new()
-                .from(from_addr)
-                .to(to_addr)
-                .chain_id(chain as u64)
-                .into()
+            Eip1559TransactionRequest::new().from(from_addr).to(to_addr).chain_id(chain.id()).into()
         };
 
         Ok(Self { to: to_addr, chain, tx, func: None, etherscan_api_key: None, provider })
@@ -158,11 +156,13 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
             // if only calldata is provided, returning a dummy function
             get_func("x()")?
         } else {
+            let chain =
+                self.chain.try_into().wrap_err("resolving via etherscan requires a known chain")?;
             get_func_etherscan(
                 sig,
                 self.to,
                 &args,
-                self.chain,
+               chain,
                 self.etherscan_api_key.as_ref().unwrap_or_else(|| panic!(r#"Unable to determine the function signature from `{}`. To find the function signature from the deployed contract via its name instead, a valid ETHERSCAN_API_KEY must be set."#, sig)),
             )
             .await?

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -19,9 +19,10 @@ use ethers::{
         types::{BlockId, BlockNumber::Latest, H256},
     },
     providers::{Middleware, Provider},
-    types::{Address, Chain, NameOrAddress, U256},
+    types::{Address, NameOrAddress, U256},
 };
 use eyre::WrapErr;
+use foundry_config::Chain;
 use foundry_utils::{
     format_tokens,
     selectors::{
@@ -177,8 +178,11 @@ async fn main() -> eyre::Result<()> {
                 config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
             )?;
 
-            let chain_id = Cast::new(&provider).chain_id().await?;
-            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
+            let chain: Chain = if let Some(chain) = eth.chain {
+                chain.into()
+            } else {
+                provider.get_chainid().await?.into()
+            };
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, chain, false).await?;
@@ -204,8 +208,11 @@ async fn main() -> eyre::Result<()> {
                 config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
             )?;
 
-            let chain_id = provider.get_chainid().await?;
-            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
+            let chain: Chain = if let Some(chain) = eth.chain {
+                chain.into()
+            } else {
+                provider.get_chainid().await?.into()
+            };
 
             let mut builder =
                 TxBuilder::new(&provider, config.sender, address, chain, false).await?;
@@ -275,11 +282,14 @@ async fn main() -> eyre::Result<()> {
                 &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
                 false,
             );
-            let chain_id = Cast::new(&provider).chain_id().await?;
-            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
+            let chain: Chain = if let Some(chain) = eth.chain {
+                chain.into()
+            } else {
+                provider.get_chainid().await?.into()
+            };
             let sig = sig.unwrap_or_default();
 
-            if let Ok(Some(signer)) = eth.signer_with(chain_id, provider.clone()).await {
+            if let Ok(Some(signer)) = eth.signer_with(chain.into(), provider.clone()).await {
                 let from = match &signer {
                     WalletType::Ledger(leger) => leger.address(),
                     WalletType::Local(local) => local.address(),
@@ -401,8 +411,11 @@ async fn main() -> eyre::Result<()> {
                 config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
             )?;
 
-            let chain_id = Cast::new(&provider).chain_id().await?;
-            let chain = Chain::try_from(chain_id.as_u64()).unwrap_or(eth.chain);
+            let chain: Chain = if let Some(chain) = eth.chain {
+                chain.into()
+            } else {
+                provider.get_chainid().await?.into()
+            };
 
             let from = eth.sender().await;
 

--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -177,7 +177,7 @@ impl WalletSubcommands {
                     wallet,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
-                    chain: Chain::Mainnet,
+                    chain: Some(Chain::Mainnet),
                     etherscan_api_key: None,
                 }
                 .signer(0u64.into())
@@ -197,7 +197,7 @@ impl WalletSubcommands {
                     wallet,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
-                    chain: Chain::Mainnet,
+                    chain: Some(Chain::Mainnet),
                     etherscan_api_key: None,
                 }
                 .signer(0u64.into())

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -61,9 +61,9 @@ pub struct EthereumOpts {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub etherscan_api_key: Option<String>,
 
-    #[clap(long, env = "CHAIN", default_value = "mainnet", value_name = "CHAIN_NAME")]
+    #[clap(long, env = "CHAIN", value_name = "CHAIN_NAME")]
     #[serde(skip)]
-    pub chain: Chain,
+    pub chain: Option<Chain>,
 
     #[clap(flatten, next_help_heading = "WALLET OPTIONS")]
     #[serde(skip)]

--- a/config/src/chain.rs
+++ b/config/src/chain.rs
@@ -1,4 +1,5 @@
-use ethers_core::types::ParseChainError;
+use crate::U256;
+use ethers_core::types::{ParseChainError, U64};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt, str::FromStr};
 
@@ -19,6 +20,15 @@ impl Chain {
         match self {
             Chain::Named(chain) => *chain as u64,
             Chain::Id(id) => *id,
+        }
+    }
+
+    /// Helper function for checking if a chainid corresponds to a legacy chainid
+    /// without eip1559
+    pub fn is_legacy(&self) -> bool {
+        match self {
+            Chain::Named(c) => c.is_legacy(),
+            Chain::Id(_) => false,
         }
     }
 }
@@ -50,12 +60,30 @@ impl From<u64> for Chain {
     }
 }
 
+impl From<U256> for Chain {
+    fn from(id: U256) -> Self {
+        id.as_u64().into()
+    }
+}
+
 impl From<Chain> for u64 {
     fn from(c: Chain) -> Self {
         match c {
             Chain::Named(c) => c as u64,
             Chain::Id(id) => id,
         }
+    }
+}
+
+impl From<Chain> for U64 {
+    fn from(c: Chain) -> Self {
+        u64::from(c).into()
+    }
+}
+
+impl From<Chain> for U256 {
+    fn from(c: Chain) -> Self {
+        u64::from(c).into()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1886
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* use config `Chain` type which allows both, named and `u64` variants 
* make `--chain` optional so it can be provided by the user as well

the chain id to will now be determined:

use the chain id provided via cli, if nothing provided retrieve via rpc

```rust
            let chain: Chain = if let Some(chain) = args.chain {
                chain.into()
            } else {
                provider.get_chainid().await?.into()
            };
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
