### PR TITLE
fix(forge): always show traces on script failure & small fixes

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -255,7 +255,7 @@ impl ScriptArgs {
             println!("Gas used: {}", result.gas);
         }
 
-        if !result.returned.is_empty() {
+        if result.success && !result.returned.is_empty() {
             println!("\n== Return ==");
             match func.decode_output(&result.returned) {
                 Ok(decoded) => {

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -226,33 +226,29 @@ impl ScriptArgs {
         let verbosity = script_config.evm_opts.verbosity;
         let func = script_config.called_function.as_ref().expect("There should be a function.");
 
-        if verbosity >= 3 {
+        if !result.success || verbosity > 3 {
             if result.traces.is_empty() {
                 eyre::bail!("Unexpected error: No traces despite verbosity level. Please report this as a bug: https://github.com/foundry-rs/foundry/issues/new?assignees=&labels=T-bug&template=BUG-FORM.yml");
             }
 
-            if !result.success && verbosity == 3 || verbosity > 3 {
-                println!("Traces:");
-                for (kind, trace) in &mut result.traces {
-                    let should_include = match kind {
-                        TraceKind::Setup => (verbosity >= 5) || (verbosity == 4 && !result.success),
-                        TraceKind::Execution => verbosity > 3 || !result.success,
-                        _ => false,
-                    };
+            println!("Traces:");
+            for (kind, trace) in &mut result.traces {
+                let should_include = match kind {
+                    TraceKind::Setup => verbosity >= 5,
+                    TraceKind::Execution => verbosity > 3,
+                    _ => false,
+                } || !result.success;
 
-                    if should_include {
-                        decoder.decode(trace).await;
-                        println!("{trace}");
-                    }
+                if should_include {
+                    decoder.decode(trace).await;
+                    println!("{trace}");
                 }
-                println!();
             }
+            println!();
         }
 
         if result.success {
             println!("{}", Paint::green("Script ran successfully."));
-        } else {
-            println!("{}", Paint::red("Script failed."));
         }
 
         if script_config.evm_opts.fork_url.is_none() {

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     opts::MultiWallet,
     utils::{get_contract_name, parse_ether_value},
 };
-use cast::executor::inspector::DEFAULT_CREATE2_DEPLOYER;
+use cast::{decode, executor::inspector::DEFAULT_CREATE2_DEPLOYER};
 use clap::{Parser, ValueHint};
 use dialoguer::Confirm;
 use ethers::{
@@ -289,7 +289,11 @@ impl ScriptArgs {
         }
 
         if !result.success {
-            eyre::bail!("{}", Paint::red("Script failed."));
+            let revert_msg = decode::decode_revert(&result.returned[..], None, None)
+                .map(|err| format!("{}\n", err))
+                .unwrap_or_else(|_| "Script failed.\n".to_string());
+
+            eyre::bail!("{}", Paint::red(revert_msg));
         }
 
         Ok(())

--- a/cli/test-utils/src/script.rs
+++ b/cli/test-utils/src/script.rs
@@ -171,6 +171,7 @@ pub enum ScriptOutcome {
     WarnSpecifyDeployer,
     MissingSender,
     MissingWallet,
+    StaticCallNotAllowed,
     FailedScript,
 }
 
@@ -182,6 +183,7 @@ impl ScriptOutcome {
             ScriptOutcome::WarnSpecifyDeployer => "You have more than one deployer who could predeploy libraries. Using `--sender` instead.",
             ScriptOutcome::MissingSender => "You seem to be using Foundry's default sender. Be sure to set your own --sender",
             ScriptOutcome::MissingWallet => "No associated wallet",
+            ScriptOutcome::StaticCallNotAllowed => "Staticcalls are not allowed after vm.broadcast. Either remove it, or use vm.startBroadcast instead.",
             ScriptOutcome::FailedScript => "Script failed.",
         }
     }
@@ -193,6 +195,7 @@ impl ScriptOutcome {
             ScriptOutcome::WarnSpecifyDeployer => false,
             ScriptOutcome::MissingSender |
             ScriptOutcome::MissingWallet |
+            ScriptOutcome::StaticCallNotAllowed |
             ScriptOutcome::FailedScript => true,
         }
     }

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -468,7 +468,7 @@ forgetest_async!(fail_broadcast_staticcall, |prj: TestProject, cmd: TestCommand|
         .load_private_keys(vec![0])
         .await
         .add_sig("BroadcastTestNoLinking", "errorStaticCall()")
-        .simulate(ScriptOutcome::FailedScript);
+        .simulate(ScriptOutcome::StaticCallNotAllowed);
 });
 
 forgetest_async!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

No reason to hide traces if the script has failed. 

closes #2793

Also:
* Hides `== Return ==` if script failed. `returned` has the revert reason, so it never shows anything here anyway.
* Decode revert on failure and add it to the `bail!` msg
* Fix: Even if `setUp()` failed, the script execution was going through. It would ultimately fail, since we do `result & method_result`, but traces would get confusing.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
