### PR TITLE
fix(config): make broadcast path canonic

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -488,6 +488,8 @@ impl Config {
         self.test = p(&root, &self.test);
         self.script = p(&root, &self.script);
         self.out = p(&root, &self.out);
+        self.broadcast = p(&root, &self.broadcast);
+        self.cache_path = p(&root, &self.cache_path);
 
         if let Some(build_info_path) = self.build_info_path {
             self.build_info_path = Some(p(&root, &build_info_path));
@@ -497,8 +499,6 @@ impl Config {
 
         self.remappings =
             self.remappings.into_iter().map(|r| RelativeRemapping::new(r.into(), &root)).collect();
-
-        self.cache_path = p(&root, &self.cache_path);
 
         self.allow_paths = self.allow_paths.into_iter().map(|allow| p(&root, &allow)).collect();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2716
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make `broadcast` path in foundry.toml canonic
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
