### PR TITLE
chore(forge): use `gas_price` from user if provided on estimating ETH required

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -283,7 +283,9 @@ impl ScriptArgs {
 
         // We don't store it in the transactions, since we want the most updated value. Right before
         // broadcasting.
-        let per_gas = {
+        let per_gas = if let Some(gas_price) = self.with_gas_price {
+            gas_price
+        } else {
             match new_txes.front().unwrap().typed_tx() {
                 TypedTransaction::Legacy(_) | TypedTransaction::Eip2930(_) => {
                     provider.get_gas_price().await?
@@ -291,6 +293,7 @@ impl ScriptArgs {
                 TypedTransaction::Eip1559(_) => provider.estimate_eip1559_fees(None).await?.0,
             }
         };
+
         println!("\n==========================");
         println!("\nEstimated total gas used for script: {}", total_gas);
         println!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If the user passes `--with-gas-price` do not make the RPC request for the estimated ETH required.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
