### PR TITLE
fix: dont drop anvil server handle

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -154,7 +154,7 @@ result: uint256 255
 
 forgetest_async!(can_deploy_script_without_lib, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -169,7 +169,7 @@ forgetest_async!(can_deploy_script_without_lib, |prj: TestProject, cmd: TestComm
 
 forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -184,7 +184,7 @@ forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand
 
 forgetest_async!(can_resume_script, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -203,7 +203,7 @@ forgetest_async!(can_resume_script, |prj: TestProject, cmd: TestCommand| async m
 
 forgetest_async!(can_deploy_broadcast_wrap, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -219,7 +219,7 @@ forgetest_async!(can_deploy_broadcast_wrap, |prj: TestProject, cmd: TestCommand|
 
 forgetest_async!(panic_no_deployer_set, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -232,7 +232,7 @@ forgetest_async!(panic_no_deployer_set, |prj: TestProject, cmd: TestCommand| asy
 
 forgetest_async!(can_deploy_no_arg_broadcast, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -248,7 +248,7 @@ forgetest_async!(can_deploy_no_arg_broadcast, |prj: TestProject, cmd: TestComman
 
 forgetest_async!(can_deploy_with_create2, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
+    let (api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     // Prepare CREATE2 Deployer
@@ -273,7 +273,7 @@ forgetest_async!(
     can_deploy_100_txes_concurrently,
     |prj: TestProject, cmd: TestCommand| async move {
         let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
+        let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
         let mut tester = ScriptTester::new(cmd, port, prj.root());
 
         tester
@@ -291,7 +291,7 @@ forgetest_async!(
     can_deploy_mixed_broadcast_modes,
     |prj: TestProject, cmd: TestCommand| async move {
         let port = next_port();
-        spawn(NodeConfig::test().with_port(port)).await;
+        let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
         let mut tester = ScriptTester::new(cmd, port, prj.root());
 
         tester
@@ -307,7 +307,7 @@ forgetest_async!(
 
 forgetest_async!(deploy_with_setup, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -322,7 +322,7 @@ forgetest_async!(deploy_with_setup, |prj: TestProject, cmd: TestCommand| async m
 
 forgetest_async!(fail_broadcast_staticcall, |prj: TestProject, cmd: TestCommand| async move {
     let port = next_port();
-    spawn(NodeConfig::test().with_port(port)).await;
+    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
     let mut tester = ScriptTester::new(cmd, port, prj.root());
 
     tester
@@ -337,7 +337,7 @@ forgetest_async!(
     check_broadcast_log,
     |prj: TestProject, cmd: TestCommand| async move {
         let port = next_port();
-        let (api, _) = spawn(NodeConfig::test().with_port(port)).await;
+        let (api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
         let mut tester = ScriptTester::new(cmd, port, prj.root());
 
         // Prepare CREATE2 Deployer


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
don't drop the handle and API object
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
keep them alive for the entirety of the test, I think it should be fine to drop them but just to rule out any side effects for https://github.com/foundry-rs/foundry/issues/1984
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
