### PR TITLE
fix(evm): set trace node depth 0 correctly

### DIFF
--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -1,7 +1,7 @@
 use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::Contract,
-    prelude::{ContractFactory, Middleware, Signer, SignerMiddleware, TransactionRequest},
+    prelude::{Action, ContractFactory, Middleware, Signer, SignerMiddleware, TransactionRequest},
     types::ActionType,
 };
 use ethers_solc::{project_util::TempProject, Artifact};
@@ -24,6 +24,15 @@ async fn test_get_transfer_parity_traces() {
 
     let traces = provider.trace_transaction(tx.transaction_hash).await.unwrap();
     assert!(!traces.is_empty());
+
+    match traces[0].action {
+        Action::Call(ref call) => {
+            assert_eq!(call.from, from);
+            assert_eq!(call.to, to);
+            assert_eq!(call.value, amount);
+        }
+        _ => unreachable!("unexpected action"),
+    }
 
     let num = provider.get_block_number().await.unwrap();
     let block_traces = provider.trace_block(num.into()).await.unwrap();

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -43,8 +43,7 @@ impl CallTraceArena {
         match new_trace.depth {
             // The entry node, just update it
             0 => {
-                let node = &mut self.arena[0];
-                node.trace.update(new_trace);
+                self.arena[0].trace = new_trace;
                 0
             }
             // We found the parent node, add the new trace as a child
@@ -326,18 +325,6 @@ pub struct CallTrace {
 // === impl CallTrace ===
 
 impl CallTrace {
-    /// Updates a trace given another trace
-    fn update(&mut self, new_trace: Self) {
-        self.success = new_trace.success;
-        self.address = new_trace.address;
-        self.kind = new_trace.kind;
-        self.value = new_trace.value;
-        self.data = new_trace.data;
-        self.output = new_trace.output;
-        self.address = new_trace.address;
-        self.gas_cost = new_trace.gas_cost;
-    }
-
     /// Whether this is a contract creation or not
     pub fn created(&self) -> bool {
         matches!(self.kind, CallKind::Create)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
when the first `CallTrace` was pushed, the `CallTrace` of the default `CallTraceNode` at index (depth) 0 was updated with the `new_trace` (`CallTrace::update(CallTrace)`), which didn't update the `caller`, so the caller was always the default address (0x00000...).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
deprecate the `update` function and instead replace the `trace` of the `CallTraceNode` if depth == 0

but maybe replacing could have side-effects? 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
