### PR TITLE
feat(forge): add contract ignore list for gas reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "yansi",
 ]
 
 [[package]]

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -492,7 +492,7 @@ fn test(
             thread::spawn(move || runner.test(&filter, Some(tx), include_fuzz_tests).unwrap());
 
         let mut results: BTreeMap<String, SuiteResult> = BTreeMap::new();
-        let mut gas_report = GasReport::new(config.gas_reports);
+        let mut gas_report = GasReport::new(config.gas_reports, config.gas_reports_ignore);
         for (contract_name, suite_result) in rx {
             let mut tests = suite_result.test_results.clone();
             println!();

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -501,6 +501,8 @@ impl TestCommand {
     }
 
     /// Runs the command and prints its output
+    /// You have to pass --nocapture to cargo test or the print won't be displayed.
+    /// The full command would be: cargo test -- --nocapture
     pub fn print_output(&mut self) {
         let output = self.execute();
         println!("stdout: {}", String::from_utf8_lossy(&output.stdout));

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -861,3 +861,400 @@ contract MyTokenCopy is MyToken {
         assert!(output.contains("Compiler run successful",));
     }
 );
+
+forgetest!(gas_report_all_contracts, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+    prj.inner()
+        .add_source(
+            "Contracts.sol",
+            r#"
+//SPDX-license-identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./test.sol";
+
+contract ContractOne {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function foo() public{
+        while(i<5){
+            i++;
+        }
+    }
+}
+
+contract ContractOneTest is DSTest {
+    ContractOne c1;
+
+    function setUp() public {
+        c1 = new ContractOne();
+    }
+
+    function testFoo() public {
+        c1.foo();
+    }
+}
+
+
+contract ContractTwo {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function bar() public{
+        while(i<50){
+            i++;
+        }
+    }
+}
+
+contract ContractTwoTest is DSTest {
+    ContractTwo c2;
+
+    function setUp() public {
+        c2 = new ContractTwo();
+    }
+
+    function testBar() public {
+        c2.bar();
+    }
+}
+
+contract ContractThree {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function baz() public{
+        while(i<500){
+            i++;
+        }
+    }
+}
+
+contract ContractThreeTest is DSTest {
+    ContractThree c3;
+
+    function setUp() public {
+        c3 = new ContractThree();
+    }
+
+    function testBaz() public {
+        c3.baz();
+    }
+}
+    "#,
+        )
+        .unwrap();
+
+    // report for all
+    prj.write_config(Config {
+        gas_reports: (vec!["*".to_string()]),
+        gas_reports_ignore: (vec![]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let first_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(first_out.contains("foo") && first_out.contains("bar") && first_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    cmd.forge_fuse();
+    prj.write_config(Config { gas_reports: (vec![]), ..Default::default() });
+    cmd.forge_fuse();
+    let second_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(second_out.contains("foo") && second_out.contains("bar") && second_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    cmd.forge_fuse();
+    prj.write_config(Config { gas_reports: (vec!["*".to_string()]), ..Default::default() });
+    cmd.forge_fuse();
+    let third_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(third_out.contains("foo") && third_out.contains("bar") && third_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    cmd.forge_fuse();
+    prj.write_config(Config {
+        gas_reports: (vec![
+            "ContractOne".to_string(),
+            "ContractTwo".to_string(),
+            "ContractThree".to_string(),
+        ]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let fourth_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(fourth_out.contains("foo") && fourth_out.contains("bar") && fourth_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+});
+
+forgetest!(gas_report_some_contracts, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+    prj.inner()
+        .add_source(
+            "Contracts.sol",
+            r#"
+//SPDX-license-identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./test.sol";
+
+contract ContractOne {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function foo() public{
+        while(i<5){
+            i++;
+        }
+    }
+}
+
+contract ContractOneTest is DSTest {
+    ContractOne c1;
+
+    function setUp() public {
+        c1 = new ContractOne();
+    }
+
+    function testFoo() public {
+        c1.foo();
+    }
+}
+
+
+contract ContractTwo {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function bar() public{
+        while(i<50){
+            i++;
+        }
+    }
+}
+
+contract ContractTwoTest is DSTest {
+    ContractTwo c2;
+
+    function setUp() public {
+        c2 = new ContractTwo();
+    }
+
+    function testBar() public {
+        c2.bar();
+    }
+}
+
+contract ContractThree {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function baz() public{
+        while(i<500){
+            i++;
+        }
+    }
+}
+
+contract ContractThreeTest is DSTest {
+    ContractThree c3;
+
+    function setUp() public {
+        c3 = new ContractThree();
+    }
+
+    function testBaz() public {
+        c3.baz();
+    }
+}
+    "#,
+        )
+        .unwrap();
+
+    // report for One
+    prj.write_config(Config {
+        gas_reports: (vec!["ContractOne".to_string()]),
+        gas_reports_ignore: (vec![]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let first_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(first_out.contains("foo") && !first_out.contains("bar") && !first_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    // report for Two
+    cmd.forge_fuse();
+    prj.write_config(Config {
+        gas_reports: (vec!["ContractTwo".to_string()]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let second_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(
+        !second_out.contains("foo") && second_out.contains("bar") && !second_out.contains("baz")
+    );
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    // report for Three
+    cmd.forge_fuse();
+    prj.write_config(Config {
+        gas_reports: (vec!["ContractThree".to_string()]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let third_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(!third_out.contains("foo") && !third_out.contains("bar") && third_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+});
+
+forgetest!(gas_ignore_some_contracts, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+    prj.inner()
+        .add_source(
+            "Contracts.sol",
+            r#"
+//SPDX-license-identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./test.sol";
+
+contract ContractOne {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function foo() public{
+        while(i<5){
+            i++;
+        }
+    }
+}
+
+contract ContractOneTest is DSTest {
+    ContractOne c1;
+
+    function setUp() public {
+        c1 = new ContractOne();
+    }
+
+    function testFoo() public {
+        c1.foo();
+    }
+}
+
+
+contract ContractTwo {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function bar() public{
+        while(i<50){
+            i++;
+        }
+    }
+}
+
+contract ContractTwoTest is DSTest {
+    ContractTwo c2;
+
+    function setUp() public {
+        c2 = new ContractTwo();
+    }
+
+    function testBar() public {
+        c2.bar();
+    }
+}
+
+contract ContractThree {
+    int public i;
+
+    constructor() {
+        i = 0;
+    }
+
+    function baz() public{
+        while(i<500){
+            i++;
+        }
+    }
+}
+
+contract ContractThreeTest is DSTest {
+    ContractThree c3;
+
+    function setUp() public {
+        c3 = new ContractThree();
+    }
+
+    function testBaz() public {
+        c3.baz();
+    }
+}
+    "#,
+        )
+        .unwrap();
+
+    // ignore ContractOne
+    prj.write_config(Config {
+        gas_reports: (vec!["*".to_string()]),
+        gas_reports_ignore: (vec!["ContractOne".to_string()]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let first_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(!first_out.contains("foo") && first_out.contains("bar") && first_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    // ignore ContractTwo
+    cmd.forge_fuse();
+    prj.write_config(Config {
+        gas_reports: (vec![]),
+        gas_reports_ignore: (vec!["ContractTwo".to_string()]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let second_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(
+        second_out.contains("foo") && !second_out.contains("bar") && second_out.contains("baz")
+    );
+    // cmd.arg("test").arg("--gas-report").print_output();
+
+    // ignore ContractThree
+    cmd.forge_fuse();
+    prj.write_config(Config {
+        gas_reports: (vec![
+            "ContractOne".to_string(),
+            "ContractTwo".to_string(),
+            "ContractThree".to_string(),
+        ]),
+        gas_reports_ignore: (vec!["ContractThree".to_string()]),
+        ..Default::default()
+    });
+    cmd.forge_fuse();
+    let third_out = cmd.arg("test").arg("--gas-report").stdout();
+    assert!(third_out.contains("foo") && third_out.contains("bar") && third_out.contains("baz"));
+    // cmd.arg("test").arg("--gas-report").print_output();
+});

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1256,5 +1256,4 @@ contract ContractThreeTest is DSTest {
     cmd.forge_fuse();
     let third_out = cmd.arg("test").arg("--gas-report").stdout();
     assert!(third_out.contains("foo") && third_out.contains("bar") && third_out.contains("baz"));
-    // cmd.arg("test").arg("--gas-report").print_output();
 });

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -35,6 +35,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         force: true,
         evm_version: EvmVersion::Byzantium,
         gas_reports: vec!["Contract".to_string()],
+        gas_reports_ignore: vec![],
         solc: Some(SolcReq::Local(PathBuf::from("custom-solc"))),
         auto_detect_solc: false,
         offline: true,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -132,6 +132,8 @@ pub struct Config {
     pub evm_version: EvmVersion,
     /// list of contracts to report gas of
     pub gas_reports: Vec<String>,
+    /// list of contracts to ignore for gas reports
+    pub gas_reports_ignore: Vec<String>,
     /// The Solc instance to use if any.
     ///
     /// This takes precedence over `auto_detect_solc`, if a version is set then this overrides
@@ -1445,6 +1447,7 @@ impl Default for Config {
             force: false,
             evm_version: Default::default(),
             gas_reports: vec!["*".to_string()],
+            gas_reports_ignore: vec![],
             solc: None,
             auto_detect_solc: true,
             offline: false,

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0.130"
 regex = { version = "1.5.4", default-features = false }
 hex = "0.4.3"
 glob = "0.3.0"
+yansi = "0.5.1"
 # TODO: Trim down
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -10,6 +10,7 @@ use std::{collections::BTreeMap, fmt::Display};
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct GasReport {
     pub report_for: Vec<String>,
+    pub ignore: Vec<String>,
     pub contracts: BTreeMap<String, ContractInfo>,
 }
 
@@ -30,22 +31,17 @@ pub struct GasInfo {
 }
 
 impl GasReport {
-    pub fn new(report_for: Vec<String>) -> Self {
-        Self { report_for, ..Default::default() }
+    pub fn new(report_for: Vec<String>, ignore: Vec<String>) -> Self {
+        Self { report_for, ignore, ..Default::default() }
     }
 
     pub fn analyze(&mut self, traces: &[(TraceKind, CallTraceArena)]) {
-        let report_for_all = self.report_for.is_empty() || self.report_for.iter().any(|s| s == "*");
         traces.iter().for_each(|(_, trace)| {
-            self.analyze_trace(trace, report_for_all);
+            self.analyze_node(0, trace);
         });
     }
 
-    fn analyze_trace(&mut self, trace: &CallTraceArena, report_for_all: bool) {
-        self.analyze_node(0, trace, report_for_all);
-    }
-
-    fn analyze_node(&mut self, node_index: usize, arena: &CallTraceArena, report_for_all: bool) {
+    fn analyze_node(&mut self, node_index: usize, arena: &CallTraceArena) {
         let node = &arena.arena[node_index];
         let trace = &node.trace;
 
@@ -54,12 +50,24 @@ impl GasReport {
         }
 
         if let Some(name) = &trace.contract {
-            // checking contract allowlist for reporting by extracting name out of identifier
-            let report_for = self
-                .report_for
-                .iter()
-                .any(|s| s == name.rsplit(':').next().unwrap_or(name.as_str()));
-            if report_for || report_for_all {
+            let contract_name = name.rsplit(':').next().unwrap_or(name.as_str()).to_string();
+            // If the user listed the contract in 'gas_reports' (the foundry.toml field) a
+            // report for the contract is generated even if it's listed in the ignore
+            // list. This is addressed this way because getting a report you don't expect is
+            // preferable than not getting one you expect. A warning is printed to stderr
+            // indicating the "double listing".
+            if self.report_for.contains(&contract_name) && self.ignore.contains(&contract_name) {
+                eprintln!(
+                    "{}: {} is listed in both 'gas_reports' and 'gas_reports_ignore'.",
+                    yansi::Paint::yellow("warning").bold(),
+                    contract_name
+                );
+            }
+            let report_contract = (!self.ignore.contains(&contract_name) &&
+                self.report_for.contains(&"*".to_string())) ||
+                (!self.ignore.contains(&contract_name) && self.report_for.is_empty()) ||
+                (self.report_for.contains(&contract_name));
+            if report_contract {
                 let mut contract_report =
                     self.contracts.entry(name.to_string()).or_insert_with(Default::default);
 
@@ -86,7 +94,7 @@ impl GasReport {
         }
 
         node.children.iter().for_each(|index| {
-            self.analyze_node(*index, arena, report_for_all);
+            self.analyze_node(*index, arena);
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
See #2464 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Create a new Config field called `gas_reports_ignore` and a new field in `GasReport` called `ignore`. (Default value for `gas_reports_ignore` is an empty Vec&lt;String&gt;.)

Pass `gas_reports_ignore` as an argument to function `GasReport::new` so `GasReport`s are built with an ignore list.

The initialization of the variable `report_contract` decides if the contract has to be reported, using this logic:
![image](https://user-images.githubusercontent.com/67139425/183603967-90d669b0-6071-4be1-8374-0ed2ea1dfa7c.png)

Were:
- a: self.report_for.contains(&contract_name)
- b: self.ignore.contains(&contract_name)
- c: self.report_for.is_empty()
- d: self.report_for.contains(&"*".to_string())

In simpler terms: Report the contract every time it's listed on `report_for`. Report all contracts if `report_for` is either empty or contains "*". If you're reporting all contracts but one of them is listed on `ignore`, don't report that one.

If the user listed the contract in 'gas_reports' (the foundry.toml field) a report for the contract is generated even if it's listed in the ignore list. This is addressed this way because getting a report you don't expect is preferable than not getting one you expect. A warning is printed to stderr indicating the "double listing".