### PR TITLE
remove --recursive flag from git submodule call in forge update

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -72,7 +72,7 @@ fn main() -> eyre::Result<()> {
         Subcommands::Update { lib } => {
             let mut cmd = Command::new("git");
 
-            cmd.args(&["submodule", "update", "--remote", "--init", "--recursive"]);
+            cmd.args(&["submodule", "update", "--remote", "--init"]);
 
             // if a lib is specified, open it
             if let Some(lib) = lib {

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -807,3 +807,52 @@ forgetest!(can_reinstall_after_manual_remove, |prj: TestProject, mut cmd: TestCo
     // install again
     install(&mut cmd);
 });
+
+// Tests that forge update doesn't break a working depencency by recursively updating nested
+// dependencies
+forgetest!(can_update_library_with_outdated_nested_dependency, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.git_init();
+
+    let libs = prj.root().join("lib");
+    let git_mod = prj.root().join(".git/modules/lib");
+    let git_mod_file = prj.root().join(".gitmodules");
+
+    let package = libs.join("outdated-foundry-package");
+    let package_mod = git_mod.join("outdated-foundry-package");
+
+    let install = |cmd: &mut TestCommand| {
+        cmd.forge_fuse().args(["install", "ckoopmann/outdated-foundry-package", "--no-commit"]);
+        cmd.assert_non_empty_stdout();
+        assert!(package.exists());
+        assert!(package_mod.exists());
+
+        let submods = read_string(&git_mod_file);
+        assert!(submods.contains("https://github.com/ckoopmann/outdated-foundry-package"));
+    };
+
+
+    install(&mut cmd);
+    cmd.forge_fuse().args(["update", "lib/outdated-foundry-package"]);
+    cmd.stdout_lossy();
+
+    prj.inner()
+        .add_source(
+            "MyTokenCopy",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.6.0;
+import "outdated-foundry-package/MyToken.sol";
+contract MyTokenCopy is MyToken {
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.forge_fuse().args(["build"]);
+    let output = cmd.stdout_lossy();
+
+    assert!(output.contains(
+        "Compiler run successful",
+    ));
+
+});

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -810,49 +810,48 @@ forgetest!(can_reinstall_after_manual_remove, |prj: TestProject, mut cmd: TestCo
 
 // Tests that forge update doesn't break a working depencency by recursively updating nested
 // dependencies
-forgetest!(can_update_library_with_outdated_nested_dependency, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.git_init();
+forgetest!(
+    can_update_library_with_outdated_nested_dependency,
+    |prj: TestProject, mut cmd: TestCommand| {
+        cmd.git_init();
 
-    let libs = prj.root().join("lib");
-    let git_mod = prj.root().join(".git/modules/lib");
-    let git_mod_file = prj.root().join(".gitmodules");
+        let libs = prj.root().join("lib");
+        let git_mod = prj.root().join(".git/modules/lib");
+        let git_mod_file = prj.root().join(".gitmodules");
 
-    let package = libs.join("outdated-foundry-package");
-    let package_mod = git_mod.join("outdated-foundry-package");
+        let package = libs.join("outdated-foundry-package");
+        let package_mod = git_mod.join("outdated-foundry-package");
 
-    let install = |cmd: &mut TestCommand| {
-        cmd.forge_fuse().args(["install", "ckoopmann/outdated-foundry-package", "--no-commit"]);
-        cmd.assert_non_empty_stdout();
-        assert!(package.exists());
-        assert!(package_mod.exists());
+        let install = |cmd: &mut TestCommand| {
+            cmd.forge_fuse().args(["install", "ckoopmann/outdated-foundry-package", "--no-commit"]);
+            cmd.assert_non_empty_stdout();
+            assert!(package.exists());
+            assert!(package_mod.exists());
 
-        let submods = read_string(&git_mod_file);
-        assert!(submods.contains("https://github.com/ckoopmann/outdated-foundry-package"));
-    };
+            let submods = read_string(&git_mod_file);
+            assert!(submods.contains("https://github.com/ckoopmann/outdated-foundry-package"));
+        };
 
+        install(&mut cmd);
+        cmd.forge_fuse().args(["update", "lib/outdated-foundry-package"]);
+        cmd.stdout_lossy();
 
-    install(&mut cmd);
-    cmd.forge_fuse().args(["update", "lib/outdated-foundry-package"]);
-    cmd.stdout_lossy();
-
-    prj.inner()
-        .add_source(
-            "MyTokenCopy",
-            r#"
+        prj.inner()
+            .add_source(
+                "MyTokenCopy",
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.6.0;
 import "outdated-foundry-package/MyToken.sol";
 contract MyTokenCopy is MyToken {
 }
    "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-    cmd.forge_fuse().args(["build"]);
-    let output = cmd.stdout_lossy();
+        cmd.forge_fuse().args(["build"]);
+        let output = cmd.stdout_lossy();
 
-    assert!(output.contains(
-        "Compiler run successful",
-    ));
-
-});
+        assert!(output.contains("Compiler run successful",));
+    }
+);

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -819,21 +819,21 @@ forgetest!(
         let git_mod = prj.root().join(".git/modules/lib");
         let git_mod_file = prj.root().join(".gitmodules");
 
-        let package = libs.join("outdated-foundry-package");
-        let package_mod = git_mod.join("outdated-foundry-package");
+        let package = libs.join("issue-2264-repro");
+        let package_mod = git_mod.join("issue-2264-repro");
 
         let install = |cmd: &mut TestCommand| {
-            cmd.forge_fuse().args(["install", "ckoopmann/outdated-foundry-package", "--no-commit"]);
+            cmd.forge_fuse().args(["install", "foundry-rs/issue-2264-repro", "--no-commit"]);
             cmd.assert_non_empty_stdout();
             assert!(package.exists());
             assert!(package_mod.exists());
 
             let submods = read_string(&git_mod_file);
-            assert!(submods.contains("https://github.com/ckoopmann/outdated-foundry-package"));
+            assert!(submods.contains("https://github.com/foundry-rs/issue-2264-repro"));
         };
 
         install(&mut cmd);
-        cmd.forge_fuse().args(["update", "lib/outdated-foundry-package"]);
+        cmd.forge_fuse().args(["update", "lib/issue-2264-repro"]);
         cmd.stdout_lossy();
 
         prj.inner()
@@ -842,7 +842,7 @@ forgetest!(
                 r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.6.0;
-import "outdated-foundry-package/MyToken.sol";
+import "issue-2264-repro/MyToken.sol";
 contract MyTokenCopy is MyToken {
 }
    "#,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently `forge update` recursively updates nested dependencies which can lead to problems outlined in https://github.com/foundry-rs/foundry/issues/2264

## Solution

Remove `--recursive` flag from `git submodule` call inside `forge update` subcommand.