### PR TITLE
feat: add contract to pretty output

### DIFF
--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -210,7 +210,9 @@ impl Cmd for InspectArgs {
                 if pretty {
                     if let Some(storage_layout) = &artifact.storage_layout {
                         let mut table = Table::new();
-                        table.set_header(vec!["Name", "Type", "Slot", "Offset", "Bytes", "Contract"]);
+                        table.set_header(vec![
+                            "Name", "Type", "Slot", "Offset", "Bytes", "Contract",
+                        ]);
 
                         for slot in &storage_layout.storage {
                             let storage_type = storage_layout.types.get(&slot.storage_type);

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -210,7 +210,7 @@ impl Cmd for InspectArgs {
                 if pretty {
                     if let Some(storage_layout) = &artifact.storage_layout {
                         let mut table = Table::new();
-                        table.set_header(vec!["Name", "Type", "Slot", "Offset", "Bytes"]);
+                        table.set_header(vec!["Name", "Type", "Slot", "Offset", "Bytes", "Contract"]);
 
                         for slot in &storage_layout.storage {
                             let storage_type = storage_layout.types.get(&slot.storage_type);
@@ -222,6 +222,7 @@ impl Cmd for InspectArgs {
                                 storage_type
                                     .as_ref()
                                     .map_or("?".to_string(), |t| t.number_of_bytes.clone()),
+                                slot.contract.clone(),
                             ]);
                         }
                         println!("{table}");


### PR DESCRIPTION
## Motivation

Found this https://github.com/foundry-rs/foundry/issues/610#issuecomment-1067972155 which is super cool. For some reason though it does not contain the contract name which sometimes is useful when checking inheritance chain.

## Solution

Added the field to the table as it's already present in the non pretty print.