### PR TITLE
feat(fmt): function call args statement

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -25,8 +25,8 @@ See [Statement](https://github.com/hyperledger-labs/solang/blob/413841b5c759eb86
 
 - [x] Block
 - [ ] Assembly
-- [ ] Args
-- [ ] If
+- [x] Args
+- [x] If
 - [x] While
 - [x] Expression
 - [x] VariableDefinition

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -770,7 +770,7 @@ impl<'a, W: Write> Formatter<'a, W> {
             // add whitespace if necessary
             let needs_space = chunk
                 .needs_space
-                .unwrap_or(self.next_char_needs_space(content.chars().next().unwrap()));
+                .unwrap_or_else(|| self.next_char_needs_space(content.chars().next().unwrap()));
             if needs_space {
                 if self.will_it_fit(&content) {
                     write!(self.buf(), " ")?;
@@ -2584,7 +2584,7 @@ mod tests {
         let mut f = Formatter::new(&mut source_formatted, source, source_comments, config.clone());
         source_pt.visit(&mut f).unwrap();
 
-        // println!("{}", source_formatted);
+        println!("{}", source_formatted);
         let source_formatted = PrettyString(source_formatted);
 
         pretty_assertions::assert_eq!(

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1,6 +1,6 @@
 //! A Solidity formatter
 
-use std::fmt::Write;
+use std::{fmt::Write, ops::Deref};
 
 use indent_write::fmt::IndentWriter;
 use itertools::Itertools;
@@ -286,6 +286,7 @@ struct Chunk {
     prefixes: Vec<CommentWithMetadata>,
     content: String,
     postfixes: Vec<CommentWithMetadata>,
+    needs_space: Option<bool>,
 }
 
 impl From<String> for Chunk {
@@ -332,14 +333,18 @@ macro_rules! write_chunk {
         write_chunk!($self, $loc, $format_str,)
     }};
     ($self:expr, $loc:expr, $format_str:literal, $($arg:tt)*) => {{
-        let chunk = $self.chunk_at($loc, None, format_args!($format_str, $($arg)*));
+        let chunk = $self.chunk_at($loc, None, None, format_args!($format_str, $($arg)*),);
         $self.write_chunk(&chunk)
     }};
     ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal) => {{
         write_chunk!($self, $loc, $end_loc, $format_str,)
     }};
     ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal, $($arg:tt)*) => {{
-        let chunk = $self.chunk_at($loc, Some($end_loc), format_args!($format_str, $($arg)*));
+        let chunk = $self.chunk_at($loc, Some($end_loc), None, format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $needs_space:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, Some($end_loc), Some($needs_space), format_args!($format_str, $($arg)*),);
         $self.write_chunk(&chunk)
     }};
 }
@@ -368,6 +373,13 @@ macro_rules! writeln_chunk {
     }};
     ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal, $($arg:tt)*) => {{
         write_chunk!($self, $loc, $end_loc, "{}\n", format_args!($format_str, $($arg)*))
+    }};
+}
+
+macro_rules! write_chunk_spaced {
+    ($self:expr, $loc:expr, $needs_space:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, None, $needs_space, format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
     }};
 }
 
@@ -481,16 +493,13 @@ impl<'a, W: Write> Formatter<'a, W> {
     }
 
     /// Does the next written character require whitespace before
