### PR TITLE
peg revm version (latest 1.6.0 broke build) and support apple silicon

### DIFF
--- a/anvil/build.rs
+++ b/anvil/build.rs
@@ -6,4 +6,7 @@ fn main() {
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
     vergen::vergen(config)
         .unwrap_or_else(|e| panic!("vergen crate failed to generate version information! {}", e));
+
+    // Supports new Apple Silicon packages installed by Homebrew
+    println!("cargo:rustc-link-search=/opt/homebrew/Cellar/libusb/1.0.26/lib");
 }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -6,4 +6,7 @@ fn main() {
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
     vergen::vergen(config)
         .unwrap_or_else(|e| panic!("vergen crate failed to generate version information! {e}"));
+
+    // Supports new Apple Silicon packages installed by Homebrew
+    println!("cargo:rustc-link-search=/opt/homebrew/Cellar/libusb/1.0.26/lib");
 }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -37,7 +37,7 @@ once_cell = "1.9.0"
 # EVM
 bytes = "1.1.0"
 hashbrown = "0.12"
-revm = { version="1.5", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
+revm = { version="=1.5.0", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
 
 # Fuzzer
 proptest = "1.0.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The repo won't build because of the minor `revm` version change that impacted some function signatures in the in-memory DB code. On new Apple Silicon, the linker also has a hard time finding the libusb package installed in by the arm64 version of Homebrew. A simple change to the build.rs file fixed this for new mac users.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

For the revm version, the trivial fix for this was to peg the revm version to 1.5.0. For the Apple Silicon fix, we needed to add the new Homebrew path so the linker can be aware of where to search.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
