### PR TITLE
Add create flag to estimate command

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -70,7 +70,7 @@ where
     /// let to = Address::from_str("0xB3C95ff08316fb2F2e3E52Ee82F8e7b605Aa1304")?;
     /// let sig = "function greeting(uint256 i) public returns (string)";
     /// let args = vec!["5".to_owned()];
-    /// let mut builder = TxBuilder::new(&provider, Address::zero(), to, Chain::Mainnet, false).await?;
+    /// let mut builder = TxBuilder::new(&provider, Address::zero(), Some(to), Chain::Mainnet, false).await?;
     /// builder
     ///     .set_args(sig, args).await?;
     /// let builder_output = builder.build();
@@ -132,7 +132,7 @@ where
     /// let to = Address::from_str("0xB3C95ff08316fb2F2e3E52Ee82F8e7b605Aa1304")?;
     /// let sig = "greeting(uint256)(string)";
     /// let args = vec!["5".to_owned()];
-    /// let mut builder = TxBuilder::new(&provider, Address::zero(), to, Chain::Mainnet, false).await?;
+    /// let mut builder = TxBuilder::new(&provider, Address::zero(), Some(to), Chain::Mainnet, false).await?;
     /// builder
     ///     .set_args(sig, args).await?;
     /// let builder_output = builder.peek();
@@ -195,7 +195,7 @@ where
     /// let gas = U256::from_str("200000").unwrap();
     /// let value = U256::from_str("1").unwrap();
     /// let nonce = U256::from_str("1").unwrap();
-    /// let mut builder = TxBuilder::new(&provider, Address::zero(), to, Chain::Mainnet, false).await?;
+    /// let mut builder = TxBuilder::new(&provider, Address::zero(), Some(to), Chain::Mainnet, false).await?;
     /// builder
     ///     .set_args(sig, args).await?
     ///     .set_gas(gas)
@@ -258,7 +258,7 @@ where
     /// let sig = "greet(string)()";
     /// let args = vec!["5".to_owned()];
     /// let value = U256::from_str("1").unwrap();
-    /// let mut builder = TxBuilder::new(&provider, from, to, Chain::Mainnet, false).await?;
+    /// let mut builder = TxBuilder::new(&provider, from, Some(to), Chain::Mainnet, false).await?;
     /// builder
     ///     .set_value(value)
     ///     .set_args(sig, args).await?;

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -222,7 +222,7 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
         value: Option<(&str, Vec<String>)>,
     ) -> Result<&mut TxBuilder<'a, M>> {
         if let Some((sig, args)) = value {
-            return self.set_args(sig, args).await;
+            return self.set_args(sig, args).await
         }
         Ok(self)
     }

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -14,7 +14,7 @@ use futures::future::join_all;
 use crate::strip_0x;
 
 pub struct TxBuilder<'a, M: Middleware> {
-    to: H160,
+    to: Option<H160>,
     chain: Chain,
     tx: TypedTransaction,
     func: Option<Function>,
@@ -31,7 +31,7 @@ pub type TxBuilderPeekOutput<'a> = (&'a TypedTransaction, &'a Option<Function>);
 ///   use ethers_core::types::{Chain, U256};
 ///   use cast::TxBuilder;
 ///   let provider = ethers_providers::test_provider::MAINNET.provider();
-///   let mut builder = TxBuilder::new(&provider, "a.eth", "b.eth", Chain::Mainnet, false).await?;
+///   let mut builder = TxBuilder::new(&provider, "a.eth", Some("b.eth"), Chain::Mainnet, false).await?;
 ///   builder
 ///       .gas(Some(U256::from(1)));
 ///   let (tx, _) = builder.build();
@@ -48,19 +48,28 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
     pub async fn new<F: Into<NameOrAddress>, T: Into<NameOrAddress>>(
         provider: &'a M,
         from: F,
-        to: T,
+        to: Option<T>,
         chain: impl Into<Chain>,
         legacy: bool,
     ) -> Result<TxBuilder<'a, M>> {
         let chain = chain.into();
         let from_addr = resolve_ens(provider, from).await?;
-        let to_addr =
-            resolve_ens(provider, foundry_utils::resolve_addr(to, chain.try_into().ok())?).await?;
 
