### PR TITLE
fix: use utf8 lossy when fmt  byte slices

### DIFF
--- a/common/src/fmt.rs
+++ b/common/src/fmt.rs
@@ -2,7 +2,6 @@
 //! types
 use ethers_core::{types::*, utils::to_checksum};
 use serde::Deserialize;
-use std::str;
 
 /// length of the name column for pretty formatting `{:>20}{value}`
 const NAME_COLUMN_LEN: usize = 20usize;
@@ -64,8 +63,7 @@ impl UIfmt for Bytes {
 
 impl UIfmt for [u8; 32] {
     fn pretty(&self) -> String {
-        let res = str::from_utf8(self).unwrap().trim_matches(char::from(0));
-        String::from(res)
+        String::from_utf8_lossy(&self[..]).trim_matches('\0').to_string()
     }
 }
 

--- a/testdata/fuzz/Fuzz.t.sol
+++ b/testdata/fuzz/Fuzz.t.sol
@@ -3,22 +3,31 @@ pragma solidity >=0.8.0;
 
 import "ds-test/test.sol";
 
+interface Cheats {
+    function toString(bytes32) external returns (string memory);
+}
+
 contract FuzzTest is DSTest {
-  constructor() {
-    emit log("constructor");
-  }
+    constructor() {
+        emit log("constructor");
+    }
 
-  function setUp() public {
-    emit log("setUp");
-  }
+    function setUp() public {
+        emit log("setUp");
+    }
 
-  function testFailFuzz(uint8 x) public {
-    emit log("testFailFuzz");
-    require(x == 5, "should revert");
-  }
+    function testFailFuzz(uint8 x) public {
+        emit log("testFailFuzz");
+        require(x == 5, "should revert");
+    }
 
-  function testSuccessfulFuzz(uint128 a, uint128 b) public {
-    emit log("testSuccessfulFuzz");
-    assertEq(uint256(a) + uint256(b), uint256(a) + uint256(b));
-  }
+    function testSuccessfulFuzz(uint128 a, uint128 b) public {
+        emit log("testSuccessfulFuzz");
+        assertEq(uint256(a) + uint256(b), uint256(a) + uint256(b));
+    }
+
+    function testToStringFuzz(bytes32 data) public {
+        Cheats cheats = Cheats(HEVM_ADDRESS);
+        cheats.toString(data);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2273


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use `from_utf8_lossy` as slices are not guaranteed to be utf8 (when fuzzed for example)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
