### PR TITLE
feat(forge): support solc --include-path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "ethers-addressbook 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-contract-derive 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-core",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "async-trait",
  "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,16 +1470,27 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
+ "ethers-addressbook 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
+ "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-core",
  "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "0.17.0"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1496,10 +1507,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
+ "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
+ "ethers-contract-derive 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-core",
  "ethers-providers",
  "futures-util",
@@ -1509,6 +1520,47 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "0.17.0"
+source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+dependencies = [
+ "ethers-contract-abigen 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "0.17.0"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+dependencies = [
+ "Inflector",
+ "cfg-if 1.0.0",
+ "dunce",
+ "ethers-core",
+ "eyre",
+ "getrandom 0.2.6",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1537,9 +1589,23 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
+dependencies = [
+ "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
+ "ethers-core",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
 dependencies = [
- "ethers-contract-abigen",
+ "ethers-contract-abigen 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
  "hex",
  "proc-macro2",
@@ -1551,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1582,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1598,10 +1664,10 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "async-trait",
- "ethers-contract",
+ "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",
@@ -1622,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1658,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1681,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#c6b77bec2a06dfd864677492c4e6a2ca548e0790"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -1946,7 +2012,7 @@ name = "foundry-binder"
 version = "0.1.0"
 dependencies = [
  "curl",
- "ethers-contract",
+ "ethers-contract 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-solc",
  "eyre",
  "foundry-config",
@@ -2114,7 +2180,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook",
+ "ethers-addressbook 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,10 +1470,10 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
- "ethers-addressbook 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
- "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
+ "ethers-addressbook",
+ "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
  "ethers-middleware",
@@ -1485,17 +1485,6 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
 dependencies = [
  "ethers-core",
@@ -1507,28 +1496,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
-dependencies = [
- "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
- "ethers-contract-derive 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "hex",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
 dependencies = [
- "ethers-contract-abigen 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract-derive 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
  "ethers-core",
  "ethers-providers",
  "futures-util",
@@ -1538,29 +1509,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
-dependencies = [
- "Inflector",
- "cfg-if 1.0.0",
- "dunce",
- "ethers-core",
- "eyre",
- "getrandom 0.2.6",
- "hex",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "syn",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -1589,23 +1537,9 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
-dependencies = [
- "ethers-contract-abigen 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
- "ethers-core",
- "hex",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "0.17.0"
 source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
 dependencies = [
- "ethers-contract-abigen 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen",
  "ethers-core",
  "hex",
  "proc-macro2",
@@ -1617,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1648,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1664,10 +1598,10 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "async-trait",
- "ethers-contract 0.17.0 (git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports)",
+ "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",
@@ -1688,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1724,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1747,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/mattsse/ethers-rs?branch=matt/resolve-absolute-library-imports#f1d263497bfbeecfc76b3b20f355f8ccf0d5e5e8"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -2012,7 +1946,7 @@ name = "foundry-binder"
 version = "0.1.0"
 dependencies = [
  "curl",
- "ethers-contract 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract",
  "ethers-solc",
  "eyre",
  "foundry-config",
@@ -2180,7 +2114,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook 0.17.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-addressbook",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1537,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#8105d8be9b0e394f34c967462c6452214277e30f"
+source = "git+https://github.com/gakonst/ethers-rs#2c33acb3ad4fc9e92739c560dae6d25d76aa5845"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
 
-## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
-#[patch."https://github.com/gakonst/ethers-rs"]
-#ethers = { path = "../ethers-rs" }
-#ethers-core = { path = "../ethers-rs/ethers-core" }
-#ethers-providers = { path = "../ethers-rs/ethers-providers" }
-#ethers-signers = { path = "../ethers-rs/ethers-signers" }
-#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
-#ethers-solc = { path = "../ethers-rs/ethers-solc" }
+# Patch ethers-rs with a local checkout then run `cargo update -p ethers`
+[patch."https://github.com/gakonst/ethers-rs"]
+ethers = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
+ethers-core = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
+ethers-providers = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
+ethers-signers = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
+ethers-etherscan = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
+ethers-solc = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
 
 #[patch.crates-io]
 #revm = { path = "../../revm/crates/revm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
 
-# Patch ethers-rs with a local checkout then run `cargo update -p ethers`
-[patch."https://github.com/gakonst/ethers-rs"]
-ethers = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
-ethers-core = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
-ethers-providers = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
-ethers-signers = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
-ethers-etherscan = { git = "https://github.com/mattsse/ethers-rs", branch = "matt/resolve-absolute-library-imports" }
-ethers-solc = { git = "https://github.com/mattsse/ethers-rs",branch = "matt/resolve-absolute-library-imports" }
+## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
+#[patch."https://github.com/gakonst/ethers-rs"]
+#ethers = { path = "../ethers-rs" }
+#ethers-core = { path = "../ethers-rs/ethers-core" }
+#ethers-providers = { path = "../ethers-rs/ethers-providers" }
+#ethers-signers = { path = "../ethers-rs/ethers-signers" }
+#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
+#ethers-solc = { path = "../ethers-rs/ethers-solc" }
 
 #[patch.crates-io]
 #revm = { path = "../../revm/crates/revm" }

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1,7 +1,10 @@
 //! Contains various tests for checking forge's commands
-use ethers::solc::{
-    artifacts::{BytecodeHash, Metadata},
-    ConfigurableContractArtifact,
+use ethers::{
+    prelude::remappings::Remapping,
+    solc::{
+        artifacts::{BytecodeHash, Metadata},
+        ConfigurableContractArtifact,
+    },
 };
 use foundry_cli_test_utils::{
     ethers_solc::PathStyle,
@@ -9,9 +12,7 @@ use foundry_cli_test_utils::{
     util::{read_string, OutputExt, TestCommand, TestProject},
 };
 use foundry_config::{parse_with_profile, BasicConfig, Chain, Config, SolidityErrorCode};
-use std::{env, fs, path::PathBuf};
-use ethers::prelude::remappings::Remapping;
-use std::str::FromStr;
+use std::{env, fs, path::PathBuf, str::FromStr};
 
 // tests `--help` is printed to std out
 forgetest!(print_help, |_: TestProject, mut cmd: TestCommand| {
@@ -1255,11 +1256,12 @@ contract ContractThreeTest is DSTest {
     assert!(third_out.contains("foo") && third_out.contains("bar") && third_out.contains("baz"));
 });
 
-
 forgetest_init!(can_use_absolute_imports, |prj: TestProject, mut cmd: TestCommand| {
     let remapping = prj.paths().libraries[0].join("myDepdendency");
     let config = Config {
-        remappings: vec![Remapping::from_str(&format!("myDepdendency/={}",remapping.display())).unwrap().into()],
+        remappings: vec![Remapping::from_str(&format!("myDepdendency/={}", remapping.display()))
+            .unwrap()
+            .into()],
         ..Default::default()
     };
     prj.write_config(config);
@@ -1275,7 +1277,7 @@ forgetest_init!(can_use_absolute_imports, |prj: TestProject, mut cmd: TestComman
         )
         .unwrap();
 
-     prj.inner()
+    prj.inner()
         .add_lib(
             "myDepdendency/src/Config.sol",
             r#"
@@ -1287,7 +1289,7 @@ forgetest_init!(can_use_absolute_imports, |prj: TestProject, mut cmd: TestComman
         )
         .unwrap();
 
-     prj.inner()
+    prj.inner()
         .add_source(
             "Greeter",
             r#"

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -98,6 +98,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         revert_strings: Some(RevertStrings::Strip),
         sparse_mode: true,
         allow_paths: vec![],
+        include_paths: vec![],
         rpc_endpoints: Default::default(),
         build_info: false,
         build_info_path: None,
@@ -477,8 +478,7 @@ forgetest_init!(
             vec![
                 "dep1/=lib/dep1/src/".parse().unwrap(),
                 "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-                "forge-std/=lib/forge-std/src/".parse().unwrap(),
-                "src/=src/".parse().unwrap()
+                "forge-std/=lib/forge-std/src/".parse().unwrap()
             ]
         );
     }

--- a/config/README.md
+++ b/config/README.md
@@ -68,6 +68,8 @@ libs = ['lib']
 remappings = []
 # additional solc allow paths
 allow_paths = []
+# additional solc include paths
+include_paths = []
 # list of libraries to link in the form of `<path to lib>:<lib name>:<address>`: `"src/MyLib.sol:MyLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"`
 # the <path to lib> supports remappings 
 libraries = []


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Blocked by https://github.com/gakonst/ethers-rs/pull/1590

## Motivation
Closes #2706
* support --include-path and absolute imports, See https://github.com/gakonst/ethers-rs/pull/1590
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* drops custom remappings for `src`, `test`, `script`, is now handled via --include-path
* add `include-paths` config
* add tests
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
