### PR TITLE
feat(fmt): default line length 120

### DIFF
--- a/config/src/fmt.rs
+++ b/config/src/fmt.rs
@@ -73,7 +73,7 @@ impl QuoteStyle {
 impl Default for FormatterConfig {
     fn default() -> Self {
         FormatterConfig {
-            line_length: 80,
+            line_length: 120,
             tab_width: 4,
             bracket_spacing: false,
             int_types: IntTypes::Long,

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -3472,7 +3472,13 @@ mod tests {
                     .map(|filename| filename.strip_suffix('.'))
                     .is_some()
                 {
-                    let mut config = toml::Value::try_from(&FormatterConfig::default()).unwrap();
+                    // The majority of the tests were written with the assumption
+                    // that the default value for max line length is `80`.
+                    // Preserve that to avoid rewriting test logic.
+                    let mut default_config = FormatterConfig::default();
+                    default_config.line_length = 80;
+
+                    let mut config = toml::Value::try_from(&default_config).unwrap();
                     let config_table = config.as_table_mut().unwrap();
                     let mut lines = source.split('\n').peekable();
                     let mut line_num = 1;


### PR DESCRIPTION
close #2411 