### PR TITLE
fix: use platform agnostic filter paths for cheat tests

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1143,8 +1143,13 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
     #[test]
     fn test_cheats_fork() {
         let mut runner = runner();
-        let suite_result =
-            runner.test(&Filter::new(".*", ".*", ".*cheats/Fork"), None, true).unwrap();
+        let suite_result = runner
+            .test(
+                &Filter::new(".*", ".*", &format!(".*cheats{}Fork", std::path::MAIN_SEPARATOR)),
+                None,
+                true,
+            )
+            .unwrap();
         assert!(!suite_result.is_empty());
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
@@ -1165,8 +1170,13 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
     #[test]
     fn test_cheats_local() {
         let mut runner = runner();
-        let suite_result =
-            runner.test(&Filter::new(".*", ".*", ".*cheats/[^Fork]"), None, true).unwrap();
+        let suite_result = runner
+            .test(
+                &Filter::new(".*", ".*", &format!(".*cheats{}[^Fork]", std::path::MAIN_SEPARATOR)),
+                None,
+                true,
+            )
+            .unwrap();
         assert!(!suite_result.is_empty());
 
         for (_, SuiteResult { test_results, .. }) in suite_result {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
updates filter paths to use `path::MAIN_SEPARATOR`, to fix an issue introduced by #1715 where we use test filter like `.*cheats/Fork`

ref https://github.com/foundry-rs/foundry/runs/7299967730?check_suite_focus=true#step:11:208
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
