### PR TITLE
feat: constant default caller address

### DIFF
--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -40,7 +40,7 @@ impl<DB: DatabaseRef> ScriptRunner<DB> {
         self.executor.set_nonce(self.sender, sender_nonce.as_u64());
 
         // We max out their balance so that they can deploy and make calls.
-        self.executor.set_balance(*CALLER, U256::MAX);
+        self.executor.set_balance(CALLER, U256::MAX);
 
         // Deploy libraries
         let mut traces: Vec<(TraceKind, CallTraceArena)> = libraries
@@ -63,7 +63,7 @@ impl<DB: DatabaseRef> ScriptRunner<DB> {
             traces: constructor_traces,
             debug: constructor_debug,
             ..
-        } = self.executor.deploy(*CALLER, code.0, 0u32.into(), None).expect("couldn't deploy");
+        } = self.executor.deploy(CALLER, code.0, 0u32.into(), None).expect("couldn't deploy");
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
         self.executor.set_balance(address, self.initial_balance);
 

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -276,7 +276,7 @@ where
         from: Option<Address>,
         address: Address,
     ) -> std::result::Result<CallResult<()>, EvmError> {
-        let from = from.unwrap_or(*CALLER);
+        let from = from.unwrap_or(CALLER);
         self.call_committing::<(), _, _>(from, address, "setUp()", (), 0.into(), None)
     }
 
@@ -622,7 +622,7 @@ where
         if success {
             // Check if a DSTest assertion failed
             let call =
-                executor.call::<bool, _, _>(*CALLER, address, "failed()(bool)", (), 0.into(), None);
+                executor.call::<bool, _, _>(CALLER, address, "failed()(bool)", (), 0.into(), None);
 
             if let Ok(CallResult { result: failed, .. }) = call {
                 success = !failed;

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -14,7 +14,7 @@ pub mod coverage;
 /// Forge test execution backends
 pub mod executor;
 
-use ethers::types::{ActionType, CallType};
+use ethers::types::{ActionType, CallType, H160};
 pub use executor::abi;
 
 /// Fuzzing wrapper for executors
@@ -26,18 +26,19 @@ pub mod utils;
 // Re-exports
 pub use ethers::types::Address;
 pub use hashbrown::{self, HashMap};
-use once_cell::sync::Lazy;
 pub use revm;
 use revm::{CallScheme, CreateScheme};
 use serde::{Deserialize, Serialize};
 
-/// Stores a random caller address to be used as _sender_ account for:
+/// Stores the caller address to be used as _sender_ account for:
 ///     - deploying Test contracts
 ///     - deploying Script contracts
 ///
-/// The address is randomly initialized once for each program and is constant for the duration of
-/// the existence of this program.
-pub static CALLER: Lazy<Address> = Lazy::new(Address::random);
+/// The address was derived from `address(uint160(uint256(keccak256("foundry default caller"))))`
+pub static CALLER: Address = H160([
+    0x18, 0x04, 0xc8, 0xAB, 0x1F, 0x12, 0xE6, 0xbb, 0xF3, 0x89, 0x4D, 0x40, 0x83, 0xF3, 0x3E, 0x07,
+    0x30, 0x9D, 0x1F, 0x38,
+]);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CallKind {

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -65,7 +65,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
     pub fn setup(&mut self, setup: bool) -> Result<TestSetup> {
         // We max out their balance so that they can deploy and make calls.
         self.executor.set_balance(self.sender, U256::MAX);
-        self.executor.set_balance(*CALLER, U256::MAX);
+        self.executor.set_balance(CALLER, U256::MAX);
 
         // We set the nonce of the deployer accounts to 1 to get the same addresses as DappTools
         self.executor.set_nonce(self.sender, 1);

--- a/forge/src/test_helpers.rs
+++ b/forge/src/test_helpers.rs
@@ -78,7 +78,7 @@ pub static EVM_OPTS: Lazy<EvmOpts> = Lazy::new(|| EvmOpts {
 pub fn fuzz_executor<DB: DatabaseRef>(executor: &Executor<DB>) -> FuzzedExecutor<DB> {
     let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
 
-    FuzzedExecutor::new(executor, proptest::test_runner::TestRunner::new(cfg), *CALLER)
+    FuzzedExecutor::new(executor, proptest::test_runner::TestRunner::new(cfg), CALLER)
 }
 
 pub mod filter {


### PR DESCRIPTION

## Motivation

Previously we used a random caller address. This results in contracts not being deployed at the same address between test runs, which is a nuisance when trying to reproduce a fuzz test failure—if one input was a contract address and you don't know which contract it was, it's hard to create a concrete reproduction test since addresses are different in subsequent runs


## Solution

Use a constant address. I chose an address computed as `address(uint160(uint256(keccak256("foundry default caller"))))`