### PR TITLE
fix(anvil): use correct env settings during validation

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1366,7 +1366,8 @@ impl TransactionValidator for Backend {
         tx: &PendingTransaction,
     ) -> Result<(), InvalidTransactionError> {
         let account = self.db.read().basic(*tx.sender());
-        self.validate_pool_transaction_for(tx, &account, &self.env().read())
+        let env = self.next_env();
+        self.validate_pool_transaction_for(tx, &account, &env)
     }
 
     fn validate_pool_transaction_for(

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -460,3 +460,21 @@ async fn test_fork_can_send_opensea_tx() {
     let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(tx.status, Some(1u64.into()));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_base_fee() {
+    let (api, handle) = spawn(fork_config()).await;
+
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    let from = accounts[0].address();
+
+    let provider = handle.http_provider();
+
+    api.anvil_set_next_block_base_fee_per_gas(U256::zero()).await.unwrap();
+
+    let addr = Address::random();
+    let val = 1337u64;
+    let tx = TransactionRequest::new().from(from).to(addr).value(val).gas(0u64);
+
+    let _res = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2255

previously during validation, the current env was used, but it should use the env of the pending block. This resulted in `anvil_set_next_block_base_fee_per_gas` not taking effect during pre-validation in `eth_sendTransaction`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use env with updated settings during validation
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
