### PR TITLE
feat(fmt): Disable format ranges

### DIFF
--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -242,25 +242,20 @@ impl Comments {
         self.postfixes.split_off(self.postfixes.len() - pos).into()
     }
 
-    /// Insert a comment
-    pub(crate) fn insert(&mut self, comment: CommentWithMetadata) {
-        let list = match comment.position {
-            CommentPosition::Prefix => &mut self.prefixes,
-            CommentPosition::Postfix => &mut self.postfixes,
-        };
-        let pos = match list.binary_search(&comment) {
-            Ok(pos) => pos,
-            Err(pos) => pos,
-        };
-        list.insert(pos, comment);
-    }
-
     /// Remove any comments that occur before the byte offset in the src
     pub(crate) fn remove_comments_before(&mut self, byte: usize) -> Vec<CommentWithMetadata> {
         self.remove_prefixes_before(byte)
             .into_iter()
             .merge(self.remove_postfixes_before(byte).into_iter())
             .collect()
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<CommentWithMetadata> {
+        if self.iter().next()?.is_prefix() {
+            self.prefixes.pop_front()
+        } else {
+            self.postfixes.pop_front()
+        }
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &CommentWithMetadata> {

--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -230,6 +230,19 @@ impl Comments {
         self.postfixes.split_off(self.postfixes.len() - pos).into()
     }
 
+    /// Insert a comment
+    pub(crate) fn insert(&mut self, comment: CommentWithMetadata) {
+        let list = match comment.position {
+            CommentPosition::Prefix => &mut self.prefixes,
+            CommentPosition::Postfix => &mut self.postfixes,
+        };
+        let pos = match list.binary_search(&comment) {
+            Ok(pos) => pos,
+            Err(pos) => pos,
+        };
+        list.insert(pos, comment);
+    }
+
     /// Remove any comments that occur before the byte offset in the src
     pub(crate) fn remove_comments_before(&mut self, byte: usize) -> Vec<CommentWithMetadata> {
         self.remove_prefixes_before(byte)

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1181,7 +1181,7 @@ impl<'a, W: Write> Formatter<'a, W> {
                             needs_space = false;
                         }
                     } else {
-                        self.write_comment(&comment, last_loc.is_none())?;
+                        self.write_comment(comment, last_loc.is_none())?;
                         if last_loc.is_some() && comment.has_newline_before {
                             needs_space = false;
                         }
@@ -1454,7 +1454,11 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         //     _ => usize::MAX,
         // });
         let loc = Loc::File(
-            source_unit.0.iter().next().map(|unit| unit.loc().file_no()).unwrap_or_default(),
+            source_unit
+                .loc()
+                .or_else(|| self.comments.iter().next().map(|comment| comment.loc))
+                .map(|loc| loc.file_no())
+                .unwrap_or_default(),
             0,
             self.source.len(),
         );

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1441,7 +1441,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             self.write_raw(&format!("\n{remainder}"))?;
         }
 
-        let _ = self.comments.remove_comments_before(loc.end());
+        let _ = self.comments.remove_all_comments_before(loc.end());
 
         Ok(())
     }

--- a/fmt/src/helpers.rs
+++ b/fmt/src/helpers.rs
@@ -1,0 +1,42 @@
+use crate::{
+    inline_config::{InlineConfig, InvalidInlineConfigItem},
+    Comments, Formatter, FormatterConfig, FormatterError, Visitable,
+};
+use itertools::Itertools;
+use solang_parser::pt::*;
+
+/// Result of parsing the source code
+#[derive(Debug)]
+pub struct Parsed<'a> {
+    /// The original source code
+    pub src: &'a str,
+    /// The Parse Tree via [`solang`]
+    pub pt: SourceUnit,
+    /// Parsed comments
+    pub comments: Comments,
+    /// Parsed inline config
+    pub inline_config: InlineConfig,
+    /// Invalid inline config items parsed
+    pub invalid_inline_config_items: Vec<(Loc, InvalidInlineConfigItem)>,
+}
+
+/// Parse source code
+pub fn parse(src: &str) -> Result<Parsed, Vec<solang_parser::diagnostics::Diagnostic>> {
+    let (pt, comments) = solang_parser::parse(src, 0)?;
+    let comments = Comments::new(comments, src);
+    let (inline_config_items, invalid_inline_config_items): (Vec<_>, Vec<_>) =
+        comments.parse_inline_config_items().partition_result();
+    let inline_config = InlineConfig::new(inline_config_items, src);
+    Ok(Parsed { src, pt, comments, inline_config, invalid_inline_config_items })
+}
+
+/// Format parsed code
+pub fn format<W: std::fmt::Write>(
+    writer: &mut W,
+    mut parsed: Parsed,
+    config: FormatterConfig,
+) -> Result<(), FormatterError> {
+    let mut formatter =
+        Formatter::new(writer, parsed.src, parsed.comments, parsed.inline_config, config);
+    parsed.pt.visit(&mut formatter)
+}

--- a/fmt/src/inline_config.rs
+++ b/fmt/src/inline_config.rs
@@ -1,4 +1,4 @@
-use crate::comments::{CommentState, CommentStringExt, Comments};
+use crate::comments::{CommentState, CommentStringExt};
 use itertools::Itertools;
 use solang_parser::pt::Loc;
 use std::{fmt, str::FromStr};
@@ -36,24 +36,6 @@ pub struct InvalidInlineConfigItem(String);
 impl fmt::Display for InvalidInlineConfigItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("Invalid inline config item: {}", self.0))
-    }
-}
-
-impl Comments {
-    /// Parse all comments to return a list of inline config items. This will return an iterator of
-    /// results of parsing comments which start with `forgefmt:`
-    pub fn parse_inline_config_items(
-        &self,
-    ) -> impl Iterator<Item = Result<(Loc, InlineConfigItem), (Loc, InvalidInlineConfigItem)>> + '_
-    {
-        self.iter()
-            .filter_map(|comment| {
-                Some((comment, comment.contents().trim_start().strip_prefix("forgefmt:")?.trim()))
-            })
-            .map(|(comment, item)| {
-                let loc = comment.loc;
-                item.parse().map(|out| (loc, out)).map_err(|out| (loc, out))
-            })
     }
 }
 

