### PR TITLE
refactor: use named Chain for ethereum ops

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -197,7 +197,7 @@ async fn main() -> eyre::Result<()> {
             )?;
 
             let chain: Chain = if let Some(chain) = eth.chain {
-                chain.into()
+                chain
             } else {
                 provider.get_chainid().await?.into()
             };
@@ -227,7 +227,7 @@ async fn main() -> eyre::Result<()> {
             )?;
 
             let chain: Chain = if let Some(chain) = eth.chain {
-                chain.into()
+                chain
             } else {
                 provider.get_chainid().await?.into()
             };
@@ -297,7 +297,7 @@ async fn main() -> eyre::Result<()> {
                 false,
             );
             let chain: Chain = if let Some(chain) = eth.chain {
-                chain.into()
+                chain
             } else {
                 provider.get_chainid().await?.into()
             };
@@ -438,7 +438,7 @@ async fn main() -> eyre::Result<()> {
             )?;
 
             let chain: Chain = if let Some(chain) = eth.chain {
-                chain.into()
+                chain
             } else {
                 provider.get_chainid().await?.into()
             };

--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -177,15 +177,13 @@ impl WalletSubcommands {
                 );
             }
             WalletSubcommands::Address { wallet, private_key_override } => {
-                // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet: private_key_override
                         .map(|pk| Wallet { private_key: Some(pk), ..Default::default() })
                         .unwrap_or(wallet),
                     rpc_url: Some("http://localhost:8545".to_string()),
-                    flashbots: false,
-                    chain: Some(Chain::Mainnet),
-                    etherscan_api_key: None,
+                    chain: Some(Chain::Mainnet.into()),
+                    ..Default::default()
                 }
                 .signer(0u64.into())
                 .await?
@@ -199,13 +197,11 @@ impl WalletSubcommands {
                 println!("Address: {}", SimpleCast::checksum_address(&addr)?);
             }
             WalletSubcommands::Sign { message, wallet } => {
-                // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet,
                     rpc_url: Some("http://localhost:8545".to_string()),
-                    flashbots: false,
-                    chain: Some(Chain::Mainnet),
-                    etherscan_api_key: None,
+                    chain: Some(Chain::Mainnet.into()),
+                    ..Default::default()
                 }
                 .signer(0u64.into())
                 .await?

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -5,7 +5,7 @@ use ethers::{
     prelude::RetryClient,
     providers::{Http, Provider},
     signers::{HDPath as LedgerHDPath, Ledger, Signer, Trezor, TrezorHDPath},
-    types::{Address, Chain, U256},
+    types::{Address, U256},
 };
 use eyre::Result;
 use foundry_config::{
@@ -14,7 +14,7 @@ use foundry_config::{
         value::{Dict, Map, Value},
         Metadata, Profile,
     },
-    impl_figment_convert_cast, Config,
+    impl_figment_convert_cast, Chain, Config,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ use std::sync::Arc;
 const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
 impl_figment_convert_cast!(EthereumOpts);
-#[derive(Parser, Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Parser, Serialize)]
 pub struct EthereumOpts {
     #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The RPC endpoint.", value_name = "URL")]
     pub rpc_url: Option<String>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
allows `cast send --chain <name of chain>`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
