### PR TITLE
refactor: change script template

### DIFF
--- a/cli/assets/ContractTemplate.s.sol
+++ b/cli/assets/ContractTemplate.s.sol
@@ -3,13 +3,10 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
 
-import {Contract} from "src/Contract.sol";
-
 contract ContractScript is Script {
     function setUp() public {}
 
     function run() public {
-        vm.broadcast();
-        new Contract();
+        vm.startBroadcast();
     }
 }

--- a/cli/assets/ContractTemplate.s.sol
+++ b/cli/assets/ContractTemplate.s.sol
@@ -7,6 +7,6 @@ contract ContractScript is Script {
     function setUp() public {}
 
     function run() public {
-        vm.startBroadcast();
+        vm.broadcast();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When I want to test something and init a new project, it won't compile if I change the contract name / file name / constructor args in `src/Contract.sol` unless I fix `script/Contract.s.sol` first.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use the same approach as for the `test/Contract.t.sol`, which does not import / interact with the template contract.

Opinionated: Use `startBroadcast` instead of `broadcast`, as it seems to be used more often.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
