### PR TITLE
fix: start line number at 0

### DIFF
--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -366,7 +366,7 @@ impl Visitor {
         SourceLocation {
             start: loc.start,
             length: loc.length,
-            line: self.source[..loc.start].lines().count() + 1,
+            line: self.source[..loc.start].lines().count(),
         }
     }
 


### PR DESCRIPTION
## Motivation

LCOV expects line numbers to start at 0 - the reason we started at 1 is because I thought LCOV required them to start at 1, lol

## Solution

Start at 0