### PR TITLE
fix: correct hit data for multi-contract files

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -238,8 +238,13 @@ impl CoverageArgs {
                         })
                         .for_each(|(id, source_map, hits)| {
                             // TODO: Distinguish between creation/runtime in a smart way
-                            map.add_hit_map(id.version.clone(), &source_map.0, hits.clone());
-                            map.add_hit_map(id.version, &source_map.1, hits.clone())
+                            map.add_hit_map(
+                                id.version.clone(),
+                                &source_map.0,
+                                &id.name,
+                                hits.clone(),
+                            );
+                            map.add_hit_map(id.version, &source_map.1, &id.name, hits.clone())
                         });
                 }
             }

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -1,4 +1,4 @@
-use super::{BranchKind, CoverageItem, SourceLocation};
+use super::{BranchKind, CoverageItem, ItemAnchor, SourceLocation};
 use ethers::{
     prelude::sourcemap::SourceMap,
     solc::artifacts::ast::{self, Ast, Node, NodeType},
@@ -353,7 +353,7 @@ impl Visitor {
         {
             self.items.push(CoverageItem::Line {
                 loc: source_location.clone(),
-                anchor: item.anchor(),
+                anchor: item.anchor().clone(),
                 hits: 0,
             });
             self.last_line = source_location.line;
@@ -370,8 +370,9 @@ impl Visitor {
         }
     }
 
-    fn anchor_for(&self, loc: &ast::SourceLocation) -> usize {
-        self.source_maps
+    fn anchor_for(&self, loc: &ast::SourceLocation) -> ItemAnchor {
+        let instruction_counter = self
+            .source_maps
             .get(&self.context)
             .and_then(|source_map| {
                 source_map
@@ -392,6 +393,8 @@ impl Visitor {
                     })
                     .map(|(ic, _)| ic)
             })
-            .unwrap_or(loc.start)
+            .unwrap_or(loc.start);
+
+        ItemAnchor { instruction: instruction_counter, contract: self.context.clone() }
     }
 }


### PR DESCRIPTION
Correctly applies hit data for files with multiple contracts.

The behavior was caused by the fact that the per-contract source maps are indexed with the instruction counter for that contracts bytecode only. This means that you could have multiple source maps for one source file, if you had multiple contracts in that source file. One range of elements in each source map might map to different ranges in the source code - which means that going by instruction counter is not enough.

Hopefully that makes a bit of sense - this PR resolves two issues:

1. Some coverage items were marked as covered multiple times, if there were multiple contracts in a source file.
2. Some coverage items were marked as covered, while they were not, if there were multiple contracts in a source file.

Closes #2103