### PR TITLE
feat: chain specific provider config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1459,7 +1459,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1525,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#54bd5253c188fbca17f3ccf86cc2d82e8e024f05"
+source = "git+https://github.com/gakonst/ethers-rs#e2754dee4fcbff811610da8a0df7110f8fc4e3a8"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -2021,12 +2021,15 @@ dependencies = [
 name = "foundry-common"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "ethers-core",
+ "ethers-providers",
  "foundry-config",
  "serde",
  "serde_json",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,6 +15,8 @@ foundry-config = { path = "../config" }
 
 # eth
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+
 # cli
 clap = { version = "3.0.10", features = [
     "derive",
@@ -27,3 +29,5 @@ clap = { version = "3.0.10", features = [
 serde = "1.0.133"
 serde_json = "1.0.67"
 thiserror = "1.0.31"
+url = { version = "2.2", default-features = false }
+async-trait = "0.1"

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -1,7 +1,12 @@
 //! Commonly used constants
 
+use std::time::Duration;
+
 /// The dev chain-id, inherited from hardhat
 pub const DEV_CHAIN_ID: u64 = 31337;
 
 /// The first four bytes of the call data for a function call specifies the function to be called.
 pub const SELECTOR_LEN: usize = 4;
+
+/// The polling interval to use for local endpoints
+pub const LOCAL_HTTP_POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,4 +7,5 @@ pub mod errors;
 pub mod evm;
 pub mod fmt;
 pub mod fs;
+pub mod provider;
 pub use constants::*;

--- a/common/src/provider.rs
+++ b/common/src/provider.rs
@@ -1,0 +1,87 @@
+//! utils for creating and configuring Providers
+
+use crate::LOCAL_HTTP_POLL_INTERVAL;
+use ethers_providers::{Http, Middleware, Provider};
+use foundry_config::Chain;
+use url::ParseError;
+
+/// Extension trait for `Provider`
+#[async_trait::async_trait]
+pub trait ProviderExt {
+    /// The error type that can occur when creating a provider
+    type Error: std::fmt::Debug;
+
+    /// Creates a new instance connected to the given `url`, exit on error
+    async fn connect(url: &str) -> Self
+    where
+        Self: Sized,
+    {
+        Self::try_connect(url).await.unwrap()
+    }
+
+    /// Try to create a new `Provider`
+    async fn try_connect(url: &str) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+
+    /// Customize `Provider` settings for chain
+    ///
+    /// Returns the customized `Provider`
+    fn for_chain(mut self, chain: impl Into<Chain>) -> Self
+    where
+        Self: Sized,
+    {
+        self.set_chain(chain);
+        self
+    }
+
+    /// Customized `Provider` settings for chain
+    fn set_chain(&mut self, chain: impl Into<Chain>) -> &mut Self;
+}
+
+#[async_trait::async_trait]
+impl ProviderExt for Provider<Http> {
+    type Error = ParseError;
+
+    async fn try_connect(url: &str) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        let mut provider = Provider::try_from(url)?;
+        if is_local_endpoint(url) {
+            provider.set_interval(LOCAL_HTTP_POLL_INTERVAL);
+        } else if let Ok(chain_id) = provider.get_chainid().await {
+            provider.set_chain(chain_id);
+        }
+
+        Ok(provider)
+    }
+
+    fn set_chain(&mut self, chain: impl Into<Chain>) -> &mut Self {
+        let chain = chain.into();
+        if let Some(blocktime) = chain.average_blocktime_hint() {
+            self.set_interval(blocktime / 2);
+        }
+        self
+    }
+}
+
+/// Returns a http `Provider` that will connect to the given endpoints
+///
+/// If the endpoints is deemed a local endpoint [`is_local_endpoint()`], then the polling interval
+/// is set to [`LOCAL_HTTP_POLL_INTERVAL`]
+pub fn http_provider(endpoint: impl AsRef<str>) -> Result<Provider<Http>, ParseError> {
+    let url = endpoint.as_ref();
+    let provider = Provider::<Http>::try_from(url)?;
+    if is_local_endpoint(url) {
+        Ok(provider.interval(LOCAL_HTTP_POLL_INTERVAL))
+    } else {
+        Ok(provider)
+    }
+}
+
+/// Returns true if the endpoint is local
+#[inline]
+pub fn is_local_endpoint(url: &str) -> bool {
+    url.contains("127.0.0.1") || url.contains("localhost")
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the default interval for an HTTP provider is 7s, or ~1/2 blocktime mainnet
this is larger than the bt of other chains and especially for local endpoint

to make adjusting this easier across all commands, this PR introduces

`ProviderExt` that can adjust interval for chains and adjust when it's created `ProviderExt::connect`

using `ProviderExt::connect` everywhere would be the easiest but could lead to a redundant HTTP  get_chainId call in some cases where `--chain-id` is provided.

this adds a non exhaustive `Chain::avg_blocktime_hint` call for known chains, which could be moved to `ethers-rs` directly

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- [x] add `ProviderExt` and impl for `Provider<Http>`
- [ ] replace all `Provider::try_from` with `ProviderExt::connect` or add `for_chain(chain)` call

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
