### PR TITLE
feat: add env var interpolation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "figment",
  "globset",
  "number_prefix",
+ "once_cell",
  "path-slash",
  "pretty_assertions",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,7 +68,7 @@ itertools = "0.10.3"
 serde = "1.0.133"
 proptest = "1.0.0"
 semver = "1.0.5"
-once_cell = "1.9.0"
+once_cell = "1.13"
 similar = { version = "2.1.0", features = ["inline"] }
 strsim = "0.10.0"
 bytes = "1.1.0"

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -14,7 +14,7 @@ ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features =
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 walkdir = "2.3.2"
-once_cell = "1.9.0"
+once_cell = "1.13"
 foundry-config = { path = "../../config" }
 serde_json = "1.0.67"
 parking_lot = "0.12.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.5.5"
 semver = { version = "1.0.5", features = ["serde"] }
 tracing = "0.1"
 ansi_term = "0.12.1"
+once_cell = "1.13"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.2.0"

--- a/config/README.md
+++ b/config/README.md
@@ -149,14 +149,16 @@ The `rpc_endpoints` value accepts a list of `alias = "<url|env var>"` pairs.
 
 The following example declares two pairs:
 The alias `optimism` references the endpoint URL directly.
-The alias `mainnet` references the environment variable `RPC_MAINNET` which holds the actual URL.
+The alias `mainnet` references the environment variable `RPC_MAINNET` which holds the entire URL.
+The alias `goerli` references an endpoint that will be interpolated with the value the `GOERLI_API_KEY` holds.
 
 Environment variables need to be wrapped in `${}`
 
 ```toml
 [default.rpc_endpoints]
-optimism = "https://optimism.alchemyapi.io/v2/..."
+optimism = "https://optimism.alchemyapi.io/v2/1234567"
 mainnet = "${RPC_MAINNET}"
+goerli = "https://eth-goerli.alchemyapi.io/v2/${GOERLI_API_KEY}"
 ```
 
 ##### Additional Model Checker settings

--- a/config/src/rpc.rs
+++ b/config/src/rpc.rs
@@ -1,7 +1,13 @@
 //! Support for multiple RPC-endpoints
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeMap, env, env::VarError, fmt, ops::Deref};
+
+/// A regex that matches `${val}` placeholders
+pub static RE_PLACEHOLDER: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?m)(?P<outer>\$\{\s*(?P<inner>.*?)\s*})").unwrap());
 
 /// Container type for rpc endpoints
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -49,7 +55,9 @@ impl Deref for RpcEndpoints {
 pub enum RpcEndpoint {
     /// A raw Url (ws, http)
     Url(String),
-    /// Reference to an env var in the form of `${ENV_VAR}`
+    /// An endpoint that contains at least one `${ENV_VAR}` placeholder
+    ///
+    /// **Note:** this contains the endpoint as is, like `https://eth-mainnet.alchemyapi.io/v2/${API_KEY}` or `${EPC_ENV_VAR}`
     Env(String),
 }
 
@@ -80,10 +88,23 @@ impl RpcEndpoint {
     pub fn resolve(self) -> Result<String, UnresolvedEnvVarError> {
         match self {
             RpcEndpoint::Url(url) => Ok(url),
-            RpcEndpoint::Env(var) => {
-                env::var(&var).map_err(|source| UnresolvedEnvVarError { var, source })
-            }
+            RpcEndpoint::Env(val) => Self::interpolate(&val),
         }
+    }
+
+    /// Replaces all Env var placeholders in the input string with the values they hold
+    pub fn interpolate(input: &str) -> Result<String, UnresolvedEnvVarError> {
+        let mut res = input.to_string();
+
+        // loop over all placeholders in the input and replace them one by one
+        for caps in RE_PLACEHOLDER.captures_iter(input) {
+            let var = &caps["inner"];
+            let value = env::var(var)
+                .map_err(|source| UnresolvedEnvVarError { var: var.to_string(), source })?;
+
+            res = res.replacen(&caps["outer"], &value, 1);
+        }
+        Ok(res)
     }
 }
 
@@ -91,9 +112,7 @@ impl fmt::Display for RpcEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RpcEndpoint::Url(url) => url.fmt(f),
-            RpcEndpoint::Env(var) => {
-                write!(f, "${{{var}}}")
-            }
+            RpcEndpoint::Env(var) => var.fmt(f),
         }
     }
 }
@@ -121,8 +140,8 @@ impl<'de> Deserialize<'de> for RpcEndpoint {
         D: Deserializer<'de>,
     {
         let val = String::deserialize(deserializer)?;
-        let endpoint = if val.starts_with('$') {
-            RpcEndpoint::Env(parse_env_ref(&val))
+        let endpoint = if RE_PLACEHOLDER.is_match(&val) {
+            RpcEndpoint::Env(val)
         } else {
             RpcEndpoint::Url(val)
         };
@@ -137,6 +156,15 @@ pub struct ResolvedRpcEndpoints {
     /// contains all named endpoints and their URL or an error if we failed to resolve the env var
     /// alias
     endpoints: BTreeMap<String, Result<String, UnresolvedEnvVarError>>,
+}
+
+// === impl ResolvedRpcEndpoints ===
+
+impl ResolvedRpcEndpoints {
+    /// Returns true if there's an endpoint that couldn't be resolved
+    pub fn has_unresolved(&self) -> bool {
+        self.endpoints.values().any(|val| val.is_err())
+    }
 }
 
 impl Deref for ResolvedRpcEndpoints {
@@ -168,9 +196,23 @@ impl std::error::Error for UnresolvedEnvVarError {
     }
 }
 
-/// Extracts the value surrounded by `${<val>}`
-///
-/// TODO(mattsse): make this a bit more sophisticated
-fn parse_env_ref(val: &str) -> String {
-    val.trim_start_matches("${").trim_end_matches('}').to_string()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_find_placeholder() {
+        let val = "https://eth-mainnet.alchemyapi.io/v2/346273846238426342";
+        assert!(!RE_PLACEHOLDER.is_match(val));
+
+        let val = "${RPC_ENV}";
+        assert!(RE_PLACEHOLDER.is_match(val));
+
+        let val = "https://eth-mainnet.alchemyapi.io/v2/${API_KEY}";
+        assert!(RE_PLACEHOLDER.is_match(val));
+
+        let cap = RE_PLACEHOLDER.captures(val).unwrap();
+        assert_eq!(cap.name("outer").unwrap().as_str(), "${API_KEY}");
+        assert_eq!(cap.name("inner").unwrap().as_str(), "API_KEY");
+    }
 }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -31,7 +31,7 @@ tracing-error = "0.2.0"
 tokio = { version = "1", features = ["time"] }
 parking_lot = "0.12.0"
 futures = "0.3.21"
-once_cell = "1.9.0"
+once_cell = "1.13"
 
 # EVM
 bytes = "1.1.0"

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = "0.3"
 proptest = "1.0.0"
 rayon = "1.5"
 rlp = "0.5.1"
-once_cell = "1.9.0"
+once_cell = "1.13"
 comfy-table = "6.0.0"
 
 [dev-dependencies]

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -435,7 +435,7 @@ mod tests {
                         .to_string(),
                 ),
             ),
-            ("rpcEnvAlias", RpcEndpoint::Env("RPC_ENV_ALIAS".to_string())),
+            ("rpcEnvAlias", RpcEndpoint::Env("${RPC_ENV_ALIAS}".to_string())),
         ])
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2302

support `rpc_endpoints` like

```
goerli = "https://eth-goerli.alchemyapi.io/v2/${GOERLI_API_KEY}"
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
replace all env var placeholders one by one
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