-        let tx: TypedTransaction = if chain.is_legacy() || legacy {
-            TransactionRequest::new().from(from_addr).to(to_addr).chain_id(chain.id()).into()
+        let mut tx: TypedTransaction = if chain.is_legacy() || legacy {
+            TransactionRequest::new().from(from_addr).chain_id(chain.id()).into()
         } else {
-            Eip1559TransactionRequest::new().from(from_addr).to(to_addr).chain_id(chain.id()).into()
+            Eip1559TransactionRequest::new().from(from_addr).chain_id(chain.id()).into()
+        };
+
+        let to_addr = match to {
+            Some(to) => {
+                let addr =
+                    resolve_ens(provider, foundry_utils::resolve_addr(to, chain.try_into().ok())?)
+                        .await?;
+                tx.set_to(addr);
+                Some(addr)
+            }
+            _ => None,
         };
 
         Ok(Self { to: to_addr, chain, tx, func: None, etherscan_api_key: None, provider })
@@ -152,18 +161,16 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
         self
     }
 
-    /// Set function arguments
-    /// `sig` can be:
-    ///  * a fragment (`do(uint32,string)`)
-    ///  * selector + abi-encoded calldata
-    ///    (`0xcdba2fd40000000000000000000000000000000000000000000000000000000000007a69`)
-    ///  * only function name (`do`) - in this case, etherscan lookup is performed on `tx.to`'s
-    ///    contract
-    pub async fn set_args(
+    pub fn set_data(&mut self, v: Vec<u8>) -> &mut Self {
+        self.tx.set_data(v.into());
+        self
+    }
+
+    pub async fn create_args(
         &mut self,
         sig: &str,
         args: Vec<String>,
-    ) -> Result<&mut TxBuilder<'a, M>> {
+    ) -> Result<(Vec<u8>, Function)> {
         let args = resolve_name_args(&args, self.provider).await;
 
         let func = if sig.contains('(') {
@@ -176,20 +183,34 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
                 self.chain.try_into().wrap_err("resolving via etherscan requires a known chain")?;
             get_func_etherscan(
                 sig,
-                self.to,
+                self.to.unwrap(),
                 &args,
-               chain,
+                chain,
                 self.etherscan_api_key.as_ref().unwrap_or_else(|| panic!(r#"Unable to determine the function signature from `{}`. To find the function signature from the deployed contract via its name instead, a valid ETHERSCAN_API_KEY must be set."#, sig)),
             )
             .await?
         };
 
-        let data = if sig.starts_with("0x") {
-            hex::decode(strip_0x(sig))?
+        if sig.starts_with("0x") {
+            Ok((hex::decode(strip_0x(sig))?, func))
         } else {
-            encode_args(&func, &args)?
-        };
+            Ok((encode_args(&func, &args)?, func))
+        }
+    }
 
+    /// Set function arguments
+    /// `sig` can be:
+    ///  * a fragment (`do(uint32,string)`)
+    ///  * selector + abi-encoded calldata
+    ///    (`0xcdba2fd40000000000000000000000000000000000000000000000000000000000007a69`)
+    ///  * only function name (`do`) - in this case, etherscan lookup is performed on `tx.to`'s
+    ///    contract
+    pub async fn set_args(
+        &mut self,
+        sig: &str,
+        args: Vec<String>,
+    ) -> Result<&mut TxBuilder<'a, M>> {
+        let (data, func) = self.create_args(sig, args).await?;
         self.tx.set_data(data.into());
         self.func = Some(func);
         Ok(self)
@@ -201,7 +222,7 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
         value: Option<(&str, Vec<String>)>,
     ) -> Result<&mut TxBuilder<'a, M>> {
         if let Some((sig, args)) = value {
-            return self.set_args(sig, args).await
+            return self.set_args(sig, args).await;
         }
         Ok(self)
     }
