### PR TITLE
fix(anvil): load account first before setting storage

### DIFF
--- a/anvil/src/eth/backend/mem/fork_db.rs
+++ b/anvil/src/eth/backend/mem/fork_db.rs
@@ -4,6 +4,7 @@ use crate::{
     Address, U256,
 };
 use ethers::prelude::H256;
+use forge::revm::Database;
 use foundry_evm::executor::fork::database::ForkDbSnapshot;
 pub use foundry_evm::executor::fork::database::ForkedDatabase;
 
@@ -14,6 +15,8 @@ impl Db for ForkedDatabase {
     }
 
     fn set_storage_at(&mut self, address: Address, slot: U256, val: U256) {
+        // this ensures the account is loaded first
+        let _ = Database::basic(self, address);
         self.database_mut().set_storage_at(address, slot, val)
     }
 

--- a/anvil/tests/it/abi.rs
+++ b/anvil/tests/it/abi.rs
@@ -39,3 +39,9 @@ abigen!(
             _exists(uint256)(bool)
 ]"#
 );
+abigen!(
+    BUSD,
+    r#"[
+            balanceOf(address)(uint256)
+]"#
+);

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -5,7 +5,11 @@ use anvil_core::eth::EthRequest;
 use ethers::{
     abi::ethereum_types::BigEndianHash,
     prelude::{Middleware, SignerMiddleware},
-    types::{Address, BlockNumber, TransactionRequest, H256, U256},
+    types::{
+        transaction::eip2718::TypedTransaction, Address, BlockNumber, TransactionRequest, H256,
+        U256,
+    },
+    utils::hex,
 };
 use std::{
     sync::Arc,
@@ -205,4 +209,33 @@ async fn test_timestamp_interval() {
     let another_block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
     // check interval is disabled
     assert!(another_block.timestamp - new_block.timestamp < U256::from(interval));
+}
+
+// <https://github.com/foundry-rs/foundry/issues/2341>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_can_set_storage_bsc_fork() {
+    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(
+        "https://bsc.getblock.io/mainnet/?api_key=d5e88e54-8d12-4342-95ab-792ffdaac250",
+    )))
+    .await;
+    let provider = handle.http_provider();
+
+    let busd_addr: Address = "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56".parse().unwrap();
+    let idx: U256 =
+        "0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49".parse().unwrap();
+    let value: H256 =
+        "0x0000000000000000000000000000000000000000000000000000000000003039".parse().unwrap();
+
+    api.anvil_set_storage_at(busd_addr, idx, value).await.unwrap();
+
+    let storage = api.storage_at(busd_addr, idx, None).await.unwrap();
+    assert_eq!(storage, value);
+
+    let input =
+        hex::decode("70a082310000000000000000000000000000000000000000000000000000000000000000")
+            .unwrap();
+
+    let tx: TypedTransaction = TransactionRequest::new().to(busd_addr).data(input).into();
+
+    let _resp = provider.call(&tx, None).await.unwrap();
 }

--- a/evm/src/executor/fork/database.rs
+++ b/evm/src/executor/fork/database.rs
@@ -141,11 +141,11 @@ impl ForkedDatabase {
 
 impl Database for ForkedDatabase {
     fn basic(&mut self, address: Address) -> AccountInfo {
-        self.cache_db.basic(address)
+        Database::basic(&mut self.cache_db, address)
     }
 
     fn code_by_hash(&mut self, code_hash: H256) -> Bytecode {
-        self.cache_db.code_by_hash(code_hash)
+        Database::code_by_hash(&mut self.cache_db, code_hash)
     }
 
     fn storage(&mut self, address: Address, index: U256) -> U256 {
@@ -153,7 +153,7 @@ impl Database for ForkedDatabase {
     }
 
     fn block_hash(&mut self, number: U256) -> H256 {
-        self.cache_db.block_hash(number)
+        Database::block_hash(&mut self.cache_db, number)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/2341
rust port of python test https://github.com/foundry-rs/foundry/issues/2341#issuecomment-1210388372

~~for some reason the ethcall returns empty bytes, unclear at this point if this is a bsc issue or something else. setting, getting storage seems to work fine~~

turns out there was a caching issue that happened when `setStorage` was called before the account was loaded. because `set_storage` inserts a default account if it's missing, sigh
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
load the account first before setting storage
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
