### PR TITLE
chore: figma -> fig

### DIFF
--- a/anvil/src/anvil.rs
+++ b/anvil/src/anvil.rs
@@ -20,7 +20,7 @@ pub enum Commands {
         #[clap(arg_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Figma autocompletion spec.")]
+    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
     GenerateFigSpec,
 }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -823,7 +823,7 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         #[clap(arg_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Figma autocompletion spec.")]
+    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
     GenerateFigSpec,
     #[clap(
         name = "run",

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -123,7 +123,7 @@ pub enum Subcommands {
         #[clap(arg_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Figma autocompletion spec.")]
+    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
     GenerateFigSpec,
     #[clap(visible_alias = "cl", about = "Remove the build artifacts and cache directories.")]
     Clean {


### PR DESCRIPTION
Help text incorrectly described the autocomplete spec as Figma spec in https://github.com/foundry-rs/foundry/pull/2736, but the terminal is called Fig: https://fig.io/