### PR TITLE
proposed error message change per #2525

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -195,7 +195,7 @@ fn install_as_submodule(
 
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
-        eyre::bail!("There are changes in your working/staging area. Commit them first or add the `--no-commit` option.")
+        eyre::bail!("This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.")
     }
     Ok(())
 }

--- a/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
+++ b/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
@@ -1,2 +1,2 @@
 Error: 
-There are changes in your working/staging area. Commit them first or add the `--no-commit` option.
+This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/2525#issuecomment-1200301785

## Solution

"There are changes in your working/staging area. Commit them first or add the `--no-commit` option."

changed to

"This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option."

(actually it would be even clearer to change that last "add" to "use" ... oh well)
