### PR TITLE
fix: remove `to_type` in `cast index`

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1342,18 +1342,13 @@ impl SimpleCast {
     ///
     /// # fn main() -> eyre::Result<()> {
     ///
-    ///    assert_eq!(Cast::index("address", "uint256" ,"0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
-    ///    assert_eq!(Cast::index("uint256", "uint256" ,"42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
+    ///    assert_eq!(Cast::index("address", "0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
+    ///    assert_eq!(Cast::index("uint256","42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
     /// #    Ok(())
     /// # }
     /// ```
-    pub fn index(
-        from_type: &str,
-        to_type: &str,
-        from_value: &str,
-        slot_number: &str,
-    ) -> Result<String> {
-        let sig = format!("x({from_type},{to_type})");
+    pub fn index(from_type: &str, from_value: &str, slot_number: &str) -> Result<String> {
+        let sig = format!("x({from_type},uint256)");
         let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
         let location: String = Self::keccak(&encoded)?;
         Ok(location)

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -451,8 +451,8 @@ async fn main() -> eyre::Result<()> {
         Subcommands::AbiEncode { sig, args } => {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
-        Subcommands::Index { key_type, value_type, key, slot_number } => {
-            let encoded = SimpleCast::index(&key_type, &value_type, &key, &slot_number)?;
+        Subcommands::Index { key_type, key, slot_number } => {
+            let encoded = SimpleCast::index(&key_type, &key, &slot_number)?;
             println!("{encoded}");
         }
         Subcommands::FourByte { selector } => {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -503,8 +503,6 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     Index {
         #[clap(help = "The mapping key type.", value_name = "KEY_TYPE")]
         key_type: String,
-        #[clap(help = "The mapping value type.", value_name = "VALUE_TYPE")]
-        value_type: String,
         #[clap(help = "The mapping key.", value_name = "KEY")]
         key: String,
         #[clap(help = "The storage slot of the mapping.", value_name = "SLOT_NUMBER")]


### PR DESCRIPTION
The value type in a mapping has no effect whatsoever on the slot it occupies, so to avoid confusion we should remove it.

The slot of all of these mappings are computed using the same command (assuming they occupy the same slot):

```solidity
mapping(address => address);
mapping(address => uint);
mapping(address => T);
```

The command being `cast index address <key> <slot>`.

To get the slot of a nested mapping, e.g. `mapping(k1 => mapping(k2 => T))` you would do:

```
cast index k2 <key 2> $(cast index k1 <key 1> <slot>)
```

`k1` being the type of `key 1` and `k2` being the type of `key 2`. Note how the order is inverted, i.e. the above command would access  `mapping[key 1][key 2]`.

Closes #2141 