### PR TITLE
feat(cast): subcommands for formatting and parsing bytes32 strings

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -9,7 +9,10 @@ use ethers_core::{
         Abi, Function, HumanReadableParser, Token,
     },
     types::{Chain, *},
-    utils::{self, get_contract_address, keccak256, parse_units, rlp},
+    utils::{
+        self, format_bytes32_string, get_contract_address, keccak256, parse_bytes32_string,
+        parse_units, rlp,
+    },
 };
 use ethers_etherscan::Client;
 use ethers_providers::{Middleware, PendingTransaction};
@@ -1390,6 +1393,26 @@ impl SimpleCast {
         let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
         let location: String = Self::keccak(&encoded)?;
         Ok(location)
+    }
+
+    /// Encodes string into bytes32 value
+    pub fn format_bytes32_string(s: &str) -> Result<String> {
+        let formatted = format_bytes32_string(s)?;
+        Ok(format!("0x{}", hex::encode(&formatted)))
+    }
+
+    /// Decodes string from bytes32 value
+    pub fn parse_bytes32_string(s: &str) -> Result<String> {
+        let s = strip_0x(s);
+        if s.len() != 64 {
+            eyre::bail!("string not 32 bytes");
+        }
+
+        let bytes = hex::decode(&s)?;
+        let mut buffer = [0u8; 32];
+        buffer.copy_from_slice(&bytes);
+
+        Ok(parse_bytes32_string(&buffer)?.to_owned())
     }
 }
 

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -684,6 +684,14 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Run(cmd) => cmd.run()?,
         Subcommands::Rpc(cmd) => cmd.run()?.await?,
+        Subcommands::FormatBytes32String { string } => {
+            let val = unwrap_or_stdin(string)?;
+            println!("{}", SimpleCast::format_bytes32_string(&val)?);
+        }
+        Subcommands::ParseBytes32String { bytes } => {
+            let val = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleCast::parse_bytes32_string(&val)?);
+        }
     };
     Ok(())
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -830,6 +830,18 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
     #[clap(visible_alias = "rp")]
     #[clap(about = "Perform a raw JSON-RPC request")]
     Rpc(RpcArgs),
+    #[clap(name = "--format-bytes32-string")]
+    #[clap(about = "Formats a string into bytes32 encoding.")]
+    FormatBytes32String {
+        #[clap(value_name = "STRING")]
+        string: Option<String>,
+    },
+    #[clap(name = "--parse-bytes32-string")]
+    #[clap(about = "Parses a string from bytes32 encoding.")]
+    ParseBytes32String {
+        #[clap(value_name = "BYTES")]
+        bytes: Option<String>,
+    },
 }
 
 pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {


### PR DESCRIPTION
## Motivation

I find myself often having to reach to `ethers.js` or `ethers-rs` when interacting with smart contracts that make use of bytes32-encoding of strings, sometimes only to generate an argument for a contract call. Since bytes32 strings have already been supported in `ethers-rs` for a long time (via 2 util functions), it makes sense to expose the functionalities through the `cast` command line tool.

## Solution

This PR adds two subcommands: `--format-bytes32-string` and `--parse-bytes32-string`. Both accept positional arguments as well as input from stdin.