### PR TITLE
fix: use platform dependant regex path separators

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -372,6 +372,7 @@ mod tests {
         decode::decode_console_logs,
         test_helpers::{
             filter::Filter, COMPILED, COMPILED_WITH_LIBS, EVM_OPTS, LIBS_PROJECT, PROJECT,
+            RE_PATH_SEPARATOR,
         },
     };
     use foundry_config::{Config, RpcEndpoint, RpcEndpoints};
@@ -1145,7 +1146,7 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
         let mut runner = runner();
         let suite_result = runner
             .test(
-                &Filter::new(".*", ".*", &format!(".*cheats{}Fork", std::path::MAIN_SEPARATOR)),
+                &Filter::new(".*", ".*", &format!(".*cheats{}Fork", RE_PATH_SEPARATOR)),
                 None,
                 true,
             )
@@ -1172,7 +1173,7 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
         let mut runner = runner();
         let suite_result = runner
             .test(
-                &Filter::new(".*", ".*", &format!(".*cheats{}[^Fork]", std::path::MAIN_SEPARATOR)),
+                &Filter::new(".*", ".*", &format!(".*cheats{}[^Fork]", RE_PATH_SEPARATOR)),
                 None,
                 true,
             )

--- a/forge/src/test_helpers.rs
+++ b/forge/src/test_helpers.rs
@@ -81,6 +81,12 @@ pub fn fuzz_executor<DB: DatabaseRef>(executor: &Executor) -> FuzzedExecutor {
     FuzzedExecutor::new(executor, proptest::test_runner::TestRunner::new(cfg), CALLER)
 }
 
+#[cfg(not(windows))]
+pub const RE_PATH_SEPARATOR: &str = "/";
+
+#[cfg(windows)]
+pub const RE_PATH_SEPARATOR: &str = "\\\\";
+
 pub mod filter {
     use super::*;
     use regex::Regex;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
path separators for windows are `\\`

tested here https://github.com/foundry-rs/foundry/runs/7327839027?check_suite_focus=true
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
