### PR TITLE
Add a `cast rpc` method for raw JSON-RPC reqs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,7 @@ dependencies = [
  "globset",
  "hex",
  "indicatif 0.17.0-rc.11",
+ "itertools",
  "once_cell",
  "pretty_assertions",
  "proptest",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -20,13 +20,13 @@ ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-featu
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
+serde = "1.0.136"
 serde_json = "1.0.67"
 chrono = "0.2"
 hex = "0.4.3"
 
 [dev-dependencies]
 async-trait = "0.1.53"
-serde = "1.0.136"
 tokio = "1.17.0"
 thiserror = "1.0.30"
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -626,6 +626,29 @@ where
         };
         Ok(receipt)
     }
+
+    /// Perform a raw JSON-RPC request
+    ///
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use std::convert::TryFrom;
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let result = cast.rpc("eth_blockNumber", []).await?;
+    /// println!("{}", receipt);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn request<T>(&self, method: &str, params: T) -> Result<String>
+    where
+        T: std::fmt::Debug + serde::Serialize + Send + Sync,
+    {
+        let res = self.provider.provider().request::<T, serde_json::Value>(method, params).await?;
+        Ok(serde_json::to_string(&res)?)
+    }
 }
 
 pub struct InterfaceSource {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -637,12 +637,13 @@ where
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
     /// let cast = Cast::new(provider);
-    /// let result = cast.rpc("eth_blockNumber", []).await?;
-    /// println!("{}", receipt);
+    /// let result = cast.rpc("eth_getBalance", &["0xc94770007dda54cF92009BFF0dE90c06F603a09f", "latest"])
+    ///     .await?;
+    /// println!("{}", result);
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn request<T>(&self, method: &str, params: T) -> Result<String>
+    pub async fn rpc<T>(&self, method: &str, params: T) -> Result<String>
     where
         T: std::fmt::Debug + serde::Serialize + Send + Sync,
     {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,6 +64,7 @@ serde_json = "1.0.67"
 regex = { version = "1.5.4", default-features = false }
 rpassword = "5.0.1"
 hex = "0.4.3"
+itertools = "0.10.3"
 serde = "1.0.133"
 proptest = "1.0.0"
 semver = "1.0.5"

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -681,27 +681,7 @@ async fn main() -> eyre::Result<()> {
             generate(shell, &mut Opts::command(), "cast", &mut std::io::stdout())
         }
         Subcommands::Run(cmd) => cmd.run()?,
-        Subcommands::Rpc { rpc_url, direct_params, method, params } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = Provider::try_from(rpc_url)?;
-            let params = if direct_params {
-                if params.len() != 1 {
-                    eyre::bail!(r#"Expected exactly one argument for "params""#);
-                }
-                let param = params.into_iter().next().unwrap();
-                serde_json::from_str(&param).unwrap_or(serde_json::Value::String(param))
-            } else {
-                serde_json::Value::Array(
-                    params
-                        .into_iter()
-                        .map(|param| {
-                            serde_json::from_str(&param).unwrap_or(serde_json::Value::String(param))
-                        })
-                        .collect(),
-                )
-            };
-            println!("{}", Cast::new(provider).rpc(&method, params).await?);
-        }
+        Subcommands::Rpc(cmd) => cmd.run()?.await?,
     };
     Ok(())
 }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -681,7 +681,7 @@ async fn main() -> eyre::Result<()> {
             generate(shell, &mut Opts::command(), "cast", &mut std::io::stdout())
         }
         Subcommands::Run(cmd) => cmd.run()?,
-        Subcommands::Request { rpc_url, method, params } => {
+        Subcommands::Rpc { rpc_url, method, params } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
             let provider = Provider::try_from(rpc_url)?;
             let params = params
@@ -698,7 +698,7 @@ async fn main() -> eyre::Result<()> {
                     }
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            println!("{}", Cast::new(provider).request(&method, params).await?);
+            println!("{}", Cast::new(provider).rpc(&method, params).await?);
         }
     };
     Ok(())

--- a/cli/src/cmd/cast/mod.rs
+++ b/cli/src/cmd/cast/mod.rs
@@ -6,5 +6,6 @@
 //! [`foundry_config::Config`].
 
 pub mod find_block;
+pub mod rpc;
 pub mod run;
 pub mod wallet;

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use ethers::prelude::*;
 use eyre::Result;
 use futures::future::BoxFuture;
