### PR TITLE
fix(forge): restore tracing setting when there are invariant tests

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -230,13 +230,15 @@ impl<'a> ContractRunner<'a> {
         let has_invariants =
             self.contract.functions().into_iter().any(|func| func.name.is_invariant_test());
 
+        // Invariant testing requires tracing to figure out what contracts were created.
+        let original_tracing = self.executor.inspector_config().tracing;
         if has_invariants && needs_setup {
-            // invariant testing requires tracing to figure
-            //   out what contracts were created
             self.executor.set_tracing(true);
         }
 
         let setup = self.setup(needs_setup)?;
+        self.executor.set_tracing(original_tracing);
+
         if setup.setup_failed {
             // The setup failed, so we return a single test result for `setUp`
             return Ok(SuiteResult::new(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Invariant testing requires `setUp` to be run with `tracing` enabled, to figure out which addresses are available. However, if there were other fuzz/normal tests in the contract, they too were being run with tracing enabled even without any verbose flag.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Restore original tracing setting.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
