### PR TITLE
fix/refactor(cast): strip struct prefix and make interface a cmd

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -717,13 +717,11 @@ impl SimpleCast {
                 // get the source
                 let contract_source = match client.contract_source_code(address).await {
                     Ok(src) => src,
+                    Err(ethers_etherscan::errors::EtherscanError::InvalidApiKey) => {
+                        eyre::bail!("Invalid Etherscan API key. Did you set it correctly? You may be using an API key for another Etherscan API chain (e.g. Ethereum API key for Polygonscan).")
+                    }
                     Err(err) => {
-                        let msg = err.to_string();
-                        if msg.contains("Invalid API Key") {
-                            eyre::bail!("Invalid Etherscan API key. Did you set it correctly? You may be using an API key for another Etherscan API chain (e.g. Ethereum API key for Polygonscan).")
-                        } else {
-                            eyre::bail!(err)
-                        }
+                        eyre::bail!(err)
                     }
                 };
 

--- a/cli/src/cmd/cast/interface.rs
+++ b/cli/src/cmd/cast/interface.rs
@@ -1,0 +1,97 @@
+use crate::{cmd::Cmd, opts::ClapChain};
+use cast::{InterfacePath, SimpleCast};
+use clap::Parser;
+use ethers::types::Address;
+use eyre::WrapErr;
+use foundry_common::fs;
+use foundry_config::Config;
+use futures::future::BoxFuture;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Parser)]
+pub struct InterfaceArgs {
+    #[clap(
+        help = "The contract address, or the path to an ABI file.",
+        long_help = r#"The contract address, or the path to an ABI file.
+
+If an address is specified, then the ABI is fetched from Etherscan."#,
+        value_name = "PATH_OR_ADDRESS"
+    )]
+    path_or_address: String,
+    #[clap(long, short, help = "The name to use for the generated interface", value_name = "NAME")]
+    name: Option<String>,
+    #[clap(
+        long,
+        short,
+        default_value = "^0.8.10",
+        help = "Solidity pragma version.",
+        value_name = "VERSION"
+    )]
+    pragma: String,
+    #[clap(
+        short,
+        help = "The path to the output file.",
+        long_help = "The path to the output file. If not specified, the interface will be output to stdout.",
+        value_name = "PATH"
+    )]
+    output_location: Option<PathBuf>,
+    #[clap(long, short, env = "ETHERSCAN_API_KEY", help = "etherscan API key", value_name = "KEY")]
+    etherscan_api_key: Option<String>,
+    #[clap(flatten)]
+    chain: ClapChain,
+}
+
+impl Cmd for InterfaceArgs {
+    type Output = BoxFuture<'static, eyre::Result<()>>;
+    fn run(self) -> eyre::Result<Self::Output> {
+        let cmd = Box::pin(async move {
+            let InterfaceArgs {
+                path_or_address,
+                name,
+                pragma,
+                output_location,
+                etherscan_api_key,
+                chain,
+            } = self;
+            let interfaces = if Path::new(&path_or_address).exists() {
+                SimpleCast::generate_interface(InterfacePath::Local { path: path_or_address, name })
+                    .await?
+            } else {
+                let api_key = etherscan_api_key.or_else(|| {
+                    let config = Config::load();
+                    config.get_etherscan_api_key(Some(chain.inner))
+                }).ok_or_else(|| eyre::eyre!("No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY env var, or setting the -e CLI argument or etherscan-api-key in foundry.toml"))?;
+
+                SimpleCast::generate_interface(InterfacePath::Etherscan {
+                    chain: chain.inner,
+                    api_key,
+                    address: path_or_address
+                        .parse::<Address>()
+                        .wrap_err("Invalid address provided. Did you make a typo?")?,
+                })
+                .await?
+            };
+
+            // put it all together
+            let pragma = format!("pragma solidity {pragma};");
+            let interfaces = interfaces
+                .iter()
+                .map(|iface| iface.source.to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let res = format!("{pragma}\n\n{interfaces}");
+
+            // print or write to file
+            if let Some(loc) = output_location {
+                fs::create_dir_all(&loc.parent().unwrap())?;
+                fs::write(&loc, res)?;
+                println!("Saved interface at {}", loc.display());
+            } else {
+                println!("{res}");
+            }
+            Ok(())
+        });
+
+        Ok(cmd)
+    }
+}

--- a/cli/src/cmd/cast/mod.rs
+++ b/cli/src/cmd/cast/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod estimate;
 pub mod find_block;
+pub mod interface;
 pub mod rpc;
 pub mod run;
 pub mod wallet;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,8 +1,8 @@
 use super::{ClapChain, EthereumOpts, TransactionOpts};
 use crate::{
     cmd::cast::{
-        estimate::EstimateArgs, find_block::FindBlockArgs, rpc::RpcArgs, run::RunArgs,
-        wallet::WalletSubcommands,
+        estimate::EstimateArgs, find_block::FindBlockArgs, interface::InterfaceArgs, rpc::RpcArgs,
+        run::RunArgs, wallet::WalletSubcommands,
     },
     utils::parse_u256,
 };
@@ -762,48 +762,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         about = "Generate a Solidity interface from a given ABI.",
         long_about = "Generate a Solidity interface from a given ABI. Currently does not support ABI encoder v2."
     )]
