### PR TITLE
cast: add progress bar to `cast run` 

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,4 +1,4 @@
-use crate::{cmd::Cmd, utils::consume_config_rpc_url};
+use crate::{cmd::Cmd, init_progress, update_progress, utils::consume_config_rpc_url};
 use cast::trace::{identifier::SignaturesIdentifier, CallTraceDecoder};
 use clap::Parser;
 use ethers::{abi::Address, prelude::Middleware, solc::utils::RuntimeOrHandle, types::H256};
@@ -12,6 +12,7 @@ use forge::{
 };
 use foundry_common::get_http_provider;
 use foundry_config::{find_project_root_path, Config};
+use indicatif::{ProgressBar, ProgressStyle};
 use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr,
@@ -84,22 +85,33 @@ impl RunArgs {
                 println!("Executing previous transactions from the block.");
 
                 let block_txes = provider.get_block_with_txs(tx_block_number).await?;
+                if let Some(block_txes) = block_txes {
+                    let pb = init_progress!(block_txes.transactions, "tx");
+                    update_progress!(pb, -1);
 
-                for past_tx in block_txes.unwrap().transactions.into_iter() {
-                    if past_tx.hash().eq(&tx_hash) {
-                        break
-                    }
+                    for (index, past_tx) in block_txes.transactions.into_iter().enumerate() {
+                        if past_tx.hash().eq(&tx_hash) {
+                            break
+                        }
 
-                    executor.set_gas_limit(past_tx.gas);
+                        executor.set_gas_limit(past_tx.gas);
 
-                    if let Some(to) = past_tx.to {
-                        executor
-                            .call_raw_committing(past_tx.from, to, past_tx.input.0, past_tx.value)
-                            .unwrap();
-                    } else {
-                        executor
-                            .deploy(past_tx.from, past_tx.input.0, past_tx.value, None)
-                            .unwrap();
+                        if let Some(to) = past_tx.to {
+                            executor
+                                .call_raw_committing(
+                                    past_tx.from,
+                                    to,
+                                    past_tx.input.0,
+                                    past_tx.value,
+                                )
+                                .unwrap();
+                        } else {
+                            executor
+                                .deploy(past_tx.from, past_tx.input.0, past_tx.value, None)
+                                .unwrap();
+                        }
+
+                        update_progress!(pb, index);
                     }
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If we run `cast run` on a block with a lot of transactions, there's a lot of waiting time without any kind of feedback.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add progress bar.

![image](https://user-images.githubusercontent.com/93316087/184447164-6f6a9ab0-8fe0-4c93-b493-e0efc1100811.png)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
