### PR TITLE
fix(forge): debugger showing wrong sources at times

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -182,7 +182,7 @@ impl RunArgs {
 
 fn run_debugger(result: RunResult, decoder: CallTraceDecoder) -> eyre::Result<()> {
     // TODO Get source from etherscan
-    let source_code: BTreeMap<u32, &str> = BTreeMap::new();
+    let source_code: BTreeMap<u32, String> = BTreeMap::new();
     let calls: Vec<DebugArena> = vec![result.debug];
     let flattened = calls.last().expect("we should have collected debug info").flatten(0);
     let tui = Tui::new(flattened, 0, decoder.contracts, HashMap::new(), source_code)?;

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -182,10 +182,9 @@ impl RunArgs {
 
 fn run_debugger(result: RunResult, decoder: CallTraceDecoder) -> eyre::Result<()> {
     // TODO Get source from etherscan
-    let source_code: BTreeMap<u32, String> = BTreeMap::new();
     let calls: Vec<DebugArena> = vec![result.debug];
     let flattened = calls.last().expect("we should have collected debug info").flatten(0);
-    let tui = Tui::new(flattened, 0, decoder.contracts, HashMap::new(), source_code)?;
+    let tui = Tui::new(flattened, 0, decoder.contracts, HashMap::new(), BTreeMap::new())?;
     match tui.start().expect("Failed to start tui") {
         TUIExitReason::CharExit => Ok(()),
     }

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -182,7 +182,7 @@ impl RunArgs {
 
 fn run_debugger(result: RunResult, decoder: CallTraceDecoder) -> eyre::Result<()> {
     // TODO Get source from etherscan
-    let source_code: BTreeMap<u32, String> = BTreeMap::new();
+    let source_code: BTreeMap<u32, &str> = BTreeMap::new();
     let calls: Vec<DebugArena> = vec![result.debug];
     let flattened = calls.last().expect("we should have collected debug info").flatten(0);
     let tui = Tui::new(flattened, 0, decoder.contracts, HashMap::new(), source_code)?;

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -354,7 +354,6 @@ impl ScriptArgs {
     ) -> eyre::Result<()> {
         let (sources, artifacts) =
             filter_sources_and_artifacts(&self.path, sources, highlevel_known_contracts, project)?;
-
         let calls: Vec<DebugArena> = result.debug.expect("we should have collected debug info");
         let flattened = calls.last().expect("we should have collected debug info").flatten(0);
         let tui = Tui::new(flattened, 0, decoder.contracts.clone(), artifacts, sources)?;

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -366,7 +366,7 @@ impl ScriptArgs {
         let (target_path, target_source) = graph.node(*target_index).unpack();
         target_tree.insert(target_path, target_source);
 
-        let source_code: BTreeMap<u32, &str> = sources
+        let source_code = sources
             .iter()
             .filter_map(|(id, path)| {
                 let mut resolved = project
@@ -378,7 +378,7 @@ impl ScriptArgs {
                     resolved = project.root().join(&resolved);
                 }
 
-                target_tree.get(&resolved).map(|source| (*id, source.content.as_str()))
+                target_tree.get(&resolved).map(|source| (*id, source.content.clone()))
             })
             .collect();
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -367,18 +367,18 @@ impl ScriptArgs {
         target_tree.insert(target_path, target_source);
 
         let source_code = sources
-            .iter()
+            .into_iter()
             .filter_map(|(id, path)| {
                 let mut resolved = project
                     .paths
-                    .resolve_library_import(&PathBuf::from(path))
-                    .unwrap_or_else(|| PathBuf::from(path));
+                    .resolve_library_import(&PathBuf::from(&path))
+                    .unwrap_or_else(|| PathBuf::from(&path));
 
                 if !resolved.is_absolute() {
                     resolved = project.root().join(&resolved);
                 }
 
-                target_tree.get(&resolved).map(|source| (*id, source.content.clone()))
+                target_tree.get(&resolved).map(|source| (id, source.content.clone()))
             })
             .collect();
 

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -6,7 +6,11 @@ use ethers::{
     prelude::Graph,
     solc::{report::NoReporter, Artifact, FileFilter, Project, ProjectCompileOutput},
 };
-use std::{collections::BTreeMap, fmt::Display, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 /// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
 /// compilation was successful or if there was a cache hit.
@@ -268,7 +272,7 @@ pub fn compile_files(
 ///
 /// If `verify` and it's a standalone script, throw error. Only allowed for projects.
 pub fn compile_target(
-    target_path: &PathBuf,
+    target_path: &Path,
     project: &Project,
     silent: bool,
     verify: bool,
@@ -280,7 +284,7 @@ pub fn compile_target(
         if verify {
             eyre::bail!("You can only verify deployments from inside a project! Make sure it exists with `forge tree`.");
         }
-        return compile_files(project, vec![target_path.clone()], silent)
+        return compile_files(project, vec![target_path.to_path_buf()], silent)
     }
 
     if silent {

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -47,7 +47,7 @@ pub enum TUIExitReason {
 mod op_effects;
 use op_effects::stack_indices_affected;
 
-pub struct Tui<'a> {
+pub struct Tui {
     debug_arena: Vec<(Address, Vec<DebugStep>, CallKind)>,
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
     /// Buffer for keys prior to execution, i.e. '10' + 'k' => move up 10 operations
@@ -56,10 +56,10 @@ pub struct Tui<'a> {
     current_step: usize,
     identified_contracts: HashMap<Address, String>,
     known_contracts: HashMap<String, ContractBytecodeSome>,
-    source_code: BTreeMap<u32, &'a str>,
+    source_code: BTreeMap<u32, String>,
 }
 
-impl<'a> Tui<'a> {
+impl Tui {
     /// Create a tui
     #[allow(unused_must_use)]
     pub fn new(
@@ -67,7 +67,7 @@ impl<'a> Tui<'a> {
         current_step: usize,
         identified_contracts: HashMap<Address, String>,
         known_contracts: HashMap<String, ContractBytecodeSome>,
-        source_code: BTreeMap<u32, &'a str>,
+        source_code: BTreeMap<u32, String>,
     ) -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
@@ -106,7 +106,7 @@ impl<'a> Tui<'a> {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, &str>,
+        source_code: &BTreeMap<u32, String>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -155,7 +155,7 @@ impl<'a> Tui<'a> {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, &str>,
+        source_code: &BTreeMap<u32, String>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -226,7 +226,7 @@ impl<'a> Tui<'a> {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, &str>,
+        source_code: &BTreeMap<u32, String>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -328,7 +328,7 @@ impl<'a> Tui<'a> {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, &str>,
+        source_code: &BTreeMap<u32, String>,
         ic: usize,
         call_kind: CallKind,
         area: Rect,
@@ -909,7 +909,7 @@ impl<'a> Tui<'a> {
     }
 }
 
-impl<'a> Ui for Tui<'a> {
+impl Ui for Tui {
     fn start(mut self) -> Result<TUIExitReason> {
         // If something panics inside here, we should do everything we can to
         // not corrupt the user's terminal.

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -47,7 +47,7 @@ pub enum TUIExitReason {
 mod op_effects;
 use op_effects::stack_indices_affected;
 
-pub struct Tui {
+pub struct Tui<'a> {
     debug_arena: Vec<(Address, Vec<DebugStep>, CallKind)>,
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
     /// Buffer for keys prior to execution, i.e. '10' + 'k' => move up 10 operations
@@ -56,10 +56,10 @@ pub struct Tui {
     current_step: usize,
     identified_contracts: HashMap<Address, String>,
     known_contracts: HashMap<String, ContractBytecodeSome>,
-    source_code: BTreeMap<u32, String>,
+    source_code: BTreeMap<u32, &'a str>,
 }
 
-impl Tui {
+impl<'a> Tui<'a> {
     /// Create a tui
     #[allow(unused_must_use)]
     pub fn new(
@@ -67,7 +67,7 @@ impl Tui {
         current_step: usize,
         identified_contracts: HashMap<Address, String>,
         known_contracts: HashMap<String, ContractBytecodeSome>,
-        source_code: BTreeMap<u32, String>,
+        source_code: BTreeMap<u32, &'a str>,
     ) -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
@@ -106,7 +106,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        source_code: &BTreeMap<u32, &str>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -155,7 +155,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        source_code: &BTreeMap<u32, &str>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -226,7 +226,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        source_code: &BTreeMap<u32, &str>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -328,7 +328,7 @@ impl Tui {
         address: Address,
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
-        source_code: &BTreeMap<u32, String>,
+        source_code: &BTreeMap<u32, &str>,
         ic: usize,
         call_kind: CallKind,
         area: Rect,
@@ -909,7 +909,7 @@ impl Tui {
     }
 }
 
-impl Ui for Tui {
+impl<'a> Ui for Tui<'a> {
     fn start(mut self) -> Result<TUIExitReason> {
         // If something panics inside here, we should do everything we can to
         // not corrupt the user's terminal.


### PR DESCRIPTION
## Motivation

There were a couple scenarios where the debugger was not showing the proper source code. This happened because of two different issues:
1. If the script was part of a project, we were still using `compile_files(...)`. However, calling `forge test --debug` would result in a weird project state where source files coming from the artifacts would be having repeated source IDs. Which would then lead to wrong sources being shown on the debugger. [Note: `forge test --debug` --calls-> `forge debug`  --calls-> `forge script --debug`]
2. `run_debugger` was passing to the `Tui` debugger all artifacts (contract_name -> artifact) and sources (source_id -> String) from the project. Contracts with the same name were overwriting each other.


## Solution
1. Only call `compile_files(...)` if it's a standalone script. Otherwise call `compile(...)`
2. Use `Graph` to filter out source codes and artifacts not part of the execution, before handing it over to `Tui`.

