### PR TITLE
fix: auto install only lib folder if git exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,7 @@ dependencies = [
  "vergen",
  "walkdir",
  "watchexec",
+ "which",
  "yansi",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,6 +77,7 @@ bytes = "1.1.0"
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1.0.30"
 indicatif = "0.17.0-rc.11"
+which = "4.2.5"
 
 [dev-dependencies]
 anvil = { path = "../anvil" }

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -76,7 +76,11 @@ impl Cmd for BuildArgs {
         let mut config = self.load_config_emit_warnings();
         let project = config.project()?;
 
-        if install::has_missing_dependencies(&project.root()) {
+        // try to auto install missing submodules in the default install dir but only if git is
+        // installed
+        if which::which("git").is_ok() &&
+            install::has_missing_dependencies(&project.root(), &config.install_lib_dir())
+        {
             // The extra newline is needed, otherwise the compiler output will overwrite the
             // message
             p_println!(!self.args.silent => "Missing dependencies found. Installing now.\n");

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -146,11 +146,12 @@ pub(crate) fn install(
 
 /// Checks if any submodules have not been initialized yet.
 ///
-/// `git submodule status` will return a new line per submodule in the repository. If any line
-/// starts with `-` then it has not been initialized yet.
-pub fn has_missing_dependencies(root: impl AsRef<Path>) -> bool {
+/// `git submodule status <lib dir>` will return a new line per submodule in the repository. If any
+/// line starts with `-` then it has not been initialized yet.
+pub fn has_missing_dependencies(root: impl AsRef<Path>, lib_dir: impl AsRef<Path>) -> bool {
     Command::new("git")
         .args(&["submodule", "status"])
+        .arg(lib_dir.as_ref())
         .current_dir(root)
         .output()
         .map(|output| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2633

which should run this automatically only if git is installed and only on the install folder, `git submodule status [path]`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
