### PR TITLE
docs: fix benchmarks image

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ _Note: In the above benchmarks, compilation was always skipped_
 
 **Compilation Benchmarks**
 
-<img alt="Compilation benchmarks" src=".github/compilation-benchmark.png" height="420px" />
+<img alt="Compilation benchmarks" src=".github/compilation-benchmark.png" width="693px" />
 
 **Takeaway: Forge compilation is consistently faster by a factor of 1.7-11.3x, depending on the amount of caching involved.**
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The Foundry/HH benchmarks image gets squashed as the view width decreases, e.g. it's squashed on mobile.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Specify image `width` instead of `height` to preserve the aspect ratio in those cases.

I kept the size of the image as was.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
