### PR TITLE
feat: support named chains for env args

### DIFF
--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -8,7 +8,7 @@ use foundry_config::{
         value::{Dict, Map, Value},
         Metadata, Profile, Provider,
     },
-    Config,
+    Chain, Config,
 };
 use serde::Serialize;
 
@@ -143,9 +143,9 @@ pub struct EnvArgs {
     pub gas_limit: Option<u64>,
 
     /// The chain ID.
-    #[clap(long, value_name = "CHAIN_ID")]
+    #[clap(long, alias = "chain", value_name = "CHAIN_ID")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub chain_id: Option<u64>,
+    pub chain_id: Option<Chain>,
 
     /// The gas price.
     #[clap(long, value_name = "GAS_PRICE")]
@@ -186,4 +186,23 @@ pub struct EnvArgs {
     #[clap(long, value_name = "GAS_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_gas_limit: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse_chain_id() {
+        let env = EnvArgs {
+            chain_id: Some(ethers_core::types::Chain::Mainnet.into()),
+            ..Default::default()
+        };
+
+        let config = Config::from_provider(env);
+        assert_eq!(config.chain_id, Some(ethers_core::types::Chain::Mainnet.into()));
+
+        let env = EnvArgs::parse_from(["--chain-id", "goerli"]);
+        assert_eq!(config.chain_id, Some(ethers_core::types::Chain::Goerli.into()));
+    }
 }

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -33,7 +33,7 @@ use serde::Serialize;
 /// let opts = figment.extract::<EvmOpts>().unwrap();
 /// # }
 /// ```
-#[derive(Debug, Clone, Parser, Serialize)]
+#[derive(Debug, Clone, Default, Parser, Serialize)]
 pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
@@ -194,15 +194,17 @@ mod tests {
 
     #[test]
     fn can_parse_chain_id() {
-        let env = EnvArgs {
-            chain_id: Some(ethers_core::types::Chain::Mainnet.into()),
+        let args = EvmArgs {
+            env: EnvArgs {
+                chain_id: Some(ethers_core::types::Chain::Mainnet.into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
-
-        let config = Config::from_provider(env);
+        let config = Config::from_provider(Config::figment().merge(args));
         assert_eq!(config.chain_id, Some(ethers_core::types::Chain::Mainnet.into()));
 
-        let env = EnvArgs::parse_from(["--chain-id", "goerli"]);
-        assert_eq!(config.chain_id, Some(ethers_core::types::Chain::Goerli.into()));
+        let env = EnvArgs::parse_from(["foundry-common", "--chain-id", "goerli"]);
+        assert_eq!(env.chain_id, Some(ethers_core::types::Chain::Goerli.into()));
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -199,7 +199,7 @@ pub struct Config {
     pub block_number: u64,
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
-    /// the chainid opcode value
+    /// The chain id to use
     pub chain_id: Option<Chain>,
     /// Block gas limit
     pub gas_limit: GasLimit,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
allow named chains in place of `--chain-id <name>`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
replace `Option<u64>` with `Option<Chain>`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