-    Interface {
-        #[clap(
-            help = "The contract address, or the path to an ABI file.",
-            long_help = r#"The contract address, or the path to an ABI file.
-
-If an address is specified, then the ABI is fetched from Etherscan."#,
-            value_name = "PATH_OR_ADDRESS"
-        )]
-        path_or_address: String,
-        #[clap(
-            long,
-            short,
-            help = "The name to use for the generated interface",
-            value_name = "NAME"
-        )]
-        name: Option<String>,
-        #[clap(
-            long,
-            short,
-            default_value = "^0.8.10",
-            help = "Solidity pragma version.",
-            value_name = "VERSION"
-        )]
-        pragma: String,
-        #[clap(
-            short,
-            help = "The path to the output file.",
-            long_help = "The path to the output file. If not specified, the interface will be output to stdout.",
-            value_name = "PATH"
-        )]
-        output_location: Option<PathBuf>,
-        #[clap(
-            long,
-            short,
-            env = "ETHERSCAN_API_KEY",
-            help = "etherscan API key",
-            value_name = "KEY"
-        )]
-        etherscan_api_key: Option<String>,
-        #[clap(flatten)]
-        chain: ClapChain,
-    },
+    Interface(InterfaceArgs),
     #[clap(name = "sig", visible_alias = "si", about = "Get the selector for a function.")]
     Sig {
         #[clap(

--- a/testdata/fixtures/SolidityGeneration/WithStructs.json
+++ b/testdata/fixtures/SolidityGeneration/WithStructs.json
@@ -1,0 +1,1219 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "AuctionEnded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "AuctionStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "starter",
+        "type": "address"
+      }
+    ],
+    "name": "AuctionStarterSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "batch_size",
+        "type": "uint16"
+      }
+    ],
+    "name": "AutopayBatchSizeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bidder",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "opportunity",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "auction_number",
+        "type": "uint256"
+      }
+    ],
+    "name": "BidAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "BidTokenSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FastLaneFeeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      }
+    ],
+    "name": "MinimumAutoshipThresholdSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "MinimumBidIncrementSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "opportunity",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "OpportunityAddressDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "opportunity",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "OpportunityAddressEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "ops",
+        "type": "address"
+      }
+    ],
+    "name": "OpsSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "state",
+        "type": "bool"
+      }
+    ],
+    "name": "PausedStateSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      }
+    ],
+    "name": "ResolverMaxGasPriceSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "ValidatorAddressDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      }
+    ],
+    "name": "ValidatorAddressEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minAutoshipAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "validatorPayableAddress",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorPreferencesSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "auction_number",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "destination",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorWithdrawnBalance",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawStuckERC20",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawStuckNativeToken",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_AUCTION_VALUE",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "auctionStarter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "auction_live",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "auction_number",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "autopay_batch_size",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bid_increment",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bid_token",
+    "outputs": [
+      {
+        "internalType": "contract ERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "checker",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "canExec",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "execPayload",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "opportunityAddress",
+        "type": "address"
+      }
+    ],
+    "name": "disableOpportunityAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validatorAddress",
+        "type": "address"
+      }
+    ],
+    "name": "disableValidatorAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "opportunityAddress",
+        "type": "address"
+      }
+    ],
+    "name": "enableOpportunityAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validatorAddress",
+        "type": "address"
+      }
+    ],
+    "name": "enableValidatorAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validatorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_minAutoshipAmount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "address",
+        "name": "_validatorPayableAddress",
+        "type": "address"
+      }
+    ],
+    "name": "enableValidatorAddressWithPreferences",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "endAuction",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fast_lane_fee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "auction_index",
+        "type": "uint128"
+      },
+      {
+        "internalType": "address",
+        "name": "validatorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "opportunityAddress",
+        "type": "address"
+      }
+    ],
+    "name": "findFinalizedAuctionWinnerAtAuction",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "validatorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "opportunityAddress",
+        "type": "address"
+      }
+    ],
+    "name": "findLastFinalizedAuctionWinner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "validatorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "opportunityAddress",
+        "type": "address"
+      }
+    ],
+    "name": "findLiveAuctionTopBid",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getActivePrivilegesAuctionNumber",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "batch_size",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint128",
+        "name": "auction_index",
+        "type": "uint128"
+      }
+    ],
+    "name": "getAutopayJobs",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "hasJobs",
+        "type": "bool"
+      },
+      {
+        "internalType": "address[]",
+        "name": "autopayRecipients",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "who",
+        "type": "address"
+      }
+    ],
+    "name": "getCheckpoint",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "pendingBalanceAtlastBid",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "outstandingBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint128",
+            "name": "lastWithdrawnAuction",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "lastBidReceivedAuction",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct ValidatorBalanceCheckpoint",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "who",
+        "type": "address"
+      }
+    ],
+    "name": "getPreferences",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "minAutoshipAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "validatorPayableAddress",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ValidatorPreferences",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "who",
+        "type": "address"
+      }
+    ],
+    "name": "getStatus",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint128",
+            "name": "activeAtAuction",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "inactiveAtAuction",
+            "type": "uint128"
+          },
+          {
+            "internalType": "enum statusType",
+            "name": "kind",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct Status",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "auction_index",
+        "type": "uint128"
+      }
+    ],
+    "name": "getValidatorsActiveAtAuction",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_initial_bid_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_ops",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_starter",
+        "type": "address"
+      }
+    ],
+    "name": "init",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "max_gas_price",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minAutoShipThreshold",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ops",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "outstandingFLBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "autopayRecipients",
+        "type": "address[]"
+      }
+    ],
+    "name": "processAutopayJobs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "outstandingValidatorWithBalance",
+        "type": "address"
+      }
+    ],
+    "name": "redeemOutstandingBalance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "size",
+        "type": "uint16"
+      }
+    ],
+    "name": "setAutopayBatchSize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_bid_token_address",
+        "type": "address"
+      }
+    ],
+    "name": "setBidToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint24",
+        "name": "_fastLaneFee",
+        "type": "uint24"
+      }
+    ],
+    "name": "setFastlaneFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "_minAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "setMinimumAutoShipThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_bid_increment",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinimumBidIncrement",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "state",
+        "type": "bool"
+      }
+    ],
+    "name": "setOffchainCheckerDisabledState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_ops",
+        "type": "address"
+      }
+    ],
+    "name": "setOps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "state",
+        "type": "bool"
+      }
+    ],
+    "name": "setPausedState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "_maxgas",
+        "type": "uint128"
+      }
+    ],
+    "name": "setResolverMaxGasPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_starter",
+        "type": "address"
+      }
+    ],
+    "name": "setStarter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "_minAutoshipAmount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "address",
+        "name": "_validatorPayableAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setValidatorPreferences",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startAuction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "opportunityAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "searcherContractAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "searcherPayableAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "bidAmount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Bid",
+        "name": "bid",
+        "type": "tuple"
+      }
+    ],
+    "name": "submitBid",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawStuckERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawStuckNativeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/testdata/fixtures/SolidityGeneration/WithStructs.sol
+++ b/testdata/fixtures/SolidityGeneration/WithStructs.sol
@@ -1,0 +1,78 @@
+interface test {
+    event AuctionEnded(uint128 indexed auction_number);
+    event AuctionStarted(uint128 indexed auction_number);
+    event AuctionStarterSet(address indexed starter);
+    event AutopayBatchSizeSet(uint16 batch_size);
+    event BidAdded(address bidder, address indexed validator, address indexed opportunity, uint256 amount, uint256 indexed auction_number);
+    event BidTokenSet(address indexed token);
+    event FastLaneFeeSet(uint256 amount);
+    event MinimumAutoshipThresholdSet(uint128 amount);
+    event MinimumBidIncrementSet(uint256 amount);
+    event OpportunityAddressDisabled(address indexed opportunity, uint128 indexed auction_number);
+    event OpportunityAddressEnabled(address indexed opportunity, uint128 indexed auction_number);
+    event OpsSet(address ops);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event PausedStateSet(bool state);
+    event ResolverMaxGasPriceSet(uint128 amount);
+    event ValidatorAddressDisabled(address indexed validator, uint128 indexed auction_number);
+    event ValidatorAddressEnabled(address indexed validator, uint128 indexed auction_number);
+    event ValidatorPreferencesSet(address indexed validator, uint256 minAutoshipAmount, address validatorPayableAddress);
+    event ValidatorWithdrawnBalance(address indexed validator, uint128 indexed auction_number, uint256 amount, address destination, address indexed caller);
+    event WithdrawStuckERC20(address indexed receiver, address indexed token, uint256 amount);
+    event WithdrawStuckNativeToken(address indexed receiver, uint256 amount);
+
+    struct Bid { address a; address b; address c; address d; uint256 e; }
+    struct Status { uint128 a; uint128 b; uint8 c; }
+    struct ValidatorBalanceCheckpoint { uint256 a; uint256 b; uint128 c; uint128 d; }
+    struct ValidatorPreferences { uint256 a; address b; }
+
+    function MAX_AUCTION_VALUE() view external returns (uint128);
+    function auctionStarter() view external returns (address);
+    function auction_live() view external returns (bool);
+    function auction_number() view external returns (uint128);
+    function autopay_batch_size() view external returns (uint16);
+    function bid_increment() view external returns (uint256);
+    function bid_token() view external returns (address);
+    function checker() view external returns (bool canExec, bytes memory execPayload);
+    function disableOpportunityAddress(address opportunityAddress) external;
+    function disableValidatorAddress(address _validatorAddress) external;
+    function enableOpportunityAddress(address opportunityAddress) external;
+    function enableValidatorAddress(address _validatorAddress) external;
+    function enableValidatorAddressWithPreferences(address _validatorAddress, uint128 _minAutoshipAmount, address _validatorPayableAddress) external;
+    function endAuction() external returns (bool);
+    function fast_lane_fee() view external returns (uint24);
+    function findFinalizedAuctionWinnerAtAuction(uint128 auction_index, address validatorAddress, address opportunityAddress) view external returns (bool, address, uint128);
+    function findLastFinalizedAuctionWinner(address validatorAddress, address opportunityAddress) view external returns (bool, address, uint128);
+    function findLiveAuctionTopBid(address validatorAddress, address opportunityAddress) view external returns (uint256, uint128);
+    function getActivePrivilegesAuctionNumber() view external returns (uint128);
+    function getAutopayJobs(uint16 batch_size, uint128 auction_index) view external returns (bool hasJobs, address[] memory autopayRecipients);
+    function getCheckpoint(address who) view external returns (ValidatorBalanceCheckpoint memory);
+    function getPreferences(address who) view external returns (ValidatorPreferences memory);
+    function getStatus(address who) view external returns (Status memory);
+    function getValidatorsActiveAtAuction(uint128 auction_index) view external returns (address[] memory);
+    function init(address _initial_bid_token, address _ops, address _starter) external;
+    function max_gas_price() view external returns (uint128);
+    function minAutoShipThreshold() view external returns (uint128);
+    function ops() view external returns (address);
+    function outstandingFLBalance() view external returns (uint256);
+    function owner() view external returns (address);
+    function processAutopayJobs(address[] memory autopayRecipients) external;
+    function redeemOutstandingBalance(address outstandingValidatorWithBalance) external;
+    function renounceOwnership() external;
+    function setAutopayBatchSize(uint16 size) external;
+    function setBidToken(address _bid_token_address) external;
+    function setFastlaneFee(uint24 _fastLaneFee) external;
+    function setMinimumAutoShipThreshold(uint128 _minAmount) external;
+    function setMinimumBidIncrement(uint256 _bid_increment) external;
+    function setOffchainCheckerDisabledState(bool state) external;
+    function setOps(address _ops) external;
+    function setPausedState(bool state) external;
+    function setResolverMaxGasPrice(uint128 _maxgas) external;
+    function setStarter(address _starter) external;
+    function setValidatorPreferences(uint128 _minAutoshipAmount, address _validatorPayableAddress) external;
+    function startAuction() external;
+    function submitBid(Bid memory bid) external;
+    function transferOwnership(address newOwner) external;
+    function withdrawStuckERC20(address _tokenAddress) external;
+    function withdrawStuckNativeToken(uint256 amount) external;
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -17,7 +17,7 @@ use ethers_solc::{
 use eyre::{Result, WrapErr};
 use futures::future::BoxFuture;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     env::VarError,
     fmt::Write,
     path::PathBuf,
@@ -35,7 +35,7 @@ pub struct PostLinkInput<'a, T, U> {
     pub known_contracts: &'a mut BTreeMap<ArtifactId, T>,
     pub id: ArtifactId,
     pub extra: &'a mut U,
-    pub dependencies: Vec<(String, ethers_core::types::Bytes)>,
+    pub dependencies: Vec<(String, Bytes)>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -143,7 +143,7 @@ pub fn recurse_link<'a>(
     // fname => Vec<(fname, file, key)>
     dependency_tree: &'a BTreeMap<String, Vec<(String, String, String)>>,
     // library deployment vector (file:contract:address, bytecode)
-    deployment: &'a mut Vec<(String, ethers_core::types::Bytes)>,
+    deployment: &'a mut Vec<(String, Bytes)>,
     // deployed library addresses fname => adddress
     deployed_library_addresses: &'a Libraries,
     // nonce to start at
@@ -539,7 +539,7 @@ fn capitalize(s: &str) -> String {
 
 // Returns the function parameter formatted as a string, as well as inserts into the provided
 // `structs` set in order to create type definitions for any Abi Encoder v2 structs.
-fn format_param(param: &Param, structs: &mut HashSet<String>) -> String {
+fn format_param(param: &Param, structs: &mut BTreeSet<String>) -> String {
     let kind = get_param_type(&param.kind, &param.name, param.internal_type.as_deref(), structs);
 
     // add `memory` if required (not needed for events, only for functions)
@@ -560,7 +560,7 @@ fn format_param(param: &Param, structs: &mut HashSet<String>) -> String {
     }
 }
 
-fn format_event_params(param: &EventParam, structs: &mut HashSet<String>) -> String {
+fn format_event_params(param: &EventParam, structs: &mut BTreeSet<String>) -> String {
     let kind = get_param_type(&param.kind, &param.name, None, structs);
 
     if param.name.is_empty() {
@@ -576,12 +576,14 @@ fn get_param_type(
     kind: &ParamType,
     name: &str,
     internal_type: Option<&str>,
-    structs: &mut HashSet<String>,
+    structs: &mut BTreeSet<String>,
 ) -> String {
     let (kind, v2_struct) = match kind {
         // We need to do some extra work to parse ABI Encoder V2 types.
         ParamType::Tuple(ref args) => {
-            let name = internal_type.map(|x| x.to_owned()).unwrap_or_else(|| capitalize(name));
+            let name = internal_type
+                .map(|ty| ty.trim_start_matches("struct ").to_string())
+                .unwrap_or_else(|| capitalize(name));
             let name = if name.contains('.') {
                 name.split('.').nth(1).expect("could not get struct name").to_owned()
             } else {
@@ -632,7 +634,7 @@ pub fn abi_to_solidity(contract_abi: &Abi, mut contract_name: &str) -> Result<St
     };
 
     // instantiate an array of all ABI Encoder v2 structs
-    let mut structs = HashSet::new();
+    let mut structs = BTreeSet::new();
 
     let events = events_iterator
         .map(|event| {
@@ -1002,31 +1004,34 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn abi2solidity() {
-        let contract_abi: Abi = serde_json::from_slice(
-            &std::fs::read("../testdata/fixtures/SolidityGeneration/InterfaceABI.json").unwrap(),
-        )
+        let contract_abi: Abi = serde_json::from_str(include_str!(
+            "../../testdata/fixtures/SolidityGeneration/InterfaceABI.json"
+        ))
         .unwrap();
         assert_eq!(
-            std::str::from_utf8(
-                &std::fs::read(
-                    "../testdata/fixtures/SolidityGeneration/GeneratedNamedInterface.sol"
-                )
-                .unwrap()
-            )
-            .unwrap()
-            .to_string(),
+            include_str!("../../testdata/fixtures/SolidityGeneration/GeneratedNamedInterface.sol"),
             abi_to_solidity(&contract_abi, "test").unwrap()
         );
         assert_eq!(
-            std::str::from_utf8(
-                &std::fs::read(
-                    "../testdata/fixtures/SolidityGeneration/GeneratedUnnamedInterface.sol"
-                )
-                .unwrap()
-            )
-            .unwrap()
-            .to_string(),
+            include_str!(
+                "../../testdata/fixtures/SolidityGeneration/GeneratedUnnamedInterface.sol"
+            ),
             abi_to_solidity(&contract_abi, "").unwrap()
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn abi2solidity_with_structs() {
+        let contract_abi: Abi = serde_json::from_str(include_str!(
+            "../../testdata/fixtures/SolidityGeneration/WithStructs.json"
+        ))
+        .unwrap();
+
+        println!("{}", abi_to_solidity(&contract_abi, "test").unwrap());
+        assert_eq!(
+            include_str!("../../testdata/fixtures/SolidityGeneration/WithStructs.sol").trim(),
+            abi_to_solidity(&contract_abi, "test").unwrap().trim()
         );
     }
 
@@ -1040,18 +1045,18 @@ mod tests {
         let log = RawLog { topics: vec![event.signature(), param0, param2], data: param1.clone() };
         let event = get_indexed_event(event, &log);
 
-        assert!(event.inputs.len() == 3);
+        assert_eq!(event.inputs.len(), 3);
 
         // Only the address fields get indexed since total_params > num_indexed_params
         let parsed = event.parse_log(log).unwrap();
 
-        assert!(event.inputs.iter().filter(|param| param.indexed).count() == 2);
-        assert!(parsed.params[0].name == "param0");
-        assert!(parsed.params[0].value == Token::Address(param0.into()));
-        assert!(parsed.params[1].name == "param1");
-        assert!(parsed.params[1].value == Token::Uint(U256::from_big_endian(&param1)));
-        assert!(parsed.params[2].name == "param2");
-        assert!(parsed.params[2].value == Token::Address(param2.into()));
+        assert_eq!(event.inputs.iter().filter(|param| param.indexed).count(), 2);
+        assert_eq!(parsed.params[0].name, "param0");
+        assert_eq!(parsed.params[0].value, Token::Address(param0.into()));
+        assert_eq!(parsed.params[1].name, "param1");
+        assert_eq!(parsed.params[1].value, Token::Uint(U256::from_big_endian(&param1)));
+        assert_eq!(parsed.params[2].name, "param2");
+        assert_eq!(parsed.params[2].value, Token::Address(param2.into()));
     }
 
     #[test]
@@ -1067,17 +1072,17 @@ mod tests {
         };
         let event = get_indexed_event(event, &log);
 
-        assert!(event.inputs.len() == 3);
+        assert_eq!(event.inputs.len(), 3);
 
         // All parameters get indexed since num_indexed_params == total_params
-        assert!(event.inputs.iter().filter(|param| param.indexed).count() == 3);
+        assert_eq!(event.inputs.iter().filter(|param| param.indexed).count(), 3);
         let parsed = event.parse_log(log).unwrap();
 
-        assert!(parsed.params[0].name == "param0");
-        assert!(parsed.params[0].value == Token::Address(param0.into()));
-        assert!(parsed.params[1].name == "param1");
-        assert!(parsed.params[1].value == Token::Uint(U256::from_big_endian(&param1)));
-        assert!(parsed.params[2].name == "param2");
-        assert!(parsed.params[2].value == Token::Address(param2.into()));
+        assert_eq!(parsed.params[0].name, "param0");
+        assert_eq!(parsed.params[0].value, Token::Address(param0.into()));
+        assert_eq!(parsed.params[1].name, "param1");
+        assert_eq!(parsed.params[1].value, Token::Uint(U256::from_big_endian(&param1)));
+        assert_eq!(parsed.params[2].name, "param2");
+        assert_eq!(parsed.params[2].value, Token::Address(param2.into()));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2722
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* turn `Interface` variant into a standalone command
* fix duplicate `struct ` prefix
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
