### PR TITLE
ci: use nextest

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -4,6 +4,9 @@ on:
 
 name: cross-platform
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,6 @@ env:
   # Will resolve to foundry-rs/foundry
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  CARGO_TERM_COLOR: always
 
 jobs:
   prepare:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
             filter: '!test(~fork)'
           - name: forking
             filter: 'test(~fork)'
+        partition: [1, 2]
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
@@ -113,7 +114,7 @@ jobs:
           git config --global user.email "<>"
 
       - name: cargo nextest
-        run: ~/.cargo/bin/cargo-nextest nextest run --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
+        run: ~/.cargo/bin/cargo-nextest nextest run --partition count:${{ matrix.partition }}/2 --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
 
   external-integration:
     name: external integration tests / ${{ matrix.job.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,29 @@ on:
 
 name: test
 
+env:
+  NEXTEST_EXPERIMENTAL_FILTER_EXPR: 1
+  CARGO_TERM_COLOR: always
+
 jobs:
-  unit:
-    name: unit tests
+  build-tests:
+    name: build tests / ${{ matrix.archive.name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    strategy:
+      matrix:
+        archive:
+          - name: unit-tests
+            file: nextest-unit.tar.zst
+            flags: --workspace --all-features --lib --bins
+          - name: integration-tests
+            file: nextest-integration.tar.zst
+            flags: --workspace
+          - name: external-integration-tests
+            file: nextest-external-integration.tar.zst
+            flags: -p foundry-cli --features external-integration-tests
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -24,140 +38,118 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
 
-      - name: cargo test
-        run: cargo test --locked --workspace --all-features --lib --bins -- --skip fork
+      - name: Build archive (unit tests)
+        run: cargo nextest archive --locked ${{ matrix.archive.flags }} --archive-file ${{ matrix.archive.file }}
+      - name: Upload archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.archive.name }}
+          path: ${{ matrix.archive.file }}
 
-  fork-unit:
-    name: fork unit tests
+  unit:
+    name: unit tests / ${{ matrix.job.name }}
     runs-on: ubuntu-latest
+    needs: build-tests
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        job:
+          - name: non-forking
+            filter: '!test(~fork)'
+          - name: forking
+            filter: 'test(~fork)'
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - run: mkdir -p ~/.cargo/bin
+      - name: Download archives
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-tests
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-      - name: Forge RPC cache
-        uses: actions/cache@v3
-        with:
-          path: "$HOME/.foundry/cache"
-          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
-
-      - name: cargo test
-        run: cargo test --locked --workspace --all-features --lib --bins fork
+      - name: cargo nextest
+        run: ~/.cargo/bin/cargo-nextest nextest run --retries 3 --archive-file nextest-unit.tar.zst -E '${{ matrix.job.filter }}'
 
   integration:
-    name: integration tests
+    name: integration tests / ${{ matrix.job.name }}
     runs-on: ubuntu-latest
+    needs: build-tests
+    strategy:
+      matrix:
+        job:
+          - name: non-forking
+            filter: '!test(~fork)'
+          - name: forking
+            filter: 'test(~fork)'
+    env:
+      ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - run: mkdir -p ~/.cargo/bin
+      - name: Download archives
+        uses: actions/download-artifact@v3
+        with:
+          name: integration-tests
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Forge RPC cache
+        uses: actions/cache@v3
+        if: matrix.job.name != 'non-forking'
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-      # required for forge commands that use git
-      - name: setup git config
+          path: "$HOME/.foundry/cache"
+          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
+      - name: Setup git config
         run: |
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "<>"
-      - name: cargo test
-        run: cargo test --locked --workspace -- --skip fork
 
-  fork-integration:
-    name: fork integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-      - name: Forge RPC cache
-        uses: actions/cache@v3
-        with:
-          path: "$HOME/.foundry/cache"
-          key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
-
-      - name: cargo test
-        run: cargo test --locked --workspace -- fork
+      - name: cargo nextest
+        run: ~/.cargo/bin/cargo-nextest nextest run --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
 
   external-integration:
-    name: external integration tests
+    name: external integration tests / ${{ matrix.job.name }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
-
-      - name: Force use of HTTPS for submodules
-        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-
-      - name: cargo test
-        run: cargo test --locked -p foundry-cli --features external-integration-tests -- --skip fork
-
-  external-fork-integration:
-    name: external fork integration tests
-    runs-on: ubuntu-latest
+    needs: build-tests
+    strategy:
+      matrix:
+        job:
+          - name: non-forking
+            filter: '!test(~fork_integration)'
+          - name: forking
+            filter: 'test(~fork_integration)'
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - run: mkdir -p ~/.cargo/bin
+      - name: Download archives
+        uses: actions/download-artifact@v3
+        with:
+          name: external-integration-tests
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
       - name: Forge RPC cache
         uses: actions/cache@v3
+        if: matrix.job.name != 'non-forking'
         with:
           path: "$HOME/.foundry/cache"
           key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
-
       - name: Force use of HTTPS for submodules
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
-      - name: cargo test
-        run: cargo test --locked -p foundry-cli --features external-integration-tests fork_integration
+      - name: cargo nextest
+        run: ~/.cargo/bin/cargo-nextest nextest run --retries 3 --archive-file nextest-external-integration.tar.zst -E '${{ matrix.job.filter }}'
 
   doc:
     name: doc tests


### PR DESCRIPTION
Replaces `cargo test` with `nextest`, and also fixes a potentially flaky port assignment routine.

Benefits of nextest:

- Instead of building 6 times, we build 3 times
- The test runs themselves do not require Rust
- Good integration with coverage tools (see https://github.com/taiki-e/cargo-llvm-cov)
- Nextest can retry and report on flaky tests
- We can partition slower test suites if we want
- Faster than Cargo

Cons:

- While nextest does not require anything special and is 1:1 compatible with Cargo's test runner, it might still be a concern that we use nextest remotely and not necessarily locally
- Since it's super fast a lot of our tests are outed as being super flaky lol

The workflow works like this:

- We build archives of test executables using nextest
- Integration tests, unit tests and external unit tests are run in matrixes off of these artifacts

Edit: The run might look somewhat slow but that's because the Rust cache had to rebuild - subsequent runs are about 3-4 mins for build.