### PR TITLE
Customized Dockerfile Template Added.

### DIFF
--- a/Dockerfile_temp
+++ b/Dockerfile_temp
@@ -1,0 +1,7 @@
+FROM foundry:nightly
+
+ARG RPC_URL
+
+ENV rpc_url  $RPC_URL
+
+ENTRYPOINT cast block --rpc-url=${rpc_url} latest


### PR DESCRIPTION
Customized Dockerfile Template Added.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation


If you want to customize your images default command line, you must only use ENTRYPOINT tag, not CMD tag, and if you want to pass ENV variables into the command, you must use SHELL FORMAT rather than JSON FORMAT. So I created a Dockerfile template to mention these tips to avoid building failures.


## Solution


Created a Dockerfile template to mention these tips to avoid building failures.

