### PR TITLE
perf(script): binary search gas estimation

### DIFF
--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -2,6 +2,7 @@ use super::*;
 use ethers::types::{Address, Bytes, NameOrAddress, U256};
 use forge::{
     executor::{CallResult, DeployResult, EvmError, Executor, RawCallResult},
+    revm::{return_ok, Return},
     trace::{CallTraceArena, TraceKind},
     CALLER,
 };
@@ -185,6 +186,12 @@ impl ScriptRunner {
         }
     }
 
+    /// Executes the call
+    ///
+    /// This will commit the changes if `commit` is true.
+    ///
+    /// This will return _estimated_ gas instead of the precise gas the call would consume, so it
+    /// can be used as `gas_limit`.
     fn call(
         &mut self,
         from: Address,
@@ -193,24 +200,57 @@ impl ScriptRunner {
         value: U256,
         commit: bool,
     ) -> eyre::Result<ScriptResult> {
-        let RawCallResult {
-            result,
-            reverted,
-            gas: tx_gas,
-            stipend,
-            logs,
-            traces,
-            labels,
-            debug,
-            transactions,
-            ..
-        } = if !commit {
-            self.executor.call_raw(from, to, calldata.0, value)?
-        } else {
-            self.executor.call_raw_committing(from, to, calldata.0, value)?
-        };
+        let mut res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
+        let mut gas = res.gas;
+        if matches!(res.status, return_ok!()) {
+            // store the current gas limit and reset it later
+            let init_gas_limit = self.executor.env_mut().tx.gas_limit;
 
-        let gas = if commit { tx_gas } else { tx_gas.overflowing_sub(stipend).0 };
+            // the executor will return the _exact_ gas value this transaction consumed, setting
+            // this value as gas limit will result in `OutOfGas` so to come up with a
+            // better estimate we search over a possible range we pick a higher gas
+            // limit 3x of a succeeded call should be safe
+            let mut highest_gas_limit = gas * 3;
+            let mut lowest_gas_limit = gas;
+            let mut last_highest_gas_limit = highest_gas_limit;
+            while (highest_gas_limit - lowest_gas_limit) > 1 {
+                let mid_gas_limit = (highest_gas_limit + lowest_gas_limit) / 2;
+                self.executor.env_mut().tx.gas_limit = mid_gas_limit;
+                let res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
+                match res.status {
+                    Return::Revert |
+                    Return::OutOfGas |
+                    Return::LackOfFundForGasLimit |
+                    Return::OutOfFund => {
+                        lowest_gas_limit = mid_gas_limit;
+                    }
+                    _ => {
+                        highest_gas_limit = mid_gas_limit;
+                        // if last two successful estimations only vary by 10%, we consider this to
+                        // sufficiently accurate
+                        const ACCURACY: u64 = 10;
+                        if (last_highest_gas_limit - highest_gas_limit) * ACCURACY /
+                            last_highest_gas_limit <
+                            1
+                        {
+                            // update the gas
+                            gas = highest_gas_limit;
+                            break
+                        }
+                        last_highest_gas_limit = highest_gas_limit;
+                    }
+                }
+            }
+            // reset gas limit in the
+            self.executor.env_mut().tx.gas_limit = init_gas_limit;
+        }
+
+        if commit {
+            // if explicitly requested we can now commit the call
+            res = self.executor.call_raw_committing(from, to, calldata.0.clone(), value)?;
+        }
+
+        let RawCallResult { result, reverted, logs, traces, labels, debug, transactions, .. } = res;
 
         Ok(ScriptResult {
             returned: result,

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -247,7 +247,7 @@ impl ScriptRunner {
 
         if commit {
             // if explicitly requested we can now commit the call
-            res = self.executor.call_raw_committing(from, to, calldata.0.clone(), value)?;
+            res = self.executor.call_raw_committing(from, to, calldata.0, value)?;
         }
 
         let RawCallResult { result, reverted, logs, traces, labels, debug, transactions, .. } = res;

--- a/cli/tests/fixtures/can_execute_script_command.stdout
+++ b/cli/tests/fixtures/can_execute_script_command.stdout
@@ -1,0 +1,8 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 23.34ms
+Compiler run successful
+Script ran successfully.
+Gas used: 24240
+
+== Logs ==
+  script ran

--- a/cli/tests/fixtures/can_execute_script_command_fqn.stdout
+++ b/cli/tests/fixtures/can_execute_script_command_fqn.stdout
@@ -1,0 +1,8 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 23.70ms
+Compiler run successful
+Script ran successfully.
+Gas used: 24240
+
+== Logs ==
+  script ran

--- a/cli/tests/fixtures/can_execute_script_command_with_args.stdout
+++ b/cli/tests/fixtures/can_execute_script_command_with_args.stdout
@@ -1,0 +1,10 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 35.28ms
+Compiler run successful
+Script ran successfully.
+Gas used: 26882
+
+== Logs ==
+  script ran
+  1
+  2

--- a/cli/tests/fixtures/can_execute_script_command_with_returned.stdout
+++ b/cli/tests/fixtures/can_execute_script_command_with_returned.stdout
@@ -1,0 +1,12 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 1.27s
+Compiler run successful
+Script ran successfully.
+Gas used: 24331
+
+== Return ==
+result: uint256 255
+1: uint8 3
+
+== Logs ==
+  script ran

--- a/cli/tests/fixtures/can_execute_script_command_with_sig.stdout
+++ b/cli/tests/fixtures/can_execute_script_command_with_sig.stdout
@@ -1,0 +1,8 @@
+Compiling 1 files with 0.8.10
+Solc 0.8.10 finished in 24.49ms
+Compiler run successful
+Script ran successfully.
+Gas used: 24240
+
+== Logs ==
+  script ran

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -44,7 +44,7 @@ contract ContractScript is Script {
 );
 
 // Tests that the `run` command works correctly
-forgetest!(can_execute_script_command, |prj: TestProject, mut cmd: TestCommand| {
+forgetest!(can_execute_script_command2, |prj: TestProject, mut cmd: TestCommand| {
     let script = prj
         .inner()
         .add_source(
@@ -63,16 +63,10 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script);
-    let output = cmd.stdout_lossy();
-    assert!(output.ends_with(
-        "Compiler run successful
-Script ran successfully.
-Gas used: 1751
-
-== Logs ==
-  script ran
-"
-    ));
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_execute_script_command.stdout"),
+    );
 });
 
 // Tests that the `run` command works correctly when path *and* script name is specified

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -3,11 +3,10 @@ use anvil::{spawn, NodeConfig};
 use ethers::abi::Address;
 use foundry_cli_test_utils::{
     forgetest, forgetest_async, forgetest_init,
-    util::{TestCommand, TestProject},
+    util::{OutputExt, TestCommand, TestProject},
     ScriptOutcome, ScriptTester,
 };
 use foundry_utils::rpc;
-
 use regex::Regex;
 use std::{env, path::PathBuf, str::FromStr};
 
@@ -96,16 +95,10 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(format!("{}:Demo", script.display()));
-    let output = cmd.stdout_lossy();
-    assert!(output.ends_with(
-        "Compiler run successful
-Script ran successfully.
-Gas used: 1751
-
-== Logs ==
-  script ran
-"
-    ));
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_execute_script_command_fqn.stdout"),
+    );
 });
 
 // Tests that the run command can run arbitrary functions
@@ -196,20 +189,10 @@ contract Demo {
         )
         .unwrap();
     cmd.arg("script").arg(script);
-    let output = cmd.stdout_lossy();
-    assert!(output.ends_with(
-        "Compiler run successful
-Script ran successfully.
-Gas used: 1836
-
-== Return ==
-result: uint256 255
-1: uint8 3
-
-== Logs ==
-  script ran
-"
-    ));
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_execute_script_command_with_returned.stdout"),
+    );
 });
 
 forgetest_async!(

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -121,16 +121,10 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script).arg("--sig").arg("myFunction()");
-    let output = cmd.stdout_lossy();
-    assert!(output.ends_with(
-        "Compiler run successful
-Script ran successfully.
-Gas used: 1751
-
-== Logs ==
-  script ran
-"
-    ));
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_execute_script_command_with_sig.stdout"),
+    );
 });
 
 // Tests that the run command can run functions with arguments
@@ -156,18 +150,10 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script).arg("--sig").arg("run(uint256,uint256)").arg("1").arg("2");
-    let output = cmd.stdout_lossy();
-    assert!(output.ends_with(
-        "Compiler run successful
-Script ran successfully.
-Gas used: 3957
-
-== Logs ==
-  script ran
-  1
-  2
-"
-    ));
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/can_execute_script_command_with_args.stdout"),
+    );
 });
 
 // Tests that the run command can run functions with return values


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
atm gas limit in script is `gas as returned by the executor` * multiplier (=1.3)

however, the gas returned by the executor is the exact gas value the call consumed, which might not be enough if used as gas_limit
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use binary search over `(gas, gas*3)` to find the lowest gas limit with which the call succeeds and use that instead
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
