### PR TITLE
perf: don't keep all fuzz case traces

### DIFF
--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -128,7 +128,7 @@ impl<'a> InvariantExecutor<'a> {
                 let mut executor = blank_executor.borrow().clone();
 
                 // Used for stat reports (eg. gas usage).
-                let mut fuzz_runs = vec![];
+                let mut fuzz_runs = Vec::with_capacity(test_options.depth as usize);
 
                 // Created contracts during a run.
                 let mut created_contracts = vec![];
@@ -166,7 +166,6 @@ impl<'a> InvariantExecutor<'a> {
                         calldata: calldata.clone(),
                         gas: call_result.gas,
                         stipend: call_result.stipend,
-                        traces: call_result.traces.clone(),
                     });
 
                     if !can_continue(

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -518,14 +518,7 @@ impl<'a> ContractRunner<'a> {
         // Record logs, labels and traces
         logs.append(&mut result.logs);
         labeled_addresses.append(&mut result.labeled_addresses);
-        traces.extend(
-            result
-                .cases
-                .last()
-                .and_then(|case| case.traces.clone())
-                .map(|traces| (TraceKind::Execution, traces))
-                .into_iter(),
-        );
+        traces.extend(result.traces.map(|traces| (TraceKind::Execution, traces)));
 
         // Record test execution time
         tracing::debug!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2796
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
only keep 1 set of traces per fuzz test, which gets rid of `fuzz_cases - 1` (redundant) traces (255 by default).
this greatly reduces memory consumption in verbose mode `-vvv`

previously running `forge test --no-match-contract 'Element|AceOfZk|StabilityPoolBridge' --no-match-test 'testRedistribution' -vvv` on https://github.com/AztecProtocol/aztec-connect-bridges peaked at ~12GB (due to large number of fuzz cases in combination with heavy test functions)

with this fix it's down to ~220MB peak
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
