### PR TITLE
refactor!(cast): nameless cast block and field attributes

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -220,23 +220,19 @@ Examples:
     #[clap(about = "Get information about a block.")]
     Block {
         #[clap(
-            long,
-            short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
             parse(try_from_str = parse_block_id),
             value_name = "BLOCK"
         )]
         block: BlockId,
-        #[clap(long, env = "CAST_FULL_BLOCK")]
-        full: bool,
         #[clap(
-            long,
-            short,
             help = "If specified, only get the given field of the block.",
             value_name = "FIELD"
         )]
         field: Option<String>,
+        #[clap(long, env = "CAST_FULL_BLOCK")]
+        full: bool,
         #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -7,6 +7,22 @@ use foundry_cli_test_utils::{
 use foundry_utils::rpc::next_http_rpc_endpoint;
 use std::path::PathBuf;
 
+// tests that the `cast block` command works correctly
+casttest!(latest_block, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+
+    // Call `cast find-block`
+    cmd.args(["block", "latest", "--rpc-url", eth_rpc_url.as_str()]);
+    let output = cmd.stdout_lossy();
+    assert!(output.contains("transactions:"));
+    assert!(output.contains("gasUsed"));
+
+    // <https://etherscan.io/block/15007840>
+    cmd.cast_fuse().args(["block", "15007840", "hash", "--rpc-url", eth_rpc_url.as_str()]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0x950091817a57e22b6c1f3b951a15f52d41ac89b299cc8f9c89bb6d185f80c415")
+});
+
 // tests that the `cast find-block` command works correctly
 casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
     // Construct args


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #2050
make `cast block` behave as `seth block`  https://github.com/dapphub/dapptools/tree/master/src/seth#seth-block
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
*breaking change*: remove `--block` and `--field` named arguments
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
