### PR TITLE
fix: match multiline correctly in ignore regex

### DIFF
--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -613,7 +613,7 @@ pub trait OutputExt {
 ///
 /// This should strip everything that can vary from run to run, like elapsed time, file paths
 static IGNORE_IN_FIXTURES: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(finished in (.*)?s|-->(.*).sol|Location(.*?)\.rs(.*)?Backtrace|installing solc version(.*?)\n|Successfully installed solc(.*?)\n)").unwrap()
+    Regex::new(r"(finished in (.*)?s|-->(.*).sol|Location(.|\n)*\.rs(.|\n)*Backtrace|installing solc version(.*?)\n|Successfully installed solc(.*?)\n)").unwrap()
 });
 
 impl OutputExt for process::Output {
@@ -683,11 +683,13 @@ mod tests {
 
     #[test]
     fn fixture_regex_matches() {
-        assert!(IGNORE_IN_FIXTURES.is_match(r#"
+        assert!(IGNORE_IN_FIXTURES.is_match(
+            r#"
 Location:
    [35mcli/src/compile.rs[0m:[35m151[0m
 
 Backtrace omitted.
-        "#));
+        "#
+        ));
     }
 }

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -680,4 +680,14 @@ mod tests {
             assert_eq!(tty_fixture_path(path), PathBuf::from(path));
         }
     }
+
+    #[test]
+    fn fixture_regex_matches() {
+        assert!(IGNORE_IN_FIXTURES.is_match(r#"
+Location:
+   [35mcli/src/compile.rs[0m:[35m151[0m
+
+Backtrace omitted.
+        "#));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
strip code dependent Backtrace info from fixtures correctly
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
match multiline everything between `Location -> Backtrace` which contains the file and line number
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
