### PR TITLE
Document latest "log_array" for address arrays

### DIFF
--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -46,6 +46,7 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
         LogNamedStringFilter(inner) => format!("{}: {}", inner.key, inner.val),
         LogNamedArray1Filter(inner) => format!("{}: {:?}", inner.key, inner.val),
         LogNamedArray2Filter(inner) => format!("{}: {:?}", inner.key, inner.val),
+        LogNamedArray3Filter(inner) => format!("{}: {:?}", inner.key, inner.val),
 
         e => e.to_string(),
     };

--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -102,6 +102,7 @@ ethers::contract::abigen!(
             event log_string             (string)
             event log_array              (uint256[] val)
             event log_array              (int256[] val)
+            event log_array              (address[] val)
             event log_named_address      (string key, address val)
             event log_named_bytes32      (string key, bytes32 val)
             event log_named_decimal_int  (string key, int val, uint decimals)
@@ -112,6 +113,7 @@ ethers::contract::abigen!(
             event log_named_string       (string key, string val)
             event log_named_array        (string key, uint256[] val)
             event log_named_array        (string key, int256[] val)
+            event log_named_array        (string key, address[] val)
     ]"#
 );
 pub use console_mod::{ConsoleEvents, CONSOLE_ABI};


### PR DESCRIPTION
Same as https://github.com/foundry-rs/foundry/pull/1916 but for `address[]` arrays.

See discussion in https://github.com/foundry-rs/forge-std/pull/95.