### PR TITLE
feat(fmt): revert named args

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -34,10 +34,10 @@ See [Statement](https://github.com/hyperledger-labs/solang/blob/413841b5c759eb86
 - [x] DoWhile
 - [x] Continue
 - [x] Break
-- [ ] Return
-- [ ] Revert
+- [x] Return
+- [x] Revert
 - [x] Emit
-- [ ] Try
+- [x] Try
 - [x] DocComment
 
 ### Expressions
@@ -52,8 +52,8 @@ See [Expression](https://github.com/hyperledger-labs/solang/blob/413841b5c759eb8
 - [ ] BoolLiteral, NumberLiteral, RationalNumberLiteral, HexNumberLiteral, StringLiteral, HexLiteral , AddressLiteral
 - [ ] ArraySubscript, ArraySlice
 - [x] MemberAccess
-- [ ] FunctionCall
-- [ ] FunctionCallBlock
+- [x] FunctionCall
+- [x] FunctionCallBlock
 - [ ] NamedFunctionCall
 - [x] New
 - [x] Delete

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -2361,8 +2361,10 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         let mut args_iter = args.iter_mut().peekable();
         let mut chunks = Vec::new();
         while let Some(NamedArgument { loc: arg_loc, name, expr }) = args_iter.next() {
-            let next_byte_offset =
-                args_iter.peek().map(|NamedArgument { loc, .. }| loc.start()).unwrap_or(loc.end());
+            let next_byte_offset = args_iter
+                .peek()
+                .map(|NamedArgument { loc: arg_loc, .. }| arg_loc.start())
+                .unwrap_or_else(|| loc.end());
             chunks.push(self.chunked(arg_loc.start(), Some(next_byte_offset), |fmt| {
                 write_chunk!(fmt, name.loc.start(), "{}: ", name.name)?;
                 expr.visit(fmt)

--- a/fmt/src/lib.rs
+++ b/fmt/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod comments;
 mod formatter;
+mod macros;
 pub mod solang_ext;
 mod visit;
 

--- a/fmt/src/macros.rs
+++ b/fmt/src/macros.rs
@@ -1,0 +1,92 @@
+macro_rules! write_chunk {
+    ($self:expr, $format_str:literal) => {{
+        write_chunk!($self, $format_str,)
+    }};
+    ($self:expr, $format_str:literal, $($arg:tt)*) => {{
+        $self.write_chunk(&format!($format_str, $($arg)*).into())
+    }};
+    ($self:expr, $loc:expr) => {{
+        write_chunk!($self, $loc, "")
+    }};
+    ($self:expr, $loc:expr, $format_str:literal) => {{
+        write_chunk!($self, $loc, $format_str,)
+    }};
+    ($self:expr, $loc:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, None, None, format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal) => {{
+        write_chunk!($self, $loc, $end_loc, $format_str,)
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, Some($end_loc), None, format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $needs_space:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, Some($end_loc), Some($needs_space), format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
+    }};
+}
+
+macro_rules! writeln_chunk {
+    ($self:expr) => {{
+        writeln_chunk!($self, "")
+    }};
+    ($self:expr, $format_str:literal) => {{
+        writeln_chunk!($self, $format_str,)
+    }};
+    ($self:expr, $format_str:literal, $($arg:tt)*) => {{
+        write_chunk!($self, "{}\n", format_args!($format_str, $($arg)*))
+    }};
+    ($self:expr, $loc:expr) => {{
+        writeln_chunk!($self, $loc, "")
+    }};
+    ($self:expr, $loc:expr, $format_str:literal) => {{
+        writeln_chunk!($self, $loc, $format_str,)
+    }};
+    ($self:expr, $loc:expr, $format_str:literal, $($arg:tt)*) => {{
+        write_chunk!($self, $loc, "{}\n", format_args!($format_str, $($arg)*))
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal) => {{
+        writeln_chunk!($self, $loc, $end_loc, $format_str,)
+    }};
+    ($self:expr, $loc:expr, $end_loc:expr, $format_str:literal, $($arg:tt)*) => {{
+        write_chunk!($self, $loc, $end_loc, "{}\n", format_args!($format_str, $($arg)*))
+    }};
+}
+
+macro_rules! write_chunk_spaced {
+    ($self:expr, $loc:expr, $needs_space:expr, $format_str:literal) => {{
+        write_chunk_spaced!($self, $loc, $needs_space, $format_str,)
+    }};
+    ($self:expr, $loc:expr, $needs_space:expr, $format_str:literal, $($arg:tt)*) => {{
+        let chunk = $self.chunk_at($loc, None, $needs_space, format_args!($format_str, $($arg)*),);
+        $self.write_chunk(&chunk)
+    }};
+}
+
+macro_rules! buf_fn {
+    ($vis:vis fn $name:ident(&self $(,)? $($arg_name:ident : $arg_ty:ty),*) $(-> $ret:ty)?) => {
+        $vis fn $name(&self, $($arg_name : $arg_ty),*) $(-> $ret)? {
+            if self.temp_bufs.is_empty() {
+                self.buf.$name($($arg_name),*)
+            } else {
+                self.temp_bufs.last().unwrap().$name($($arg_name),*)
+            }
+        }
+    };
+    ($vis:vis fn $name:ident(&mut self $(,)? $($arg_name:ident : $arg_ty:ty),*) $(-> $ret:ty)?) => {
+        $vis fn $name(&mut self, $($arg_name : $arg_ty),*) $(-> $ret)? {
+            if self.temp_bufs.is_empty() {
+                self.buf.$name($($arg_name),*)
+            } else {
+                self.temp_bufs.last_mut().unwrap().$name($($arg_name),*)
+            }
+        }
+    };
+}
+
+pub(crate) use buf_fn;
+pub(crate) use write_chunk;
+pub(crate) use write_chunk_spaced;
+pub(crate) use writeln_chunk;

--- a/fmt/testdata/RevertNamedArgsStatement/fmt.sol
+++ b/fmt/testdata/RevertNamedArgsStatement/fmt.sol
@@ -1,0 +1,36 @@
+contract RevertNamedArgsStatement {
+    error EmptyError();
+    error SimpleError(uint256 val);
+    error ComplexError(uint256 val, uint256 ts, string message);
+    error SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength(
+        uint256 val, uint256 ts, string message
+    );
+
+    function test() external {
+        revert({});
+
+        revert EmptyError({});
+
+        revert SimpleError({val: 0});
+
+        revert ComplexError({
+            val: 0,
+            ts: block.timestamp,
+            message: "some reason"
+        });
+
+        revert
+            SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({
+                val: 0,
+                ts: block.timestamp,
+                message: "something happened that caused execution to revert"
+            });
+
+        revert({}); // comment1
+
+        revert /* comment2 */ SimpleError({ /* comment3 */ // comment4
+            val: 0
+        });
+        // comment 5
+    }
+}

--- a/fmt/testdata/RevertNamedArgsStatement/fmt.sol
+++ b/fmt/testdata/RevertNamedArgsStatement/fmt.sol
@@ -22,15 +22,14 @@ contract RevertNamedArgsStatement {
         revert
             SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({
                 val: 0,
-                ts: block.timestamp,
-                message: "something happened that caused execution to revert"
+                ts: 0x00,
+                message: "something unpredictable happened that caused execution to revert"
             });
 
         revert({}); // comment1
 
         revert /* comment2 */ SimpleError({ /* comment3 */ // comment4
-            val: 0
+            val: 0 // comment 5
         });
-        // comment 5
     }
 }

--- a/fmt/testdata/RevertNamedArgsStatement/original.sol
+++ b/fmt/testdata/RevertNamedArgsStatement/original.sol
@@ -20,14 +20,13 @@ contract RevertNamedArgsStatement {
                         message: "some reason"
             });
         
-        revert SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({ val: 0, ts: block.timestamp, message: "something happened that caused execution to revert"});
+        revert SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({ val: 0, ts: 0x00, message: "something unpredictable happened that caused execution to revert"});
 
         revert // comment1 
         ({});
 
          revert /* comment2 */ SimpleError /* comment3 */ ({ // comment4 
-        val:0
-        // comment 5
+        val:0 // comment 5
         });
     }
 }

--- a/fmt/testdata/RevertNamedArgsStatement/original.sol
+++ b/fmt/testdata/RevertNamedArgsStatement/original.sol
@@ -1,0 +1,33 @@
+contract RevertNamedArgsStatement {
+    error EmptyError();
+    error SimpleError(uint256 val);
+    error ComplexError(uint256 val, uint256 ts, string message);
+    error SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength(
+        uint256 val, uint256 ts, string message
+    );
+
+    function test() external {
+        revert ({ });
+
+        revert EmptyError({});
+
+        revert SimpleError({ val: 0 });
+
+        revert ComplexError(
+            {
+                val: 0,
+                    ts: block.timestamp,
+                        message: "some reason"
+            });
+        
+        revert SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({ val: 0, ts: block.timestamp, message: "something happened that caused execution to revert"});
+
+        revert // comment1 
+        ({});
+
+         revert /* comment2 */ SimpleError /* comment3 */ ({ // comment4 
+        val:0
+        // comment 5
+        });
+    }
+}


### PR DESCRIPTION
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- fmt formatting of `Statement::RevertNamedArgs`
- separate `macros` module
