### PR TITLE
fix(anvil): Fix initial block timestamp in fork-mode

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -631,7 +631,15 @@ impl NodeConfig {
                     panic!("Failed to get block for block number: {}", fork_block_number)
                 };
 
-                env.block.number = fork_block_number.into();
+                env.block = BlockEnv {
+                    number: fork_block_number.into(),
+                    timestamp: block.timestamp,
+                    difficulty: block.difficulty,
+                    gas_limit: block.gas_limit,
+                    // Keep previous `coinbase` and `basefee` value
+                    coinbase: env.block.coinbase,
+                    basefee: env.block.basefee,
+                };
                 fork_timestamp = Some(block.timestamp);
 
                 // if not set explicitly we use the base fee of the latest block


### PR DESCRIPTION
## Motivation

When using `anvil` in fork-mode, the `latest` block context had a timestamp of `1`. This was causing some issues when calling some contracts (cf. the added test, which calls a Yearn token's method, which down the stack depends on the timestamp).

## Solution

Correctly set the `timestamp` in the block-env when creating the node, as well as when resetting the fork.
