### PR TITLE
Fix long `cast upload-signature` description

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -517,14 +517,16 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     },
     #[clap(name = "upload-signature")]
     #[clap(visible_aliases = &["ups"])]
-    #[clap(about = r#"Upload the given signatures to https://sig.eth.samczsun.com.
+    #[clap(
+        about = "Upload the given signatures to https://sig.eth.samczsun.com.",
+        long_about = r#"Upload the given signatures to https://sig.eth.samczsun.com.
 
-    Examples:
-    - cast upload-signature "transfer(address,uint256)"
-    - cast upload-signature "function transfer(address,uint256)"
-    - cast upload-signature "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
-    - cast upload-signature ./out/Contract.sol/Contract.json
-    "#)]
+Examples:
+- cast upload-signature "transfer(address,uint256)"
+- cast upload-signature "function transfer(address,uint256)"
+- cast upload-signature "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
+- cast upload-signature ./out/Contract.sol/Contract.json""#
+    )]
     UploadSignature {
         #[clap(
             help = "The signatures to upload. Prefix with 'function', 'event', or 'error'. Defaults to function if no prefix given. Can also take paths to contract artifact JSON."


### PR DESCRIPTION
Minor fix that turns this

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/2109710/181105752-593c0c4e-a6ec-438d-a901-5e74e04839dd.png">

Into this

<img width="677" alt="image" src="https://user-images.githubusercontent.com/2109710/181106067-bf93d8d6-d242-4b04-a722-4e3db4f2b294.png">

<img width="871" alt="image" src="https://user-images.githubusercontent.com/2109710/181105919-d0b1d139-6b6f-429c-ba81-6711b9fd8730.png">

