### PR TITLE
refactor(cast): --cast-async to --async but keep alias

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -340,7 +340,13 @@ Examples:
             value_name = "CONFIRMATIONS"
         )]
         confirmations: usize,
-        #[clap(long, env = "CAST_ASYNC")]
+        #[clap(
+            long = "async",
+            env = "CAST_ASYNC",
+            name = "async",
+            alias = "cast-async",
+            help = "Exit immediately if the transaction was not found."
+        )]
         cast_async: bool,
         #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
@@ -361,7 +367,13 @@ Examples:
         sig: Option<String>,
         #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
         args: Vec<String>,
-        #[clap(long, env = "CAST_ASYNC")]
+        #[clap(
+            long = "async",
+            env = "CAST_ASYNC",
+            name = "async",
+            alias = "cast-async",
+            help = "Only print the transaction hash and exit immediately."
+        )]
         cast_async: bool,
         #[clap(flatten, next_help_heading = "TRANSACTION OPTIONS")]
         tx: TransactionOpts,
@@ -390,7 +402,13 @@ Examples:
     PublishTx {
         #[clap(help = "The raw transaction", value_name = "RAW_TX")]
         raw_tx: String,
-        #[clap(long, env = "CAST_ASYNC")]
+        #[clap(
+            long = "async",
+            env = "CAST_ASYNC",
+            name = "async",
+            alias = "cast-async",
+            help = "Only print the transaction hash and exit immediately."
+        )]
         cast_async: bool,
         // FIXME: We only need the RPC URL and `--flashbots` options from this.
         #[clap(flatten)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2338

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* use `--async`, but keep `--cast-async` alias
* document flag

```
        --async
            Only print the transaction hash and exit immediately.

```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
