### PR TITLE
fix: pick latest fork block safely

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -561,7 +561,8 @@ impl NodeConfig {
             let fork_block_number = if let Some(fork_block_number) = self.fork_block_number {
                 fork_block_number
             } else {
-                provider.get_block_number().await.expect("Failed to get fork block number").as_u64()
+                // pick the last block number but also ensure it's not pending anymore
+                find_latest_fork_block(&provider).await.expect("Failed to get fork block number")
             };
 
             let block = provider
@@ -601,8 +602,8 @@ impl NodeConfig {
 
             let block_chain_db = BlockchainDb::new(meta, self.block_cache_path());
 
-            // This will spawn the background thread that will use the provider to fetch blockchain
-            // data from the other client
+            // This will spawn the background thread that will use the provider to fetch
+            // blockchain data from the other client
             let backend = SharedBackend::spawn_backend_thread(
                 Arc::clone(&provider),
                 block_chain_db.clone(),
@@ -778,4 +779,26 @@ impl AccountGenerator {
         }
         wallets
     }
+}
+
+/// Finds the latest appropriate block to fork
+///
+/// This fetches the "latest" block and checks whether the `Block` is fully populated (`hash` field
+/// is present). This prevents edge cases where anvil forks the "latest" block but `eth_getBlockByNumber` still returns a pending block, <https://github.com/foundry-rs/foundry/issues/2036>
+async fn find_latest_fork_block<M: Middleware>(provider: M) -> Result<u64, M::Error> {
+    let mut num = provider.get_block_number().await?.as_u64();
+
+    // walk back from the head of the chain, but at most 2 blocks, which should be more than enough
+    // leeway
+    for _ in 0..2 {
+        if let Some(block) = provider.get_block(num).await? {
+            if block.hash.is_some() {
+                break
+            }
+        }
+        // block not actually finalized, so we try the block before
+        num = num.saturating_sub(1)
+    }
+
+    Ok(num)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #2036

depending on the endpoint, `eth_getBlockByNumber` may still return a pending block for the block number returned by `eth_blockNumber

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
if not set, we find the latest block that has a `hash` field.
we start with "latest" and walk back, but at most 2 blocks, which should be sufficient
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
