### PR TITLE
fix: bump default timeout to 120s

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -12,4 +12,8 @@ pub const SELECTOR_LEN: usize = 4;
 pub const CONTRACT_MAX_SIZE: usize = 24576;
 
 /// Default request timeout for http requests
-pub const REQUEST_TIMEOUT: Duration = Duration::from_millis(30_000);
+///
+/// Note: this is only used so that connections, that are discarded on the server side won't stay
+/// open forever. We assume some nodes may have some backoff baked into them and will delay some
+/// responses. This timeout should be a reasonable amount of time to wait for a request.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As seen here https://github.com/foundry-rs/foundry/issues/2646 the previous 30s timeout may not be enough.

this bumps it to 2minutes, which is high but this is basically only used as a precaution for hanging connections 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
