### PR TITLE
fix(forge): Remove an alias for script subcommand

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,36 +12,42 @@ e.g.:`RUST_LOG=forge=trace,evm_adapters=trace forge test`
 ## Forge
 
 ```
-foundry-cli 0.1.0
-Build, test, fuzz, formally verify, debug & deploy solidity contracts.
+forge 0.2.0
+Build, test, fuzz, debug and deploy Solidity contracts.
 
 USAGE:
     forge <SUBCOMMAND>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    bind               Generate rust bindings for your smart contracts
-    build              Build your smart contracts
-    cache              Manage the foundry cache
-    clean              Removes the build artifacts and cache directories
-    completions        Generate shell completions script
-    config             Shows the currently set config values
-    create             Deploy a compiled contract
-    flatten            Concats a file with all of its imports
-    help               Print this message or the help of the given subcommand(s)
-    init               Initializes a new forge sample project
-    install            Installs one or more dependencies as git submodules
-    remappings         Prints the automatically inferred remappings for this repository
-    remove             Removes one or more dependencies from git submodules
-    run                Run a single smart contract as a script
-    snapshot           Creates a snapshot of each test's gas usage
-    test               Test your smart contracts
-    update             Fetches all upstream lib changes
-    verify-check       Check verification status on Etherscan. Requires `ETHERSCAN_API_KEY` to be set.
-    verify-contract    Verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set.
+    bind                Generate Rust bindings for smart contracts.
+    build               Build the project's smart contracts. [aliases: b]
+    cache               Manage the Foundry cache.
+    clean               Remove the build artifacts and cache directories. [aliases: cl]
+    completions         Generate shell completions script. [aliases: com]
+    config              Display the current config. [aliases: co]
+    coverage            Generate coverage reports.
+    create              Deploy a smart contract. [aliases: c]
+    debug               Debugs a single smart contract as a script. [aliases: d]
+    flatten             Flatten a source file and all of its imports into one file. [aliases: f]
+    fmt                 Formats Solidity source files.
+    help                Print this message or the help of the given subcommand(s)
+    init                Create a new Forge project.
+    inspect             Get specialized information about a smart contract. [aliases: in]
+    install             Install one or multiple dependencies. [aliases: i]
+    remappings          Get the automatically inferred remappings for the project. [aliases: re]
+    remove              Remove one or multiple dependencies. [aliases: rm]
+    script              Run a smart contract as a script, building transactions that can be sent onchain.
+    snapshot            Create a snapshot of each test's gas usage. [aliases: s]
+    test                Run the project's tests. [aliases: t]
+    tree                Display a tree visualization of the project's dependency graph. [aliases: tr]
+    update              Update one or multiple dependencies. [aliases: u]
+    upload-selectors    Uploads abi of given contract to https://sig.eth.samczsun.com function selector database. [aliases: up]
+    verify-check        Check verification status on Etherscan. [aliases: vc]
+    verify-contract     Verify smart contracts on Etherscan. [aliases: v]
 ```
 
 The subcommands are also aliased to their first letter, e.g. you can do

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -53,7 +53,6 @@ pub enum Subcommands {
     Test(test::TestArgs),
 
     #[clap(
-        visible_alias = "s",
         about = "Run a smart contract as a script, building transactions that can be sent onchain."
     )]
     Script(ScriptArgs),
@@ -119,7 +118,7 @@ pub enum Subcommands {
     #[clap(about = "Create a new Forge project.")]
     Init(InitArgs),
 
-    #[clap(visible_alias = "com", about = "Generate shell completions script")]
+    #[clap(visible_alias = "com", about = "Generate shell completions script.")]
     Completions {
         #[clap(arg_enum)]
         shell: clap_complete::Shell,
@@ -151,15 +150,15 @@ pub enum Subcommands {
     )]
     Flatten(flatten::FlattenArgs),
 
-    #[clap(about = "Formats Solidity source files")]
+    #[clap(about = "Formats Solidity source files.")]
     Fmt(FmtArgs),
 
-    #[clap(visible_alias = "in", about = "Get specialized information about a smart contract")]
+    #[clap(visible_alias = "in", about = "Get specialized information about a smart contract.")]
     Inspect(inspect::InspectArgs),
 
     #[clap(
         visible_alias = "up",
-        about = "Uploads abi of given contract to https://sig.eth.samczsun.com function selector database"
+        about = "Uploads abi of given contract to https://sig.eth.samczsun.com function selector database."
     )]
     UploadSelectors(UploadSelectorsArgs),
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This PR removes an alias `s` for `script` subcommand since it duplicates with one for `snapshot`.
(Also adds `.` to the end of some subcommand descriptions as with other ones and updates README.md to follow the latest `forge` command for maintenance)

Closes https://github.com/foundry-rs/foundry/issues/2254



## Solution

```console
$ cargo run --bin forge -- --help
   Compiling foundry-cli v0.2.0 (/Users/m-ikeda/src/moricho/foundry/cli)
    Finished dev [unoptimized] target(s) in 33.58s
     Running `target/debug/forge --help`
forge 0.2.0 (0f6ed04 2022-07-11T16:00:34.562576Z)
Build, test, fuzz, debug and deploy Solidity contracts.

USAGE:
    forge <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    bind                Generate Rust bindings for smart contracts.
    build               Build the project's smart contracts. [aliases: b]
    cache               Manage the Foundry cache.
    clean               Remove the build artifacts and cache directories. [aliases: cl]
    completions         Generate shell completions script. [aliases: com]
    config              Display the current config. [aliases: co]
    coverage            Generate coverage reports.
    create              Deploy a smart contract. [aliases: c]
    debug               Debugs a single smart contract as a script. [aliases: d]
    flatten             Flatten a source file and all of its imports into one file. [aliases: f]
    fmt                 Formats Solidity source files.
    help                Print this message or the help of the given subcommand(s)
    init                Create a new Forge project.
    inspect             Get specialized information about a smart contract. [aliases: in]
    install             Install one or multiple dependencies. [aliases: i]
    remappings          Get the automatically inferred remappings for the project. [aliases: re]
    remove              Remove one or multiple dependencies. [aliases: rm]
    script              Run a smart contract as a script, building transactions that can be sent onchain.
    snapshot            Create a snapshot of each test's gas usage. [aliases: s]
    test                Run the project's tests. [aliases: t]
    tree                Display a tree visualization of the project's dependency graph. [aliases: tr]
    update              Update one or multiple dependencies. [aliases: u]
    upload-selectors    Uploads abi of given contract to https://sig.eth.samczsun.com function selector database.
                            [aliases: up]
    verify-check        Check verification status on Etherscan. [aliases: vc]
    verify-contract     Verify smart contracts on Etherscan. [aliases: v]

Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html
```
