### PR TITLE
feat(coverage): better branch handling

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -170,8 +170,8 @@ impl CoverageArgs {
                         })
                         .collect();
 
-                    let items = Visitor::new(source.id, fs::read_to_string(&path)?, source_maps)
-                        .visit_ast(ast)?;
+                    let items =
+                        Visitor::new(fs::read_to_string(&path)?, source_maps).visit_ast(ast)?;
 
                     if items.is_empty() {
                         continue

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -10,7 +10,7 @@ use crate::{
 use cast::trace::identifier::TraceIdentifier;
 use clap::{AppSettings, ArgEnum, Parser};
 use ethers::{
-    prelude::{Artifact, Project, ProjectCompileOutput},
+    prelude::{Artifact, Bytes, Project, ProjectCompileOutput},
     solc::{artifacts::contract::CompactContractBytecode, sourcemap::SourceMap, ArtifactId},
 };
 use forge::{
@@ -24,7 +24,7 @@ use forge::{
 };
 use foundry_common::{evm::EvmArgs, fs};
 use foundry_config::{figment::Figment, Config};
-use std::{collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
+use std::{borrow::Cow, collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
@@ -119,15 +119,19 @@ impl CoverageArgs {
 
     /// Builds the coverage map.
     fn prepare(&self, output: ProjectCompileOutput) -> eyre::Result<(CoverageMap, SourceMaps)> {
-        // Get sources and source maps
+        // Extract artifacts
         let (artifacts, sources) = output.into_artifacts_with_sources();
-
-        let source_maps: SourceMaps = artifacts
+        let artifacts: HashMap<ArtifactId, CompactContractBytecode> = artifacts
             .into_iter()
             .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
-            .filter_map(|(id, artifact): (ArtifactId, CompactContractBytecode)| {
+            .collect();
+
+        // Get source maps
+        let source_maps: SourceMaps = artifacts
+            .iter()
+            .filter_map(|(id, artifact)| {
                 Some((
-                    id,
+                    id.clone(),
                     (
                         artifact.get_source_map()?.ok()?,
                         artifact
@@ -138,6 +142,17 @@ impl CoverageArgs {
                             .source_map()?
                             .ok()?,
                     ),
+                ))
+            })
+            .collect();
+
+        // Get bytecodes
+        let bytecodes: HashMap<ArtifactId, (Cow<Bytes>, Cow<Bytes>)> = artifacts
+            .iter()
+            .filter_map(|(id, artifact)| {
+                Some((
+                    id.clone(),
+                    (artifact.get_bytecode_bytes()?, artifact.get_deployed_bytecode_bytes()?),
                 ))
             })
             .collect();
@@ -165,13 +180,24 @@ impl CoverageArgs {
                                 id.source == PathBuf::from(&path)
                         })
                         .map(|(id, (_, source_map))| {
-                            // TODO: Deploy source map too?
+                            // TODO: Deploy source map too
                             (id.name.clone(), source_map.clone())
                         })
                         .collect();
+                    let bytecodes: HashMap<String, Cow<Bytes>> = bytecodes
+                        .iter()
+                        .filter(|(id, _)| {
+                            id.version == versioned_source.version &&
+                                id.source == PathBuf::from(&path)
+                        })
+                        .map(|(id, (_, bytecode))| {
+                            // TODO: Deploy bytecode too
+                            (id.name.clone(), bytecode.clone())
+                        })
+                        .collect();
 
-                    let items =
-                        Visitor::new(fs::read_to_string(&path)?, source_maps).visit_ast(ast)?;
+                    let items = Visitor::new(fs::read_to_string(&path)?, source_maps, bytecodes)
+                        .visit_ast(ast)?;
 
                     if items.is_empty() {
                         continue

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -24,7 +24,7 @@ use forge::{
 };
 use foundry_common::{evm::EvmArgs, fs};
 use foundry_config::{figment::Figment, Config};
-use std::{borrow::Cow, collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
+use std::{collections::HashMap, path::PathBuf, sync::mpsc::channel, thread};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
@@ -147,12 +147,15 @@ impl CoverageArgs {
             .collect();
 
         // Get bytecodes
-        let bytecodes: HashMap<ArtifactId, (Cow<Bytes>, Cow<Bytes>)> = artifacts
+        let bytecodes: HashMap<ArtifactId, (Bytes, Bytes)> = artifacts
             .iter()
             .filter_map(|(id, artifact)| {
                 Some((
                     id.clone(),
-                    (artifact.get_bytecode_bytes()?, artifact.get_deployed_bytecode_bytes()?),
+                    (
+                        artifact.get_bytecode_bytes()?.into_owned(),
+                        artifact.get_deployed_bytecode_bytes()?.into_owned(),
+                    ),
                 ))
             })
             .collect();
@@ -184,7 +187,7 @@ impl CoverageArgs {
                             (id.name.clone(), source_map.clone())
                         })
                         .collect();
-                    let bytecodes: HashMap<String, Cow<Bytes>> = bytecodes
+                    let bytecodes: HashMap<String, Bytes> = bytecodes
                         .iter()
                         .filter(|(id, _)| {
                             id.version == versioned_source.version &&

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -213,8 +213,6 @@ pub enum CoverageItem {
         ///
         /// The first path has ID 0, the next ID 1, and so on.
         path_id: usize,
-        /// The branch kind.
-        kind: BranchKind,
         /// The number of times this item was hit.
         hits: u64,
     },
@@ -279,11 +277,8 @@ impl Display for CoverageItem {
             CoverageItem::Statement { loc, anchor, hits } => {
                 write!(f, "Statement (location: {loc}, anchor: {anchor}, hits: {hits})")
             }
-            CoverageItem::Branch { loc, anchor, hits, branch_id, path_id, kind } => {
-                write!(f, "{} Branch (branch: {branch_id}, path: {path_id}) (location: {loc}, anchor: {anchor}, hits: {hits})", match kind {
-                    BranchKind::True => "True",
-                    BranchKind::False => "False",
-                })
+            CoverageItem::Branch { loc, anchor, hits, branch_id, path_id } => {
+                write!(f, "Branch (branch: {branch_id}, path: {path_id}) (location: {loc}, anchor: {anchor}, hits: {hits})")
             }
             CoverageItem::Function { loc, anchor, hits, name } => {
                 write!(f, r#"Function "{name}" (location: {loc}, anchor: {anchor}, hits: {hits})"#)
@@ -312,14 +307,6 @@ impl Display for SourceLocation {
             self.length.map_or(self.start, |length| self.start + length)
         )
     }
-}
-
-#[derive(Debug, Clone)]
-pub enum BranchKind {
-    /// A false branch
-    True,
-    /// A true branch
-    False,
 }
 
 /// Coverage summary for a source file.

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -486,7 +486,7 @@ impl<'a> Visitor<'a> {
                         CoverageItem::Branch {
                             branch_id,
                             path_id: 0,
-                            loc: self.source_location_for(&loc),
+                            loc: self.source_location_for(loc),
                             anchor: ItemAnchor {
                                 instruction: first_branch_ic.unwrap(),
                                 contract: self.context.clone(),
@@ -496,7 +496,7 @@ impl<'a> Visitor<'a> {
                         CoverageItem::Branch {
                             branch_id,
                             path_id: 1,
-                            loc: self.source_location_for(&loc),
+                            loc: self.source_location_for(loc),
                             anchor: ItemAnchor {
                                 instruction: second_branch_pc - cumulative_push_size,
                                 contract: self.context.clone(),

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -4,20 +4,17 @@ use ethers::{
     solc::artifacts::ast::{self, Ast, Node, NodeType},
 };
 use revm::{opcode, spec_opcode_gas, SpecId};
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-};
+use std::collections::{BTreeMap, HashMap};
 use tracing::warn;
 
 #[derive(Debug, Default, Clone)]
-pub struct Visitor<'a> {
+pub struct Visitor {
     /// The source code that contains the AST being walked.
     source: String,
     /// Source maps for this specific source file, keyed by the contract name.
     source_maps: HashMap<String, SourceMap>,
     /// Bytecodes for this specific source file, keyed by the contract name.
-    bytecodes: HashMap<String, Cow<'a, Bytes>>,
+    bytecodes: HashMap<String, Bytes>,
 
     /// The contract whose AST we are currently walking
     context: String,
@@ -30,11 +27,11 @@ pub struct Visitor<'a> {
     items: Vec<CoverageItem>,
 }
 
-impl<'a> Visitor<'a> {
+impl Visitor {
     pub fn new(
         source: String,
         source_maps: HashMap<String, SourceMap>,
-        bytecodes: HashMap<String, Cow<'a, Bytes>>,
+        bytecodes: HashMap<String, Bytes>,
     ) -> Self {
         Self { source, source_maps, bytecodes, ..Default::default() }
     }

--- a/evm/src/coverage/visitor.rs
+++ b/evm/src/coverage/visitor.rs
@@ -84,7 +84,7 @@ impl Visitor {
             // Skip virtual functions
             Some(body) if !is_virtual => {
                 self.push_item(CoverageItem::Function {
-                    name,
+                    name: format!("{}.{}", self.context, name),
                     loc: self.source_location_for(&node.src),
                     anchor: self.anchor_for(&body.src),
                     hits: 0,

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -4,13 +4,14 @@ use crate::{
         inspector::utils::{gas_used, get_create_address},
         CHEATCODE_ADDRESS,
     },
+    utils::build_ic_map,
     CallKind,
 };
 use bytes::Bytes;
 use ethers::types::Address;
 use revm::{
     opcode, spec_opcode_gas, CallInputs, CreateInputs, Database, EVMData, Gas, Inspector,
-    Interpreter, Memory, Return, SpecId,
+    Interpreter, Memory, Return,
 };
 use std::collections::BTreeMap;
 
@@ -48,31 +49,6 @@ pub struct Debugger {
 }
 
 impl Debugger {
-    /// Builds the instruction counter map for the given bytecode.
-    // TODO: Some of the same logic is performed in REVM, but then later discarded. We should
-    // investigate if we can reuse it
-    pub fn build_ic_map(&mut self, spec: SpecId, code: &Bytes) {
-        let opcode_infos = spec_opcode_gas(spec);
-        let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
-
-        let mut i = 0;
-        let mut cumulative_push_size = 0;
-        while i < code.len() {
-            let op = code[i];
-            ic_map.insert(i, i - cumulative_push_size);
-            if opcode_infos[op as usize].is_push {
-                // Skip the push bytes.
-                //
-                // For more context on the math, see: https://github.com/bluealloy/revm/blob/007b8807b5ad7705d3cacce4d92b89d880a83301/crates/revm/src/interpreter/contract.rs#L114-L115
-                i += (op - opcode::PUSH1 + 1) as usize;
-                cumulative_push_size += (op - opcode::PUSH1 + 1) as usize;
-            }
-            i += 1;
-        }
-
-        self.ic_map.insert(self.context, ic_map);
-    }
-
     /// Enters a new execution context.
     pub fn enter(&mut self, depth: usize, address: Address, kind: CallKind) {
         self.context = address;
@@ -127,7 +103,8 @@ where
         // TODO: This is rebuilt for all contracts every time. We should only run this if the IC
         // map for a given address does not exist, *but* we need to account for the fact that the
         // code given by the interpreter may either be the contract init code, or the runtime code.
-        self.build_ic_map(data.env.cfg.spec_id, &interp.contract().code);
+        self.ic_map
+            .insert(self.context, build_ic_map(data.env.cfg.spec_id, &interp.contract().code));
         self.previous_gas_block = interp.contract.first_gas_block();
         Return::Continue
     }

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -1,4 +1,7 @@
+use bytes::Bytes;
 use ethers::prelude::{H256, U256};
+use revm::{opcode, spec_opcode_gas, SpecId};
+use std::collections::BTreeMap;
 
 /// Small helper function to convert [U256] into [H256].
 pub fn u256_to_h256_le(u: U256) -> H256 {
@@ -22,4 +25,29 @@ pub fn h256_to_u256_be(storage: H256) -> U256 {
 /// Small helper function to convert [H256] into [U256].
 pub fn h256_to_u256_le(storage: H256) -> U256 {
     U256::from_little_endian(storage.as_bytes())
+}
+
+/// Builds the instruction counter map for the given bytecode.
+// TODO: Some of the same logic is performed in REVM, but then later discarded. We should
+// investigate if we can reuse it
+pub fn build_ic_map(spec: SpecId, code: &Bytes) -> BTreeMap<usize, usize> {
+    let opcode_infos = spec_opcode_gas(spec);
+    let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
+
+    let mut i = 0;
+    let mut cumulative_push_size = 0;
+    while i < code.len() {
+        let op = code[i];
+        ic_map.insert(i, i - cumulative_push_size);
+        if opcode_infos[op as usize].is_push {
+            // Skip the push bytes.
+            //
+            // For more context on the math, see: https://github.com/bluealloy/revm/blob/007b8807b5ad7705d3cacce4d92b89d880a83301/crates/revm/src/interpreter/contract.rs#L114-L115
+            i += (op - opcode::PUSH1 + 1) as usize;
+            cumulative_push_size += (op - opcode::PUSH1 + 1) as usize;
+        }
+        i += 1;
+    }
+
+    ic_map
 }


### PR DESCRIPTION
Some small refactoring and solution for #1967 

## Motivation

We want good branch coverage in `forge coverage`, which means detecting the following scenarios:

- Calls to `assert` and `require` should result in branching (one branch reverts, the other one doesn't)
- If statements with no else block should have an implicit else
- Else if statements should also be considered a branch

## Solution

`assert` and `require` require us to inspect the bytecode that the source map identifies as representing them. Generally, this bytecode follows the format:

```
PUSH [PC if condition is true]
JUMPI
[eventually revert]
```

That is, we need to find bytecode that identifies an `assert` or a `require` and look for a JUMPI preceded by a PUSH. The first branch is the instruction directly after JUMPI, because this branch will eventually end in a REVERT. The second branch is the instruction at the PC we pushed before JUMPI. Both of these locations need to be translated to instruction counters (i.e. program counters minus any push bytes leading up to that program counter) because this is how the source maps are indexed.

For if statements, the general format is somewhat the same:
```
PUSH [PC if condition is false]
JUMPI
[true branch]
```

There is a special case though: if you have more complex conditions for `assert`, `require` or your if statement, then there might be multiple sections of bytecode that match the same template. The *last* piece of bytecode that matches this template seems to be the "main" jump, so we always need to find the last JUMPI to find the branches.

Closes #1967 