### PR TITLE
feat(forge): add cheatcodes vm.recordLogs() and vm.getRecordedLogs()

### DIFF
--- a/evm/src/executor/abi.rs
+++ b/evm/src/executor/abi.rs
@@ -14,6 +14,7 @@ pub static CHEATCODE_ADDRESS: Address = H160([
 ethers::contract::abigen!(
     HEVM,
     r#"[
+            struct Log {bytes32[] topics; bytes data;}
             roll(uint256)
             warp(uint256)
             fee(uint256)
@@ -50,6 +51,8 @@ ethers::contract::abigen!(
             expectRevert(bytes4)
             record()
             accesses(address)(bytes32[],bytes32[])
+            recordLogs()
+            getRecordedLogs()(Log[])
             expectEmit(bool,bool,bool,bool)
             expectEmit(bool,bool,bool,bool,address)
             mockCall(address,bytes,bytes)

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -115,7 +115,6 @@ fn start_record_logs(state: &mut Cheatcodes) {
 
 fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
     if let Some(recorded_logs) = state.recorded_logs.replace(Default::default()) {
-
         ethers::abi::encode(
             &recorded_logs
                 .entries

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -4,7 +4,7 @@ use super::Cheatcodes;
 use crate::abi::HEVMCalls;
 use bytes::Bytes;
 use ethers::{
-    abi::{self, AbiEncode, Token, Tokenize},
+    abi::{self, AbiEncode, RawLog, Token, Tokenize},
     types::{Address, H256, U256},
     utils::keccak256,
 };
@@ -104,6 +104,42 @@ fn accesses(state: &mut Cheatcodes, address: Address) -> Bytes {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct RecordedLogs {
+    pub entries: Vec<RawLog>,
+}
+
+fn start_record_logs(state: &mut Cheatcodes) {
+    state.recorded_logs = Some(Default::default());
+}
+
+fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
+    if let Some(recorded_logs) = &mut state.recorded_logs {
+        let tuples = recorded_logs
+            .entries
+            .iter()
+            .map(|entry| {
+                Token::Tuple(
+                    [
+                        Token::Array(
+                            entry
+                                .topics
+                                .iter()
+                                .map(|topic| Token::FixedBytes(topic.clone().as_bytes().to_vec()))
+                                .collect(),
+                        ),
+                        Token::Bytes(entry.data.clone()),
+                    ]
+                    .to_vec(),
+                )
+            })
+            .collect::<Vec<Token>>();
+        ethers::abi::encode(&[Token::Array(tuples)]).into()
+    } else {
+        ethers::abi::encode(&[Token::Array(vec![])]).into()
+    }
+}
+
 pub fn apply<DB: Database>(
     state: &mut Cheatcodes,
     data: &mut EVMData<'_, DB>,
@@ -197,6 +233,11 @@ pub fn apply<DB: Database>(
             Ok(Bytes::new())
         }
         HEVMCalls::Accesses(inner) => Ok(accesses(state, inner.0)),
+        HEVMCalls::RecordLogs(_) => {
+            start_record_logs(state);
+            Ok(Bytes::new())
+        }
+        HEVMCalls::GetRecordedLogs(_) => Ok(get_recorded_logs(state)),
         HEVMCalls::SetNonce(inner) => {
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -114,7 +114,10 @@ fn start_record_logs(state: &mut Cheatcodes) {
 }
 
 fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
-    if let Some(recorded_logs) = &mut state.recorded_logs {
+    if let Some(recorded_logs) = state.recorded_logs.clone() {
+        // reset the records
+        start_record_logs(state);
+
         ethers::abi::encode(
             &recorded_logs
                 .entries

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -114,9 +114,7 @@ fn start_record_logs(state: &mut Cheatcodes) {
 }
 
 fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
-    if let Some(recorded_logs) = state.recorded_logs.clone() {
-        // reset the records
-        start_record_logs(state);
+    if let Some(recorded_logs) = state.recorded_logs.replace(Default::default()) {
 
         ethers::abi::encode(
             &recorded_logs

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -1,6 +1,6 @@
 /// Cheatcodes related to the execution environment.
 mod env;
-pub use env::{Prank, RecordAccess};
+pub use env::{Prank, RecordAccess, RecordedLogs};
 /// Assertion helpers (such as `expectEmit`)
 mod expect;
 pub use expect::{ExpectedCallData, ExpectedEmit, ExpectedRevert, MockCallDataContext};
@@ -73,6 +73,9 @@ pub struct Cheatcodes {
 
     /// Recorded storage reads and writes
     pub accesses: Option<RecordAccess>,
+
+    /// Recorded logs
+    pub recorded_logs: Option<RecordedLogs>,
 
     /// Mocked calls
     pub mocked_calls: BTreeMap<Address, BTreeMap<MockCallDataContext, Bytes>>,
@@ -318,6 +321,13 @@ where
                 RawLog { topics: topics.to_vec(), data: data.to_vec() },
                 address,
             );
+        }
+
+        // Stores this log if `recordLogs` has been called
+        if let Some(storage_recorded_logs) = &mut self.recorded_logs {
+            storage_recorded_logs
+                .entries
+                .push(RawLog { topics: topics.to_vec(), data: data.to_vec() });
         }
     }
 

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.0;
 
 interface Cheats {
+    // This allows us to getRecordedLogs()
+    struct Log {bytes32[] topics; bytes data;}
     // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
     // Set block.height (newHeight)
@@ -60,6 +62,10 @@ interface Cheats {
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Record all the transaction logs
+    function recordLogs() external;
+    // Gets all the recorded logs
+    function getRecordedLogs() external returns (Log[] memory);
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans).

--- a/testdata/cheats/RecordLogs.t.sol
+++ b/testdata/cheats/RecordLogs.t.sol
@@ -219,4 +219,39 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[2].topics[3], bytes32(uint256(6)));
         assertEq(abi.decode(entries[2].data, (string)), string(testData2));
     }
+
+    function testRecordsConsumednAsRead() public {
+        Cheats.Log[] memory entries;
+
+        emitter.emitEvent(1, generateTestData(16));
+
+        // hit record now
+        cheats.recordLogs();
+
+        entries = cheats.getRecordedLogs();
+        assertEq(entries.length, 0);
+
+        // emit after calling .getRecordedLogs()
+        emitter.emitEvent(2, 3, generateTestData(24));
+
+        entries = cheats.getRecordedLogs();
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 3);
+
+        // let's emit two more!
+        emitter.emitEvent(4, 5, 6, generateTestData(20));
+        emitter.emitEvent(generateTestData(32));
+
+        entries = cheats.getRecordedLogs();
+        assertEq(entries.length, 2);
+        assertEq(entries[0].topics.length, 4);
+        assertEq(entries[1].topics.length, 1);
+
+        // the last one
+        emitter.emitEvent(7, 8, 9, generateTestData(24));
+
+        entries = cheats.getRecordedLogs();
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 4);
+    }
 }

--- a/testdata/cheats/RecordLogs.t.sol
+++ b/testdata/cheats/RecordLogs.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "./Cheats.sol";
+
+contract Emitter {
+    event LogAnonymous(
+        bytes data
+    ) anonymous;
+
+    event LogTopic0(
+        bytes data
+    );
+
+    event LogTopic1(
+        uint256 indexed topic1,
+        bytes data
+    );
+
+    event LogTopic12(
+        uint256 indexed topic1,
+        uint256 indexed topic2,
+        bytes data
+    );
+
+    event LogTopic123(
+        uint256 indexed topic1,
+        uint256 indexed topic2,
+        uint256 indexed topic3,
+        bytes data
+    );
+
+    function emitAnonymousEvent(
+        bytes memory data
+    ) public {
+        emit LogAnonymous(data);
+    }
+
+    function emitEvent(
+        bytes memory data
+    ) public {
+        emit LogTopic0(data);
+    }
+
+    function emitEvent(
+        uint256 topic1,
+        bytes memory data
+    ) public {
+        emit LogTopic1(topic1, data);
+    }
+
+    function emitEvent(
+        uint256 topic1,
+        uint256 topic2,
+        bytes memory data
+    ) public {
+        emit LogTopic12(topic1, topic2, data);
+    }
+
+    function emitEvent(
+        uint256 topic1,
+        uint256 topic2,
+        uint256 topic3,
+        bytes memory data
+    ) public {
+        emit LogTopic123(topic1, topic2, topic3, data);
+    }
+}
+
+contract Emitterv2 {
+    Emitter emitter  = new Emitter();
+
+    function emitEvent(
+        uint256 topic1,
+        uint256 topic2,
+        uint256 topic3,
+        bytes memory data
+    ) public {
+        emitter.emitEvent(topic1, topic2, topic3, data);
+    }
+}
+
+contract RecordLogsTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    Emitter emitter;
+    bytes32 internal seedTestData = keccak256(abi.encodePacked("Some data"));
+
+    // Used on testRecordOnEmitDifferentDepths()
+    event LogTopic(
+        uint256 indexed topic1,
+        bytes data
+    );
+
+    function setUp() public {
+        emitter = new Emitter();
+    }
+
+    function generateTestData(uint8 n) internal returns (bytes memory) {
+        bytes memory output = new bytes(n);
+
+        for (uint8 i = 0; i < n; i++) {
+            output[i] = seedTestData[ i % 32 ];
+            if ( i % 32 == 31 ) {
+                seedTestData = keccak256(abi.encodePacked(seedTestData));
+            }
+        }
+
+        return output;
+    }
+
+    function testRecordOffGetsNothing() public {
+        emitter.emitEvent(1, 2, 3, generateTestData(48));
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 0);
+    }
+
+    function testRecordOnNoLogs() public {
+        cheats.recordLogs();
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 0);
+    }
+
+    function testRecordOnSingleLog() public {
+        bytes memory testData = "Event Data in String";
+
+        cheats.recordLogs();
+        emitter.emitEvent(1, 2, 3, testData);
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 4);
+        assertEq(entries[0].topics[0], keccak256("LogTopic123(uint256,uint256,uint256,bytes)"));
+        assertEq(entries[0].topics[1], bytes32(uint256(1)));
+        assertEq(entries[0].topics[2], bytes32(uint256(2)));
+        assertEq(entries[0].topics[3], bytes32(uint256(3)));
+        assertEq(abi.decode(entries[0].data, (string)), string(testData));
+    }
+
+    // TODO
+    // This crashes on decoding!
+    //   The application panicked (crashed).
+    //   Message:  index out of bounds: the len is 0 but the index is 0
+    //   Location: <local-dir>/evm/src/trace/decoder.rs:299
+    function NOtestRecordOnAnonymousEvent() public {
+        bytes memory testData = generateTestData(48);
+
+        cheats.recordLogs();
+        emitter.emitAnonymousEvent(testData);
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 1);
+    }
+
+    function testRecordOnSingleLogTopic0() public {
+        bytes memory testData = generateTestData(48);
+
+        cheats.recordLogs();
+        emitter.emitEvent(testData);
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 1);
+        assertEq(entries[0].topics[0], keccak256("LogTopic0(bytes)"));
+        // While not a proper string, this conversion allows the comparison.
+        assertEq(abi.decode(entries[0].data, (string)), string(testData));
+    }
+
+    function testEmitRecordEmit() public {
+        bytes memory testData0 = generateTestData(32);
+        emitter.emitEvent(1, 2, testData0);
+
+        cheats.recordLogs();
+        bytes memory testData1 = generateTestData(16);
+        emitter.emitEvent(3, testData1);
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 2);
+        assertEq(entries[0].topics[0], keccak256("LogTopic1(uint256,bytes)"));
+        assertEq(entries[0].topics[1], bytes32(uint256(3)));
+        assertEq(abi.decode(entries[0].data, (string)), string(testData1));
+    }
+
+    function testRecordOnEmitDifferentDepths() public {
+        cheats.recordLogs();
+
+        bytes memory testData0 = generateTestData(16);
+        emit LogTopic(1, testData0);
+
+        bytes memory testData1 = generateTestData(20);
+        emitter.emitEvent(2, 3, testData1);
+
+        bytes memory testData2 = generateTestData(24);
+        Emitterv2 emitter2 = new Emitterv2();
+        emitter2.emitEvent(4, 5, 6, testData2);
+
+        Cheats.Log[] memory entries = cheats.getRecordedLogs();
+
+        assertEq(entries.length, 3);
+
+        assertEq(entries[0].topics.length, 2);
+        assertEq(entries[0].topics[0], keccak256("LogTopic(uint256,bytes)"));
+        assertEq(entries[0].topics[1], bytes32(uint256(1)));
+        assertEq(abi.decode(entries[0].data, (string)), string(testData0));
+
+        assertEq(entries[1].topics.length, 3);
+        assertEq(entries[1].topics[0], keccak256("LogTopic12(uint256,uint256,bytes)"));
+        assertEq(entries[1].topics[1], bytes32(uint256(2)));
+        assertEq(entries[1].topics[2], bytes32(uint256(3)));
+        assertEq(abi.decode(entries[1].data, (string)), string(testData1));
+
+        assertEq(entries[2].topics.length, 4);
+        assertEq(entries[2].topics[0], keccak256("LogTopic123(uint256,uint256,uint256,bytes)"));
+        assertEq(entries[2].topics[1], bytes32(uint256(4)));
+        assertEq(entries[2].topics[2], bytes32(uint256(5)));
+        assertEq(entries[2].topics[3], bytes32(uint256(6)));
+        assertEq(abi.decode(entries[2].data, (string)), string(testData2));
+    }
+}


### PR DESCRIPTION
## Overview

The methods `vm.recordLogs()` and `vm.getRecordedLogs()` provide the tester the ability to leverage information from the events emitted during the execution of a transaction.

Ref: https://github.com/foundry-rs/foundry/issues/543

## Motivation

While porting solutions from the CTF Ethernaut to Foundry, got bumped by the fact that when you create a challenge, you are calling the `Ethernaut.sol` contract with the address of the factory of the challenge you want to solve. `Ethernaut.sol` will invoke the factory, deploy a new challenge for you, and return the address of this new contract within an event `LevelInstanceCreatedLog(address indexed player, address instance)`.

In practical terms, one [can just modify the Ethernaut contract](https://github.com/OpenZeppelin/ethernaut/blob/60ba307bf3bc79c93b271d58c584b3905cf848b2/contracts/contracts/Ethernaut.sol#L48) to return you the address instead of emitting such event, _but_, this is a motivation to just build the feature into Foundry!

## Solution

* Implement `vm.captureLogs()`: Function mirroring `vm.record()`.
* Implement `vm.getRecordedLogs()`: Function mirroring `vm.accesses()`.