### PR TITLE
fix(anvil): use H256 for setStorage value parameter

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -282,7 +282,7 @@ pub enum EthRequest {
         /// slot
         U256,
         /// value
-        U256,
+        H256,
     ),
 
     /// Sets the coinbase address
@@ -697,7 +697,11 @@ mod tests {
 
     #[test]
     fn test_serde_custom_set_storage_at() {
-        let s = r#"{"method": "anvil_setStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "0x00"]}"#;
+        let s = r#"{"method": "anvil_setStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "0x0000000000000000000000000000000000000000000000000000000000003039"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "hardhat_setStorageAt", "params": ["0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56", "0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49", "0x0000000000000000000000000000000000000000000000000000000000003039"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1260,7 +1260,7 @@ impl EthApi {
         &self,
         address: Address,
         slot: U256,
-        val: U256,
+        val: H256,
     ) -> Result<()> {
         node_info!("anvil_setStorageAt");
         self.backend.set_storage_at(address, slot, val);

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -36,6 +36,7 @@ use anvil_core::{
 };
 use anvil_rpc::error::RpcError;
 use ethers::{
+    abi::ethereum_types::BigEndianHash,
     prelude::{BlockNumber, TxHash, H256, U256, U64},
     types::{
         Address, Block as EthersBlock, BlockId, Bytes, Filter, FilteredParams, Log, Trace,
@@ -327,8 +328,8 @@ impl Backend {
     }
 
     /// Sets the value for the given slot of the given address
-    pub fn set_storage_at(&self, address: Address, slot: U256, val: U256) {
-        self.db.write().set_storage_at(address, slot, val);
+    pub fn set_storage_at(&self, address: Address, slot: U256, val: H256) {
+        self.db.write().set_storage_at(address, slot, val.into_uint());
     }
 
     /// Returns true for post London


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2341

hardhat uses DATA (H256) for the value field of `setStorageAt`:

https://github.com/NomicFoundation/hardhat/blob/e5d7c0d099780f477c28af23520a2ddf74fb317a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts#L305-L311

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use H256 instead of U256

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
