### PR TITLE
ci: skip all fork tests during cross platform test

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -89,4 +89,4 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --verbose --workspace
+          args: --verbose --workspace -- --skip fork


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
noticed an uptick in long running cross-platform tests, possibly related to fork test, suggest skipping them.

makes me think that the current backoff impl might need some fine tuning since it currently is exp with the number of requests that are currently ratelimited which can get large real quick
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
