### PR TITLE
feat: fuzz test traces

### DIFF
--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -108,7 +108,7 @@ impl InvariantFuzzError {
 
             // Identify newly generated contracts, if they exist.
             ided_contracts.extend(load_contracts(
-                vec![(TraceKind::Execution, call_result.traces.unwrap())],
+                vec![(TraceKind::Execution, call_result.traces.clone().unwrap())],
                 known_contracts,
             ));
 
@@ -117,6 +117,7 @@ impl InvariantFuzzError {
                 *addr,
                 bytes,
                 &ided_contracts,
+                call_result.traces,
             ));
 
             // Checks the invariant.

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -169,6 +169,7 @@ impl<'a> InvariantExecutor<'a> {
                         calldata: calldata.clone(),
                         gas: call_result.gas,
                         stipend: call_result.stipend,
+                        traces: call_result.traces.clone(),
                     });
 
                     if !can_continue(

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -102,6 +102,7 @@ impl<'a> FuzzedExecutor<'a> {
                     calldata,
                     gas: call.gas,
                     stipend: call.stipend,
+                    traces: call.traces,
                 });
                 Ok(())
             } else {
@@ -131,7 +132,6 @@ impl<'a> FuzzedExecutor<'a> {
             reason: None,
             counterexample: None,
             logs: call.logs,
-            traces: call.traces,
             labeled_addresses: call.labels,
         };
 
@@ -152,6 +152,7 @@ impl<'a> FuzzedExecutor<'a> {
                     addr: None,
                     signature: None,
                     contract_name: None,
+                    traces: call.traces,
                     calldata,
                     args,
                 }));
@@ -183,6 +184,8 @@ pub struct BaseCounterExample {
     pub signature: Option<String>,
     /// Contract name if it exists
     pub contract_name: Option<String>,
+    /// Traces
+    pub traces: Option<CallTraceArena>,
     // Token does not implement Serde (lol), so we just serialize the calldata
     #[serde(skip)]
     pub args: Vec<Token>,
@@ -194,6 +197,7 @@ impl BaseCounterExample {
         addr: Address,
         bytes: &Bytes,
         contracts: &ContractsByAddress,
+        traces: Option<CallTraceArena>,
     ) -> Self {
         let (name, abi) = &contracts.get(&addr).expect("Couldnt call unknown contract");
 
@@ -211,6 +215,7 @@ impl BaseCounterExample {
             calldata: bytes.clone(),
             signature: Some(func.signature()),
             contract_name: Some(name.clone()),
+            traces,
             args,
         }
     }
@@ -264,9 +269,6 @@ pub struct FuzzTestResult {
     /// be printed to the user.
     pub logs: Vec<Log>,
 
-    /// Traces
-    pub traces: Option<CallTraceArena>,
-
     /// Labeled addresses
     pub labeled_addresses: BTreeMap<Address, String>,
 }
@@ -290,6 +292,11 @@ impl FuzzedCases {
 
     pub fn into_cases(self) -> Vec<FuzzCase> {
         self.cases
+    }
+
+    /// Get the last [FuzzCase]
+    pub fn last(&self) -> Option<&FuzzCase> {
+        self.cases.last()
     }
 
     /// Returns the median gas of all test cases
@@ -342,4 +349,6 @@ pub struct FuzzCase {
     pub gas: u64,
     /// The initial gas stipend for the transaction
     pub stipend: u64,
+    /// Traces
+    pub traces: Option<CallTraceArena>,
 }

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -518,7 +518,14 @@ impl<'a> ContractRunner<'a> {
         // Record logs, labels and traces
         logs.append(&mut result.logs);
         labeled_addresses.append(&mut result.labeled_addresses);
-        traces.extend(result.traces.map(|traces| (TraceKind::Execution, traces)).into_iter());
+        traces.extend(
+            result
+                .cases
+                .last()
+                .and_then(|case| case.traces.clone())
+                .map(|traces| (TraceKind::Execution, traces))
+                .into_iter(),
+        );
 
         // Record test execution time
         tracing::debug!(


### PR DESCRIPTION
## Motivation

- Needed for coverage so we can identify contracts in fuzz tests for the coverage reports (#1964)
- Needed for gas reports (#1023)
- Separately asked for (#1102)

## Solution

We were in fact already collecting traces in the EVM itself, we were just not carrying them over with us into other parts of Forge. Each fuzz case can now carry its own separate traces, and each counter example can as well.

In order to not flood the CLI only the last trace is displayed for fuzz tests that pass if the verbosity is high enough

Closes #1102