### PR TITLE
fix(anvil): return tx out data correctly on revert

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1568,7 +1568,7 @@ impl EthApi {
         call_to_estimate.gas = Some(gas_limit);
 
         // execute the call without writing to db
-        let (exit, _, gas, _) =
+        let (exit, out, gas, _) =
             self.backend.call(call_to_estimate, fees.clone(), block_number).await?;
         match exit {
             return_ok!() => {
@@ -1601,7 +1601,7 @@ impl EthApi {
                     }
                 } else {
                     // the transaction did fail due to lack of gas from the user
-                    Err(InvalidTransactionError::Revert(request.data).into())
+                    Err(InvalidTransactionError::Revert(Some(convert_transact_out(&out))).into())
                 }
             }
             reason => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #1871 (for good)
in the event of a revert while estimating gas we returned the request's data instead of the transaction out data...

while debugging this I also came accross #2117
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
return revert data correctly
Referenced example in #1871 now prints:

```text
Failed: execution reverted: RevertStringFooBar
```
cc @unparalleled-js
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
