### PR TITLE
refactor(anvil): use tokio::sync::RwLock to guard Db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -53,6 +53,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tokio = { version = "1", features = ["time"] }
 parking_lot = "0.12"
 futures = "0.3"
+async-trait = "0.1"
 
 # misc
 serde_json = "1.0.67"
@@ -67,7 +68,6 @@ clap = { version = "3.0.10", features = [
     "wrap_help",
 ], optional = true }
 clap_complete =  { version = "3.0.4", optional = true }
-async-trait = "0.1.53"
 chrono = "0.4.19"
 auto_impl = "0.5.0"
 ctrlc = { version = "3", optional = true }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -196,7 +196,9 @@ impl EthApi {
             EthRequest::EthSignTypedDataV4(addr, data) => {
                 self.sign_typed_data_v4(addr, &data).await.to_rpc_result()
             }
-            EthRequest::EthSendRawTransaction(tx) => self.send_raw_transaction(tx).to_rpc_result(),
+            EthRequest::EthSendRawTransaction(tx) => {
+                self.send_raw_transaction(tx).await.to_rpc_result()
+            }
             EthRequest::EthCall(call, block) => self.call(call, block).await.to_rpc_result(),
             EthRequest::EthCreateAccessList(call, block) => {
                 self.create_access_list(call, block).await.to_rpc_result()
@@ -485,7 +487,7 @@ impl EthApi {
     pub async fn block_by_number(&self, number: BlockNumber) -> Result<Option<Block<TxHash>>> {
         node_info!("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
-            return Ok(Some(self.pending_block()))
+            return Ok(Some(self.pending_block().await))
         }
 
         self.backend.block_by_number(number).await
@@ -500,7 +502,7 @@ impl EthApi {
     ) -> Result<Option<Block<Transaction>>> {
         node_info!("eth_getBlockByNumber");
         if number == BlockNumber::Pending {
-            return Ok(self.pending_block_full())
+            return Ok(self.pending_block_full().await)
         }
         self.backend.block_by_number_full(number).await
     }
@@ -573,7 +575,7 @@ impl EthApi {
     ) -> Result<AccountProof> {
         node_info!("eth_getProof");
         let number = self.backend.ensure_block_number(block_number)?;
-        let proof = self.backend.prove_account_at(address, keys, Some(number.into()))?;
+        let proof = self.backend.prove_account_at(address, keys, Some(number.into())).await?;
         Ok(proof)
     }
 
@@ -647,7 +649,7 @@ impl EthApi {
         };
 
         // pre-validate
-        self.backend.validate_pool_transaction(&pending_transaction)?;
+        self.backend.validate_pool_transaction(&pending_transaction).await?;
 
         let requires = required_marker(nonce, on_chain_nonce, from);
         let provides = vec![to_marker(nonce.as_u64(), from)];
@@ -659,7 +661,7 @@ impl EthApi {
     /// Sends signed transaction, returning its hash.
     ///
     /// Handler for ETH RPC call: `eth_sendRawTransaction`
-    pub fn send_raw_transaction(&self, tx: Bytes) -> Result<TxHash> {
+    pub async fn send_raw_transaction(&self, tx: Bytes) -> Result<TxHash> {
         node_info!("eth_sendRawTransaction");
         let data = tx.as_ref();
         if data.is_empty() {
@@ -686,9 +688,9 @@ impl EthApi {
         let pending_transaction = PendingTransaction::new(transaction)?;
 
         // pre-validate
-        self.backend.validate_pool_transaction(&pending_transaction)?;
+        self.backend.validate_pool_transaction(&pending_transaction).await?;
 
-        let on_chain_nonce = self.backend.current_nonce(*pending_transaction.sender());
+        let on_chain_nonce = self.backend.current_nonce(*pending_transaction.sender()).await;
         let from = *pending_transaction.sender();
         let nonce = *pending_transaction.transaction.nonce();
         let requires = required_marker(nonce, on_chain_nonce, from);
@@ -1150,7 +1152,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `anvil_impersonateAccount`
     pub async fn anvil_impersonate_account(&self, address: Address) -> Result<()> {
         node_info!("anvil_impersonateAccount");
-        self.backend.impersonate(address);
+        self.backend.impersonate(address).await;
         Ok(())
     }
 
@@ -1159,7 +1161,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `anvil_stopImpersonatingAccount`
     pub async fn anvil_stop_impersonating_account(&self, address: Address) -> Result<()> {
         node_info!("anvil_stopImpersonatingAccount");
-        self.backend.stop_impersonating(address);
+        self.backend.stop_impersonating(address).await;
         Ok(())
     }
 
@@ -1251,7 +1253,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_setBalance`
     pub async fn anvil_set_balance(&self, address: Address, balance: U256) -> Result<()> {
         node_info!("anvil_setBalance");
-        self.backend.set_balance(address, balance);
+        self.backend.set_balance(address, balance).await;
         Ok(())
     }
 
@@ -1260,7 +1262,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_setCode`
     pub async fn anvil_set_code(&self, address: Address, code: Bytes) -> Result<()> {
         node_info!("anvil_setCode");
-        self.backend.set_code(address, code);
+        self.backend.set_code(address, code).await;
         Ok(())
     }
 
@@ -1269,7 +1271,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_setNonce`
     pub async fn anvil_set_nonce(&self, address: Address, nonce: U256) -> Result<()> {
         node_info!("anvil_setNonce");
-        self.backend.set_nonce(address, nonce);
+        self.backend.set_nonce(address, nonce).await;
         Ok(())
     }
 
@@ -1283,7 +1285,7 @@ impl EthApi {
         val: H256,
     ) -> Result<()> {
         node_info!("anvil_setStorageAt");
-        self.backend.set_storage_at(address, slot, val);
+        self.backend.set_storage_at(address, slot, val).await;
         Ok(())
     }
 
@@ -1330,12 +1332,12 @@ impl EthApi {
     }
 
     /// Create a bufer that represents all state on the chain, which can be loaded to separate
-    /// process by calling `anvil_laodState`
+    /// process by calling `anvil_loadState`
     ///
     /// Handler for RPC call: `anvil_dumpState`
     pub async fn anvil_dump_state(&self) -> Result<Bytes> {
         node_info!("anvil_dumpState");
-        self.backend.dump_state()
+        self.backend.dump_state().await
     }
 
     /// Append chain state buffer to current chain. Will overwrite any conflicting addresses or
@@ -1344,7 +1346,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_loadState`
     pub async fn anvil_load_state(&self, buf: Bytes) -> Result<bool> {
         node_info!("anvil_loadState");
-        self.backend.load_state(buf)
+        self.backend.load_state(buf).await
     }
 
     /// Snapshot the state of the blockchain at the current block.
@@ -1352,7 +1354,7 @@ impl EthApi {
     /// Handler for RPC call: `evm_snapshot`
     pub async fn evm_snapshot(&self) -> Result<U256> {
         node_info!("evm_snapshot");
-        Ok(self.backend.create_snapshot())
+        Ok(self.backend.create_snapshot().await)
     }
 
     /// Revert the state of the blockchain to a previous snapshot.
@@ -1361,7 +1363,7 @@ impl EthApi {
     /// Handler for RPC call: `evm_revert`
     pub async fn evm_revert(&self, id: U256) -> Result<bool> {
         node_info!("evm_revert");
-        Ok(self.backend.revert_snapshot(id))
+        Ok(self.backend.revert_snapshot(id).await)
     }
 
     /// Jump forward in time by the given amount of time, in seconds.
@@ -1490,7 +1492,7 @@ impl EthApi {
         let pending_transaction = PendingTransaction::with_sender(transaction, from);
 
         // pre-validate
-        self.backend.validate_pool_transaction(&pending_transaction)?;
+        self.backend.validate_pool_transaction(&pending_transaction).await?;
 
         let requires = required_marker(nonce, on_chain_nonce, from);
         let provides = vec![to_marker(nonce.as_u64(), from)];
@@ -1806,17 +1808,17 @@ impl EthApi {
     }
 
     /// Returns the pending block with tx hashes
-    fn pending_block(&self) -> Block<TxHash> {
+    async fn pending_block(&self) -> Block<TxHash> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let info = self.backend.pending_block(transactions);
+        let info = self.backend.pending_block(transactions).await;
         self.backend.convert_block(info.block)
     }
 
     /// Returns the full pending block with `Transaction` objects
-    fn pending_block_full(&self) -> Option<Block<Transaction>> {
+    async fn pending_block_full(&self) -> Option<Block<Transaction>> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
         let BlockInfo { block, transactions, receipts: _ } =
-            self.backend.pending_block(transactions);
+            self.backend.pending_block(transactions).await;
 
         let ethers_block = self.backend.convert_block(block.clone());
 
@@ -1944,8 +1946,8 @@ impl EthApi {
     }
 
     /// Returns the current state root
-    pub fn state_root(&self) -> Option<H256> {
-        self.backend.get_db().read().maybe_state_root()
+    pub async fn state_root(&self) -> Option<H256> {
+        self.backend.get_db().read().await.maybe_state_root()
     }
 }
 

--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -20,65 +20,8 @@ use foundry_evm::{
     revm::{BlockEnv, CfgEnv, Env, Return, SpecId, TransactOut},
     trace::node::CallTraceNode,
 };
-use parking_lot::RwLock;
 use std::sync::Arc;
 use tracing::{trace, warn};
-
-/// A lock that's used to guard access to evm execution, depending on the mode of the evm
-///
-/// The necessity for this type is that when in fork, transacting on the evm can take quite a bit of
-/// time if the requested state needs to be fetched from the remote endpoint first. This can cause
-/// block production to stall, because this is a blocking operation. This type is used to guard
-/// access to evm execution.
-///
-/// This is only necessary in fork mode, so if `is_fork` is `false` `read` and `write` will be a
-/// noop.
-#[derive(Debug, Clone)]
-pub(crate) struct EvmExecutorLock {
-    executor_lock: Arc<tokio::sync::RwLock<()>>,
-    is_fork: Arc<RwLock<bool>>,
-}
-
-// === impl EvmExecutorLock ===
-
-impl EvmExecutorLock {
-    pub fn new(is_fork: bool) -> Self {
-        Self {
-            executor_lock: Arc::new(tokio::sync::RwLock::new(())),
-            is_fork: Arc::new(RwLock::new(is_fork)),
-        }
-    }
-
-    /// Sets the fork status
-    #[allow(unused)]
-    pub fn set_fork(&self, is_fork: bool) {
-        *self.is_fork.write() = is_fork
-    }
-
-    pub fn is_fork(&self) -> bool {
-        *self.is_fork.read()
-    }
-
-    /// Locks this RwLock with shared read access, causing the current task to yield until the lock
-    /// has been acquired.
-    pub async fn read(&self) -> EvmExecutorReadGuard<'_> {
-        let guard = if self.is_fork() { Some(self.executor_lock.read().await) } else { None };
-        EvmExecutorReadGuard(guard)
-    }
-
-    /// Locks this RwLock with exclusive write access, causing the current task to yield until the
-    /// lock has been acquired.
-    pub async fn write(&self) -> EvmExecutorWriteGuard<'_> {
-        let guard = if self.is_fork() { Some(self.executor_lock.write().await) } else { None };
-        EvmExecutorWriteGuard(guard)
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct EvmExecutorReadGuard<'a>(Option<tokio::sync::RwLockReadGuard<'a, ()>>);
-
-#[derive(Debug)]
-pub(crate) struct EvmExecutorWriteGuard<'a>(Option<tokio::sync::RwLockWriteGuard<'a, ()>>);
 
 /// Represents an executed transaction (transacted on the DB)
 pub struct ExecutedTransaction {

--- a/anvil/src/eth/backend/fork.rs
+++ b/anvil/src/eth/backend/fork.rs
@@ -16,6 +16,7 @@ use parking_lot::{
     RawRwLock, RwLock,
 };
 use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::trace;
 
 /// Represents a fork of a remote client
@@ -31,14 +32,14 @@ pub struct ClientFork {
     // endpoints
     pub config: Arc<RwLock<ClientForkConfig>>,
     /// This also holds a handle to the underlying database
-    pub database: Arc<RwLock<ForkedDatabase>>,
+    pub database: Arc<AsyncRwLock<ForkedDatabase>>,
 }
 
 // === impl ClientFork ===
 
 impl ClientFork {
     /// Creates a new instance of the fork
-    pub fn new(config: ClientForkConfig, database: Arc<RwLock<ForkedDatabase>>) -> Self {
+    pub fn new(config: ClientForkConfig, database: Arc<AsyncRwLock<ForkedDatabase>>) -> Self {
         Self { storage: Default::default(), config: Arc::new(RwLock::new(config)), database }
     }
 
@@ -51,6 +52,7 @@ impl ClientFork {
         {
             self.database
                 .write()
+                .await
                 .reset(url.clone(), block_number)
                 .map_err(BlockchainError::Internal)?;
         }

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -73,9 +73,24 @@ pub type State = foundry_evm::HashMap<Address, Account>;
 /// Gives access to the [revm::Database]
 #[derive(Clone)]
 pub struct Backend {
-    /// access to revm's database related operations
-    /// This stores the actual state of the blockchain
-    /// Supports concurrent reads
+    /// Access to [`revm::Database`] abstraction.
+    ///
+    /// This will be used in combination with [`revm::Evm`] and is responsible for feeding data to
+    /// the evm during its execution.
+    ///
+    /// At time of writing, there are two different types of `Db`:
+    ///   - [`MemDb`](crate::mem::MemDb): everything is stored in memory
+    ///   - [`ForkDb`](crate::mem::fork_db::ForkedDatabase): forks off a remote client, missing
+    ///     data is retrieved via RPC-calls
+    ///
+    /// In order to commit changes to the [`revm::Database`], the [`revm::Evm`] requires mutable
+    /// access, which requires a write-lock from this `db`. In forking mode, the time during
+    /// which the write-lock is active depends on whether the `ForkDb` can provide all requested
+    /// data from memory or whether it has to retrieve it via RPC calls first. This means that it
+    /// potentially blocks for some time, even taking into account the rate limits of RPC
+    /// endpoints. Therefor the `Db` is guarded by a `tokio::sync::RwLock` here so calls that
+    /// need to read from it, while it's currently written to, don't block. E.g. a new block is
+    /// currently mined and a new [`Self::set_storage()`] request is being executed.
     db: Arc<AsyncRwLock<dyn Db>>,
     /// stores all block related data in memory
     blockchain: Blockchain,

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -5,7 +5,7 @@ use crate::{
             cheats,
             cheats::CheatsManager,
             db::{AsHashDB, Db, MaybeHashDatabase, SerializableState},
-            executor::{EvmExecutorLock, ExecutedTransactions, TransactionExecutor},
+            executor::{ExecutedTransactions, TransactionExecutor},
             fork::ClientFork,
             genesis::GenesisConfig,
             notifications::{NewBlockNotification, NewBlockNotifications},
@@ -59,6 +59,7 @@ use hash_db::HashDB;
 use parking_lot::{Mutex, RwLock};
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 use storage::{Blockchain, MinedTransaction};
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{trace, warn};
 use trie_db::{Recorder, Trie};
 
@@ -75,7 +76,7 @@ pub struct Backend {
     /// access to revm's database related operations
     /// This stores the actual state of the blockchain
     /// Supports concurrent reads
-    db: Arc<RwLock<dyn Db>>,
+    db: Arc<AsyncRwLock<dyn Db>>,
     /// stores all block related data in memory
     blockchain: Blockchain,
     /// Historic states of previous blocks
@@ -96,13 +97,11 @@ pub struct Backend {
     new_block_listeners: Arc<Mutex<Vec<UnboundedSender<NewBlockNotification>>>>,
     /// keeps track of active snapshots at a specific block
     active_snapshots: Arc<Mutex<HashMap<U256, (u64, H256)>>>,
-    /// A lock used to sync evm executor access
-    executor_lock: EvmExecutorLock,
 }
 
 impl Backend {
     /// Create a new instance of in-mem backend.
-    pub fn new(db: Arc<RwLock<dyn Db>>, env: Arc<RwLock<Env>>, fees: FeeManager) -> Self {
+    pub fn new(db: Arc<AsyncRwLock<dyn Db>>, env: Arc<RwLock<Env>>, fees: FeeManager) -> Self {
         let blockchain = Blockchain::new(&env.read(), fees.is_eip1559().then(|| fees.base_fee()));
         Self {
             db,
@@ -116,7 +115,6 @@ impl Backend {
             fees,
             genesis: Default::default(),
             active_snapshots: Arc::new(Mutex::new(Default::default())),
-            executor_lock: EvmExecutorLock::new(false),
         }
     }
 
@@ -124,12 +122,12 @@ impl Backend {
     pub fn empty(env: Arc<RwLock<Env>>, gas_price: U256) -> Self {
         let db = MemDb::default();
         let fees = FeeManager::new(env.read().cfg.spec_id, gas_price, gas_price);
-        Self::new(Arc::new(RwLock::new(db)), env, fees)
+        Self::new(Arc::new(AsyncRwLock::new(db)), env, fees)
     }
 
     /// Initialises the balance of the given accounts
-    pub fn with_genesis(
-        db: Arc<RwLock<dyn Db>>,
+    pub async fn with_genesis(
+        db: Arc<AsyncRwLock<dyn Db>>,
         env: Arc<RwLock<Env>>,
         genesis: GenesisConfig,
         fees: FeeManager,
@@ -148,7 +146,6 @@ impl Backend {
             blockchain,
             states: Arc::new(RwLock::new(Default::default())),
             env,
-            executor_lock: EvmExecutorLock::new(fork.is_some()),
             fork,
             time: Default::default(),
             cheats: Default::default(),
@@ -158,16 +155,16 @@ impl Backend {
             active_snapshots: Arc::new(Mutex::new(Default::default())),
         };
 
-        backend.apply_genesis();
+        backend.apply_genesis().await;
         backend
     }
 
     /// Applies the configured genesis settings
     ///
     /// This will fund, create the genesis accounts
-    fn apply_genesis(&self) {
+    async fn apply_genesis(&self) {
         trace!(target: "backend", "setting genesis balances");
-        let mut db = self.db.write();
+        let mut db = self.db.write().await;
 
         if self.fork.is_some() {
             // in fork mode we only set the balance, this way the accountinfo is fetched from the
@@ -186,25 +183,25 @@ impl Backend {
     /// Sets the account to impersonate
     ///
     /// Returns `true` if the account is already impersonated
-    pub fn impersonate(&self, addr: Address) -> bool {
+    pub async fn impersonate(&self, addr: Address) -> bool {
         if self.cheats.is_impersonated(addr) {
             return true
         }
         // need to bypass EIP-3607: Reject transactions from senders with deployed code by setting
         // the code hash to `KECCAK_EMPTY` temporarily
-        let mut account = self.db.read().basic(addr);
+        let mut account = self.db.read().await.basic(addr);
         let mut code_hash = None;
         if account.code_hash != KECCAK_EMPTY {
             code_hash = Some(std::mem::replace(&mut account.code_hash, KECCAK_EMPTY));
-            self.db.write().insert_account(addr, account);
+            self.db.write().await.insert_account(addr, account);
         }
         self.cheats.impersonate(addr, code_hash)
     }
 
     /// Removes the account that from the impersonated set
-    pub fn stop_impersonating(&self, addr: Address) {
+    pub async fn stop_impersonating(&self, addr: Address) {
         if let Some(code_hash) = self.cheats.stop_impersonating(&addr) {
-            let mut db = self.db.write();
+            let mut db = self.db.write().await;
             let mut account = db.basic(addr);
             account.code_hash = code_hash;
             db.insert_account(addr, account)
@@ -217,7 +214,7 @@ impl Backend {
     }
 
     /// Returns the database
-    pub fn get_db(&self) -> &Arc<RwLock<dyn Db>> {
+    pub fn get_db(&self) -> &Arc<AsyncRwLock<dyn Db>> {
         &self.db
     }
 
@@ -247,7 +244,7 @@ impl Backend {
                 BlockchainStorage::forked(fork.block_number(), fork.block_hash());
             self.states.write().clear();
 
-            self.apply_genesis();
+            self.apply_genesis().await;
             Ok(())
         } else {
             Err(RpcError::invalid_params("Forking not enabled").into())
@@ -307,13 +304,13 @@ impl Backend {
     }
 
     /// Returns balance of the given account.
-    pub fn current_balance(&self, address: Address) -> U256 {
-        self.db.read().basic(address).balance
+    pub async fn current_balance(&self, address: Address) -> U256 {
+        self.db.read().await.basic(address).balance
     }
 
     /// Returns balance of the given account.
-    pub fn current_nonce(&self, address: Address) -> U256 {
-        self.db.read().basic(address).nonce.into()
+    pub async fn current_nonce(&self, address: Address) -> U256 {
+        self.db.read().await.basic(address).nonce.into()
     }
 
     /// Sets the coinbase address
@@ -322,23 +319,23 @@ impl Backend {
     }
 
     /// Sets the nonce of the given address
-    pub fn set_nonce(&self, address: Address, nonce: U256) {
-        self.db.write().set_nonce(address, nonce.try_into().unwrap_or(u64::MAX));
+    pub async fn set_nonce(&self, address: Address, nonce: U256) {
+        self.db.write().await.set_nonce(address, nonce.try_into().unwrap_or(u64::MAX));
     }
 
     /// Sets the balance of the given address
-    pub fn set_balance(&self, address: Address, balance: U256) {
-        self.db.write().set_balance(address, balance);
+    pub async fn set_balance(&self, address: Address, balance: U256) {
+        self.db.write().await.set_balance(address, balance);
     }
 
     /// Sets the code of the given address
-    pub fn set_code(&self, address: Address, code: Bytes) {
-        self.db.write().set_code(address, code);
+    pub async fn set_code(&self, address: Address, code: Bytes) {
+        self.db.write().await.set_code(address, code);
     }
 
     /// Sets the value for the given slot of the given address
-    pub fn set_storage_at(&self, address: Address, slot: U256, val: H256) {
-        self.db.write().set_storage_at(address, slot, val.into_uint());
+    pub async fn set_storage_at(&self, address: Address, slot: U256, val: H256) {
+        self.db.write().await.set_storage_at(address, slot, val.into_uint());
     }
 
     /// Returns true for post London
@@ -378,17 +375,17 @@ impl Backend {
     /// Creates a new `evm_snapshot` at the current height
     ///
     /// Returns the id of the snapshot created
-    pub fn create_snapshot(&self) -> U256 {
+    pub async fn create_snapshot(&self) -> U256 {
         let num = self.best_number().as_u64();
         let hash = self.best_hash();
-        let id = self.db.write().snapshot();
+        let id = self.db.write().await.snapshot();
         trace!(target: "backend", "creating snapshot {} at {}", id, num);
         self.active_snapshots.lock().insert(id, (num, hash));
         id
     }
 
     /// Reverts the state to the snapshot
-    pub fn revert_snapshot(&self, id: U256) -> bool {
+    pub async fn revert_snapshot(&self, id: U256) -> bool {
         let block = { self.active_snapshots.lock().remove(&id) };
         if let Some((num, hash)) = block {
             {
@@ -413,13 +410,14 @@ impl Backend {
             }
             self.set_block_number(num.into());
         }
-        self.db.write().revert(id)
+        self.db.write().await.revert(id)
     }
 
     /// Write all chain data to serialized bytes buffer
-    pub fn dump_state(&self) -> Result<Bytes, BlockchainError> {
+    pub async fn dump_state(&self) -> Result<Bytes, BlockchainError> {
         self.db
             .read()
+            .await
             .dump_state()
             .map(|s| serde_json::to_vec(&s).unwrap_or_default().into())
             .ok_or_else(|| {
@@ -431,11 +429,11 @@ impl Backend {
     }
 
     /// Deserialize and add all chain data to the backend storage
-    pub fn load_state(&self, buf: Bytes) -> Result<bool, BlockchainError> {
+    pub async fn load_state(&self, buf: Bytes) -> Result<bool, BlockchainError> {
         let state: SerializableState =
             serde_json::from_slice(&buf.0).map_err(|_| BlockchainError::FailedToDecodeStateDump)?;
 
-        if !self.db.write().load_state(state) {
+        if !self.db.write().await.load_state(state) {
             Err(RpcError::invalid_params(
                 "Loading state not supported with the current configuration",
             )
@@ -456,13 +454,13 @@ impl Backend {
     }
 
     /// executes the transactions without writing to the underlying database
-    pub fn inspect_tx(
+    pub async fn inspect_tx(
         &self,
         tx: Arc<PoolTransaction>,
     ) -> (Return, TransactOut, u64, State, Vec<revm::Log>) {
         let mut env = self.next_env();
         env.tx = tx.pending_transaction.to_revm_tx_env();
-        let db = self.db.read();
+        let db = self.db.read().await;
 
         let mut evm = revm::EVM::new();
         evm.env = env;
@@ -473,8 +471,8 @@ impl Backend {
     /// Creates the pending block
     ///
     /// This will execute all transaction in the order they come but will not mine the block
-    pub fn pending_block(&self, pool_transactions: Vec<Arc<PoolTransaction>>) -> BlockInfo {
-        let db = self.db.read();
+    pub async fn pending_block(&self, pool_transactions: Vec<Arc<PoolTransaction>>) -> BlockInfo {
+        let db = self.db.read().await;
         let env = self.next_env();
 
         let mut cache_db = CacheDB::new(&*db);
@@ -514,8 +512,6 @@ impl Backend {
         trace!(target: "backend", "creating new block with {} transactions", pool_transactions.len());
 
         let (outcome, header, block_hash) = {
-            let _lock = self.executor_lock.write().await;
-
             let current_base_fee = self.base_fee();
 
             let mut env = self.env.read().clone();
@@ -526,11 +522,12 @@ impl Backend {
 
             let best_hash = self.blockchain.storage.read().best_hash;
 
+            let db = self.db.read().await.current_state();
             // store current state before executing all transactions
-            self.states.write().insert(best_hash, self.db.read().current_state());
+            self.states.write().insert(best_hash, db);
 
             let (executed_tx, block_hash) = {
-                let mut db = self.db.write();
+                let mut db = self.db.write().await;
                 let executor = TransactionExecutor {
                     db: &mut *db,
                     validator: self,
@@ -632,8 +629,6 @@ impl Backend {
         fee_details: FeeDetails,
         block_number: Option<BlockNumber>,
     ) -> Result<(Return, TransactOut, u64, State), BlockchainError> {
-        let _lock = self.executor_lock.read().await;
-
         let EthTransactionRequest { from, to, gas, value, data, nonce, access_list, .. } = request;
 
         let FeeDetails { gas_price, max_fee_per_gas, max_priority_fee_per_gas } = fee_details;
@@ -693,7 +688,7 @@ impl Backend {
             }
         }
 
-        let db = self.db.read();
+        let db = self.db.read().await;
         let mut evm = revm::EVM::new();
         evm.env = env;
         evm.database(&*db);
@@ -1065,7 +1060,7 @@ impl Backend {
     }
 
     /// Helper function to execute a closure with the database at a specific block
-    pub fn with_database_at<F, T>(&self, block_number: Option<BlockNumber>, f: F) -> T
+    pub async fn with_database_at<F, T>(&self, block_number: Option<BlockNumber>, f: F) -> T
     where
         F: FnOnce(Box<dyn MaybeHashDatabase + '_>) -> T,
     {
@@ -1079,7 +1074,7 @@ impl Backend {
                 return f(Box::new(state))
             }
         }
-        let db = self.db.read();
+        let db = self.db.read().await;
         f(Box::new(&*db))
     }
 
@@ -1094,6 +1089,7 @@ impl Backend {
             let val = db.storage(address, index);
             Ok(u256_to_h256_be(val))
         })
+        .await
     }
 
     /// Returns the code of the address
@@ -1115,6 +1111,7 @@ impl Backend {
             };
             Ok(code.bytes()[..code.len()].to_vec().into())
         })
+        .await
     }
 
     /// Returns the balance of the address
@@ -1129,6 +1126,7 @@ impl Backend {
             trace!(target: "backend", "get balance for {:?}", address);
             Ok(db.basic(address).balance)
         })
+        .await
     }
 
     /// Returns the nonce of the address
@@ -1143,6 +1141,7 @@ impl Backend {
             trace!(target: "backend", "get nonce for {:?}", address);
             Ok(db.basic(address).nonce.into())
         })
+        .await
     }
 
     /// Returns the traces for the given transaction
@@ -1387,7 +1386,7 @@ impl Backend {
     /// Prove an account's existence or nonexistence in the state trie.
     ///
     /// Returns a merkle proof of the account's trie node, `account_key` == keccak(address)
-    pub fn prove_account_at(
+    pub async fn prove_account_at(
         &self,
         addr: Address,
         values: Vec<U256>,
@@ -1446,6 +1445,7 @@ impl Backend {
 
             Ok(account_proof)
         })
+        .await
     }
 
     /// Returns a new block event stream
@@ -1470,12 +1470,13 @@ impl Backend {
     }
 }
 
+#[async_trait::async_trait]
 impl TransactionValidator for Backend {
-    fn validate_pool_transaction(
+    async fn validate_pool_transaction(
         &self,
         tx: &PendingTransaction,
     ) -> Result<(), InvalidTransactionError> {
-        let account = self.db.read().basic(*tx.sender());
+        let account = self.db.read().await.basic(*tx.sender());
         let env = self.next_env();
         self.validate_pool_transaction_for(tx, &account, &env)
     }

--- a/anvil/src/eth/backend/validate.rs
+++ b/anvil/src/eth/backend/validate.rs
@@ -5,13 +5,14 @@ use anvil_core::eth::transaction::PendingTransaction;
 use foundry_evm::revm::{AccountInfo, Env};
 
 /// A trait for validating transactions
+#[async_trait::async_trait]
 #[auto_impl::auto_impl(&, Box)]
 pub trait TransactionValidator {
     /// Validates the transaction's validity when it comes to nonce, payment
     ///
     /// This is intended to be checked before the transaction makes it into the pool and whether it
     /// should rather be outright rejected if the sender has insufficient funds.
-    fn validate_pool_transaction(
+    async fn validate_pool_transaction(
         &self,
         tx: &PendingTransaction,
     ) -> Result<(), InvalidTransactionError>;

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -217,7 +217,7 @@ async fn test_separate_states() {
     assert_eq!(balance, 1337u64.into());
 
     let fork = api.get_fork().unwrap();
-    let fork_db = fork.database.read();
+    let fork_db = fork.database.read().await;
     let acc = fork_db.inner().db().accounts.read().get(&addr).cloned().unwrap();
 
     assert_eq!(acc.balance, remote_balance)

--- a/anvil/tests/it/proof/mod.rs
+++ b/anvil/tests/it/proof/mod.rs
@@ -37,7 +37,7 @@ async fn can_get_proof() {
 
     let rlp_account = rlp::encode(&account);
 
-    let root: H256 = api.state_root().unwrap();
+    let root: H256 = api.state_root().await.unwrap();
     let acc_proof: Vec<Vec<u8>> = proof.account_proof.into_iter().map(|b| b.to_vec()).collect();
 
     verify_proof::<ExtensionLayout>(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
#2646 was the final straw for `parking_lot::RwLock<Db>`.

After looking at the logs and wrapping my head around what's locked sync and what's locked async in various contexts, I came to the conclusion the `Db` should be guarded by `tokio::sync::RwLock` instead for several reasons:

the `Db` trait is a sync abstraction over fork+mem db, fork being the critical implementation.

when we execute transactions, we need mutable access due to `revm`'s `Database` abstraction, this means we need to acquire a `WriteGuard` for the duration of the evm execution.

In fork mode, is can take a while because if the evm needs data we don't have yet it will be fetched.

So while the `WriteGuard` is active for mining a block, a call to 

`set_balance(&self) {
   self.db.read()....
}`

becomes blocking until mining has finished. tokio really does not like that.

the alternative would be to wrap these into `task_blocking` calls, but it's easy to miss, so imo wrapping db in `AsyncRWlock` makes more sense, even if less convenient.
 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* wrap `Db` in `tokio::sync::RWlock as AsyncRWlock`
* update everything accordingly
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
