### PR TITLE
Add "multibuild" subcommand to Forge

### DIFF
--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -49,17 +49,6 @@ pub struct CoreBuildArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignored_error_codes: Vec<u64>,
 
-    #[clap(help_heading = "COMPILER OPTIONS", help = "Do not auto-detect solc.", long)]
-    #[serde(skip)]
-    pub no_auto_detect: bool,
-
-    /// Specify the solc version, or a path to a local solc, to build with.
-    ///
-    /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
-    #[clap(help_heading = "COMPILER OPTIONS", value_name = "SOLC_VERSION", long = "use")]
-    #[serde(skip)]
-    pub use_solc: Option<String>,
-
     #[clap(
         help_heading = "COMPILER OPTIONS",
         help = "Do not access the network.",
@@ -125,8 +114,8 @@ impl CoreBuildArgs {
     /// Returns the `Project` for the current workspace
     ///
     /// This loads the `foundry_config::Config` for the current workspace (see
-    /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
-    /// [`foundry_config::Config::project()`]
+    /// [`utils::find_project_root_path`]) and merges the cli `BuildArgs` into it before
+    /// returning [`foundry_config::Config::project()`]
     pub fn project(&self) -> eyre::Result<Project> {
         let config: Config = self.into();
         Ok(config.project()?)
@@ -187,14 +176,6 @@ impl Provider for CoreBuildArgs {
         let value = Value::serialize(self)?;
         let error = InvalidType(value.to_actual(), "map".into());
         let mut dict = value.into_dict().ok_or(error)?;
-
-        if self.no_auto_detect {
-            dict.insert("auto_detect_solc".to_string(), false.into());
-        }
-
-        if let Some(ref solc) = self.use_solc {
-            dict.insert("solc".to_string(), solc.trim_start_matches("solc:").into());
-        }
 
         if self.offline {
             dict.insert("offline".to_string(), true.into());

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -24,6 +24,9 @@ pub use self::core::CoreBuildArgs;
 mod paths;
 pub use self::paths::ProjectPathsArgs;
 
+mod solc;
+pub use self::solc::SolcArgs;
+
 // All `forge build` related arguments
 //
 // CLI arguments take the highest precedence in the Config/Figment hierarchy.
@@ -49,6 +52,10 @@ pub struct BuildArgs {
     #[clap(flatten)]
     #[serde(flatten)]
     pub args: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "SOLC OPTIONS")]
+    #[serde(flatten)]
+    pub solc: SolcArgs,
 
     #[clap(help = "Print compiled contract names.", long = "names")]
     #[serde(skip)]
@@ -80,8 +87,8 @@ impl BuildArgs {
     /// Returns the `Project` for the current workspace
     ///
     /// This loads the `foundry_config::Config` for the current workspace (see
-    /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
-    /// [`foundry_config::Config::project()`]
+    /// [`utils::find_project_root_path`]) and merges the cli `BuildArgs` into it before
+    /// returning [`foundry_config::Config::project()`]
     pub fn project(&self) -> eyre::Result<Project> {
         self.args.project()
     }

--- a/cli/src/cmd/forge/build/solc.rs
+++ b/cli/src/cmd/forge/build/solc.rs
@@ -1,0 +1,47 @@
+use clap::Parser;
+use foundry_config::{
+    figment::{
+        error::Kind::InvalidType,
+        value::{Dict, Map, Value},
+        Error, Metadata, Profile, Provider,
+    },
+    Config,
+};
+use serde::Serialize;
+
+/// Solc-specific build arguments used by multiple subcommands.
+#[derive(Debug, Clone, Parser, Serialize, Default)]
+pub struct SolcArgs {
+    #[clap(help_heading = "COMPILER OPTIONS", help = "Do not auto-detect solc.", long)]
+    #[serde(skip)]
+    pub no_auto_detect: bool,
+
+    /// Specify the solc version, or a path to a local solc, to build with.
+    ///
+    /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+    #[clap(help_heading = "COMPILER OPTIONS", value_name = "SOLC_VERSION", long = "use")]
+    #[serde(skip)]
+    pub use_solc: Option<String>,
+}
+
+impl Provider for SolcArgs {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("Solc Args Provider")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        let value = Value::serialize(self)?;
+        let error = InvalidType(value.to_actual(), "map".into());
+        let mut dict = value.into_dict().ok_or(error)?;
+
+        if self.no_auto_detect {
+            dict.insert("auto_detect_solc".to_string(), false.into());
+        }
+
+        if let Some(ref solc) = self.use_solc {
+            dict.insert("solc".to_string(), solc.trim_start_matches("solc:").into());
+        }
+
+        Ok(Map::from([(Config::selected_profile(), dict)]))
+    }
+}

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -1,7 +1,10 @@
 //! Coverage command
 use crate::{
     cmd::{
-        forge::{build::CoreBuildArgs, test::Filter},
+        forge::{
+            build::{CoreBuildArgs, SolcArgs},
+            test::Filter,
+        },
         Cmd,
     },
     compile::ProjectCompiler,
@@ -49,6 +52,9 @@ pub struct CoverageArgs {
 
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
     opts: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "SOLC OPTIONS")]
+    solc: SolcArgs,
 }
 
 impl CoverageArgs {

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -1,7 +1,10 @@
 //! Create command
 use super::verify;
 use crate::{
-    cmd::{forge::build::CoreBuildArgs, utils, RetryArgs},
+    cmd::{
+        forge::build::{CoreBuildArgs, SolcArgs},
+        utils, RetryArgs,
+    },
     compile,
     opts::{EthereumOpts, TransactionOpts, WalletType},
     utils::get_http_provider,
@@ -58,6 +61,9 @@ pub struct CreateArgs {
 
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
     opts: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "SOLC OPTIONS")]
+    solc: SolcArgs,
 
     #[clap(flatten, next_help_heading = "TRANSACTION OPTIONS")]
     tx: TransactionOpts,

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -1,4 +1,8 @@
-use super::{build::BuildArgs, script::ScriptArgs, watch::WatchArgs};
+use super::{
+    build::{BuildArgs, SolcArgs},
+    script::ScriptArgs,
+    watch::WatchArgs,
+};
 use crate::{
     cmd::forge::{build::CoreBuildArgs, create::RETRY_VERIFY_ON_CREATE},
     opts::MultiWallet,
@@ -38,6 +42,9 @@ pub struct DebugArgs {
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
     pub opts: CoreBuildArgs,
 
+    #[clap(flatten, next_help_heading = "SOLC OPTIONS")]
+    pub solc: SolcArgs,
+
     #[clap(flatten, next_help_heading = "EVM OPTIONS")]
     pub evm_opts: EvmArgs,
 }
@@ -55,6 +62,7 @@ impl DebugArgs {
                 args: self.opts,
                 names: false,
                 sizes: false,
+                solc: SolcArgs { no_auto_detect: false, use_solc: None },
                 watch: WatchArgs::default(),
             },
             wallets: MultiWallet::default(),

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -31,14 +31,13 @@ impl Cmd for FlattenArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let FlattenArgs { target_path, output, project_paths } = self;
 
-        // flatten is a subset of `BuildArgs` so we can reuse that to get the config
+        // flatten is a subset of `CoreBuildArgs` so we can reuse that to get the config
         let build_args = CoreBuildArgs {
             project_paths,
             out_path: Default::default(),
             compiler: Default::default(),
             ignored_error_codes: vec![],
-            no_auto_detect: false,
-            use_solc: None,
+
             offline: false,
             force: false,
             libraries: vec![],

--- a/cli/src/cmd/forge/mod.rs
+++ b/cli/src/cmd/forge/mod.rs
@@ -50,6 +50,7 @@ pub mod fourbyte;
 pub mod init;
 pub mod inspect;
 pub mod install;
+pub mod multibuild;
 pub mod remappings;
 pub mod remove;
 pub mod script;

--- a/cli/src/cmd/forge/multibuild.rs
+++ b/cli/src/cmd/forge/multibuild.rs
@@ -1,0 +1,100 @@
+//! multibuild command
+
+use crate::{
+    cmd::{forge::build::CoreBuildArgs, Cmd},
+    compile::ProjectCompiler,
+};
+use clap::Parser;
+use ethers::solc::{Project, RELEASES};
+use foundry_config::{Config, SolcReq};
+use semver::Version;
+use serde::Serialize;
+
+/// Command for building with multiple Solidity versions
+#[derive(Clone, Debug, Default, Parser, Serialize)]
+pub struct MultibuildArgs {
+    /// The Solidity version from which to build.
+    ///
+    /// Valid values are in the format `x.y.z`.
+    #[clap(long, value_name = "SOLC_VERSION")]
+    #[serde(skip)]
+    from: String,
+
+    /// The Solidity version up to which to build. Must be greater than or equal to `from`.
+    ///
+    /// Valid values are in the format `x.y.z`.
+    #[clap(long, value_name = "SOLC_VERSION")]
+    #[serde(skip)]
+    to: String,
+
+    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    opts: CoreBuildArgs,
+}
+
+impl MultibuildArgs {
+    /// Returns the flattened [`CoreBuildArgs`]
+    pub fn build_args(&self) -> &CoreBuildArgs {
+        &self.opts
+    }
+
+    /// Returns the `Project` for the current workspace.
+    ///
+    /// This loads the `foundry_config::Config` for the current workspace (see
+    /// [`utils::find_project_root_path`]) merges the cli `BuildArgs` into it, sets the provided
+    /// `solc`, and finally it returns [`foundry_config::Config::project()`]
+    pub fn project(&self, solc: SolcReq) -> eyre::Result<Project> {
+        let mut config: Config = self.build_args().into();
+        config.solc = Some(solc);
+        Ok(config.project()?)
+    }
+}
+
+impl Cmd for MultibuildArgs {
+    type Output = ();
+
+    fn run(self) -> eyre::Result<Self::Output> {
+        if !RELEASES.2 {
+            return Err(eyre::eyre!(
+                "Unknown error occurred while accessing the Solidity version list"
+            ))
+        }
+
+        // Get the sorted list of all Solidity versions.
+        let versions: &Vec<Version> = &RELEASES.1;
+
+        // Get the index for `from`.
+        let from_index: usize = versions
+            .iter()
+            .position(|v| v.to_string() == self.from)
+            .ok_or_else(|| eyre::eyre!("{} is not a valid Solidity version", self.from))?;
+
+        // Get the index for `to`.
+        let to_index: usize = versions
+            .iter()
+            .position(|v| v.to_string() == self.to)
+            .ok_or_else(|| eyre::eyre!("{} is not a valid Solidity version", self.to))?;
+
+        // `to` must be greater than or equal to `from`.
+        if from_index > to_index {
+            return Err(eyre::eyre!(
+                "The `to` version must be greater than or equal to the `from` version"
+            ))
+        }
+
+        // Run the "build" command over the provided range of Solidity versions. The `try_for_each`
+        // iterator applies a fallible function and stops at the first error, returning it,
+        // if it encounters one.
+        let compiler = ProjectCompiler::default();
+        let mut range = from_index..=to_index;
+        range.try_for_each(|i| -> eyre::Result<_> {
+            let project = self.project(SolcReq::Version(versions[i].clone()))?;
+            compiler.compile(&project)?;
+            if i != to_index {
+                println!();
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -1,7 +1,11 @@
 //! Test command
 use crate::{
     cmd::{
-        forge::{build::CoreBuildArgs, debug::DebugArgs, watch::WatchArgs},
+        forge::{
+            build::{CoreBuildArgs, SolcArgs},
+            debug::DebugArgs,
+            watch::WatchArgs,
+        },
         Cmd,
     },
     compile,
@@ -267,6 +271,9 @@ pub struct TestArgs {
 
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
     opts: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "SOLC OPTIONS")]
+    solc: SolcArgs,
 
     #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
     pub watch: WatchArgs,
@@ -538,6 +545,7 @@ pub fn custom_run(args: TestArgs, include_fuzz_tests: bool) -> eyre::Result<Test
                         args: Vec::new(),
                         debug: true,
                         opts: args.opts,
+                        solc: args.solc,
                         evm_opts: args.evm_opts,
                     };
                     utils::block_on(debugger.debug())?;

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -181,7 +181,7 @@ impl VerifyArgs {
         Ok(())
     }
 
-    /// Creates the `VerifyContract` etherescan request in order to verify the contract
+    /// Creates the `VerifyContract` Etherscan request in order to verify the contract
     ///
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
@@ -191,8 +191,6 @@ impl VerifyArgs {
             out_path: Default::default(),
             compiler: Default::default(),
             ignored_error_codes: vec![],
-            no_auto_detect: false,
-            use_solc: None,
             offline: false,
             force: false,
             libraries: self.libraries.clone(),

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -91,6 +91,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Remappings(cmd) => {
             cmd.run()?;
         }
+        Subcommands::Multibuild(cmd) => {
+            cmd.run()?;
+        }
         Subcommands::Init(cmd) => {
             cmd.run()?;
         }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -16,6 +16,7 @@ use crate::cmd::forge::{
     init::InitArgs,
     inspect,
     install::InstallArgs,
+    multibuild::MultibuildArgs,
     remappings::RemappingArgs,
     script::ScriptArgs,
     snapshot, test, tree,
@@ -97,6 +98,12 @@ pub enum Subcommands {
         about = "Get the automatically inferred remappings for the project."
     )]
     Remappings(RemappingArgs),
+
+    #[clap(
+        visible_alias = "mb",
+        about = "Build the project's smart contracts with multiple Solidity versions."
+    )]
+    Multibuild(MultibuildArgs),
 
     #[clap(
         visible_alias = "v",

--- a/cli/tests/fixtures/can_multibuild_equal_versions.stdout
+++ b/cli/tests/fixtures/can_multibuild_equal_versions.stdout
@@ -1,0 +1,3 @@
+Compiling 1 files with 0.8.15
+Solc 0.8.15 finished in 348.12ms
+Compiler run successful

--- a/cli/tests/fixtures/can_multibuild_many_versions.stdout
+++ b/cli/tests/fixtures/can_multibuild_many_versions.stdout
@@ -1,0 +1,91 @@
+Compiling 1 files with 0.7.0
+Solc 0.7.0 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.1
+Solc 0.7.1 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.2
+Solc 0.7.2 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.3
+Solc 0.7.3 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.4
+Solc 0.7.4 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.5
+Solc 0.7.5 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.7.6
+Solc 0.7.6 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.0
+Solc 0.8.0 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.1
+Solc 0.8.1 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.2
+Solc 0.8.2 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.3
+Solc 0.8.3 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.4
+Solc 0.8.4 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.5
+Solc 0.8.5 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.6
+Solc 0.8.6 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.7
+Solc 0.8.7 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.8
+Solc 0.8.8 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.9
+Solc 0.8.9 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.11
+Solc 0.8.11 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.12
+Solc 0.8.12 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.13
+Solc 0.8.13 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.14
+Solc 0.8.14 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.15
+Solc 0.8.15 finished in 348.12ms
+Compiler run successful

--- a/cli/tests/fixtures/can_multibuild_some_versions.stdout
+++ b/cli/tests/fixtures/can_multibuild_some_versions.stdout
@@ -1,0 +1,23 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.11
+Solc 0.8.11 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.12
+Solc 0.8.12 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.13
+Solc 0.8.13 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.14
+Solc 0.8.14 finished in 348.12ms
+Compiler run successful
+
+Compiling 1 files with 0.8.15
+Solc 0.8.15 finished in 348.12ms
+Compiler run successful

--- a/cli/tests/it/main.rs
+++ b/cli/tests/it/main.rs
@@ -7,6 +7,8 @@ mod config;
 #[cfg(not(feature = "external-integration-tests"))]
 mod create;
 #[cfg(not(feature = "external-integration-tests"))]
+mod multibuild;
+#[cfg(not(feature = "external-integration-tests"))]
 mod script;
 #[cfg(not(feature = "external-integration-tests"))]
 mod test_cmd;

--- a/cli/tests/it/multibuild.rs
+++ b/cli/tests/it/multibuild.rs
@@ -1,0 +1,72 @@
+use foundry_cli_test_utils::{
+    forgetest,
+    util::{OutputExt, TestCommand, TestProject},
+};
+use std::path::PathBuf;
+
+forgetest!(fail_invalid_solidity_version, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.args(["multibuild", "--from", "0.7.100", "--to", "0.8.15"]);
+    cmd.assert_non_empty_stderr();
+});
+
+forgetest!(fail_from_greater_than_to, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.args(["multibuild", "--from", "0.8.15", "--to", "0.8.14"]);
+    cmd.assert_non_empty_stderr();
+
+    cmd.args(["multibuild", "--from", "0.8.0", "--to", "0.7.6"]);
+    cmd.assert_non_empty_stderr();
+});
+
+forgetest!(can_multibuild_equal_versions, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.15;
+contract Foo {}
+"#,
+        )
+        .unwrap();
+    cmd.args(["multibuild", "--from", "0.8.15", "--to", "0.8.15"]);
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_multibuild_equal_versions.stdout"),
+    );
+});
+
+forgetest!(can_multibuild_some_versions, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10 <=0.9.0;
+contract Foo {}
+"#,
+        )
+        .unwrap();
+    cmd.args(["multibuild", "--from", "0.8.10", "--to", "0.8.15"]);
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_multibuild_some_versions.stdout"),
+    );
+});
+
+forgetest!(can_multibuild_many_versions, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.5.0 <=0.9.0;
+contract Foo {}
+"#,
+        )
+        .unwrap();
+    cmd.args(["multibuild", "--from", "0.7.0", "--to", "0.8.15"]);
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_multibuild_many_versions.stdout"),
+    );
+});


