### PR TITLE
feat(anvil): impl TypedTransaction fastrlp traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,9 @@ dependencies = [
 name = "anvil-core"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "ethers-core",
+ "fastrlp",
  "foundry-evm",
  "hash-db",
  "hash256-std-hasher",

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -11,6 +11,8 @@ foundry-evm = { path = "../../evm" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+bytes = { version = "1.1" }
+fastrlp = { version = "0.1.2" }
 
 # trie
 hash-db = { version = "0.15", default-features = false }


### PR DESCRIPTION
## Motivation

Implementing these traits will allow `TypedTransaction` to be encoded / decoded from RLP bytes, and allow `fastrlp` traits to be derived on types which contain a `TypedTransaction`.

## Solution

 * impl `fastrlp::Encodable` and `fastrlp::Decodable` for `TypedTransaction`
 * non-legacy transactions are encoded and decoded with a RLP string header
 * add encoding and decoding tests
