### PR TITLE
chore(build): exit early if nothing to compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1482,7 +1482,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.13.0"
-source = "git+https://github.com/gakonst/ethers-rs#fb3fb161c060b2bc5e3b8eab0a24c72f399cde97"
+source = "git+https://github.com/gakonst/ethers-rs#cca3fcec9358808816b31fdaa35afa6f30b03b52"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -4798,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac21094817e231b55e691c925262bb0658894d0760ea1163e981885247b7cd02"
+checksum = "3f01d0d76a6e080f1c6fc1a00f5095fa90704f32797f9189fbcb67a10e675329"
 dependencies = [
  "build_const",
  "hex",
@@ -5057,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -5286,9 +5286,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -135,6 +135,12 @@ impl ProjectCompiler {
     {
         let ProjectCompiler { print_sizes, print_names } = self;
 
+        if !project.paths.has_input_files() {
+            println!("Nothing to compile");
+            // nothing to do here
+            std::process::exit(0);
+        }
+
         let now = std::time::Instant::now();
         tracing::trace!(target : "forge::compile", "start compiling project");
 

--- a/cli/tests/fixtures/warn_no_tests.stdout
+++ b/cli/tests/fixtures/warn_no_tests.stdout
@@ -1,3 +1,5 @@
-No files changed, compilation skipped
+Compiling 1 files with 0.8.13
+Solc 0.8.13 
+Compiler run successful
 
 No tests found in project! Forge looks for functions that starts with `test`.

--- a/cli/tests/fixtures/warn_no_tests_match.stdout
+++ b/cli/tests/fixtures/warn_no_tests_match.stdout
@@ -1,4 +1,6 @@
-No files changed, compilation skipped
+Compiling 1 files with 0.8.13
+Solc 0.8.13 
+Compiler run successful
 
 No tests match the provided pattern:
 	match-test: `testA.*`

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -34,7 +34,18 @@ forgetest!(can_set_filter_values, |prj: TestProject, mut cmd: TestCommand| {
 });
 
 // tests that warning is displayed when there are no tests in project
-forgetest!(warn_no_tests, |_prj: TestProject, mut cmd: TestCommand| {
+forgetest!(warn_no_tests, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "dummy",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.13;
+
+contract Dummy {}
+"#,
+        )
+        .unwrap();
     // set up command
     cmd.args(["test"]);
 
@@ -45,7 +56,19 @@ forgetest!(warn_no_tests, |_prj: TestProject, mut cmd: TestCommand| {
 });
 
 // tests that warning is displayed with pattern when no tests match
-forgetest!(warn_no_tests_match, |_prj: TestProject, mut cmd: TestCommand| {
+forgetest!(warn_no_tests_match, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "dummy",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.13;
+
+contract Dummy {}
+"#,
+        )
+        .unwrap();
+
     // set up command
     cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
     cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

~~Blocked by https://github.com/gakonst/ethers-rs/pull/1480~~ bumped ethers

## Motivation

`forge build` can be executed in any dir and it will call `Project::compile` regardless.

running on a regular dir (with no sol files) will output:

```
forge build
[⠊] Compiling...
No files changed, compilation skipped
```

this will handle the case if there are no sol files in the entire project and exit early with

`Nothing to compile`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