@@ -297,7 +318,8 @@ mod tests {
     #[tokio::test]
     async fn builder_new_non_legacy() -> eyre::Result<()> {
         let provider = MyProvider {};
-        let builder = TxBuilder::new(&provider, "a.eth", "b.eth", Chain::Mainnet, false).await?;
+        let builder =
+            TxBuilder::new(&provider, "a.eth", Some("b.eth"), Chain::Mainnet, false).await?;
         let (tx, args) = builder.build();
         assert_eq!(*tx.from().unwrap(), H160::from_str(ADDR_1).unwrap());
         assert_eq!(*tx.to().unwrap(), NameOrAddress::Address(H160::from_str(ADDR_2).unwrap()));
@@ -315,7 +337,8 @@ mod tests {
     #[tokio::test]
     async fn builder_new_legacy() -> eyre::Result<()> {
         let provider = MyProvider {};
-        let builder = TxBuilder::new(&provider, "a.eth", "b.eth", Chain::Mainnet, true).await?;
+        let builder =
+            TxBuilder::new(&provider, "a.eth", Some("b.eth"), Chain::Mainnet, true).await?;
         // don't check anything other than the tx type - the rest is covered in the non-legacy case
         let (tx, _) = builder.build();
         match tx {
@@ -331,7 +354,7 @@ mod tests {
     async fn builder_fields() -> eyre::Result<()> {
         let provider = MyProvider {};
         let mut builder =
-            TxBuilder::new(&provider, "a.eth", "b.eth", Chain::Mainnet, false).await.unwrap();
+            TxBuilder::new(&provider, "a.eth", Some("b.eth"), Chain::Mainnet, false).await.unwrap();
         builder
             .gas(Some(U256::from(12u32)))
             .gas_price(Some(U256::from(34u32)))
@@ -353,7 +376,7 @@ mod tests {
     async fn builder_args() -> eyre::Result<()> {
         let provider = MyProvider {};
         let mut builder =
-            TxBuilder::new(&provider, "a.eth", "b.eth", Chain::Mainnet, false).await.unwrap();
+            TxBuilder::new(&provider, "a.eth", Some("b.eth"), Chain::Mainnet, false).await.unwrap();
         builder.args(Some(("what_a_day(int)", vec![String::from("31337")]))).await?;
         let (_, function_maybe) = builder.build();
 

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -10,7 +10,7 @@ use cast::{Cast, SimpleCast, TxBuilder};
 use foundry_config::Config;
 use utils::get_http_provider;
 mod opts;
-use crate::{cmd::Cmd, utils::consume_config_rpc_url, cmd::cast::estimate};
+use crate::{cmd::Cmd, utils::consume_config_rpc_url};
 use cast::InterfacePath;
 use clap::{IntoApp, Parser};
 use clap_complete::generate;
@@ -676,14 +676,7 @@ async fn main() -> eyre::Result<()> {
             println!("0x{}", hex::encode(selector));
         }
         Subcommands::FindBlock(cmd) => cmd.run()?.await?,
-        Subcommands::Estimate { to, 
-                                sig,
-                                args,
-                                value,
-                                eth,
-                                command } => {
-            estimate::run(to, sig, args, value, eth, command).await?
-        },
+        Subcommands::Estimate(cmd) => cmd.run().await?,
         Subcommands::Wallet { command } => command.run().await?,
         Subcommands::Completions { shell } => {
             generate(shell, &mut Opts::command(), "cast", &mut std::io::stdout())

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -42,9 +42,9 @@ pub enum EstimateSubcommands {
     Create {
         #[clap(help = "Bytecode of contract.", value_name = "CODE")]
         code: String,
-        #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+        #[clap(help = "The signature of the constructor.", value_name = "SIG")]
         sig: Option<String>,
-        #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+        #[clap(help = "Constructor arguments", value_name = "ARGS")]
         args: Vec<String>,
         #[clap(
             long,

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -1,6 +1,8 @@
 // cast estimate subcommands
-use crate::opts::EthereumOpts;
-use crate::utils::parse_ether_value;
+use crate::{
+    opts::{cast::parse_name_or_address, EthereumOpts},
+    utils::parse_ether_value,
+};
 use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{
@@ -8,6 +10,31 @@ use ethers::{
     types::{NameOrAddress, U256},
 };
 use foundry_config::{Chain, Config};
+
+#[derive(Debug, Parser)]
+pub struct EstimateArgs {
+    #[clap(help = "The destination of the transaction.", parse(try_from_str = parse_name_or_address), value_name = "TO")]
+    to: Option<NameOrAddress>,
+    #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+    sig: Option<String>,
+    #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+    args: Vec<String>,
+    #[clap(
+        long,
+        help = "Ether to send in the transaction.",
+        long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+
+Examples: 1ether, 10gwei, 0.01ether"#,
+        parse(try_from_str = parse_ether_value),
+        value_name = "VALUE"
+    )]
+    value: Option<U256>,
+    #[clap(flatten)]
+    // TODO: We only need RPC URL and Etherscan API key here.
+    eth: EthereumOpts,
+    #[clap(subcommand)]
+    command: Option<EstimateSubcommands>,
+}
 
 #[derive(Debug, Parser)]
 pub enum EstimateSubcommands {
@@ -31,55 +58,44 @@ Examples: 1ether, 10gwei, 0.01ether"#,
         value: Option<U256>,
     },
 }
+impl EstimateArgs {
+    pub async fn run(self) -> eyre::Result<()> {
+        let EstimateArgs { to, sig, args, value, eth, command } = self;
+        let config = Config::from(&eth);
+        let provider = Provider::try_from(
+            config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+        )?;
 
-pub async fn run(
-    to: Option<NameOrAddress>,
-    sig: Option<String>,
-    args: Vec<String>,
-    value: Option<U256>,
-    eth: EthereumOpts,
-    command: Option<EstimateSubcommands>,
-) -> eyre::Result<()> {
-    let config = Config::from(&eth);
-    let provider = Provider::try_from(
-        config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-    )?;
+        let chain: Chain =
+            if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
 
-    let chain: Chain = if let Some(chain) = eth.chain {
-        chain.into()
-    } else {
-        provider.get_chainid().await?.into()
-    };
+        let from = eth.sender().await;
+        let mut builder = TxBuilder::new(&provider, from, to, chain, false).await?;
+        match command {
+            Some(EstimateSubcommands::Create { code, sig, args, value }) => {
+                builder.etherscan_api_key(config.etherscan_api_key).value(value);
 
-    let from = eth.sender().await;
-    let mut builder = TxBuilder::new(&provider, from, to, chain, false).await?;
-    match command {
-        Some(EstimateSubcommands::Create { code, sig, args, value }) => {
-            builder.etherscan_api_key(config.etherscan_api_key).value(value);
+                let mut data = hex::decode(code.strip_prefix("0x").unwrap_or(&code))?;
 
-            let mut data = hex::decode(code.strip_prefix("0x").unwrap_or(&code))?;
-
-            match sig {
-                Some(sig) => {
-                    let (mut sigdata, _func) = builder.create_args(&sig, args).await?;
+                if let Some(s) = sig {
+                    let (mut sigdata, _func) = builder.create_args(&s, args).await?;
                     data.append(&mut sigdata);
                 }
-                None => {}
-            };
 
-            builder.set_data(data);
-        }
-        _ => {
-            builder
-                .etherscan_api_key(config.etherscan_api_key)
-                .value(value)
-                .set_args(sig.unwrap().as_str(), args)
-                .await?;
-        }
-    };
+                builder.set_data(data);
+            }
+            _ => {
+                builder
+                    .etherscan_api_key(config.etherscan_api_key)
+                    .value(value)
+                    .set_args(sig.unwrap().as_str(), args)
+                    .await?;
+            }
+        };
 
-    let builder_output = builder.peek();
-    let gas = Cast::new(&provider).estimate(builder_output).await?;
-    println!("{gas}");
-    Ok(())
+        let builder_output = builder.peek();
+        let gas = Cast::new(&provider).estimate(builder_output).await?;
+        println!("{gas}");
+        Ok(())
+    }
 }

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -1,0 +1,85 @@
+// cast estimate subcommands
+use crate::opts::EthereumOpts;
+use crate::utils::parse_ether_value;
+use cast::{Cast, TxBuilder};
+use clap::Parser;
+use ethers::{
+    providers::{Middleware, Provider},
+    types::{NameOrAddress, U256},
+};
+use foundry_config::{Chain, Config};
+
+#[derive(Debug, Parser)]
+pub enum EstimateSubcommands {
+    #[clap(name = "--create", about = "Estimate gas cost to deploy a smart contract")]
+    Create {
+        #[clap(help = "Bytecode of contract.", value_name = "CODE")]
+        code: String,
+        #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+        sig: Option<String>,
+        #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+        args: Vec<String>,
+        #[clap(
+            long,
+            help = "Ether to send in the transaction.",
+            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+
+Examples: 1ether, 10gwei, 0.01ether"#,
+            parse(try_from_str = parse_ether_value),
+            value_name = "VALUE"
+        )]
+        value: Option<U256>,
+    },
+}
+
+pub async fn run(
+    to: Option<NameOrAddress>,
+    sig: Option<String>,
+    args: Vec<String>,
+    value: Option<U256>,
+    eth: EthereumOpts,
+    command: Option<EstimateSubcommands>,
+) -> eyre::Result<()> {
+    let config = Config::from(&eth);
+    let provider = Provider::try_from(
+        config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
+    )?;
+
+    let chain: Chain = if let Some(chain) = eth.chain {
+        chain.into()
+    } else {
+        provider.get_chainid().await?.into()
+    };
+
+    let from = eth.sender().await;
+    let mut builder = TxBuilder::new(&provider, from, to, chain, false).await?;
+    match command {
+        Some(EstimateSubcommands::Create { code, sig, args, value }) => {
+            builder.etherscan_api_key(config.etherscan_api_key).value(value);
+
+            let mut data = hex::decode(code.strip_prefix("0x").unwrap_or(&code))?;
+
+            match sig {
+                Some(sig) => {
+                    let (mut sigdata, _func) = builder.create_args(&sig, args).await?;
+                    data.append(&mut sigdata);
+                }
+                None => {}
+            };
+
+            builder.set_data(data);
+        }
+        _ => {
+            builder
+                .etherscan_api_key(config.etherscan_api_key)
+                .value(value)
+                .set_args(sig.unwrap().as_str(), args)
+                .await?;
+        }
+    };
+
+    let builder_output = builder.peek();
+    let gas = Cast::new(&provider).estimate(builder_output).await?;
+    println!("{gas}");
+    Ok(())
+}

--- a/cli/src/cmd/cast/mod.rs
+++ b/cli/src/cmd/cast/mod.rs
@@ -5,6 +5,7 @@
 //! implement `figment::Provider` which allows the subcommand to override the config's defaults, see
 //! [`foundry_config::Config`].
 
+pub mod estimate;
 pub mod find_block;
 pub mod rpc;
 pub mod run;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,10 +1,10 @@
 use super::{ClapChain, EthereumOpts, TransactionOpts};
 use crate::{
     cmd::cast::{
-        estimate::EstimateSubcommands, find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs,
+        estimate::EstimateArgs, find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs,
         wallet::WalletSubcommands,
     },
-    utils::{parse_ether_value, parse_u256},
+    utils::parse_u256,
 };
 use clap::{Parser, Subcommand, ValueHint};
 use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256, U256};
@@ -455,29 +455,7 @@ Examples:
     #[clap(name = "estimate")]
     #[clap(visible_alias = "e")]
     #[clap(about = "Estimate the gas cost of a transaction.")]
-    Estimate {
-        #[clap(help = "The destination of the transaction.", parse(try_from_str = parse_name_or_address), value_name = "TO")]
-        to: Option<NameOrAddress>,
-        #[clap(help = "The signature of the function to call.", value_name = "SIG")]
-        sig: Option<String>,
-        #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
-        args: Vec<String>,
-        #[clap(
-            long,
-            help = "Ether to send in the transaction.",
-            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
-
-Examples: 1ether, 10gwei, 0.01ether"#,
-            parse(try_from_str = parse_ether_value),
-            value_name = "VALUE"
-        )]
-        value: Option<U256>,
-        #[clap(flatten)]
-        // TODO: We only need RPC URL and Etherscan API key here.
-        eth: EthereumOpts,
-        #[clap(subcommand)]
-        command: Option<EstimateSubcommands>,
-    },
+    Estimate(EstimateArgs),
     #[clap(name = "--calldata-decode")]
     #[clap(visible_alias = "cdd")]
     #[clap(about = "Decode ABI-encoded input data.")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,6 +1,9 @@
 use super::{ClapChain, EthereumOpts, TransactionOpts};
 use crate::{
-    cmd::cast::{find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs, wallet::WalletSubcommands},
+    cmd::cast::{
+        estimate::EstimateSubcommands, find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs,
+        wallet::WalletSubcommands,
+    },
     utils::{parse_ether_value, parse_u256},
 };
 use clap::{Parser, Subcommand, ValueHint};
@@ -19,6 +22,7 @@ pub struct Opts {
     about = "Perform Ethereum RPC calls from the comfort of your command line.",
     after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html"
 )]
+
 pub enum Subcommands {
     #[clap(name = "--max-int")]
     #[clap(visible_aliases = &["max-int", "maxi"])]
@@ -453,9 +457,9 @@ Examples:
     #[clap(about = "Estimate the gas cost of a transaction.")]
     Estimate {
         #[clap(help = "The destination of the transaction.", parse(try_from_str = parse_name_or_address), value_name = "TO")]
-        to: NameOrAddress,
+        to: Option<NameOrAddress>,
         #[clap(help = "The signature of the function to call.", value_name = "SIG")]
-        sig: String,
+        sig: Option<String>,
         #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
         args: Vec<String>,
         #[clap(
@@ -471,6 +475,8 @@ Examples: 1ether, 10gwei, 0.01ether"#,
         #[clap(flatten)]
         // TODO: We only need RPC URL and Etherscan API key here.
         eth: EthereumOpts,
+        #[clap(subcommand)]
+        command: Option<EstimateSubcommands>,
     },
     #[clap(name = "--calldata-decode")]
     #[clap(visible_alias = "cdd")]

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -49,6 +49,45 @@ casttest!(new_wallet_keystore_with_password, |_: TestProject, mut cmd: TestComma
     assert!(out.contains("Public Address of the key"));
 });
 
+// tests that `cast estimate` is working correctly.
+casttest!(estimate_function_gas, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    cmd.args([
+        "estimate",
+        "vitalik.eth",
+        "--value",
+        "100",
+        "deposit()",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+    ]);
+    let out: u32 = cmd.stdout_lossy().trim().parse().unwrap();
+    // ensure we get a positive non-error value for gas estimate
+    assert!(out.ge(&0));
+});
+
+// tests that `cast estimate --create` is working correctly.
+casttest!(estimate_contract_deploy_gas, |_: TestProject, mut cmd: TestCommand| {
+    let eth_rpc_url = next_http_rpc_endpoint();
+    // sample contract code bytecode. Wouldn't run but is valid bytecode that the estimate method
+    // accepts and could be deployed.
+    cmd.args([
+        "estimate",
+        "--create",
+        "0000",
+        "ERC20(uint256,string,string)",
+        "100",
+        "Test",
+        "TST",
+        "--",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+    ]);
+    let out: u32 = cmd.stdout_lossy().trim().parse().unwrap();
+    // ensure we get a positive non-error value for gas estimate
+    assert!(out.ge(&0));
+});
+
 // tests that the `cast upload-signatures` command works correctly
 casttest!(upload_signatures, |_: TestProject, mut cmd: TestCommand| {
     // test no prefix is accepted as function


### PR DESCRIPTION
## Motivation
This PR aims to implement https://github.com/foundry-rs/foundry/issues/2253

We add a `--create` flag to `cast estimate` that accepts contract bytecode, constructor, and arguments. 

## Solution
In order to maintain the existing interface and use `--create` the way `seth` does, I split out the `Estimate` command into default args, and optional subcommands `--create`.

If `--create` is set, we use a different set of arguments. We hash the constructor and argument data, append it to the contract bytecode, and set it to the data field. Setting the `to` value is technically allowed, but drastically changes the gas estimation -- and results in a potentially inaccurate estimate.

Any of the following are valid usages:
`cast estimate --create <CODE> <SIG> [ARGS...]`
`cast estimate --create <CODE> DATA`
`cast estimate --create <CODE>`

And of course, the original cast estimate work exactly the same.

`cast estimate <TO>  <SIG>  <ARGS>`