### PR TITLE
feat(anvil): add genesis block timestamp parameter

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -50,6 +50,9 @@ pub struct NodeArgs {
     )]
     pub balance: u64,
 
+    #[clap(long, help = "The timestamp of the genesis block", value_name = "NUM")]
+    pub timestamp: Option<u64>,
+
     #[clap(
         long,
         short,
@@ -129,6 +132,7 @@ impl NodeArgs {
             .with_no_mining(self.no_mining)
             .with_account_generator(self.account_generator())
             .with_genesis_balance(genesis_balance)
+            .with_genesis_timestamp(self.timestamp)
             .with_port(self.port)
             .with_fork_block_number(
                 self.evm_opts
@@ -278,14 +282,14 @@ impl FromStr for ForkUrl {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((url, block)) = s.rsplit_once('@') {
             if block == "latest" {
-                return Ok(ForkUrl { url: url.to_string(), block: None })
+                return Ok(ForkUrl { url: url.to_string(), block: None });
             }
             // this will prevent false positives for auths `user:password@example.com`
             if !block.is_empty() && !block.contains(':') && !block.contains('.') {
                 let block: u64 = block
                     .parse()
                     .map_err(|_| format!("Failed to parse block number: `{block}`"))?;
-                return Ok(ForkUrl { url: url.to_string(), block: Some(block) })
+                return Ok(ForkUrl { url: url.to_string(), block: Some(block) });
             }
         }
         Ok(ForkUrl { url: s.to_string(), block: None })

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -282,14 +282,14 @@ impl FromStr for ForkUrl {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some((url, block)) = s.rsplit_once('@') {
             if block == "latest" {
-                return Ok(ForkUrl { url: url.to_string(), block: None });
+                return Ok(ForkUrl { url: url.to_string(), block: None })
             }
             // this will prevent false positives for auths `user:password@example.com`
             if !block.is_empty() && !block.contains(':') && !block.contains('.') {
                 let block: u64 = block
                     .parse()
                     .map_err(|_| format!("Failed to parse block number: `{block}`"))?;
-                return Ok(ForkUrl { url: url.to_string(), block: Some(block) });
+                return Ok(ForkUrl { url: url.to_string(), block: Some(block) })
             }
         }
         Ok(ForkUrl { url: s.to_string(), block: None })

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -302,7 +302,7 @@ impl Default for NodeConfig {
             gas_price: None,
             hardfork: None,
             signer_accounts: genesis_accounts.clone(),
-            genesis_timestamp: Some(duration_since_unix_epoch().as_secs()),
+            genesis_timestamp: None,
             genesis_accounts,
             // 100ETH default balance
             genesis_balance: WEI_IN_ETHER.saturating_mul(100u64.into()),
@@ -391,7 +391,7 @@ impl NodeConfig {
 
     /// Returns the genesis timestamp to use
     pub fn get_genesis_timestamp(&self) -> u64 {
-        self.genesis_timestamp.unwrap_or_default()
+        self.genesis_timestamp.unwrap_or_else(|| duration_since_unix_epoch().as_secs())
     }
 
     /// Sets the genesis timestamp

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -5,6 +5,7 @@ use crate::{
             fork::{ClientFork, ClientForkConfig},
             genesis::GenesisConfig,
             mem::fork_db::ForkedDatabase,
+            time::duration_since_unix_epoch,
         },
         fees::{INITIAL_BASE_FEE, INITIAL_GAS_PRICE},
         pool::transactions::TransactionOrder,
@@ -83,6 +84,8 @@ pub struct NodeConfig {
     pub genesis_accounts: Vec<Wallet<SigningKey>>,
     /// Native token balance of every genesis account in the genesis block
     pub genesis_balance: U256,
+    /// Genesis block timestamp
+    pub genesis_timestamp: Option<u64>,
     /// Signer accounts that can sign messages/transactions from the EVM node
     pub signer_accounts: Vec<Wallet<SigningKey>>,
     /// Configured block time for the EVM chain. Use `None` to mine a new block for every tx
@@ -201,6 +204,16 @@ Gas Limit
             Paint::green(format!("\n{}", self.gas_limit))
         );
 
+        let _ = write!(
+            config_string,
+            r#"
+Genesis Timestamp
+==================
+{}
+"#,
+            Paint::green(format!("\n{}", self.get_genesis_timestamp()))
+        );
+
         if let Some(fork) = fork {
             let _ = write!(
                 config_string,
@@ -262,6 +275,7 @@ Chain ID:       {}
               "base_fee": format!("{}", self.get_base_fee()),
               "gas_price": format!("{}", self.get_gas_price()),
               "gas_limit": format!("{}", self.gas_limit),
+              "genesis_timestamp": format!("{}", self.get_genesis_timestamp()),
             })
         }
     }
@@ -288,6 +302,7 @@ impl Default for NodeConfig {
             gas_price: None,
             hardfork: None,
             signer_accounts: genesis_accounts.clone(),
+            genesis_timestamp: Some(duration_since_unix_epoch().as_secs()),
             genesis_accounts,
             // 100ETH default balance
             genesis_balance: WEI_IN_ETHER.saturating_mul(100u64.into()),
@@ -371,6 +386,20 @@ impl NodeConfig {
     #[must_use]
     pub fn with_base_fee<U: Into<U256>>(mut self, base_fee: Option<U>) -> Self {
         self.base_fee = base_fee.map(Into::into);
+        self
+    }
+
+    /// Returns the genesis timestamp to use
+    pub fn get_genesis_timestamp(&self) -> u64 {
+        self.genesis_timestamp.unwrap_or_default()
+    }
+
+    /// Sets the genesis timestamp
+    #[must_use]
+    pub fn with_genesis_timestamp<U: Into<u64>>(mut self, timestamp: Option<U>) -> Self {
+        if let Some(timestamp) = timestamp {
+            self.genesis_timestamp = Some(timestamp.into());
+        }
         self
     }
 
@@ -514,7 +543,7 @@ impl NodeConfig {
             .expect("Failed writing json");
         }
         if self.silent {
-            return
+            return;
         }
 
         println!("{}", self.as_string(fork))
@@ -525,7 +554,7 @@ impl NodeConfig {
     /// See also [ Config::foundry_block_cache_file()]
     pub fn block_cache_path(&self) -> Option<PathBuf> {
         if self.no_storage_caching || self.eth_rpc_url.is_none() {
-            return None
+            return None;
         }
         // cache only if block explicitly set
         let block = self.fork_block_number?;
@@ -680,6 +709,7 @@ impl NodeConfig {
             };
 
         let genesis = GenesisConfig {
+            timestamp: self.get_genesis_timestamp(),
             balance: self.genesis_balance,
             accounts: self.genesis_accounts.iter().map(|acc| acc.address()).collect(),
         };
@@ -690,6 +720,8 @@ impl NodeConfig {
 
         if let Some(timestamp) = fork_timestamp {
             backend.time().set_start_timestamp(timestamp.as_u64());
+        } else {
+            backend.time().set_start_timestamp(self.get_genesis_timestamp());
         }
         backend
     }
@@ -870,7 +902,7 @@ async fn find_latest_fork_block<M: Middleware>(provider: M) -> Result<u64, M::Er
     for _ in 0..2 {
         if let Some(block) = provider.get_block(num).await? {
             if block.hash.is_some() {
-                break
+                break;
             }
         }
         // block not actually finalized, so we try the block before

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -543,7 +543,7 @@ impl NodeConfig {
             .expect("Failed writing json");
         }
         if self.silent {
-            return;
+            return
         }
 
         println!("{}", self.as_string(fork))
@@ -554,7 +554,7 @@ impl NodeConfig {
     /// See also [ Config::foundry_block_cache_file()]
     pub fn block_cache_path(&self) -> Option<PathBuf> {
         if self.no_storage_caching || self.eth_rpc_url.is_none() {
-            return None;
+            return None
         }
         // cache only if block explicitly set
         let block = self.fork_block_number?;
@@ -902,7 +902,7 @@ async fn find_latest_fork_block<M: Middleware>(provider: M) -> Result<u64, M::Er
     for _ in 0..2 {
         if let Some(block) = provider.get_block(num).await? {
             if block.hash.is_some() {
-                break;
+                break
             }
         }
         // block not actually finalized, so we try the block before

--- a/anvil/src/eth/backend/genesis.rs
+++ b/anvil/src/eth/backend/genesis.rs
@@ -7,6 +7,8 @@ use foundry_evm::revm::AccountInfo;
 /// Genesis settings
 #[derive(Debug, Clone, Default)]
 pub struct GenesisConfig {
+    /// The initial timestamp for the genesis block
+    pub timestamp: u64,
     /// Balance for genesis accounts
     pub balance: U256,
     /// All accounts that should be initialised at genesis

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -63,6 +63,8 @@ use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{trace, warn};
 use trie_db::{Recorder, Trie};
 
+use super::time::duration_since_unix_epoch;
+
 pub mod fork_db;
 pub mod in_memory_db;
 pub mod state;
@@ -117,7 +119,11 @@ pub struct Backend {
 impl Backend {
     /// Create a new instance of in-mem backend.
     pub fn new(db: Arc<AsyncRwLock<dyn Db>>, env: Arc<RwLock<Env>>, fees: FeeManager) -> Self {
-        let blockchain = Blockchain::new(&env.read(), fees.is_eip1559().then(|| fees.base_fee()));
+        let blockchain = Blockchain::new(
+            &env.read(),
+            fees.is_eip1559().then(|| fees.base_fee()),
+            duration_since_unix_epoch().as_secs(),
+        );
         Self {
             db,
             blockchain,
@@ -153,7 +159,11 @@ impl Backend {
             trace!(target: "backend", "using forked blockchain at {}", fork.block_number());
             Blockchain::forked(fork.block_number(), fork.block_hash())
         } else {
-            Blockchain::new(&env.read(), fees.is_eip1559().then(|| fees.base_fee()))
+            Blockchain::new(
+                &env.read(),
+                fees.is_eip1559().then(|| fees.base_fee()),
+                genesis.timestamp,
+            )
         };
 
         let backend = Self {
@@ -200,7 +210,7 @@ impl Backend {
     /// Returns `true` if the account is already impersonated
     pub async fn impersonate(&self, addr: Address) -> bool {
         if self.cheats.is_impersonated(addr) {
-            return true
+            return true;
         }
         // need to bypass EIP-3607: Reject transactions from senders with deployed code by setting
         // the code hash to `KECCAK_EMPTY` temporarily and also remove the code itself and add back
@@ -706,7 +716,7 @@ impl Backend {
                     env.block.number.as_u64(),
                     block_number.as_u64(),
                 ))
-            }
+            };
         }
 
         let db = self.db.read().await;
@@ -741,12 +751,12 @@ impl Backend {
         hash: H256,
     ) -> Result<Vec<Log>, BlockchainError> {
         if let Some(block) = self.blockchain.storage.read().blocks.get(&hash).cloned() {
-            return Ok(self.mined_logs_for_block(filter, block))
+            return Ok(self.mined_logs_for_block(filter, block));
         }
 
         if let Some(fork) = self.get_fork() {
             let filter = filter;
-            return Ok(fork.logs(&filter).await?)
+            return Ok(fork.logs(&filter).await?);
         }
 
         Ok(Vec::new())
@@ -873,11 +883,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
         if let tx @ Some(_) = self.mined_block_by_hash(hash) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_hash(hash).await?)
+            return Ok(fork.block_by_hash(hash).await?);
         }
 
         Ok(None)
@@ -889,11 +899,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
         if let tx @ Some(_) = self.get_full_block(hash) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_hash_full(hash).await?)
+            return Ok(fork.block_by_hash_full(hash).await?);
         }
 
         Ok(None)
@@ -925,11 +935,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
         if let tx @ Some(_) = self.mined_block_by_number(number) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_number(self.convert_block_number(Some(number))).await?)
+            return Ok(fork.block_by_number(self.convert_block_number(Some(number))).await?);
         }
 
         Ok(None)
@@ -941,11 +951,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
         if let tx @ Some(_) = self.get_full_block(number) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_number_full(self.convert_block_number(Some(number))).await?)
+            return Ok(fork.block_by_number_full(self.convert_block_number(Some(number))).await?);
         }
 
         Ok(None)
@@ -1092,7 +1102,7 @@ impl Backend {
             if let Some(state) =
                 self.hash_for_block_number(block_number.as_u64()).and_then(|hash| states.get(&hash))
             {
-                return f(Box::new(state))
+                return f(Box::new(state));
             }
         }
         let db = self.db.read().await;
@@ -1127,7 +1137,7 @@ impl Backend {
             let account = db.basic(address);
             if account.code_hash == KECCAK_EMPTY {
                 // if the code hash is `KECCAK_EMPTY`, we check no further
-                return Ok(Default::default())
+                return Ok(Default::default());
             }
             let code = if let Some(code) = account.code {
                 code
@@ -1172,11 +1182,11 @@ impl Backend {
     /// Returns the traces for the given transaction
     pub async fn trace_transaction(&self, hash: H256) -> Result<Vec<Trace>, BlockchainError> {
         if let Some(traces) = self.mined_parity_trace_transaction(hash) {
-            return Ok(traces)
+            return Ok(traces);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.trace_transaction(hash).await?)
+            return Ok(fork.trace_transaction(hash).await?);
         }
 
         Ok(vec![])
@@ -1202,12 +1212,12 @@ impl Backend {
     pub async fn trace_block(&self, block: BlockNumber) -> Result<Vec<Trace>, BlockchainError> {
         let number = self.convert_block_number(Some(block));
         if let Some(traces) = self.mined_parity_trace_block(number) {
-            return Ok(traces)
+            return Ok(traces);
         }
 
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork(number) {
-                return Ok(fork.trace_block(number).await?)
+                return Ok(fork.trace_block(number).await?);
             }
         }
 
@@ -1219,11 +1229,11 @@ impl Backend {
         hash: H256,
     ) -> Result<Option<TransactionReceipt>, BlockchainError> {
         if let tx @ Some(_) = self.mined_transaction_receipt(hash) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_receipt(hash).await?)
+            return Ok(fork.transaction_receipt(hash).await?);
         }
 
         Ok(None)
@@ -1326,13 +1336,15 @@ impl Backend {
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
         if let Some(hash) = self.mined_block_by_number(number).and_then(|b| b.hash) {
-            return Ok(self.mined_transaction_by_block_hash_and_index(hash, index))
+            return Ok(self.mined_transaction_by_block_hash_and_index(hash, index));
         }
 
         let number = self.convert_block_number(Some(number));
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork(number) {
-                return Ok(fork.transaction_by_block_number_and_index(number, index.into()).await?)
+                return Ok(fork
+                    .transaction_by_block_number_and_index(number, index.into())
+                    .await?);
             }
         }
 
@@ -1345,11 +1357,11 @@ impl Backend {
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
         if let tx @ Some(_) = self.mined_transaction_by_block_hash_and_index(hash, index) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_by_block_hash_and_index(hash, index.into()).await?)
+            return Ok(fork.transaction_by_block_hash_and_index(hash, index.into()).await?);
         }
 
         Ok(None)
@@ -1378,11 +1390,11 @@ impl Backend {
     ) -> Result<Option<Transaction>, BlockchainError> {
         trace!(target: "backend", "transaction_by_hash={:?}", hash);
         if let tx @ Some(_) = self.mined_transaction_by_hash(hash) {
-            return Ok(tx)
+            return Ok(tx);
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_by_hash(hash).await?)
+            return Ok(fork.transaction_by_hash(hash).await?);
         }
 
         Ok(None)
@@ -1508,19 +1520,19 @@ impl TransactionValidator for Backend {
         let tx = &pending.transaction;
         if tx.gas_limit() > env.block.gas_limit {
             warn!(target: "backend", "[{:?}] gas too high", tx.hash());
-            return Err(InvalidTransactionError::GasTooHigh)
+            return Err(InvalidTransactionError::GasTooHigh);
         }
 
         // check nonce
         let nonce: u64 = (*tx.nonce()).try_into().map_err(|_| InvalidTransactionError::NonceMax)?;
         if nonce < account.nonce {
             warn!(target: "backend", "[{:?}] nonce too low", tx.hash());
-            return Err(InvalidTransactionError::NonceTooLow)
+            return Err(InvalidTransactionError::NonceTooLow);
         }
 
         if (env.cfg.spec_id as u8) >= (SpecId::LONDON as u8) && tx.gas_price() < env.block.basefee {
             warn!(target: "backend", "max fee per gas={}, too low, block basefee={}",tx.gas_price(),  env.block.basefee);
-            return Err(InvalidTransactionError::FeeTooLow)
+            return Err(InvalidTransactionError::FeeTooLow);
         }
 
         let max_cost = tx.max_cost();
@@ -1534,7 +1546,7 @@ impl TransactionValidator for Backend {
 
         if account.balance < req_funds {
             warn!(target: "backend", "[{:?}] insufficient allowance={}, required={} account={:?}", tx.hash(), account.balance, req_funds, *pending.sender());
-            return Err(InvalidTransactionError::Payment)
+            return Err(InvalidTransactionError::Payment);
         }
         Ok(())
     }
@@ -1547,7 +1559,7 @@ impl TransactionValidator for Backend {
     ) -> Result<(), InvalidTransactionError> {
         self.validate_pool_transaction_for(tx, account, env)?;
         if tx.nonce().as_u64() > account.nonce {
-            return Err(InvalidTransactionError::NonceTooHigh)
+            return Err(InvalidTransactionError::NonceTooHigh);
         }
         Ok(())
     }

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -9,7 +9,7 @@ use crate::{
             fork::ClientFork,
             genesis::GenesisConfig,
             notifications::{NewBlockNotification, NewBlockNotifications},
-            time::{utc_from_secs, TimeManager},
+            time::{duration_since_unix_epoch, utc_from_secs, TimeManager},
             validate::TransactionValidator,
         },
         error::{BlockchainError, InvalidTransactionError},
@@ -62,8 +62,6 @@ use storage::{Blockchain, MinedTransaction};
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{trace, warn};
 use trie_db::{Recorder, Trie};
-
-use super::time::duration_since_unix_epoch;
 
 pub mod fork_db;
 pub mod in_memory_db;
@@ -210,7 +208,7 @@ impl Backend {
     /// Returns `true` if the account is already impersonated
     pub async fn impersonate(&self, addr: Address) -> bool {
         if self.cheats.is_impersonated(addr) {
-            return true;
+            return true
         }
         // need to bypass EIP-3607: Reject transactions from senders with deployed code by setting
         // the code hash to `KECCAK_EMPTY` temporarily and also remove the code itself and add back
@@ -716,7 +714,7 @@ impl Backend {
                     env.block.number.as_u64(),
                     block_number.as_u64(),
                 ))
-            };
+            }
         }
 
         let db = self.db.read().await;
@@ -751,12 +749,12 @@ impl Backend {
         hash: H256,
     ) -> Result<Vec<Log>, BlockchainError> {
         if let Some(block) = self.blockchain.storage.read().blocks.get(&hash).cloned() {
-            return Ok(self.mined_logs_for_block(filter, block));
+            return Ok(self.mined_logs_for_block(filter, block))
         }
 
         if let Some(fork) = self.get_fork() {
             let filter = filter;
-            return Ok(fork.logs(&filter).await?);
+            return Ok(fork.logs(&filter).await?)
         }
 
         Ok(Vec::new())
@@ -883,11 +881,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
         if let tx @ Some(_) = self.mined_block_by_hash(hash) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_hash(hash).await?);
+            return Ok(fork.block_by_hash(hash).await?)
         }
 
         Ok(None)
@@ -899,11 +897,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by hash {:?}", hash);
         if let tx @ Some(_) = self.get_full_block(hash) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_hash_full(hash).await?);
+            return Ok(fork.block_by_hash_full(hash).await?)
         }
 
         Ok(None)
@@ -935,11 +933,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<TxHash>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
         if let tx @ Some(_) = self.mined_block_by_number(number) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_number(self.convert_block_number(Some(number))).await?);
+            return Ok(fork.block_by_number(self.convert_block_number(Some(number))).await?)
         }
 
         Ok(None)
@@ -951,11 +949,11 @@ impl Backend {
     ) -> Result<Option<EthersBlock<Transaction>>, BlockchainError> {
         trace!(target: "backend", "get block by number {:?}", number);
         if let tx @ Some(_) = self.get_full_block(number) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.block_by_number_full(self.convert_block_number(Some(number))).await?);
+            return Ok(fork.block_by_number_full(self.convert_block_number(Some(number))).await?)
         }
 
         Ok(None)
@@ -1102,7 +1100,7 @@ impl Backend {
             if let Some(state) =
                 self.hash_for_block_number(block_number.as_u64()).and_then(|hash| states.get(&hash))
             {
-                return f(Box::new(state));
+                return f(Box::new(state))
             }
         }
         let db = self.db.read().await;
@@ -1137,7 +1135,7 @@ impl Backend {
             let account = db.basic(address);
             if account.code_hash == KECCAK_EMPTY {
                 // if the code hash is `KECCAK_EMPTY`, we check no further
-                return Ok(Default::default());
+                return Ok(Default::default())
             }
             let code = if let Some(code) = account.code {
                 code
@@ -1182,11 +1180,11 @@ impl Backend {
     /// Returns the traces for the given transaction
     pub async fn trace_transaction(&self, hash: H256) -> Result<Vec<Trace>, BlockchainError> {
         if let Some(traces) = self.mined_parity_trace_transaction(hash) {
-            return Ok(traces);
+            return Ok(traces)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.trace_transaction(hash).await?);
+            return Ok(fork.trace_transaction(hash).await?)
         }
 
         Ok(vec![])
@@ -1212,12 +1210,12 @@ impl Backend {
     pub async fn trace_block(&self, block: BlockNumber) -> Result<Vec<Trace>, BlockchainError> {
         let number = self.convert_block_number(Some(block));
         if let Some(traces) = self.mined_parity_trace_block(number) {
-            return Ok(traces);
+            return Ok(traces)
         }
 
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork(number) {
-                return Ok(fork.trace_block(number).await?);
+                return Ok(fork.trace_block(number).await?)
             }
         }
 
@@ -1229,11 +1227,11 @@ impl Backend {
         hash: H256,
     ) -> Result<Option<TransactionReceipt>, BlockchainError> {
         if let tx @ Some(_) = self.mined_transaction_receipt(hash) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_receipt(hash).await?);
+            return Ok(fork.transaction_receipt(hash).await?)
         }
 
         Ok(None)
@@ -1336,15 +1334,13 @@ impl Backend {
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
         if let Some(hash) = self.mined_block_by_number(number).and_then(|b| b.hash) {
-            return Ok(self.mined_transaction_by_block_hash_and_index(hash, index));
+            return Ok(self.mined_transaction_by_block_hash_and_index(hash, index))
         }
 
         let number = self.convert_block_number(Some(number));
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork(number) {
-                return Ok(fork
-                    .transaction_by_block_number_and_index(number, index.into())
-                    .await?);
+                return Ok(fork.transaction_by_block_number_and_index(number, index.into()).await?)
             }
         }
 
@@ -1357,11 +1353,11 @@ impl Backend {
         index: Index,
     ) -> Result<Option<Transaction>, BlockchainError> {
         if let tx @ Some(_) = self.mined_transaction_by_block_hash_and_index(hash, index) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_by_block_hash_and_index(hash, index.into()).await?);
+            return Ok(fork.transaction_by_block_hash_and_index(hash, index.into()).await?)
         }
 
         Ok(None)
@@ -1390,11 +1386,11 @@ impl Backend {
     ) -> Result<Option<Transaction>, BlockchainError> {
         trace!(target: "backend", "transaction_by_hash={:?}", hash);
         if let tx @ Some(_) = self.mined_transaction_by_hash(hash) {
-            return Ok(tx);
+            return Ok(tx)
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_by_hash(hash).await?);
+            return Ok(fork.transaction_by_hash(hash).await?)
         }
 
         Ok(None)
@@ -1520,19 +1516,19 @@ impl TransactionValidator for Backend {
         let tx = &pending.transaction;
         if tx.gas_limit() > env.block.gas_limit {
             warn!(target: "backend", "[{:?}] gas too high", tx.hash());
-            return Err(InvalidTransactionError::GasTooHigh);
+            return Err(InvalidTransactionError::GasTooHigh)
         }
 
         // check nonce
         let nonce: u64 = (*tx.nonce()).try_into().map_err(|_| InvalidTransactionError::NonceMax)?;
         if nonce < account.nonce {
             warn!(target: "backend", "[{:?}] nonce too low", tx.hash());
-            return Err(InvalidTransactionError::NonceTooLow);
+            return Err(InvalidTransactionError::NonceTooLow)
         }
 
         if (env.cfg.spec_id as u8) >= (SpecId::LONDON as u8) && tx.gas_price() < env.block.basefee {
             warn!(target: "backend", "max fee per gas={}, too low, block basefee={}",tx.gas_price(),  env.block.basefee);
-            return Err(InvalidTransactionError::FeeTooLow);
+            return Err(InvalidTransactionError::FeeTooLow)
         }
 
         let max_cost = tx.max_cost();
@@ -1546,7 +1542,7 @@ impl TransactionValidator for Backend {
 
         if account.balance < req_funds {
             warn!(target: "backend", "[{:?}] insufficient allowance={}, required={} account={:?}", tx.hash(), account.balance, req_funds, *pending.sender());
-            return Err(InvalidTransactionError::Payment);
+            return Err(InvalidTransactionError::Payment)
         }
         Ok(())
     }
@@ -1559,7 +1555,7 @@ impl TransactionValidator for Backend {
     ) -> Result<(), InvalidTransactionError> {
         self.validate_pool_transaction_for(tx, account, env)?;
         if tx.nonce().as_u64() > account.nonce {
-            return Err(InvalidTransactionError::NonceTooHigh);
+            return Err(InvalidTransactionError::NonceTooHigh)
         }
         Ok(())
     }

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -1,8 +1,5 @@
 //! In-memory blockchain storage
-use crate::eth::{
-    backend::{db::StateDb, time::duration_since_unix_epoch},
-    pool::transactions::PoolTransaction,
-};
+use crate::eth::{backend::db::StateDb, pool::transactions::PoolTransaction};
 use anvil_core::eth::{
     block::{Block, PartialHeader},
     receipt::TypedReceipt,
@@ -99,10 +96,10 @@ pub struct BlockchainStorage {
 
 impl BlockchainStorage {
     /// Creates a new storage with a genesis block
-    pub fn new(env: &Env, base_fee: Option<U256>) -> Self {
+    pub fn new(env: &Env, base_fee: Option<U256>, timestamp: u64) -> Self {
         // create a dummy genesis block
         let partial_header = PartialHeader {
-            timestamp: duration_since_unix_epoch().as_secs(),
+            timestamp,
             base_fee,
             gas_limit: env.block.gas_limit,
             beneficiary: env.block.coinbase,
@@ -173,8 +170,8 @@ pub struct Blockchain {
 
 impl Blockchain {
     /// Creates a new storage with a genesis block
-    pub fn new(env: &Env, base_fee: Option<U256>) -> Self {
-        Self { storage: Arc::new(RwLock::new(BlockchainStorage::new(env, base_fee))) }
+    pub fn new(env: &Env, base_fee: Option<U256>, timestamp: u64) -> Self {
+        Self { storage: Arc::new(RwLock::new(BlockchainStorage::new(env, base_fee, timestamp))) }
     }
 
     pub fn forked(block_number: u64, block_hash: H256) -> Self {

--- a/anvil/tests/it/anvil.rs
+++ b/anvil/tests/it/anvil.rs
@@ -43,3 +43,21 @@ async fn can_set_empty_code() {
     let code = api.get_code(addr, None).await.unwrap();
     assert!(code.as_ref().is_empty());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_can_set_genesis_timestamp() {
+    let genesis_timestamp = 1000u64;
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(genesis_timestamp.into())).await;
+    let provider = handle.http_provider();
+
+    assert_eq!(genesis_timestamp, provider.get_block(0).await.unwrap().unwrap().timestamp.as_u64());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_can_use_default_genesis_timestamp() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    assert_ne!(0u64, provider.get_block(0).await.unwrap().unwrap().timestamp.as_u64());
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

currently if using anvil, keeping a consistent genesis block hash on new instances is impossible since the genesis timestamp cannot be manually specified. this is particularly important for running with graph-node as it checks the genesis hash on startup.

## Solution

add a genesis block timestamp parameter, which allows the genesis block to be consistent every time

- [x] tests
