### PR TITLE
fix: don't statically link C runtime on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,22 +2,12 @@
 rustflags = [
   # Increases the stack size to 10MB, which is
   # in line with Linux (whereas default for Windows is 1MB)
-  "-C", "link-arg=/STACK:10000000",
-  # On Windows MSVC, statically link the C runtime so that the resulting EXE does
-  # not depend on the vcruntime DLL.
-  #
-  # See: https://github.com/BurntSushi/ripgrep/pull/1613
-  "-C", "target-feature=+crt-static"
+  "-C", "link-arg=/STACK:10000000"
 ]
 
 [target.i686-pc-windows-msvc]
 rustflags = [
   # Increases the stack size to 10MB, which is
   # in line with Linux (whereas default for Windows is 1MB)
-  "-C", "link-arg=/STACK:10000000",
-  # On Windows MSVC, statically link the C runtime so that the resulting EXE does
-  # not depend on the vcruntime DLL.
-  #
-  # See: https://github.com/BurntSushi/ripgrep/pull/1613
-  "-C", "target-feature=+crt-static"
+  "-C", "link-arg=/STACK:10000000"
 ]


### PR DESCRIPTION
I think this might mess up some hidapi stuff, so I'll merge and try to run a new nightly