### PR TITLE
perf: improve pc/ic mapping stuff

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -25,7 +25,9 @@ use forge::{
     },
     executor::{inspector::CheatsConfig, opts::EvmOpts},
     result::SuiteResult,
+    revm::SpecId,
     trace::identifier::LocalTraceIdentifier,
+    utils::{build_ic_pc_map, ICPCMap},
     MultiContractRunnerBuilder, TestOptions,
 };
 use foundry_common::{evm::EvmArgs, fs};
@@ -164,48 +166,62 @@ impl CoverageArgs {
             .into_iter()
             .map(|(id, artifact)| (id, CompactContractBytecode::from(artifact)))
             .filter_map(|(id, artifact)| {
-                Some((
+                let contract_id = ContractId {
+                    version: id.version.clone(),
+                    source_id: *report
+                        .get_source_id(id.version, id.source.to_string_lossy().to_string())?,
+                    contract_name: id.name,
+                };
+                let source_maps = (
+                    contract_id.clone(),
                     (
-                        ContractId {
-                            version: id.version.clone(),
-                            source_id: *report.get_source_id(
-                                id.version.clone(),
-                                id.source.to_string_lossy().to_string(),
-                            )?,
-                            contract_name: id.name.clone(),
-                        },
-                        (
-                            artifact.get_source_map()?.ok()?,
-                            artifact
-                                .get_deployed_bytecode()
-                                .as_ref()?
-                                .bytecode
-                                .as_ref()?
-                                .source_map()?
-                                .ok()?,
-                        ),
+                        artifact.get_source_map()?.ok()?,
+                        artifact
+                            .get_deployed_bytecode()
+                            .as_ref()?
+                            .bytecode
+                            .as_ref()?
+                            .source_map()?
+                            .ok()?,
                     ),
+                );
+                let bytecodes = (
+                    contract_id,
                     (
-                        ContractId {
-                            version: id.version.clone(),
-                            source_id: *report.get_source_id(
-                                id.version.clone(),
-                                id.source.to_string_lossy().to_string(),
-                            )?,
-                            contract_name: id.name.clone(),
-                        },
-                        (
-                            artifact
-                                .get_bytecode()
-                                .and_then(|bytecode| dummy_link_bytecode(bytecode.into_owned()))?,
-                            artifact.get_deployed_bytecode().and_then(|bytecode| {
-                                dummy_link_deployed_bytecode(bytecode.into_owned())
-                            })?,
-                        ),
+                        artifact
+                            .get_bytecode()
+                            .and_then(|bytecode| dummy_link_bytecode(bytecode.into_owned()))?,
+                        artifact.get_deployed_bytecode().and_then(|bytecode| {
+                            dummy_link_deployed_bytecode(bytecode.into_owned())
+                        })?,
                     ),
-                ))
+                );
+
+                Some((source_maps, bytecodes))
             })
             .unzip();
+
+        // Build IC -> PC mappings
+        //
+        // The source maps are indexed by *instruction counters*, which are the indexes of
+        // instructions in the bytecode *minus any push bytes*.
+        //
+        // Since our coverage inspector collects hit data using program counters, the anchors also
+        // need to be based on program counters.
+        // TODO: Index by contract ID
+        let ic_pc_maps: HashMap<ContractId, (ICPCMap, ICPCMap)> = bytecodes
+            .iter()
+            .map(|(id, bytecodes)| {
+                // TODO: Creation bytecode as well
+                (
+                    id.clone(),
+                    (
+                        build_ic_pc_map(SpecId::LATEST, bytecodes.0.as_ref()),
+                        build_ic_pc_map(SpecId::LATEST, bytecodes.1.as_ref()),
+                    ),
+                )
+            })
+            .collect();
 
         // Add coverage items
         for (version, asts) in versioned_asts.into_iter() {
@@ -229,6 +245,7 @@ impl CoverageArgs {
                         find_anchors(
                             &bytecodes.get(contract_id)?.1,
                             &source_maps.get(contract_id)?.1,
+                            &ic_pc_maps.get(contract_id)?.1,
                             item_ids,
                             &source_analysis.items,
                         ),
@@ -251,62 +268,62 @@ impl CoverageArgs {
         config: Config,
         evm_opts: EvmOpts,
     ) -> eyre::Result<()> {
-        let test_options = TestOptions {
-            fuzz_runs: config.fuzz_runs,
-            fuzz_max_local_rejects: config.fuzz_max_local_rejects,
-            fuzz_max_global_rejects: config.fuzz_max_global_rejects,
-            ..Default::default()
-        };
-
         let root = project.paths.root;
-
-        let env = evm_opts.evm_env_blocking();
 
         // Build the contract runner
         let evm_spec = utils::evm_spec(&config.evm_version);
+        let env = evm_opts.evm_env_blocking();
         let mut runner = MultiContractRunnerBuilder::default()
             .initial_balance(evm_opts.initial_balance)
             .evm_spec(evm_spec)
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, &evm_opts))
-            .with_test_options(test_options)
+            .with_test_options(TestOptions {
+                fuzz_runs: config.fuzz_runs,
+                fuzz_max_local_rejects: config.fuzz_max_local_rejects,
+                fuzz_max_global_rejects: config.fuzz_max_global_rejects,
+                ..Default::default()
+            })
             .set_coverage(true)
             .build(root.clone(), output, env, evm_opts)?;
-
-        let (tx, rx) = channel::<(String, SuiteResult)>();
 
         // Set up identifier
         let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
 
-        // TODO: Coverage for fuzz tests
+        // Run tests
+        let (tx, rx) = channel::<(String, SuiteResult)>();
         let handle =
             thread::spawn(move || runner.test(&self.filter, Some(tx), Default::default()).unwrap());
-        for mut result in rx.into_iter().flat_map(|(_, suite)| suite.test_results.into_values()) {
-            if let Some(hit_map) = result.coverage.take() {
-                for (_, trace) in &mut result.traces {
-                    local_identifier
-                        .identify_addresses(trace.addresses().into_iter().collect())
-                        .into_iter()
-                        .for_each(|identity| {
-                            if let Some((artifact_id, hits)) =
-                                identity.artifact_id.zip(hit_map.get(&identity.address))
-                            {
-                                if let Some(source_id) = report.get_source_id(
-                                    artifact_id.version.clone(),
-                                    artifact_id.source.to_string_lossy().to_string(),
-                                ) {
-                                    let contract_id = ContractId {
-                                        version: artifact_id.version,
-                                        source_id: *source_id,
-                                        contract_name: artifact_id.name,
-                                    };
 
-                                    // TODO: Distinguish between creation/runtime in a smart way
-                                    report.add_hit_map(&contract_id, hits);
-                                }
-                            }
-                        });
+        // Add hit data to the coverage report
+        for (hit_map, traces) in rx
+            .into_iter()
+            .flat_map(|(_, suite)| suite.test_results.into_values())
+            .flat_map(|mut result| Some((result.coverage.take()?, result.traces)))
+        {
+            let hits = traces
+                .into_iter()
+                .flat_map(|(_, trace)| {
+                    local_identifier.identify_addresses(trace.addresses().into_iter().collect())
+                })
+                .flat_map(|identity| identity.artifact_id.zip(hit_map.get(&identity.address)));
+            // TODO: Coverage for fuzz tests
+            // TODO: Note down failing tests
+            for (artifact_id, hits) in hits {
+                if let Some(source_id) = report.get_source_id(
+                    artifact_id.version.clone(),
+                    artifact_id.source.to_string_lossy().to_string(),
+                ) {
+                    // TODO: Distinguish between creation/runtime in a smart way
+                    report.add_hit_map(
+                        &ContractId {
+                            version: artifact_id.version,
+                            source_id: *source_id,
+                            contract_name: artifact_id.name,
+                        },
+                        hits,
+                    );
                 }
             }
         }
@@ -314,6 +331,7 @@ impl CoverageArgs {
         // Reattach the thread
         let _ = handle.join();
 
+        // Output final report
         match self.report {
             CoverageReportKind::Summary => SummaryReporter::default().report(report),
             // TODO: Sensible place to put the LCOV file

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -374,8 +374,10 @@ impl ScriptArgs {
     ) -> eyre::Result<()> {
         let (sources, artifacts) =
             filter_sources_and_artifacts(&self.path, sources, highlevel_known_contracts, project)?;
-        let calls: Vec<DebugArena> = result.debug.expect("we should have collected debug info");
-        let flattened = calls.last().expect("we should have collected debug info").flatten(0);
+        let flattened = result
+            .debug
+            .and_then(|arena| arena.last().map(|arena| arena.flatten(0)))
+            .expect("We should have collected debug information");
         let identified_contracts = decoder
             .contracts
             .iter()

--- a/evm/src/coverage/anchors.rs
+++ b/evm/src/coverage/anchors.rs
@@ -1,12 +1,13 @@
 use super::{CoverageItem, CoverageItemKind, ItemAnchor, SourceLocation};
+use crate::utils::ICPCMap;
 use ethers::prelude::{sourcemap::SourceMap, Bytes};
 use revm::{opcode, spec_opcode_gas, SpecId};
-use std::collections::BTreeMap;
 
 /// Attempts to find anchors for the given items using the given source map and bytecode.
 pub fn find_anchors(
     bytecode: &Bytes,
     source_map: &SourceMap,
+    ic_pc_map: &ICPCMap,
     item_ids: &[usize],
     items: &[CoverageItem],
 ) -> Vec<ItemAnchor> {
@@ -29,7 +30,7 @@ pub fn find_anchors(
                         }
                     }
                 }
-                _ => match find_anchor_simple(source_map, *item_id, &item.loc) {
+                _ => match find_anchor_simple(source_map, ic_pc_map, *item_id, &item.loc) {
                     Ok(anchor) => Some(anchor),
                     Err(e) => {
                         tracing::warn!("Could not find anchor for item: {}, error: {e}", item);
@@ -44,6 +45,7 @@ pub fn find_anchors(
 /// Find an anchor representing the first opcode within the given source range.
 pub fn find_anchor_simple(
     source_map: &SourceMap,
+    ic_pc_map: &ICPCMap,
     item_id: usize,
     loc: &SourceLocation,
 ) -> eyre::Result<ItemAnchor> {
@@ -65,7 +67,12 @@ pub fn find_anchor_simple(
             eyre::eyre!("Could not find anchor: No matching instruction in range {}", loc)
         })?;
 
-    Ok(ItemAnchor { instruction, item_id })
+    Ok(ItemAnchor {
+        instruction: *ic_pc_map.get(&instruction).ok_or_else(|| {
+            eyre::eyre!("We found an anchor, but we cant translate it to a program counter")
+        })?,
+        item_id,
+    })
 }
 
 /// Finds the anchor corresponding to a branch item.
@@ -93,9 +100,9 @@ pub fn find_anchor_simple(
 /// <true branch>
 /// ```
 ///
-/// This function will look for the last JUMPI instruction, backtrack to find the instruction
-/// counter of the first branch, and return an item for that instruction counter, and the
-/// instruction counter immediately after the JUMPI instruction.
+/// This function will look for the last JUMPI instruction, backtrack to find the program
+/// counter of the first branch, and return an item for that program counter, and the
+/// program counter immediately after the JUMPI instruction.
 pub fn find_anchor_branch(
     bytecode: &Bytes,
     source_map: &SourceMap,
@@ -106,14 +113,10 @@ pub fn find_anchor_branch(
     // is the gas cost.
     let opcode_infos = spec_opcode_gas(SpecId::LATEST);
 
-    let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
-    let mut first_branch_ic = None;
-    let mut second_branch_pc = None;
     let mut pc = 0;
     let mut cumulative_push_size = 0;
     while pc < bytecode.0.len() {
         let op = bytecode.0[pc];
-        ic_map.insert(pc, pc - cumulative_push_size);
 
         // We found a push, so we do some PC -> IC translation accounting, but we also check if
         // this push is coupled with the JUMPI we are interested in.
@@ -143,9 +146,6 @@ pub fn find_anchor_branch(
                     panic!("We found the anchor for the branch, but it refers to a program counter bigger than 64 bits.");
                 }
 
-                // The first branch is the opcode directly after JUMPI
-                first_branch_ic = Some(pc + 2 - cumulative_push_size);
-
                 // Convert the push bytes for the second branch's PC to a usize
                 let push_bytes_start = pc - push_size + 1;
                 let mut pc_bytes: [u8; 8] = [0; 8];
@@ -154,23 +154,19 @@ pub fn find_anchor_branch(
                 {
                     pc_bytes[8 - push_size + i] = *push_byte;
                 }
-                second_branch_pc = Some(usize::from_be_bytes(pc_bytes));
+
+                return Ok((
+                    ItemAnchor {
+                        item_id,
+                        // The first branch is the opcode directly after JUMPI
+                        instruction: pc + 2,
+                    },
+                    ItemAnchor { item_id, instruction: usize::from_be_bytes(pc_bytes) },
+                ))
             }
         }
         pc += 1;
     }
 
-    match (first_branch_ic, second_branch_pc) {
-            (Some(first_branch_ic), Some(second_branch_pc)) => Ok((
-                    ItemAnchor {
-                        item_id,
-                        instruction: first_branch_ic,
-                    },
-                    ItemAnchor {
-                        item_id,
-                        instruction: *ic_map.get(&second_branch_pc).expect("Could not translate the program counter of the second branch to an instruction counter"),
-                    }
-            )),
-            _ => eyre::bail!("Could not detect branches in source: {}", loc)
-        }
+    eyre::bail!("Could not detect branches in source: {}", loc)
 }

--- a/evm/src/coverage/mod.rs
+++ b/evm/src/coverage/mod.rs
@@ -124,9 +124,9 @@ pub struct HitMap {
 }
 
 impl HitMap {
-    /// Increase the hit counter for the given instruction counter.
-    pub fn hit(&mut self, ic: usize) {
-        *self.hits.entry(ic).or_default() += 1;
+    /// Increase the hit counter for the given program counter.
+    pub fn hit(&mut self, pc: usize) {
+        *self.hits.entry(pc).or_default() += 1;
     }
 }
 
@@ -151,7 +151,7 @@ impl Display for ContractId {
 /// An item anchor describes what instruction marks a [CoverageItem] as covered.
 #[derive(Clone, Debug)]
 pub struct ItemAnchor {
-    /// The instruction counter for the opcode of this anchor
+    /// The program counter for the opcode of this anchor
     pub instruction: usize,
     /// The item ID this anchor points to
     pub item_id: usize,

--- a/evm/src/debug.rs
+++ b/evm/src/debug.rs
@@ -110,8 +110,6 @@ impl DebugNode {
 /// pushed onto the stack, and the instruction counter for use with sourcemap.
 #[derive(Debug, Clone)]
 pub struct DebugStep {
-    /// The program counter
-    pub pc: usize,
     /// Stack *prior* to running the associated opcode
     pub stack: Vec<U256>,
     /// Memory *prior* to running the associated opcode
@@ -120,8 +118,11 @@ pub struct DebugStep {
     pub instruction: Instruction,
     /// Optional bytes that are being pushed onto the stack
     pub push_bytes: Option<Vec<u8>>,
-    /// Instruction counter, used to map this instruction to source code
-    pub ic: usize,
+    /// The program counter at this step.
+    ///
+    /// Note: To map this step onto source code using a source map, you must convert the program
+    /// counter to an instruction counter.
+    pub pc: usize,
     /// Cumulative gas usage
     pub total_gas_used: u64,
 }
@@ -129,12 +130,11 @@ pub struct DebugStep {
 impl Default for DebugStep {
     fn default() -> Self {
         Self {
-            pc: 0,
             stack: vec![],
             memory: Memory::new(),
             instruction: Instruction::OpCode(revm::opcode::INVALID),
             push_bytes: None,
-            ic: 0,
+            pc: 0,
             total_gas_used: 0,
         }
     }

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -1,10 +1,7 @@
-use crate::{
-    coverage::HitMaps, executor::inspector::utils::get_create_address, utils::build_ic_map,
-};
+use crate::{coverage::HitMaps, executor::inspector::utils::get_create_address};
 use bytes::Bytes;
 use ethers::types::Address;
 use revm::{CallInputs, CreateInputs, Database, EVMData, Gas, Inspector, Interpreter, Return};
-use std::collections::BTreeMap;
 
 #[derive(Default, Debug)]
 pub struct CoverageCollector {
@@ -13,14 +10,6 @@ pub struct CoverageCollector {
 
     /// The execution addresses, with the topmost one being the current address.
     context: Vec<Address>,
-
-    /// A mapping of program counters to instruction counters.
-    ///
-    /// The program counter keeps track of where we are in the contract bytecode as a whole,
-    /// including push bytes, while the instruction counter ignores push bytes.
-    ///
-    /// The instruction counter is used in Solidity source maps.
-    pub ic_map: BTreeMap<Address, BTreeMap<usize, usize>>,
 }
 
 impl CoverageCollector {
@@ -48,39 +37,14 @@ where
         (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
 
-    // TODO: Duplicate code of the debugger inspector
-    fn initialize_interp(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        _: bool,
-    ) -> Return {
-        // TODO: This is rebuilt for all contracts every time. We should only run this if the IC
-        // map for a given address does not exist, *but* we need to account for the fact that the
-        // code given by the interpreter may either be the contract init code, or the runtime code.
-        if let Some(context) = self.context.last() {
-            self.ic_map.insert(
-                *context,
-                build_ic_map(data.env.cfg.spec_id, interp.contract().bytecode.bytecode()),
-            );
-        }
-        Return::Continue
-    }
-
-    // TODO: Don't collect coverage for test contract if possible
     fn step(
         &mut self,
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
         _is_static: bool,
     ) -> Return {
-        let pc = interpreter.program_counter();
         if let Some(context) = self.context.last() {
-            if let Some(ic) = self.ic_map.get(context).and_then(|ic_map| ic_map.get(&pc)) {
-                let map = self.maps.entry(*context).or_default();
-
-                map.hit(*ic);
-            }
+            self.maps.entry(*context).or_default().hit(interpreter.program_counter());
         }
 
         Return::Continue

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -4,7 +4,7 @@ use crate::{
         inspector::utils::{gas_used, get_create_address},
         CHEATCODE_ADDRESS,
     },
-    utils::build_ic_map,
+    utils::{build_pc_ic_map, PCICMap},
     CallKind,
 };
 use bytes::Bytes;
@@ -30,7 +30,7 @@ pub struct Debugger {
     /// including push bytes, while the instruction counter ignores push bytes.
     ///
     /// The instruction counter is used in Solidity source maps.
-    pub ic_map: BTreeMap<Address, BTreeMap<usize, usize>>,
+    pub ic_map: BTreeMap<Address, PCICMap>,
     /// The amount of gas spent in the current gas block.
     ///
     /// REVM adds gas in blocks, so we need to keep track of this separately to get accurate gas
@@ -105,7 +105,7 @@ where
         // code given by the interpreter may either be the contract init code, or the runtime code.
         self.ic_map.insert(
             self.context,
-            build_ic_map(data.env.cfg.spec_id, interp.contract().bytecode.bytecode()),
+            build_pc_ic_map(data.env.cfg.spec_id, interp.contract().bytecode.bytecode()),
         );
         self.previous_gas_block = interp.contract.first_gas_block();
         Return::Continue

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -4,7 +4,6 @@ use crate::{
         inspector::utils::{gas_used, get_create_address},
         CHEATCODE_ADDRESS,
     },
-    utils::{build_pc_ic_map, PCICMap},
     CallKind,
 };
 use bytes::Bytes;
@@ -13,7 +12,6 @@ use revm::{
     opcode, spec_opcode_gas, CallInputs, CreateInputs, Database, EVMData, Gas, Inspector,
     Interpreter, Memory, Return,
 };
-use std::collections::BTreeMap;
 
 /// An inspector that collects debug nodes on every step of the interpreter.
 #[derive(Default, Debug)]
@@ -24,13 +22,6 @@ pub struct Debugger {
     pub head: usize,
     /// The current execution address.
     pub context: Address,
-    /// A mapping of program counters to instruction counters.
-    ///
-    /// The program counter keeps track of where we are in the contract bytecode as a whole,
-    /// including push bytes, while the instruction counter ignores push bytes.
-    ///
-    /// The instruction counter is used in Solidity source maps.
-    pub ic_map: BTreeMap<Address, PCICMap>,
     /// The amount of gas spent in the current gas block.
     ///
     /// REVM adds gas in blocks, so we need to keep track of this separately to get accurate gas
@@ -97,16 +88,9 @@ where
     fn initialize_interp(
         &mut self,
         interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
+        _: &mut EVMData<'_, DB>,
         _: bool,
     ) -> Return {
-        // TODO: This is rebuilt for all contracts every time. We should only run this if the IC
-        // map for a given address does not exist, *but* we need to account for the fact that the
-        // code given by the interpreter may either be the contract init code, or the runtime code.
-        self.ic_map.insert(
-            self.context,
-            build_pc_ic_map(data.env.cfg.spec_id, interp.contract().bytecode.bytecode()),
-        );
         self.previous_gas_block = interp.contract.first_gas_block();
         Return::Continue
     }
@@ -154,12 +138,6 @@ where
             memory: interpreter.memory.clone(),
             instruction: Instruction::OpCode(op),
             push_bytes,
-            ic: *self
-                .ic_map
-                .get(&self.context)
-                .expect("no instruction counter map")
-                .get(&pc)
-                .expect("unknown ic for pc"),
             total_gas_used: gas_used(data.env.cfg.spec_id, total_gas_spent, gas.refunded() as u64),
         });
 

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -78,9 +78,9 @@ impl<'a> FuzzedExecutor<'a> {
             let call = self
                 .executor
                 .call_raw(self.sender, address, calldata.0.clone(), 0.into())
-                .expect("could not make raw evm call");
+                .expect("Could not call contract with fuzzed input.");
             let state_changeset =
-                call.state_changeset.as_ref().expect("we should have a state changeset");
+                call.state_changeset.as_ref().expect("We should have a state changeset.");
 
             // Build fuzzer state
             collect_state_from_call(&call.logs, state_changeset, state.clone());

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -26,18 +26,21 @@ pub fn h256_to_u256_le(storage: H256) -> U256 {
     U256::from_little_endian(storage.as_bytes())
 }
 
-/// Builds the instruction counter map for the given bytecode.
+/// A map of program counters to instruction counters.
+pub type PCICMap = BTreeMap<usize, usize>;
+
+/// Builds a mapping from program counters to instruction counters.
 // TODO: Some of the same logic is performed in REVM, but then later discarded. We should
 // investigate if we can reuse it
-pub fn build_ic_map(spec: SpecId, code: &[u8]) -> BTreeMap<usize, usize> {
+pub fn build_pc_ic_map(spec: SpecId, code: &[u8]) -> PCICMap {
     let opcode_infos = spec_opcode_gas(spec);
-    let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut pc_ic_map: PCICMap = BTreeMap::new();
 
     let mut i = 0;
     let mut cumulative_push_size = 0;
     while i < code.len() {
         let op = code[i];
-        ic_map.insert(i, i - cumulative_push_size);
+        pc_ic_map.insert(i, i - cumulative_push_size);
         if opcode_infos[op as usize].is_push() {
             // Skip the push bytes.
             //
@@ -48,5 +51,31 @@ pub fn build_ic_map(spec: SpecId, code: &[u8]) -> BTreeMap<usize, usize> {
         i += 1;
     }
 
-    ic_map
+    pc_ic_map
+}
+
+/// A map of instruction counters to program counters.
+pub type ICPCMap = BTreeMap<usize, usize>;
+
+/// Builds a mapping from instruction counters to program counters.
+pub fn build_ic_pc_map(spec: SpecId, code: &[u8]) -> ICPCMap {
+    let opcode_infos = spec_opcode_gas(spec);
+    let mut ic_pc_map: ICPCMap = ICPCMap::new();
+
+    let mut i = 0;
+    let mut cumulative_push_size = 0;
+    while i < code.len() {
+        let op = code[i];
+        ic_pc_map.insert(i - cumulative_push_size, i);
+        if opcode_infos[op as usize].is_push() {
+            // Skip the push bytes.
+            //
+            // For more context on the math, see: https://github.com/bluealloy/revm/blob/007b8807b5ad7705d3cacce4d92b89d880a83301/crates/revm/src/interpreter/contract.rs#L114-L115
+            i += (op - opcode::PUSH1 + 1) as usize;
+            cumulative_push_size += (op - opcode::PUSH1 + 1) as usize;
+        }
+        i += 1;
+    }
+
+    ic_pc_map
 }

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -30,8 +30,6 @@ pub fn h256_to_u256_le(storage: H256) -> U256 {
 pub type PCICMap = BTreeMap<usize, usize>;
 
 /// Builds a mapping from program counters to instruction counters.
-// TODO: Some of the same logic is performed in REVM, but then later discarded. We should
-// investigate if we can reuse it
 pub fn build_pc_ic_map(spec: SpecId, code: &[u8]) -> PCICMap {
     let opcode_infos = spec_opcode_gas(spec);
     let mut pc_ic_map: PCICMap = BTreeMap::new();

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,3 +1,6 @@
+use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
+use tracing::trace;
+
 /// Gas reports
 pub mod gas_report;
 
@@ -48,4 +51,28 @@ pub struct TestOptions {
     /// Allows overriding an unsafe external call when running invariant tests. eg. reetrancy
     /// checks
     pub invariant_call_override: bool,
+}
+
+impl TestOptions {
+    pub fn fuzzer(&self) -> TestRunner {
+        // TODO: Add Options to modify the persistence
+        let cfg = proptest::test_runner::Config {
+            failure_persistence: None,
+            cases: self.fuzz_runs,
+            max_local_rejects: self.fuzz_max_local_rejects,
+            max_global_rejects: self.fuzz_max_global_rejects,
+            ..Default::default()
+        };
+
+        if let Some(ref fuzz_seed) = self.fuzz_seed {
+            trace!(target: "forge::test", "building deterministic fuzzer with seed {}", fuzz_seed);
+            let mut bytes: [u8; 32] = [0; 32];
+            fuzz_seed.to_big_endian(&mut bytes);
+            let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &bytes);
+            proptest::test_runner::TestRunner::new_with_rng(cfg, rng)
+        } else {
+            trace!(target: "forge::test", "building stochastic fuzzer");
+            proptest::test_runner::TestRunner::new(cfg)
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

After enabling fuzz tests in coverage (no data is used yet) coverage went from taking about 2 seconds for solmate to 27 seconds. The hottest piece of code seems to be the coverage collector itself that does some very expensive computations (translating program counters to instruction counters and then recording them) on every call.

## Solution

Instead of doing the PC -> IC translation in the inspector, we can do it once before or after we collect hit data. The hit data is then just a mapping of PC -> hits. This took the time back down to 2 seconds.

For coverage I opted to just move from using instruction counters in the anchors to program counters, so we use an IC -> PC map (since source maps are based on instruction counters, we need to translate from instruction counters to program counters in some cases).

I'll look into doing the same for the debugger, because it uses the same translation mechanism