### PR TITLE
fix: use separated SubRoutines for multifork

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -251,6 +251,23 @@ pub struct Backend {
     forks: MultiFork,
     // The default in memory db
     mem_db: InMemoryDB,
+    /// The subroutine to use to initialize new forks with
+    ///
+    /// The way [`revm::SubRoutine`] works is, that it holds the "hot" accounts loaded from the
+    /// underlying `Database` that feeds the Account and State data ([`revm::AccountInfo`])to the
+    /// subroutine so it can apply changes to the state while the evm executes.
+    ///
+    /// In a way the `Subroutine` is something like a cache that
+    /// 1. check if account is already loaded (hot)
+    /// 2. if not load from the `Database` (this will then retrieve the account via RPC in forking
+    /// mode)
+    ///
+    /// To properly initialize we store the `Subroutine` before the first fork is selected
+    /// ([`DatabaseExt::select_fork`]).
+    ///
+    /// This will be an empty `Subroutine`, which will be populated with persistent accounts, See
+    /// [`Self::update_fork_db()`] and [`clone_data()`].
+    fork_init_subroutine: SubRoutine,
     /// The currently active fork database
     ///
     /// If this is set, then the Backend is currently in forking mode
@@ -276,6 +293,7 @@ impl Backend {
         let mut backend = Self {
             forks,
             mem_db: InMemoryDB::default(),
+            fork_init_subroutine: Default::default(),
             active_fork_ids: None,
             inner: BackendInner {
                 persistent_accounts: HashSet::from(DEFAULT_PERSISTENT_ACCOUNTS),
@@ -300,6 +318,7 @@ impl Backend {
         Self {
             forks: self.forks.clone(),
             mem_db: InMemoryDB::default(),
+            fork_init_subroutine: Default::default(),
             active_fork_ids: None,
             inner: Default::default(),
         }
@@ -436,6 +455,11 @@ impl Backend {
         self.active_fork_ids.map(|(i, _)| i == id).unwrap_or_default()
     }
 
+    /// Returns `true` if the `Backend` is currently in forking mode
+    pub fn is_in_forking_mode(&self) -> bool {
+        self.active_fork().is_some()
+    }
+
     /// Returns the currently active `Fork`, if any
     pub fn active_fork(&self) -> Option<&Fork> {
         self.active_fork_ids.map(|(_, idx)| self.inner.get_fork(idx))
@@ -561,12 +585,14 @@ impl DatabaseExt for Backend {
     fn create_fork(
         &mut self,
         fork: CreateFork,
-        subroutine: &SubRoutine,
+        _subroutine: &SubRoutine,
     ) -> eyre::Result<LocalForkId> {
         trace!("create fork");
         let (fork_id, fork, _) = self.forks.create_fork(fork)?;
         let fork_db = ForkDB::new(fork);
-        let (id, _) = self.inner.insert_new_fork(fork_id, fork_db, subroutine.clone());
+
+        let (id, _) =
+            self.inner.insert_new_fork(fork_id, fork_db, self.fork_init_subroutine.clone());
         Ok(id)
     }
 
@@ -590,9 +616,21 @@ impl DatabaseExt for Backend {
             .get_env(fork_id)?
             .ok_or_else(|| eyre::eyre!("Requested fork `{}` does not exit", id))?;
 
-        // if currently active we need to update the subroutine to this point
+        // If we're currently in forking mode we need to update the subroutine to this point, this
+        // ensures the changes performed while the fork was active are recorded
         if let Some(active) = self.active_fork_mut() {
             active.subroutine = subroutine.clone();
+        } else {
+            // this is the first time a fork is selected. This means up to this point all changes
+            // are made in a single `SubRoutine`, for example after a `setup` that only created
+            // different forks. Since the `Subroutine` is valid for all forks until the
+            // first fork is selected, we need to update it for all forks and use it as init state
+            // for all future forks
+            trace!("recording fork init subroutine");
+            self.fork_init_subroutine = subroutine.clone();
+            for fork in self.inner.forks_iter_mut() {
+                fork.subroutine = self.fork_init_subroutine.clone();
+            }
         }
 
         // update the shared state and track
@@ -936,6 +974,11 @@ impl BackendInner {
         self.issued_local_fork_ids
             .iter()
             .map(|(id, fork_id)| (*id, self.get_fork(self.created_forks[fork_id])))
+    }
+
+    /// Returns a mutable iterator over all Forks
+    pub fn forks_iter_mut(&mut self) -> impl Iterator<Item = &mut Fork> + '_ {
+        self.forks.iter_mut().filter_map(|f| f.as_mut())
     }
 
     /// Reverts the entire fork database

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -25,3 +25,25 @@ fn test_issue_2623() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/2629>
+#[test]
+fn test_issue_2629() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue2629"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue2629.t.sol
+++ b/testdata/repros/Issue2629.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/2629
+contract Issue2629Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testSelectFork() public {
+        address coinbase = 0x0193d941b50d91BE6567c7eE1C0Fe7AF498b4137;
+
+        uint f1 = vm.createSelectFork("rpcAlias", 9);
+        vm.selectFork(f1);
+
+        assertEq(block.number, 9);
+        assertEq(coinbase.balance, 11250000000000000000);
+
+        uint f2 = vm.createFork("rpcAlias", 10);
+        vm.selectFork(f2);
+
+        assertEq(block.number, 10);
+        assertEq(coinbase.balance, 16250000000000000000);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2629

>juggling different evm states at a time is a bit complex.
>
> The way this works with https://github.com/bluealloy/revm is, that there's a Subroutine that holds the "hot" accounts loaded from the underlying Database that feeds the Account/State data to the subroutine so it can apply changes to the state while the evm executes.
In a way the Subroutine is something like a cache that

> check if account is already loaded (hot)
if not load from the Datbase (this will then retrieve the account via RPC in forking mode)
when we created a fork, we only replaced the Database object, so if the account was loaded (1.) previously, then wouldn't reach 2. and the state is not updated on this new fork.

> the fix is to adjust the SubRoutine when creating a fork.

As explained
https://github.com/foundry-rs/foundry/issues/2629#issuecomment-1206521093

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
maintain a separate `fork_init_subroutine` that stores the `SubRoutine` up to the point where the very first fork is selected
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
