### PR TITLE
fix: join array items correctly

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1182,8 +1182,9 @@ impl SimpleCast {
     ///     Ok(())
     /// }
     /// ```
-    pub fn from_rlp(value: String) -> Result<String> {
-        let striped_value = strip_0x(&value);
+    pub fn from_rlp(value: impl AsRef<str>) -> Result<String> {
+        let value = value.as_ref();
+        let striped_value = strip_0x(value);
         let bytes = hex::decode(striped_value).expect("Could not decode hex");
         let item = rlp::decode::<Item>(&bytes).expect("Could not decode rlp");
         Ok(format!("{}", item))
@@ -1453,5 +1454,15 @@ mod tests {
     fn concat_hex() {
         assert_eq!(Cast::concat_hex(vec!["0x00".to_string(), "0x01".to_string()]), "0x0001");
         assert_eq!(Cast::concat_hex(vec!["1".to_string(), "2".to_string()]), "0x12");
+    }
+
+    #[test]
+    fn from_rlp() {
+        let rlp = "0xf8b1a02b5df5f0757397573e8ff34a8b987b21680357de1f6c8d10273aa528a851eaca8080a02838ac1d2d2721ba883169179b48480b2ba4f43d70fcf806956746bd9e83f90380a0e46fff283b0ab96a32a7cc375cecc3ed7b6303a43d64e0a12eceb0bc6bd8754980a01d818c1c414c665a9c9a0e0c0ef1ef87cacb380b8c1f6223cb2a68a4b2d023f5808080a0236e8f61ecde6abfebc6c529441f782f62469d8a2cc47b7aace2c136bd3b1ff08080808080";
+        let item = Cast::from_rlp(rlp).unwrap();
+        assert_eq!(
+            item,
+            r#"["0x2b5df5f0757397573e8ff34a8b987b21680357de1f6c8d10273aa528a851eaca","0x","0x","0x2838ac1d2d2721ba883169179b48480b2ba4f43d70fcf806956746bd9e83f903","0x","0xe46fff283b0ab96a32a7cc375cecc3ed7b6303a43d64e0a12eceb0bc6bd87549","0x","0x1d818c1c414c665a9c9a0e0c0ef1ef87cacb380b8c1f6223cb2a68a4b2d023f5","0x","0x","0x","0x236e8f61ecde6abfebc6c529441f782f62469d8a2cc47b7aace2c136bd3b1ff0","0x","0x","0x","0x","0x"]"#
+        )
     }
 }

--- a/cast/src/rlp_converter.rs
+++ b/cast/src/rlp_converter.rs
@@ -1,6 +1,6 @@
 use ethers_core::utils::rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use serde_json::Value;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Display, Formatter, Write};
 
 /// Arbitrarly nested data
 /// Item::Array(vec![]); is equivalent to []
@@ -29,7 +29,7 @@ impl Encodable for Item {
 }
 
 impl Decodable for Item {
-    fn decode(rlp: &Rlp) -> std::result::Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
         if rlp.is_data() {
             return Ok(Item::Data(Vec::from(rlp.data()?)))
         }
@@ -73,11 +73,11 @@ impl Display for Item {
             }
             Item::Array(arr) => {
                 write!(f, "[")?;
-                for item in arr {
-                    if arr.last() == Some(item) {
-                        write!(f, "{item}")?;
-                    } else {
-                        write!(f, "{item},")?;
+                let mut iter = arr.iter().peekable();
+                while let Some(item) = iter.next() {
+                    write!(f, "{item}")?;
+                    if iter.peek().is_some() {
+                        f.write_char(',')?;
                     }
                 }
                 write!(f, "]")?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2683
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
handle ',' correctly, instead of comparing if the value is `eq(last)` use peekable
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
