### PR TITLE
Fix anon events tracing and expects

### DIFF
--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -300,6 +300,11 @@ impl CallTraceDecoder {
 
     async fn decode_event(&self, log: &mut RawOrDecodedLog) {
         if let RawOrDecodedLog::Raw(raw_log) = log {
+            // do not attempt decoding if no topics
+            if raw_log.topics.is_empty() {
+                return
+            }
+
             let mut events = vec![];
             if let Some(evs) = self.events.get(&(raw_log.topics[0], raw_log.topics.len() - 1)) {
                 events = evs.clone();


### PR DESCRIPTION
Fixes https://github.com/foundry-rs/foundry/issues/2206

## Motivation

Topics can be empty, so naked `topics[0]` accesses can panic.

## Solution

Check if topics exist before trying to access `topic[0]`
