### PR TITLE
perf(anvil): cache genesis accounts

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -712,6 +712,7 @@ impl NodeConfig {
             timestamp: self.get_genesis_timestamp(),
             balance: self.genesis_balance,
             accounts: self.genesis_accounts.iter().map(|acc| acc.address()).collect(),
+            fork_genesis_account_infos: Arc::new(Default::default()),
         };
         // only memory based backend for now
 

--- a/anvil/src/eth/backend/genesis.rs
+++ b/anvil/src/eth/backend/genesis.rs
@@ -3,6 +3,8 @@
 use ethers::types::{Address, U256};
 use forge::revm::KECCAK_EMPTY;
 use foundry_evm::revm::AccountInfo;
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 /// Genesis settings
 #[derive(Debug, Clone, Default)]
@@ -13,6 +15,11 @@ pub struct GenesisConfig {
     pub balance: U256,
     /// All accounts that should be initialised at genesis
     pub accounts: Vec<Address>,
+    /// The account object stored in the [`revm::Database`]
+    ///
+    /// We store this for forking mode so we can cheaply reset the dev accounts and don't
+    /// need to fetch them again.
+    pub fork_genesis_account_infos: Arc<Mutex<Vec<AccountInfo>>>,
 }
 
 // === impl GenesisConfig ===

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -213,8 +213,16 @@ impl Backend {
             // in fork mode we only set the balance, this way the accountinfo is fetched from the
             // remote client, preserving code and nonce. The reason for that is private keys for dev
             // accounts are commonly known and are used on testnets
+            let mut fork_genesis_infos = self.genesis.fork_genesis_account_infos.lock();
+            fork_genesis_infos.clear();
+
             for address in self.genesis.accounts.iter().copied() {
-                db.set_balance(address, self.genesis.balance)
+                let mut info = db.basic(address);
+                info.balance = self.genesis.balance;
+                db.insert_account(address, info.clone());
+
+                // store the fetched AccountInfo, so we can cheaply reset in [Self::reset_fork()]
+                fork_genesis_infos.push(info);
             }
         } else {
             for (account, info) in self.genesis.account_infos() {
@@ -293,7 +301,16 @@ impl Backend {
                 BlockchainStorage::forked(fork.block_number(), fork.block_hash());
             self.states.write().clear();
 
-            self.apply_genesis().await;
+            // insert back all genesis accounts, by reusing cached `AccountInfo`s we don't need to
+            // fetch the data via RPC again
+            let mut db = self.db.write().await;
+            let fork_genesis_infos = self.genesis.fork_genesis_account_infos.lock();
+            for (address, info) in
+                self.genesis.accounts.iter().copied().zip(fork_genesis_infos.iter().cloned())
+            {
+                db.insert_account(address, info);
+            }
+
             Ok(())
         } else {
             Err(RpcError::invalid_params("Forking not enabled").into())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
when resetting fork, all account data including genesis/dev accounts got wiped, which then need to be fetched again via RPC.

Ref #2801
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* cache genesis accounts at launch and reuse them after fork reset
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
