### PR TITLE
refactor: turn cli crate into lib crate

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -1,16 +1,4 @@
-pub mod cmd;
-pub mod compile;
-
-mod handler;
-mod suggestions;
-mod term;
-mod utils;
-
-use cast::{Cast, SimpleCast, TxBuilder};
-use foundry_config::Config;
-mod opts;
-use crate::{cmd::Cmd, utils::consume_config_rpc_url};
-use cast::InterfacePath;
+use cast::{Cast, InterfacePath, SimpleCast, TxBuilder};
 use clap::{IntoApp, Parser};
 use clap_complete::generate;
 use ethers::{
@@ -20,18 +8,24 @@ use ethers::{
     types::{Address, NameOrAddress, U256},
 };
 use eyre::WrapErr;
+use foundry_cli::{
+    cmd::Cmd,
+    handler,
+    opts::{
+        cast::{Opts, Subcommands},
+        WalletType,
+    },
+    utils,
+    utils::consume_config_rpc_url,
+};
 use foundry_common::{fs, get_http_provider};
-use foundry_config::Chain;
+use foundry_config::{Chain, Config};
 use foundry_utils::{
     format_tokens,
     selectors::{
         decode_calldata, decode_event_topic, decode_function_selector, import_selectors,
         parse_signatures, pretty_calldata, ParsedSignatures, SelectorImportData,
     },
-};
-use opts::{
-    cast::{Opts, Subcommands},
-    WalletType,
 };
 use rustc_hex::ToHex;
 use std::{

--- a/cli/src/cmd/forge/mod.rs
+++ b/cli/src/cmd/forge/mod.rs
@@ -13,9 +13,11 @@
 //! create a `clap` subcommand into a `figment::Provider` and integrate it in the
 //! `foundry_config::Config`:
 //!
-//! ```rust
-//! use crate::{cmd::build::BuildArgs, foundry_common::evm::EvmArgs};
+//! ```
 //! use clap::Parser;
+//! use forge::executor::opts::EvmOpts;
+//! use foundry_cli::cmd::forge::build::BuildArgs;
+//! use foundry_common::evm::EvmArgs;
 //! use foundry_config::{figment::Figment, *};
 //!
 //! // A new clap subcommand that accepts both `EvmArgs` and `BuildArgs`

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -1,3 +1,4 @@
+use crate::cmd::LoadConfig;
 use async_trait::async_trait;
 use cast::SimpleCast;
 use ethers::{
@@ -25,8 +26,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use tracing::{trace, warn};
-
-use crate::cmd::LoadConfig;
 
 use super::{VerificationProvider, VerifyArgs, VerifyCheckArgs, RETRY_CHECK_ON_VERIFY};
 
@@ -405,7 +404,9 @@ fn strip_build_meta(version: Version) -> Version {
 /// Given any solc [Version] return a [Version] with build metadata
 ///
 /// # Example
-/// ```
+///
+/// ```ignore
+/// use semver::{BuildMetadata, Version};
 /// let version = Version::new(1, 2, 3);
 /// let version = ensure_solc_build_metadata(version).await?;
 /// assert_ne!(version.build, BuildMetadata::EMPTY);

--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -126,6 +126,7 @@ impl ProjectCompiler {
     /// # Example
     ///
     /// ```no_run
+    /// use foundry_cli::compile::ProjectCompiler;
     /// let config = foundry_config::Config::load();
     /// ProjectCompiler::default()
     ///     .compile_with(&config.project().unwrap(), |prj| Ok(prj.compile()?));

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -1,21 +1,15 @@
-pub mod cmd;
-pub mod compile;
-mod handler;
-mod opts;
-mod suggestions;
-mod term;
-mod utils;
-
-use crate::{
+use clap::{IntoApp, Parser};
+use clap_complete::generate;
+use foundry_cli::{
     cmd::{
         forge::{cache::CacheSubcommands, watch},
         Cmd,
     },
+    handler,
+    opts::forge::{Opts, Subcommands},
+    utils,
     utils::CommandUtils,
 };
-use clap::{IntoApp, Parser};
-use clap_complete::generate;
-use opts::forge::{Opts, Subcommands};
 use std::process::Command;
 
 fn main() -> eyre::Result<()> {
@@ -45,7 +39,7 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::Build(cmd) => {
             if cmd.is_watch() {
-                utils::block_on(crate::cmd::forge::watch::watch_build(cmd))?;
+                utils::block_on(watch::watch_build(cmd))?;
             } else {
                 cmd.run()?;
             }
@@ -104,7 +98,7 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::Snapshot(cmd) => {
             if cmd.is_watch() {
-                utils::block_on(crate::cmd::forge::watch::watch_snapshot(cmd))?;
+                utils::block_on(watch::watch_snapshot(cmd))?;
             } else {
                 cmd.run()?;
             }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod cmd;
+pub mod compile;
+pub mod handler;
+pub mod opts;
+pub mod suggestions;
+pub mod term;
+pub mod utils;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -94,6 +94,7 @@ pub fn evm_spec(evm: &EvmVersion) -> SpecId {
 /// # Example
 ///
 /// ```
+/// use foundry_cli::utils;
 /// assert_eq!(
 ///     "SafeTransferLibTest",
 ///     utils::get_contract_name("SafeTransferLibTest.json:SafeTransferLibTest")
@@ -108,6 +109,7 @@ pub fn get_contract_name(id: &str) -> &str {
 /// # Example
 ///
 /// ```
+/// use foundry_cli::utils;
 /// assert_eq!(
 ///     "SafeTransferLibTest.json",
 ///     utils::get_file_name("SafeTransferLibTest.json:SafeTransferLibTest")
@@ -174,7 +176,7 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
 ///
 /// This macro accepts a predicate and the message to print if the predicate is tru
 ///
-/// ```rust
+/// ```ignore
 /// let quiet = true;
 /// p_println!(!quiet => "message");
 /// ```


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
turn `cli` crate into a real lib crate which `forge` and `cast` then use.
this ensures that we compile cli as lib crate. before that, we basically had two `cli` crates since both bins declared the `mods` separately.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `lib.rs` with all mod declarations.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
