### PR TITLE
test: fix tests

### DIFF
--- a/testdata/fuzz/Fuzz.t.sol
+++ b/testdata/fuzz/Fuzz.t.sol
@@ -18,7 +18,7 @@ contract FuzzTest is DSTest {
 
     function testFailFuzz(uint8 x) public {
         emit log("testFailFuzz");
-        require(x == 5, "should revert");
+        require(x > 128, "should revert");
     }
 
     function testSuccessfulFuzz(uint128 a, uint128 b) public {


### PR DESCRIPTION
## Motivation

Tests are failing

## Solution

Fix them

1. `testFailFuzz` did not fail as it should in some cases. This is because `proptest` just makes us generate a new tree on every test case, so effectively we're just throwing random numbers at the fuzz test. Since we run 256 times, there is a probability that we don't hit `x = 5` exactly, so I just broadened the chance of failure (`x > 128` fails the test)

Closes #2548 