### PR TITLE
Add force flag to add submodule

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -204,7 +204,7 @@ fn git_submodule(dep: &Dependency, libs: &Path, target_dir: &str) -> eyre::Resul
     let url = dep.url.as_ref().unwrap();
 
     let output = Command::new("git")
-        .args(&["submodule", "add", url, target_dir])
+        .args(&["submodule", "add", "--force", url, target_dir])
         .current_dir(&libs)
         .output()?;
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -797,7 +797,6 @@ forgetest!(can_reinstall_after_manual_remove, |prj: TestProject, mut cmd: TestCo
         assert!(submods.contains("https://github.com/foundry-rs/forge-std"));
     };
 
-
     install(&mut cmd);
     fs::remove_dir_all(forge_std.clone()).expect("Failed to remove forge-std");
 

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -775,3 +775,32 @@ forgetest!(can_install_and_remove, |prj: TestProject, mut cmd: TestCommand| {
     install(&mut cmd);
     remove(&mut cmd, "lib/forge-std");
 });
+
+// test to check that package can be reinstalled after manually removing the directory
+forgetest!(can_reinstall_after_manual_remove, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.git_init();
+
+    let libs = prj.root().join("lib");
+    let git_mod = prj.root().join(".git/modules/lib");
+    let git_mod_file = prj.root().join(".gitmodules");
+
+    let forge_std = libs.join("forge-std");
+    let forge_std_mod = git_mod.join("forge-std");
+
+    let install = |cmd: &mut TestCommand| {
+        cmd.forge_fuse().args(["install", "foundry-rs/forge-std", "--no-commit"]);
+        cmd.assert_non_empty_stdout();
+        assert!(forge_std.exists());
+        assert!(forge_std_mod.exists());
+
+        let submods = read_string(&git_mod_file);
+        assert!(submods.contains("https://github.com/foundry-rs/forge-std"));
+    };
+
+
+    install(&mut cmd);
+    fs::remove_dir_all(forge_std.clone()).expect("Failed to remove forge-std");
+
+    // install again
+    install(&mut cmd);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If an unwitting user mistakenly tries to remove a `lib` using the `rm` command, a project can end up in a "broken" state where the respective dependency can be neither installed, removed nor upgraded. See: https://github.com/foundry-rs/foundry/issues/2207

## Solution

Use the `--force` flag of the `git submodule add` command to enable a user to reinstall a package even after comitting  above mentioned mistake.
