### PR TITLE
fix: don't use provider gas estimate for optimism

### DIFF
--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -200,6 +200,6 @@ macro_rules! update_progress {
 pub fn has_different_gas_calc(chain: u64) -> bool {
     matches!(
         Chain::try_from(chain).unwrap_or(Chain::Mainnet),
-        Chain::Arbitrum | Chain::ArbitrumTestnet | Chain::Optimism | Chain::OptimismKovan
+        Chain::Arbitrum | Chain::ArbitrumTestnet
     )
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Context provided here: https://github.com/foundry-rs/foundry/issues/2002. This change ensures that gas estimation is not underestimated for Optimism.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Following the solution to ensure we don't calculate gas differently for Optimism, as explained here by @mds1 and @joshieDo (thanks for the help! 😄) https://github.com/foundry-rs/foundry/issues/2002#issuecomment-1158936417. I am only addressing the first point in this changeset.

To test, successfully ran the same script with the same contract and args as specified in the [issue](https://github.com/foundry-rs/foundry/issues/2002#issue-1273968058) on anvil forks of optimism and optimism kovan. Also successfully ran a separate deploy script that was previously failing on prod optimism.