### PR TITLE
fix(forge): properly handle `forge script` initialization errors

### DIFF
--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
     cmd::{
+        ensure_clean_constructor,
         forge::script::{runner::SimulationStage, sequence::TransactionWithMetadata},
         needs_setup,
     },
@@ -32,6 +33,8 @@ impl ScriptArgs {
 
         let abi = abi.expect("no ABI for contract");
         let bytecode = bytecode.expect("no bytecode for contract").object.into_bytes().unwrap();
+
+        ensure_clean_constructor(&abi)?;
 
         let mut runner = self.prepare_runner(script_config, sender, SimulationStage::Local).await;
         let (address, mut result) = runner.setup(

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -21,6 +21,7 @@ use ethers::{
         U256,
     },
 };
+use eyre::ContextCompat;
 use forge::{
     debug::DebugArena,
     decode::decode_console_logs,
@@ -408,7 +409,10 @@ impl ScriptArgs {
                 (
                     abi.functions()
                         .find(|&abi_func| abi_func.short_signature() == func.short_signature())
-                        .expect("Function signature not found in the ABI"),
+                        .wrap_err(format!(
+                            "Function `{}` is not implemented in your script.",
+                            self.sig
+                        ))?,
                     encode_args(&func, &self.args)?.into(),
                 )
             }

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -72,7 +72,11 @@ impl ScriptRunner {
             traces: constructor_traces,
             debug: constructor_debug,
             ..
-        } = self.executor.deploy(CALLER, code.0, 0u32.into(), None).expect("couldn't deploy");
+        } = self
+            .executor
+            .deploy(CALLER, code.0, 0u32.into(), None)
+            .map_err(|err| eyre::eyre!("Constructor failed:\n{}", err))?;
+
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
         self.executor.set_balance(address, self.initial_balance);
 

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -75,7 +75,7 @@ impl ScriptRunner {
         } = self
             .executor
             .deploy(CALLER, code.0, 0u32.into(), None)
-            .map_err(|err| eyre::eyre!("Constructor failed:\n{}", err))?;
+            .map_err(|err| eyre::eyre!("Failed to deploy script:\n{}", err))?;
 
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
         self.executor.set_balance(address, self.initial_balance);

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -151,6 +151,16 @@ impl From<RetryArgs> for Retry {
     }
 }
 
+/// Returns error if constructor has arguments.
+pub fn ensure_clean_constructor(abi: &Abi) -> eyre::Result<()> {
+    if let Some(constructor) = &abi.constructor {
+        if !constructor.inputs.is_empty() {
+            eyre::bail!("Contract constructor should have no arguments. Add those arguments to  `run(...)` instead, and call it with `--sig run(...)`.");
+        }
+    }
+    Ok(())
+}
+
 pub fn needs_setup(abi: &Abi) -> bool {
     let setup_fns: Vec<_> = abi.functions().filter(|func| func.name.is_setup()).collect();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Long time coming. By default we call `run()` on `forge script`, and we expect the script contract to have no arguments. However, we were not properly handling when that didn't happen.

closes #2770
ref #2432

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Give a proper error when:
* the run signature is not found
* the constructor has arguments
* the constructor fails its execution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
