### PR TITLE
test: set opt-3 level for deps in test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ debug = 0
 [profile.dev.package]
 # These speed up local tests
 ethers-solc.opt-level = 3
+revm.opt-level = 3
 
 [profile.test.package]
 # These will speed up all forge script related integration tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ debug = 0
 # These speed up local tests
 ethers-solc.opt-level = 3
 
+[profile.test.package]
+# These will speed up all forge script related integration tests
+anvil.opt-level = 3
+axum.opt-level = 3
+
 # local "release" mode
 [profile.local]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ revm.opt-level = 3
 
 [profile.test.package]
 # These will speed up all forge script related integration tests
-anvil.opt-level = 3
 axum.opt-level = 3
 
 # local "release" mode


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
check if this will speed up the forge integration job a bit

it should be acceptable that we'll spend a bit more time compiling foreign deps since these are cached anyways and won't impact local testing significantly

alternatively we could try running with `local` profile (at least for integration test), I think the release profile will  be to demanding and slow things down even more

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