-    fn next_chunk_needs_space(&self, next_char: char) -> bool {
+    fn next_char_needs_space(&self, next_char: char) -> bool {
         if self.is_beginning_of_line() {
             return false
         }
         let last_char =
             if let Some(last_char) = self.last_char() { last_char } else { return false };
-        if last_char.is_whitespace() {
-            return false
-        }
-        if next_char.is_whitespace() {
+        if last_char.is_whitespace() || next_char.is_whitespace() {
             return false
         }
         match last_char {
@@ -518,7 +527,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         if text.contains('\n') {
             return false
         }
-        let space = if self.next_chunk_needs_space(text.chars().next().unwrap()) { 1 } else { 0 };
+        let space = if self.next_char_needs_space(text.chars().next().unwrap()) { 1 } else { 0 };
         self.config.line_length >=
             self.last_indent_len()
                 .saturating_add(self.current_line_len())
@@ -566,6 +575,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         &mut self,
         byte_offset: usize,
         next_byte_offset: Option<usize>,
+        needs_space: Option<bool>,
         content: impl std::fmt::Display,
     ) -> Chunk {
         Chunk {
@@ -575,6 +585,7 @@ impl<'a, W: Write> Formatter<'a, W> {
             postfixes: next_byte_offset
                 .map(|byte_offset| self.comments.remove_postfixes_before(byte_offset))
                 .unwrap_or_default(),
+            needs_space, // TODO:
         }
     }
 
@@ -591,7 +602,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         let postfixes = next_byte_offset
             .map(|byte_offset| self.comments.remove_postfixes_before(byte_offset))
             .unwrap_or_default();
-        Ok(Chunk { postfixes_before, prefixes, content, postfixes })
+        Ok(Chunk { postfixes_before, prefixes, content, postfixes, needs_space: None }) // TODO:
     }
 
     /// Create a chunk given a [Visitable] item
@@ -669,7 +680,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         } else {
             let indented = self.is_beginning_of_line();
             self.indented_if(indented, 1, |fmt| {
-                if !indented && fmt.next_chunk_needs_space('/') {
+                if !indented && fmt.next_char_needs_space('/') {
                     write!(fmt.buf(), " ")?;
                 }
                 let mut lines = comment.comment.splitn(2, '\n');
@@ -731,7 +742,7 @@ impl<'a, W: Write> Formatter<'a, W> {
 
     /// Write the chunk and any surrounding comments into the buffer
     /// This will automatically add whitespace before the chunk given the rule set in
-    /// `next_chunk_needs_space`. If the chunk does not fit on the current line it will be put on
+    /// `next_char_needs_space`. If the chunk does not fit on the current line it will be put on
     /// to the next line
     fn write_chunk(&mut self, chunk: &Chunk) -> Result<()> {
         // handle comments before chunk
@@ -757,7 +768,10 @@ impl<'a, W: Write> Formatter<'a, W> {
 
         if !content.is_empty() {
             // add whitespace if necessary
-            if self.next_chunk_needs_space(content.chars().next().unwrap()) {
+            let needs_space = chunk
+                .needs_space
+                .unwrap_or(self.next_char_needs_space(content.chars().next().unwrap()));
+            if needs_space {
                 if self.will_it_fit(&content) {
                     write!(self.buf(), " ")?;
                 } else {
@@ -1509,7 +1523,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         Ok(())
     }
 
-    fn visit_expr(&mut self, loc: Loc, expr: &mut Expression, append: Option<&str>) -> Result<()> {
+    fn visit_expr(&mut self, loc: Loc, expr: &mut Expression) -> Result<()> {
         match expr {
             Expression::Type(loc, typ) => match typ {
                 Type::Address => write_chunk!(self, loc.start(), "address")?,
@@ -1607,8 +1621,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 })?;
             }
             Expression::Variable(ident) => {
-                let chunk = format!("{}{}", ident.name, append.unwrap_or(""));
-                write_chunk!(self, loc.end(), "{}", chunk)?;
+                write_chunk!(self, loc.end(), "{}", ident.name)?;
             }
             Expression::MemberAccess(_, expr, ident) => {
                 let (remaining, idents) = {
@@ -1622,15 +1635,15 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                     (remaining, idents)
                 };
 
-                self.visit_expr(remaining.loc(), remaining, None)?;
+                self.visit_expr(remaining.loc(), remaining)?;
 
                 let mut chunks = self.items_to_chunks(
                     Some(loc.end()),
                     idents.into_iter().map(|ident| Ok((ident.loc, ident))),
                 )?;
                 chunks.iter_mut().for_each(|chunk| chunk.content.insert(0, '.'));
-                if let (Some(append), Some(last)) = (append, chunks.last_mut()) {
-                    last.content.push_str(append)
+                if let Some(last) = chunks.last_mut() {
+                    last.needs_space = Some(false);
                 }
                 let multiline = self.are_chunks_separated_multiline("{}", &chunks, "")?;
                 self.write_chunks_separated(&chunks, "", multiline)?;
@@ -1656,7 +1669,9 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 )?;
             }
             Expression::FunctionCall(loc, expr, exprs) => {
-                self.visit_expr(expr.loc(), expr, Some("("))?;
+                self.visit_expr(expr.loc(), expr)?;
+                // write_chunk_spaced!(self, expr.loc().end(), Some(false), "{}", "(")?;
+                write!(self.buf(), "(")?;
                 self.surrounded(expr.loc().end(), "", ")", Some(loc.end()), |fmt, _| {
                     let exprs = fmt.items_to_chunks(
                         Some(loc.end()),
@@ -1669,11 +1684,19 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 })?
             }
             Expression::FunctionCallBlock(loc, expr, stmt) => {
-                let last_chunk = format!("}}{}", append.unwrap_or(""));
-                self.visit_expr(expr.loc(), expr, Some("{"))?;
-                self.surrounded(stmt.loc().start(), "", last_chunk, Some(loc.end()), |fmt, _| {
-                    stmt.visit(fmt)
-                })?;
+                let chunks = vec![self.chunked(loc.start(), Some(loc.end()), |fmt| {
+                    fmt.grouped(|fmt| {
+                        expr.visit(fmt)?;
+                        write!(fmt.buf(), "{{")?;
+                        fmt.write_postfix_comments_before(stmt.loc().start())?;
+                        stmt.visit(fmt)
+                    })?;
+                    Ok(())
+                })?];
+                let multiline = self.are_chunks_separated_multiline("{}", &chunks, "")?;
+                self.write_chunks_separated(&chunks, "", multiline)?;
+                let closing_bracket = format!("{}{}", if multiline { "\n" } else { "" }, "}");
+                write_chunk_spaced!(self, expr.loc().end(), Some(false), "{}", closing_bracket)?;
             }
             _ => self.visit_source(loc)?,
         };
@@ -2185,12 +2208,13 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         let for_chunk = self.chunk_at(
             using.loc.start(),
             Some(ty_start.or(global_start).unwrap_or(loc_end)),
+            None,
             "for",
         );
         let ty_chunk = if let Some(ty) = &mut using.ty {
             self.visit_to_chunk(ty.loc().start(), Some(global_start.unwrap_or(loc_end)), ty)?
         } else {
-            self.chunk_at(using.loc.start(), Some(global_start.unwrap_or(loc_end)), "*")
+            self.chunk_at(using.loc.start(), Some(global_start.unwrap_or(loc_end)), None, "*")
         };
         let global_chunk = using
             .global
@@ -2341,9 +2365,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                             Statement::VariableDefinition(loc, ref mut decl, ref mut expr) => {
                                 fmt.visit_var_definition_stmt(loc, decl, expr, false)
                             }
-                            Statement::Expression(loc, ref mut expr) => {
-                                fmt.visit_expr(loc, expr, None)
-                            }
+                            Statement::Expression(loc, ref mut expr) => fmt.visit_expr(loc, expr),
                             _ => stmt.visit(fmt), // unreachable
                         }
                     })
@@ -2364,9 +2386,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                             Statement::VariableDefinition(_, ref mut decl, ref mut expr) => {
                                 fmt.visit_var_definition_stmt(loc, decl, expr, false)
                             }
-                            Statement::Expression(loc, ref mut expr) => {
-                                fmt.visit_expr(loc, expr, None)
-                            }
+                            Statement::Expression(loc, ref mut expr) => fmt.visit_expr(loc, expr),
                             _ => stmt.visit(fmt), // unreachable
                         }
                     })
@@ -2430,15 +2450,16 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_args(&mut self, _loc: Loc, args: &mut Vec<NamedArgument>) -> Result<(), Self::Error> {
-        let mut args = args.iter_mut().peekable();
+        let mut args = args.iter_mut().enumerate().peekable();
         let mut chunks = Vec::new();
-        while let Some(NamedArgument { loc, name, expr }) = args.next() {
+        while let Some((idx, NamedArgument { loc, name, expr })) = args.next() {
             chunks.push(self.chunked(
                 loc.start(),
-                args.peek().map(|NamedArgument { loc, .. }| loc.start()),
+                args.peek().map(|(_, NamedArgument { loc, .. })| loc.start()),
                 |fmt| {
                     fmt.grouped(|fmt| {
-                        write_chunk!(fmt, name.loc.end(), "{}:", name.name)?;
+                        let needs_space = if idx == 0 { Some(false) } else { None };
+                        write_chunk_spaced!(fmt, name.loc.end(), needs_space, "{}:", name.name)?;
                         expr.visit(fmt)
                     })?;
                     Ok(())

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1510,7 +1510,6 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
     }
 
     fn visit_expr(&mut self, loc: Loc, expr: &mut Expression, append: Option<&str>) -> Result<()> {
-        // println!("expr {:?}", expr);
         match expr {
             Expression::Type(loc, typ) => match typ {
                 Type::Address => write_chunk!(self, loc.start(), "address")?,
@@ -1620,7 +1619,6 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                         remaining = expr;
                     }
                     idents.reverse();
-
                     (remaining, idents)
                 };
 
@@ -2435,11 +2433,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         Ok(())
     }
 
-    fn visit_args(&mut self, loc: Loc, args: &mut Vec<NamedArgument>) -> Result<(), Self::Error> {
-        // self.surrounded(loc.start(), "{", "}", Some(loc.end()), |fmt, _| {
-
-        // })?;
-        // Ok(())
+    fn visit_args(&mut self, _loc: Loc, args: &mut Vec<NamedArgument>) -> Result<(), Self::Error> {
         let mut args = args.iter_mut().peekable();
         let mut chunks = Vec::new();
         while let Some(NamedArgument { loc, name, expr }) = args.next() {

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1629,9 +1629,8 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                     idents.into_iter().map(|ident| Ok((ident.loc, ident))),
                 )?;
                 chunks.iter_mut().for_each(|chunk| chunk.content.insert(0, '.'));
-                match (append, chunks.last_mut()) {
-                    (Some(append), Some(last)) => last.content.push_str(append),
-                    _ => {}
+                if let (Some(append), Some(last)) = (append, chunks.last_mut()) {
+                    last.content.push_str(append)
                 }
                 let multiline = self.are_chunks_separated_multiline("{}", &chunks, "")?;
                 self.write_chunks_separated(&chunks, "", multiline)?;
@@ -2441,7 +2440,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 loc.start(),
                 args.peek().map(|NamedArgument { loc, .. }| loc.start()),
                 |fmt| {
-                    write_chunk!(fmt, name.loc.end(), expr.loc().start(), "{}:", name.name)?;
+                    write_chunk!(fmt, name.loc.end(), "{}:", name.name)?;
                     expr.visit(fmt)?;
                     Ok(())
                 },

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -89,7 +89,12 @@ pub trait Visitor {
 
     /// Don't write semicolon at the end because expressions can appear as both
     /// part of other node and a statement in the function body
-    fn visit_expr(&mut self, loc: Loc, _expr: &mut Expression) -> Result<(), Self::Error> {
+    fn visit_expr(
+        &mut self,
+        loc: Loc,
+        _expr: &mut Expression,
+        _append: Option<&str>,
+    ) -> Result<(), Self::Error> {
         self.visit_source(loc)
     }
 
@@ -436,7 +441,7 @@ impl Visitable for Statement {
             }
             Statement::While(loc, cond, body) => v.visit_while(*loc, cond, body),
             Statement::Expression(loc, expr) => {
-                v.visit_expr(*loc, expr)?;
+                v.visit_expr(*loc, expr, None)?;
                 v.visit_stray_semicolon()
             }
             Statement::VariableDefinition(loc, declaration, expr) => {
@@ -476,7 +481,7 @@ impl Visitable for Expression {
     where
         V: Visitor,
     {
-        v.visit_expr(LineOfCode::loc(self), self)
+        v.visit_expr(LineOfCode::loc(self), self, None)
     }
 }
 

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -89,12 +89,7 @@ pub trait Visitor {
 
     /// Don't write semicolon at the end because expressions can appear as both
     /// part of other node and a statement in the function body
-    fn visit_expr(
-        &mut self,
-        loc: Loc,
-        _expr: &mut Expression,
-        _append: Option<&str>,
-    ) -> Result<(), Self::Error> {
+    fn visit_expr(&mut self, loc: Loc, _expr: &mut Expression) -> Result<(), Self::Error> {
         self.visit_source(loc)
     }
 
@@ -441,7 +436,7 @@ impl Visitable for Statement {
             }
             Statement::While(loc, cond, body) => v.visit_while(*loc, cond, body),
             Statement::Expression(loc, expr) => {
-                v.visit_expr(*loc, expr, None)?;
+                v.visit_expr(*loc, expr)?;
                 v.visit_stray_semicolon()
             }
             Statement::VariableDefinition(loc, declaration, expr) => {
@@ -481,7 +476,7 @@ impl Visitable for Expression {
     where
         V: Visitor,
     {
-        v.visit_expr(LineOfCode::loc(self), self, None)
+        v.visit_expr(LineOfCode::loc(self), self)
     }
 }
 

--- a/fmt/testdata/FunctionCallArgsStatement/fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/fmt.sol
@@ -35,5 +35,19 @@ contract FunctionCallArgsStatement {
             value: value(1 ether),
             gas: veryAndVeryLongNameOfSomeGasEstimateFunction()
         }();
+
+        target.run{ /* comment 1 */ value: /* comment2 */ 1 };
+
+        target.run{ /* comment3 */
+            value: 1, // comment4
+            gas: gasleft()
+        };
+
+        target.run{
+            // comment5
+            value: 1,
+            // comment6
+            gas: gasleft()
+        };
     }
 }

--- a/fmt/testdata/FunctionCallArgsStatement/fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/fmt.sol
@@ -23,22 +23,22 @@ contract FunctionCallArgsStatement {
     }
 
     function test() external {
-        target.run{ gas: gasleft(), value: 1 wei };
+        target.run{gas: gasleft(), value: 1 wei};
 
-        target.run{ gas: 1, value: 0x00 }();
+        target.run{gas: 1, value: 0x00}();
 
-        target.run{ gas: 1000, value: 1 ether }();
+        target.run{gas: 1000, value: 1 ether}();
 
-        target.run{ gas: estimate(), value: value(1) }();
+        target.run{gas: estimate(), value: value(1)}();
 
         target.run{
             value: value(1 ether),
             gas: veryAndVeryLongNameOfSomeGasEstimateFunction()
         }();
 
-        target.run{ /* comment 1 */ value: /* comment2 */ 1 };
+        target.run{/* comment 1 */ value: /* comment2 */ 1};
 
-        target.run{ /* comment3 */
+        target.run{/* comment3 */
             value: 1, // comment4
             gas: gasleft()
         };

--- a/fmt/testdata/FunctionCallArgsStatement/fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/fmt.sol
@@ -36,9 +36,9 @@ contract FunctionCallArgsStatement {
             gas: veryAndVeryLongNameOfSomeGasEstimateFunction()
         }();
 
-        target.run{/* comment 1 */ value: /* comment2 */ 1};
+        target.run{ /* comment 1 */ value: /* comment2 */ 1};
 
-        target.run{/* comment3 */
+        target.run{ /* comment3 */
             value: 1, // comment4
             gas: gasleft()
         };

--- a/fmt/testdata/FunctionCallArgsStatement/fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/fmt.sol
@@ -26,7 +26,7 @@ contract FunctionCallArgsStatement {
         target.run{ gas: gasleft(), value: 1 wei };
 
         target.run{ gas: 1, value: 0x00 }();
-        
+
         target.run{ gas: 1000, value: 1 ether }();
 
         target.run{ gas: estimate(), value: value(1) }();

--- a/fmt/testdata/FunctionCallArgsStatement/fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/fmt.sol
@@ -1,0 +1,39 @@
+// config: bracket-spacing=true
+interface ITarget {
+    function run() external payable;
+    function veryAndVeryLongNameOfSomeRunFunction() external payable;
+}
+
+contract FunctionCallArgsStatement {
+    ITarget public target;
+
+    function estimate() public returns (uint256 gas) {
+        gas = 1 gwei;
+    }
+
+    function veryAndVeryLongNameOfSomeGasEstimateFunction()
+        public
+        returns (uint256)
+    {
+        return gasleft();
+    }
+
+    function value(uint256 val) public returns (uint256) {
+        return val;
+    }
+
+    function test() external {
+        target.run{ gas: gasleft(), value: 1 wei };
+
+        target.run{ gas: 1, value: 0x00 }();
+        
+        target.run{ gas: 1000, value: 1 ether }();
+
+        target.run{ gas: estimate(), value: value(1) }();
+
+        target.run{
+            value: value(1 ether),
+            gas: veryAndVeryLongNameOfSomeGasEstimateFunction()
+        }();
+    }
+}

--- a/fmt/testdata/FunctionCallArgsStatement/original.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/original.sol
@@ -33,5 +33,16 @@ contract FunctionCallArgsStatement {
 
         target.run { value:
         value(1 ether), gas: veryAndVeryLongNameOfSomeGasEstimateFunction() } ();
+
+        target.run /* comment 1 */ { value: /* comment2 */ 1 }; 
+
+        target.run { /* comment3 */ value: 1, // comment4
+        gas: gasleft()};
+
+        target.run {
+            // comment5
+            value: 1,
+            // comment6
+            gas: gasleft()};
     }
 }

--- a/fmt/testdata/FunctionCallArgsStatement/original.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/original.sol
@@ -1,0 +1,37 @@
+interface ITarget {
+    function run() external payable;
+    function veryAndVeryLongNameOfSomeRunFunction() external payable;
+}
+
+contract FunctionCallArgsStatement {
+    ITarget public target;
+
+    function estimate() public returns (uint256 gas) {
+        gas = 1 gwei;
+    }
+
+    function veryAndVeryLongNameOfSomeGasEstimateFunction() public returns (uint256) {
+        return gasleft();
+    }
+
+    function value(uint256 val) public returns (uint256) {
+        return val;
+    }
+
+    function test() external {
+        target.run{ gas: gasleft(), value: 1 wei };
+
+        target.run{gas:1,value:0x00}();
+
+        target.run{ 
+                gas : 1000, 
+        value: 1 ether 
+        } ();
+
+        target.run{  gas: estimate(),
+    value: value(1) }(); 
+
+        target.run { value:
+        value(1 ether), gas: veryAndVeryLongNameOfSomeGasEstimateFunction() } ();
+    }
+}


### PR DESCRIPTION
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

add support for formatting `Expression::FunctionCall`, `Expression::FunctionCallBlock` & `Statement::Args`