### PR TITLE
fix(invariant): only considere contracts with at least 1 function

### DIFF
--- a/evm/src/fuzz/strategies/invariants.rs
+++ b/evm/src/fuzz/strategies/invariants.rs
@@ -100,7 +100,7 @@ fn select_random_sender(senders: Vec<Address>) -> impl Strategy<Value = Address>
     }
 }
 
-/// Strategy to randomly select a contract from the `contracts` list.
+/// Strategy to randomly select a contract from the `contracts` list that has at least 1 function
 fn select_random_contract(
     contracts: FuzzRunIdentifiedContracts,
 ) -> impl Strategy<Value = (Address, Abi, Vec<Function>)> {
@@ -108,7 +108,8 @@ fn select_random_contract(
 
     selectors.prop_map(move |selector| {
         let contracts = contracts.lock();
-        let (addr, (_, abi, functions)) = selector.select(contracts.iter());
+        let (addr, (_, abi, functions)) =
+            selector.select(contracts.iter().filter(|(_, (_, abi, _))| !abi.functions.is_empty()));
         (*addr, abi.clone(), functions.clone())
     })
 }

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -465,6 +465,7 @@ impl<'a> ContractRunner<'a> {
         known_contracts: Option<&BTreeMap<ArtifactId, (Abi, Vec<u8>)>>,
         identified_contracts: BTreeMap<Address, (String, Abi)>,
     ) -> Result<Vec<TestResult>> {
+        trace!(target: "forge::test::fuzz", "executing invariant test with invariant functions {:?}",  functions.iter().map(|f|&f.name).collect::<Vec<_>>());
         let empty = BTreeMap::new();
         let project_contracts = known_contracts.unwrap_or(&empty);
         let TestSetup { address, logs, traces, labeled_addresses, .. } = setup;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2651

this was an invariant bug

where both `targeted_functions` and `possible_funcs` are empty

https://github.com/foundry-rs/foundry/blob/master/evm/src/fuzz/strategies/invariants.rs#L120

so it panics here 

https://github.com/foundry-rs/foundry/blob/e306e24c9bcf223af0de6f54e1774b727c430cfa/evm/src/fuzz/strategies/invariants.rs#L137


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
only select contracts with at least 1 function
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
