### PR TITLE
feat(anvil): add eth_getBlocksByArray

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -61,6 +61,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_getBlockByNumber")]
     EthGetBlockByNumber(#[serde(deserialize_with = "lenient_block_number")] BlockNumber, bool),
 
+    #[serde(rename = "eth_getBlocksByArray")]
+    EthGetBlocksByArray(#[serde(deserialize_with = "lenient_block_number_array")] Vec<BlockNumber>),
+
     #[serde(rename = "eth_getTransactionCount")]
     EthGetTransactionCount(Address, Option<BlockId>),
 

--- a/anvil/core/src/eth/serde_helpers.rs
+++ b/anvil/core/src/eth/serde_helpers.rs
@@ -115,6 +115,15 @@ where
     Ok(num)
 }
 
+pub fn lenient_block_number_array<'de, D>(deserializer: D) -> Result<Vec<BlockNumber>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let num =
+        <[Vec<LenientBlockNumber>; 1]>::deserialize(deserializer)?.into_iter().next().unwrap().into_iter().map(Into::into).collect();
+    Ok(num)
+}
+
 /// Wrapper type that ensures the type is named `params`
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Params<T: Default> {

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -162,6 +162,9 @@ impl EthApi {
                     self.block_by_number(num).await.to_rpc_result()
                 }
             }
+            EthRequest::EthGetBlocksByArray(nums) => {
+                self.blocks_by_array(nums).await.to_rpc_result()
+            }
             EthRequest::EthGetTransactionCount(addr, block) => {
                 self.transaction_count(addr, block).await.to_rpc_result()
             }
@@ -488,6 +491,25 @@ impl EthApi {
             return Ok(self.pending_block_full())
         }
         self.backend.block_by_number_full(number).await
+    }
+
+    /// Returns blocks with given numbers array.
+    ///
+    /// Handler for ETH RPC call: `eth_getBlocksByArray`
+    pub async fn blocks_by_array(
+        &self,
+        numbers: Vec<BlockNumber>,
+    ) -> Result<Option<Vec<Block<Transaction>>>> {
+        node_info!("eth_getBlocksByArray");
+
+        let mut blocks: Vec<Block<Transaction>> = Vec::new();
+        for number in numbers {
+            if let Some(block) = self.block_by_number_full(number).await? {
+                blocks.push(block);
+            }
+        }
+
+        Ok(Some(blocks))
     }
 
     /// Returns the number of transactions sent from given address at given time (block number).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Adds RPC method as mentioned in #2405.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. registers `eth_getBlocksByArray` request in anvil/core/src/eth/mod.rs
2. adds `lenient_block_number_array` to parse block number array in `anvil/core/src/eth/serde_helpers.rs`.
3. adds `blocks_by_array` that fetches full blocks serially atm.

### TODO

- [ ] Look into fetching the blocks in parallel. Tried to follow [rust docs](https://rust-lang.github.io/async-book/06_multiple_futures/01_chapter.html), still confused how it can be done in a Promise.all kind of fashion.
- [ ] Include logs if needed