### PR TITLE
fix(anvil): block block mining in place

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -429,6 +429,10 @@ impl Backend {
     /// this will execute all transaction in the order they come in and return all the markers they
     /// provide.
     pub fn mine_block(&self, pool_transactions: Vec<Arc<PoolTransaction>>) -> MinedBlockOutcome {
+        tokio::task::block_in_place(|| self.do_mine_block(pool_transactions))
+    }
+
+    fn do_mine_block(&self, pool_transactions: Vec<Arc<PoolTransaction>>) -> MinedBlockOutcome {
         trace!(target: "backend", "creating new block with {} transactions", pool_transactions.len());
 
         let current_base_fee = self.base_fee();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
mining a block can lead to issues in fork mode and async context since it needs to hold all locks over the duration of block production, during which the fork backend kicks in.

there can be some side effects with auto block production if there's a concurrent `eth_call` that requires read access to the db and can be moved to another task, however the auto block production may now block the executor and prevent the `eth_call` to complete and therefor deadlocks as seen: https://github.com/foundry-rs/foundry/issues/1920#issuecomment-1155787175


Overall we run into these issues mainly because in order to support fork and normal mode we have to perform some blocking io in async context, in order to use a fork revm database we need to block until the data is fetched from remote... 

we could wrap every incoming rpc call into a spawn_blocking, https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html however this would not affect the `EthApi` object which is basically the executor for an rpc...

the other solution I see is fully transitioning to async and tokio's locks, which perhaps would be more appropriate here since we already have ~50% async API functions that require async (due to fork mode) anyways

wdyt @gakonst

Ref https://github.com/foundry-rs/foundry/issues/1920

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
