### PR TITLE
fix(fork): update env correctly on roll fork

### DIFF
--- a/evm/src/executor/fork/multi.rs
+++ b/evm/src/executor/fork/multi.rs
@@ -367,6 +367,7 @@ impl Future for MultiForkHandler {
 }
 
 /// Tracks the created Fork
+#[derive(Debug)]
 struct CreatedFork {
     /// How the fork was initially created
     opts: CreateFork,

--- a/evm/src/executor/fork/multi.rs
+++ b/evm/src/executor/fork/multi.rs
@@ -112,7 +112,7 @@ impl MultiFork {
     /// Returns a fork backend
     ///
     /// If no matching fork backend exists it will be created
-    pub fn create_fork(&self, fork: CreateFork) -> eyre::Result<(ForkId, SharedBackend)> {
+    pub fn create_fork(&self, fork: CreateFork) -> eyre::Result<(ForkId, SharedBackend, Env)> {
         trace!("Creating new fork, url={}, block={:?}", fork.url, fork.evm_opts.fork_block_number);
         let (sender, rx) = oneshot_channel();
         let req = Request::CreateFork(Box::new(fork), sender);
@@ -123,7 +123,11 @@ impl MultiFork {
     /// Rolls the block of the fork
     ///
     /// If no matching fork backend exists it will be created
-    pub fn roll_fork(&self, fork: ForkId, block: u64) -> eyre::Result<(ForkId, SharedBackend)> {
+    pub fn roll_fork(
+        &self,
+        fork: ForkId,
+        block: u64,
+    ) -> eyre::Result<(ForkId, SharedBackend, Env)> {
         trace!(?fork, ?block, "rolling fork");
         let (sender, rx) = oneshot_channel();
         let req = Request::RollFork(fork, block, sender);
@@ -156,7 +160,7 @@ impl MultiFork {
 type Handler = BackendHandler<Arc<Provider<RetryClient<Http>>>>;
 
 type CreateFuture = Pin<Box<dyn Future<Output = eyre::Result<(CreatedFork, Handler)>> + Send>>;
-type CreateSender = OneshotSender<eyre::Result<(ForkId, SharedBackend)>>;
+type CreateSender = OneshotSender<eyre::Result<(ForkId, SharedBackend, Env)>>;
 type GetEnvSender = OneshotSender<Option<Env>>;
 
 /// Request that's send to the handler
@@ -235,7 +239,7 @@ impl MultiForkHandler {
 
         if let Some(fork) = self.forks.get_mut(&fork_id) {
             fork.num_senders += 1;
-            let _ = sender.send(Ok((fork_id, fork.backend.clone())));
+            let _ = sender.send(Ok((fork_id, fork.backend.clone(), fork.opts.env.clone())));
         } else {
             let retries = self.retries;
             let backoff = self.backoff;
@@ -309,8 +313,9 @@ impl Future for MultiForkHandler {
                             Ok((fork, handler)) => {
                                 pin.handlers.push((id.clone(), handler));
                                 let backend = fork.backend.clone();
+                                let env = fork.opts.env.clone();
                                 pin.forks.insert(id.clone(), fork);
-                                let _ = sender.send(Ok((id, backend)));
+                                let _ = sender.send(Ok((id, backend, env)));
                             }
                             Err(err) => {
                                 let _ = sender.send(Err(err));
@@ -367,7 +372,7 @@ struct CreatedFork {
     opts: CreateFork,
     /// Copy of the sender
     backend: SharedBackend,
-    /// How many different consumers there are, since a `SharedBacked` can be used by multiple
+    /// How many consumers there are, since a `SharedBacked` can be used by multiple
     /// consumers
     num_senders: usize,
 }
@@ -380,7 +385,7 @@ impl CreatedFork {
     }
 }
 
-/// A type that's used to signaling the `MultiForkHandler` when it's time to shutdown.
+/// A type that's used to signaling the `MultiForkHandler` when it's time to shut down.
 ///
 /// This is essentially a sync on drop, so that the `MultiForkHandler` can flush all rpc cashes
 ///

--- a/evm/src/executor/fork/multi.rs
+++ b/evm/src/executor/fork/multi.rs
@@ -425,11 +425,8 @@ async fn create_fork(
     retries: u32,
     backoff: u64,
 ) -> eyre::Result<(CreatedFork, Handler)> {
-    let provider = Arc::new(Provider::<RetryClient<Http>>::new_client(
-        fork.url.clone().as_str(),
-        retries,
-        backoff,
-    )?);
+    let provider =
+        Arc::new(Provider::<RetryClient<Http>>::new_client(fork.url.as_str(), retries, backoff)?);
 
     // initialise the fork environment
     fork.env = fork.evm_opts.fork_evm_env(&fork.url).await?;

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1208,6 +1208,28 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
 
     /// Executes all non-reverting fork cheatcodes
     #[test]
+    fn test_issue_2623() {
+        let mut runner = runner();
+        let suite_result =
+            runner.test(&Filter::new(".*", ".*", ".*repros/Issue2623"), None, TEST_OPTS).unwrap();
+        assert!(!suite_result.is_empty());
+
+        for (_, SuiteResult { test_results, .. }) in suite_result {
+            for (test_name, result) in test_results {
+                let logs = decode_console_logs(&result.logs);
+                assert!(
+                    result.success,
+                    "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                    test_name,
+                    result.reason,
+                    logs.join("\n")
+                );
+            }
+        }
+    }
+
+    /// Executes all non-reverting fork cheatcodes
+    #[test]
     fn test_cheats_fork() {
         let mut runner = runner();
         let suite_result = runner

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1206,7 +1206,7 @@ Reason: `setEnv` failed to set an environment variable `{}={}`",
         }
     }
 
-    /// Executes all non-reverting fork cheatcodes
+    // <https://github.com/foundry-rs/foundry/issues/2623>
     #[test]
     fn test_issue_2623() {
         let mut runner = runner();

--- a/testdata/repros/Issue2623.t.sol
+++ b/testdata/repros/Issue2623.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 import "../cheats/Cheats.sol";
 
-
+// https://github.com/foundry-rs/foundry/issues/2623
 contract Issue2623Test is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
 

--- a/testdata/repros/Issue2623.t.sol
+++ b/testdata/repros/Issue2623.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+
+contract Issue2623Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testRollFork() public {
+        uint256 fork = vm.createFork("rpcAlias", 10);
+        vm.selectFork(fork);
+
+        assertEq(block.number, 10);
+        assertEq(block.timestamp, 1438270128);
+
+        vm.rollFork(11);
+
+        assertEq(block.number, 11);
+        assertEq(block.timestamp, 1438270136);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #2623

fixes the issue where env.block values like timestamp weren't updated correctly on `rollFork`.

couldn't reproduce the RPC issues mentioned

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* update current env.block with fork values on `rollFork`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
