### PR TITLE
fix(anvil): return networkId as string

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -377,9 +377,10 @@ impl EthApi {
     /// Returns the same as `chain_id`
     ///
     /// Handler for ETH RPC call: `eth_networkId`
-    pub fn network_id(&self) -> Result<Option<U64>> {
+    pub fn network_id(&self) -> Result<Option<String>> {
         node_info!("eth_networkId");
-        Ok(Some(self.backend.chain_id().as_u64().into()))
+        let chain_id = self.backend.chain_id().as_u64();
+        Ok(Some(format!("{chain_id}")))
     }
 
     /// Returns true if client is actively listening for network connections.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`eth_networkId` returns a String
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
convert chain id to string
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
