### PR TITLE
chore(script): remove gas limit entirely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1620,7 +1620,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#f5793525f229e4808e0d0ccc5f12225da06152f7"
+source = "git+https://github.com/gakonst/ethers-rs#7e85b331674b451e7861f21e04253398f32ec08a"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -339,8 +339,9 @@ where
     // Chains which use `eth_estimateGas` are being sent sequentially and require their gas to be
     // re-estimated right before broadcasting.
     if has_different_gas_calc(signer.signer().chain_id()) {
-        // If we don't, some RPCs might just return our estimated gas anyway.
-        legacy_or_1559.set_gas(0);
+        // if already set, some RPC endpoints might simply return the gas value that is already set
+        // in the request and omit the estimate altogether, so we remove it here
+        let _ = legacy_or_1559.gas_mut().take();
 
         legacy_or_1559.set_gas(
             signer


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Blocked by https://github.com/gakonst/ethers-rs/pull/1427

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/2137

This is mainly a problem for L2s with different gas calc

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
instead of setting gas limit to 0 which may be interpreted as a desired cap during gas estimation (by anvil), we remove it
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
