### PR TITLE
Fixed fuzz int overflow

### DIFF
--- a/evm/src/fuzz/strategies/int.rs
+++ b/evm/src/fuzz/strategies/int.rs
@@ -143,7 +143,7 @@ impl IntStrategy {
         let bits = rng.gen_range(0..=self.bits);
 
         if bits == 0 {
-            return Ok(IntValueTree::new(0.into(), false));
+            return Ok(IntValueTree::new(0.into(), false))
         }
 
         // init 2 128-bit randoms
@@ -167,7 +167,7 @@ impl IntStrategy {
         inner[1] = (lower >> 64) as u64;
         inner[2] = (higher & mask64) as u64;
         inner[3] = (higher >> 64) as u64;
-        let sign = if rng.gen_bool(0.5) { Sign::Positive } else {Sign::Negative};
+        let sign = if rng.gen_bool(0.5) { Sign::Positive } else { Sign::Negative };
         // we have a small bias here, i.e. intN::min will never be generated
         // but it's ok since it's generated in `fn generate_edge_tree(...)`
         let (start, _) = I256::overflowing_from_sign_and_abs(sign, U256(inner));

--- a/evm/src/fuzz/strategies/int.rs
+++ b/evm/src/fuzz/strategies/int.rs
@@ -142,12 +142,16 @@ impl IntStrategy {
         // generate random number of bits uniformly
         let bits = rng.gen_range(0..=self.bits);
 
+        if bits == 0 {
+            return Ok(IntValueTree::new(0.into(), false));
+        }
+
         // init 2 128-bit randoms
         let mut higher: u128 = rng.gen_range(0..=u128::MAX);
         let mut lower: u128 = rng.gen_range(0..=u128::MAX);
 
         // cut 2 randoms according to bits size
-        match bits {
+        match bits - 1 {
             x if x < 128 => {
                 lower &= (1u128 << x) - 1;
                 higher = 0;
@@ -163,8 +167,10 @@ impl IntStrategy {
         inner[1] = (lower >> 64) as u64;
         inner[2] = (higher & mask64) as u64;
         inner[3] = (higher >> 64) as u64;
-        // on overflow it will just go negative
-        let (start, _) = I256::overflowing_from_sign_and_abs(Sign::Positive, U256(inner));
+        let sign = if rng.gen_bool(0.5) { Sign::Positive } else {Sign::Negative};
+        // we have a small bias here, i.e. intN::min will never be generated
+        // but it's ok since it's generated in `fn generate_edge_tree(...)`
+        let (start, _) = I256::overflowing_from_sign_and_abs(sign, U256(inner));
 
         Ok(IntValueTree::new(start, false))
     }


### PR DESCRIPTION
## Motivation

Fixes #2560 

The problem was that generating random int relied on the overflow behavior for U256. I.e. it assumed that bits for U256 are just the bits of I256. This perfectly generates random I256. However it stops working when we generate I128 and use I256 for that. Because U128 is not overflown in I256.