### PR TITLE
feat: add RpcEndpoints type

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -95,6 +95,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         revert_strings: Some(RevertStrings::Strip),
         sparse_mode: true,
         allow_paths: vec![],
+        rpc_endpoints: Default::default(),
         __non_exhaustive: (),
     };
     prj.write_config(input.clone());

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -21,6 +21,7 @@ use figment::{
     Error, Figment, Metadata, Profile, Provider,
 };
 use inflector::Inflector;
+use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -30,6 +31,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use tracing::trace;
 
 // Macros useful for creating a figment.
 mod macros;
@@ -38,15 +40,17 @@ mod macros;
 pub mod utils;
 pub use crate::utils::*;
 
+mod rpc;
+pub use rpc::RpcEndpoints;
+
 pub mod cache;
 use cache::{Cache, ChainCache};
+
 mod chain;
 pub use chain::Chain;
 
 // reexport so cli types can implement `figment::Provider` to easily merge compiler arguments
 pub use figment;
-use regex::Regex;
-use tracing::trace;
 
 /// Foundry configuration
 ///
@@ -252,6 +256,9 @@ pub struct Config {
     /// Disables storage caching entirely. This overrides any settings made in
     /// `rpc_storage_caching`
     pub no_storage_caching: bool,
+    /// Multiple rpc endpoints and their aliases
+    #[serde(default, skip_serializing_if = "RpcEndpoints::is_empty")]
+    pub rpc_endpoints: RpcEndpoints,
     /// Whether to include the metadata hash.
     ///
     /// The metadata hash is machine dependent. By default, this is set to [BytecodeHash::None] to allow for deterministic code, See: <https://docs.soliditylang.org/en/latest/metadata.html>
@@ -912,6 +919,10 @@ impl Config {
         }
         s = s.replace("[rpc_storage_caching]", &format!("[{}.rpc_storage_caching]", self.profile));
 
+        if !self.rpc_endpoints.is_empty() {
+            s = s.replace("[rpc_endpoints]", &format!("[{}.rpc_endpoints]", self.profile));
+        }
+
         Ok(format!(
             r#"[{}]
 {}"#,
@@ -1392,6 +1403,7 @@ impl Default for Config {
             __non_exhaustive: (),
             via_ir: false,
             rpc_storage_caching: Default::default(),
+            rpc_endpoints: Default::default(),
             no_storage_caching: false,
             bytecode_hash: BytecodeHash::Ipfs,
             revert_strings: None,
@@ -2039,6 +2051,7 @@ mod tests {
 
     use super::*;
 
+    use crate::rpc::RpcEndpoint;
     use std::{fs::File, io::Write};
     use tempfile::tempdir;
 
@@ -2402,6 +2415,7 @@ mod tests {
                 remappings = ["ds-test=lib/ds-test/"]
                 via_ir = true
                 rpc_storage_caching = { chains = [1, "optimism", 999999], endpoints = "all"}
+                rpc_endpoints = { optimism = "https://example.com/", mainnet = "${RPC_MAINNET}" }
                 bytecode_hash = "ipfs"
                 revert_strings = "strip"
                 allow_paths = ["allow", "paths"]
@@ -2430,6 +2444,10 @@ mod tests {
                     bytecode_hash: BytecodeHash::Ipfs,
                     revert_strings: Some(RevertStrings::Strip),
                     allow_paths: vec![PathBuf::from("allow"), PathBuf::from("paths")],
+                    rpc_endpoints: RpcEndpoints::new([
+                        ("optimism", RpcEndpoint::Url("https://example.com/".to_string())),
+                        ("mainnet", RpcEndpoint::Env("RPC_MAINNET".to_string()))
+                    ]),
                     ..Config::default()
                 }
             );

--- a/config/src/rpc.rs
+++ b/config/src/rpc.rs
@@ -1,0 +1,131 @@
+//! Support for multiple RPC-endpoints
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::BTreeMap, env, env::VarError, fmt};
+
+/// Container type for rpc endpoints
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RpcEndpoints {
+    endpoints: BTreeMap<String, RpcEndpoint>,
+}
+
+// === impl RpcEndpoints ===
+
+impl RpcEndpoints {
+    /// Creates anew list of endpoints
+    pub fn new(endpoints: impl IntoIterator<Item = (impl Into<String>, RpcEndpoint)>) -> Self {
+        Self { endpoints: endpoints.into_iter().map(|(name, url)| (name.into(), url)).collect() }
+    }
+
+    /// Returns `true` if this type holds no endpoints
+    pub fn is_empty(&self) -> bool {
+        self.endpoints.is_empty()
+    }
+
+    /// Returns all (alias -> url) pairs
+    ///
+    /// # Errors
+    ///
+    /// returns an error if it contains a reference to an env var that is not set
+    pub fn resolve_all(self) -> Result<BTreeMap<String, String>, VarError> {
+        self.endpoints.into_iter().map(|(name, e)| (e.resolve().map(|url| (name, url)))).collect()
+    }
+}
+
+/// Represents a single endpoint
+///
+/// This type preserves the value as it's stored in the config. If the value is a reference to an
+/// env var, then the `RpcEndpoint::Env` var will hold the reference (`${MAIN_NET}`) and _not_ the
+/// value of the env var itself.
+/// In other words, this type does not resolve env vars when it's being deserialized
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RpcEndpoint {
+    /// A raw Url (ws, http)
+    Url(String),
+    // Reference to an env var in the form of `${ENV_VAR}`
+    Env(String),
+}
+
+// === impl RpcEndpoint ===
+
+impl RpcEndpoint {
+    /// Returns the url variant
+    pub fn as_url(&self) -> Option<&str> {
+        match self {
+            RpcEndpoint::Url(url) => Some(url),
+            RpcEndpoint::Env(_) => None,
+        }
+    }
+
+    /// Returns the url variant
+    pub fn as_env(&self) -> Option<&str> {
+        match self {
+            RpcEndpoint::Env(val) => Some(val),
+            RpcEndpoint::Url(_) => None,
+        }
+    }
+
+    /// Returns the url this type holds
+    ///
+    /// # Error
+    ///
+    /// Returns an error if the type holds a reference to an env var and the env var is not set
+    pub fn resolve(self) -> Result<String, VarError> {
+        match self {
+            RpcEndpoint::Url(url) => Ok(url),
+            RpcEndpoint::Env(v) => env::var(v),
+        }
+    }
+}
+
+impl fmt::Display for RpcEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcEndpoint::Url(url) => url.fmt(f),
+            RpcEndpoint::Env(var) => {
+                write!(f, "${{{var}}}")
+            }
+        }
+    }
+}
+
+impl TryFrom<RpcEndpoint> for String {
+    type Error = VarError;
+
+    fn try_from(value: RpcEndpoint) -> Result<Self, Self::Error> {
+        value.resolve()
+    }
+}
+
+impl Serialize for RpcEndpoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RpcEndpoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let val = String::deserialize(deserializer)?;
+        let endpoint = if val.starts_with('$') {
+            RpcEndpoint::Env(parse_env_ref(&val))
+        } else {
+            RpcEndpoint::Url(val)
+        };
+
+        Ok(endpoint)
+    }
+}
+
+/// Extracts the value surrounded by `${<val>}`
+///
+/// TODO(mattsse): make this a bit more sophisticated
+fn parse_env_ref(val: &str) -> String {
+    val.trim_start_matches("${").trim_end_matches('}').to_string()
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1935
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* adds a new config type where multiple rpc pairs can be defined, including env vars (#1034)

Note: 
* env var format is preliminary and may change, env var parsing is not very sophisticated atm, only looks for `${}`
* this only adds support for declaring them in the config but nothing else, will get integrated in with (https://github.com/foundry-rs/foundry/pull/1715)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
