### PR TITLE
anvil: Run RPC calls in `pending` block when requested

### DIFF
--- a/anvil/tests/it/api.rs
+++ b/anvil/tests/it/api.rs
@@ -2,10 +2,15 @@
 
 use anvil::{eth::api::CLIENT_VERSION, spawn, NodeConfig, CHAIN_ID};
 use ethers::{
-    prelude::Middleware,
+    abi::Address,
+    prelude::{Middleware, SignerMiddleware},
     signers::Signer,
     types::{Block, BlockNumber, Chain, Transaction, TransactionRequest, U256},
+    utils::get_contract_address,
 };
+use std::{sync::Arc, time::Duration};
+
+use crate::abi::MulticallContract;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_block_number() {
@@ -140,4 +145,69 @@ async fn can_get_pending_block() {
     let block = provider.get_block_with_txs(BlockNumber::Pending).await.unwrap().unwrap();
     assert_eq!(block.number.unwrap().as_u64(), 1u64);
     assert_eq!(block.transactions.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_call_on_pending_block() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let num = provider.get_block_number().await.unwrap();
+    assert_eq!(num.as_u64(), 0u64);
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let sender = wallet.address();
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    let mut deploy_tx = MulticallContract::deploy(Arc::clone(&client), ()).unwrap().deployer.tx;
+    deploy_tx.set_nonce(0);
+    let pending_contract_address = get_contract_address(sender, deploy_tx.nonce().unwrap());
+
+    client.send_transaction(deploy_tx, None).await.unwrap();
+
+    let pending_contract = MulticallContract::new(pending_contract_address, client.clone());
+
+    let num = client.get_block_number().await.unwrap();
+    assert_eq!(num.as_u64(), 0u64);
+
+    // Ensure that we can get the block_number from the pending contract
+    let (ret_block_number, _) =
+        pending_contract.aggregate(vec![]).block(BlockNumber::Pending).call().await.unwrap();
+    assert_eq!(ret_block_number.as_u64(), 1u64);
+
+    let accounts: Vec<Address> = handle.dev_wallets().map(|w| w.address()).collect();
+    for i in 1..10 {
+        api.anvil_set_coinbase(accounts[i % accounts.len()]).await.unwrap();
+        api.evm_set_block_gas_limit((30_000_000 + i).into()).unwrap();
+
+        api.anvil_mine(Some(1.into()), None).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    // Ensure that the right header values are set when calling a past block
+    for block_number in 1..(api.block_number().unwrap().as_usize() + 1) {
+        let block_number = BlockNumber::Number(block_number.into());
+        let block = api.block_by_number(block_number).await.unwrap().unwrap();
+
+        let block_timestamp = pending_contract
+            .get_current_block_timestamp()
+            .block(block_number)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(block.timestamp, block_timestamp);
+
+        let block_gas_limit = pending_contract
+            .get_current_block_gas_limit()
+            .block(block_number)
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(block.gas_limit, block_gas_limit);
+
+        let block_coinbase =
+            pending_contract.get_current_block_coinbase().block(block_number).call().await.unwrap();
+        assert_eq!(block.author.unwrap(), block_coinbase);
+    }
 }

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -480,7 +480,8 @@ async fn test_fork_can_send_opensea_tx() {
         .to(to)
         .value(20000000000000000u64)
         .data(input)
-        .gas_price(22180711707u64);
+        .gas_price(22180711707u64)
+        .gas(150_000u64);
 
     let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(tx.status, Some(1u64.into()));

--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -100,7 +100,7 @@ async fn test_trace_address_fork() {
 
     let from: Address = "0x2e4777139254ff76db957e284b186a4507ff8c67".parse().unwrap();
     let to: Address = "0xe2f2a5c287993345a840db3b0845fbc70f5935a5".parse().unwrap();
-    let tx = TransactionRequest::new().to(to).from(from).data(input);
+    let tx = TransactionRequest::new().to(to).from(from).data(input).gas(300_000);
 
     api.anvil_impersonate_account(from).await.unwrap();
 

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -389,14 +389,25 @@ async fn get_blocktimestamp_works() {
 
     assert!(timestamp > U256::one());
 
-    // mock timestamp
-    api.evm_set_next_block_timestamp(1337).unwrap();
+    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
 
     let timestamp = contract.get_current_block_timestamp().call().await.unwrap();
-    assert_eq!(timestamp, 1337u64.into());
+    assert_eq!(timestamp, latest_block.timestamp.into());
 
     // repeat call same result
     let timestamp = contract.get_current_block_timestamp().call().await.unwrap();
+    assert_eq!(timestamp, latest_block.timestamp.into());
+
+    // mock timestamp
+    api.evm_set_next_block_timestamp(1337).unwrap();
+
+    let timestamp =
+        contract.get_current_block_timestamp().block(BlockNumber::Pending).call().await.unwrap();
+    assert_eq!(timestamp, 1337u64.into());
+
+    // repeat call same result
+    let timestamp =
+        contract.get_current_block_timestamp().block(BlockNumber::Pending).call().await.unwrap();
     assert_eq!(timestamp, 1337u64.into());
 }
 


### PR DESCRIPTION
## Motivation

This fixes the issue reported in #2599 : the `pending` block wasn't taken into account for any of the state-reading RPC calls: `estimateGas`, `call`, `getCode`, etc.

## Solution

The solution I'm proposing here is to re-work the `with_database_at` method, so that it can accept a `Pending` block argument, which includes the *required* pending transactions list in order to execute them, and pass the updated (temporary) `state` to anyone who needs it.

With this in place, all the required methods are now using this, which also simplifies some parts of the code (no need to manually count the pending transactions of an account to get the last `nonce`, etc.)

There are a couple of behavior changes though:
1. In the `eth_getCode`, `eth_getBalance`, etc. methods, when requesting on a previous block that is missing, it now returns an error. It seemed that before it would just execute on the latest block
2. When calling `eth_call` on a previous block, the block env. is now properly set, so it's using the `timestamp`, `coinbase`, etc. of the requested block.

I'm pretty sure (1) is fine. The only issue with (2) I can see is that when calling `eth_call` without a block number (or with `latest`), the timestamp is now set to the one of the latest block, whereas before it was getting incremented with time passing by. I don't think it's a big deal, but I just want to point it out to gather you thoughts.
