### PR TITLE
chore(forge): set script verification retries at 5 with a 5 second delay

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -531,7 +531,7 @@ impl VerifyBundle {
         project: &Project,
         config: &Config,
         known_contracts: ContractsByArtifact,
-        retry: RetryArgs,
+        mut retry: RetryArgs,
     ) -> Self {
         let num_of_optimizations =
             if config.optimizer { Some(config.optimizer_runs) } else { None };
@@ -548,6 +548,12 @@ impl VerifyBundle {
             hardhat: config.profile == Config::HARDHAT_PROFILE,
             config_path: if config_path.exists() { Some(config_path) } else { None },
         };
+
+        // Default from `RetryArgs` struct.
+        if retry.delay.is_none() && retry.retries == 1 {
+            retry.delay = Some(5);
+            retry.retries = 5;
+        }
 
         VerifyBundle {
             num_of_optimizations,


### PR DESCRIPTION
## Motivation

Getting quite a few user reports of the verification process failing with:
```
Error: 
Etherscan could not detect the deployment.
```
This usually happens when the indexer is too slow on picking up the contract (looking at you rinkeby...).

## Solution
While `Retry` args are available, most users are not aware. And given that we have a lot of flags, it's understandable. Other commands have their own specific defaults for `Retry`, so I added more reasonable ones to `forge script`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
