### PR TITLE
fix(forge): always enable tracing to collect contract names without requiring `-vvvv` on `forge script`

### DIFF
--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -176,7 +176,8 @@ impl ScriptArgs {
             .with_config(env)
             .with_spec(utils::evm_spec(&script_config.config.evm_version))
             .with_gas_limit(script_config.evm_opts.gas_limit())
-            .set_tracing(script_config.evm_opts.verbosity >= 3 || self.debug);
+            // We need it enabled to decode contract names: local or external.
+            .set_tracing(true);
 
         if let SimulationStage::Local = stage {
             builder = builder


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

closes #2593

We collect local and external contract names through tracing. However, tracing is only enabled with verbose mode.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Always enable tracing. Since we're only talking about `forge script`, I'd say the performance hit is not significant.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