+use itertools::Itertools;
 
 #[derive(Debug, Clone, Parser)]
 pub struct RpcArgs {
@@ -59,9 +60,9 @@ impl RpcArgs {
                     .into_iter()
                     .next()
                     .transpose()?
-                    .unwrap()
+                    .ok_or_else(|| eyre::format_err!("Empty JSON parameters"))?
             } else {
-                Self::to_json_or_string(params.into_iter().next().unwrap())
+                Self::to_json_or_string(params.into_iter().join(" "))
             }
         } else {
             serde_json::Value::Array(params.into_iter().map(Self::to_json_or_string).collect())

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -1,0 +1,75 @@
+use crate::{cmd::Cmd, utils::consume_config_rpc_url};
+use cast::Cast;
+use clap::Parser;
+use ethers::prelude::*;
+use eyre::Result;
+use futures::future::BoxFuture;
+
+#[derive(Debug, Clone, Parser)]
+pub struct RpcArgs {
+    #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
+    rpc_url: Option<String>,
+    #[clap(
+        short = 'w',
+        long,
+        help = r#"Pass the "params" as is"#,
+        long_help = r#"Pass the "params" as is
+
+If --raw is passed the first PARAM will be taken as the value of "params". If no params are given, stdin will be used. For example:
+
+rpc eth_getBlockByNumber '["0x123", false]' --raw
+    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
+    )]
+    raw: bool,
+    #[clap(value_name = "METHOD", help = "RPC method name")]
+    method: String,
+    #[clap(
+        value_name = "PARAMS",
+        help = "RPC parameters",
+        long_help = r#"RPC parameters
+
+Parameters are interpreted as JSON and then fall back to string. For example:
+
+rpc eth_getBlockByNumber 0x123 false
+    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
+    )]
+    params: Vec<String>,
+}
+
+impl Cmd for RpcArgs {
+    type Output = BoxFuture<'static, Result<()>>;
+    fn run(self) -> eyre::Result<Self::Output> {
+        let RpcArgs { rpc_url, raw, method, params } = self;
+        Ok(Box::pin(Self::do_rpc(rpc_url, raw, method, params)))
+    }
+}
+
+impl RpcArgs {
+    async fn do_rpc(
+        rpc_url: Option<String>,
+        raw: bool,
+        method: String,
+        params: Vec<String>,
+    ) -> Result<()> {
+        let rpc_url = consume_config_rpc_url(rpc_url);
+        let provider = Provider::try_from(rpc_url)?;
+        let params = if raw {
+            if params.is_empty() {
+                serde_json::Deserializer::from_reader(std::io::stdin())
+                    .into_iter()
+                    .next()
+                    .transpose()?
+                    .unwrap()
+            } else {
+                Self::to_json_or_string(params.into_iter().next().unwrap())
+            }
+        } else {
+            serde_json::Value::Array(params.into_iter().map(Self::to_json_or_string).collect())
+        };
+        println!("{}", Cast::new(provider).rpc(&method, params).await?);
+        Ok(())
+    }
+    fn to_json_or_string(value: String) -> serde_json::Value {
+        serde_json::from_str(&value).unwrap_or(serde_json::Value::String(value))
+    }
+}

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -828,6 +828,18 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
     Rpc {
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
+        #[clap(
+            short,
+            long,
+            help = "Do not put parameters in an array",
+            long_help = r#"Do not put parameters in an array
+
+If --direct-params is passed the first PARAM will be taken as the value of "params". For example:
+
+rpc --direct-params eth_getBlockByNumber '["0x123", false]'
+    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
+        )]
+        direct_params: bool,
         #[clap(value_name = "METHOD", help = "RPC method name")]
         method: String,
         #[clap(
@@ -835,11 +847,10 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
             help = "RPC parameters",
             long_help = r#"RPC parameters
 
-Parameters are interpreted as strings. If you wish to pass a JSON value you can prepend the value with a ':'. To start a string with a ':' prepend with '::'. For example:
+Parameters are interpreted as JSON and then fall back to string. For example:
 
-request doThing 123   => {"method": "doThing", "params": ["123"] ... }
-request doThing :123  => {"method": "doThing", "params": [123] ... }
-request doThing ::123 => {"method": "doThing", "params": [":123"] ... }"#
+rpc eth_getBlockByNumber 0x123 false
+    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
         )]
         params: Vec<String>,
     },

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -822,6 +822,27 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         about = "Runs a published transaction in a local environment and prints the trace."
     )]
     Run(RunArgs),
+    #[clap(name = "request")]
+    #[clap(visible_aliases = &["rq", "req"])]
+    #[clap(about = "Perform a raw JSON-RPC request")]
+    Request {
+        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
+        rpc_url: Option<String>,
+        #[clap(value_name = "METHOD", help = "RPC method name")]
+        method: String,
+        #[clap(
+            value_name = "PARAMS",
+            help = "RPC parameters",
+            long_help = r#"RPC parameters
+
+Parameters are interpreted as strings. If you wish to pass a JSON value you can prepend the value with a ':'. To start a string with a ':' prepend with '::'. For example:
+
+request doThing 123   => {"method": "doThing", "params": ["123"] ... }
+request doThing :123  => {"method": "doThing", "params": [123] ... }
+request doThing ::123 => {"method": "doThing", "params": [":123"] ... }"#
+        )]
+        params: Vec<String>,
+    },
 }
 
 pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,6 +1,6 @@
 use super::{ClapChain, EthereumOpts};
 use crate::{
-    cmd::cast::{find_block::FindBlockArgs, run::RunArgs, wallet::WalletSubcommands},
+    cmd::cast::{find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs, wallet::WalletSubcommands},
     utils::{parse_ether_value, parse_u256},
 };
 use clap::{Parser, Subcommand, ValueHint};
