### PR TITLE
fix(forge): correct nonce before vm.getNonce on `script`

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -287,7 +287,7 @@ forgetest_async!(
         tester
             .load_private_keys(vec![0])
             .await
-            .add_sig("BroadcastTestNoLinking", "deployMix()")
+            .add_sig("BroadcastMix", "deployMix()")
             .simulate(ScriptOutcome::OkSimulation)
             .broadcast(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment(vec![(0, 15)])

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -213,6 +213,8 @@ pub fn apply<DB: Database>(
             }
         }
         HEVMCalls::GetNonce(inner) => {
+            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
+
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
             data.subroutine.load_account(inner.0, data.db);
@@ -250,7 +252,7 @@ pub fn apply<DB: Database>(
 }
 
 /// When using `forge script`, the script method is called using the address from `--sender`.
-/// That leads to the its nonce being incremented by `call_raw`. In a `broadcast` scenario this is
+/// That leads to its nonce being incremented by `call_raw`. In a `broadcast` scenario this is
 /// undesirable. Therefore, we make sure to fix the sender's nonce **once**.
 fn correct_sender_nonce(
     sender: &Address,

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -160,6 +160,9 @@ contract BroadcastTestNoLinking is DSTest {
     }
 
     function deployMany() public {
+
+        assert(cheats.getNonce(msg.sender) == 0);
+
         cheats.startBroadcast();
 
         for(uint i; i< 100; i++) {
@@ -177,6 +180,25 @@ contract BroadcastTestNoLinking is DSTest {
         cheats.stopBroadcast();
     
     }
+    function errorStaticCall() public {
+        cheats.broadcast();
+        NoLink test11 = new NoLink();
+
+        cheats.broadcast();
+        test11.view_me();
+    }
+}
+
+contract BroadcastMix is DSTest {
+
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    // ganache-cli -d 1st
+    address public ACCOUNT_A = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+
+    // ganache-cli -d 2nd
+    address public ACCOUNT_B = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+
     function more() internal {
         cheats.broadcast();
         NoLink test11 = new NoLink();
@@ -224,14 +246,6 @@ contract BroadcastTestNoLinking is DSTest {
 
         more();
     }
-
-    function errorStaticCall() public {
-        cheats.broadcast();
-        NoLink test11 = new NoLink();
-
-        cheats.broadcast();
-        test11.view_me();
-    }
 }
 
 
@@ -239,6 +253,10 @@ contract BroadcastTestSetup is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function setUp() public {
+
+        // It predeployed a library first
+        assert(cheats.getNonce(msg.sender) == 1);
+
         cheats.broadcast();
         Test t = new Test();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

ref https://github.com/foundry-rs/foundry/issues/2110

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Apply the same prehook patch that we use on `broadcast` cheatcodes. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
