### PR TITLE
feat: bypass eip-3607 when impersonating contracts

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1071,7 +1071,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `anvil_impersonateAccount`
     pub async fn anvil_impersonate_account(&self, address: Address) -> Result<()> {
         node_info!("anvil_impersonateAccount");
-        self.backend.cheats().impersonate(address);
+        self.backend.impersonate(address);
         Ok(())
     }
 
@@ -1080,7 +1080,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `anvil_stopImpersonatingAccount`
     pub async fn anvil_stop_impersonating_account(&self, address: Address) -> Result<()> {
         node_info!("anvil_stopImpersonatingAccount");
-        self.backend.cheats().stop_impersonating(&address);
+        self.backend.stop_impersonating(address);
         Ok(())
     }
 

--- a/anvil/src/eth/backend/cheats.rs
+++ b/anvil/src/eth/backend/cheats.rs
@@ -1,9 +1,9 @@
 //! Support for "cheat codes" / bypass functions
 
 use anvil_core::eth::transaction::TypedTransaction;
-use ethers::types::{Address, Signature, U256};
+use ethers::types::{Address, Signature, H256, U256};
 use parking_lot::RwLock;
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use tracing::trace;
 
 /// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
@@ -29,21 +29,23 @@ pub struct CheatsManager {
 impl CheatsManager {
     /// Sets the account to impersonate
     ///
+    /// This also accepts the actual code hash if the address is a contract to bypass EIP-3607
+    ///
     /// Returns `true` if the account is already impersonated
-    pub fn impersonate(&self, addr: Address) -> bool {
+    pub fn impersonate(&self, addr: Address, code_hash: Option<H256>) -> bool {
         trace!(target: "cheats", "Start impersonating {:?}", addr);
-        self.state.write().impersonated_account.insert(addr)
+        self.state.write().impersonated_account.insert(addr, code_hash).is_some()
     }
 
     /// Removes the account that from the impersonated set
-    pub fn stop_impersonating(&self, addr: &Address) {
+    pub fn stop_impersonating(&self, addr: &Address) -> Option<H256> {
         trace!(target: "cheats", "Stop impersonating {:?}", addr);
-        self.state.write().impersonated_account.remove(addr);
+        self.state.write().impersonated_account.remove(addr).flatten()
     }
 
     /// Returns true if the `addr` is currently impersonated
     pub fn is_impersonated(&self, addr: Address) -> bool {
-        self.state.read().impersonated_account.contains(&addr)
+        self.state.read().impersonated_account.contains_key(&addr)
     }
 
     /// Returns the signature to use to bypass transaction signing
@@ -56,7 +58,11 @@ impl CheatsManager {
 #[derive(Debug, Clone)]
 pub struct CheatsState {
     /// All accounts that are currently impersonated
-    pub impersonated_account: HashSet<Address>,
+    ///
+    /// If the account is a contract it holds the hash of the contracts code that is temporarily
+    /// set to `KECCAK_EMPTY` to bypass EIP-3607 which rejects transactions from senders with
+    /// deployed code
+    pub impersonated_account: HashMap<Address, Option<H256>>,
     /// The signature used for the `eth_sendUnsignedTransaction` cheat code
     pub bypass_signature: Signature,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As highlighted here https://github.com/foundry-rs/foundry/issues/1943#issuecomment-1164214164 when impersonating contracts, calls from the impersonated contract get rejected due to [EIP-3607](https://eips.ethereum.org/EIPS/eip-3607). 
So it's required to remove the code first manually.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
revm checks eip3607 by looking at the account's code hash, and rejects the call if it is not empty.
this temporarily sets the code hash of a contract to KECCAK_EMPTY so the revm check passes.

The downside of this is that this messes with revm internals and renders the contract's code unusable for the time the contract is impersonated, but the same happens when removing the code manually. So temporarily setting it to empty is less invasive


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
