### PR TITLE
fix(forge): exclude artifacts without mutable functions on invariant testing

### DIFF
--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -327,7 +327,10 @@ impl<'a> InvariantExecutor<'a> {
                         ethers::abi::StateMutability::Pure | ethers::abi::StateMutability::View
                     )
                 })
-                .count() == 0 && !self.artifact_filters.excluded.contains(&artifact.identifier()) {
+                .count() ==
+                0 &&
+                !self.artifact_filters.excluded.contains(&artifact.identifier())
+            {
                 self.artifact_filters.excluded.push(artifact.identifier());
             }
         }

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -275,6 +275,8 @@ impl<'a> InvariantExecutor<'a> {
     /// format). They will be used to filter contracts after the `setUp`, and more importantly,
     /// during the runs.
     ///
+    /// Also excludes any contract without any mutable functions.
+    ///
     /// Priority:
     ///
     /// targetArtifactSelectors > excludeArtifacts > targetArtifacts
@@ -312,6 +314,21 @@ impl<'a> InvariantExecutor<'a> {
 
             if !self.artifact_filters.excluded.contains(&identifier) {
                 self.artifact_filters.excluded.push(identifier);
+            }
+        }
+
+        // Exclude any artifact without mutable functions.
+        for (artifact, (abi, _)) in self.project_contracts.iter() {
+            if abi
+                .functions()
+                .filter(|func| {
+                    !matches!(
+                        func.state_mutability,
+                        ethers::abi::StateMutability::Pure | ethers::abi::StateMutability::View
+                    )
+                })
+                .count() == 0 && !self.artifact_filters.excluded.contains(&artifact.identifier()) {
+                self.artifact_filters.excluded.push(artifact.identifier());
             }
         }
 

--- a/evm/src/fuzz/strategies/param.rs
+++ b/evm/src/fuzz/strategies/param.rs
@@ -134,7 +134,6 @@ pub fn fuzz_param_from_state(param: &ParamType, arc_state: EvmFuzzState) -> Boxe
 mod tests {
     use crate::{
         fuzz::strategies::{build_initial_state, fuzz_calldata, fuzz_calldata_from_state},
-        CALLER,
     };
     use ethers::abi::HumanReadableParser;
     use revm::db::{CacheDB, EmptyDB};

--- a/evm/src/fuzz/strategies/param.rs
+++ b/evm/src/fuzz/strategies/param.rs
@@ -132,9 +132,7 @@ pub fn fuzz_param_from_state(param: &ParamType, arc_state: EvmFuzzState) -> Boxe
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        fuzz::strategies::{build_initial_state, fuzz_calldata, fuzz_calldata_from_state},
-    };
+    use crate::fuzz::strategies::{build_initial_state, fuzz_calldata, fuzz_calldata_from_state};
     use ethers::abi::HumanReadableParser;
     use revm::db::{CacheDB, EmptyDB};
 

--- a/testdata/fuzz/invariant/targetAbi/ExcludeArtifacts.t.sol
+++ b/testdata/fuzz/invariant/targetAbi/ExcludeArtifacts.t.sol
@@ -3,6 +3,12 @@ pragma solidity >=0.8.0;
 
 import "ds-test/test.sol";
 
+// Will get automatically excluded. Otherwise it would throw error.
+contract NoMutFunctions {
+    function no_change() public pure {
+    }
+}
+
 contract Excluded {
     bool public world = true;
 
@@ -25,6 +31,7 @@ contract ExcludeArtifacts is DSTest {
     function setUp() public {
         excluded = new Excluded();
         new Hello();
+        new NoMutFunctions();
     }
 
     function excludeArtifacts() public returns (string[] memory) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Functions without any mutable functions were not being excluded from potential targets. This would lead `proptest` to try and select from an empty list of random functions.

closes #2804
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Exclude contracts without mutable functions at the artifact level.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
