### PR TITLE
fix(fmt): preserve line comments in blocks 

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -624,7 +624,13 @@ impl<'a, W: Write> Formatter<'a, W> {
 
     /// Write all prefix comments before a given location
     fn write_prefix_comments_before(&mut self, byte_end: usize) -> Result<()> {
-        for prefix in self.comments.remove_prefixes_before(byte_end) {
+        let prefix_comments = self.comments.remove_prefixes_before(byte_end);
+        if let Some(CommentWithMetadata { has_newline_before, .. }) = prefix_comments.first() {
+            if *has_newline_before && !self.is_beginning_of_line() {
+                write!(self.buf(), "\n\n")?;
+            }
+        }
+        for prefix in prefix_comments {
             self.write_comment(&prefix)?;
         }
         Ok(())
@@ -2873,4 +2879,5 @@ mod tests {
     test_directory! { ArrayExpressions }
     test_directory! { UnitExpression }
     test_directory! { ThisExpression }
+    test_directory! { SimpleComments }
 }

--- a/fmt/testdata/SimpleComments/fmt.sol
+++ b/fmt/testdata/SimpleComments/fmt.sol
@@ -1,0 +1,9 @@
+contract SimpleComments {
+    constructor() {
+        // TODO: do this and that
+
+        uint256 a = 1;
+
+        // TODO: do that and this
+    }
+}

--- a/fmt/testdata/SimpleComments/fmt.sol
+++ b/fmt/testdata/SimpleComments/fmt.sol
@@ -5,5 +5,7 @@ contract SimpleComments {
         uint256 a = 1;
 
         // TODO: do that and this
+        // or maybe
+        // smth else
     }
 }

--- a/fmt/testdata/SimpleComments/original.sol
+++ b/fmt/testdata/SimpleComments/original.sol
@@ -1,0 +1,9 @@
+contract SimpleComments {
+    constructor() {
+        // TODO: do this and that
+
+        uint256 a = 1;
+
+        // TODO: do that and this
+    }
+}

--- a/fmt/testdata/SimpleComments/original.sol
+++ b/fmt/testdata/SimpleComments/original.sol
@@ -5,5 +5,7 @@ contract SimpleComments {
         uint256 a = 1;
 
         // TODO: do that and this
+        // or maybe
+        // smth else
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
on the block level, simple line comments get formatted as prefix comments

### Example with old behavior
before formatting:
 ```solidity
contract Format {
    constructor() {
        uint256 a = 1;

        // TODO: do this and that
    }
}
```

after first run:
 ```solidity
contract Format {
    constructor() {
        uint256 a = 1;

        // TODO: do this and that
    }
}
```

after second run:
 ```solidity
contract Format {
    constructor() {
        uint256 a = 1; // TODO: do this and that
    }
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

preserve the line comments on the block level
