### PR TITLE
feat(create): add --unlock for sending with unlocked account

### DIFF
--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -101,7 +101,7 @@ impl EthereumOpts {
                 .or_else(|| self.wallet.mnemonic().transpose())
                 .or_else(|| self.wallet.keystore().transpose())
                 .transpose()?
-                .ok_or_else(|| eyre::eyre!("error accessing local wallet, did you set a private key, mnemonic or keystore? Run `cast send --help` or `forge create --help` and use the corresponding CLI flag to set your key via --private-key, --mnemonic-path, --interactive, --trezor or --ledger. Alternatively, if you're using a local node with unlocked accounts, set the `ETH_FROM` environment variable to the address of the account you want to use"))?;
+                .ok_or_else(|| eyre::eyre!("error accessing local wallet, did you set a private key, mnemonic or keystore? Run `cast send --help` or `forge create --help` and use the corresponding CLI flag to set your key via --private-key, --mnemonic-path, --interactive, --trezor or --ledger. Alternatively, if you're using a local node with unlocked accounts, use the --unlocked flag and set the `ETH_FROM` environment variable to the address of the unlocked account you want to use"))?;
 
             let local = local.with_chain_id(chain_id.as_u64());
 

--- a/cli/tests/fixtures/can_create_using_unlocked-2nd.stdout
+++ b/cli/tests/fixtures/can_create_using_unlocked-2nd.stdout
@@ -1,0 +1,4 @@
+No files changed, compilation skipped
+Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+Transaction hash: 0x895cf3bea47e1c1aa71924e954ee22bb8c5aa7cd7c0162cd3718ba7a4763a11e

--- a/cli/tests/fixtures/can_create_using_unlocked.stdout
+++ b/cli/tests/fixtures/can_create_using_unlocked.stdout
@@ -1,0 +1,6 @@
+Compiling 9 files with 0.8.15
+Solc 0.8.15 finished in 1.95s
+Compiler run successful
+Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
+Transaction hash: 0xbab43c05b6afb9f987ea7c3b83a73dba260cd3419cd21c7c8d7072001abb09f5

--- a/cli/tests/it/create.rs
+++ b/cli/tests/it/create.rs
@@ -174,3 +174,38 @@ forgetest_async!(
         );
     }
 );
+
+// tests that we can deploy the template contract
+forgetest_async!(can_create_using_unlocked, |prj: TestProject, mut cmd: TestCommand| async move {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let dev = handle.dev_accounts().next().unwrap();
+    cmd.args(["init", "--force"]);
+    cmd.assert_non_empty_stdout();
+
+    // explicitly byte code hash for consistent checks
+    let config = Config { bytecode_hash: BytecodeHash::None, ..Default::default() };
+    prj.write_config(config);
+
+    cmd.forge_fuse().args([
+        "create",
+        "./src/Contract.sol:Contract",
+        "--use",
+        "solc:0.8.15",
+        "--rpc-url",
+        rpc.as_str(),
+        "--from",
+        format!("{:?}", dev).as_str(),
+        "--unlocked",
+    ]);
+
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_create_using_unlocked.stdout"),
+    );
+
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_create_using_unlocked-2nd.stdout"),
+    );
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2337
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `--unlocked` flag that allows sending with `eth_sendTransaction` if `ETH_FROM` is set
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
