### PR TITLE
Add indication about VSCode and rust-analyzer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,16 @@ cargo +nightly fmt -- --check
 cargo +nightly clippy --all --all-features -- -D warnings
 ```
 
+If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension, and use the following VSCode user settings:
+
+```json
+"editor.formatOnSave": true,
+"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+"[rust]": {
+  "editor.defaultFormatter": "rust-lang.rust-analyzer"
+}
+```
+
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.
 
 If you would like to test the binaries built from your change, see [foundryup](https://github.com/foundry-rs/foundry/tree/master/foundryup).


### PR DESCRIPTION
## Motivation

I [spent](https://users.rust-lang.org/t/rustfmt-option-trailing-semicolon-not-respected-by-rust-analyzer/78788/2) hours today trying to figure out why running <kbd>CMD</kbd> + <kbd>S</kbd> in VSCode produced different formatting results compared to running `cargo +nightly fmt` in the CLI.

Other users have bumped into the same issue in the past (image source: the Telegram group "Foundry"):

<img width="527" alt="Screen Shot 2022-07-23 at 7 53 05 PM" src="https://user-images.githubusercontent.com/8782666/180615184-907c18ac-6be3-4fd2-bd8d-12a82183b239.png">

## Solution

Document the recommended settings Foundry contributors should have in the VSCode user settings.