### PR TITLE
Handle whitespace better with forge create constructor args file

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -118,7 +118,7 @@ impl CreateArgs {
                             eyre::bail!("constructor args path not found");
                         }
                         let file = fs::read_to_string(constructor_args_path)?;
-                        file.split(' ').map(|s| s.to_string()).collect::<Vec<String>>()
+                        file.split_whitespace().map(|s| s.to_string()).collect::<Vec<String>>()
                     } else {
                         self.constructor_args.clone()
                     };

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -119,12 +119,19 @@ impl CreateArgs {
                 let constructor_args =
                     if let Some(ref constructor_args_path) = self.constructor_args_path {
                         if !constructor_args_path.exists() {
-                            eyre::bail!("Constructor args file \"{}\" not found", constructor_args_path.display());
+                            eyre::bail!(
+                                "Constructor args file \"{}\" not found",
+                                constructor_args_path.display()
+                            );
                         }
                         if constructor_args_path.extension() == Some(std::ffi::OsStr::new("json")) {
                             match read_json_file(constructor_args_path) {
                                 Ok(args) => args,
-                                Err(err) => eyre::bail!("Constructor args file \"{}\" must encode a json array: \"{}\"", constructor_args_path.display(), err)
+                                Err(err) => eyre::bail!(
+                                    "Constructor args file \"{}\" must encode a json array: \"{}\"",
+                                    constructor_args_path.display(),
+                                    err
+                                ),
                             }
                         } else {
                             let file = fs::read_to_string(constructor_args_path)?;


### PR DESCRIPTION
Handle whitespace correctly for constructor args file with forge create.

This was flagged in this issue I raised:
https://github.com/foundry-rs/foundry/issues/1384

## Motivation

If the constructor args file has whitespace at the end (ie a new line) then this adds anomalous (and unexpected) whitespace onto the end of the constructor argument string data, which is probably not what the user wanted. However, to make it easier to encode whitespace explicitly, if the constructor args file explicitly ends with a .json extension it interprets the file content as a json encoded array of arguments.

## Solution

This uses .split_whitespace() instead of the less general .split(' ') to fix the whitespace issue for the non json case.

Otherwise, it uses serde_json on the file for json decoding.

