### PR TITLE
feat: snapshot fuzz tests using deterministic seed

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -283,7 +283,7 @@ impl CoverageArgs {
         let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
 
         // TODO: Coverage for fuzz tests
-        let handle = thread::spawn(move || runner.test(&self.filter, Some(tx), false).unwrap());
+        let handle = thread::spawn(move || runner.test(&self.filter, Some(tx)).unwrap());
         for mut result in rx.into_iter().flat_map(|(_, suite)| suite.test_results.into_values()) {
             if let Some(hit_map) = result.coverage.take() {
                 for (_, trace) in &mut result.traces {


### PR DESCRIPTION
## Motivation

We introduced `--include-fuzz-tests` to make gas snapshots less prone to change from fuzz RNG because we had no way to make the fuzzer deterministic. Now that the fuzzer is deterministic we can remove the flag and include fuzz tests always

## Solution

Removes `--include-fuzz-tests` and uses a deterministic seed for `forge snapshot` runs. This also cleans up the code a bit, since we introduced a variable we had to carry into many files to disable fuzz tests.

Closes #2553