### PR TITLE
feat(forge): filesystem cheatcodes should respect allowed paths

### DIFF
--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -19,12 +19,18 @@ pub enum FsPathError {
     /// Provides additional path context for `std::fs::File::create`.
     #[error("failed to create file {path:?}: {source}")]
     CreateFile { source: io::Error, path: PathBuf },
+    /// Provides additional path context for `std::fs::remove_file`.
+    #[error("failed to remove file {path:?}: {source}")]
+    RemoveFile { source: io::Error, path: PathBuf },
     /// Provides additional path context for `std::fs::create_dir`.
     #[error("failed to create dir {path:?}: {source}")]
     CreateDir { source: io::Error, path: PathBuf },
     /// Provides additional path context for `std::fs::write_dir`.
     #[error("failed to remove dir {path:?}: {source}")]
     RemoveDir { source: io::Error, path: PathBuf },
+    /// Provides additional path context for `std::fs::open`.
+    #[error("failed to open file {path:?}: {source}")]
+    Open { source: io::Error, path: PathBuf },
 }
 
 impl FsPathError {
@@ -43,6 +49,11 @@ impl FsPathError {
         FsPathError::CreateFile { source, path: path.into() }
     }
 
+    /// Returns the complementary error variant for `std::fs::remove_file`.
+    pub fn remove_file(source: io::Error, path: impl Into<PathBuf>) -> Self {
+        FsPathError::RemoveFile { source, path: path.into() }
+    }
+
     /// Returns the complementary error variant for `std::fs::create_dir`.
     pub fn create_dir(source: io::Error, path: impl Into<PathBuf>) -> Self {
         FsPathError::CreateDir { source, path: path.into() }
@@ -51,6 +62,11 @@ impl FsPathError {
     /// Returns the complementary error variant for `std::fs::remove_dir`.
     pub fn remove_dir(source: io::Error, path: impl Into<PathBuf>) -> Self {
         FsPathError::RemoveDir { source, path: path.into() }
+    }
+
+    /// Returns the complementary error variant for `std::fs::File::open`.
+    pub fn open(source: io::Error, path: impl Into<PathBuf>) -> Self {
+        FsPathError::Open { source, path: path.into() }
     }
 }
 
@@ -62,6 +78,8 @@ impl AsRef<Path> for FsPathError {
             FsPathError::CreateDir { path, .. } => path,
             FsPathError::RemoveDir { path, .. } => path,
             FsPathError::CreateFile { path, .. } => path,
+            FsPathError::RemoveFile { path, .. } => path,
+            FsPathError::Open { path, .. } => path,
         }
     }
 }
@@ -74,6 +92,8 @@ impl From<FsPathError> for io::Error {
             FsPathError::CreateDir { source, .. } => source,
             FsPathError::RemoveDir { source, .. } => source,
             FsPathError::CreateFile { source, .. } => source,
+            FsPathError::RemoveFile { source, .. } => source,
+            FsPathError::Open { source, .. } => source,
         }
     }
 }

--- a/common/src/fs.rs
+++ b/common/src/fs.rs
@@ -4,10 +4,15 @@ use std::{fs, path::Path};
 
 type Result<T> = std::result::Result<T, FsPathError>;
 
-/// Wrapper for `std::File::create`
+/// Wrapper for `std::fs::File::create`
 pub fn create_file(path: impl AsRef<Path>) -> Result<fs::File> {
     let path = path.as_ref();
     fs::File::create(path).map_err(|err| FsPathError::create_file(err, path))
+}
+/// Wrapper for `std::fs::remove_file`
+pub fn remove_file(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    fs::remove_file(path).map_err(|err| FsPathError::remove_file(err, path))
 }
 
 /// Wrapper for `std::fs::read`
