### PR TITLE
feat(anvil): Print the transaction's revert reasons

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -19,7 +19,7 @@ use ethers_core::{
 };
 use fastrlp::{length_of_length, Header, RlpDecodable, RlpEncodable};
 use foundry_evm::{
-    revm::{CreateScheme, TransactTo, TxEnv},
+    revm::{CreateScheme, Return, TransactTo, TxEnv},
     trace::node::CallTraceNode,
 };
 use serde::{Deserialize, Serialize};
@@ -1034,7 +1034,7 @@ impl PendingTransaction {
 }
 
 /// Represents all relevant information of an executed transaction
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TransactionInfo {
     pub transaction_hash: H256,
     pub transaction_index: u32,
@@ -1044,6 +1044,8 @@ pub struct TransactionInfo {
     pub logs: Vec<Log>,
     pub logs_bloom: Bloom,
     pub traces: Vec<CallTraceNode>,
+    pub exit: Return,
+    pub out: Option<Bytes>,
 }
 
 // === impl TransactionInfo ===

--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -131,7 +131,7 @@ impl<'a, DB: Db + ?Sized, Validator: TransactionValidator> TransactionExecutor<'
             };
             let receipt = tx.create_receipt();
             cumulative_gas_used = cumulative_gas_used.saturating_add(receipt.gas_used());
-            let ExecutedTransaction { transaction, logs, out, traces, .. } = tx;
+            let ExecutedTransaction { transaction, logs, out, traces, exit, .. } = tx;
             logs_bloom(logs.clone(), &mut bloom);
 
             let contract_address = if let TransactOut::Create(_, contract_address) = out {
@@ -149,6 +149,12 @@ impl<'a, DB: Db + ?Sized, Validator: TransactionValidator> TransactionExecutor<'
                 logs,
                 logs_bloom: *receipt.logs_bloom(),
                 traces,
+                exit,
+                out: match out {
+                    TransactOut::Call(b) => Some(b.into()),
+                    TransactOut::Create(b, _) => Some(b.into()),
+                    _ => None,
+                },
             };
 
             transaction_infos.push(info);