@@ -825,35 +825,7 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
     #[clap(name = "rpc")]
     #[clap(visible_alias = "rp")]
     #[clap(about = "Perform a raw JSON-RPC request")]
-    Rpc {
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
-        #[clap(
-            short,
-            long,
-            help = "Do not put parameters in an array",
-            long_help = r#"Do not put parameters in an array
-
-If --direct-params is passed the first PARAM will be taken as the value of "params". For example:
-
-rpc --direct-params eth_getBlockByNumber '["0x123", false]'
-    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
-        )]
-        direct_params: bool,
-        #[clap(value_name = "METHOD", help = "RPC method name")]
-        method: String,
-        #[clap(
-            value_name = "PARAMS",
-            help = "RPC parameters",
-            long_help = r#"RPC parameters
-
-Parameters are interpreted as JSON and then fall back to string. For example:
-
-rpc eth_getBlockByNumber 0x123 false
-    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
-        )]
-        params: Vec<String>,
-    },
+    Rpc(RpcArgs),
 }
 
 pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -822,10 +822,10 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         about = "Runs a published transaction in a local environment and prints the trace."
     )]
     Run(RunArgs),
-    #[clap(name = "request")]
-    #[clap(visible_aliases = &["rq", "req"])]
+    #[clap(name = "rpc")]
+    #[clap(visible_alias = "rp")]
     #[clap(about = "Perform a raw JSON-RPC request")]
-    Request {
+    Rpc {
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
         #[clap(value_name = "METHOD", help = "RPC method name")]

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -92,3 +92,23 @@ casttest!(cast_rlp, |_: TestProject, mut cmd: TestCommand| {
     let out = cmd.stdout_lossy();
     assert!(out.contains("[[\"0x55556666\"],[],[],[[[]]]]"), "{}", out);
 });
+
+// test for cast_rpc without arguments
+casttest!(cast_rpc_no_args, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+
+    // Call `cast rpc eth_chainId`
+    cmd.args(["rpc", "--rpc-url", eth_rpc_url.as_str(), "eth_chainId"]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim_end(), r#""0x1""#);
+});
+
+// test for cast_rpc with arguments
+casttest!(cast_rpc_with_args, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+
+    // Call `cast rpc eth_getBlockByNumber 0x123 :false`
+    cmd.args(["rpc", "--rpc-url", eth_rpc_url.as_str(), "eth_getBlockByNumber", "0x123", ":false"]);
+    let output = cmd.stdout_lossy();
+    assert!(output.contains(r#""number":"0x123""#), "{}", output);
+});

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -107,8 +107,25 @@ casttest!(cast_rpc_no_args, |_: TestProject, mut cmd: TestCommand| {
 casttest!(cast_rpc_with_args, |_: TestProject, mut cmd: TestCommand| {
     let eth_rpc_url = next_http_rpc_endpoint();
 
-    // Call `cast rpc eth_getBlockByNumber 0x123 :false`
-    cmd.args(["rpc", "--rpc-url", eth_rpc_url.as_str(), "eth_getBlockByNumber", "0x123", ":false"]);
+    // Call `cast rpc eth_getBlockByNumber 0x123 false`
+    cmd.args(["rpc", "--rpc-url", eth_rpc_url.as_str(), "eth_getBlockByNumber", "0x123", "false"]);
+    let output = cmd.stdout_lossy();
+    assert!(output.contains(r#""number":"0x123""#), "{}", output);
+});
+
+// test for cast_rpc with direct params
+casttest!(cast_rpc_direct_params, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+
+    // Call `cast rpc --direct-params eth_getBlockByNumber '["0x123", false]'`
+    cmd.args([
+        "rpc",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+        "--direct-params",
+        "eth_getBlockByNumber",
+        r#"["0x123", false]"#,
+    ]);
     let output = cmd.stdout_lossy();
     assert!(output.contains(r#""number":"0x123""#), "{}", output);
 });


### PR DESCRIPTION
## Motivation

Cast doesn't have any way to interact with non-standard RPC endpoints. The main use case here would be something like `anvil_mine`

## Solution

Implement a `cast request` subcommand to send raw JSON-RPC requests.

```
cast-request 
Perform a raw JSON-RPC request

USAGE:
    cast request [OPTIONS] <METHOD> [PARAMS]...

ARGS:
    <METHOD>
            RPC method name

    <PARAMS>...
            RPC parameters
            
            Parameters are interpreted as strings. If you wish to pass a JSON value you can prepend
            the value with a ':'. To start a string with a ':' prepend with '::'. For example:
            
            request doThing 123   => {"method": "doThing", "params": ["123"] ... }
            request doThing :123  => {"method": "doThing", "params": [123] ... }
            request doThing ::123 => {"method": "doThing", "params": [":123"] ... }

OPTIONS:
    -h, --help
            Print help information

    -r, --rpc-url <URL>
            [env: ETH_RPC_URL=]
```

For example running `anvil_mine` for 100 blocks would be as simple as `cast rq anvil_mine :100`. Of course, I think there can be some discussion about incorporating the anvil commands directly into cast as a subcommand tree itself.
