### PR TITLE
chore(forge): warn which contracts cant be verified on `forge script`

### DIFF
--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -11,6 +11,7 @@ use eyre::ContextCompat;
 use forge::trace::CallTraceDecoder;
 use foundry_common::fs;
 use foundry_config::Config;
+use yansi::Paint;
 
 use crate::cmd::forge::verify::VerificationProviderType;
 
@@ -152,11 +153,12 @@ impl ScriptSequence {
         trace!(?chain, "verifying {} contracts", verify.known_contracts.len());
         if let Some(etherscan_key) = &verify.etherscan_key {
             let mut future_verifications = vec![];
+            let mut unverifiable_contracts = vec![];
 
             // Make sure the receipts have the right order first.
             self.sort_receipts();
 
-            for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
+            'receipts: for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
                 let mut create2_offset = 0;
 
                 if tx.is_create2() {
@@ -212,9 +214,24 @@ impl ScriptSequence {
                             };
 
                             future_verifications.push(verify.run());
+                            continue 'receipts
                         }
                     }
+                    unverifiable_contracts.push(contract_address);
                 }
+            }
+
+            if !unverifiable_contracts.is_empty() {
+                println!(
+                    "\n{}\n\n{}",
+                    Paint::yellow(format!(
+                        "We haven't found any matching bytecode for the following contracts: {:?}.",
+                        unverifiable_contracts
+                    ))
+                    .bold(),
+                    Paint::yellow("This may occur when resuming a verification, but the underlying source code or compiler version has changed.".to_string())
+                    .bold(),
+                );
             }
 
             println!("##\nStart Contract Verification");

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -223,13 +223,12 @@ impl ScriptSequence {
 
             if !unverifiable_contracts.is_empty() {
                 println!(
-                    "\n{}\n\n{}",
+                    "\n{}",
                     Paint::yellow(format!(
-                        "We haven't found any matching bytecode for the following contracts: {:?}.",
-                        unverifiable_contracts
+                        "We haven't found any matching bytecode for the following contracts: {:?}.\n\n{}",
+                        unverifiable_contracts,
+                        "This may occur when resuming a verification, but the underlying source code or compiler version has changed."
                     ))
-                    .bold(),
-                    Paint::yellow("This may occur when resuming a verification, but the underlying source code or compiler version has changed.".to_string())
                     .bold(),
                 );
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When a contract doesn't find a matching bytecode during verification, the user is left with no warning message.

closes #2807

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Warn when matching bytecodes are not found, and provide a small hint on what the issue might be.

small fix: ends the loop early when it finds a matching contract, instead of going through the rest.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