--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -191,7 +191,7 @@ pub fn decode_revert(
                 .or_else(|| {
                     // try decoding as unknown err
                     String::decode(&err[SELECTOR_LEN..])
-                        .map(|err| format!("{}:{}", hex::encode(&err[..SELECTOR_LEN]), err))
+                        .map(|err_str| format!("{}:{}", hex::encode(&err[..SELECTOR_LEN]), err_str))
                         .ok()
                 })
                 .ok_or_else(|| eyre::eyre!("Non-native error and not string"))


### PR DESCRIPTION
## Motivation

When running an `anvil`, it would be useful to print-out why a transaction reverted, when possible.

With [this bash script](https://gist.github.com/ngotchac/4ce8246a5f4c29fd5416430ab9649e7b), which sends reverting transactions (with and without a reason string, and with a custom error):


<details>
<summary>Hardhat prints the following logs:</summary>

```
eth_sendTransaction
  Contract deployment: <UnrecognizedContract>
  Transaction:         0xc00de227c941c281c89069a908a23220450ff65a062d6a2bcc5fe5a5610ac2f5
  From:                0xb60e8dd61c5d32be8058bb8eb970870f07233155
  Value:               0 ETH
  Gas used:            53376 of 30000000
  Block #1:            0xc6449303b0e267931e7f21767ff4310a4be860dda67044f9ab2d00dac2561dfa

  Error: Transaction reverted without a reason string
    [...]

eth_sendTransaction
  Contract deployment: <UnrecognizedContract>
  Transaction:         0x1ef184c3b4c0bd031e6d5c4cb13947168d2cc3dfe97e207f643fa14c0ed80459
  From:                0xb60e8dd61c5d32be8058bb8eb970870f07233155
  Value:               0 ETH
  Gas used:            55877 of 30000000
  Block #2:            0xfe3e99928f4aa442ebb31f72cfcc1491f25027c300ed184ee7b1d56059ae5839

  Error: VM Exception while processing transaction: reverted with reason string 'random reason string'
    [...]

eth_sendTransaction
  Contract deployment: <UnrecognizedContract>
  Transaction:         0x1d42563e0fc438a5ef8cd547479818b0327809b93d29f900412066f5ec261dc0
  From:                0xb60e8dd61c5d32be8058bb8eb970870f07233155
  Value:               0 ETH
  Gas used:            55673 of 30000000
  Block #3:            0x1b77aae5a8a71ccf330c347fe15f178528ca567a76a4353241b8d639eeccd325

  Error: Transaction reverted without a reason string
    [...]

eth_sendTransaction

  Transaction requires at least 53328 gas but got 21000
```
</details>


<details>
<summary>Current master of Anvil prints:</summary>

```
eth_sendTransaction

    Transaction: 0xcdb22675460f581888bb215c7d454977d60e640721782e40043e5fd625e4f0ea
    Contract created: 0x5b83755ea152665553cacde043aece8739a2f49a
    Gas used: 53376
    Block Number: 1
    Block Hash: 0x1834e8aecc70564723a0e5093ba1251748a0a80e31c3bd83daf715b51ff59396
    Block Time: "Mon, 15 Aug 2022 12:14:06 +0000"

eth_sendTransaction

    Transaction: 0xc8dbdaba56344b8db53ec4cb4497e9e315cfb99ef4684745ae7254c37fdf55b8
    Contract created: 0xabf5eee44d90c357f72b3c310a49328863ce004d
    Gas used: 55877
    Block Number: 2
    Block Hash: 0xaba7036fca5a50a34087fdb85d732314db9a770ae2a296be8b30b8b051b8f068
    Block Time: "Mon, 15 Aug 2022 12:14:06 +0000"

eth_sendTransaction

    Transaction: 0xb3f3f64970249da59132f78baf9b82c4a74a4ea3ba104dcd377ef64aaace751c
    Contract created: 0x8bc3967c5033c0de51efa5b3abd970878399e2e9
    Gas used: 55673
    Block Number: 3
    Block Hash: 0x524afbfb9af072a10cc7cb4faa71f64cf85bfbf7043888e2eb63d7c527f2c551
    Block Time: "Mon, 15 Aug 2022 12:14:06 +0000"

eth_sendTransaction

    Transaction: 0x680226d3d6303d71b161438e0bb05bc290f0e62c988b044ba135a51c49a48234
    Gas used: 0
    Block Number: 4
    Block Hash: 0xe8bd55684322adf69f340302d3d659c9f1d158981fec463353dc420046cf2d7f
    Block Time: "Mon, 15 Aug 2022 12:14:06 +0000"
```
</details>

## Solution

Pass the necessary transaction information from the execution, and print the reason of a revert when possible.

<details>
<summary>The result is the following logs lines:</summary>

```
eth_sendTransaction

    Transaction: 0xcdb22675460f581888bb215c7d454977d60e640721782e40043e5fd625e4f0ea
    Contract created: 0x5b83755ea152665553cacde043aece8739a2f49a
    Gas used: 53376
    Error: reverted without a reason string

    Block Number: 1
    Block Hash: 0x9cb4c74e2122b6387a0086429200ece468cbe075b17994dc43374dad33cf440c
    Block Time: "Mon, 15 Aug 2022 12:06:54 +0000"

eth_sendTransaction

    Transaction: 0xc8dbdaba56344b8db53ec4cb4497e9e315cfb99ef4684745ae7254c37fdf55b8
    Contract created: 0xabf5eee44d90c357f72b3c310a49328863ce004d
    Gas used: 55877
    Error: reverted with 'random reason string'

    Block Number: 2
    Block Hash: 0x82af7448472ceeb08c7b76b8aa637823e1d6cd604c6f1005f111905c6e835f5c
    Block Time: "Mon, 15 Aug 2022 12:06:54 +0000"

eth_sendTransaction

    Transaction: 0xb3f3f64970249da59132f78baf9b82c4a74a4ea3ba104dcd377ef64aaace751c
    Contract created: 0x8bc3967c5033c0de51efa5b3abd970878399e2e9
    Gas used: 55673
    Error: reverted with '8b3d2d43:n/a'

    Block Number: 3
    Block Hash: 0xcc32aa8011f54ba8ec23b6b7a88bd7dc7ce30c04d1978f23873290eba3320476
    Block Time: "Mon, 15 Aug 2022 12:06:54 +0000"

eth_sendTransaction

    Transaction: 0x680226d3d6303d71b161438e0bb05bc290f0e62c988b044ba135a51c49a48234
    Gas used: 0
    Error: failed due to OutOfGas

    Block Number: 4
    Block Hash: 0x8ed771fb9c9a762d7658d6279698690f44184c29be3f1e2ac381e4c68661813d
    Block Time: "Mon, 15 Aug 2022 12:06:54 +0000"
```
</details>