### PR TITLE
feat(anvil): impl fastrlp traits for Block

### DIFF
--- a/anvil/core/src/eth/block.rs
+++ b/anvil/core/src/eth/block.rs
@@ -10,6 +10,10 @@ use ethers_core::{
         rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream},
     },
 };
+use fastrlp::{
+    length_of_length, Decodable as FastDecodable, Encodable as FastEncodable, RlpDecodable,
+    RlpEncodable,
+};
 use serde::{Deserialize, Serialize};
 
 /// Container type that gathers all block data
@@ -21,7 +25,7 @@ pub struct BlockInfo {
 }
 
 /// ethereum block
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, RlpEncodable, RlpDecodable)]
 pub struct Block {
     pub header: Header,
     pub transactions: Vec<TypedTransaction>,
@@ -113,6 +117,30 @@ impl Header {
     pub fn hash(&self) -> H256 {
         H256::from_slice(keccak256(&rlp::encode(self)).as_slice())
     }
+
+    /// Returns the rlp length of the Header body, _not including_ trailing EIP155 fields or the
+    /// rlp list header
+    /// To get the length including the rlp list header, refer to the Encodable implementation.
+    pub(crate) fn header_payload_length(&self) -> usize {
+        let mut length = 0;
+        length += self.parent_hash.length();
+        length += self.ommers_hash.length();
+        length += self.beneficiary.length();
+        length += self.state_root.length();
+        length += self.transactions_root.length();
+        length += self.receipts_root.length();
+        length += self.logs_bloom.length();
+        length += self.difficulty.length();
+        length += self.number.length();
+        length += self.gas_limit.length();
+        length += self.gas_used.length();
+        length += self.timestamp.length();
+        length += self.extra_data.length();
+        length += self.mix_hash.length();
+        length += self.nonce.length();
+        length += self.base_fee_per_gas.map(|fee| fee.length()).unwrap_or_default();
+        length
+    }
 }
 
 impl rlp::Encodable for Header {
@@ -158,12 +186,79 @@ impl rlp::Decodable for Header {
             mix_hash: rlp.val_at(13)?,
             nonce: rlp.val_at(14)?,
             base_fee_per_gas: if let Ok(base_fee) = rlp.at(15) {
-                Some(U256::decode(&base_fee)?)
+                Some(<U256 as Decodable>::decode(&base_fee)?)
             } else {
                 None
             },
         };
         Ok(result)
+    }
+}
+
+impl fastrlp::Encodable for Header {
+    fn length(&self) -> usize {
+        // add each of the fields' rlp encoded lengths
+        let mut length = 0;
+        length += self.header_payload_length();
+        length += length_of_length(length);
+
+        length
+    }
+
+    fn encode(&self, out: &mut dyn fastrlp::BufMut) {
+        let list_header =
+            fastrlp::Header { list: true, payload_length: self.header_payload_length() };
+        list_header.encode(out);
+        self.parent_hash.encode(out);
+        self.ommers_hash.encode(out);
+        self.beneficiary.encode(out);
+        self.state_root.encode(out);
+        self.transactions_root.encode(out);
+        self.receipts_root.encode(out);
+        self.logs_bloom.encode(out);
+        self.difficulty.encode(out);
+        self.number.encode(out);
+        self.gas_limit.encode(out);
+        self.gas_used.encode(out);
+        self.timestamp.encode(out);
+        self.extra_data.encode(out);
+        self.mix_hash.encode(out);
+        self.nonce.encode(out);
+        if let Some(base_fee_per_gas) = self.base_fee_per_gas {
+            base_fee_per_gas.encode(out);
+        }
+    }
+}
+
+impl fastrlp::Decodable for Header {
+    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
+        // slice out the rlp list header
+        let header = fastrlp::Header::decode(buf)?;
+        let start_len = buf.len();
+
+        Ok(Header {
+            parent_hash: <H256 as FastDecodable>::decode(buf)?,
+            ommers_hash: <H256 as FastDecodable>::decode(buf)?,
+            beneficiary: <Address as FastDecodable>::decode(buf)?,
+            state_root: <H256 as FastDecodable>::decode(buf)?,
+            transactions_root: <H256 as FastDecodable>::decode(buf)?,
+            receipts_root: <H256 as FastDecodable>::decode(buf)?,
+            logs_bloom: <Bloom as FastDecodable>::decode(buf)?,
+            difficulty: <U256 as FastDecodable>::decode(buf)?,
+            number: <U256 as FastDecodable>::decode(buf)?,
+            gas_limit: <U256 as FastDecodable>::decode(buf)?,
+            gas_used: <U256 as FastDecodable>::decode(buf)?,
+            timestamp: <u64 as FastDecodable>::decode(buf)?,
+            extra_data: <Bytes as FastDecodable>::decode(buf)?,
+            mix_hash: <H256 as FastDecodable>::decode(buf)?,
+            nonce: <H64 as FastDecodable>::decode(buf)?,
+            base_fee_per_gas: if start_len - header.payload_length < buf.len() {
+                // if there is leftover data in the payload, decode the base fee
+                Some(<U256 as FastDecodable>::decode(buf)?)
+            } else {
+                None
+            },
+        })
     }
 }
 
