### PR TITLE
fix(forge): `contractName` not showing up on broadcast log

### DIFF
--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -86,11 +86,12 @@ impl ScriptArgs {
         let address_to_abi: BTreeMap<Address, (String, &Abi)> = decoder
             .contracts
             .iter()
-            .filter_map(|(addr, contract_name)| {
+            .filter_map(|(addr, contract_id)| {
+                let contract_name = utils::get_contract_name(contract_id);
                 if let Some((_, (abi, _))) =
-                    contracts.iter().find(|(artifact, _)| artifact.name == *contract_name)
+                    contracts.iter().find(|(artifact, _)| artifact.name == contract_name)
                 {
-                    return Some((*addr, (contract_name.clone(), abi)))
+                    return Some((*addr, (contract_name.to_string(), abi)))
                 }
                 None
             })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`AddressIdentity` now saves the identifier [path:contractName] on `AddressIdentity.contract`, instead of just the name. This caused `contractName` not to be picked up on `TransactionWithMetadata`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use `utils::get_contract_name` on the identifier when creating `address_to_abi`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
