### PR TITLE
feat(cast): add signature identifier to `cast run`

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,5 +1,5 @@
 use crate::{cmd::Cmd, utils, utils::consume_config_rpc_url};
-use cast::trace::CallTraceDecoder;
+use cast::trace::{identifier::SignaturesIdentifier, CallTraceDecoder};
 use clap::Parser;
 use ethers::{
     abi::Address,
@@ -162,6 +162,9 @@ impl RunArgs {
                 .collect();
 
             let mut decoder = CallTraceDecoderBuilder::new().with_labels(labeled_addresses).build();
+
+            decoder
+                .add_signature_identifier(SignaturesIdentifier::new(Config::foundry_cache_dir())?);
 
             for (_, trace) in &mut result.traces {
                 decoder.identify(trace, &etherscan_identifier);

--- a/evm/src/trace/node.rs
+++ b/evm/src/trace/node.rs
@@ -131,13 +131,17 @@ impl CallTraceNode {
                         if let Some(tokens) =
                             funcs.iter().find_map(|func| func.decode_output(&bytes[..]).ok())
                         {
-                            self.trace.output = RawOrDecodedReturnData::Decoded(
-                                tokens
-                                    .iter()
-                                    .map(|token| utils::label(token, labels))
-                                    .collect::<Vec<_>>()
-                                    .join(", "),
-                            );
+                            // Functions coming from an external database do not have any outputs
+                            // specified, and will lead to returning an empty list of tokens.
+                            if !tokens.is_empty() {
+                                self.trace.output = RawOrDecodedReturnData::Decoded(
+                                    tokens
+                                        .iter()
+                                        .map(|token| utils::label(token, labels))
+                                        .collect::<Vec<_>>()
+                                        .join(", "),
+                                );
+                            }
                         }
                     } else if let Ok(decoded_error) =
                         foundry_utils::decode_revert(&bytes[..], Some(errors))


### PR DESCRIPTION

## Motivation
`cast run` is another command which benefits from the signature identifier. I don't think `forge test` benefits from it, for example.

## Solution
before:
![image](https://user-images.githubusercontent.com/93316087/174783740-2626a0e8-cd80-4219-86bd-c5fa8554b2ab.png)

after:
![image](https://user-images.githubusercontent.com/93316087/174783768-cc5dbbd3-d01c-4102-8c77-cda3def36a32.png)

While adding, I noticed another issue. Since the external databases (4byte and sam) do not specify the function outputs, we were getting an empty list of output tokens.

after fix:
![image](https://user-images.githubusercontent.com/93316087/174783976-83aeea9f-71c5-4ddf-9d07-fd18d17eeb58.png)

