### PR TITLE
chore: etherscan traces and Arc'ed

### DIFF
--- a/evm/src/trace/identifier/etherscan.rs
+++ b/evm/src/trace/identifier/etherscan.rs
@@ -11,7 +11,7 @@ use futures::{
     stream::{FuturesUnordered, Stream, StreamExt},
     task::{Context, Poll},
 };
-use std::{borrow::Cow, pin::Pin};
+use std::{borrow::Cow, pin::Pin, sync::Arc};
 use tokio::time::{Duration, Interval};
 use tracing::{trace, warn};
 
@@ -19,14 +19,15 @@ use tracing::{trace, warn};
 #[derive(Default)]
 pub struct EtherscanIdentifier {
     /// The Etherscan client
-    client: Option<etherscan::Client>,
+    client: Option<Arc<etherscan::Client>>,
 }
 
 impl EtherscanIdentifier {
     /// Creates a new Etherscan identifier with the given client
     pub fn new(config: &Config, chain: Option<impl Into<Chain>>) -> eyre::Result<Self> {
         if let Some(config) = config.get_etherscan_config_with_chain(chain)? {
-            Ok(Self { client: Some(config.into_client()?) })
+            trace!(target: "etherscanidentifier", chain=?config.chain, url=?config.api_url, "using etherscan identifier");
+            Ok(Self { client: Some(Arc::new(config.into_client()?)) })
         } else {
             Ok(Default::default())
         }
@@ -38,8 +39,9 @@ impl TraceIdentifier for EtherscanIdentifier {
         &self,
         addresses: Vec<(&Address, Option<&Vec<u8>>)>,
     ) -> Vec<AddressIdentity> {
+        trace!(target: "etherscanidentifier", "identify {} addresses", addresses.len());
         self.client.as_ref().map_or(Default::default(), |client| {
-            let mut fetcher = EtherscanFetcher::new(client.clone(), Duration::from_secs(1), 5);
+            let mut fetcher = EtherscanFetcher::new(Arc::clone(&client), Duration::from_secs(1), 5);
 
             for (addr, _) in addresses {
                 fetcher.push(*addr);
@@ -68,7 +70,7 @@ type EtherscanFuture =
 /// Fetches information about multiple addresses concurrently, while respecting rate limits.
 pub struct EtherscanFetcher {
     /// The Etherscan client
-    client: etherscan::Client,
+    client: Arc<etherscan::Client>,
     /// The time we wait if we hit the rate limit
     timeout: Duration,
     /// The interval we are currently waiting for before making a new request
@@ -82,7 +84,7 @@ pub struct EtherscanFetcher {
 }
 
 impl EtherscanFetcher {
-    pub fn new(client: etherscan::Client, timeout: Duration, concurrency: usize) -> Self {
+    pub fn new(client: Arc<etherscan::Client>, timeout: Duration, concurrency: usize) -> Self {
         Self {
             client,
             timeout,
@@ -100,7 +102,7 @@ impl EtherscanFetcher {
     fn queue_next_reqs(&mut self) {
         while self.in_progress.len() < self.concurrency {
             if let Some(addr) = self.queue.pop() {
-                let client = self.client.clone();
+                let client = Arc::clone(&self.client);
                 trace!(target: "etherscanidentifier", "fetching info for {:?}", addr);
                 self.in_progress.push(Box::pin(async move {
                     let res = client.contract_source_code(addr).await;
@@ -143,7 +145,7 @@ impl Stream for EtherscanFetcher {
                                 }
                             }
                         }
-                        Err(etherscan::errors::EtherscanError::RateLimitExceeded) => {
+                        Err(EtherscanError::RateLimitExceeded) => {
                             warn!(target: "etherscanidentifier", "rate limit exceeded on attempt");
                             pin.backoff = Some(tokio::time::interval(pin.timeout));
                             pin.queue.push(addr);

--- a/evm/src/trace/identifier/etherscan.rs
+++ b/evm/src/trace/identifier/etherscan.rs
@@ -41,7 +41,7 @@ impl TraceIdentifier for EtherscanIdentifier {
     ) -> Vec<AddressIdentity> {
         trace!(target: "etherscanidentifier", "identify {} addresses", addresses.len());
         self.client.as_ref().map_or(Default::default(), |client| {
-            let mut fetcher = EtherscanFetcher::new(Arc::clone(&client), Duration::from_secs(1), 5);
+            let mut fetcher = EtherscanFetcher::new(Arc::clone(client), Duration::from_secs(1), 5);
 
             for (addr, _) in addresses {
                 fetcher.push(*addr);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
* add additional etherscan traces
* Arc client, while `etherscan::Client` is cheap to clone, `Arc<Client>` is more appropriate here
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
