### PR TITLE
fix(fmt): unexpected error exit code without --check

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -161,6 +161,8 @@ impl Cmd for FmtArgs {
             .collect::<Vec<String>>();
 
         if !diffs.is_empty() {
+            // This branch is only reachable with stdin or --check
+
             if !self.raw {
                 for (i, diff) in diffs.iter().enumerate() {
                     if i > 0 {
@@ -170,7 +172,9 @@ impl Cmd for FmtArgs {
                 }
             }
 
-            std::process::exit(1);
+            if self.check {
+                std::process::exit(1);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Motivation

Currently when formatting from stdin, the process always exits with code `1` if diffs are found, even when `--check` is not supplied. This should be considered a bug, as in this case an error code should only be used when formatting fails.

## Solution

This PR adds a check on the `exit()` call for the `--check` flag.