### PR TITLE
fix(anvil): update blockhash in db 

### DIFF
--- a/anvil/src/eth/backend/db.rs
+++ b/anvil/src/eth/backend/db.rs
@@ -50,6 +50,9 @@ pub trait Db: DatabaseRef + Database + DatabaseCommit + Send + Sync {
     /// Sets the balance of the given address
     fn set_storage_at(&mut self, address: Address, slot: U256, val: U256);
 
+    /// inserts a blockhash for the given number
+    fn insert_block_hash(&mut self, number: U256, hash: H256);
+
     /// Write all chain data to serialized bytes buffer
     fn dump_state(&self) -> Option<SerializableState>;
 
@@ -84,6 +87,10 @@ impl<T: DatabaseRef + Send + Sync + Clone> Db for CacheDB<T> {
 
     fn set_storage_at(&mut self, address: Address, slot: U256, val: U256) {
         self.insert_account_storage(address, slot, val)
+    }
+
+    fn insert_block_hash(&mut self, number: U256, hash: H256) {
+        self.block_hashes.insert(number, hash);
     }
 
     fn dump_state(&self) -> Option<SerializableState> {

--- a/anvil/src/eth/backend/mem/fork_db.rs
+++ b/anvil/src/eth/backend/mem/fork_db.rs
@@ -3,6 +3,7 @@ use crate::{
     revm::AccountInfo,
     Address, U256,
 };
+use ethers::prelude::H256;
 pub use foundry_evm::executor::fork::database::ForkedDatabase;
 
 /// Implement the helper for the fork database
@@ -13,6 +14,10 @@ impl Db for ForkedDatabase {
 
     fn set_storage_at(&mut self, address: Address, slot: U256, val: U256) {
         self.database_mut().set_storage_at(address, slot, val)
+    }
+
+    fn insert_block_hash(&mut self, number: U256, hash: H256) {
+        self.inner().block_hashes().write().insert(number.as_u64(), hash);
     }
 
     fn dump_state(&self) -> Option<SerializableState> {

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -22,6 +22,10 @@ impl Db for MemDb {
         self.inner.insert_account_storage(address, slot, val)
     }
 
+    fn insert_block_hash(&mut self, number: U256, hash: H256) {
+        self.inner.block_hashes.insert(number, hash);
+    }
+
     fn dump_state(&self) -> Option<SerializableState> {
         let accounts = self
             .inner

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -265,9 +265,8 @@ fn default_vec_of_strings() -> Option<Vec<String>> {
 }
 
 impl TransactionWithMetadata {
-    pub fn from_typed_transaction(transaction: TypedTransaction) -> eyre::Result<Self> {
-        let metadata = Self { transaction, ..Default::default() };
-        Ok(metadata)
+    pub fn from_typed_transaction(transaction: TypedTransaction) -> Self {
+        Self { transaction, ..Default::default() }
     }
 
     pub fn new(

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -11,9 +11,6 @@ use foundry_utils::rpc;
 use regex::Regex;
 use std::{env, path::PathBuf, str::FromStr};
 
-/// A randomly chosen block number, a constant block number increases the probability that the data is already cached and therefore speeds up the tests. <https://etherscan.io/block/15272118>
-const RNG_MAINNET_BLOCK_NUMBER: u64 = 15_272_118;
-
 // Tests that fork cheat codes can be used in script
 forgetest_init!(
     #[ignore]
@@ -254,7 +251,6 @@ contract Demo is Script {
 
         let node_config = NodeConfig::test()
             .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_endpoint()))
-            .with_fork_block_number(Some(RNG_MAINNET_BLOCK_NUMBER))
             .silent();
 
         let (_api, handle) = spawn(node_config).await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the test introduced in #2524 makes use of `roll` cheatcode, first by

`vm.roll(block.number - numUpdates)`;

then simulates mining by 
```
for(uint i = 0; i < numUpdates; i++) {
   vm.roll(block.number + 1);
   hashChecker.update();
}
```

which does `blockhash(block.number - 1)`

this highlighted a problem with block hashes in anvil that were not updated internally in the `Db`

this meant that if a tx requires a hash for a block that was already mined _by_ anvil but is now missing in the DB's internal storage it will try to query it from the endpoint but if there's no new block it will return the 0 hash `blockhash(block.number - 1)`


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
manually insert the new blockhash in the db after mining a new block
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
