### PR TITLE
fix(anvil): set base fee of next block in fork mode properly

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -602,8 +602,16 @@ impl NodeConfig {
             if self.base_fee.is_none() {
                 if let Some(base_fee) = block.base_fee_per_gas {
                     self.base_fee = Some(base_fee);
-                    fees.set_base_fee(base_fee);
                     env.block.basefee = base_fee;
+                    // this is the base fee of the current block, but we need the base fee of the
+                    // next block
+                    let next_block_base_fee = fees.get_next_block_base_fee_per_gas(
+                        block.gas_used,
+                        block.gas_limit,
+                        block.base_fee_per_gas.unwrap_or_default(),
+                    );
+                    // update next base fee
+                    fees.set_base_fee(next_block_base_fee.into());
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2262
when in fork mode, we also used the base fee of the forked block as the _next_ base fee.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
calculate and set the next base fee properly based on the forked block
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