@@ -209,6 +304,13 @@ impl From<Header> for PartialHeader {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use ethers_core::{
+        types::H160,
+        utils::{hex, hex::FromHex},
+    };
+
     use super::*;
 
     #[test]
@@ -241,5 +343,111 @@ mod tests {
         let encoded = rlp::encode(&header);
         let decoded: Header = rlp::decode(encoded.as_ref()).unwrap();
         assert_eq!(header, decoded);
+    }
+
+    #[test]
+    fn header_fastrlp_roundtrip() {
+        let mut header = Header {
+            parent_hash: Default::default(),
+            ommers_hash: Default::default(),
+            beneficiary: Default::default(),
+            state_root: Default::default(),
+            transactions_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: Default::default(),
+            difficulty: Default::default(),
+            number: 124u64.into(),
+            gas_limit: Default::default(),
+            gas_used: 1337u64.into(),
+            timestamp: 0,
+            extra_data: Default::default(),
+            mix_hash: Default::default(),
+            nonce: H64::from_low_u64_be(99u64),
+            base_fee_per_gas: None,
+        };
+
+        let mut encoded = vec![];
+        <Header as fastrlp::Encodable>::encode(&header, &mut encoded);
+        let decoded: Header =
+            <Header as fastrlp::Decodable>::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(header, decoded);
+
+        header.base_fee_per_gas = Some(12345u64.into());
+
+        encoded.clear();
+        <Header as fastrlp::Encodable>::encode(&header, &mut encoded);
+        let decoded: Header =
+            <Header as fastrlp::Decodable>::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(header, decoded);
+    }
+
+    #[test]
+    // Test vector from: https://eips.ethereum.org/EIPS/eip-2481
+    fn test_encode_block_header() {
+        let expected = hex::decode("f901f9a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000940000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008208ae820d0582115c8215b3821a0a827788a00000000000000000000000000000000000000000000000000000000000000000880000000000000000").unwrap();
+        let mut data = vec![];
+        let header = Header {
+            parent_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            ommers_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            beneficiary: H160::from_str("0000000000000000000000000000000000000000").unwrap(),
+            state_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            transactions_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            receipts_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            logs_bloom: <[u8; 256]>::from_hex("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().into(),
+            difficulty: 0x8aeu64.into(),
+            number: 0xd05u64.into(),
+            gas_limit: 0x115cu64.into(),
+            gas_used: 0x15b3u64.into(),
+            timestamp: 0x1a0au64,
+            extra_data: hex::decode("7788").unwrap().into(),
+            mix_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            nonce: H64::from_low_u64_be(0x0),
+            base_fee_per_gas: None,
+        };
+        header.encode(&mut data);
+        assert_eq!(hex::encode(&data), hex::encode(expected));
+        assert_eq!(header.length(), data.len());
+    }
+
+    #[test]
+    // Test vector from: https://eips.ethereum.org/EIPS/eip-2481
+    fn test_decode_block_header() {
+        let data = hex::decode("f901f9a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000940000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008208ae820d0582115c8215b3821a0a827788a00000000000000000000000000000000000000000000000000000000000000000880000000000000000").unwrap();
+        let expected = Header {
+            parent_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            ommers_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            beneficiary: H160::from_str("0000000000000000000000000000000000000000").unwrap(),
+            state_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            transactions_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            receipts_root: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            logs_bloom: <[u8; 256]>::from_hex("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().into(),
+            difficulty: 0x8aeu64.into(),
+            number: 0xd05u64.into(),
+            gas_limit: 0x115cu64.into(),
+            gas_used: 0x15b3u64.into(),
+            timestamp: 0x1a0au64,
+            extra_data: hex::decode("7788").unwrap().into(),
+            mix_hash: H256::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            nonce: H64::from_low_u64_be(0x0),
+            base_fee_per_gas: None,
+        };
+        let header = <Header as fastrlp::Decodable>::decode(&mut data.as_slice()).unwrap();
+        assert_eq!(header, expected);
+    }
+
+    #[test]
+    // Test vector from network
+    fn block_network_fastrlp_roundtrip() {
+        let data = hex::decode("f9034df90348a0fbdbd8d2d0ac5f14bd5fa90e547fe6f1d15019c724f8e7b60972d381cd5d9cf8a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d4934794c9577e7945db22e38fc060909f2278c7746b0f9ba05017cfa3b0247e35197215ae8d610265ffebc8edca8ea66d6567eb0adecda867a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018355bb7b871fffffffffffff808462bd0e1ab9014bf90148a00000000000000000000000000000000000000000000000000000000000000000f85494319fa8f1bc4e53410e92d10d918659b16540e60a945a573efb304d04c1224cd012313e827eca5dce5d94a9c831c5a268031176ebf5f3de5051e8cba0dbfe94c9577e7945db22e38fc060909f2278c7746b0f9b808400000000f8c9b841a6946f2d16f68338cbcbd8b117374ab421128ce422467088456bceba9d70c34106128e6d4564659cf6776c08a4186063c0a05f7cffd695c10cf26a6f301b67f800b8412b782100c18c35102dc0a37ece1a152544f04ad7dc1868d18a9570f744ace60870f822f53d35e89a2ea9709ccbf1f4a25ee5003944faa845d02dde0a41d5704601b841d53caebd6c8a82456e85c2806a9e08381f959a31fb94a77e58f00e38ad97b2e0355b8519ab2122662cbe022f2a4ef7ff16adc0b2d5dcd123181ec79705116db300a063746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365880000000000000000c0c0").unwrap();
+
+        let block = <Block as fastrlp::Decodable>::decode(&mut data.as_slice()).unwrap();
+
+        // encode and check that it matches the original data
+        let mut encoded = Vec::new();
+        block.encode(&mut encoded);
+        assert_eq!(data, encoded);
+
+        // check that length of encoding is the same as the output of `length`
+        assert_eq!(block.length(), encoded.len());
     }
 }


### PR DESCRIPTION
## Motivation

Implementing these traits will allow `Block` and `Header` to be encoded / decoded from RLP bytes, and allow `fastrlp` traits to be derived on types which contain a `Block` or `Header`.

## Solution

 * impl `fastrlp::Encodable` and `fastrlp::Decodable` for `Header`
 * derive `fastrlp::Encodable` and `fastrlp::Decodable` for `Block`
 * add tests for `Header` encoding and decoding
 * add roundtrip test for `Block` using network data