### PR TITLE
refactor: use port 0 in tests

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -269,10 +269,11 @@ Chain ID:       {}
 // === impl NodeConfig ===
 
 impl NodeConfig {
-    /// Test config
+    /// Returns a new config intended to be used in tests, which does not print and binds to a
+    /// random, free port by setting it to `0`
     #[doc(hidden)]
     pub fn test() -> Self {
-        Self { enable_tracing: false, silent: true, ..Default::default() }
+        Self { enable_tracing: false, silent: true, port: 0, ..Default::default() }
     }
 }
 

--- a/anvil/src/server/mod.rs
+++ b/anvil/src/server/mod.rs
@@ -1,17 +1,13 @@
 //! Contains the code to launch an ethereum RPC-Server
 use crate::EthApi;
-use anvil_server::ServerConfig;
+use anvil_server::{AnvilServer, ServerConfig};
 use handler::{HttpEthRpcHandler, WsEthRpcHandler};
-use std::{future::Future, net::SocketAddr};
+use std::net::SocketAddr;
 
 mod handler;
 
 /// Configures an [axum::Server] that handles [EthApi] related JSON-RPC calls via HTTP and WS
-pub fn serve(
-    addr: SocketAddr,
-    api: EthApi,
-    config: ServerConfig,
-) -> impl Future<Output = hyper::Result<()>> {
+pub fn serve(addr: SocketAddr, api: EthApi, config: ServerConfig) -> AnvilServer {
     let http = HttpEthRpcHandler::new(api.clone());
     let ws = WsEthRpcHandler::new(api);
     anvil_server::serve_http_ws(addr, config, http, ws)

--- a/anvil/tests/it/anvil.rs
+++ b/anvil/tests/it/anvil.rs
@@ -1,12 +1,11 @@
 //! tests for anvil specific logic
 
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{prelude::Middleware, types::Address};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_change_mining_mode() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     assert!(api.anvil_get_auto_mine().unwrap());
@@ -28,7 +27,7 @@ async fn test_can_change_mining_mode() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_default_dev_keys() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let dev_accounts = handle.dev_accounts().collect::<Vec<_>>();
@@ -38,7 +37,7 @@ async fn can_get_default_dev_keys() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_set_empty_code() {
-    let (api, _handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, _handle) = spawn(NodeConfig::test()).await;
     let addr = Address::random();
     api.anvil_set_code(addr, Vec::new().into()).await.unwrap();
     let code = api.get_code(addr, None).await.unwrap();

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -1,6 +1,5 @@
 //! tests for custom anvil endpoints
 
-use crate::next_port;
 use anvil::{spawn, Hardfork, NodeConfig};
 use ethers::{
     prelude::Middleware,
@@ -10,8 +9,7 @@ use std::time::{Duration, SystemTime};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_set_gas_price() {
-    let (api, handle) =
-        spawn(NodeConfig::test().with_port(next_port()).with_hardfork(Hardfork::Berlin)).await;
+    let (api, handle) = spawn(NodeConfig::test().with_hardfork(Hardfork::Berlin)).await;
     let provider = handle.http_provider();
 
     let gas_price = 1337u64.into();
@@ -21,7 +19,7 @@ async fn can_set_gas_price() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_impersonate_account() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let impersonate = Address::random();
@@ -54,7 +52,7 @@ async fn can_impersonate_account() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_mine_manually() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let start_num = provider.get_block_number().await.unwrap();
@@ -68,7 +66,7 @@ async fn can_mine_manually() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_set_next_timestamp() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
@@ -95,7 +93,7 @@ async fn test_set_next_timestamp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_timestamp_interval() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     api.evm_mine(None).await.unwrap();

--- a/anvil/tests/it/api.rs
+++ b/anvil/tests/it/api.rs
@@ -1,6 +1,5 @@
 //! general eth api tests
 
-use crate::next_port;
 use anvil::{eth::api::CLIENT_VERSION, spawn, NodeConfig, CHAIN_ID};
 use ethers::{
     prelude::Middleware,
@@ -10,7 +9,7 @@ use ethers::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_block_number() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     let block_num = api.block_number().unwrap();
     assert_eq!(block_num, U256::zero());
@@ -23,7 +22,7 @@ async fn can_get_block_number() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_dev_get_balance() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let genesis_balance = handle.genesis_balance();
@@ -35,7 +34,7 @@ async fn can_dev_get_balance() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_price() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let _ = provider.get_gas_price().await.unwrap();
@@ -43,7 +42,7 @@ async fn can_get_price() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_accounts() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let _ = provider.get_accounts().await.unwrap();
@@ -51,7 +50,7 @@ async fn can_get_accounts() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_client_version() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let version = provider.client_version().await.unwrap();
@@ -60,7 +59,7 @@ async fn can_get_client_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_chain_id() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let chain_id = provider.get_chainid().await.unwrap();
@@ -69,7 +68,7 @@ async fn can_get_chain_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_network_id() {
-    let (api, _handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, _handle) = spawn(NodeConfig::test()).await;
 
     let chain_id = api.network_id().unwrap().unwrap();
     assert_eq!(chain_id, CHAIN_ID.to_string());
@@ -77,7 +76,7 @@ async fn can_get_network_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_block_by_number() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
     let accounts: Vec<_> = handle.dev_wallets().collect();
     let from = accounts[0].address();
@@ -99,7 +98,7 @@ async fn can_get_block_by_number() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_pending_block() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
     let accounts: Vec<_> = handle.dev_wallets().collect();
 

--- a/anvil/tests/it/gas.rs
+++ b/anvil/tests/it/gas.rs
@@ -1,6 +1,5 @@
 //! Gas related tests
 
-use crate::next_port;
 use anvil::{eth::fees::INITIAL_BASE_FEE, spawn, NodeConfig};
 use ethers::{
     prelude::Middleware,
@@ -12,10 +11,7 @@ const GAS_TRANSFER: u64 = 21_000u64;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_full_block() {
     let (_api, handle) = spawn(
-        NodeConfig::test()
-            .with_port(next_port())
-            .with_base_fee(Some(INITIAL_BASE_FEE))
-            .with_gas_limit(Some(GAS_TRANSFER)),
+        NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE)).with_gas_limit(Some(GAS_TRANSFER)),
     )
     .await;
     let provider = handle.http_provider();
@@ -37,7 +33,6 @@ async fn test_basefee_full_block() {
 async fn test_basefee_half_block() {
     let (_api, handle) = spawn(
         NodeConfig::test()
-            .with_port(next_port())
             .with_base_fee(Some(INITIAL_BASE_FEE))
             .with_gas_limit(Some(GAS_TRANSFER * 2)),
     )
@@ -55,9 +50,7 @@ async fn test_basefee_half_block() {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_empty_block() {
-    let (api, handle) =
-        spawn(NodeConfig::test().with_port(next_port()).with_base_fee(Some(INITIAL_BASE_FEE)))
-            .await;
+    let (api, handle) = spawn(NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE))).await;
 
     let provider = handle.http_provider();
     let tx = TransactionRequest::new().to(Address::random()).value(1337u64);

--- a/anvil/tests/it/logs.rs
+++ b/anvil/tests/it/logs.rs
@@ -1,6 +1,6 @@
 //! log/event related tests
 
-use crate::{abi::*, next_port};
+use crate::abi::*;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     middleware::SignerMiddleware,
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_past_events() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -49,7 +49,7 @@ async fn get_past_events() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_all_events() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -86,7 +86,7 @@ async fn get_all_events() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_install_filter() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -128,7 +128,7 @@ async fn can_install_filter() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn watch_events() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap();
     let client = Arc::new(SignerMiddleware::new(handle.http_provider(), wallet));
 

--- a/anvil/tests/it/main.rs
+++ b/anvil/tests/it/main.rs
@@ -1,8 +1,3 @@
-use std::{
-    net::TcpStream,
-    sync::atomic::{AtomicU16, Ordering},
-};
-
 mod abi;
 mod anvil;
 mod anvil_api;
@@ -19,21 +14,6 @@ mod transaction;
 mod txpool;
 pub mod utils;
 mod wsapi;
-
-// keeps track of ports that can be used
-pub static NEXT_PORT: AtomicU16 = AtomicU16::new(8546);
-
-/// Returns the next free port to use
-pub fn next_port() -> u16 {
-    loop {
-        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
-        // while simply incrementing ports is fine for a single test process, there might be
-        // multiple concurrent anvil related test process, so we check if the port is already in use
-        if TcpStream::connect(("0.0.0.0", port)).is_err() {
-            return port
-        }
-    }
-}
 
 #[allow(unused)]
 pub(crate) fn init_tracing() {

--- a/anvil/tests/it/pubsub.rs
+++ b/anvil/tests/it/pubsub.rs
@@ -1,6 +1,5 @@
 //! tests for subscriptions
 
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::abigen,
@@ -15,7 +14,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sub_new_heads() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     let provider = handle.ws_provider().await;
 
@@ -34,7 +33,7 @@ async fn test_sub_new_heads() {
 async fn test_sub_logs_legacy() {
     abigen!(EmitLogs, "test-data/emit_logs.json");
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -73,7 +72,7 @@ async fn test_sub_logs_legacy() {
 async fn test_sub_logs() {
     abigen!(EmitLogs, "test-data/emit_logs.json");
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -111,7 +110,7 @@ async fn test_sub_logs() {
 async fn test_filters_legacy() {
     abigen!(EmitLogs, "test-data/emit_logs.json");
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -152,7 +151,7 @@ async fn test_filters_legacy() {
 async fn test_filters() {
     abigen!(EmitLogs, "test-data/emit_logs.json");
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -190,12 +189,8 @@ async fn test_filters() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscriptions() {
-    let (_api, handle) = spawn(
-        NodeConfig::test()
-            .with_port(next_port())
-            .with_blocktime(Some(std::time::Duration::from_secs(1))),
-    )
-    .await;
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_blocktime(Some(std::time::Duration::from_secs(1)))).await;
     let ws = Ws::connect(handle.ws_endpoint()).await.unwrap();
 
     // Subscribing requires sending the sub request and then subscribing to

--- a/anvil/tests/it/revert.rs
+++ b/anvil/tests/it/revert.rs
@@ -1,4 +1,3 @@
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::{Contract, ContractFactory},
@@ -30,7 +29,7 @@ contract Contract {
     let contract = compiled.remove("Contract").unwrap();
     let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -74,7 +73,7 @@ contract Contract {
     let contract = compiled.remove("Contract").unwrap();
     let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
@@ -131,7 +130,7 @@ async fn test_solc_revert_example() {
     let contract = compiled.remove("VendingMachine").unwrap();
     let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));

--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -1,4 +1,3 @@
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::Contract,
@@ -10,7 +9,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_transfer_parity_traces() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
@@ -58,7 +57,7 @@ contract Contract {
     let contract = compiled.remove("Contract").unwrap();
     let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
 
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -1,4 +1,4 @@
-use crate::{abi::*, next_port};
+use crate::abi::*;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     prelude::{
@@ -14,7 +14,7 @@ use tokio::time::timeout;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_transfer_eth() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
@@ -49,7 +49,7 @@ async fn can_transfer_eth() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_order_transactions() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     // disable automine
@@ -83,7 +83,7 @@ async fn can_order_transactions() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_respect_nonces() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
@@ -118,7 +118,7 @@ async fn can_respect_nonces() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_replace_transaction() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     // disable auto mining
     api.anvil_set_auto_mine(false).await.unwrap();
@@ -160,7 +160,7 @@ async fn can_replace_transaction() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_reject_too_high_gas_limits() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
@@ -192,7 +192,7 @@ async fn can_reject_too_high_gas_limits() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_reject_underpriced_replacement() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     // disable auto mining
     api.anvil_set_auto_mine(false).await.unwrap();
@@ -231,7 +231,7 @@ async fn can_reject_underpriced_replacement() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deploy_greeter_http() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -256,7 +256,7 @@ async fn can_deploy_greeter_http() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deploy_and_mine_manually() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     // can mine in auto-mine mode
     api.evm_mine(None).await.unwrap();
@@ -297,7 +297,7 @@ async fn can_deploy_and_mine_manually() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_call_greeter_historic() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -332,7 +332,7 @@ async fn can_call_greeter_historic() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deploy_greeter_ws() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -357,7 +357,7 @@ async fn can_deploy_greeter_ws() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deploy_get_code() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -376,7 +376,7 @@ async fn can_deploy_get_code() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_blocktimestamp_works() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -402,7 +402,7 @@ async fn get_blocktimestamp_works() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn call_past_state() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -458,7 +458,7 @@ async fn call_past_state() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_multiple_concurrent_transfers_with_same_nonce() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
 
     let provider = handle.ws_provider().await;
 
@@ -489,7 +489,7 @@ async fn can_handle_multiple_concurrent_transfers_with_same_nonce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_multiple_concurrent_deploys_with_same_nonce() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -523,7 +523,7 @@ async fn can_handle_multiple_concurrent_deploys_with_same_nonce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_multiple_concurrent_transactions_with_same_nonce() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let wallet = handle.dev_wallets().next().unwrap();
@@ -578,7 +578,7 @@ async fn can_handle_multiple_concurrent_transactions_with_same_nonce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_pending_transaction() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     // disable auto mining so we can check if we can return pending tx from the mempool
     api.anvil_set_auto_mine(false).await.unwrap();
@@ -600,7 +600,7 @@ async fn can_get_pending_transaction() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn includes_pending_tx_for_transaction_count() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
 
     api.anvil_set_auto_mine(false).await.unwrap();
 
@@ -630,7 +630,7 @@ async fn includes_pending_tx_for_transaction_count() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_historic_info() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
@@ -665,7 +665,7 @@ async fn can_get_historic_info() {
 // <https://github.com/eth-brownie/brownie/issues/1549>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tx_receipt() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
 
     let wallet = handle.dev_wallets().next().unwrap();
     let client = Arc::new(SignerMiddleware::new(handle.http_provider(), wallet));
@@ -686,10 +686,8 @@ async fn test_tx_receipt() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_stream_pending_transactions() {
-    let (_api, handle) = spawn(
-        NodeConfig::test().with_port(next_port()).with_blocktime(Some(Duration::from_secs(2))),
-    )
-    .await;
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_blocktime(Some(Duration::from_secs(2)))).await;
     let num_txs = 5;
     let provider = handle.http_provider();
     let ws_provider = handle.ws_provider().await;

--- a/anvil/tests/it/txpool.rs
+++ b/anvil/tests/it/txpool.rs
@@ -1,6 +1,5 @@
 //! txpool related tests
 
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     prelude::Middleware,
@@ -9,7 +8,7 @@ use ethers::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn geth_txpool() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
     api.anvil_set_auto_mine(false).await.unwrap();
 

--- a/anvil/tests/it/wsapi.rs
+++ b/anvil/tests/it/wsapi.rs
@@ -1,12 +1,11 @@
 //! general eth api tests with websocket provider
 
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::{prelude::Middleware, types::U256};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_block_number_ws() {
-    let (api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
     let block_num = api.block_number().unwrap();
     assert_eq!(block_num, U256::zero());
 
@@ -18,7 +17,7 @@ async fn can_get_block_number_ws() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_dev_get_balance_ws() {
-    let (_api, handle) = spawn(NodeConfig::test().with_port(next_port())).await;
+    let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider().await;
 
     let genesis_balance = handle.genesis_balance();

--- a/cli/test-utils/src/script.rs
+++ b/cli/test-utils/src/script.rs
@@ -53,12 +53,11 @@ pub struct ScriptTester {
 }
 
 impl ScriptTester {
-    pub fn new(mut cmd: TestCommand, port: u16, current_dir: &Path) -> Self {
+    pub fn new(mut cmd: TestCommand, endpoint: &str, current_dir: &Path) -> Self {
         ScriptTester::link_testdata(current_dir).unwrap();
         cmd.set_current_dir(current_dir);
 
         let target_contract = current_dir.join(BROADCAST_TEST_PATH).to_string_lossy().to_string();
-        let url = format!("http://127.0.0.1:{port}");
 
         cmd.args([
             "script",
@@ -68,7 +67,7 @@ impl ScriptTester {
             "--root",
             current_dir.to_str().unwrap(),
             "--fork-url",
-            url.as_str(),
+            endpoint,
             "-vvvvv",
         ]);
 
@@ -83,7 +82,7 @@ impl ScriptTester {
                 "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".to_string(),
                 "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a".to_string(),
             ],
-            provider: Provider::<Http>::try_from(url).unwrap(),
+            provider: Provider::<Http>::try_from(endpoint).unwrap(),
             nonces: BTreeMap::default(),
             cmd,
         }

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -427,7 +427,7 @@ warning[5667]: Warning: Unused function parameter. Remove or comment out the var
 });
 
 // tests that direct import paths are handled correctly
-forgetest!(can_handle_direct_imports_into_src, |prj: TestProject, mut cmd: TestCommand| {
+forgetest!(canhandle_direct_imports_into_src, |prj: TestProject, mut cmd: TestCommand| {
     prj.inner()
         .add_source(
             "Foo",

--- a/cli/tests/it/main.rs
+++ b/cli/tests/it/main.rs
@@ -1,7 +1,3 @@
-use std::{
-    net::TcpStream,
-    sync::atomic::{AtomicU16, Ordering},
-};
 #[cfg(not(feature = "external-integration-tests"))]
 mod cast;
 #[cfg(not(feature = "external-integration-tests"))]
@@ -26,20 +22,5 @@ pub(crate) mod forge_utils;
 
 #[cfg(feature = "external-integration-tests")]
 mod integration;
-
-// keeps track of ports that can be used
-pub static NEXT_PORT: AtomicU16 = AtomicU16::new(8546);
-
-/// Returns the next free port to use
-pub fn next_port() -> u16 {
-    loop {
-        let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
-        // while simply incrementing ports is fine for a single test process, there might be
-        // multiple concurrent anvil related test process, so we check if the port is already in use
-        if TcpStream::connect(("0.0.0.0", port)).is_err() {
-            return port
-        }
-    }
-}
 
 fn main() {}

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -1,5 +1,4 @@
 //! Contains various tests related to forge script
-use crate::next_port;
 use anvil::{spawn, NodeConfig};
 use ethers::abi::Address;
 use foundry_cli_test_utils::{
@@ -153,9 +152,8 @@ result: uint256 255
 });
 
 forgetest_async!(can_deploy_script_without_lib, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0, 1])
@@ -168,9 +166,8 @@ forgetest_async!(can_deploy_script_without_lib, |prj: TestProject, cmd: TestComm
 });
 
 forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0, 1])
@@ -183,9 +180,8 @@ forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand
 });
 
 forgetest_async!(can_resume_script, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0])
@@ -202,9 +198,8 @@ forgetest_async!(can_resume_script, |prj: TestProject, cmd: TestCommand| async m
 });
 
 forgetest_async!(can_deploy_broadcast_wrap, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(2)
@@ -218,9 +213,8 @@ forgetest_async!(can_deploy_broadcast_wrap, |prj: TestProject, cmd: TestCommand|
 });
 
 forgetest_async!(panic_no_deployer_set, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0, 1])
@@ -231,9 +225,8 @@ forgetest_async!(panic_no_deployer_set, |prj: TestProject, cmd: TestCommand| asy
 });
 
 forgetest_async!(can_deploy_no_arg_broadcast, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .add_deployer(0)
@@ -247,9 +240,8 @@ forgetest_async!(can_deploy_no_arg_broadcast, |prj: TestProject, cmd: TestComman
 });
 
 forgetest_async!(can_deploy_with_create2, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     // Prepare CREATE2 Deployer
     let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();
@@ -272,9 +264,8 @@ forgetest_async!(can_deploy_with_create2, |prj: TestProject, cmd: TestCommand| a
 forgetest_async!(
     can_deploy_100_txes_concurrently,
     |prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+        let (_api, handle) = spawn(NodeConfig::test()).await;
+        let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
         tester
             .load_private_keys(vec![0])
@@ -290,9 +281,8 @@ forgetest_async!(
 forgetest_async!(
     can_deploy_mixed_broadcast_modes,
     |prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+        let (_api, handle) = spawn(NodeConfig::test()).await;
+        let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
         tester
             .load_private_keys(vec![0])
@@ -306,9 +296,8 @@ forgetest_async!(
 );
 
 forgetest_async!(deploy_with_setup, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0])
@@ -321,9 +310,8 @@ forgetest_async!(deploy_with_setup, |prj: TestProject, cmd: TestCommand| async m
 });
 
 forgetest_async!(fail_broadcast_staticcall, |prj: TestProject, cmd: TestCommand| async move {
-    let port = next_port();
-    let (_api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-    let mut tester = ScriptTester::new(cmd, port, prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
     tester
         .load_private_keys(vec![0])
@@ -336,9 +324,8 @@ forgetest_async!(
     #[ignore]
     check_broadcast_log,
     |prj: TestProject, cmd: TestCommand| async move {
-        let port = next_port();
-        let (api, _handle) = spawn(NodeConfig::test().with_port(port)).await;
-        let mut tester = ScriptTester::new(cmd, port, prj.root());
+        let (api, handle) = spawn(NodeConfig::test()).await;
+        let mut tester = ScriptTester::new(cmd, &handle.http_endpoint(), prj.root());
 
         // Prepare CREATE2 Deployer
         let addr = Address::from_str("0x4e59b44847b379578588920ca78fbf26c0b4956c").unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
gets rid of the `next_port` stuff and use port 0 by default so the OS can auto select a port

ref #2045
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use proper `axum::Server` type aliases that allows us to retrieve the actual local addr that we need for the `NodeHandle`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
