### PR TITLE
fix: only load env vars from cwd and prj root

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -188,7 +188,7 @@ macro_rules! p_println {
 }
 pub(crate) use p_println;
 
-/// Loads a dotenv file, ignoring potential failure.
+/// Loads a dotenv file, from the cwd and the project root, ignoring potential failure.
 ///
 /// We could use `tracing::warn!` here, but that would imply that the dotenv file can't configure
 /// the logging behavior of Foundry.
@@ -196,7 +196,24 @@ pub(crate) use p_println;
 /// Similarly, we could just use `eprintln!`, but colors are off limits otherwise dotenv is implied
 /// to not be able to configure the colors. It would also mess up the JSON output.
 pub fn load_dotenv() {
-    dotenv::dotenv().ok();
+    let load = |p: &Path| {
+        dotenv::from_path(p.join(".env")).ok();
+    };
+
+    // we only want the .env file of the cwd and project root
+    match (std::env::current_dir(), find_project_root_path()) {
+        (Ok(cwd), Ok(prj_root)) => {
+            load(&prj_root);
+            if cwd != prj_root {
+                // prj root and cwd can be identical
+                load(&cwd);
+            }
+        }
+        _ => {
+            // `find_project_root_path` calls `current_dir` internally so both paths are either both
+            // `Ok` or both `Err`
+        }
+    };
 }
 
 /// Disables terminal colours if either:
@@ -295,6 +312,9 @@ impl CommandUtils for Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_cli_test_utils::tempfile::tempdir;
+    use foundry_common::fs;
+    use std::{env, fs::File, io::Write};
 
     #[test]
     fn foundry_path_ext_works() {
@@ -303,5 +323,33 @@ mod tests {
         assert!(p.is_sol());
         let p = Path::new("contracts/Greeter.sol");
         assert!(!p.is_sol_test());
+    }
+
+    // loads .env from cwd and project dir, See [`find_project_root_path()`]
+    #[test]
+    fn can_load_dotenv() {
+        let temp = tempdir().unwrap();
+        Command::new("git").arg("init").current_dir(temp.path()).exec().unwrap();
+        let cwd_env = temp.path().join(".env");
+        fs::create_file(temp.path().join("foundry.toml")).unwrap();
+        let nested = temp.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+
+        let mut cwd_file = File::create(cwd_env).unwrap();
+        let mut prj_file = File::create(nested.join(".env")).unwrap();
+
+        cwd_file.write_all("TESTCWDKEY=cwd_val".as_bytes()).unwrap();
+        cwd_file.sync_all().unwrap();
+
+        prj_file.write_all("TESTPRJKEY=prj_val".as_bytes()).unwrap();
+        prj_file.sync_all().unwrap();
+
+        let cwd = env::current_dir().unwrap();
+        env::set_current_dir(nested).unwrap();
+        load_dotenv();
+        env::set_current_dir(cwd).unwrap();
+
+        assert_eq!(env::var("TESTCWDKEY").unwrap(), "cwd_val");
+        assert_eq!(env::var("TESTPRJKEY").unwrap(), "prj_val");
     }
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -201,17 +201,13 @@ pub fn load_dotenv() {
     };
 
     // we only want the .env file of the cwd and project root
-    match (std::env::current_dir(), find_project_root_path()) {
-        (Ok(cwd), Ok(prj_root)) => {
-            load(&prj_root);
-            if cwd != prj_root {
-                // prj root and cwd can be identical
-                load(&cwd);
-            }
-        }
-        _ => {
-            // `find_project_root_path` calls `current_dir` internally so both paths are either both
-            // `Ok` or both `Err`
+    // `find_project_root_path` calls `current_dir` internally so both paths are either both `Ok` or
+    // both `Err`
+    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), find_project_root_path()) {
+        load(&prj_root);
+        if cwd != prj_root {
+            // prj root and cwd can be identical
+            load(&cwd);
         }
     };
 }

--- a/cli/test-utils/src/lib.rs
+++ b/cli/test-utils/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 // Macros useful for testing.
 mod macros;
 
@@ -10,4 +8,6 @@ pub use util::{TestCommand, TestProject};
 pub mod script;
 pub use script::{ScriptOutcome, ScriptTester};
 
+// re-exports for convenience
 pub use ethers_solc;
+pub use tempfile;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`dotenv()`

>  It loads the .env file located in the environment's current directory or its parents in sequence.

I think we should restrict this to cwd + project dir only, so no env vars are read from outside the project

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
