### PR TITLE
fix(fmt): unexpected use of stdin

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -48,14 +48,14 @@ impl FmtArgs {
     /// Returns all inputs to format
     fn inputs(&self) -> Vec<Input> {
         if let Some(ref path) = self.path {
-            if path == Path::new("-") || !atty::is(atty::Stream::Stdin) {
-                let mut buf = String::new();
-                io::stdin().read_to_string(&mut buf).expect("Failed to read from stdin");
-                vec![Input::Stdin(buf)]
-            } else if path.is_dir() {
+            if path.is_dir() {
                 ethers::solc::utils::source_files(path).into_iter().map(Input::Path).collect()
             } else if path.is_sol() {
                 vec![Input::Path(path.to_path_buf())]
+            } else if path == Path::new("-") || !atty::is(atty::Stream::Stdin) {
+                let mut buf = String::new();
+                io::stdin().read_to_string(&mut buf).expect("Failed to read from stdin");
+                vec![Input::Stdin(buf)]
             } else {
                 vec![]
             }


### PR DESCRIPTION
## Motivation

Fixes #2192.

## Solution

I'm too scared to remove `|| !atty::is(atty::Stream::Stdin)` so I just re-ordered the branches instead.