### PR TITLE
fix(anvil): calculate trace address acording to the spec

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -1069,7 +1069,7 @@ impl TransactionInfo {
             let child_idx = node.idx;
             node = &self.traces[parent];
             // find the index of the child call in the parent node
-            let call_idx  = node
+            let call_idx = node
                 .children
                 .iter()
                 .position(|child| *child == child_idx)

--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -1049,17 +1049,34 @@ pub struct TransactionInfo {
 // === impl TransactionInfo ===
 
 impl TransactionInfo {
-    /// Returns the callgraph of the trace
-    pub fn trace_call_graph(&self, idx: usize) -> Vec<usize> {
+    /// Returns the `traceAddress` of the node in the arena
+    ///
+    /// The `traceAddress` field of all returned traces, gives the exact location in the call trace
+    /// [index in root, index in first CALL, index in second CALL, …].
+    ///
+    /// # Panics
+    ///
+    /// if the `idx` does not belong to a node
+    pub fn trace_address(&self, idx: usize) -> Vec<usize> {
+        if idx == 0 {
+            // root call has empty traceAddress
+            return vec![]
+        }
         let mut graph = vec![];
         let mut node = &self.traces[idx];
-
         while let Some(parent) = node.parent {
+            // the index of the child call in the arena
+            let child_idx = node.idx;
             node = &self.traces[parent];
-            graph.push(node.trace.depth);
+            // find the index of the child call in the parent node
+            let call_idx  = node
+                .children
+                .iter()
+                .position(|child| *child == child_idx)
+                .expect("child exists in parent");
+            graph.push(call_idx);
         }
         graph.reverse();
-        graph.push(self.traces[idx].trace.depth);
         graph
     }
 }

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -235,7 +235,7 @@ impl MinedTransaction {
             let trace = Trace {
                 action,
                 result: Some(result),
-                trace_address: self.info.trace_call_graph(idx),
+                trace_address: self.info.trace_address(idx),
                 subtraces: node.children.len(),
                 transaction_position: Some(self.info.transaction_index as usize),
                 transaction_hash: Some(self.info.transaction_hash),

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -46,7 +46,7 @@ impl LocalFork {
     }
 }
 
-fn fork_config() -> NodeConfig {
+pub fn fork_config() -> NodeConfig {
     NodeConfig::test()
         .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_endpoint()))
         .with_fork_block_number(Some(BLOCK_NUMBER))

--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -1,8 +1,10 @@
+use crate::fork::fork_config;
 use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::Contract,
     prelude::{Action, ContractFactory, Middleware, Signer, SignerMiddleware, TransactionRequest},
-    types::ActionType,
+    types::{ActionType, Address, Trace},
+    utils::hex,
 };
 use ethers_solc::{project_util::TempProject, Artifact};
 use std::sync::Arc;
@@ -86,4 +88,212 @@ contract Contract {
     let traces = handle.http_provider().trace_transaction(tx.transaction_hash).await.unwrap();
     assert!(!traces.is_empty());
     assert_eq!(traces[0].action_type, ActionType::Suicide);
+}
+
+// <https://github.com/foundry-rs/foundry/issues/2656>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_address_fork() {
+    let (api, handle) = spawn(fork_config().with_fork_block_number(Some(15291050u64))).await;
+    let provider = handle.http_provider();
+
+    let input = hex::decode("43bcfab60000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000e0bd811c8769a824b00000000000000000000000000000000000000000000000e0ae9925047d8440b60000000000000000000000002e4777139254ff76db957e284b186a4507ff8c67").unwrap();
+
+    let from: Address = "0x2e4777139254ff76db957e284b186a4507ff8c67".parse().unwrap();
+    let to: Address = "0xe2f2a5c287993345a840db3b0845fbc70f5935a5".parse().unwrap();
+    let tx = TransactionRequest::new().to(to).from(from).data(input);
+
+    api.anvil_impersonate_account(from).await.unwrap();
+
+    let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
+
+    let traces = provider.trace_transaction(tx.transaction_hash).await.unwrap();
+    assert!(!traces.is_empty());
+    match traces[0].action {
+        Action::Call(ref call) => {
+            assert_eq!(call.from, from);
+            assert_eq!(call.to, to);
+        }
+        _ => unreachable!("unexpected action"),
+    }
+
+    let json = serde_json::json!(
+        [
+        {
+            "action": {
+                "callType": "call",
+                "from": "0x2e4777139254ff76db957e284b186a4507ff8c67",
+                "gas": "0x262b3",
+                "input": "0x43bcfab60000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000e0bd811c8769a824b00000000000000000000000000000000000000000000000e0ae9925047d8440b60000000000000000000000002e4777139254ff76db957e284b186a4507ff8c67",
+                "to": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x2131b",
+                "output": "0x0000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d3"
+            },
+            "subtraces": 1,
+            "traceAddress": [],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "delegatecall",
+                "from": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "gas": "0x23d88",
+                "input": "0x43bcfab60000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000e0bd811c8769a824b00000000000000000000000000000000000000000000000e0ae9925047d8440b60000000000000000000000002e4777139254ff76db957e284b186a4507ff8c67",
+                "to": "0x15b2838cd28cc353afbe59385db3f366d8945aee",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x1f6e1",
+                "output": "0x0000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d3"
+            },
+            "subtraces": 2,
+            "traceAddress": [
+                0
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "staticcall",
+                "from": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "gas": "0x192ed",
+                "input": "0x50494dc000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000e0b1ff65617f654b2f00000000000000000000000000000000000000000000000000000000000061a800000000000000000000000000000000000000000000000000b1a2bc2ec5000000000000000000000000000000000000000000000000000006f05b59d3b2000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000414ec22973db48fd3a3370000000000000000000000000000000000000000000000056bc75e2d6310000000000000000000000000000000000000000000000000000000000a7314a9ba5c0000000000000000000000000000000000000000000000000000000005f5e100000000000000000000000000000000000000000000095f783edc5a5dabcb4ba70000000000000000000000000000000000000000000000056bc75e2d6310000000000000000000000000000000000000000000000000000000000a3f42df4dab",
+                "to": "0xca480d596e6717c95a62a4dc1bd4fbd7b7e7d705",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x661a",
+                "output": "0x0000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d3"
+            },
+            "subtraces": 0,
+            "traceAddress": [
+                0,
+                0
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "delegatecall",
+                "from": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "gas": "0xd2dc",
+                "input": "0x4e331a540000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d30000000000000000000000006b175474e89094c44da98b954eedeac495271d0f000000000000000000000000a2a3cae63476891ab2d640d9a5a800755ee79d6e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000005f5e100000000000000000000000000000000000000000000095f783edc5a5dabcb4ba70000000000000000000000002e4777139254ff76db957e284b186a4507ff8c6700000000000000000000000000000000000000000000f7be2b91f8a2e2df496e",
+                "to": "0x1e91f826fa8aa4fa4d3f595898af3a64dd188848",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x7617",
+                "output": "0x"
+            },
+            "subtraces": 2,
+            "traceAddress": [
+                0,
+                1
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "staticcall",
+                "from": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "gas": "0xbf50",
+                "input": "0x70a08231000000000000000000000000a2a3cae63476891ab2d640d9a5a800755ee79d6e",
+                "to": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0xa2a",
+                "output": "0x0000000000000000000000000000000000000000000020fe99f8898600d94750"
+            },
+            "subtraces": 0,
+            "traceAddress": [
+                0,
+                1,
+                0
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "call",
+                "from": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "gas": "0xa92a",
+                "input": "0xa4e285950000000000000000000000002e4777139254ff76db957e284b186a4507ff8c670000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d3",
+                "to": "0xa2a3cae63476891ab2d640d9a5a800755ee79d6e",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x4ed3",
+                "output": "0x"
+            },
+            "subtraces": 1,
+            "traceAddress": [
+                0,
+                1,
+                1
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        },
+        {
+            "action": {
+                "callType": "call",
+                "from": "0xa2a3cae63476891ab2d640d9a5a800755ee79d6e",
+                "gas": "0x8c90",
+                "input": "0xa9059cbb0000000000000000000000002e4777139254ff76db957e284b186a4507ff8c670000000000000000000000000000000000000000000000e0e82ca52ec6e6a4d3",
+                "to": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "value": "0x0"
+            },
+            "blockHash": "0xa47c8f1d8c284cb614e9c8e10d260b33eae16b1957a83141191bc335838d7e29",
+            "blockNumber": 15291051,
+            "result": {
+                "gasUsed": "0x2b42",
+                "output": "0x0000000000000000000000000000000000000000000000000000000000000001"
+            },
+            "subtraces": 0,
+            "traceAddress": [
+                0,
+                1,
+                1,
+                0
+            ],
+            "transactionHash": "0x3255cce7312e9c4470e1a1883be13718e971f6faafb96199b8bd75e5b7c39e3a",
+            "transactionPosition": 19,
+            "type": "call"
+        }
+    ]
+    );
+
+    let expected_traces: Vec<Trace> = serde_json::from_value(json).unwrap();
+
+    // test matching traceAddress
+    traces.into_iter().zip(expected_traces).for_each(|(a, b)| {
+        assert_eq!(a.trace_address, b.trace_address);
+        assert_eq!(a.subtraces, b.subtraces);
+    })
 }

--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -295,5 +295,12 @@ async fn test_trace_address_fork() {
     traces.into_iter().zip(expected_traces).for_each(|(a, b)| {
         assert_eq!(a.trace_address, b.trace_address);
         assert_eq!(a.subtraces, b.subtraces);
+        match (a.action, b.action) {
+            (Action::Call(a), Action::Call(b)) => {
+                assert_eq!(a.from, b.from);
+                assert_eq!(a.to, b.to);
+            }
+            _ => unreachable!("unexpected action"),
+        }
     })
 }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -52,8 +52,12 @@ impl CallTraceArena {
 
                 let trace_location = self.arena[entry].children.len();
                 self.arena[entry].ordering.push(LogCallOrder::Call(trace_location));
-                let node =
-                    CallTraceNode { parent: Some(entry), trace: new_trace, ..Default::default() };
+                let node = CallTraceNode {
+                    parent: Some(entry),
+                    trace: new_trace,
+                    idx: id,
+                    ..Default::default()
+                };
                 self.arena.push(node);
                 self.arena[entry].children.push(id);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/2656
Closes #2663

Fixes `traceAddress` calculation. this will add the index of the call in the parent node instead of the parent's depth


@naddison36 mind giving this another try, the from issue should be fixed as well

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
