### PR TITLE
fix: update active subroutine if belongs to rolled fork

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -95,12 +95,13 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
 
     fn roll_fork(
         &mut self,
-        env: &mut Env,
-        block_number: U256,
         id: Option<LocalForkId>,
+        block_number: U256,
+        env: &mut Env,
+        subroutine: &mut SubRoutine,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "fuzz: roll fork");
-        self.backend.to_mut().roll_fork(env, block_number, id)
+        self.backend.to_mut().roll_fork(id, block_number, env, subroutine)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -65,14 +65,14 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::RollFork0(fork) => {
             let block_number = fork.0;
             data.db
-                .roll_fork(data.env, block_number, None)
+                .roll_fork(None, block_number, data.env, &mut data.subroutine)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }
         HEVMCalls::RollFork1(fork) => {
             let block_number = fork.1;
             data.db
-                .roll_fork(data.env, block_number, Some(fork.0))
+                .roll_fork(Some(fork.0), block_number, data.env, &mut data.subroutine)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -47,3 +47,25 @@ fn test_issue_2629() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/2723>
+#[test]
+fn test_issue_2723() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue2723"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue2723.t.sol
+++ b/testdata/repros/Issue2723.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/2723
+contract Issue2629Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testRollFork() public {
+        address coinbase = 0x0193d941b50d91BE6567c7eE1C0Fe7AF498b4137;
+
+        vm.createSelectFork("rpcAlias", 9);
+
+        assertEq(block.number, 9);
+        assertEq(coinbase.balance, 11250000000000000000);
+
+        vm.rollFork(10);
+
+//        assertEq(block.number, 10);
+//        assertEq(coinbase.balance, 16250000000000000000);
+    }
+}

--- a/testdata/repros/Issue2723.t.sol
+++ b/testdata/repros/Issue2723.t.sol
@@ -5,7 +5,7 @@ import "ds-test/test.sol";
 import "../cheats/Cheats.sol";
 
 // https://github.com/foundry-rs/foundry/issues/2723
-contract Issue2629Test is DSTest {
+contract Issue2723Test is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
 
     function testRollFork() public {
@@ -18,7 +18,7 @@ contract Issue2629Test is DSTest {
 
         vm.rollFork(10);
 
-//        assertEq(block.number, 10);
-//        assertEq(coinbase.balance, 16250000000000000000);
+        assertEq(block.number, 10);
+        assertEq(coinbase.balance, 16250000000000000000);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2723
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
when the rolled fork is the active fork, update the active subroutine right away, this will ensure cached state (from previous block) is discarded
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
