### PR TITLE
ci: add 60min timeout

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -7,6 +7,7 @@ jobs:
   add-to-project:
     name: add issue
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/add-to-project@main
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   unit:
     name: unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Saw some jobs taking more than 2 hours https://github.com/foundry-rs/foundry/runs/6950320447?check_suite_focus=true which means it should be fixed spereately this just adds a safely check to ensure CI execution time is not drained 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
GitHub default is 360min which is a lot. Looking at past runs nothing that passes really goes beyond 40mins so having a 60min timeout should give enough room.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
