### PR TITLE
fix(script): use correct fork url

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -206,7 +206,7 @@ impl ScriptArgs {
         verify: VerifyBundle,
     ) -> eyre::Result<()> {
         if let Some(txs) = result.transactions {
-            if script_config.evm_opts.fork_url.is_some() {
+            if let Some(fork_url) = script_config.evm_opts.fork_url.clone() {
                 let gas_filled_txs = if self.skip_simulation {
                     println!("\nSKIPPING ON CHAIN SIMULATION.");
                     txs.into_iter().map(TransactionWithMetadata::from_typed_transaction).collect()
@@ -225,8 +225,6 @@ impl ScriptArgs {
                         )
                     })?
                 };
-
-                let fork_url = self.evm_opts.fork_url.as_ref().unwrap().clone();
 
                 let provider = Arc::new(get_http_provider(&fork_url));
                 let chain = provider.get_chainid().await?.as_u64();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/2679

the if branch was not great because we had:

`script_config.evm_opts.fork_url.is_some() {self.evm_opts.fork_url.unwrap()}`


@joshieDo this section is a bit hard to make sense of, but this condition seemed off, is that the correct fix?

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
uses the fork_url that's initialized in the `ScriptConfig`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
