### PR TITLE
fix: set interval from provider for PendingTransaction

### DIFF
--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -30,7 +30,10 @@ pub async fn wait_for_receipts(
 ) -> eyre::Result<()> {
     trace!("waiting for receipts of {} transactions", tx_hashes.len());
     let mut tasks = futures::stream::iter(
-        tx_hashes.iter().map(|tx| PendingTransaction::new(*tx, &provider)).collect::<Vec<_>>(),
+        tx_hashes
+            .iter()
+            .map(|tx| PendingTransaction::new(*tx, &provider).interval(provider.get_interval()))
+            .collect::<Vec<_>>(),
     )
     .buffer_unordered(10);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When using `forge script` against a localhost RPC, we weren't respecting the provider interval time.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Set interval when creating the `PendingTransaction`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
