### PR TITLE
fix(forge/create): fix forge create tx value setting

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -228,6 +228,11 @@ impl CreateArgs {
             self.legacy || Chain::try_from(chain).map(|x| Chain::is_legacy(&x)).unwrap_or_default();
         let mut deployer = if is_legacy { deployer.legacy() } else { deployer };
 
+        // set tx value if specified
+        if let Some(value) = self.value {
+            deployer.tx.set_value(value);
+        }
+
         // fill tx first because if you target a lower gas than current base, eth_estimateGas
         // will fail and create will fail
         let mut tx = deployer.tx;
@@ -260,11 +265,6 @@ impl CreateArgs {
                 ),
                 _ => deployer.tx,
             };
-        }
-
-        // set tx value if specified
-        if let Some(value) = self.value {
-            deployer.tx.set_value(value);
         }
 
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes https://github.com/foundry-rs/foundry/issues/2123.

I think the issue stems from that when `estimate_gas` call in `provider.fill_transaction` is executed, `value` hasn't been set yet.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Set `value` before calling `provider.fill_transaction`.
