### PR TITLE
feat: support stdin in `cast 4byte-decode`

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -455,6 +455,7 @@ async fn main() -> eyre::Result<()> {
             sigs.iter().for_each(|sig| println!("{}", sig));
         }
         Subcommands::FourByteDecode { calldata } => {
+            let calldata = unwrap_or_stdin(calldata)?;
             let sigs = decode_calldata(&calldata).await?;
             sigs.iter().enumerate().for_each(|(i, sig)| println!("{}) \"{}\"", i + 1, sig));
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -516,7 +516,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     #[clap(about = "Decode ABI-encoded calldata using https://sig.eth.samczsun.com.")]
     FourByteDecode {
         #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
-        calldata: String,
+        calldata: Option<String>,
     },
     #[clap(name = "4byte-event")]
     #[clap(visible_aliases = &["4e", "4be"])]


### PR DESCRIPTION
Closes #2077

```
$ ./target/local/cast tx 0x8ee80b1fdc814a71aaf11d01b4409c37de43e48b2221251d625d123df221098f --json | jq -r .input | ./target/local/cast 4byte-decode
1) "mint(uint256,bytes)"
1655145740
0xe26b098c2e13597b890be3e99cd4d77d2d2ac222d4097a3c6e3109b8214f53862ee444293619012a112d647143ff8f178983b663db20d7a98c6a0d2bca56150e
```