### PR TITLE
test: set estimate params correctly

### DIFF
--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -73,19 +73,19 @@ casttest!(estimate_contract_deploy_gas, |_: TestProject, mut cmd: TestCommand| {
     // accepts and could be deployed.
     cmd.args([
         "estimate",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
         "--create",
         "0000",
         "ERC20(uint256,string,string)",
         "100",
         "Test",
         "TST",
-        "--",
-        "--rpc-url",
-        eth_rpc_url.as_str(),
     ]);
-    let out: u32 = cmd.stdout_lossy().trim().parse().unwrap();
+
+    let gas: u32 = cmd.stdout_lossy().trim().parse().unwrap();
     // ensure we get a positive non-error value for gas estimate
-    assert!(out.ge(&0));
+    assert!(gas > 0);
 });
 
 // tests that the `cast upload-signatures` command works correctly


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
common args must be set before the `--create` subcommand
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
