### PR TITLE
docs: explain `offline` check in `ensure_solc`

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -575,7 +575,7 @@ impl Config {
     /// Ensures that the configured version is installed if explicitly set
     ///
     /// If `solc` is [`SolcReq::Version`] then this will download and install the solc version if
-    /// it's missing.
+    /// it's missing, unless the `offline` flag is enabled, in which case an error is thrown.
     ///
     /// If `solc` is [`SolcReq::Local`] then this will ensure that the path exists.
     fn ensure_solc(&self) -> Result<Option<Solc>, SolcError> {


### PR DESCRIPTION
https://github.com/foundry-rs/foundry/commit/585e59e76b032b031faa8354f11bf2ff111cdd41 fixed #2412, but didn't update the docs for `ensure_solc` function to explain what happens now when the `offline` flag is enabled.