### PR TITLE
refactor: use forge-std/Test.sol for tests

### DIFF
--- a/testdata/cheats/Addr.t.sol
+++ b/testdata/cheats/Addr.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract AddrTest is DSTest {
+contract AddrTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testFailPrivKeyZero() public {

--- a/testdata/cheats/Assume.t.sol
+++ b/testdata/cheats/Assume.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract AssumeTest is DSTest {
+contract AssumeTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testAssume(uint8 x) public {

--- a/testdata/cheats/Bank.t.sol
+++ b/testdata/cheats/Bank.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract CoinbaseTest is DSTest {
+contract CoinbaseTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testCoinbase() public {

--- a/testdata/cheats/Deal.t.sol
+++ b/testdata/cheats/Deal.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract DealTest is DSTest {
+contract DealTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testDeal(uint256 amount) public {

--- a/testdata/cheats/Env.t.sol
+++ b/testdata/cheats/Env.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract EnvTest is DSTest {
+contract EnvTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testSetEnv() public {

--- a/testdata/cheats/Etch.t.sol
+++ b/testdata/cheats/Etch.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract EtchTest is DSTest {
+contract EtchTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testEtch() public {

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Contract {
@@ -38,7 +38,7 @@ contract NestedContract {
     }
 }
 
-contract ExpectCallTest is DSTest {
+contract ExpectCallTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testExpectCallWithData() public {

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Emitter {
@@ -69,7 +69,7 @@ contract LowLevelCaller {
     function g() public {}
 }
 
-contract ExpectEmitTest is DSTest {
+contract ExpectEmitTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     Emitter emitter;
 

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Reverter {
@@ -47,7 +47,7 @@ contract Dummy {
     }
 }
 
-contract ExpectRevertTest is DSTest {
+contract ExpectRevertTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testExpectRevertString() public {

--- a/testdata/cheats/Fee.t.sol
+++ b/testdata/cheats/Fee.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract FeeTest is DSTest {
+contract FeeTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testFee() public {

--- a/testdata/cheats/Ffi.t.sol
+++ b/testdata/cheats/Ffi.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract FfiTest is DSTest {
+contract FfiTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testFfi() public {

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract FileTest is DSTest {
+contract FileTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testReadFile() public {

--- a/testdata/cheats/Fork.t.sol
+++ b/testdata/cheats/Fork.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 interface IWETH {
@@ -9,7 +9,7 @@ interface IWETH {
     function balanceOf(address) external view returns (uint);
 }
 
-contract ForkTest is DSTest {
+contract ForkTest is Test {
     address constant WETH_TOKEN_ADDR = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     uint256 constant mainblock = 14_608_400;
 

--- a/testdata/cheats/Fork2.t.sol
+++ b/testdata/cheats/Fork2.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 struct MyStruct {
@@ -29,7 +29,7 @@ contract MyContract {
     }
 }
 
-contract ForkTest is DSTest {
+contract ForkTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     uint256 mainnetFork;

--- a/testdata/cheats/GetCode.t.sol
+++ b/testdata/cheats/GetCode.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract GetCodeTest is DSTest {
+contract GetCodeTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testGetCode() public {

--- a/testdata/cheats/GetNonce.t.sol
+++ b/testdata/cheats/GetNonce.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Foo {}
 
-contract GetNonceTest is DSTest {
+contract GetNonceTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testGetNonce() public {

--- a/testdata/cheats/Label.t.sol
+++ b/testdata/cheats/Label.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract LabelTest is DSTest {
+contract LabelTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testLabel() public {

--- a/testdata/cheats/Load.t.sol
+++ b/testdata/cheats/Load.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Storage {
     uint256 slot0 = 10;
 }
 
-contract LoadTest is DSTest {
+contract LoadTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     uint256 slot0 = 20;
     Storage store;

--- a/testdata/cheats/MockCall.t.sol
+++ b/testdata/cheats/MockCall.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Mock {
@@ -34,7 +34,7 @@ contract NestedMock {
     }
 }
 
-contract MockCallTest is DSTest {
+contract MockCallTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testMockGetters() public {

--- a/testdata/cheats/Prank.t.sol
+++ b/testdata/cheats/Prank.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Victim {
@@ -93,7 +93,7 @@ contract NestedPranker {
     }
 }
 
-contract PrankTest is DSTest {
+contract PrankTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testPrankSender(address sender) public {

--- a/testdata/cheats/Record.t.sol
+++ b/testdata/cheats/Record.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract RecordAccess {
@@ -25,7 +25,7 @@ contract NestedRecordAccess {
     }
 }
 
-contract RecordTest is DSTest {
+contract RecordTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testRecordAccess() public {

--- a/testdata/cheats/RecordLogs.t.sol
+++ b/testdata/cheats/RecordLogs.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Emitter {
@@ -81,7 +81,7 @@ contract Emitterv2 {
     }
 }
 
-contract RecordLogsTest is DSTest {
+contract RecordLogsTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     Emitter emitter;
     bytes32 internal seedTestData = keccak256(abi.encodePacked("Some data"));

--- a/testdata/cheats/Roll.t.sol
+++ b/testdata/cheats/Roll.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract RollTest is DSTest {
+contract RollTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testRoll() public {

--- a/testdata/cheats/RpcUrls.t.sol
+++ b/testdata/cheats/RpcUrls.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract RpcUrlTest is DSTest {
+contract RpcUrlTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     // returns the correct url

--- a/testdata/cheats/SetNonce.t.sol
+++ b/testdata/cheats/SetNonce.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Foo {
@@ -10,7 +10,7 @@ contract Foo {
     }
 }
 
-contract SetNonceTest is DSTest {
+contract SetNonceTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     Foo public foo;
 

--- a/testdata/cheats/Setup.t.sol
+++ b/testdata/cheats/Setup.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Victim {
@@ -10,7 +10,7 @@ contract Victim {
     }
 }
 
-contract CheatsSetupTest is DSTest {
+contract CheatsSetupTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     Victim victim;
 

--- a/testdata/cheats/Sign.t.sol
+++ b/testdata/cheats/Sign.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract SignTest is DSTest {
+contract SignTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testSignDigest(uint248 pk, bytes32 digest) public {

--- a/testdata/cheats/Snapshots.t.sol
+++ b/testdata/cheats/Snapshots.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 struct Storage {
@@ -9,7 +9,7 @@ struct Storage {
     uint slot1;
 }
 
-contract SnapshotTest is DSTest {
+contract SnapshotTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     Storage store;

--- a/testdata/cheats/Store.t.sol
+++ b/testdata/cheats/Store.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
 contract Storage {
@@ -9,7 +9,7 @@ contract Storage {
     uint public slot1 = 20;
 }
 
-contract StoreTest is DSTest {
+contract StoreTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
     Storage store;
 

--- a/testdata/cheats/ToString.t.sol
+++ b/testdata/cheats/ToString.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract ToStringTest is DSTest {
+contract ToStringTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testAddressToString() public {

--- a/testdata/cheats/Travel.t.sol
+++ b/testdata/cheats/Travel.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract ChainIdTest is DSTest {
+contract ChainIdTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testChainId() public {

--- a/testdata/cheats/Warp.t.sol
+++ b/testdata/cheats/Warp.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./Cheats.sol";
 
-contract WarpTest is DSTest {
+contract WarpTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testWarp() public {

--- a/testdata/core/ContractEnvironment.t.sol
+++ b/testdata/core/ContractEnvironment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract ContractEnvironmentTest is DSTest {
+contract ContractEnvironmentTest is Test {
     function chainId() internal view returns (uint256 id) {
         assembly {
             id := chainid()

--- a/testdata/core/DSStyle.t.sol
+++ b/testdata/core/DSStyle.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract DSStyleTest is DSTest {
+contract DSStyleTest is Test {
     function testFailingAssertions() public {
         emit log_string("assertionOne");
         assertEq(uint(1), uint(2));

--- a/testdata/core/FailingSetup.t.sol
+++ b/testdata/core/FailingSetup.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract FailingSetupTest is DSTest {
+contract FailingSetupTest is Test {
     event Test(uint256 n);
 
     function setUp() public {

--- a/testdata/core/LibraryLinking.t.sol
+++ b/testdata/core/LibraryLinking.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 library Lib {
     function plus100(uint256 a) public pure returns (uint256) {
@@ -25,7 +25,7 @@ contract LibraryConsumer {
     }
 }
 
-contract LibraryLinkingTest is DSTest {
+contract LibraryLinkingTest is Test {
     LibraryConsumer consumer;
 
     function setUp() public {

--- a/testdata/core/MultipleSetup.t.sol
+++ b/testdata/core/MultipleSetup.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract MultipleSetup is DSTest {
+contract MultipleSetup is Test {
     function setUp() public { }
 
     function setup() public { }

--- a/testdata/core/PaymentFailure.t.sol
+++ b/testdata/core/PaymentFailure.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "../cheats/Cheats.sol";
 
 contract Payable {
     function pay() payable public {}
 }
 
-contract PaymentFailureTest is DSTest {
+contract PaymentFailureTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     function testCantPay() public {

--- a/testdata/core/SetupConsistency.t.sol
+++ b/testdata/core/SetupConsistency.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract SetupConsistencyCheck is DSTest {
+contract SetupConsistencyCheck is Test {
     uint256 two;
     uint256 four;
     uint256 result;

--- a/testdata/fork/Fork.t.sol
+++ b/testdata/fork/Fork.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.6.12;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "./DssExecLib.sol";
 
 interface Cheats {
@@ -24,7 +24,7 @@ contract DummyContract {
 }
 
 
-contract ForkTest is DSTest {
+contract ForkTest is Test {
     address constant DAI_TOKEN_ADDR = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address constant WETH_TOKEN_ADDR = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -29,7 +29,10 @@ offline = false
 optimizer = true
 optimizer_runs = 200
 out = 'out'
-remappings = ['ds-test/=lib/ds-test/src/']
+remappings = [
+    'ds-test/=lib/forge-std/lib/ds-test/src/',
+    'forge-std/=lib/forge-std/src/'
+]
 sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
 sizes = false
 sparse_mode = false

--- a/testdata/fuzz/Fuzz.t.sol
+++ b/testdata/fuzz/Fuzz.t.sol
@@ -3,6 +3,10 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 
+interface Cheats {
+    function toString(bytes32) external returns (string memory);
+}
+
 contract FuzzTest is Test {
   constructor() {
     emit log("constructor");

--- a/testdata/fuzz/Fuzz.t.sol
+++ b/testdata/fuzz/Fuzz.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract FuzzTest is DSTest {
+contract FuzzTest is Test {
   constructor() {
     emit log("constructor");
   }

--- a/testdata/fuzz/FuzzNumbers.t.sol
+++ b/testdata/fuzz/FuzzNumbers.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 // See https://github.com/foundry-rs/foundry/pull/735 for context
-contract FuzzNumbersTest is DSTest {
+contract FuzzNumbersTest is Test {
     function testPositive(uint256) public {
         assertTrue(true);
     }

--- a/testdata/lib/forge-std/src/Script.sol
+++ b/testdata/lib/forge-std/src/Script.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.6.0 <0.9.0;
+
+import "./Vm.sol";
+import "./console.sol";
+import "./console2.sol";
+
+abstract contract Script {
+    bool public IS_SCRIPT = true;
+    address constant private VM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
+
+    Vm public constant vm = Vm(VM_ADDRESS);
+
+    /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
+    /// @notice adapated from Solmate implementation (https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol)
+    function computeCreateAddress(address deployer, uint256 nonce) internal pure returns (address) {
+        // The integer zero is treated as an empty byte string, and as a result it only has a length prefix, 0x80, computed via 0x80 + 0.
+        // A one byte integer uses its own value as its length prefix, there is no additional "0x80 + length" prefix that comes before it.
+        if (nonce == 0x00)             return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, bytes1(0x80))));
+        if (nonce <= 0x7f)             return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, uint8(nonce))));
+
+        // Nonces greater than 1 byte all follow a consistent encoding scheme, where each value is preceded by a prefix of 0x80 + length.
+        if (nonce <= 2**8 - 1)  return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xd7), bytes1(0x94), deployer, bytes1(0x81), uint8(nonce))));
+        if (nonce <= 2**16 - 1) return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xd8), bytes1(0x94), deployer, bytes1(0x82), uint16(nonce))));
+        if (nonce <= 2**24 - 1) return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xd9), bytes1(0x94), deployer, bytes1(0x83), uint24(nonce))));
+
+        // More details about RLP encoding can be found here: https://eth.wiki/fundamentals/rlp
+        // 0xda = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x84 ++ nonce)
+        // 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex)
+        // 0x84 = 0x80 + 0x04 (0x04 = the bytes length of the nonce, 4 bytes, in hex)
+        // We assume nobody can have a nonce large enough to require more than 32 bytes.
+        return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xda), bytes1(0x94), deployer, bytes1(0x84), uint32(nonce))));
+    }
+
+    function addressFromLast20Bytes(bytes32 bytesValue) internal pure returns (address) {
+        return address(uint160(uint256(bytesValue)));
+    }
+}

--- a/testdata/lib/forge-std/src/Test.sol
+++ b/testdata/lib/forge-std/src/Test.sol
@@ -1,0 +1,733 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.6.0 <0.9.0;
+
+import "./Script.sol";
+import "ds-test/test.sol";
+
+// Wrappers around Cheatcodes to avoid footguns
+abstract contract Test is DSTest, Script {
+    using stdStorage for StdStorage;
+
+    uint256 internal constant UINT256_MAX =
+        115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
+    StdStorage internal stdstore;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    STD-LOGS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    event log_array(uint256[] val);
+    event log_array(int256[] val);
+    event log_array(address[] val);
+    event log_named_array(string key, uint256[] val);
+    event log_named_array(string key, int256[] val);
+    event log_named_array(string key, address[] val);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    STD-CHEATS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // Skip forward or rewind time by the specified number of seconds
+    function skip(uint256 time) public {
+        vm.warp(block.timestamp + time);
+    }
+
+    function rewind(uint256 time) public {
+        vm.warp(block.timestamp - time);
+    }
+
+    // Setup a prank from an address that has some ether
+    function hoax(address who) public {
+        vm.deal(who, 1 << 128);
+        vm.prank(who);
+    }
+
+    function hoax(address who, uint256 give) public {
+        vm.deal(who, give);
+        vm.prank(who);
+    }
+
+    function hoax(address who, address origin) public {
+        vm.deal(who, 1 << 128);
+        vm.prank(who, origin);
+    }
+
+    function hoax(address who, address origin, uint256 give) public {
+        vm.deal(who, give);
+        vm.prank(who, origin);
+    }
+
+    // Start perpetual prank from an address that has some ether
+    function startHoax(address who) public {
+        vm.deal(who, 1 << 128);
+        vm.startPrank(who);
+    }
+
+    function startHoax(address who, uint256 give) public {
+        vm.deal(who, give);
+        vm.startPrank(who);
+    }
+
+    // Start perpetual prank from an address that has some ether
+    // tx.origin is set to the origin parameter
+    function startHoax(address who, address origin) public {
+        vm.deal(who, 1 << 128);
+        vm.startPrank(who, origin);
+    }
+
+    function startHoax(address who, address origin, uint256 give) public {
+        vm.deal(who, give);
+        vm.startPrank(who, origin);
+    }
+
+    function changePrank(address who) internal {
+        vm.stopPrank();
+        vm.startPrank(who);
+    }
+
+    // DEPRECATED: Use `deal` instead
+    function tip(address token, address to, uint256 give) public {
+        emit log_named_string("WARNING", "Test tip(address,address,uint256): The `tip` stdcheat has been deprecated. Use `deal` instead.");
+        stdstore
+            .target(token)
+            .sig(0x70a08231)
+            .with_key(to)
+            .checked_write(give);
+    }
+
+    // The same as Vm's `deal`
+    // Use the alternative signature for ERC20 tokens
+    function deal(address to, uint256 give) public {
+        vm.deal(to, give);
+    }
+
+    // Set the balance of an account for any ERC20 token
+    // Use the alternative signature to update `totalSupply`
+    function deal(address token, address to, uint256 give) public {
+        deal(token, to, give, false);
+    }
+
+    function deal(address token, address to, uint256 give, bool adjust) public {
+        // get current balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        uint256 prevBal = abi.decode(balData, (uint256));
+
+        // update balance
+        stdstore
+            .target(token)
+            .sig(0x70a08231)
+            .with_key(to)
+            .checked_write(give);
+
+        // update total supply
+        if(adjust){
+            (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0x18160ddd));
+            uint256 totSup = abi.decode(totSupData, (uint256));
+            if(give < prevBal) {
+                totSup -= (prevBal - give);
+            } else {
+                totSup += (give - prevBal);
+            }
+            stdstore
+                .target(token)
+                .sig(0x18160ddd)
+                .checked_write(totSup);
+        }
+    }
+
+    function bound(uint256 x, uint256 min, uint256 max) internal virtual returns (uint256 result) {
+        require(min <= max, "Test bound(uint256,uint256,uint256): Max is less than min.");
+
+        uint256 size = max - min;
+
+        if (size == 0)
+        {
+            result = min;
+        }
+        else if (size == UINT256_MAX)
+        {
+            result = x;
+        }
+        else
+        {
+            ++size; // make `max` inclusive
+            uint256 mod = x % size;
+            result = min + mod;
+        }
+
+        emit log_named_uint("Bound Result", result);
+    }
+
+    // Deploy a contract by fetching the contract bytecode from
+    // the artifacts directory
+    // e.g. `deployCode(code, abi.encode(arg1,arg2,arg3))`
+    function deployCode(string memory what, bytes memory args)
+        public
+        returns (address addr)
+    {
+        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,bytes): Deployment failed."
+        );
+    }
+
+    function deployCode(string memory what)
+        public
+        returns (address addr)
+    {
+        bytes memory bytecode = vm.getCode(what);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string): Deployment failed."
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    STD-ASSERTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function fail(string memory err) internal virtual {
+        emit log_named_string("Error", err);
+        fail();
+    }
+
+    function assertFalse(bool data) internal virtual {
+        assertTrue(!data);
+    }
+
+    function assertFalse(bool data, string memory err) internal virtual {
+        assertTrue(!data, err);
+    }
+
+    function assertEq(bool a, bool b) internal {
+        if (a != b) {
+            emit log                ("Error: a == b not satisfied [bool]");
+            emit log_named_string   ("  Expected", b ? "true" : "false");
+            emit log_named_string   ("    Actual", a ? "true" : "false");
+            fail();
+        }
+    }
+
+    function assertEq(bool a, bool b, string memory err) internal {
+        if (a != b) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+    function assertEq(bytes memory a, bytes memory b) internal {
+        assertEq0(a, b);
+    }
+
+    function assertEq(bytes memory a, bytes memory b, string memory err) internal {
+        assertEq0(a, b, err);
+    }
+
+    function assertEq(uint256[] memory a, uint256[] memory b) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log("Error: a == b not satisfied [uint[]]");
+            emit log_named_array("  Expected", b);
+            emit log_named_array("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq(int256[] memory a, int256[] memory b) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log("Error: a == b not satisfied [int[]]");
+            emit log_named_array("  Expected", b);
+            emit log_named_array("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq(address[] memory a, address[] memory b) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log("Error: a == b not satisfied [address[]]");
+            emit log_named_array("  Expected", b);
+            emit log_named_array("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq(uint256[] memory a, uint256[] memory b, string memory err) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+    function assertEq(int256[] memory a, int256[] memory b, string memory err) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+
+    function assertEq(address[] memory a, address[] memory b, string memory err) internal {
+        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
+            emit log_named_string("Error", err);
+            assertEq(a, b);
+        }
+    }
+
+    function assertApproxEqAbs(
+        uint256 a,
+        uint256 b,
+        uint256 maxDelta
+    ) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log            ("Error: a ~= b not satisfied [uint]");
+            emit log_named_uint ("  Expected", b);
+            emit log_named_uint ("    Actual", a);
+            emit log_named_uint (" Max Delta", maxDelta);
+            emit log_named_uint ("     Delta", delta);
+            fail();
+        }
+    }
+
+    function assertApproxEqAbs(
+        uint256 a,
+        uint256 b,
+        uint256 maxDelta,
+        string memory err
+    ) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log_named_string   ("Error", err);
+            assertApproxEqAbs(a, b, maxDelta);
+        }
+    }
+
+    function assertApproxEqAbs(
+        int256 a,
+        int256 b,
+        uint256 maxDelta
+    ) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log            ("Error: a ~= b not satisfied [int]");
+            emit log_named_int  ("  Expected", b);
+            emit log_named_int  ("    Actual", a);
+            emit log_named_uint (" Max Delta", maxDelta);
+            emit log_named_uint ("     Delta", delta);
+            fail();
+        }
+    }
+
+    function assertApproxEqAbs(
+        int256 a,
+        int256 b,
+        uint256 maxDelta,
+        string memory err
+    ) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log_named_string   ("Error", err);
+            assertApproxEqAbs(a, b, maxDelta);
+        }
+    }
+
+    function assertApproxEqRel(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta // An 18 decimal fixed point number, where 1e18 == 100%
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log                    ("Error: a ~= b not satisfied [uint]");
+            emit log_named_uint         ("    Expected", b);
+            emit log_named_uint         ("      Actual", a);
+            emit log_named_decimal_uint (" Max % Delta", maxPercentDelta, 18);
+            emit log_named_decimal_uint ("     % Delta", percentDelta, 18);
+            fail();
+        }
+    }
+
+    function assertApproxEqRel(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        string memory err
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log_named_string       ("Error", err);
+            assertApproxEqRel(a, b, maxPercentDelta);
+        }
+    }
+
+    function assertApproxEqRel(
+        int256 a,
+        int256 b,
+        uint256 maxPercentDelta
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log                   ("Error: a ~= b not satisfied [int]");
+            emit log_named_int         ("    Expected", b);
+            emit log_named_int         ("      Actual", a);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            fail();
+        }
+    }
+
+    function assertApproxEqRel(
+        int256 a,
+        int256 b,
+        uint256 maxPercentDelta,
+        string memory err
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log_named_string      ("Error", err);
+            assertApproxEqRel(a, b, maxPercentDelta);
+        }
+    }
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                STD-ERRORS
+//////////////////////////////////////////////////////////////////////////*/
+
+library stdError {
+    bytes public constant assertionError = abi.encodeWithSignature("Panic(uint256)", 0x01);
+    bytes public constant arithmeticError = abi.encodeWithSignature("Panic(uint256)", 0x11);
+    bytes public constant divisionError = abi.encodeWithSignature("Panic(uint256)", 0x12);
+    bytes public constant enumConversionError = abi.encodeWithSignature("Panic(uint256)", 0x21);
+    bytes public constant encodeStorageError = abi.encodeWithSignature("Panic(uint256)", 0x22);
+    bytes public constant popError = abi.encodeWithSignature("Panic(uint256)", 0x31);
+    bytes public constant indexOOBError = abi.encodeWithSignature("Panic(uint256)", 0x32);
+    bytes public constant memOverflowError = abi.encodeWithSignature("Panic(uint256)", 0x41);
+    bytes public constant zeroVarError = abi.encodeWithSignature("Panic(uint256)", 0x51);
+    // DEPRECATED: Use Vm's `expectRevert` without any arguments instead
+    bytes public constant lowLevelError = bytes(""); // `0x`
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                STD-STORAGE
+//////////////////////////////////////////////////////////////////////////*/
+
+struct StdStorage {
+    mapping (address => mapping(bytes4 => mapping(bytes32 => uint256))) slots;
+    mapping (address => mapping(bytes4 =>  mapping(bytes32 => bool))) finds;
+
+    bytes32[] _keys;
+    bytes4 _sig;
+    uint256 _depth;
+    address _target;
+    bytes32 _set;
+}
+
+library stdStorage {
+    event SlotFound(address who, bytes4 fsig, bytes32 keysHash, uint slot);
+    event WARNING_UninitedSlot(address who, uint slot);
+
+    uint256 private constant UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    int256 private constant INT256_MAX = 57896044618658097711785492504343953926634992332820282019728792003956564819967;
+
+    Vm private constant vm_std_store = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+    function sigs(
+        string memory sigStr
+    )
+        internal
+        pure
+        returns (bytes4)
+    {
+        return bytes4(keccak256(bytes(sigStr)));
+    }
+
+    /// @notice find an arbitrary storage slot given a function sig, input data, address of the contract and a value to check against
+    // slot complexity:
+    //  if flat, will be bytes32(uint256(uint));
+    //  if map, will be keccak256(abi.encode(key, uint(slot)));
+    //  if deep map, will be keccak256(abi.encode(key1, keccak256(abi.encode(key0, uint(slot)))));
+    //  if map struct, will be bytes32(uint256(keccak256(abi.encode(key1, keccak256(abi.encode(key0, uint(slot)))))) + structFieldDepth);
+    function find(
+        StdStorage storage self
+    )
+        internal
+        returns (uint256)
+    {
+        address who = self._target;
+        bytes4 fsig = self._sig;
+        uint256 field_depth = self._depth;
+        bytes32[] memory ins = self._keys;
+
+        // calldata to test against
+        if (self.finds[who][fsig][keccak256(abi.encodePacked(ins, field_depth))]) {
+            return self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))];
+        }
+        bytes memory cald = abi.encodePacked(fsig, flatten(ins));
+        vm_std_store.record();
+        bytes32 fdat;
+        {
+            (, bytes memory rdat) = who.staticcall(cald);
+            fdat = bytesToBytes32(rdat, 32*field_depth);
+        }
+
+        (bytes32[] memory reads, ) = vm_std_store.accesses(address(who));
+        if (reads.length == 1) {
+            bytes32 curr = vm_std_store.load(who, reads[0]);
+            if (curr == bytes32(0)) {
+                emit WARNING_UninitedSlot(who, uint256(reads[0]));
+            }
+            if (fdat != curr) {
+                require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isn't supported.");
+            }
+            emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[0]));
+            self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[0]);
+            self.finds[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = true;
+        } else if (reads.length > 1) {
+            for (uint256 i = 0; i < reads.length; i++) {
+                bytes32 prev = vm_std_store.load(who, reads[i]);
+                if (prev == bytes32(0)) {
+                    emit WARNING_UninitedSlot(who, uint256(reads[i]));
+                }
+                // store
+                vm_std_store.store(who, reads[i], bytes32(hex"1337"));
+                bool success;
+                bytes memory rdat;
+                {
+                    (success, rdat) = who.staticcall(cald);
+                    fdat = bytesToBytes32(rdat, 32*field_depth);
+                }
+
+                if (success && fdat == bytes32(hex"1337")) {
+                    // we found which of the slots is the actual one
+                    emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[i]));
+                    self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[i]);
+                    self.finds[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = true;
+                    vm_std_store.store(who, reads[i], prev);
+                    break;
+                }
+                vm_std_store.store(who, reads[i], prev);
+            }
+        } else {
+            require(false, "stdStorage find(StdStorage): No storage use detected for target.");
+        }
+
+        require(self.finds[who][fsig][keccak256(abi.encodePacked(ins, field_depth))], "stdStorage find(StdStorage): Slot(s) not found.");
+
+        delete self._target;
+        delete self._sig;
+        delete self._keys;
+        delete self._depth;
+
+        return self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))];
+    }
+
+    function target(StdStorage storage self, address _target) internal returns (StdStorage storage) {
+        self._target = _target;
+        return self;
+    }
+
+    function sig(StdStorage storage self, bytes4 _sig) internal returns (StdStorage storage) {
+        self._sig = _sig;
+        return self;
+    }
+
+    function sig(StdStorage storage self, string memory _sig) internal returns (StdStorage storage) {
+        self._sig = sigs(_sig);
+        return self;
+    }
+
+    function with_key(StdStorage storage self, address who) internal returns (StdStorage storage) {
+        self._keys.push(bytes32(uint256(uint160(who))));
+        return self;
+    }
+
+    function with_key(StdStorage storage self, uint256 amt) internal returns (StdStorage storage) {
+        self._keys.push(bytes32(amt));
+        return self;
+    }
+    function with_key(StdStorage storage self, bytes32 key) internal returns (StdStorage storage) {
+        self._keys.push(key);
+        return self;
+    }
+
+    function depth(StdStorage storage self, uint256 _depth) internal returns (StdStorage storage) {
+        self._depth = _depth;
+        return self;
+    }
+
+    function checked_write(StdStorage storage self, address who) internal {
+        checked_write(self, bytes32(uint256(uint160(who))));
+    }
+
+    function checked_write(StdStorage storage self, uint256 amt) internal {
+        checked_write(self, bytes32(amt));
+    }
+
+    function checked_write(StdStorage storage self, bool write) internal {
+        bytes32 t;
+        /// @solidity memory-safe-assembly
+        assembly {
+            t := write
+        }
+        checked_write(self, t);
+    }
+
+    function checked_write(
+        StdStorage storage self,
+        bytes32 set
+    ) internal {
+        address who = self._target;
+        bytes4 fsig = self._sig;
+        uint256 field_depth = self._depth;
+        bytes32[] memory ins = self._keys;
+
+        bytes memory cald = abi.encodePacked(fsig, flatten(ins));
+        if (!self.finds[who][fsig][keccak256(abi.encodePacked(ins, field_depth))]) {
+            find(self);
+        }
+        bytes32 slot = bytes32(self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))]);
+
+        bytes32 fdat;
+        {
+            (, bytes memory rdat) = who.staticcall(cald);
+            fdat = bytesToBytes32(rdat, 32*field_depth);
+        }
+        bytes32 curr = vm_std_store.load(who, slot);
+
+        if (fdat != curr) {
+            require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isn't supported.");
+        }
+        vm_std_store.store(who, slot, set);
+        delete self._target;
+        delete self._sig;
+        delete self._keys;
+        delete self._depth;
+    }
+
+    function read(StdStorage storage self) private returns (bytes memory) {
+        address t = self._target;
+        uint256 s = find(self);
+        return abi.encode(vm_std_store.load(t, bytes32(s)));
+    }
+
+    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
+        return abi.decode(read(self), (bytes32));
+    }
+
+
+    function read_bool(StdStorage storage self) internal returns (bool) {
+        int256 v = read_int(self);
+        if (v == 0) return false;
+        if (v == 1) return true;
+        revert("stdStorage read_bool(StdStorage): Cannot decode. Make sure you are reading a bool.");
+    }
+
+    function read_address(StdStorage storage self) internal returns (address) {
+        return abi.decode(read(self), (address));
+    }
+
+    function read_uint(StdStorage storage self) internal returns (uint256) {
+        return abi.decode(read(self), (uint256));
+    }
+
+    function read_int(StdStorage storage self) internal returns (int256) {
+        return abi.decode(read(self), (int256));
+    }
+
+    function bytesToBytes32(bytes memory b, uint offset) public pure returns (bytes32) {
+        bytes32 out;
+
+        uint256 max = b.length > 32 ? 32 : b.length;
+        for (uint i = 0; i < max; i++) {
+            out |= bytes32(b[offset + i] & 0xFF) >> (i * 8);
+        }
+        return out;
+    }
+
+    function flatten(bytes32[] memory b) private pure returns (bytes memory)
+    {
+        bytes memory result = new bytes(b.length * 32);
+        for (uint256 i = 0; i < b.length; i++) {
+            bytes32 k = b[i];
+            /// @solidity memory-safe-assembly
+            assembly {
+                mstore(add(result, add(32, mul(32, i))), k)
+            }
+        }
+
+        return result;
+    }
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                STD-MATH
+//////////////////////////////////////////////////////////////////////////*/
+
+library stdMath {
+    int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+
+    function abs(int256 a) internal pure returns (uint256) {
+        // Required or it will fail when `a = type(int256).min`
+        if (a == INT256_MIN)
+            return 57896044618658097711785492504343953926634992332820282019728792003956564819968;
+
+        return uint256(a >= 0 ? a : -a);
+    }
+
+    function delta(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b
+            ? a - b
+            : b - a;
+    }
+
+    function delta(int256 a, int256 b) internal pure returns (uint256) {
+        // a and b are of the same sign
+        if (a >= 0 && b >= 0 || a < 0 && b < 0) {
+            return delta(abs(a), abs(b));
+        }
+
+        // a and b are of opposite signs
+        return abs(a) + abs(b);
+    }
+
+    function percentDelta(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 absDelta = delta(a, b);
+
+        return absDelta * 1e18 / b;
+    }
+
+    function percentDelta(int256 a, int256 b) internal pure returns (uint256) {
+        uint256 absDelta = delta(a, b);
+        uint256 absB = abs(b);
+
+        return absDelta * 1e18 / absB;
+    }
+}

--- a/testdata/lib/forge-std/src/Vm.sol
+++ b/testdata/lib/forge-std/src/Vm.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.6.0;
+pragma experimental ABIEncoderV2;
+
+interface Vm {
+    struct Log {
+        bytes32[] topics;
+        bytes data;
+    }
+
+    // Sets block.timestamp (newTimestamp)
+    function warp(uint256) external;
+    // Sets block.height (newHeight)
+    function roll(uint256) external;
+    // Sets block.basefee (newBasefee)
+    function fee(uint256) external;
+    // Sets block.chainid
+    function chainId(uint256) external;
+    // Loads a storage slot from an address (who, slot)
+    function load(address,bytes32) external returns (bytes32);
+    // Stores a value to an address' storage slot, (who, slot, value)
+    function store(address,bytes32,bytes32) external;
+    // Signs data, (privateKey, digest) => (v, r, s)
+    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
+    // Gets the address for a given private key, (privateKey) => (address)
+    function addr(uint256) external returns (address);
+    // Gets the nonce of an account
+    function getNonce(address) external returns (uint64);
+    // Sets the nonce of an account; must be higher than the current nonce of the account
+    function setNonce(address, uint64) external;
+    // Performs a foreign function call via the terminal, (stringInputs) => (result)
+    function ffi(string[] calldata) external returns (bytes memory);
+    // Sets environment variables, (name, value)
+    function setEnv(string calldata, string calldata) external;
+    // Reads environment variables, (name) => (value)
+    function envBool(string calldata) external returns (bool);
+    function envUint(string calldata) external returns (uint256);
+    function envInt(string calldata) external returns (int256);
+    function envAddress(string calldata) external returns (address);
+    function envBytes32(string calldata) external returns (bytes32);
+    function envString(string calldata) external returns (string memory);
+    function envBytes(string calldata) external returns (bytes memory);
+    // Reads environment variables as arrays, (name, delim) => (value[])
+    function envBool(string calldata, string calldata) external returns (bool[] memory);
+    function envUint(string calldata, string calldata) external returns (uint256[] memory);
+    function envInt(string calldata, string calldata) external returns (int256[] memory);
+    function envAddress(string calldata, string calldata) external returns (address[] memory);
+    function envBytes32(string calldata, string calldata) external returns (bytes32[] memory);
+    function envString(string calldata, string calldata) external returns (string[] memory);
+    function envBytes(string calldata, string calldata) external returns (bytes[] memory);
+    // Sets the *next* call's msg.sender to be the input address
+    function prank(address) external;
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
+    function startPrank(address) external;
+    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+    function prank(address,address) external;
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+    function startPrank(address,address) external;
+    // Resets subsequent calls' msg.sender to be `address(this)`
+    function stopPrank() external;
+    // Sets an address' balance, (who, newBalance)
+    function deal(address, uint256) external;
+    // Sets an address' code, (who, newCode)
+    function etch(address, bytes calldata) external;
+    // Expects an error on next call
+    function expectRevert(bytes calldata) external;
+    function expectRevert(bytes4) external;
+    function expectRevert() external;
+    // Records all storage reads and writes
+    function record() external;
+    // Gets all accessed reads and write slot from a recording session, for a given address
+    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
+    function expectEmit(bool,bool,bool,bool) external;
+    function expectEmit(bool,bool,bool,bool,address) external;
+    // Mocks a call to an address, returning specified data.
+    // Calldata can either be strict or a partial match, e.g. if you only
+    // pass a Solidity selector to the expected calldata, then the entire Solidity
+    // function will be mocked.
+    function mockCall(address,bytes calldata,bytes calldata) external;
+    // Mocks a call to an address with a specific msg.value, returning specified data.
+    // Calldata match takes precedence over msg.value in case of ambiguity.
+    function mockCall(address,uint256,bytes calldata,bytes calldata) external;
+    // Clears all mocked calls
+    function clearMockedCalls() external;
+    // Expects a call to an address with the specified calldata.
+    // Calldata can either be a strict or a partial match
+    function expectCall(address,bytes calldata) external;
+    // Expects a call to an address with the specified msg.value and calldata
+    function expectCall(address,uint256,bytes calldata) external;
+    // Gets the code from an artifact file. Takes in the relative path to the json file
+    function getCode(string calldata) external returns (bytes memory);
+    // Labels an address in call traces
+    function label(address, string calldata) external;
+    // If the condition is false, discard this run's fuzz inputs and generate new ones
+    function assume(bool) external;
+    // Sets block.coinbase (who)
+    function coinbase(address) external;
+    // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
+    function broadcast() external;
+    // Has the next call (at this call depth only) create a transaction with the address provided as the sender that can later be signed and sent onchain
+    function broadcast(address) external;
+    // Using the address that calls the test contract, has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
+    function startBroadcast() external;
+    // Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
+    function startBroadcast(address) external;
+    // Stops collecting onchain transactions
+    function stopBroadcast() external;
+    // Reads the entire content of file to string, (path) => (data)
+    function readFile(string calldata) external returns (string memory);
+    // Reads next line of file to string, (path) => (line)
+    function readLine(string calldata) external returns (string memory);
+    // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
+    // (path, data) => ()
+    function writeFile(string calldata, string calldata) external;
+    // Writes line to file, creating a file if it does not exist.
+    // (path, data) => ()
+    function writeLine(string calldata, string calldata) external;
+    // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
+    // (path) => ()
+    function closeFile(string calldata) external;
+    // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - Path points to a directory.
+    // - The file doesn't exist.
+    // - The user lacks permissions to remove the file.
+    // (path) => ()
+    function removeFile(string calldata) external;
+    // Convert values to a string, (value) => (stringified value)
+    function toString(address) external returns(string memory);
+    function toString(bytes calldata) external returns(string memory);
+    function toString(bytes32) external returns(string memory);
+    function toString(bool) external returns(string memory);
+    function toString(uint256) external returns(string memory);
+    function toString(int256) external returns(string memory);
+    // Record all the transaction logs
+    function recordLogs() external;
+    // Gets all the recorded logs, () => (logs)
+    function getRecordedLogs() external returns (Log[] memory);
+}

--- a/testdata/lib/forge-std/src/console.sol
+++ b/testdata/lib/forge-std/src/console.sol
@@ -1,0 +1,1533 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+library console {
+    address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
+
+    function _sendLogPayload(bytes memory payload) private view {
+        uint256 payloadLength = payload.length;
+        address consoleAddress = CONSOLE_ADDRESS;
+        /// @solidity memory-safe-assembly
+        assembly {
+            let payloadStart := add(payload, 32)
+            let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+        }
+    }
+
+    function log() internal view {
+        _sendLogPayload(abi.encodeWithSignature("log()"));
+    }
+
+    function logInt(int p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(int)", p0));
+    }
+
+    function logUint(uint p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    }
+
+    function logString(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function logBool(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function logAddress(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function logBytes(bytes memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes)", p0));
+    }
+
+    function logBytes1(bytes1 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes1)", p0));
+    }
+
+    function logBytes2(bytes2 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes2)", p0));
+    }
+
+    function logBytes3(bytes3 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes3)", p0));
+    }
+
+    function logBytes4(bytes4 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes4)", p0));
+    }
+
+    function logBytes5(bytes5 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes5)", p0));
+    }
+
+    function logBytes6(bytes6 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes6)", p0));
+    }
+
+    function logBytes7(bytes7 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes7)", p0));
+    }
+
+    function logBytes8(bytes8 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes8)", p0));
+    }
+
+    function logBytes9(bytes9 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes9)", p0));
+    }
+
+    function logBytes10(bytes10 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes10)", p0));
+    }
+
+    function logBytes11(bytes11 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes11)", p0));
+    }
+
+    function logBytes12(bytes12 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes12)", p0));
+    }
+
+    function logBytes13(bytes13 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes13)", p0));
+    }
+
+    function logBytes14(bytes14 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes14)", p0));
+    }
+
+    function logBytes15(bytes15 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes15)", p0));
+    }
+
+    function logBytes16(bytes16 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes16)", p0));
+    }
+
+    function logBytes17(bytes17 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes17)", p0));
+    }
+
+    function logBytes18(bytes18 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes18)", p0));
+    }
+
+    function logBytes19(bytes19 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes19)", p0));
+    }
+
+    function logBytes20(bytes20 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes20)", p0));
+    }
+
+    function logBytes21(bytes21 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes21)", p0));
+    }
+
+    function logBytes22(bytes22 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes22)", p0));
+    }
+
+    function logBytes23(bytes23 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes23)", p0));
+    }
+
+    function logBytes24(bytes24 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes24)", p0));
+    }
+
+    function logBytes25(bytes25 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes25)", p0));
+    }
+
+    function logBytes26(bytes26 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes26)", p0));
+    }
+
+    function logBytes27(bytes27 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes27)", p0));
+    }
+
+    function logBytes28(bytes28 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes28)", p0));
+    }
+
+    function logBytes29(bytes29 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes29)", p0));
+    }
+
+    function logBytes30(bytes30 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes30)", p0));
+    }
+
+    function logBytes31(bytes31 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes31)", p0));
+    }
+
+    function logBytes32(bytes32 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
+    }
+
+    function log(uint p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    }
+
+    function log(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function log(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function log(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function log(uint p0, uint p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint)", p0, p1));
+    }
+
+    function log(uint p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string)", p0, p1));
+    }
+
+    function log(uint p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool)", p0, p1));
+    }
+
+    function log(uint p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address)", p0, p1));
+    }
+
+    function log(string memory p0, uint p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
+    }
+
+    function log(string memory p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+    }
+
+    function log(string memory p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+    }
+
+    function log(string memory p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+    }
+
+    function log(bool p0, uint p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint)", p0, p1));
+    }
+
+    function log(bool p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string)", p0, p1));
+    }
+
+    function log(bool p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool)", p0, p1));
+    }
+
+    function log(bool p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
+    }
+
+    function log(address p0, uint p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint)", p0, p1));
+    }
+
+    function log(address p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string)", p0, p1));
+    }
+
+    function log(address p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool)", p0, p1));
+    }
+
+    function log(address p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
+    }
+
+    function log(uint p0, uint p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint)", p0, p1, p2));
+    }
+
+    function log(uint p0, uint p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string)", p0, p1, p2));
+    }
+
+    function log(uint p0, uint p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool)", p0, p1, p2));
+    }
+
+    function log(uint p0, uint p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address)", p0, p1, p2));
+    }
+
+    function log(uint p0, string memory p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint)", p0, p1, p2));
+    }
+
+    function log(uint p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string)", p0, p1, p2));
+    }
+
+    function log(uint p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool)", p0, p1, p2));
+    }
+
+    function log(uint p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address)", p0, p1, p2));
+    }
+
+    function log(uint p0, bool p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint)", p0, p1, p2));
+    }
+
+    function log(uint p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string)", p0, p1, p2));
+    }
+
+    function log(uint p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool)", p0, p1, p2));
+    }
+
+    function log(uint p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address)", p0, p1, p2));
+    }
+
+    function log(uint p0, address p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint)", p0, p1, p2));
+    }
+
+    function log(uint p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string)", p0, p1, p2));
+    }
+
+    function log(uint p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool)", p0, p1, p2));
+    }
+
+    function log(uint p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
+    }
+
+    function log(address p0, uint p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint)", p0, p1, p2));
+    }
+
+    function log(address p0, uint p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string)", p0, p1, p2));
+    }
+
+    function log(address p0, uint p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, uint p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, uint p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
+    }
+
+    function log(uint p0, uint p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, uint p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, uint p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
+    }
+
+}

