### PR TITLE
fix(fmt): fix extra empty line on --raw

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -122,7 +122,7 @@ impl Cmd for FmtArgs {
 
                 if self.check || matches!(input, Input::Stdin(_)) {
                     if self.raw {
-                        println!("{}", output);
+                        print!("{}", output);
                     }
 
                     let diff = TextDiff::from_lines(&source, &output);


### PR DESCRIPTION
## Motivation

Thanks to #2177, `forge fmt` now correctly outputs a trailing new line. However, when using the `--raw` flag, `forge` now prints an extra line:

```sh
$ cat Contract.sol | forge fmt --raw
....
....
}

$
```

## Solution

This PR simply changes `println` to `print` to get rid of the extra empty line.
