### PR TITLE
fix: increase dummy return data to 512 bytes

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -15,9 +15,9 @@ use std::cmp::Ordering;
 /// Solidity will see a successful call and attempt to decode the return data. Therefore, we need
 /// to populate the return with dummy bytes so the decode doesn't fail.
 ///
-/// 320 bytes was arbitrarily chosen because it is long enough for return values up to 10 words in
+/// 512 bytes was arbitrarily chosen because it is long enough for return values up to 16 words in
 /// size.
-static DUMMY_CALL_OUTPUT: [u8; 320] = [0u8; 320];
+static DUMMY_CALL_OUTPUT: [u8; 512] = [0u8; 512];
 
 /// Same reasoning as [DUMMY_CALL_OUTPUT], but for creates.
 static DUMMY_CREATE_ADDRESS: Address =

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -41,9 +41,29 @@ contract ConstructorReverter {
     }
 }
 
+/// Used to ensure that the dummy data from `vm.expectRevert`
+/// is large enough to decode big structs.
+///
+/// The struct is based on issue #2454
+struct LargeDummyStruct {
+    address a;
+    uint256 b;
+    bool c;
+    address d;
+    address e;
+    string f;
+    address[8] g;
+    address h;
+    uint256 i;
+}
+
 contract Dummy {
     function callMe() public pure returns (string memory) {
         return "thanks for calling";
+    }
+
+    function largeReturnType() public pure returns (LargeDummyStruct memory) {
+        require(false, "reverted with large return type");
     }
 }
 
@@ -85,6 +105,12 @@ contract ExpectRevertTest is DSTest {
         Dummy dummy = new Dummy();
         cheats.expectRevert("called a function and then reverted");
         reverter.callThenRevert(dummy, "called a function and then reverted");
+    }
+
+    function testDummyReturnDataForBigType() public {
+        Dummy dummy = new Dummy();
+        cheats.expectRevert("reverted with large return type");
+        dummy.largeReturnType();
     }
 
     function testFailExpectRevertErrorDoesNotMatch() public {


### PR DESCRIPTION

## Motivation

`vm.expectRevert` returns some dummy return data that Solidity can decode. This is needed since if the call does not revert, and the function returns some data, Solidity **will** try to decode the return data.

The previous 320 bytes was not big enough in some cases, so we just increase to 512 bytes.

## Solution

Increase dummy return data to 512 bytes (16 words of 256 bits).

Closes #2454