### PR TITLE
perf(anvil): remove block_in_place task wrappers

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -866,7 +866,7 @@ impl Backend {
         hash: H256,
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.mined_block_by_hash(hash)) {
+        if let tx @ Some(_) = self.mined_block_by_hash(hash) {
             return Ok(tx)
         }
 
@@ -882,7 +882,7 @@ impl Backend {
         hash: H256,
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.get_full_block(hash)) {
+        if let tx @ Some(_) = self.get_full_block(hash) {
             return Ok(tx)
         }
 
@@ -918,7 +918,7 @@ impl Backend {
         number: BlockNumber,
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.mined_block_by_number(number)) {
+        if let tx @ Some(_) = self.mined_block_by_number(number) {
             return Ok(tx)
         }
 
@@ -934,7 +934,7 @@ impl Backend {
         number: BlockNumber,
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.get_full_block(number)) {
+        if let tx @ Some(_) = self.get_full_block(number) {
             return Ok(tx)
         }
 
@@ -1161,9 +1161,7 @@ impl Backend {
 
     /// Returns the traces for the given transaction
     pub async fn trace_transaction(&self, hash: H256) -> Result<Vec<Trace>, BlockchainError> {
-        if let Some(traces) =
-            tokio::task::block_in_place(|| self.mined_parity_trace_transaction(hash))
-        {
+        if let Some(traces) = self.mined_parity_trace_transaction(hash) {
             return Ok(traces)
         }
 
@@ -1193,8 +1191,7 @@ impl Backend {
     /// Returns the traces for the given block
     pub async fn trace_block(&self, block: BlockNumber) -> Result<Vec<Trace>, BlockchainError> {
         let number = self.convert_block_number(Some(block));
-        if let Some(traces) = tokio::task::block_in_place(|| self.mined_parity_trace_block(number))
-        {
+        if let Some(traces) = self.mined_parity_trace_block(number) {
             return Ok(traces)
         }
 
@@ -1211,7 +1208,7 @@ impl Backend {
         &self,
         hash: H256,
     ) -> Result<Option<TransactionReceipt>, BlockchainError> {
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.mined_transaction_receipt(hash)) {
+        if let tx @ Some(_) = self.mined_transaction_receipt(hash) {
             return Ok(tx)
         }
 
@@ -1318,9 +1315,7 @@ impl Backend {
         number: BlockNumber,
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
-        if let Some(hash) =
-            tokio::task::block_in_place(|| self.mined_block_by_number(number).and_then(|b| b.hash))
-        {
+        if let Some(hash) = self.mined_block_by_number(number).and_then(|b| b.hash) {
             return Ok(self.mined_transaction_by_block_hash_and_index(hash, index))
         }
 
@@ -1339,9 +1334,7 @@ impl Backend {
         hash: H256,
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
-        if let tx @ Some(_) = tokio::task::block_in_place(|| {
-            self.mined_transaction_by_block_hash_and_index(hash, index)
-        }) {
+        if let tx @ Some(_) = self.mined_transaction_by_block_hash_and_index(hash, index) {
             return Ok(tx)
         }
 
@@ -1374,7 +1367,7 @@ impl Backend {
         hash: H256,
     ) -> Result<Option<Transaction>, BlockchainError> {
         trace!(target: "backend", "transaction_by_hash={:?}", hash);
-        if let tx @ Some(_) = tokio::task::block_in_place(|| self.mined_transaction_by_hash(hash)) {
+        if let tx @ Some(_) = self.mined_transaction_by_hash(hash) {
             return Ok(tx)
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
since https://github.com/foundry-rs/foundry/pull/2369 the `storage` lock is no longer kept during mining so the `block_in_place` wrappers to read data from `storage` is no longer required as all write operations to `storage` are fast enough, only write to memory.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* rm `block_inplace` wrappers
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
