### PR TITLE
feat(config): impl fastrlp traits for Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "ethers-core",
  "ethers-solc",
  "eyre",
+ "fastrlp",
  "figment",
  "globset",
  "number_prefix",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -28,6 +28,9 @@ dirs-next = "2.0.0"
 globset = "0.4.8"
 walkdir = "2.3.2"
 
+# encoding
+fastrlp = { version = "0.1.2" }
+
 # misc
 eyre = "0.6.5"
 regex = "1.5.5"


### PR DESCRIPTION
# Motivation

We should be able to include `Chain` in types that need to be sent over the wire.

# Solution

 * Derive `Hash` for `Chain`
 * Encode and decode `Chain` as a RLP `u64`