### PR TITLE
fix(cli): don't check sources directory existance during compilation

### DIFF
--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -134,16 +134,6 @@ impl ProjectCompiler {
         F: FnOnce(&Project) -> eyre::Result<ProjectCompileOutput>,
     {
         let ProjectCompiler { print_sizes, print_names } = self;
-        if !project.paths.sources.exists() {
-            eyre::bail!(
-                r#"no contracts to compile, contracts folder "{}" does not exist.
-Check the configured workspace settings:
-{}
-If you are in a subdirectory in a Git repository, try adding `--root .`"#,
-                project.paths.sources.display(),
-                project.paths
-            );
-        }
 
         let now = std::time::Instant::now();
         tracing::trace!(target : "forge::compile", "start compiling project");
@@ -219,17 +209,6 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
 /// compilation was successful or if there was a cache hit.
 /// Doesn't print anything to stdout, thus is "suppressed".
 pub fn suppress_compile(project: &Project) -> eyre::Result<ProjectCompileOutput> {
-    if !project.paths.sources.exists() {
-        eyre::bail!(
-            r#"no contracts to compile, contracts folder "{}" does not exist.
-Check the configured workspace settings:
-{}
-If you are in a subdirectory in a Git repository, try adding `--root .`"#,
-            project.paths.sources.display(),
-            project.paths
-        );
-    }
-
     let output = ethers::solc::report::with_scoped(
         &ethers::solc::report::Report::new(NoReporter::default()),
         || project.compile(),


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/2093

## Solution

```console
➜  mev-example git:(curve20220521) ls
cache  foundry.toml  interface  lib  out  README.md  remappings.txt  test
```

## Before
```console
➜  mev-example git:(curve20220521) forge test --fork-url $ETH_RPC_URL --fork-block-number 14811888 -vvv
Error:
no contracts to compile, contracts folder "/Users/shekhirin/Projects/mev-example/src" does not exist.
Check the configured workspace settings:
root: /Users/shekhirin/Projects/mev-example
contracts: /Users/shekhirin/Projects/mev-example/src
artifacts: /Users/shekhirin/Projects/mev-example/out
tests: /Users/shekhirin/Projects/mev-example/test
scripts: /Users/shekhirin/Projects/mev-example/script
libs:
    /Users/shekhirin/Projects/mev-example/lib
remappings:
    ds-test/=/Users/shekhirin/Projects/mev-example/lib/forge-std/lib/ds-test/src/
    forge-std/=/Users/shekhirin/Projects/mev-example/lib/forge-std/src/
    openzeppelin-contracts/=/Users/shekhirin/Projects/mev-example/lib/openzeppelin-contracts/contracts/
    src/=/Users/shekhirin/Projects/mev-example/src/
    test/=/Users/shekhirin/Projects/mev-example/test/

If you are in a subdirectory in a Git repository, try adding `--root .`
```

## After
```console
➜  mev-example git:(curve20220521) ../foundry/target/debug/forge test --fork-url $ETH_RPC_URL --fork-block-number 14811888 -vvv
[⠘] Compiling...
No files changed, compilation skipped

Running 1 test for test/MEV.t.sol:MEVSimulation
[PASS] testMEV() (gas: 2043432)
Test result: ok. 1 passed; 0 failed; finished in 133.98ms
```