### PR DESCRIPTION
## Motivation

Many Solidity libraries accept a wide range of Solidity versions by using the `^` and `>=` comparison operators in their version pragma, e.g. this is what [forge-std](https://github.com/foundry-rs/forge-std) currently uses:

```solidity
pragma solidity >=0.6.0 <0.9.0
```

But, with time, it becomes difficult to continuously check that the library code remains compatible with all compiler versions allowed by the version pragma. For instance, when new maintainers come in and propose a new feature, they might not realize that their change broke compatibility with an older version of Solidity. Or there might be cases when the library is not compatible with one specific version of Solidity, due to a bug in that version.

Here's a list of issues that occurred due to a lack of an easy way to build a library with multiple Solidity versions:

- https://github.com/foundry-rs/forge-std/pull/56
- https://github.com/foundry-rs/forge-std/issues/117
- https://github.com/paulrberg/prb-test/issues/5

## Solution

Add a `multibuild` subcommand to the Forge CLI that can be used like this:

```sh
forge multibuild [OPTIONS] --from <SOLC_VERSION> --to <SOLC_VERSION>
```

This will compile the project's smart contracts with all Solidity versions starting with `from` and ending with `to`. This would be very useful to Solidity library developers, especially as a check performed in CI.

## Notes

1. To make this work, I had to disable the `--use` and `--no-auto-detect` build flags, which I did by refactoring them out of `cli/src/cmd/forge/build/core.rs` to a new struct `SolcArgs` in `cli/src/cmd/forge/build/solc.rs`. I added the new struct `SolcArgs` in all subcommands where `CoreBuildArgs` is used, so that this PR doesn't introduce any breaking changes.
2. I have written tests - though naturally due to the nature of this feature, tests take some time to run because of the many Solidity versions that need to be installed. Happy to lower the interval of Solidity versions tested if you think that that would be worth it (currently it tests from `0.7.0` to `0.8.15`).

## Alternative Implementations

The approach I have chosen to implement this was to add a ` project` method in the new `MultibuildArgs` struct, which can create an instance of `Project` with a specific `solc`.

But this is the first time that I fiddled with the Foundry code base, so I'm not sure that this approach can be considered good. I'm very open to refactoring the PR if you can guide me in the right direction.

For example, I was thinking to add a `project_with_solc` method in `BuildArgs`, since that would make the method callable from multiple places (maybe other subcommands will in the future need to create an instance of `Project` with a specific `solc`).