### PR TITLE
Nit: fix doc comment in "forge/install.rs"

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -1,4 +1,4 @@
-//! Create command
+//! Install command
 use crate::{
     cmd::Cmd,
     opts::forge::Dependency,


### PR DESCRIPTION
## Motivation

The doc comment in `cmd/forge/install.rs` is incorrectly referring to the "Create command":

https://github.com/foundry-rs/foundry/blob/649d7ff42489dd993fa50d094fac8a81710587eb/cli/src/cmd/forge/install.rs#L1

## Solution

Change the comment to "Install command".