--- a/testdata/lib/forge-std/src/console2.sol
+++ b/testdata/lib/forge-std/src/console2.sol
@@ -1,0 +1,1538 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+// The orignal console.sol uses `int` and `uint` for computing function selectors, but it should
+// use `int256` and `uint256`. This modified version fixes that. This version is recommended
+// over `console.sol` if you don't need compatibility with Hardhat as the logs will show up in
+// forge stack traces. If you do need compatibility with Hardhat, you must use `console.sol`.
+// Reference: https://github.com/NomicFoundation/hardhat/issues/2178
+
+library console2 {
+    address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
+
+    function _sendLogPayload(bytes memory payload) private view {
+        uint256 payloadLength = payload.length;
+        address consoleAddress = CONSOLE_ADDRESS;
+        assembly {
+            let payloadStart := add(payload, 32)
+            let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+        }
+    }
+
+    function log() internal view {
+        _sendLogPayload(abi.encodeWithSignature("log()"));
+    }
+
+    function logInt(int256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
+    }
+
+    function logUint(uint256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
+    }
+
+    function logString(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function logBool(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function logAddress(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function logBytes(bytes memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes)", p0));
+    }
+
+    function logBytes1(bytes1 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes1)", p0));
+    }
+
+    function logBytes2(bytes2 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes2)", p0));
+    }
+
+    function logBytes3(bytes3 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes3)", p0));
+    }
+
+    function logBytes4(bytes4 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes4)", p0));
+    }
+
+    function logBytes5(bytes5 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes5)", p0));
+    }
+
+    function logBytes6(bytes6 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes6)", p0));
+    }
+
+    function logBytes7(bytes7 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes7)", p0));
+    }
+
+    function logBytes8(bytes8 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes8)", p0));
+    }
+
+    function logBytes9(bytes9 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes9)", p0));
+    }
+
+    function logBytes10(bytes10 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes10)", p0));
+    }
+
+    function logBytes11(bytes11 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes11)", p0));
+    }
+
+    function logBytes12(bytes12 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes12)", p0));
+    }
+
+    function logBytes13(bytes13 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes13)", p0));
+    }
+
+    function logBytes14(bytes14 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes14)", p0));
+    }
+
+    function logBytes15(bytes15 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes15)", p0));
+    }
+
+    function logBytes16(bytes16 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes16)", p0));
+    }
+
+    function logBytes17(bytes17 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes17)", p0));
+    }
+
+    function logBytes18(bytes18 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes18)", p0));
+    }
+
+    function logBytes19(bytes19 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes19)", p0));
+    }
+
+    function logBytes20(bytes20 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes20)", p0));
+    }
+
+    function logBytes21(bytes21 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes21)", p0));
+    }
+
+    function logBytes22(bytes22 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes22)", p0));
+    }
+
+    function logBytes23(bytes23 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes23)", p0));
+    }
+
+    function logBytes24(bytes24 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes24)", p0));
+    }
+
+    function logBytes25(bytes25 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes25)", p0));
+    }
+
+    function logBytes26(bytes26 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes26)", p0));
+    }
+
+    function logBytes27(bytes27 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes27)", p0));
+    }
+
+    function logBytes28(bytes28 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes28)", p0));
+    }
+
+    function logBytes29(bytes29 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes29)", p0));
+    }
+
+    function logBytes30(bytes30 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes30)", p0));
+    }
+
+    function logBytes31(bytes31 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes31)", p0));
+    }
+
+    function logBytes32(bytes32 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
+    }
+
+    function log(uint256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
+    }
+
+    function log(string memory p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
+
+    function log(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
+
+    function log(address p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
+
+    function log(uint256 p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256)", p0, p1));
+    }
+
+    function log(uint256 p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string)", p0, p1));
+    }
+
+    function log(uint256 p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool)", p0, p1));
+    }
+
+    function log(uint256 p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address)", p0, p1));
+    }
+
+    function log(string memory p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
+    }
+
+    function log(string memory p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+    }
+
+    function log(string memory p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+    }
+
+    function log(string memory p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+    }
+
+    function log(bool p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256)", p0, p1));
+    }
+
+    function log(bool p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string)", p0, p1));
+    }
+
+    function log(bool p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool)", p0, p1));
+    }
+
+    function log(bool p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
+    }
+
+    function log(address p0, uint256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256)", p0, p1));
+    }
+
+    function log(address p0, string memory p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string)", p0, p1));
+    }
+
+    function log(address p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool)", p0, p1));
+    }
+
+    function log(address p0, address p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, uint256 p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, uint256 p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, string memory p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, address p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint256 p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint256 p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint256 p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, uint256 p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool)", p0, p1, p2));
+    }
+
+    function log(string memory p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint256 p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint256 p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, uint256 p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool)", p0, p1, p2));
+    }
+
+    function log(bool p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
+    }
+
+    function log(address p0, uint256 p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256)", p0, p1, p2));
+    }
+
+    function log(address p0, uint256 p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string)", p0, p1, p2));
+    }
+
+    function log(address p0, uint256 p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, uint256 p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, string memory p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, bool p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, uint256 p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, string memory p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, bool p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool)", p0, p1, p2));
+    }
+
+    function log(address p0, address p1, address p2) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(uint256 p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, uint256 p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(string memory p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, uint256 p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(bool p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, uint256 p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, string memory p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, bool p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint256 p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint256 p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint256 p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, uint256 p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, string memory p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, bool p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, uint256 p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint256)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, string memory p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,string)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, bool p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,bool)", p0, p1, p2, p3));
+    }
+
+    function log(address p0, address p1, address p2, address p3) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
+    }
+
+}

