### PR TITLE
fix: hex encode bytes32 slice

### DIFF
--- a/common/src/fmt.rs
+++ b/common/src/fmt.rs
@@ -1,6 +1,9 @@
 //! Contains a helper pretty() function to print human redeable string versions of usual ethers
 //! types
-use ethers_core::{types::*, utils::to_checksum};
+use ethers_core::{
+    types::*,
+    utils::{hex, to_checksum},
+};
 use serde::Deserialize;
 
 /// length of the name column for pretty formatting `{:>20}{value}`
@@ -63,7 +66,7 @@ impl UIfmt for Bytes {
 
 impl UIfmt for [u8; 32] {
     fn pretty(&self) -> String {
-        String::from_utf8_lossy(&self[..]).trim_matches('\0').to_string()
+        format!("0x{}", hex::encode(&self[..]))
     }
 }
 
@@ -326,6 +329,21 @@ pub fn to_bytes(uint: U256) -> Bytes {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn can_format_bytes32() {
+        let val = hex::decode("7465737400000000000000000000000000000000000000000000000000000000")
+            .unwrap();
+        let mut b32 = [0u8; 32];
+        b32.copy_from_slice(&val);
+
+        assert_eq!(
+            b32.pretty(),
+            "0x7465737400000000000000000000000000000000000000000000000000000000"
+        );
+        let b: Bytes = val.into();
+        assert_eq!(b.pretty(), b32.pretty());
+    }
 
     #[test]
     fn can_pretty_print_optimism_tx() {

--- a/testdata/cheats/ToString.t.sol
+++ b/testdata/cheats/ToString.t.sol
@@ -17,7 +17,7 @@ contract ToStringTest is DSTest {
     function testBytes32ToString() public {
         bytes32 testBytes = "test";
         string memory stringBytes = cheats.toString(testBytes);
-        assertEq("test", stringBytes);
+        assertEq("0x7465737400000000000000000000000000000000000000000000000000000000", stringBytes);
     }
 
     function testBoolToString() public {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2306
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
hex encode bytes32 slices, same as `Bytes`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
