### PR TITLE
fix(cast): configure env properly for cast run

### DIFF
--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -304,3 +304,296 @@ async fn test_trace_address_fork() {
         }
     })
 }
+
+// <https://github.com/foundry-rs/foundry/issues/2705>
+// <https://etherscan.io/tx/0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_address_fork2() {
+    let (api, handle) = spawn(fork_config().with_fork_block_number(Some(15314401u64))).await;
+    let provider = handle.http_provider();
+
+    let input = hex::decode("30000003000000000000000000000000adda1059a6c6c102b0fa562b9bb2cb9a0de5b1f4000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a300000004fffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000004319b52bf08b65295d49117e790000000000000000000000000000000000000000000000008b6d9e8818d6141f000000000000000000000000000000000000000000000000000000086a23af210000000000000000000000000000000000000000000000000000000000").unwrap();
+
+    let from: Address = "0xa009fa1ac416ec02f6f902a3a4a584b092ae6123".parse().unwrap();
+    let to: Address = "0x99999999d116ffa7d76590de2f427d8e15aeb0b8".parse().unwrap();
+    let tx = TransactionRequest::new().to(to).from(from).data(input).gas(350_000);
+
+    api.anvil_impersonate_account(from).await.unwrap();
+
+    let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
+    assert_eq!(tx.status, Some(1u64.into()));
+
+    let traces = provider.trace_transaction(tx.transaction_hash).await.unwrap();
+
+    assert!(!traces.is_empty());
+    match traces[0].action {
+        Action::Call(ref call) => {
+            assert_eq!(call.from, from);
+            assert_eq!(call.to, to);
+        }
+        _ => unreachable!("unexpected action"),
+    }
+
+    let json = serde_json::json!(
+          [
+
+    {
+      "action": {
+        "from": "0xa009fa1ac416ec02f6f902a3a4a584b092ae6123",
+        "callType": "call",
+        "gas": "0x4fabc",
+        "input": "0x30000003000000000000000000000000adda1059a6c6c102b0fa562b9bb2cb9a0de5b1f4000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a300000004fffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000004319b52bf08b65295d49117e790000000000000000000000000000000000000000000000008b6d9e8818d6141f000000000000000000000000000000000000000000000000000000086a23af210000000000000000000000000000000000000000000000000000000000",
+        "to": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x1d51b",
+        "output": "0x"
+      },
+      "subtraces": 1,
+      "traceAddress": [],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "callType": "delegatecall",
+        "gas": "0x4d594",
+        "input": "0x00000004fffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000004319b52bf08b65295d49117e790000000000000000000000000000000000000000000000008b6d9e8818d6141f000000000000000000000000000000000000000000000000000000086a23af21",
+        "to": "0xadda1059a6c6c102b0fa562b9bb2cb9a0de5b1f4",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x1c35f",
+        "output": "0x"
+      },
+      "subtraces": 3,
+      "traceAddress": [
+        0
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "callType": "call",
+        "gas": "0x4b6d6",
+        "input": "0x16b2da82000000000000000000000000000000000000000000000000000000086a23af21",
+        "to": "0xd1663cfb8ceaf22039ebb98914a8c98264643710",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0xd6d",
+        "output": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        0
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "callType": "staticcall",
+        "gas": "0x49c35",
+        "input": "0x3850c7bd",
+        "to": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0xa88",
+        "output": "0x000000000000000000000000000000000000004319b52bf08b65295d49117e7900000000000000000000000000000000000000000000000000000000000148a0000000000000000000000000000000000000000000000000000000000000010e000000000000000000000000000000000000000000000000000000000000012c000000000000000000000000000000000000000000000000000000000000012c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        1
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "callType": "call",
+        "gas": "0x48d01",
+        "input": "0x128acb0800000000000000000000000099999999d116ffa7d76590de2f427d8e15aeb0b80000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb98000000000000000000000000000000000000000000000000000000001000276a400000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002bc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000000000000000000000000000000000",
+        "to": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x18c20",
+        "output": "0x0000000000000000000000000000000000000000000000008b5116525f9edc3efffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980"
+      },
+      "subtraces": 4,
+      "traceAddress": [
+        0,
+        2
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "callType": "call",
+        "gas": "0x3802a",
+        "input": "0xa9059cbb00000000000000000000000099999999d116ffa7d76590de2f427d8e15aeb0b8000000000000000000000000000000000000000000000986236e1301eaf04680",
+        "to": "0xf4d2888d29d722226fafa5d9b24f9164c092421e",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x31b6",
+        "output": "0x0000000000000000000000000000000000000000000000000000000000000001"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        2,
+        0
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "callType": "staticcall",
+        "gas": "0x34237",
+        "input": "0x70a082310000000000000000000000004b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "to": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x9e6",
+        "output": "0x000000000000000000000000000000000000000000000091cda6c1ce33e53b89"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        2,
+        1
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "callType": "call",
+        "gas": "0x3357e",
+        "input": "0xfa461e330000000000000000000000000000000000000000000000008b5116525f9edc3efffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb9800000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000002bc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000000000000000000000000000000000",
+        "to": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x2e8b",
+        "output": "0x"
+      },
+      "subtraces": 1,
+      "traceAddress": [
+        0,
+        2,
+        2
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x99999999d116ffa7d76590de2f427d8e15aeb0b8",
+        "callType": "call",
+        "gas": "0x324db",
+        "input": "0xa9059cbb0000000000000000000000004b5ab61593a2401b1075b90c04cbcdd3f87ce0110000000000000000000000000000000000000000000000008b5116525f9edc3e",
+        "to": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x2a6e",
+        "output": "0x0000000000000000000000000000000000000000000000000000000000000001"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        2,
+        2,
+        0
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    },
+    {
+      "action": {
+        "from": "0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "callType": "staticcall",
+        "gas": "0x30535",
+        "input": "0x70a082310000000000000000000000004b5ab61593a2401b1075b90c04cbcdd3f87ce011",
+        "to": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "value": "0x0"
+      },
+      "blockHash": "0xf689ba7749648b8c5c8f5eedd73001033f0aed7ea50b7c81048ad1533b8d3d73",
+      "blockNumber": 15314402,
+      "result": {
+        "gasUsed": "0x216",
+        "output": "0x00000000000000000000000000000000000000000000009258f7d820938417c7"
+      },
+      "subtraces": 0,
+      "traceAddress": [
+        0,
+        2,
+        3
+      ],
+      "transactionHash": "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+      "transactionPosition": 289,
+      "type": "call"
+    }
+      ]
+      );
+
+    let expected_traces: Vec<Trace> = serde_json::from_value(json).unwrap();
+
+    // test matching traceAddress
+    traces.into_iter().zip(expected_traces).for_each(|(a, b)| {
+        assert_eq!(a.trace_address, b.trace_address);
+        assert_eq!(a.subtraces, b.subtraces);
+        match (a.action, b.action) {
+            (Action::Call(a), Action::Call(b)) => {
+                assert_eq!(a.from, b.from);
+                assert_eq!(a.to, b.to);
+            }
+            _ => unreachable!("unexpected action"),
+        }
+    })
+}

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -206,3 +206,18 @@ casttest!(calldata_array, |_: TestProject, mut cmd: TestCommand| {
     assert_eq!(out.trim(),"0xcde2baba0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
     );
 });
