### PR TITLE
chore: make auto install missing dep err a warning

### DIFF
--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use clap::Parser;
 use ethers::solc::{Project, ProjectCompileOutput};
-use eyre::WrapErr;
+
 use foundry_config::{
     figment::{
         self,
@@ -94,16 +94,15 @@ impl Cmd for BuildArgs {
                     ..Default::default()
                 },
             )
-            .is_err()
+            .is_err() &&
+                !self.args.silent
             {
-                if !self.args.silent {
-                    eprintln!(
-                        "{}",
-                        Paint::yellow(
-                            "Your project has missing dependencies that could not be installed."
-                        )
+                eprintln!(
+                    "{}",
+                    Paint::yellow(
+                        "Your project has missing dependencies that could not be installed."
                     )
-                }
+                )
             }
         }
 

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -24,6 +24,7 @@ use foundry_config::{
 };
 use serde::Serialize;
 use watchexec::config::{InitConfig, RuntimeConfig};
+use yansi::Paint;
 
 mod core;
 pub use self::core::CoreBuildArgs;
@@ -84,7 +85,7 @@ impl Cmd for BuildArgs {
             // The extra newline is needed, otherwise the compiler output will overwrite the
             // message
             p_println!(!self.args.silent => "Missing dependencies found. Installing now.\n");
-            install::install(
+            if install::install(
                 &mut config,
                 Vec::new(),
                 DependencyInstallOpts {
@@ -92,7 +93,18 @@ impl Cmd for BuildArgs {
                     quiet: self.args.silent,
                     ..Default::default()
                 },
-            ).wrap_err("Your project has missing dependencies that could not be installed. Please ensure git is installed and available.")?
+            )
+            .is_err()
+            {
+                if !self.args.silent {
+                    eprintln!(
+                        "{}",
+                        Paint::yellow(
+                            "Your project has missing dependencies that could not be installed."
+                        )
+                    )
+                }
+            }
         }
 
         if self.args.silent {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2633

instead of aborting if we fail to auto install missing deps, make this a warning. If the deps are indeed missing it will fail regardless.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
