### PR TITLE
ci(docker): improve docker build time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,8 @@
 name: Build and Publish Docker
 
 on: 
-  workflow_dispatch:
+  # Trigger without any parameters a proactive rebuild 
+  workflow_dispatch: {}
   workflow_call:
 
 env:
@@ -10,21 +11,33 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  container:
 
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
     permissions:
-      contents: read
+      id-token: write
       packages: write
+      contents: read
     timeout-minutes: 60
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Install Docker BuildX
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v1.14.1
+      # Ensure this doesn't trigger on PR's
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,7 +47,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3.6.2
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -64,11 +77,17 @@ jobs:
 
       # Build and push Docker image
       # https://github.com/docker/build-push-action
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md
       - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
           tags: ${{ steps.docker_tagging.outputs.docker_tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}


### PR DESCRIPTION
updates actions deps
uses cache mount via docker buildx for faster rebuild
enforces permissions for id-token
