### PR TITLE
Make FormatBuffer handle strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,6 @@ dependencies = [
 name = "forge-fmt"
 version = "0.2.0"
 dependencies = [
- "indent_write",
  "itertools",
  "pretty_assertions",
  "semver",
@@ -2679,12 +2678,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
 
 [[package]]
 name = "indenter"

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/foundry-rs/foundry"
 keywords = ["ethereum", "web3", "solidity", "linter"]
 
 [dependencies]
-indent_write = "2.2.0"
 semver = "1.0.4"
 solang-parser = "=0.1.14"
 itertools = "0.10.3"

--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -161,50 +161,104 @@ impl Comments {
     }
 }
 
-enum CommentState {
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CommentState {
     None,
+    LineStart1,
+    LineStart2,
     Line,
+    BlockStart1,
+    BlockStart2,
     Block,
+    BlockEnd1,
+    BlockEnd2,
+}
+
+impl Default for CommentState {
+    fn default() -> Self {
+        CommentState::None
+    }
+}
+
+/// An Iterator over characters and indexes in a string slice with information about the state of
+/// comments
+pub struct CommentStateCharIndices<'a> {
+    iter: std::iter::Peekable<std::str::CharIndices<'a>>,
+    state: CommentState,
+}
+
+impl<'a> CommentStateCharIndices<'a> {
+    fn from_str(string: &'a str) -> Self {
+        Self { iter: string.char_indices().peekable(), state: CommentState::None }
+    }
+    pub fn with_state(mut self, state: CommentState) -> Self {
+        self.state = state;
+        self
+    }
+}
+
+impl<'a> Iterator for CommentStateCharIndices<'a> {
+    type Item = (CommentState, usize, char);
+    fn next(&mut self) -> Option<Self::Item> {
+        let (idx, ch) = self.iter.next()?;
+        match self.state {
+            CommentState::None => {
+                if ch == '/' {
+                    match self.iter.peek() {
+                        Some((_, '/')) => {
+                            self.state = CommentState::LineStart1;
+                        }
+                        Some((_, '*')) => {
+                            self.state = CommentState::BlockStart1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            CommentState::LineStart1 => {
+                self.state = CommentState::LineStart2;
+            }
+            CommentState::LineStart2 => {
+                self.state = CommentState::Line;
+            }
+            CommentState::Line => {
+                if ch == '\n' {
+                    self.state = CommentState::None;
+                }
+            }
+            CommentState::BlockStart1 => {
+                self.state = CommentState::BlockStart2;
+            }
+            CommentState::BlockStart2 => {
+                self.state = CommentState::Block;
+            }
+            CommentState::Block => {
+                if ch == '*' {
+                    if let Some((_, '/')) = self.iter.peek() {
+                        self.state = CommentState::BlockEnd1;
+                    }
+                }
+            }
+            CommentState::BlockEnd1 => {
+                self.state = CommentState::BlockEnd2;
+            }
+            CommentState::BlockEnd2 => {
+                self.state = CommentState::None;
+            }
+        }
+        Some((self.state, idx, ch))
+    }
 }
 
 /// An Iterator over characters in a string slice which are not a apart of comments
-pub struct NonCommentChars<'a> {
-    iter: std::iter::Peekable<std::str::Chars<'a>>,
-    state: CommentState,
-}
+pub struct NonCommentChars<'a>(CommentStateCharIndices<'a>);
 
 impl<'a> Iterator for NonCommentChars<'a> {
     type Item = char;
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(ch) = self.iter.next() {
-            match self.state {
-                CommentState::None => match ch {
-                    '/' => match self.iter.peek() {
-                        Some('/') => {
-                            self.iter.next();
-                            self.state = CommentState::Line;
-                        }
-                        Some('*') => {
-                            self.iter.next();
-                            self.state = CommentState::Block;
-                        }
-                        _ => return Some(ch),
-                    },
-                    _ => return Some(ch),
-                },
-                CommentState::Line => {
-                    if ch == '\n' {
-                        self.state = CommentState::None;
-                        return Some('\n')
-                    }
-                }
-                CommentState::Block => {
-                    if ch == '*' {
-                        if let Some('/') = self.iter.next() {
-                            self.state = CommentState::None
-                        }
-                    }
-                }
+        for (state, _, ch) in self.0.by_ref() {
+            if state == CommentState::None {
+                return Some(ch)
             }
         }
         None
@@ -213,7 +267,10 @@ impl<'a> Iterator for NonCommentChars<'a> {
 
 /// Helpers for iterating over non-comment characters
 pub trait CommentStringExt {
-    fn non_comment_chars(&self) -> NonCommentChars;
+    fn comment_state_char_indices(&self) -> CommentStateCharIndices;
+    fn non_comment_chars(&self) -> NonCommentChars {
+        NonCommentChars(self.comment_state_char_indices())
+    }
     fn trim_comments(&self) -> String {
         self.non_comment_chars().collect()
     }
@@ -223,13 +280,13 @@ impl<T> CommentStringExt for T
 where
     T: AsRef<str>,
 {
-    fn non_comment_chars(&self) -> NonCommentChars {
-        NonCommentChars { iter: self.as_ref().chars().peekable(), state: CommentState::None }
+    fn comment_state_char_indices(&self) -> CommentStateCharIndices {
+        CommentStateCharIndices::from_str(self.as_ref())
     }
 }
 
 impl CommentStringExt for str {
-    fn non_comment_chars(&self) -> NonCommentChars {
-        NonCommentChars { iter: self.chars().peekable(), state: CommentState::None }
+    fn comment_state_char_indices(&self) -> CommentStateCharIndices {
+        CommentStateCharIndices::from_str(self)
     }
 }

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -2,13 +2,12 @@
 
 use std::fmt::Write;
 
-use indent_write::fmt::IndentWriter;
 use itertools::Itertools;
 use solang_parser::pt::*;
 use thiserror::Error;
 
 use crate::{
-    comments::{CommentStringExt, CommentWithMetadata, Comments},
+    comments::{CommentState, CommentStringExt, CommentWithMetadata, Comments},
     macros::*,
     solang_ext::*,
     visit::{Visitable, Visitor},
@@ -80,24 +79,48 @@ impl Default for FormatterConfig {
 }
 
 /// An indent group. The group may optionally skip the first line
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 struct IndentGroup {
     skip_line: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WriteState {
+    LineStart(CommentState),
+    WriteTokens(CommentState),
+    WriteString(char),
+}
+
+impl WriteState {
+    fn comment_state(&self) -> CommentState {
+        match self {
+            WriteState::LineStart(state) => *state,
+            WriteState::WriteTokens(state) => *state,
+            WriteState::WriteString(_) => CommentState::None,
+        }
+    }
+}
+
+impl Default for WriteState {
+    fn default() -> Self {
+        WriteState::LineStart(CommentState::None)
+    }
 }
 
 /// A wrapper around a `std::fmt::Write` interface. The wrapper keeps track of indentation as well
 /// as information about the last `write_str` command if available. The formatter may also be
 /// restricted to a single line, in which case it will throw an error on a newline
+#[derive(Clone, Debug)]
 struct FormatBuffer<W: Sized> {
     indents: Vec<IndentGroup>,
     base_indent_len: usize,
     tab_width: usize,
-    is_beginning_of_line: bool,
     last_indent: String,
     last_char: Option<char>,
     current_line_len: usize,
     w: W,
     restrict_to_single_line: bool,
+    state: WriteState,
 }
 
 impl<W: Sized> FormatBuffer<W> {
@@ -108,10 +131,10 @@ impl<W: Sized> FormatBuffer<W> {
             base_indent_len: 0,
             indents: vec![],
             current_line_len: 0,
-            is_beginning_of_line: true,
             last_indent: String::new(),
             last_char: None,
             restrict_to_single_line: false,
+            state: WriteState::default(),
         }
     }
 
@@ -124,6 +147,12 @@ impl<W: Sized> FormatBuffer<W> {
         new.current_line_len = self.current_line_len();
         new.last_char = self.last_char;
         new.restrict_to_single_line = self.restrict_to_single_line;
+        new.state = match self.state {
+            WriteState::WriteTokens(state) | WriteState::LineStart(state) => {
+                WriteState::LineStart(state)
+            }
+            WriteState::WriteString(ch) => WriteState::WriteString(ch),
+        };
         new
     }
 
@@ -182,7 +211,7 @@ impl<W: Sized> FormatBuffer<W> {
 
     /// Check if the buffer is at the beggining of a new line
     fn is_beginning_of_line(&self) -> bool {
-        self.is_beginning_of_line
+        matches!(self.state, WriteState::LineStart(_))
     }
 
     /// Start a new indent group (skips first indent)
@@ -206,28 +235,34 @@ impl<W: Write> FormatBuffer<W> {
     /// written string to match the current base indent of this buffer if it is a temp buffer
     fn write_raw(&mut self, s: impl AsRef<str>) -> std::fmt::Result {
         let mut lines = s.as_ref().lines().peekable();
+        let mut comment_state = self.state.comment_state();
         while let Some(line) = lines.next() {
             // remove the whitespace that covered by the base indent length (this is normally the
             // case with temporary buffers as this will be readded by the underlying IndentWriter
             // later on
-            let line_start = line
-                .char_indices()
+            let (new_comment_state, line_start) = line
+                .comment_state_char_indices()
+                .with_state(comment_state)
                 .take(self.base_indent_len)
-                .take_while(|(_, ch)| ch.is_whitespace())
+                .take_while(|(_, _, ch)| ch.is_whitespace())
                 .last()
-                .map(|(idx, _)| idx + 1)
-                .unwrap_or(0);
+                .map(|(state, idx, _)| (state, idx + 1))
+                .unwrap_or((comment_state, 0));
+            comment_state = new_comment_state;
             let trimmed_line = &line[line_start..];
             if !trimmed_line.is_empty() {
                 self.w.write_str(trimmed_line)?;
-                self.is_beginning_of_line = false;
+                self.state = WriteState::WriteTokens(comment_state);
             }
             if lines.peek().is_some() {
                 if self.restrict_to_single_line {
                     return Err(std::fmt::Error)
                 }
                 self.w.write_char('\n')?;
-                self.is_beginning_of_line = true;
+                if comment_state == CommentState::Line {
+                    comment_state = CommentState::None;
+                }
+                self.state = WriteState::LineStart(comment_state);
             }
         }
         Ok(())
@@ -235,45 +270,135 @@ impl<W: Write> FormatBuffer<W> {
 }
 
 impl<W: Write> Write for FormatBuffer<W> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+    fn write_str(&mut self, mut s: &str) -> std::fmt::Result {
         if s.is_empty() {
             return Ok(())
         }
-        let is_multiline = s.contains('\n');
-        if is_multiline && self.restrict_to_single_line {
-            return Err(std::fmt::Error)
-        }
 
-        let mut level = self.level();
+        let level = self.level();
+        let mut indent = " ".repeat(self.tab_width * level);
 
-        if self.is_beginning_of_line && !s.trim_start().is_empty() {
-            let indent = " ".repeat(self.tab_width * level);
-            self.w.write_str(&indent)?;
-            self.last_indent = indent;
-        }
+        loop {
+            match self.state {
+                WriteState::LineStart(mut comment_state) => {
+                    match s.find(|b| b != '\n') {
+                        // No non-empty lines in input, write the entire string (only newlines)
+                        None => {
+                            if !s.is_empty() {
+                                self.w.write_str(s)?;
+                                self.current_line_len = 0;
+                                self.last_char = s.chars().next_back();
+                                self.set_last_indent_group_skipped(false);
+                                if comment_state == CommentState::Line {
+                                    self.state = WriteState::LineStart(CommentState::None);
+                                }
+                            }
+                            break
+                        }
 
-        if self.last_indent_group_skipped() {
-            level += 1;
-        }
-        let indent = " ".repeat(self.tab_width * level);
-        IndentWriter::new_skip_initial(&indent, &mut self.w).write_str(s)?;
+                        // We can see the next non-empty line. Write up to the
+                        // beginning of that line, then insert an indent, then
+                        // continue.
+                        Some(len) => {
+                            let (head, tail) = s.split_at(len);
+                            self.w.write_str(head)?;
+                            self.w.write_str(&indent)?;
+                            self.last_indent = indent.clone();
+                            self.current_line_len = 0;
+                            self.last_char = Some(' ');
+                            // a newline has been inserted
+                            if len > 0 {
+                                if self.last_indent_group_skipped() {
+                                    indent = " ".repeat(self.tab_width * (level + 1));
+                                    self.set_last_indent_group_skipped(false);
+                                }
+                                if comment_state == CommentState::Line {
+                                    comment_state = CommentState::None;
+                                }
+                            }
+                            s = tail;
+                            self.state = WriteState::WriteTokens(comment_state);
+                        }
+                    }
+                }
+                WriteState::WriteTokens(comment_state) => {
+                    if s.is_empty() {
+                        break
+                    }
 
-        if let Some(last_char) = s.chars().next_back() {
-            self.last_char = Some(last_char);
-        }
+                    // find the next newline or non-comment string separator (e.g. ' or ")
+                    let mut len = 0;
+                    let mut new_state = WriteState::WriteTokens(comment_state);
+                    for (state, idx, ch) in s.comment_state_char_indices().with_state(comment_state)
+                    {
+                        len = idx;
+                        if ch == '\n' {
+                            if self.restrict_to_single_line {
+                                return Err(std::fmt::Error)
+                            }
+                            new_state = WriteState::LineStart(state);
+                            break
+                        } else if state == CommentState::None && (ch == '\'' || ch == '"') {
+                            new_state = WriteState::WriteString(ch);
+                            break
+                        } else {
+                            new_state = WriteState::WriteTokens(state);
+                        }
+                    }
 
-        if is_multiline {
-            self.set_last_indent_group_skipped(false);
-            self.last_indent = indent;
-            self.is_beginning_of_line = s.ends_with('\n');
-            if self.is_beginning_of_line {
-                self.current_line_len = 0;
-            } else {
-                self.current_line_len = s.lines().last().unwrap().len();
+                    if matches!(new_state, WriteState::WriteTokens(_)) {
+                        // No newlines or strings found, write the entire string
+                        self.w.write_str(s)?;
+                        self.current_line_len += s.len();
+                        self.last_char = s.chars().next_back();
+                        self.state = new_state;
+                        break
+                    } else {
+                        // A newline or string has been found. Write up to that character and
+                        // continue on the tail
+                        let (head, tail) = s.split_at(len);
+                        self.w.write_str(head)?;
+                        self.current_line_len += head.len();
+                        self.last_char = head.chars().next_back();
+                        s = tail;
+                        self.state = new_state;
+                    }
+                }
+                WriteState::WriteString(quote) => {
+                    // find the end of the string
+                    let mut str_end = None;
+                    let mut chars = s.char_indices().skip(1).peekable();
+                    while let Some((idx, ch)) = chars.next() {
+                        if ch == '\\' {
+                            chars.next();
+                            continue
+                        }
+                        if ch == quote {
+                            str_end = Some(idx);
+                            break
+                        }
+                    }
+
+                    match str_end {
+                        // No end found, write the rest of the string
+                        None => {
+                            self.w.write_str(s)?;
+                            self.current_line_len += s.len();
+                            self.last_char = s.chars().next_back();
+                            break
+                        }
+                        // String end found, write the string and continue to add tokens after
+                        Some(len) => {
+                            let (head, tail) = s.split_at(len + 1);
+                            self.w.write_str(head)?;
+                            self.current_line_len += head.len();
+                            self.last_char = Some(quote);
+                            s = tail;
+                            self.state = WriteState::WriteTokens(CommentState::None);
+                        }
+                    }
+                }
             }
-        } else {
-            self.is_beginning_of_line = false;
-            self.current_line_len += s.len();
         }
 
         Ok(())
@@ -1479,13 +1604,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             }
             Expression::StringLiteral(vals) => {
                 for StringLiteral { loc, string } in vals {
-                    if !string.contains('\n') {
-                        write_chunk!(self, loc.start(), loc.end(), "\"{string}\"")?;
-                    } else {
-                        write_chunk!(self, loc.start(), "\"")?;
-                        self.write_raw(string)?;
-                        write_chunk_spaced!(self, loc.end(), Some(false), "\"")?;
-                    }
+                    write_chunk!(self, loc.start(), loc.end(), "\"{string}\"")?;
                 }
             }
             Expression::HexLiteral(vals) => {


### PR DESCRIPTION
## Motivation

Multi-line strings get indented where no indent should be added

## Solution

The FormatBuffer automatically adds indents after newlines, so it needs
to handle string based newlines and be aware that no indent should be
added. Therefore the FormatBuffer tracks the state of whether or not its in a
string (it also needs to track the state of whether or not its inside of
a comment in order to do this) and only adds indents where necessary.
