### PR TITLE
ci: re-enable windows

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -23,8 +23,8 @@ jobs:
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-          #- os: windows-latest
-          #  target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -76,18 +76,18 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --profile local --verbose --locked --workspace
+          args: --verbose --locked --bins --tests
 
       - name: Run forge
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: run
-          args: --profile local --locked -p foundry-cli --bin forge -- --help
+          args: --locked --bin forge -- --help
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --profile local --locked --workspace -- --skip fork
+          args: --locked --workspace -- --skip fork

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,11 @@ jobs:
             target: aarch64-apple-darwin
             arch: arm64
             svm_target_platform: macosx-aarch64
-          #- os: windows-latest
-          #  platform: win32
-          #  target: x86_64-pc-windows-msvc
-          #  arch: amd64
-          #  svm_target_platform: macosx-amd64
+          - os: windows-latest
+            platform: win32
+            target: x86_64-pc-windows-msvc
+            arch: amd64
+            svm_target_platform: windows-amd64
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Motivation

We originally disabled Windows cross-platform builds and releases because we ran out of memory for some reason. Building from source for Windows might be a non-starter for some (experience/effort/resource constraints) so we should investigate re-adding Windows support.

## Solution

Re-enable Windows and figure out if it works/why it didn't before. Also fix any cross-platform tests that fail on Windows

Closes #773 and #2021