### PR TITLE
Add `PRIVATE_KEY` arg to `cast wallet address`

### DIFF
--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -60,6 +60,11 @@ pub enum WalletSubcommands {
     },
     #[clap(name = "address", visible_aliases = &["a", "addr"], about = "Convert a private key to an address.")]
     Address {
+        #[clap(
+            help = "If provided, the address will be derived from the specified private key.",
+            value_name = "PRIVATE_KEY"
+        )]
+        private_key_override: Option<String>,
         #[clap(flatten)]
         wallet: Wallet,
     },
@@ -171,10 +176,12 @@ impl WalletSubcommands {
                     hex::encode(wallet.signer().to_bytes()),
                 );
             }
-            WalletSubcommands::Address { wallet } => {
+            WalletSubcommands::Address { wallet, private_key_override } => {
                 // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
-                    wallet,
+                    wallet: private_key_override
+                        .map(|pk| Wallet { private_key: Some(pk), ..Default::default() })
+                        .unwrap_or(wallet),
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
                     chain: Some(Chain::Mainnet),

--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -49,7 +49,7 @@ impl WalletType {
     }
 }
 
-#[derive(Parser, Debug, Clone, Serialize)]
+#[derive(Parser, Debug, Default, Clone, Serialize)]
 #[cfg_attr(not(doc), allow(missing_docs))]
 #[cfg_attr(
     doc,


### PR DESCRIPTION
## Motivation

Often the intended usage for the `cast wallet address` is to get an address for a specific private key different from the ones specified in your environment.

## Solution

It's natural to specify this private key as a single argument to this command like so `cast wallet address 0x0123...`. This PR preserves previous behavior if no argument is specified, but will override environment wallet settings if the argument is present.

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/2109710/181303459-44f455cc-f643-451c-8375-2845e17d7383.png">

## WIP

The code I wrote to initialize `Wallet` struct looks too verbose, maybe there is a better way to write it?