### PR TITLE
fix(forge): new error message for vm.addr() when passing invalid private keys

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -31,7 +31,7 @@ fn addr(private_key: U256) -> Result<Bytes, Bytes> {
     }
 
     if private_key > U256::from_big_endian(&Secp256k1::ORDER.to_be_bytes()) {
-        return Err("Private key must be less than 115792089237316195423570985008687907852837564279074904382605163141518161494337.".to_string().encode().into())
+        return Err("Private key must be less than 115792089237316195423570985008687907852837564279074904382605163141518161494337 (the secp256k1 curve order).".to_string().encode().into())
     }
 
     let mut bytes: [u8; 32] = [0; 32];
@@ -48,7 +48,7 @@ fn sign(private_key: U256, digest: H256, chain_id: U256) -> Result<Bytes, Bytes>
     }
 
     if private_key > U256::from_big_endian(&Secp256k1::ORDER.to_be_bytes()) {
-        return Err("Private key must be less than 115792089237316195423570985008687907852837564279074904382605163141518161494337.".to_string().encode().into())
+        return Err("Private key must be less than 115792089237316195423570985008687907852837564279074904382605163141518161494337 (the secp256k1 curve order).".to_string().encode().into())
     }
 
     let mut bytes: [u8; 32] = [0; 32];

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -10,6 +10,7 @@ use ethers::{
 };
 use foundry_common::fmt::*;
 use revm::{CreateInputs, Database, EVMData};
+use std::str::FromStr;
 
 pub const DEFAULT_CREATE2_DEPLOYER: H160 = H160([
     78, 89, 180, 72, 71, 179, 121, 87, 133, 136, 146, 12, 167, 143, 191, 38, 192, 180, 149, 108,
@@ -24,6 +25,13 @@ pub static ERROR_PREFIX: Lazy<[u8; 32]> = Lazy::new(|| keccak256("CheatCodeError
 fn addr(private_key: U256) -> Result<Bytes, Bytes> {
     if private_key.is_zero() {
         return Err("Private key cannot be 0.".to_string().encode().into())
+    }
+
+    let secp256k1_order =
+        U256::from_str("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")
+            .unwrap();
+    if private_key > secp256k1_order {
+        return Err("Private key is greater than secp256k1 curve order.".to_string().encode().into())
     }
 
     let mut bytes: [u8; 32] = [0; 32];

--- a/forge/README.md
+++ b/forge/README.md
@@ -138,7 +138,8 @@ which implements the following methods:
 
 - `function addr(uint sk) public returns (address addr)` Derives an ethereum
   address from the private key `sk`. Note that `hevm.addr(0)` will fail with
-  `BadCheatCode` as `0` is an invalid ECDSA private key.
+  `BadCheatCode` as `0` is an invalid ECDSA private key. `sk` values above the 
+  secp256k1 curve order, near the max uint256 value will also fail.
 
 - `function ffi(string[] calldata) external returns (bytes memory)` Executes the
   arguments as a command in the system shell and returns stdout. Note that this


### PR DESCRIPTION
Fixes #2158 

I thought about storing the curve order value in another way, like an array of bytes, but i think the marginal perf gain is not worth the less readable code.
