### PR TITLE
feat(forge): add cheatcode vm.difficulty()

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -18,6 +18,7 @@ ethers::contract::abigen!(
             struct Log {bytes32[] topics; bytes data;}
             roll(uint256)
             warp(uint256)
+            difficulty(uint256)
             fee(uint256)
             coinbase(address)
             store(address,bytes32,bytes32)

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -144,6 +144,10 @@ pub fn apply<DB: Database>(
             data.env.block.timestamp = inner.0;
             Ok(Bytes::new())
         }
+        HEVMCalls::Difficulty(inner) => {
+            data.env.block.difficulty = inner.0;
+            Ok(Bytes::new())
+        }
         HEVMCalls::Roll(inner) => {
             data.env.block.number = inner.0;
             Ok(Bytes::new())

--- a/forge/README.md
+++ b/forge/README.md
@@ -122,6 +122,8 @@ which implements the following methods:
 
 - `function warp(uint x) public` Sets the block timestamp to `x`.
 
+- `function difficulty(uint x) public` Sets the block difficulty to `x`.
+
 - `function roll(uint x) public` Sets the block number to `x`.
 
 - `function coinbase(address c) public` Sets the block coinbase to `c`.

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -6,6 +6,8 @@ interface Cheats {
     struct Log {bytes32[] topics; bytes data;}
     // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
+    // Set block.difficulty (newDifficulty)
+    function difficulty(uint256) external;
     // Set block.height (newHeight)
     function roll(uint256) external;
     // Set block.basefee (newBasefee)

--- a/testdata/cheats/Difficulty.t.sol
+++ b/testdata/cheats/Difficulty.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "./Cheats.sol";
+
+contract DifficultyTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function testDifficulty() public {
+        assertEq(block.difficulty, 0);
+        cheats.difficulty(10);
+        assertEq(block.difficulty, 10, "difficulty cheatcode failed");
+    }
+
+    function testDifficultyFuzzed(uint256 newDifficulty) public {
+        cheats.assume(newDifficulty != block.difficulty);
+        assertEq(block.difficulty, 0);
+        cheats.difficulty(newDifficulty);
+        assertEq(block.difficulty, newDifficulty);
+    }
+
+    function testDifficultySnapshotFuzzed(uint256 newDifficulty) public {
+        cheats.assume(newDifficulty != block.difficulty);
+        uint256 oldDifficulty = block.difficulty;
+        uint256 snapshot = cheats.snapshot();
+
+        cheats.difficulty(newDifficulty);
+        assertEq(block.difficulty, newDifficulty);
+
+        assert(cheats.revertTo(snapshot));
+        assertEq(block.difficulty, oldDifficulty);
+    }
+}

--- a/testdata/cheats/Setup.t.sol
+++ b/testdata/cheats/Setup.t.sol
@@ -20,6 +20,7 @@ contract CheatsSetupTest is DSTest {
         cheats.warp(10);
         cheats.roll(100);
         cheats.fee(1000);
+        cheats.difficulty(10000);
         cheats.startPrank(address(1337));
     }
 
@@ -27,6 +28,7 @@ contract CheatsSetupTest is DSTest {
         assertEq(block.timestamp, 10, "block timestamp was not persisted from setup");
         assertEq(block.number, 100, "block number was not persisted from setup");
         assertEq(block.basefee, 1000, "basefee was not persisted from setup");
+        assertEq(block.difficulty, 10000, "difficulty was not persisted from setup");
         victim.assertSender(address(1337));
     }
 }

--- a/testdata/cheats/Snapshots.t.sol
+++ b/testdata/cheats/Snapshots.t.sol
@@ -36,6 +36,7 @@ contract SnapshotTest is DSTest {
     function testBlockValues() public  {
         uint256 num = block.number;
         uint256 time = block.timestamp;
+        uint256 difficulty = block.difficulty;
 
         uint256 snapshot = cheats.snapshot();
 
@@ -45,10 +46,14 @@ contract SnapshotTest is DSTest {
         cheats.roll(99);
         assertEq(block.number, 99);
 
+        cheats.difficulty(123);
+        assertEq(block.difficulty, 123);
+
         assert(cheats.revertTo(snapshot));
 
         assertEq(block.number, num, "snapshot revert for block.number unsuccessful");
         assertEq(block.timestamp, time, "snapshot revert for block.timestamp unsuccessful");
+        assertEq(block.difficulty, difficulty, "snapshot revert for block.difficulty unsuccessful");
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Wanting to mock `block.difficulty`.

## Solution

Adding a new cheatcode `vm.difficulty(uint256 newDifficulty)` to mock `block.difficulty`.