--- a/testdata/logs/DebugLogs.t.sol
+++ b/testdata/logs/DebugLogs.t.sol
@@ -1,8 +1,8 @@
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract DebugLogsTest is DSTest {
+contract DebugLogsTest is Test {
     constructor() {
         emit log_uint(0);
     }
@@ -92,7 +92,7 @@ contract DebugLogsTest is DSTest {
 
 }
 
-contract Fails is DSTest {
+contract Fails is Test {
     function failure() public {
         emit log_uint(100);
         revert();

--- a/testdata/trace/ConflictingSignatures.t.sol
+++ b/testdata/trace/ConflictingSignatures.t.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "../cheats/Cheats.sol";
 
 contract ReturnsNothing {
@@ -19,7 +19,7 @@ contract ReturnsUint {
     }
 }
 
-contract ConflictingSignaturesTest is DSTest {
+contract ConflictingSignaturesTest is Test {
     ReturnsNothing retsNothing;
     ReturnsString retsString;
     ReturnsUint retsUint;

--- a/testdata/trace/Trace.t.sol
+++ b/testdata/trace/Trace.t.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.8.0;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "../cheats/Cheats.sol";
 
 contract RecursiveCall {
@@ -51,7 +51,7 @@ contract RecursiveCall {
     }
 }
 
-contract TraceTest is DSTest {
+contract TraceTest is Test {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
     uint256 nodeId = 0;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
replace `<ForgeTest> is DSTest` with `<ForgeTest> is STest` so we use the actual `forge-std/Test.sol` for our tests
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
copy excerpt of forge-std contracts into `testdata/lib/forge-std` and update usage in `testdata`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
