### PR TITLE
feat(forge): detect max code size on deployed contracts during `forge script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "color-eyre",
  "comfy-table 5.0.1",
  "console 0.15.0",
+ "dialoguer",
  "dotenv",
  "dunce",
  "ethers",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,7 @@ watchexec = "2.0.0"
 atty = "0.2.14"
 comfy-table = "5.0.0"
 dotenv = "0.15.0"
+dialoguer = { version = "0.8.0", default-features = false }
 
 # async / parallel
 tokio = { version = "1", features = ["macros"] }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -147,6 +147,12 @@ impl ScriptArgs {
                 }
 
                 verify.known_contracts = unwrap_contracts(&highlevel_known_contracts, false);
+
+                self.check_contract_sizes(
+                    result.transactions.as_ref(),
+                    &highlevel_known_contracts,
+                )?;
+
                 self.handle_broadcastable_transactions(
                     &target,
                     result,

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -7,14 +7,19 @@ use crate::{
     opts::MultiWallet,
     utils::{get_contract_name, parse_ether_value},
 };
+use cast::executor::inspector::DEFAULT_CREATE2_DEPLOYER;
 use clap::{Parser, ValueHint};
+use dialoguer::Confirm;
 use ethers::{
     abi::{Abi, Function},
     prelude::{
         artifacts::{ContractBytecodeSome, Libraries},
         ArtifactId, Bytes, Project,
     },
-    types::{transaction::eip2718::TypedTransaction, Address, Log, TransactionRequest, U256},
+    types::{
+        transaction::eip2718::TypedTransaction, Address, Log, NameOrAddress, TransactionRequest,
+        U256,
+    },
 };
 use forge::{
     debug::DebugArena,
@@ -25,7 +30,7 @@ use forge::{
         CallTraceArena, CallTraceDecoder, CallTraceDecoderBuilder, TraceKind,
     },
 };
-use foundry_common::evm::EvmArgs;
+use foundry_common::{evm::EvmArgs, CONTRACT_MAX_SIZE};
 use foundry_config::Config;
 use foundry_utils::{encode_args, format_token, IntoFunction};
 use serde::{Deserialize, Serialize};
@@ -49,6 +54,7 @@ mod cmd;
 mod executor;
 mod receipts;
 mod sequence;
+pub use sequence::TransactionWithMetadata;
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(ScriptArgs, opts, evm_opts);
@@ -409,6 +415,72 @@ impl ScriptArgs {
             }
         };
         Ok((func.clone(), data))
+    }
+
+    /// Checks if the transaction is a deployment with a size above the `CONTRACT_MAX_SIZE`.
+    ///
+    /// If `self.broadcast` is enabled, it asks confirmation of the user. Otherwise, it just warns
+    /// the user.
+    fn check_contract_sizes(
+        &self,
+        transactions: Option<&VecDeque<TypedTransaction>>,
+        known_contracts: &BTreeMap<ArtifactId, ContractBytecodeSome>,
+    ) -> eyre::Result<()> {
+        if let Some(txes) = transactions {
+            for tx in txes {
+                if let Some(data) = tx.data() {
+                    if data.len() > CONTRACT_MAX_SIZE {
+                        let mut offset = 0;
+
+                        // Find if it's a CREATE or CREATE2. Otherwise, skip transaction.
+                        if let Some(NameOrAddress::Address(to)) = tx.to() {
+                            if *to == DEFAULT_CREATE2_DEPLOYER {
+                                // Size of the salt prefix.
+                                offset = 32;
+                            }
+                        } else if tx.to().is_some() {
+                            continue
+                        }
+
+                        // Find artifact with a deployment code same as the data.
+                        if let Some((artifact, bytecode)) =
+                            known_contracts.iter().find(|(_, bytecode)| {
+                                bytecode
+                                    .bytecode
+                                    .object
+                                    .as_bytes()
+                                    .expect("Code should have been linked before.") ==
+                                    &data[offset..]
+                            })
+                        {
+                            // Find the deployed code size of the artifact.
+                            if let Some(deployed_bytecode) = &bytecode.deployed_bytecode.bytecode {
+                                let deployment_size = deployed_bytecode.object.bytes_len();
+
+                                if deployment_size > CONTRACT_MAX_SIZE {
+                                    println!(
+                                        "{}",
+                                        Paint::red(format!(
+                                            "`{}` is above the contract size limit ({} vs {}).",
+                                            artifact.name, deployment_size, CONTRACT_MAX_SIZE
+                                        ))
+                                    );
+
+                                    if self.broadcast &&
+                                        !Confirm::new()
+                                            .with_prompt("Do you wish to continue?".to_string())
+                                            .interact()?
+                                    {
+                                        eyre::bail!("User canceled the script.");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -6,5 +6,5 @@ pub const DEV_CHAIN_ID: u64 = 31337;
 /// The first four bytes of the call data for a function call specifies the function to be called.
 pub const SELECTOR_LEN: usize = 4;
 
-/// Maximum size in bytes that a contract can have.
-pub const CONTRACT_MAX_SIZE: usize = 0x6000;
+/// Maximum size in bytes (0x6000) that a contract can have.
+pub const CONTRACT_MAX_SIZE: usize = 24576;

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -5,3 +5,6 @@ pub const DEV_CHAIN_ID: u64 = 31337;
 
 /// The first four bytes of the call data for a function call specifies the function to be called.
 pub const SELECTOR_LEN: usize = 4;
+
+/// Maximum size in bytes that a contract can have.
+pub const CONTRACT_MAX_SIZE: usize = 0x6000;


### PR DESCRIPTION

## Motivation
Contracts above 24KB were getting deployed, leading to failed transactions.
closes #2535

## Solution
Checks for the deployed bytecode size and issues a warning if above it. If `--broadcast` is passed, then it requires the user for manual confirmation to deploy.
