### PR TITLE
test: check if next port is free

### DIFF
--- a/anvil/tests/it/main.rs
+++ b/anvil/tests/it/main.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::{
+    net::TcpStream,
+    sync::atomic::{AtomicU16, Ordering},
+};
 
 mod abi;
 mod anvil;
@@ -20,8 +23,16 @@ mod wsapi;
 // keeps track of ports that can be used
 pub static NEXT_PORT: AtomicU16 = AtomicU16::new(8546);
 
+/// Returns the next free port to use
 pub fn next_port() -> u16 {
-    NEXT_PORT.fetch_add(1, Ordering::SeqCst)
+    loop {
+        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+        // while simply incrementing ports is fine for a single test process, there might be
+        // multiple concurrent anvil related test process, so we check if the port is already in use
+        if TcpStream::connect(("0.0.0.0", port)).is_err() {
+            return port
+        }
+    }
 }
 
 #[allow(unused)]

--- a/cli/tests/it/main.rs
+++ b/cli/tests/it/main.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::{
+    net::TcpStream,
+    sync::atomic::{AtomicU16, Ordering},
+};
 #[cfg(not(feature = "external-integration-tests"))]
 mod cast;
 #[cfg(not(feature = "external-integration-tests"))]
@@ -27,8 +30,16 @@ mod integration;
 // keeps track of ports that can be used
 pub static NEXT_PORT: AtomicU16 = AtomicU16::new(8546);
 
+/// Returns the next free port to use
 pub fn next_port() -> u16 {
-    NEXT_PORT.fetch_add(1, Ordering::SeqCst)
+    loop {
+        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+        // while simply incrementing ports is fine for a single test process, there might be
+        // multiple concurrent anvil related test process, so we check if the port is already in use
+        if TcpStream::connect(("0.0.0.0", port)).is_err() {
+            return port
+        }
+    }
 }
 
 fn main() {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
(semi)ensure we're using a free port ref #1984

a better way would be to use port 0 and let the OS find one but it would be a bit messy returning this from the axum Server object after binding it...
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
has code duplication, but negligible imo
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
