### PR TITLE
fix(anvil): use geth compliant error code for reverts

### DIFF
--- a/anvil/rpc/src/error.rs
+++ b/anvil/rpc/src/error.rs
@@ -90,6 +90,8 @@ pub enum ErrorCode {
     InternalError,
     /// Failed to send transaction, See also <https://github.com/MetaMask/eth-rpc-errors/blob/main/src/error-constants.ts>
     TransactionRejected,
+    /// Custom geth error code, <https://github.com/vapory-legacy/wiki/blob/master/JSON-RPC-Error-Codes-Improvement-Proposal.md>
+    ExecutionError,
     /// Used for server specific errors.
     ServerError(i64),
 }
@@ -104,6 +106,7 @@ impl ErrorCode {
             ErrorCode::InvalidParams => -32602,
             ErrorCode::InternalError => -32603,
             ErrorCode::TransactionRejected => -32003,
+            ErrorCode::ExecutionError => 3,
             ErrorCode::ServerError(c) => c,
         }
     }
@@ -118,6 +121,7 @@ impl ErrorCode {
             ErrorCode::InternalError => "Internal error",
             ErrorCode::TransactionRejected => "Transaction rejected",
             ErrorCode::ServerError(_) => "Server error",
+            ErrorCode::ExecutionError => "Execution error",
         }
     }
 }
@@ -148,6 +152,8 @@ impl From<i64> for ErrorCode {
             -32601 => ErrorCode::MethodNotFound,
             -32602 => ErrorCode::InvalidParams,
             -32603 => ErrorCode::InternalError,
+            -32003 => ErrorCode::TransactionRejected,
+            3 => ErrorCode::ExecutionError,
             _ => ErrorCode::ServerError(code),
         }
     }

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -180,12 +180,14 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 }
                 BlockchainError::InvalidTransaction(err) => match err {
                     InvalidTransactionError::Revert(data) => {
+                        // this mimics geth revert error
                         let mut msg = "execution reverted".to_string();
                         if let Some(reason) = data.as_ref().and_then(decode_revert_reason) {
                             msg = format!("{}: {}", msg, reason);
                         }
                         RpcError {
-                            code: ErrorCode::TransactionRejected,
+                            // geth returns this error code on reverts, See <https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal>
+                            code: ErrorCode::ExecutionError,
                             message: msg.into(),
                             data: serde_json::to_value(data).ok(),
                         }

--- a/anvil/tests/it/geth.rs
+++ b/anvil/tests/it/geth.rs
@@ -1,11 +1,16 @@
 //! tests against local geth for local debug purposes
 
+use crate::revert::VENDING_MACHINE_CONTRACT;
 use ethers::{
     abi::Address,
+    contract::{Contract, ContractFactory},
     prelude::{Middleware, TransactionRequest},
     providers::Provider,
+    utils::WEI_IN_ETHER,
 };
+use ethers_solc::{project_util::TempProject, Artifact};
 use futures::StreamExt;
+use std::sync::Arc;
 use tokio::time::timeout;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -26,4 +31,40 @@ async fn test_geth_pending_transaction() {
 
     let pending = timeout(std::time::Duration::from_secs(3), watch_tx_stream.next()).await;
     assert!(pending.is_err());
+}
+
+// check how geth returns reverts
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_geth_revert_transaction() {
+    let prj = TempProject::dapptools().unwrap();
+    prj.add_source("VendingMachine", VENDING_MACHINE_CONTRACT).unwrap();
+
+    let mut compiled = prj.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+    let contract = compiled.remove("VendingMachine").unwrap();
+    let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
+
+    let client = Arc::new(Provider::try_from("http://127.0.0.1:8545").unwrap());
+
+    let account = client.get_accounts().await.unwrap().remove(0);
+
+    // deploy successfully
+    let factory =
+        ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), Arc::clone(&client));
+
+    let mut tx = factory.deploy(()).unwrap().tx;
+    tx.set_from(account);
+
+    let resp = client.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
+
+    let contract =
+        Contract::<Provider<_>>::new(resp.contract_address.unwrap(), abi.unwrap(), client);
+
+    let ten = WEI_IN_ETHER.saturating_mul(10u64.into());
+    let call = contract.method::<_, ()>("buyRevert", ten).unwrap().value(ten).from(account);
+    let resp = call.call().await;
+    let err = resp.unwrap_err().to_string();
+    assert!(err.contains("execution reverted: Not enough Ether provided."));
+    assert!(err.contains("code: 3"));
 }

--- a/anvil/tests/it/revert.rs
+++ b/anvil/tests/it/revert.rs
@@ -4,6 +4,7 @@ use ethers::{
     contract::{Contract, ContractFactory},
     middleware::SignerMiddleware,
     types::U256,
+    utils::WEI_IN_ETHER,
 };
 use ethers_solc::{project_util::TempProject, Artifact};
 use std::sync::Arc;
@@ -93,4 +94,68 @@ contract Contract {
     let err = resp.unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("execution reverted: !authorized"));
+}
+
+// <https://docs.soliditylang.org/en/latest/control-structures.html#revert>
+pub(crate) const VENDING_MACHINE_CONTRACT: &str = r#"// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+contract VendingMachine {
+    address owner;
+    error Unauthorized();
+    function buyRevert(uint amount) public payable {
+        if (amount > msg.value / 2 ether)
+            revert("Not enough Ether provided.");
+    }
+    function buyRequire(uint amount) public payable {
+        require(
+            amount <= msg.value / 2 ether,
+            "Not enough Ether provided."
+        );
+    }
+    function withdraw() public {
+        if (msg.sender != owner)
+            revert Unauthorized();
+
+        payable(msg.sender).transfer(address(this).balance);
+    }
+}"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_solc_revert_example() {
+    let prj = TempProject::dapptools().unwrap();
+    prj.add_source("VendingMachine", VENDING_MACHINE_CONTRACT).unwrap();
+
+    let mut compiled = prj.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+    let contract = compiled.remove("VendingMachine").unwrap();
+    let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
+
+    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let provider = handle.ws_provider().await;
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
+
+    // deploy successfully
+    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let contract = factory.deploy(()).unwrap().send().await.unwrap();
+
+    let contract = Contract::new(
+        contract.address(),
+        abi.unwrap(),
+        SignerMiddleware::new(handle.http_provider(), wallets[1].clone()),
+    );
+
+    for fun in ["buyRevert", "buyRequire"] {
+        let resp = contract.method::<_, ()>(fun, U256::zero()).unwrap().call().await;
+        assert!(resp.is_ok());
+
+        let ten = WEI_IN_ETHER.saturating_mul(10u64.into());
+        let call = contract.method::<_, ()>(fun, ten).unwrap().value(ten);
+
+        let resp = call.clone().call().await;
+        let err = resp.unwrap_err().to_string();
+        assert!(err.contains("execution reverted: Not enough Ether provided."));
+        assert!(err.contains("code: 3"));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1871

geth returns `code: 3` for revert errors which web3.py expects

https://github.com/ethereum/web3.py/blob/c741e55b8ac95fed72a7135e7bb0e9f0d4a40431/web3/_utils/method_formatters.py#L628


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
return 3 for revert
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

cc @[unparalleled-js](https://github.com/unparalleled-js)
