### PR TITLE
feat: dotenv support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1961,7 @@ dependencies = [
  "color-eyre",
  "comfy-table 5.0.1",
  "console 0.15.0",
+ "dotenv",
  "dunce",
  "ethers",
  "eyre",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,6 +44,7 @@ console = "0.15.0"
 watchexec = "2.0.0"
 atty = "0.2.14"
 comfy-table = "5.0.0"
+dotenv = "0.15.0"
 
 # async / parallel
 tokio = { version = "1", features = ["macros"] }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -44,6 +44,7 @@ use std::{
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    utils::load_dotenv();
     handler::install()?;
     utils::subscriber();
     utils::enable_paint();

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -19,6 +19,7 @@ use opts::forge::{Opts, Subcommands};
 use std::process::Command;
 
 fn main() -> eyre::Result<()> {
+    utils::load_dotenv();
     handler::install()?;
     utils::subscriber();
     utils::enable_paint();

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -188,6 +188,17 @@ macro_rules! p_println {
 }
 pub(crate) use p_println;
 
+/// Loads a dotenv file, ignoring potential failure.
+///
+/// We could use `tracing::warn!` here, but that would imply that the dotenv file can't configure
+/// the logging behavior of Foundry.
+///
+/// Similarly, we could just use `eprintln!`, but colors are off limits otherwise dotenv is implied
+/// to not be able to configure the colors. It would also mess up the JSON output.
+pub fn load_dotenv() {
+    dotenv::dotenv().ok();
+}
+
 /// Disables terminal colours if either:
 /// - Running windows and the terminal does not support colour codes.
 /// - Colour has been disabled by some environment variable.


### PR DESCRIPTION
## Motivation

People want `.env` support

## Solution

Loads `.env` before anything else so anything is configurable (`NO_COLOR` etc). Uses the `dotenv` crate which hasn't had an update in a while, but is widely used. Not sure if there are good alternatives.

Closes #840