### PR TITLE
Fix mean on empty arrays

### DIFF
--- a/common/src/calc.rs
+++ b/common/src/calc.rs
@@ -22,16 +22,16 @@ pub fn median_sorted<T>(values: &[T]) -> T
 where
     T: Add<Output = T> + Div<u64, Output = T> + From<u64> + Copy,
 {
+    if values.is_empty() {
+        return 0u64.into()
+    }
+
     let len = values.len();
-    if len > 0 {
-        let mid = len / 2;
-        if len % 2 == 0 {
-            (values[mid - 1] + values[mid]) / 2u64
-        } else {
-            values[mid]
-        }
+    let mid = len / 2;
+    if len % 2 == 0 {
+        (values[mid - 1] + values[mid]) / 2u64
     } else {
-        0u64.into()
+        values[mid]
     }
 }
 
@@ -40,10 +40,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn calc_mean_empty() {
+        let values: [u64; 0] = [];
+        let m = mean(&values);
+        assert_eq!(m, U256::zero());
+    }
+
+    #[test]
     fn calc_mean() {
         let values = [0u64, 1u64, 2u64, 3u64, 4u64, 5u64, 6u64];
         let m = mean(&values);
         assert_eq!(m, 3u64.into());
+    }
+
+    #[test]
+    fn calc_median_empty() {
+        let values: Vec<u64> = vec![];
+        let m = median_sorted(&values);
+        assert_eq!(m, 0);
     }
 
     #[test]

--- a/common/src/calc.rs
+++ b/common/src/calc.rs
@@ -9,12 +9,11 @@ pub fn mean<T>(values: &[T]) -> U256
 where
     T: Into<U256> + Copy,
 {
-    let len = values.len();
-    if len > 0 {
-        values.iter().copied().fold(U256::zero(), |sum, val| sum + val.into()) / len
-    } else {
-        U256::zero()
+    if values.is_empty() {
+        return U256::zero()
     }
+
+    values.iter().copied().fold(U256::zero(), |sum, val| sum + val.into()) / values.len()
 }
 
 /// Returns the median of a _sorted_ slice

--- a/common/src/calc.rs
+++ b/common/src/calc.rs
@@ -9,7 +9,12 @@ pub fn mean<T>(values: &[T]) -> U256
 where
     T: Into<U256> + Copy,
 {
-    values.iter().copied().fold(U256::zero(), |sum, val| sum + val.into()) / values.len()
+    let len = values.len();
+    if len > 0 {
+        values.iter().copied().fold(U256::zero(), |sum, val| sum + val.into()) / len
+    } else {
+        U256::zero()
+    }
 }
 
 /// Returns the median of a _sorted_ slice


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The gas report of my test suite is panicking when providing `FOUNDRY_FUZZ_RUNS=0`, because it's computing the mean of an empty array (`&func.calls`)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Check if the array is empty in `calc::mean`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Closes #2611 