### PR TITLE
fix(forge): `test_fuzz` was not executing the tests

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1239,14 +1239,21 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
     #[test]
     fn test_fuzz() {
         let mut runner = runner();
+        let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
+        runner.fuzzer = Some(proptest::test_runner::TestRunner::new(cfg));
+
         let suite_result = runner.test(&Filter::new(".*", ".*", ".*fuzz"), None, true).unwrap();
+
+        assert!(!suite_result.is_empty());
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
             for (test_name, result) in test_results {
                 let logs = decode_console_logs(&result.logs);
 
                 match test_name.as_ref() {
-                    "testPositive(uint256)" | "testSuccessfulFuzz(uint128,uint128)" => assert!(
+                    "testPositive(uint256)" |
+                    "testSuccessfulFuzz(uint128,uint128)" |
+                    "testToStringFuzz(bytes32)" => assert!(
                         result.success,
                         "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                         test_name,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`test_fuzz` is not executing tests, since the runner does not include a `fuzzer`. Leading to `suite_result` being empty.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `fuzzer` and assert that `suite_result` is not empty.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
