### PR TITLE
fix: strict selector/topic lengths in cast

### DIFF
--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -98,12 +98,7 @@ pub async fn decode_selector(selector: &str, selector_type: SelectorType) -> Res
         .get(selector)
         .ok_or(eyre::eyre!("No signature found"))?
         .iter()
-        .filter_map(|d| {
-            if !d.filtered {
-                return Some(d.name.clone())
-            }
-            None
-        })
+        .filter_map(|d| d.filtered.then(|| d.name.clone()))
         .collect::<Vec<String>>())
 }
 
@@ -133,10 +128,7 @@ pub async fn decode_calldata(calldata: &str) -> Result<Vec<String>> {
     Ok(sigs
         .iter()
         .cloned()
-        .filter(|sig| {
-            let res = abi_decode(sig, calldata, true);
-            res.is_ok()
-        })
+        .filter(|sig| abi_decode(sig, calldata, true).is_ok())
         .collect::<Vec<String>>())
 }
 

--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -119,7 +119,19 @@ pub async fn decode_function_selector(selector: &str) -> Result<Vec<String>> {
 
 /// Fetches all possible signatures and attempts to abi decode the calldata
 pub async fn decode_calldata(calldata: &str) -> Result<Vec<String>> {
-    let sigs = decode_function_selector(calldata).await?;
+    if calldata.len() < 8 {
+        return Err(eyre::eyre!(
+            "Calldata too short: expected at least 8 characters (excluding 0x prefix), got {}.",
+            calldata.len()
+        ))
+    }
+
+    let sigs = decode_function_selector(if calldata.starts_with("0x") {
+        &calldata[..10]
+    } else {
+        &calldata[..8]
+    })
+    .await?;
 
     // filter for signatures that can be decoded
     Ok(sigs

--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -110,8 +110,8 @@ pub async fn decode_selector(selector: &str, selector_type: SelectorType) -> Res
 /// Fetches a function signature given the selector using sig.eth.samczsun.com
 pub async fn decode_function_selector(selector: &str) -> Result<Vec<String>> {
     let prefixed_selector = format!("0x{}", selector.strip_prefix("0x").unwrap_or(selector));
-    if prefixed_selector.len() < 10 {
-        return Err(eyre::eyre!("Invalid selector"))
+    if prefixed_selector.len() != 10 {
+        return Err(eyre::eyre!("Invalid selector: expected 8 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_selector.len()));
     }
 
     decode_selector(&prefixed_selector[..10], SelectorType::Function).await
@@ -135,8 +135,8 @@ pub async fn decode_calldata(calldata: &str) -> Result<Vec<String>> {
 /// Fetches a event signature given the 32 byte topic using sig.eth.samczsun.com
 pub async fn decode_event_topic(topic: &str) -> Result<Vec<String>> {
     let prefixed_topic = format!("0x{}", topic.strip_prefix("0x").unwrap_or(topic));
-    if prefixed_topic.len() < 66 {
-        return Err(eyre::eyre!("Invalid topic"))
+    if prefixed_topic.len() != 66 {
+        return Err(eyre::eyre!("Invalid topic: expected 64 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_topic.len()));
     }
     decode_selector(&prefixed_topic[..66], SelectorType::Event).await
 }

--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -350,7 +350,7 @@ async fn test_decode_selector() {
     // invalid signature
     decode_function_selector("0xa9059c")
         .await
-        .map_err(|e| assert_eq!(e.to_string(), "Invalid selector"))
+        .map_err(|e| assert_eq!(e.to_string(), "Invalid selector: expected 8 characters (excluding 0x prefix), got 8 characters (including 0x prefix)."))
         .map(|_| panic!("Expected fourbyte error"))
         .ok();
 }

--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -98,7 +98,7 @@ pub async fn decode_selector(selector: &str, selector_type: SelectorType) -> Res
         .get(selector)
         .ok_or(eyre::eyre!("No signature found"))?
         .iter()
-        .filter_map(|d| d.filtered.then(|| d.name.clone()))
+        .filter_map(|d| (!d.filtered).then(|| d.name.clone()))
         .collect::<Vec<String>>())
 }
 

--- a/utils/src/selectors.rs
+++ b/utils/src/selectors.rs
@@ -111,7 +111,7 @@ pub async fn decode_selector(selector: &str, selector_type: SelectorType) -> Res
 pub async fn decode_function_selector(selector: &str) -> Result<Vec<String>> {
     let prefixed_selector = format!("0x{}", selector.strip_prefix("0x").unwrap_or(selector));
     if prefixed_selector.len() != 10 {
-        return Err(eyre::eyre!("Invalid selector: expected 8 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_selector.len()));
+        eyre::bail!("Invalid selector: expected 8 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_selector.len())
     }
 
     decode_selector(&prefixed_selector[..10], SelectorType::Function).await
@@ -119,19 +119,15 @@ pub async fn decode_function_selector(selector: &str) -> Result<Vec<String>> {
 
 /// Fetches all possible signatures and attempts to abi decode the calldata
 pub async fn decode_calldata(calldata: &str) -> Result<Vec<String>> {
+    let calldata = calldata.strip_prefix("0x").unwrap_or(calldata);
     if calldata.len() < 8 {
-        return Err(eyre::eyre!(
+        eyre::bail!(
             "Calldata too short: expected at least 8 characters (excluding 0x prefix), got {}.",
             calldata.len()
-        ))
+        )
     }
 
-    let sigs = decode_function_selector(if calldata.starts_with("0x") {
-        &calldata[..10]
-    } else {
-        &calldata[..8]
-    })
-    .await?;
+    let sigs = decode_function_selector(&calldata[..8]).await?;
 
     // filter for signatures that can be decoded
     Ok(sigs
@@ -148,7 +144,7 @@ pub async fn decode_calldata(calldata: &str) -> Result<Vec<String>> {
 pub async fn decode_event_topic(topic: &str) -> Result<Vec<String>> {
     let prefixed_topic = format!("0x{}", topic.strip_prefix("0x").unwrap_or(topic));
     if prefixed_topic.len() != 66 {
-        return Err(eyre::eyre!("Invalid topic: expected 64 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_topic.len()));
+        eyre::bail!("Invalid topic: expected 64 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_topic.len())
     }
     decode_selector(&prefixed_topic[..66], SelectorType::Event).await
 }


### PR DESCRIPTION
## Motivation

@mds1 reported that `cast 4byte` would also return events that matched the signature (instead of just functions):

```
$ cast 4byte 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
Approval(address,address,uint256)

$ cast 4byte-event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
Approval(address,address,uint256)
```

Upon further investigation we were actually just looking up `0x8c5be1e5` with `cast 4byte`, and the function that matches that selector has the signature `Approval(address,address,uint256)`.

## Solution

This PR is strict about the length of topic 0 and function selectors to avoid confusion.

Another alternative I've considered was to just warn the user and perform the lookup anyway.

```
$ cast 4byte 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
Error:
   0: Invalid selector: expected 8 characters (excluding 0x prefix), got 66 characters (including 0x prefix).

Location:
   /home/oliver/Projects/github/foundry-rs/foundry/utils/src/selectors.rs:114

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

$ cast 4byte-event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925
Approval(address,address,uint256)
```