### PR TITLE
feat(anvil): Set bind host with environment variable

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -104,6 +104,7 @@ pub struct NodeArgs {
         long,
         help = "The host the server will listen on",
         value_name = "IP_ADDR",
+        env = "ANVIL_IP_ADDR",
         help_heading = "SERVER OPTIONS"
     )]
     pub host: Option<IpAddr>,


### PR DESCRIPTION
Allow users to set the bind host of anvil via ANVIL_IP_ADDR environment variable.

## Motivation
Running anvil as a service in Github Actions with the docker container is currently not feasible because it's not possible to bind to all interfaces. Github actions allows setting an entrypoint, but cannot pass arguments to the entrypoint command, so `--host 0.0.0.0` will not work. Setting environment variables with options is possible with `--env ANVIL_IP_ADDR=0.0.0.0`, and would allow jobs in the workflow to access anvil.
 
## Solution
Leverage clap to assign the host variable via environment variable if present.