--- a/fmt/src/inline_config.rs
+++ b/fmt/src/inline_config.rs
@@ -118,7 +118,7 @@ impl InlineConfig {
                         start += offset;
                         let end = char_indices
                             .find(|(_, ch)| *ch == '\n')
-                            .map(|(idx, _)| offset + idx)
+                            .map(|(idx, _)| offset + idx + 1)
                             .unwrap_or(src.len());
                         disabled_ranges.push(DisabledRange { start, end, loose: false });
                     }

--- a/fmt/src/inline_config.rs
+++ b/fmt/src/inline_config.rs
@@ -1,0 +1,156 @@
+use crate::comments::{CommentState, CommentStringExt, Comments};
+use itertools::Itertools;
+use solang_parser::pt::Loc;
+use std::{fmt, str::FromStr};
+
+/// An inline config item
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy)]
+pub enum InlineConfigItem {
+    /// Disables the next code item regardless of newlines
+    DisableNextItem,
+    /// Disables formatting between the next newline and the newline after
+    DisableNextLine,
+    /// Disables formatting for any code that follows this and before the next "disable-end"
+    DisableStart,
+    /// Disables formatting for any code that precedes this and after the previous "disable-start"
+    DisableEnd,
+}
+
+impl FromStr for InlineConfigItem {
+    type Err = InvalidInlineConfigItem;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "disable-next-item" => InlineConfigItem::DisableNextItem,
+            "disable-next-line" => InlineConfigItem::DisableNextLine,
+            "disable-start" => InlineConfigItem::DisableStart,
+            "disable-end" => InlineConfigItem::DisableEnd,
+            s => return Err(InvalidInlineConfigItem(s.into())),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidInlineConfigItem(String);
+
+impl fmt::Display for InvalidInlineConfigItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("Invalid inline config item: {}", self.0))
+    }
+}
+
+impl Comments {
+    /// Parse all comments to return a list of inline config items. This will return an iterator of
+    /// results of parsing comments which start with `forgefmt:`
+    pub fn parse_inline_config_items(
+        &self,
+    ) -> impl Iterator<Item = Result<(Loc, InlineConfigItem), (Loc, InvalidInlineConfigItem)>> + '_
+    {
+        self.iter()
+            .filter_map(|comment| {
+                Some((comment, comment.contents().trim_start().strip_prefix("forgefmt:")?.trim()))
+            })
+            .map(|(comment, item)| {
+                let loc = comment.loc;
+                item.parse().map(|out| (loc, out)).map_err(|out| (loc, out))
+            })
+    }
+}
+
+/// A disabled formatting range. `loose` designates that the range includes any loc which
+/// may start in between start and end, whereas the strict version requires that
+/// `range.start >= loc.start <=> loc.end <= range.end`
+#[derive(Debug)]
+struct DisabledRange {
+    start: usize,
+    end: usize,
+    loose: bool,
+}
+
+impl DisabledRange {
+    fn includes(&self, loc: Loc) -> bool {
+        loc.start() >= self.start && (if self.loose { loc.start() } else { loc.end() } <= self.end)
+    }
+}
+
+/// An inline config. Keeps track of disabled ranges.
+///
+/// This is a list of Inline Config items for locations in a source file. This is
+/// usually acquired by parsing the comments for an `forgefmt:` items. See
+/// [`Comments::parse_inline_config_items`] for details.
+#[derive(Debug)]
+pub struct InlineConfig {
+    disabled_ranges: Vec<DisabledRange>,
+}
+
+impl InlineConfig {
+    /// Build a new inline config with an iterator of inline config items and their locations in a
+    /// source file
+    pub fn new(items: impl IntoIterator<Item = (Loc, InlineConfigItem)>, src: &str) -> Self {
+        let mut disabled_ranges = vec![];
+        let mut disabled_range_start = None;
+        let mut disabled_depth = 0usize;
+        for (loc, item) in items.into_iter().sorted_by_key(|(loc, _)| loc.start()) {
+            match item {
+                InlineConfigItem::DisableNextItem => {
+                    let offset = loc.end();
+                    let mut char_indices = src[offset..]
+                        .comment_state_char_indices()
+                        .filter_map(|(state, idx, ch)| match state {
+                            CommentState::None => Some((idx, ch)),
+                            _ => None,
+                        })
+                        .skip_while(|(_, ch)| ch.is_whitespace());
+                    if let Some((mut start, _)) = char_indices.next() {
+                        start += offset;
+                        let end = char_indices
+                            .find(|(_, ch)| !ch.is_whitespace())
+                            .map(|(idx, _)| offset + idx)
+                            .unwrap_or(src.len());
+                        disabled_ranges.push(DisabledRange { start, end, loose: true });
+                    }
+                }
+                InlineConfigItem::DisableNextLine => {
+                    let offset = loc.end();
+                    let mut char_indices =
+                        src[offset..].char_indices().skip_while(|(_, ch)| *ch != '\n').skip(1);
+                    if let Some((mut start, _)) = char_indices.next() {
+                        start += offset;
+                        let end = char_indices
+                            .find(|(_, ch)| *ch == '\n')
+                            .map(|(idx, _)| offset + idx)
+                            .unwrap_or(src.len());
+                        disabled_ranges.push(DisabledRange { start, end, loose: false });
+                    }
+                }
+                InlineConfigItem::DisableStart => {
+                    if disabled_depth == 0 {
+                        disabled_range_start = Some(loc.end());
+                    }
+                    disabled_depth += 1;
+                }
+                InlineConfigItem::DisableEnd => {
+                    disabled_depth = disabled_depth.saturating_sub(1);
+                    if disabled_depth == 0 {
+                        if let Some(start) = disabled_range_start.take() {
+                            disabled_ranges.push(DisabledRange {
+                                start,
+                                end: loc.start(),
+                                loose: false,
+                            })
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(start) = disabled_range_start.take() {
+            disabled_ranges.push(DisabledRange { start, end: src.len(), loose: false })
+        }
+        Self { disabled_ranges }
+    }
+
+    /// Check if the location is in a disabled range
+    pub fn is_disabled(&self, loc: Loc) -> bool {
+        self.disabled_ranges.iter().any(|range| range.includes(loc))
+    }
+}

--- a/fmt/src/lib.rs
+++ b/fmt/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod comments;
 mod formatter;
+mod helpers;
+pub mod inline_config;
 mod macros;
 pub mod solang_ext;
 mod string;
@@ -11,4 +13,6 @@ pub use foundry_config::fmt::*;
 
 pub use comments::Comments;
 pub use formatter::{Formatter, FormatterError};
+pub use helpers::{format, parse, Parsed};
+pub use inline_config::InlineConfig;
 pub use visit::{Visitable, Visitor};

--- a/fmt/src/macros.rs
+++ b/fmt/src/macros.rs
@@ -86,7 +86,38 @@ macro_rules! buf_fn {
     };
 }
 
+macro_rules! return_source_if_disabled {
+    ($self:expr, $loc:expr) => {{
+        let loc = $loc;
+        if $self.inline_config.is_disabled(loc) {
+            return $self.visit_source(loc)
+        }
+    }};
+    ($self:expr, $loc:expr, $suffix:literal) => {{
+        let mut loc = $loc;
+        let has_suffix = $self.extend_loc_until(&mut loc, $suffix);
+        if $self.inline_config.is_disabled(loc) {
+            $self.visit_source(loc)?;
+            if !has_suffix {
+                write!($self.buf(), "{}", $suffix)?;
+            }
+            return Ok(())
+        }
+    }};
+}
+
+macro_rules! visit_source_if_disabled_else {
+    ($self:expr, $loc:expr, $block:block) => {{
+        let loc = $loc;
+        if $self.inline_config.is_disabled(loc) {
+            $self.visit_source(loc)?;
+        } else $block
+    }};
+}
+
 pub(crate) use buf_fn;
+pub(crate) use return_source_if_disabled;
+pub(crate) use visit_source_if_disabled_else;
 pub(crate) use write_chunk;
 pub(crate) use write_chunk_spaced;
 pub(crate) use writeln_chunk;

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -456,3 +456,28 @@ impl_loc! { IdentifierPath }
 impl_loc! { YulTypedIdentifier }
 impl_loc! { EventParameter }
 impl_loc! { ErrorParameter }
+
+/// Extra helpers for Locs
+pub trait LocExt {
+    fn with_start_from(self, other: &Self) -> Self;
+    fn with_end_from(self, other: &Self) -> Self;
+    fn with_start(self, start: usize) -> Self;
+    fn with_end(self, end: usize) -> Self;
+}
+
+impl LocExt for Loc {
+    fn with_start_from(mut self, other: &Self) -> Self {
+        self.use_start_from(other);
+        self
+    }
+    fn with_end_from(mut self, other: &Self) -> Self {
+        self.use_end_from(other);
+        self
+    }
+    fn with_start(self, start: usize) -> Self {
+        Loc::File(self.file_no(), start, self.end())
+    }
+    fn with_end(self, end: usize) -> Self {
+        Loc::File(self.file_no(), self.start(), end)
+    }
+}

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -80,7 +80,7 @@ impl LineOfCode for SourceUnitPart {
             SourceUnitPart::StructDefinition(structure) => structure.loc,
             SourceUnitPart::EventDefinition(event) => event.loc,
             SourceUnitPart::ErrorDefinition(error) => error.loc,
-            SourceUnitPart::FunctionDefinition(function) => function.loc,
+            SourceUnitPart::FunctionDefinition(function) => function.loc(),
             SourceUnitPart::VariableDefinition(variable) => variable.loc,
             SourceUnitPart::TypeDefinition(def) => def.loc,
             SourceUnitPart::Using(using) => using.loc,

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -427,6 +427,12 @@ impl<T> OptionalLineOfCode for Vec<(Loc, T)> {
     }
 }
 
+impl OptionalLineOfCode for SourceUnit {
+    fn loc(&self) -> Option<Loc> {
+        self.0.get(0).map(|unit| *unit.loc())
+    }
+}
+
 impl LineOfCode for Unit {
     fn loc(&self) -> Loc {
         match *self {

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -463,6 +463,7 @@ pub trait LocExt {
     fn with_end_from(self, other: &Self) -> Self;
     fn with_start(self, start: usize) -> Self;
     fn with_end(self, end: usize) -> Self;
+    fn range(self) -> std::ops::Range<usize>;
 }
 
 impl LocExt for Loc {
@@ -479,5 +480,8 @@ impl LocExt for Loc {
     }
     fn with_end(self, end: usize) -> Self {
         Loc::File(self.file_no(), self.start(), end)
+    }
+    fn range(self) -> std::ops::Range<usize> {
+        self.start()..self.end()
     }
 }

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -24,10 +24,11 @@ pub trait Visitor {
 
     fn visit_pragma(
         &mut self,
+        loc: Loc,
         _ident: &mut Identifier,
         _str: &mut StringLiteral,
     ) -> Result<(), Self::Error> {
-        Ok(())
+        self.visit_source(loc)
     }
 
     fn visit_import_plain(
@@ -430,7 +431,7 @@ impl Visitable for SourceUnitPart {
     {
         match self {
             SourceUnitPart::ContractDefinition(contract) => v.visit_contract(contract),
-            SourceUnitPart::PragmaDirective(_, ident, str) => v.visit_pragma(ident, str),
+            SourceUnitPart::PragmaDirective(loc, ident, str) => v.visit_pragma(*loc, ident, str),
             SourceUnitPart::ImportDirective(import) => import.visit(v),
             SourceUnitPart::EnumDefinition(enumeration) => v.visit_enum(enumeration),
             SourceUnitPart::StructDefinition(structure) => v.visit_struct(structure),

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -33,9 +33,33 @@ bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b6
 
 // forgefmt: disable-start
 
-// hello
+// comment1
+
+
+// comment2
+/* comment 3 */ /* 
+    comment4
+     */ // comment 5
+
 
 // forgefmt: disable-end
+
+// forgefmt: disable-start
+
+function test1() {}
+
+function test2() {}
+
+// forgefmt: disable-end
+
+contract Constructors is Ownable, Changeable {
+    //forgefmt: disable-next-item
+    function Constructors(variable1) public Changeable(variable1) Ownable() onlyOwner {
+    }
+
+    //forgefmt: disable-next-item
+    constructor(variable1, variable2, variable3, variable4, variable5, variable6, variable7) public Changeable(variable1, variable2, variable3, variable4, variable5, variable6, variable7) Ownable() onlyOwner {}
+}
 
 function test() {
     uint256 pi_approx = 666 / 212;
@@ -62,3 +86,26 @@ function testParams(uint256   num, bytes32 data  ,    address receiver)
     attr1
     Cool("hello")
 {}
+
+function testDoWhile() external {
+    //forgefmt: disable-start
+    uint256 i;
+    do { "test"; } while (i != 0);
+
+    do 
+    {}
+    while
+    (
+i != 0);
+
+    bool someVeryVeryLongCondition;
+    do { "test"; } while(
+        someVeryVeryLongCondition && !someVeryVeryLongCondition && 
+!someVeryVeryLongCondition &&
+someVeryVeryLongCondition); 
+
+    do i++; while(i < 10);
+
+    do do i++; while (i < 30); while(i < 20);
+    //forgefmt: disable-end
+}

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -42,6 +42,14 @@ bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b6
      */ // comment 5
 
 
+/// Doccomment 1
+    /// Doccomment 2
+
+/**
+     * docccoment 3
+  */
+
+
 // forgefmt: disable-end
 
 // forgefmt: disable-start
@@ -115,3 +123,358 @@ someVeryVeryLongCondition);
     do do i++; while (i < 30); while(i < 20);
     //forgefmt: disable-end
 }
+
+function forStatement() {
+    //forgefmt: disable-start
+        for
+    (uint256 i1
+        ; i1 < 10;      i1++)
+    {
+             i1++;
+            }
+
+        uint256 i2;
+        for(++i2;i2<10;i2++)
+        
+        {}
+
+        uint256 veryLongVariableName = 1000;
+        for ( uint256 i3; i3 < 10
+        && veryLongVariableName>999 &&      veryLongVariableName< 1001
+        ; i3++)
+        { i3 ++ ; }
+
+        for (type(uint256).min;;) {}
+
+        for (;;) { "test" ; }
+
+        for (uint256 i4; i4< 10; i4++) i4++;
+
+        for (uint256 i5; ;)
+            for (uint256 i6 = 10; i6 > i5; i6--)
+                i5++;
+    //forgefmt: disable-end
+}
+
+function callArgTest() {
+    //forgefmt: disable-start
+        target.run{ gas: gasleft(), value: 1 wei };
+
+        target.run{gas:1,value:0x00}();
+
+        target.run{ 
+                gas : 1000, 
+        value: 1 ether 
+        } ();
+
+        target.run{  gas: estimate(),
+    value: value(1) }(); 
+
+        target.run { value:
+        value(1 ether), gas: veryAndVeryLongNameOfSomeGasEstimateFunction() } ();
+
+        target.run /* comment 1 */ { value: /* comment2 */ 1 }; 
+
+        target.run { /* comment3 */ value: 1, // comment4
+        gas: gasleft()};
+
+        target.run {
+            // comment5
+            value: 1,
+            // comment6
+            gas: gasleft()};
+    //forgefmt: disable-end
+}
+
+function ifTest() {
+    // forgefmt: disable-start
+    if (condition)
+            execute();
+        else
+            executeElse();
+    // forgefmt: disable-end
+
+    /* forgefmt: disable-next-line */
+    if (condition   &&   anotherLongCondition ) {
+        execute();
+    }
+}
+
+function yulTest() {
+    // forgefmt: disable-start
+        assembly {
+            let payloadSize := sub(calldatasize(), 4)
+            calldatacopy(0, 4, payloadSize)
+            mstore(payloadSize, shl(96, caller()))
+
+            let result :=
+                delegatecall(gas(), moduleImpl, 0, add(payloadSize, 20), 0, 0)
+
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    // forgefmt: disable-end
+}
+
+function literalTest() {
+    // forgefmt: disable-start
+
+        true;
+            0x123_456;
+        .1;
+    "foobar";
+            hex"001122FF";
+        0xc02aaa39b223Fe8D0A0e5C4F27ead9083c756Cc2;
+    // forgefmt: disable-end
+}
+
+function returnTest() {
+    // forgefmt: disable-start
+        if (val == 0) {
+        return // return single 1
+        0x00;
+        }
+
+        if (val == 1) { return 
+        1; }
+
+        if (val == 2) {
+                return 3
+                -
+                    1;
+        }
+
+        if (val == 4) {
+            /* return single 2 */ return 2** // return single 3
+            3 // return single 4
+            ;
+        }
+
+        return  value(); // return single 5
+            return  ;
+            return /* return mul 4 */
+            (
+                987654321, 1234567890,/* return mul 5 */ false);
+    // forgefmt: disable-end
+}
+
+function namedFuncCall() {
+    // forgefmt: disable-start
+        SimpleStruct memory simple = SimpleStruct({ val: 0 });
+
+        ComplexStruct memory complex = ComplexStruct({ val: 1, anotherVal: 2, flag: true, timestamp: block.timestamp });
+
+        StructWithAVeryLongNameThatExceedsMaximumLengthThatIsAllowedForFormatting memory long = StructWithAVeryLongNameThatExceedsMaximumLengthThatIsAllowedForFormatting({ whyNameSoLong: "dunno" });
+    
+        SimpleStruct memory simple2 = SimpleStruct(
+    { // comment1 
+        /* comment2 */ val : /* comment3 */ 0
+    
+    }
+        );
+    // forgefmt: disable-end
+}
+
+function revertTest() {
+    // forgefmt: disable-start
+        revert ({ });
+
+        revert EmptyError({});
+
+        revert SimpleError({ val: 0 });
+
+        revert ComplexError(
+            {
+                val: 0,
+                    ts: block.timestamp,
+                        message: "some reason"
+            });
+        
+        revert SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({ val: 0, ts: 0x00, message: "something unpredictable happened that caused execution to revert"});
+
+        revert // comment1 
+        ({});
+    // forgefmt: disable-end
+}
+
+function testTernary() {
+    // forgefmt: disable-start
+        bool condition;
+        bool someVeryVeryLongConditionUsedInTheTernaryExpression;
+
+        condition ? 0 : 1;
+
+        someVeryVeryLongConditionUsedInTheTernaryExpression ? 1234567890 : 987654321;
+
+        condition /* comment1 */ ? /* comment2 */ 1001 /* comment3 */ : /* comment4 */ 2002;
+
+        // comment5
+        someVeryVeryLongConditionUsedInTheTernaryExpression ? 1
+        // comment6
+        :
+        // comment7
+        0; // comment8
+    // forgefmt: disable-end
+}
+
+function thisTest() {
+    // forgefmt: disable-start
+        this.someFunc();
+        this.someVeryVeryVeryLongVariableNameThatWillBeAccessedByThisKeyword();
+        this // comment1
+            .someVeryVeryVeryLongVariableNameThatWillBeAccessedByThisKeyword();
+        address(this).balance;
+        
+        address thisAddress = address(
+            // comment2
+             /* comment3 */ this // comment 4
+        );
+    // forgefmt: disable-end
+}
+
+function tryTest() {
+    // forgefmt: disable-start
+        try unknown.empty() {} catch {}
+
+        try unknown.lookup() returns (uint256) {} catch Error(string memory) {}
+
+        try unknown.lookup() returns (uint256) {} catch Error(string memory) {} catch (bytes memory) {}
+
+    try unknown
+        .lookup() returns   (uint256
+                ) {
+                } catch ( bytes  memory ){}
+
+        try unknown.empty() {
+            unknown.doSomething();
+        } catch {
+            unknown.handleError();
+        }
+
+        try unknown.empty() {
+            unknown.doSomething();
+        } catch Error(string memory) {}
+        catch Panic(uint) {}
+        catch {
+            unknown.handleError();
+        }
+
+        try unknown.lookupMultipleValues() returns (uint256, uint256, uint256, uint256, uint256) {} catch Error(string memory) {} catch {}
+ 
+        try unknown.lookupMultipleValues() returns (uint256, uint256, uint256, uint256, uint256) {
+            unknown.doSomething();
+        } 
+        catch Error(string memory) {
+             unknown.handleError();
+        }
+        catch {}
+    // forgefmt: disable-end
+}
+
+function testArray() {
+    // forgefmt: disable-start
+        msg.data[
+            // comment1
+            4:];
+        msg.data[
+            : /* comment2 */ msg.data.length // comment3
+            ];
+        msg.data[
+        // comment4 
+        4 // comment5
+        :msg.data.length /* comment6 */];
+    // forgefmt: disable-end
+}
+
+function testUnit() {
+    // forgefmt: disable-start
+        uint256 timestamp;
+        timestamp = 1 seconds;
+        timestamp = 1 minutes;
+        timestamp = 1 hours;
+        timestamp = 1 days;
+        timestamp = 1 weeks;
+
+        uint256 value;
+        value = 1 wei;
+        value = 1 gwei;
+        value = 1 ether;
+
+        uint256 someVeryVeryVeryLongVaribleNameForTheMultiplierForEtherValue;
+
+        value =  someVeryVeryVeryLongVaribleNameForTheMultiplierForEtherValue * 1 /* comment1 */ ether; // comment2
+
+        value = 1 // comment3
+        // comment4
+        ether; // comment5
+    // forgefmt: disable-end
+}
+
+contract UsingExampleContract {
+    // forgefmt: disable-start
+    using  UsingExampleLibrary      for   *  ;
+        using UsingExampleLibrary for uint;
+    using Example.UsingExampleLibrary  for  uint;
+            using { M.g, M.f} for uint;
+    using UsingExampleLibrary for   uint  global;
+    using { These, Are, MultipleLibraries, ThatNeedToBePut, OnSeparateLines } for uint;
+    using { This.isareally.longmember.access.expression.that.needs.to.besplit.into.lines } for uint;
+    // forgefmt: disable-end
+}
+
+function testAssignment() {
+    // forgefmt: disable-start
+        (, uint256 second) = (1, 2);
+        (uint256 listItem001) = 1;
+        (uint256 listItem002, uint256 listItem003) = (10, 20);
+        (uint256 listItem004, uint256 listItem005, uint256 listItem006) =
+            (10, 20, 30);
+    // forgefmt: disable-end
+}
+
+function testWhile() {
+    // forgefmt: disable-start
+        uint256 i1;
+            while (  i1 <  10 ) {
+            i1++;
+        }
+
+        while (i1<10) i1++;
+
+        while (i1<10)
+            while (i1<10)
+                i1++;
+
+         uint256 i2;
+        while ( i2   < 10) { i2++; }
+
+        uint256 i3; while (
+            i3 < 10
+        ) { i3++; }
+
+        uint256 i4; while (i4 < 10) 
+
+        { i4 ++ ;}
+
+        uint256 someLongVariableName;
+        while (
+            someLongVariableName < 10 && someLongVariableName < 11 && someLongVariableName < 12
+        ) { someLongVariableName ++; } someLongVariableName++;
+    // forgefmt: disable-end
+}
+
+// forgefmt: disable-start
+
+    type Hello is uint256;
+
+error
+  TopLevelCustomError();
+  error TopLevelCustomErrorWithArg(uint    x)  ;
+error TopLevelCustomErrorArgWithoutName  (string);
+
+    event Event1(uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a);
+
+// forgefmt: disable-stop

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -68,6 +68,12 @@ function test() {
     // forgefmt: disable-next-item
     uint256 pi_approx = 666 /
         212;
+
+    uint256 test_postfix = 1; // forgefmt: disable-start
+                              // comment1
+                              // comment2
+                              // comment3
+                              // forgefmt: disable-end
 }
 
 // forgefmt: disable-next-item

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -28,6 +28,15 @@ enum States {
 // forgefmt: disable-next-line
 enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
 
+// forgefmt: disable-next-line
+bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+
+// forgefmt: disable-start
+
+// hello
+
+// forgefmt: disable-end
+
 function test() {
     uint256 pi_approx = 666 / 212;
     uint256 pi_approx = /* forgefmt: disable-start */ 666    /    212; /* forgefmt: disable-end */

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.5.2;
+
+// forgefmt: disable-next-line
+pragma    solidity     ^0.5.2;
+
+import {
+    symbol1 as alias1,
+    symbol2 as alias2,
+    symbol3 as alias3,
+    symbol4
+} from "File2.sol";
+
+// forgefmt: disable-next-line
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
+
+enum States {
+    State1,
+    State2,
+    State3,
+    State4,
+    State5,
+    State6,
+    State7,
+    State8,
+    State9
+}
+
+// forgefmt: disable-next-line
+enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+
+function test() {
+    uint256 pi_approx = 666 / 212;
+    uint256 pi_approx = /* forgefmt: disable-start */ 666    /    212; /* forgefmt: disable-end */
+
+    // forgefmt: disable-next-item
+    uint256 pi_approx = 666 /
+        212;
+}
+
+// forgefmt: disable-next-item
+function testFunc(uint256   num, bytes32 data  ,    address receiver)
+    public payable    attr1   Cool( "hello"   ) {}
+
+function testAttrs(uint256 num, bytes32 data, address receiver)
+    // forgefmt: disable-next-line
+    public payable    attr1   Cool( "hello"   )
+{}
+
+// forgefmt: disable-next-line
+function testParams(uint256   num, bytes32 data  ,    address receiver)
+    public
+    payable
+    attr1
+    Cool("hello")
+{}

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -27,6 +27,14 @@ bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b6
      */ // comment 5
 
 
+/// Doccomment 1
+    /// Doccomment 2
+
+/**
+     * docccoment 3
+  */
+
+
 // forgefmt: disable-end
 
 // forgefmt: disable-start
@@ -73,6 +81,7 @@ function testAttrs(uint256   num, bytes32 data  ,    address receiver)
 function testParams(uint256   num, bytes32 data  ,    address receiver)
     public payable    attr1   Cool( "hello"   ) {}
 
+
 function testDoWhile() external {
     //forgefmt: disable-start
     uint256 i;
@@ -95,3 +104,357 @@ someVeryVeryLongCondition);
     do do i++; while (i < 30); while(i < 20);
     //forgefmt: disable-end
 }
+
+function forStatement() {
+    //forgefmt: disable-start
+        for
+    (uint256 i1
+        ; i1 < 10;      i1++)
+    {
+             i1++;
+            }
+
+        uint256 i2;
+        for(++i2;i2<10;i2++)
+        
+        {}
+
+        uint256 veryLongVariableName = 1000;
+        for ( uint256 i3; i3 < 10
+        && veryLongVariableName>999 &&      veryLongVariableName< 1001
+        ; i3++)
+        { i3 ++ ; }
+
+        for (type(uint256).min;;) {}
+
+        for (;;) { "test" ; }
+
+        for (uint256 i4; i4< 10; i4++) i4++;
+
+        for (uint256 i5; ;)
+            for (uint256 i6 = 10; i6 > i5; i6--)
+                i5++;
+    //forgefmt: disable-end
+}
+
+function callArgTest() {
+    //forgefmt: disable-start
+        target.run{ gas: gasleft(), value: 1 wei };
+
+        target.run{gas:1,value:0x00}();
+
+        target.run{ 
+                gas : 1000, 
+        value: 1 ether 
+        } ();
+
+        target.run{  gas: estimate(),
+    value: value(1) }(); 
+
+        target.run { value:
+        value(1 ether), gas: veryAndVeryLongNameOfSomeGasEstimateFunction() } ();
+
+        target.run /* comment 1 */ { value: /* comment2 */ 1 }; 
+
+        target.run { /* comment3 */ value: 1, // comment4
+        gas: gasleft()};
+
+        target.run {
+            // comment5
+            value: 1,
+            // comment6
+            gas: gasleft()};
+    //forgefmt: disable-end
+}
+
+function ifTest() {
+    // forgefmt: disable-start
+    if (condition)
+            execute();
+        else
+            executeElse();
+    // forgefmt: disable-end
+
+    /* forgefmt: disable-next-line */
+    if (condition   &&   anotherLongCondition ) {
+            execute(); }
+}
+
+function yulTest() {
+    // forgefmt: disable-start
+        assembly {
+            let payloadSize := sub(calldatasize(), 4)
+            calldatacopy(0, 4, payloadSize)
+            mstore(payloadSize, shl(96, caller()))
+
+            let result :=
+                delegatecall(gas(), moduleImpl, 0, add(payloadSize, 20), 0, 0)
+
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    // forgefmt: disable-end
+}
+
+function literalTest() {
+    // forgefmt: disable-start
+
+        true;
+            0x123_456;
+        .1;
+    "foobar";
+            hex"001122FF";
+        0xc02aaa39b223Fe8D0A0e5C4F27ead9083c756Cc2;
+    // forgefmt: disable-end
+}
+
+function returnTest() {
+    // forgefmt: disable-start
+        if (val == 0) {
+        return // return single 1
+        0x00;
+        }
+
+        if (val == 1) { return 
+        1; }
+
+        if (val == 2) {
+                return 3
+                -
+                    1;
+        }
+
+        if (val == 4) {
+            /* return single 2 */ return 2** // return single 3
+            3 // return single 4
+            ;
+        }
+
+        return  value(); // return single 5
+            return  ;
+            return /* return mul 4 */
+            (
+                987654321, 1234567890,/* return mul 5 */ false);
+    // forgefmt: disable-end
+}
+
+function namedFuncCall() {
+    // forgefmt: disable-start
+        SimpleStruct memory simple = SimpleStruct({ val: 0 });
+
+        ComplexStruct memory complex = ComplexStruct({ val: 1, anotherVal: 2, flag: true, timestamp: block.timestamp });
+
+        StructWithAVeryLongNameThatExceedsMaximumLengthThatIsAllowedForFormatting memory long = StructWithAVeryLongNameThatExceedsMaximumLengthThatIsAllowedForFormatting({ whyNameSoLong: "dunno" });
+    
+        SimpleStruct memory simple2 = SimpleStruct(
+    { // comment1 
+        /* comment2 */ val : /* comment3 */ 0
+    
+    }
+        );
+    // forgefmt: disable-end
+}
+
+function revertTest() {
+    // forgefmt: disable-start
+        revert ({ });
+
+        revert EmptyError({});
+
+        revert SimpleError({ val: 0 });
+
+        revert ComplexError(
+            {
+                val: 0,
+                    ts: block.timestamp,
+                        message: "some reason"
+            });
+        
+        revert SomeVeryVeryVeryLongErrorNameWithNamedArgumentsThatExceedsMaximumLength({ val: 0, ts: 0x00, message: "something unpredictable happened that caused execution to revert"});
+
+        revert // comment1 
+        ({});
+    // forgefmt: disable-end
+}
+
+function testTernary() {
+    // forgefmt: disable-start
+        bool condition;
+        bool someVeryVeryLongConditionUsedInTheTernaryExpression;
+
+        condition ? 0 : 1;
+
+        someVeryVeryLongConditionUsedInTheTernaryExpression ? 1234567890 : 987654321;
+
+        condition /* comment1 */ ? /* comment2 */ 1001 /* comment3 */ : /* comment4 */ 2002;
+
+        // comment5
+        someVeryVeryLongConditionUsedInTheTernaryExpression ? 1
+        // comment6
+        :
+        // comment7
+        0; // comment8
+    // forgefmt: disable-end
+}
+
+function thisTest() {
+    // forgefmt: disable-start
+        this.someFunc();
+        this.someVeryVeryVeryLongVariableNameThatWillBeAccessedByThisKeyword();
+        this // comment1
+            .someVeryVeryVeryLongVariableNameThatWillBeAccessedByThisKeyword();
+        address(this).balance;
+        
+        address thisAddress = address(
+            // comment2
+             /* comment3 */ this // comment 4
+        );
+    // forgefmt: disable-end
+}
+
+function tryTest() {
+    // forgefmt: disable-start
+        try unknown.empty() {} catch {}
+
+        try unknown.lookup() returns (uint256) {} catch Error(string memory) {}
+
+        try unknown.lookup() returns (uint256) {} catch Error(string memory) {} catch (bytes memory) {}
+
+    try unknown
+        .lookup() returns   (uint256
+                ) {
+                } catch ( bytes  memory ){}
+
+        try unknown.empty() {
+            unknown.doSomething();
+        } catch {
+            unknown.handleError();
+        }
+
+        try unknown.empty() {
+            unknown.doSomething();
+        } catch Error(string memory) {}
+        catch Panic(uint) {}
+        catch {
+            unknown.handleError();
+        }
+
+        try unknown.lookupMultipleValues() returns (uint256, uint256, uint256, uint256, uint256) {} catch Error(string memory) {} catch {}
+ 
+        try unknown.lookupMultipleValues() returns (uint256, uint256, uint256, uint256, uint256) {
+            unknown.doSomething();
+        } 
+        catch Error(string memory) {
+             unknown.handleError();
+        }
+        catch {}
+    // forgefmt: disable-end
+}
+
+function testArray() {
+    // forgefmt: disable-start
+        msg.data[
+            // comment1
+            4:];
+        msg.data[
+            : /* comment2 */ msg.data.length // comment3
+            ];
+        msg.data[
+        // comment4 
+        4 // comment5
+        :msg.data.length /* comment6 */];
+    // forgefmt: disable-end
+}
+
+function testUnit() {
+    // forgefmt: disable-start
+        uint256 timestamp;
+        timestamp = 1 seconds;
+        timestamp = 1 minutes;
+        timestamp = 1 hours;
+        timestamp = 1 days;
+        timestamp = 1 weeks;
+
+        uint256 value;
+        value = 1 wei;
+        value = 1 gwei;
+        value = 1 ether;
+
+        uint256 someVeryVeryVeryLongVaribleNameForTheMultiplierForEtherValue;
+
+        value =  someVeryVeryVeryLongVaribleNameForTheMultiplierForEtherValue * 1 /* comment1 */ ether; // comment2
+
+        value = 1 // comment3
+        // comment4
+        ether; // comment5
+    // forgefmt: disable-end
+}
+
+contract UsingExampleContract {
+    // forgefmt: disable-start
+    using  UsingExampleLibrary      for   *  ;
+        using UsingExampleLibrary for uint;
+    using Example.UsingExampleLibrary  for  uint;
+            using { M.g, M.f} for uint;
+    using UsingExampleLibrary for   uint  global;
+    using { These, Are, MultipleLibraries, ThatNeedToBePut, OnSeparateLines } for uint;
+    using { This.isareally.longmember.access.expression.that.needs.to.besplit.into.lines } for uint;
+    // forgefmt: disable-end
+}
+
+function testAssignment() {
+    // forgefmt: disable-start
+        (, uint256 second) = (1, 2);
+        (uint256 listItem001) = 1;
+        (uint256 listItem002, uint256 listItem003) = (10, 20);
+        (uint256 listItem004, uint256 listItem005, uint256 listItem006) =
+            (10, 20, 30);
+    // forgefmt: disable-end
+}
+
+function testWhile() {
+    // forgefmt: disable-start
+        uint256 i1;
+            while (  i1 <  10 ) {
+            i1++;
+        }
+
+        while (i1<10) i1++;
+
+        while (i1<10)
+            while (i1<10)
+                i1++;
+
+         uint256 i2;
+        while ( i2   < 10) { i2++; }
+
+        uint256 i3; while (
+            i3 < 10
+        ) { i3++; }
+
+        uint256 i4; while (i4 < 10) 
+
+        { i4 ++ ;}
+
+        uint256 someLongVariableName;
+        while (
+            someLongVariableName < 10 && someLongVariableName < 11 && someLongVariableName < 12
+        ) { someLongVariableName ++; } someLongVariableName++;
+    // forgefmt: disable-end
+}
+
+// forgefmt: disable-start
+
+    type Hello is uint256;
+
+error
+  TopLevelCustomError();
+  error TopLevelCustomErrorWithArg(uint    x)  ;
+error TopLevelCustomErrorArgWithoutName  (string);
+
+    event Event1(uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a);
+
+// forgefmt: disable-stop

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -18,9 +18,33 @@ bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b6
 
 // forgefmt: disable-start
 
-// hello
+// comment1
+
+
+// comment2
+/* comment 3 */ /* 
+    comment4
+     */ // comment 5
+
 
 // forgefmt: disable-end
+
+// forgefmt: disable-start
+
+function test1() {}
+
+function test2() {}
+
+// forgefmt: disable-end
+
+contract Constructors is Ownable, Changeable {
+    //forgefmt: disable-next-item
+    function Constructors(variable1) public Changeable(variable1) Ownable() onlyOwner {
+    }
+
+    //forgefmt: disable-next-item
+    constructor(variable1, variable2, variable3, variable4, variable5, variable6, variable7) public Changeable(variable1, variable2, variable3, variable4, variable5, variable6, variable7) Ownable() onlyOwner {}
+}
 
 function test() {
     uint256 pi_approx = 666    /    212;
@@ -42,3 +66,26 @@ function testAttrs(uint256   num, bytes32 data  ,    address receiver)
 // forgefmt: disable-next-line
 function testParams(uint256   num, bytes32 data  ,    address receiver)
     public payable    attr1   Cool( "hello"   ) {}
+
+function testDoWhile() external {
+    //forgefmt: disable-start
+    uint256 i;
+    do { "test"; } while (i != 0);
+
+    do 
+    {}
+    while
+    (
+i != 0);
+
+    bool someVeryVeryLongCondition;
+    do { "test"; } while(
+        someVeryVeryLongCondition && !someVeryVeryLongCondition && 
+!someVeryVeryLongCondition &&
+someVeryVeryLongCondition); 
+
+    do i++; while(i < 10);
+
+    do do i++; while (i < 30); while(i < 20);
+    //forgefmt: disable-end
+}

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -13,6 +13,15 @@ enum States { State1, State2, State3, State4, State5, State6, State7, State8, St
 // forgefmt: disable-next-line
 enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
 
+// forgefmt: disable-next-line
+bytes32 constant private BYTES = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
+
+// forgefmt: disable-start
+
+// hello
+
+// forgefmt: disable-end
+
 function test() {
     uint256 pi_approx = 666    /    212;
     uint256 pi_approx = /* forgefmt: disable-start */ 666    /    212; /* forgefmt: disable-end */

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -53,6 +53,12 @@ function test() {
     // forgefmt: disable-next-item
     uint256 pi_approx = 666 /
         212;
+
+    uint256 test_postfix = 1; // forgefmt: disable-start
+                              // comment1
+                              // comment2
+                              // comment3
+                              // forgefmt: disable-end
 }
 
 // forgefmt: disable-next-item

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -1,0 +1,35 @@
+pragma    solidity     ^0.5.2;
+
+// forgefmt: disable-next-line
+pragma    solidity     ^0.5.2;
+
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
+
+// forgefmt: disable-next-line
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from 'File2.sol';
+
+enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+
+// forgefmt: disable-next-line
+enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+
+function test() {
+    uint256 pi_approx = 666    /    212;
+    uint256 pi_approx = /* forgefmt: disable-start */ 666    /    212; /* forgefmt: disable-end */
+
+    // forgefmt: disable-next-item
+    uint256 pi_approx = 666 /
+        212;
+}
+
+// forgefmt: disable-next-item
+function testFunc(uint256   num, bytes32 data  ,    address receiver)
+    public payable    attr1   Cool( "hello"   ) {}
+
+function testAttrs(uint256   num, bytes32 data  ,    address receiver)
+    // forgefmt: disable-next-line
+    public payable    attr1   Cool( "hello"   ) {}
+
+// forgefmt: disable-next-line
+function testParams(uint256   num, bytes32 data  ,    address receiver)
+    public payable    attr1   Cool( "hello"   ) {}


### PR DESCRIPTION
## Motivation

Users may want to disable formatting for certain sections of code

## Solution

Allows for inserting special comments in the source to disable formatting

```solidity
// forgefmt: disable-next-item
// forgefmt: disable-next-line
// forgefmt: disable-start
// forgefmt: disable-end
```