@@ -50,4 +55,10 @@ pub fn remove_dir(path: impl AsRef<Path>) -> Result<()> {
 pub fn remove_dir_all(path: impl AsRef<Path>) -> Result<()> {
     let path = path.as_ref();
     fs::remove_dir_all(path).map_err(|err| FsPathError::remove_dir(err, path))
+}
+
+/// Wrapper for `std::fs::File::open`
+pub fn open(path: impl AsRef<Path>) -> Result<fs::File> {
+    let path = path.as_ref();
+    fs::File::open(path).map_err(|err| FsPathError::open(err, path))
 }

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -1,5 +1,4 @@
-use crate::executor::{inspector::cheatcodes::util, opts::EvmOpts};
-use bytes::Bytes;
+use crate::executor::opts::EvmOpts;
 use foundry_config::{cache::StorageCachingConfig, Config, RpcEndpoints};
 use std::path::{Path, PathBuf};
 
@@ -45,9 +44,9 @@ impl CheatsConfig {
         return self.allowed_paths.iter().any(|allowed_path| path.as_ref().starts_with(allowed_path))
     }
 
-    pub fn ensure_path_allowed(&self, path: impl AsRef<Path>) -> Result<(), Bytes> {
+    pub fn ensure_path_allowed(&self, path: impl AsRef<Path>) -> Result<(), String> {
         if !self.is_path_allowed(path) {
-            return Err(util::encode_error("Path is not allowed."))
+            return Err("Path is not allowed.".to_string())
         }
 
         Ok(())

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -1,6 +1,6 @@
 use crate::executor::opts::EvmOpts;
 use foundry_config::{cache::StorageCachingConfig, Config, RpcEndpoints};
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 /// Additional, configurable context the `Cheatcodes` inspector has access to
 ///
@@ -11,9 +11,9 @@ use std::{path::PathBuf, sync::Arc};
 pub struct CheatsConfig {
     pub ffi: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
-    pub rpc_storage_caching: Arc<StorageCachingConfig>,
+    pub rpc_storage_caching: StorageCachingConfig,
     /// All known endpoints and their aliases
-    pub rpc_endpoints: Arc<RpcEndpoints>,
+    pub rpc_endpoints: RpcEndpoints,
 
     pub root: PathBuf,
     pub allowed_paths: Vec<PathBuf>,
@@ -30,8 +30,8 @@ impl CheatsConfig {
 
         Self {
             ffi: evm_opts.ffi,
-            rpc_storage_caching: Arc::new(config.rpc_storage_caching.clone()),
-            rpc_endpoints: Arc::new(config.rpc_endpoints.clone()),
+            rpc_storage_caching: config.rpc_storage_caching.clone(),
+            rpc_endpoints: config.rpc_endpoints.clone(),
             root: config.__root.0.clone(),
             allowed_paths,
         }

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -1,6 +1,7 @@
-use crate::executor::opts::EvmOpts;
+use crate::executor::{inspector::cheatcodes::util, opts::EvmOpts};
+use bytes::Bytes;
 use foundry_config::{cache::StorageCachingConfig, Config, RpcEndpoints};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Additional, configurable context the `Cheatcodes` inspector has access to
 ///
@@ -38,5 +39,17 @@ impl CheatsConfig {
             root: config.__root.0.clone(),
             allowed_paths,
         }
+    }
+
+    pub fn is_path_allowed(&self, path: impl AsRef<Path>) -> bool {
+        return self.allowed_paths.iter().any(|allowed_path| path.as_ref().starts_with(allowed_path))
+    }
+
+    pub fn ensure_path_allowed(&self, path: impl AsRef<Path>) -> Result<(), Bytes> {
+        if !self.is_path_allowed(path) {
+            return Err(util::encode_error("Path is not allowed."))
+        }
+
+        Ok(())
     }
 }

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -1,6 +1,6 @@
 use crate::executor::opts::EvmOpts;
 use foundry_config::{cache::StorageCachingConfig, Config, RpcEndpoints};
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 /// Additional, configurable context the `Cheatcodes` inspector has access to
 ///
@@ -14,6 +14,8 @@ pub struct CheatsConfig {
     pub rpc_storage_caching: Arc<StorageCachingConfig>,
     /// All known endpoints and their aliases
     pub rpc_endpoints: Arc<RpcEndpoints>,
+
+    pub allowed_paths: Vec<PathBuf>,
 }
 
 // === impl CheatsConfig ===
@@ -21,10 +23,15 @@ pub struct CheatsConfig {
 impl CheatsConfig {
     /// Extracts the necessary settings from the Config
     pub fn new(config: &Config, evm_opts: &EvmOpts) -> Self {
+        let mut allowed_paths = vec![config.__root.0.clone()];
+        allowed_paths.extend(config.libs.clone());
+        allowed_paths.extend(config.allow_paths.clone());
+
         Self {
             ffi: evm_opts.ffi,
             rpc_storage_caching: Arc::new(config.rpc_storage_caching.clone()),
             rpc_endpoints: Arc::new(config.rpc_endpoints.clone()),
+            allowed_paths,
         }
     }
 }

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -15,6 +15,7 @@ pub struct CheatsConfig {
     /// All known endpoints and their aliases
     pub rpc_endpoints: Arc<RpcEndpoints>,
 
+    pub root: PathBuf,
     pub allowed_paths: Vec<PathBuf>,
 }
 
@@ -31,6 +32,7 @@ impl CheatsConfig {
             ffi: evm_opts.ffi,
             rpc_storage_caching: Arc::new(config.rpc_storage_caching.clone()),
             rpc_endpoints: Arc::new(config.rpc_endpoints.clone()),
+            root: config.__root.0.clone(),
             allowed_paths,
         }
     }

--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -15,7 +15,10 @@ pub struct CheatsConfig {
     /// All known endpoints and their aliases
     pub rpc_endpoints: RpcEndpoints,
 
+    /// Project root
     pub root: PathBuf,
+
+    /// Paths (directories) where file reading/writing is allowed
     pub allowed_paths: Vec<PathBuf>,
 }
 

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytes::Bytes;
 use ethers::{
-    abi::{AbiEncode, RawLog},
+    abi::{AbiDecode, AbiEncode, RawLog},
     types::{Address, H160, U256},
 };
 use revm::{return_ok, Database, EVMData, Return};
@@ -75,12 +75,8 @@ pub fn handle_expect_revert(
     let (err, actual_revert): (_, Bytes) = match string_data {
         Some(data) => {
             // It's a revert string, so we do some conversion to perform the check
-            let decoded_data: Bytes = ethers::abi::decode(&[ethers::abi::ParamType::Bytes], data)
-                .expect("String error code, but data is not a string")[0]
-                .clone()
-                .into_bytes()
-                .expect("Cannot fail as this is bytes")
-                .into();
+            let decoded_data = ethers::prelude::Bytes::decode(data)
+                .expect("String error code, but data can't be decoded as bytes");
 
             (
                 format!(
@@ -94,7 +90,7 @@ pub fn handle_expect_revert(
                 )
                 .encode()
                 .into(),
-                decoded_data,
+                decoded_data.0,
             )
         }
         _ => (

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -165,7 +165,7 @@ fn full_path(state: &Cheatcodes, path: impl AsRef<Path>) -> PathBuf {
 
 fn read_file(state: &Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     let data = fs::read_to_string(path).map_err(util::encode_error)?;
 
@@ -174,7 +174,7 @@ fn read_file(state: &Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes>
 
 fn read_line(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     // Get reader for previously opened file to continue reading OR initialize new reader
     let reader = state
@@ -199,7 +199,7 @@ fn read_line(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, By
 
 fn write_file(state: &Cheatcodes, path: impl AsRef<Path>, data: &str) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     fs::write(path, data).map_err(util::encode_error)?;
 
@@ -208,7 +208,7 @@ fn write_file(state: &Cheatcodes, path: impl AsRef<Path>, data: &str) -> Result<
 
 fn write_line(state: &Cheatcodes, path: impl AsRef<Path>, line: &str) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     let mut file = std::fs::OpenOptions::new()
         .append(true)
@@ -223,7 +223,7 @@ fn write_line(state: &Cheatcodes, path: impl AsRef<Path>, line: &str) -> Result<
 
 fn close_file(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     state.context.opened_read_files.remove(&path);
 
@@ -232,7 +232,7 @@ fn close_file(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, B
 
 fn remove_file(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes> {
     let path = full_path(state, &path);
-    state.config.ensure_path_allowed(&path)?;
+    state.config.ensure_path_allowed(&path).map_err(util::encode_error)?;
 
     close_file(state, &path)?;
     fs::remove_file(&path).map_err(util::encode_error)?;

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -37,6 +37,7 @@ use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     fs::File,
     io::BufReader,
+    path::PathBuf,
 };
 
 mod config;
@@ -100,7 +101,7 @@ pub struct Cheatcodes {
 #[derive(Debug, Default)]
 pub struct Context {
     //// Buffered readers for files opened for reading (path => BufReader mapping)
-    pub opened_read_files: HashMap<String, BufReader<File>>,
+    pub opened_read_files: HashMap<PathBuf, BufReader<File>>,
 }
 
 /// Every time we clone `Context`, we want it to be empty

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -38,6 +38,7 @@ use std::{
     fs::File,
     io::BufReader,
     path::PathBuf,
+    sync::Arc,
 };
 
 mod config;
@@ -92,7 +93,7 @@ pub struct Cheatcodes {
     pub broadcastable_transactions: VecDeque<TypedTransaction>,
 
     /// Additional, user configurable context this Inspector has access to when inspecting a call
-    pub config: CheatsConfig,
+    pub config: Arc<CheatsConfig>,
 
     /// Test-scoped context holding data that needs to be reset every test run
     pub context: Context,
@@ -117,7 +118,7 @@ impl Cheatcodes {
             corrected_nonce: false,
             block: Some(block),
             gas_price: Some(gas_price),
-            config,
+            config: Arc::new(config),
             ..Default::default()
         }
     }

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 /// Decoding helpers
 pub mod decode;
 

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 /// Decoding helpers
 pub mod decode;
 

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -364,7 +364,10 @@ mod tests {
 
     /// Builds a non-tracing runner
     fn runner() -> MultiContractRunner {
-        base_runner().build(&(*PROJECT).paths.root, (*COMPILED).clone(), EVM_OPTS.clone()).unwrap()
+        base_runner()
+            .with_cheats_config(CheatsConfig::new(&Config::with_root(PROJECT.root()), &*EVM_OPTS))
+            .build(&(*PROJECT).paths.root, (*COMPILED).clone(), EVM_OPTS.clone())
+            .unwrap()
     }
 
     /// Builds a tracing runner

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -103,23 +103,23 @@ interface Cheats {
     function startBroadcast(address) external;
     // Stops collecting onchain transactions
     function stopBroadcast() external;
-    // Reads the entire content of file to string, (path) => (data)
+    // Reads the entire content of file to string. Path is relative to the project root. (path) => (data)
     function readFile(string calldata) external returns (string memory);
     // Reads next line of file to string, (path) => (line)
     function readLine(string calldata) external returns (string memory);
     // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
-    // (path, data) => ()
+    // Path is relative to the project root. (path, data) => ()
     function writeFile(string calldata, string calldata) external;
     // Writes line to file, creating a file if it does not exist.
-    // (path, data) => ()
+    // Path is relative to the project root. (path, data) => ()
     function writeLine(string calldata, string calldata) external;
     // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
-    // (path) => ()
+    // Path is relative to the project root. (path) => ()
     function closeFile(string calldata) external;
     // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
     // - Path points to a directory.
     // - The file doesn't exist.
     // - The user lacks permissions to remove the file.
-    // (path) => ()
+    // Path is relative to the project root. (path) => ()
     function removeFile(string calldata) external;
 }

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -11,6 +11,9 @@ contract FileTest is DSTest {
         string memory path = "../testdata/fixtures/File/read.txt";
 
         assertEq(cheats.readFile(path), "hello readable world\nthis is the second line!");
+
+        cheats.expectRevert("Path is not allowed.");
+        cheats.readFile("/etc/hosts");
     }
 
     function testReadLine() public {
@@ -19,6 +22,9 @@ contract FileTest is DSTest {
         assertEq(cheats.readLine(path), "hello readable world");
         assertEq(cheats.readLine(path), "this is the second line!");
         assertEq(cheats.readLine(path), "");
+
+        cheats.expectRevert("Path is not allowed.");
+        cheats.readLine("/etc/hosts");
     }
 
     function testWriteFile() public {
@@ -29,6 +35,9 @@ contract FileTest is DSTest {
         assertEq(cheats.readFile(path), data);
 
         cheats.removeFile(path);
+
+        cheats.expectRevert("Path is not allowed.");
+        cheats.writeFile("/etc/hosts", "malicious stuff");
     }
 
     function testWriteLine() public {
@@ -43,6 +52,9 @@ contract FileTest is DSTest {
         assertEq(cheats.readFile(path), string.concat(line1, "\n", line2, "\n"));
 
         cheats.removeFile(path);
+
+        cheats.expectRevert("Path is not allowed.");
+        cheats.writeLine("/etc/hosts", "malicious stuff");
     }
 
     function testCloseFile() public {
@@ -65,5 +77,8 @@ contract FileTest is DSTest {
         assertEq(cheats.readLine(path), data);
 
         cheats.removeFile(path);
+
+        cheats.expectRevert("Path is not allowed.");
+        cheats.removeFile("/etc/hosts");
     }
 }

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -63,5 +63,7 @@ contract FileTest is DSTest {
         cheats.removeFile(path);
         cheats.writeLine(path, data);
         assertEq(cheats.readLine(path), data);
+
+        cheats.removeFile(path);
     }
 }


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/2096

## Solution

1. Collect allowed paths same way we do it for solc compilation.
2. Check every file reading/writing operation against allowed paths and revert if path isn't allowed.