### PR TITLE
feat: add ProviderBuilder helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "ethers-core",
+ "ethers-providers",
+ "eyre",
  "foundry-config",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -17,7 +17,7 @@ use anvil_server::ServerConfig;
 use ethers::{
     core::k256::ecdsa::SigningKey,
     prelude::{rand::thread_rng, Wallet, U256},
-    providers::{Http, Middleware, Provider, RetryClient},
+    providers::Middleware,
     signers::{
         coins_bip39::{English, Mnemonic},
         MnemonicBuilder, Signer,
@@ -25,6 +25,7 @@ use ethers::{
     types::BlockNumber,
     utils::{format_ether, hex, WEI_IN_ETHER},
 };
+use foundry_common::ProviderBuilder;
 use foundry_config::Config;
 use foundry_evm::{
     executor::fork::{BlockchainDb, BlockchainDbMeta, SharedBackend},
@@ -560,7 +561,11 @@ impl NodeConfig {
         {
             // TODO make provider agnostic
             let provider = Arc::new(
-                Provider::<RetryClient<Http>>::new_client(&eth_rpc_url, 10, 1000)
+                ProviderBuilder::new(&eth_rpc_url)
+                    .max_retry(10)
+                    .initial_backoff(1000)
+                    .connect()
+                    .await
                     .expect("Failed to establish provider to fork url"),
             );
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -21,7 +21,7 @@ use crate::{
     filter::{EthFilter, Filters, LogsFilter},
     mem::transaction_build,
     revm::TransactOut,
-    ClientFork, LoggingManager, Miner, MiningMode, Provider, StorageInfo,
+    ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
 };
 use anvil_core::{
     eth::{
@@ -39,7 +39,7 @@ use anvil_rpc::{error::RpcError, response::ResponseResult};
 use ethers::{
     abi::ethereum_types::H64,
     prelude::TxpoolInspect,
-    providers::{Http, ProviderError, RetryClient},
+    providers::ProviderError,
     types::{
         transaction::{
             eip2930::{AccessList, AccessListItem, AccessListWithGasUsed},
@@ -51,6 +51,7 @@ use ethers::{
     },
     utils::rlp,
 };
+use foundry_common::ProviderBuilder;
 use foundry_evm::{
     revm::{return_ok, return_revert, Return},
     utils::u256_to_h256_be,
@@ -1448,14 +1449,21 @@ impl EthApi {
     pub fn anvil_set_rpc_url(&self, url: String) -> Result<()> {
         node_info!("anvil_setRpcUrl");
         if let Some(fork) = self.backend.get_fork() {
-            let new_provider =
-                Arc::new(Provider::<RetryClient<Http>>::new_client(&url, 10, 1000).map_err(
-                    |_| ProviderError::CustomError(format!("Failed to parse invalid url {}", url)),
-                )?);
             let mut config = fork.config.write();
+            let interval = config.provider.get_interval();
+            let new_provider = Arc::new(
+                ProviderBuilder::new(&url)
+                    .max_retry(10)
+                    .initial_backoff(1000)
+                    .build()
+                    .map_err(|_| {
+                        ProviderError::CustomError(format!("Failed to parse invalid url {}", url))
+                    })?
+                    .interval(interval),
+            );
+            config.provider = new_provider;
             trace!(target: "backend", "Updated fork rpc from \"{}\" to \"{}\"", config.eth_rpc_url, url);
             config.eth_rpc_url = url;
-            config.provider = new_provider;
         }
         Ok(())
     }

--- a/anvil/src/eth/backend/fork.rs
+++ b/anvil/src/eth/backend/fork.rs
@@ -3,13 +3,14 @@
 use crate::eth::{backend::mem::fork_db::ForkedDatabase, error::BlockchainError};
 use anvil_core::eth::transaction::EthTransactionRequest;
 use ethers::{
-    prelude::{BlockNumber, Http, Provider},
-    providers::{Middleware, ProviderError, RetryClient},
+    prelude::BlockNumber,
+    providers::{Middleware, ProviderError},
     types::{
         transaction::eip2930::AccessListWithGasUsed, Address, Block, BlockId, Bytes, FeeHistory,
         Filter, Log, Trace, Transaction, TransactionReceipt, TxHash, H256, U256,
     },
 };
+use foundry_common::{ProviderBuilder, RetryProvider};
 use foundry_evm::utils::u256_to_h256_be;
 use parking_lot::{
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
@@ -117,7 +118,7 @@ impl ClientFork {
         self.config.read().chain_id
     }
 
-    fn provider(&self) -> Arc<Provider<RetryClient<Http>>> {
+    fn provider(&self) -> Arc<RetryProvider> {
         self.config.read().provider.clone()
     }
 
@@ -396,7 +397,7 @@ pub struct ClientForkConfig {
     pub block_number: u64,
     pub block_hash: H256,
     // TODO make provider agnostic
-    pub provider: Arc<Provider<RetryClient<Http>>>,
+    pub provider: Arc<RetryProvider>,
     pub chain_id: u64,
     pub override_chain_id: Option<u64>,
     /// The timestamp for the forked block
@@ -414,9 +415,14 @@ impl ClientForkConfig {
     ///
     /// This will fail if no new provider could be established (erroneous URL)
     fn update_url(&mut self, url: String) -> Result<(), BlockchainError> {
+        let interval = self.provider.get_interval();
         self.provider = Arc::new(
-            Provider::<RetryClient<Http>>::new_client(url.as_str(), 10, 1000)
-                .map_err(|_| BlockchainError::InvalidUrl(url.clone()))?,
+            ProviderBuilder::new(url.as_str())
+                .max_retry(10)
+                .initial_backoff(1000)
+                .build()
+                .map_err(|_| BlockchainError::InvalidUrl(url.clone()))?
+                .interval(interval),
         );
         trace!(target: "fork", "Updated rpc url  {}", url);
         self.eth_rpc_url = url;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,6 +15,11 @@ foundry-config = { path = "../config" }
 
 # eth
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+
+# io
+reqwest = { version = "0.11", default-features = false }
+
 # cli
 clap = { version = "3.0.10", features = [
     "derive",
@@ -27,3 +32,4 @@ clap = { version = "3.0.10", features = [
 serde = "1.0.133"
 serde_json = "1.0.67"
 thiserror = "1.0.31"
+eyre = "0.6"

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -1,5 +1,7 @@
 //! Commonly used constants
 
+use std::time::Duration;
+
 /// The dev chain-id, inherited from hardhat
 pub const DEV_CHAIN_ID: u64 = 31337;
 
@@ -8,3 +10,6 @@ pub const SELECTOR_LEN: usize = 4;
 
 /// Maximum size in bytes (0x6000) that a contract can have.
 pub const CONTRACT_MAX_SIZE: usize = 24576;
+
+/// Default request timeout for http requests
+pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(30_000);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,8 @@ pub mod errors;
 pub mod evm;
 pub mod fmt;
 pub mod fs;
+pub mod provider;
+pub use provider::*;
 pub mod traits;
 pub use constants::*;
 pub use traits::*;

--- a/common/src/provider.rs
+++ b/common/src/provider.rs
@@ -1,0 +1,144 @@
+//! Commonly used helpers to construct `Provider`s
+
+use crate::REQUEST_TIMEOUT;
+use ethers_core::types::Chain;
+use ethers_providers::{
+    is_local_endpoint, Http, HttpRateLimitRetryPolicy, Middleware, Provider, RetryClient,
+    DEFAULT_LOCAL_POLL_INTERVAL,
+};
+use reqwest::{IntoUrl, Url};
+use std::time::Duration;
+
+/// Helper type alias for a retry provider
+pub type RetryProvider = Provider<RetryClient<Http>>;
+
+/// Same as `try_get_http_provider`
+///
+/// # Panics
+///
+/// If invalid URL
+///
+/// # Example
+///
+/// ```
+/// use foundry_common::get_http_provider;
+/// # fn f() {
+///  let retry_provider = get_http_provider("http://localhost:8545");
+/// # }
+/// ```
+pub fn get_http_provider(builder: impl Into<ProviderBuilder>) -> RetryProvider {
+    try_get_http_provider(builder).unwrap()
+}
+
+/// Gives out a provider with a `100ms` interval poll if it's a localhost URL (most likely an anvil
+/// or other dev node) and with the default, `7s` if otherwise.
+pub fn try_get_http_provider(builder: impl Into<ProviderBuilder>) -> eyre::Result<RetryProvider> {
+    builder.into().build()
+}
+
+/// Helper type to construct a `RetryProvider`
+#[derive(Debug)]
+pub struct ProviderBuilder {
+    // Note: this is a result so we can easily chain builder calls
+    url: reqwest::Result<Url>,
+    chain: Chain,
+    max_retry: u32,
+    initial_backoff: u64,
+    timeout: Duration,
+}
+
+// === impl ProviderBuilder ===
+
+impl ProviderBuilder {
+    /// Creates a new builder instance
+    pub fn new(url: impl IntoUrl) -> Self {
+        Self {
+            url: url.into_url(),
+            chain: Chain::Mainnet,
+            max_retry: 100,
+            initial_backoff: 100,
+            timeout: REQUEST_TIMEOUT,
+        }
+    }
+
+    /// Enables a request timeout.
+    ///
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished.
+    ///
+    /// Default is no timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Sets the chain of the node the provider will connect to
+    pub fn chain(mut self, chain: impl Into<foundry_config::Chain>) -> Self {
+        if let foundry_config::Chain::Named(chain) = chain.into() {
+            self.chain = chain;
+        }
+        self
+    }
+
+    /// How often to retry a failed request
+    pub fn max_retry(mut self, max_retry: u32) -> Self {
+        self.max_retry = max_retry;
+        self
+    }
+
+    /// The starting backoff delay to use after the first failed request
+    pub fn initial_backoff(mut self, initial_backoff: u64) -> Self {
+        self.initial_backoff = initial_backoff;
+        self
+    }
+
+    /// Sets aggressive `max_retry` and `initial_backoff` values
+    ///
+    /// This is only recommend for local dev nodes
+    pub fn aggressive(self) -> Self {
+        self.max_retry(100).initial_backoff(100)
+    }
+
+    /// Same as [`Self:build()`] but also retrieves the `chainId` in order to derive an appropriate
+    /// interval
+    pub async fn connect(self) -> eyre::Result<RetryProvider> {
+        let mut provider = self.build()?;
+        if let Some(blocktime) = provider.get_chainid().await.ok().and_then(|id| {
+            Chain::try_from(id).ok().and_then(|chain| chain.average_blocktime_hint())
+        }) {
+            provider = provider.interval(blocktime / 2);
+        }
+        Ok(provider)
+    }
+
+    /// Constructs the `RetryProvider` taking all configs into account
+    pub fn build(self) -> eyre::Result<RetryProvider> {
+        let ProviderBuilder { url, chain, max_retry, initial_backoff, timeout } = self;
+        let url = url?;
+
+        let client = reqwest::Client::builder().timeout(timeout).build()?;
+        let is_local = is_local_endpoint(url.as_str());
+
+        let provider = Http::new_with_client(url, client);
+
+        let mut provider = Provider::new(RetryClient::new(
+            provider,
+            Box::new(HttpRateLimitRetryPolicy::default()),
+            max_retry,
+            initial_backoff,
+        ));
+
+        if is_local {
+            provider = provider.interval(DEFAULT_LOCAL_POLL_INTERVAL);
+        } else if let Some(blocktime) = chain.average_blocktime_hint() {
+            provider = provider.interval(blocktime / 2);
+        }
+        Ok(provider)
+    }
+}
+
+impl<'a> From<&'a str> for ProviderBuilder {
+    fn from(url: &'a str) -> Self {
+        Self::new(url)
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Make creating Retry providers more convenient,
this also includes a new timeout setting to set reqwest request timeouts to 30s, the default is None which can result in hanging requests
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* `ProviderBuilder` helper

needs followup to replace all usage in cast
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
