### PR TITLE
test: shuffle rpc keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,8 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
+ "once_cell",
+ "rand 0.8.5",
  "reqwest",
  "rlp",
  "rustc-hex",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -25,6 +25,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 rlp = "0.5.1"
 futures = "0.3.17"
 tracing = "0.1"
+once_cell = "1.13"
+rand = "0.8"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["solc-full"] }

--- a/utils/src/rpc.rs
+++ b/utils/src/rpc.rs
@@ -1,29 +1,43 @@
 //! Support rpc api keys
 
+use once_cell::sync::Lazy;
+use rand::seq::SliceRandom;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 // List of general purpose infura keys to rotate through
-const INFURA_KEYS: &[&str] = &[
-    "6770454bc6ea42c58aac12978531b93f",
-    "7a8769b798b642f6933f2ed52042bd70",
-    "631fd9a6539644088297dc605d35fff3",
-    "16a8be88795540b9b3903d8de0f7baa5",
-    "f4a0bdad42674adab5fc0ac077ffab2b",
-    "5c812e02193c4ba793f8c214317582bd",
-];
+static INFURA_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
+    let mut keys = vec![
+        "6770454bc6ea42c58aac12978531b93f",
+        "7a8769b798b642f6933f2ed52042bd70",
+        "631fd9a6539644088297dc605d35fff3",
+        "16a8be88795540b9b3903d8de0f7baa5",
+        "f4a0bdad42674adab5fc0ac077ffab2b",
+        "5c812e02193c4ba793f8c214317582bd",
+    ];
+
+    keys.shuffle(&mut rand::thread_rng());
+
+    keys
+});
 
 // List of alchemy keys for mainnet
-const ALCHEMY_MAINNET_KEYS: &[&str] = &[
-    "ib1f4u1ojm-9lJJypwkeZeG-75TJRB7O",
-    "7mTtk6IW4DwroGnKmG_bOWri2hyaGYhX",
-    "GL4M0hfzSYGU5e1_t804HoUDOObWP-FA",
-    "WV407BEiBmjNJfKo9Uo_55u0z0ITyCOX",
-    "Ge56dH9siMF4T0whP99sQXOcr2mFs8wZ",
-    "QC55XC151AgkS3FNtWvz9VZGeu9Xd9lb",
-    "pwc5rmJhrdoaSEfimoKEmsvOjKSmPDrP",
-    "A5sZ85MIr4SzCMkT0zXh2eeamGIq3vGL",
-    "9VWGraLx0tMiSWx05WH-ywgSVmMxs66W",
-];
+static ALCHEMY_MAINNET_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
+    let mut keys = vec![
+        "ib1f4u1ojm-9lJJypwkeZeG-75TJRB7O",
+        "7mTtk6IW4DwroGnKmG_bOWri2hyaGYhX",
+        "GL4M0hfzSYGU5e1_t804HoUDOObWP-FA",
+        "WV407BEiBmjNJfKo9Uo_55u0z0ITyCOX",
+        "Ge56dH9siMF4T0whP99sQXOcr2mFs8wZ",
+        "QC55XC151AgkS3FNtWvz9VZGeu9Xd9lb",
+        "pwc5rmJhrdoaSEfimoKEmsvOjKSmPDrP",
+        "A5sZ85MIr4SzCMkT0zXh2eeamGIq3vGL",
+        "9VWGraLx0tMiSWx05WH-ywgSVmMxs66W",
+    ];
+
+    keys.shuffle(&mut rand::thread_rng());
+
+    keys
+});
 
 /// counts how many times a rpc endpoint was requested for _mainnet_
 static NEXT_RPC_ENDPOINT: AtomicUsize = AtomicUsize::new(0);
@@ -33,7 +47,7 @@ fn next() -> usize {
     NEXT_RPC_ENDPOINT.fetch_add(1, Ordering::SeqCst)
 }
 
-const fn num_keys() -> usize {
+fn num_keys() -> usize {
     INFURA_KEYS.len() + ALCHEMY_MAINNET_KEYS.len()
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
shuffles all rpc keys once,
prevent imbalance, where most of the load falls on the first keys
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