+
+// <https://github.com/foundry-rs/foundry/issues/2705>
+casttest!(cast_run_succeeds, |_: TestProject, mut cmd: TestCommand| {
+    let rpc = next_http_rpc_endpoint();
+    cmd.args([
+        "run",
+        "-v",
+        "0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845",
+        "--rpc-url",
+        rpc.as_str(),
+    ]);
+    let output = cmd.stdout_lossy();
+    assert!(output.contains("Transaction successfully executed"));
+    assert!(!output.contains("Revert"));
+});

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -7,7 +7,7 @@ use revm::{BlockEnv, CfgEnv, SpecId, TxEnv};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::executor::fork::CreateFork;
-use foundry_common;
+use foundry_common::{self, try_get_http_provider};
 use foundry_config::Config;
 
 use super::fork::environment;
@@ -74,7 +74,7 @@ impl EvmOpts {
 
     /// Returns the `revm::Env` configured with settings retrieved from the endpoints
     pub async fn fork_evm_env(&self, fork_url: impl AsRef<str>) -> eyre::Result<revm::Env> {
-        let provider = Provider::try_from(fork_url.as_ref())?;
+        let provider = try_get_http_provider(fork_url.as_ref())?;
         environment(
             &provider,
             self.memory_limit,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2705

The `env` was not configured properly, and instead used the default testing env of the `Executor`.
Also the executor was configured with cheatcodes which also modifies the env
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add new `Executor` functions to provide the env to execute a tx
* configure the `env` properly for the block of the tx
* disable cheatcodes

```console
cast run -v 0x2d951c5c95d374263ca99ad9c20c9797fc714330a8037429a3aa4c83d456f845
Executing previous transactions from the block.
Traces:
  [120091] 0x99999999d116ffa7d76590de2f427d8e15aeb0b8::30000003(000000000000000000000000adda1059a6c6c102b0fa562b9bb2cb9a0de5b1f4000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a300000004fffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8000000000000004319b52bf08b65295d49117e790000000000000000000000000000000000000000000000008b6d9e8818d6141f000000000000000000000000000000000000000000000000000000086a23af210000000000000000000000000000000000000000000000000000000000) 
    ├─ [115551] 0xadda1059a6c6c102b0fa562b9bb2cb9a0de5b1f4::gjafkehcdbi(115792089237316195423570985008687907853269984665640563994481868957271519639936, 86919449357064148262411970471323700346584099574301774320296519197531982243289, 0x0000000000004319b52bf08b65295d49117e7900) [delegatecall]
    │   ├─ [3437] 0xd1663cfb8ceaf22039ebb98914a8c98264643710::16b2da82(000000000000000000000000000000000000000000000000000000086a23af21) 
    │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    │   ├─ [2696] 0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011::slot0() [staticcall]
    │   │   └─ ← 0x000000000000000000000000000000000000004319b52bf08b65295d49117e7900000000000000000000000000000000000000000000000000000000000148a0000000000000000000000000000000000000000000000000000000000000010e000000000000000000000000000000000000000000000000000000000000012c000000000000000000000000000000000000000000000000000000000000012c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001
    │   ├─ [101408] 0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011::swap(0x99999999d116ffa7d76590de2f427d8e15aeb0b8, true, -44975715050641610000000, 4295128740, 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8) 
    │   │   ├─ [12726] 0xf4d2888d29d722226fafa5d9b24f9164c092421e::transfer(0x99999999d116ffa7d76590de2f427d8e15aeb0b8, 44975715050641610000000) 
    │   │   │   ├─ emit Transfer(param0: 0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011, param1: 0x99999999d116ffa7d76590de2f427d8e15aeb0b8, param2: 44975715050641610000000)
    │   │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000001
    │   │   ├─ [2534] 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2::balanceOf(0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011) [staticcall]
    │   │   │   └─ ← 0x000000000000000000000000000000000000000000000091cda6c1ce33e53b89
    │   │   ├─ [11915] 0x99999999d116ffa7d76590de2f427d8e15aeb0b8::uniswapV3SwapCallback(10038829587432922174, -44975715050641610000000, 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2f4d2888d29d722226fafa5d9b24f9164c092421e000bb8) 
    │   │   │   ├─ [10862] 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2::transfer(0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011, 10038829587432922174) 
    │   │   │   │   ├─ emit Transfer(param0: 0x99999999d116ffa7d76590de2f427d8e15aeb0b8, param1: 0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011, param2: 10038829587432922174)
    │   │   │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000001
    │   │   │   └─ ← ()
    │   │   ├─ [534] 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2::balanceOf(0x4b5ab61593a2401b1075b90c04cbcdd3f87ce011) [staticcall]
    │   │   │   └─ ← 0x00000000000000000000000000000000000000000000009258f7d820938417c7
    │   │   ├─ emit Swap(param0: 0x99999999d116ffa7d76590de2f427d8e15aeb0b8, param1: 0x99999999d116ffa7d76590de2f427d8e15aeb0b8, param2: 10038829587432922174, param3: -44975715050641610000000, param4: 5305863644538427492850688048784, param5: 344280855150421223778441, param6: 84088)
    │   │   └─ ← 0x0000000000000000000000000000000000000000000000008b5116525f9edc3efffffffffffffffffffffffffffffffffffffffffffff679dc91ecfe150fb980
    │   └─ ← ()
    └─ ← ()

```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
