### PR TITLE
perf(forge): compile single file if possible

### DIFF
--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -241,7 +241,9 @@ pub fn compile_files(
     if output.has_compiler_errors() {
         eyre::bail!(output.to_string())
     }
-    println!("{output}");
+    if !silent {
+        println!("{output}");
+    }
     Ok(output)
 }
 
@@ -250,6 +252,8 @@ pub fn compile_files(
 /// If `silent` no solc related output will be emitted to stdout.
 ///
 /// If `verify` and it's a standalone script, throw error. Only allowed for projects.
+///
+/// **Note:** this expects the `target_path` to be absolute
 pub fn compile_target(
     target_path: &Path,
     project: &Project,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`forge inspect` only accepted a Contract name so the entire project had to be compiled to get it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* allow `<path>:<name>` so we can compile a single file.
* also cleans up some inspect code
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
