### PR TITLE
chore: remove `rust-toolchain`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.62"
-profile = "default"


### PR DESCRIPTION
## Motivation

We added the `rust-toolchain` file because of an issue with a dependency that has since been resolved.

## Solution

https://github.com/foundry-rs/foundry/issues/2314 suggested setting the `rust-version` field in `Cargo.toml` but as far as I could tell this does not work in a top-level `Cargo.toml` file for workspaces, so I opted to not add it to every single `Cargo.toml` here.

Closes #2314
