### PR TITLE
fix(anvil): Fix AccessList generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "memory-db",
  "parking_lot 0.12.0",
  "pretty_assertions",
+ "revm_precompiles",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1585,7 +1585,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1687,9 +1687,10 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "async-trait",
+ "auto_impl 0.5.0",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1711,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1747,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1770,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#6f1d47f3aa972b2dbfd5b20eef37cf1ffb88087c"
+source = "git+https://github.com/gakonst/ethers-rs#71b4893a3dd174025548748592dd7357296f1587"
 dependencies = [
  "cfg-if 1.0.0",
  "colored",
@@ -5102,8 +5103,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.15"
-source = "git+https://github.com/onbjerg/svm-rs?branch=onbjerg/linux-aarch-bump#69ce21dacbf00f5c529e3b49b306608c5e4a43f9"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9da7be4aa3d6b944579b66af0cfdca48f2682de7d5b85cf40449805e2e93db9"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5132,8 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.7"
-source = "git+https://github.com/onbjerg/svm-rs?branch=onbjerg/linux-aarch-bump#69ce21dacbf00f5c529e3b49b306608c5e4a43f9"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d68b31f727e62896d9c1d375f169ca3b4e3ba4c8fa5ab23eaf4de244bb43d3"
 dependencies = [
  "build_const",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,5 +65,3 @@ debug = 0
 
 [patch.crates-io]
 #revm = { path = "../../revm/crates/revm" }
-svm-rs = { git = "https://github.com/onbjerg/svm-rs", branch = "onbjerg/linux-aarch-bump" }
-svm-rs-builds = { git = "https://github.com/onbjerg/svm-rs", branch = "onbjerg/linux-aarch-bump" }

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -38,6 +38,7 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["ws"] }
 trie-db = { version = "0.23" }
 hash-db = { version = "0.15" }
 memory-db = { version = "0.29" }
+revm_precompiles = "1.1.0"
 
 # axum related
 axum = { version = "0.5", features = ["ws"] }

--- a/anvil/src/eth/util.rs
+++ b/anvil/src/eth/util.rs
@@ -1,33 +1,32 @@
-use ethers::types::H160;
+use ethers::abi::Address;
+use forge::revm::SpecId;
 use std::fmt;
 
-macro_rules! precompile_addr {
-    ($idx:expr) => {{
-        H160([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, $idx])
+macro_rules! precompiles_for {
+    ($spec:ident) => {{
+        let precompiles =
+            revm_precompiles::Precompiles::new::<{ SpecId::to_precompile_id(SpecId::$spec) }>();
+        precompiles.as_slice().iter().map(|(a, _)| a).copied().collect()
     }};
 }
 
-/// All ethereum precompiles ref <https://ethereum.github.io/yellowpaper/paper.pdf>
-pub static PRECOMPILES: [H160; 9] = [
-    // ecrecover
-    precompile_addr!(1),
-    // keccak
-    precompile_addr!(2),
-    // ripemd
-    precompile_addr!(3),
-    // identity
-    precompile_addr!(4),
-    // modexp
-    precompile_addr!(5),
-    // ecadd
-    precompile_addr!(6),
-    // ecmul
-    precompile_addr!(7),
-    // ecpairing
-    precompile_addr!(8),
-    // blake2f
-    precompile_addr!(9),
-];
+pub fn get_precompiles_for(spec_id: SpecId) -> Vec<Address> {
+    match spec_id {
+        SpecId::FRONTIER => precompiles_for!(FRONTIER),
+        SpecId::HOMESTEAD => precompiles_for!(HOMESTEAD),
+        SpecId::TANGERINE => precompiles_for!(TANGERINE),
+        SpecId::SPURIOUS_DRAGON => precompiles_for!(SPURIOUS_DRAGON),
+        SpecId::BYZANTIUM => precompiles_for!(BYZANTIUM),
+        SpecId::CONSTANTINOPLE => precompiles_for!(CONSTANTINOPLE),
+        SpecId::PETERSBURG => precompiles_for!(PETERSBURG),
+        SpecId::ISTANBUL => precompiles_for!(ISTANBUL),
+        SpecId::MUIRGLACIER => precompiles_for!(MUIRGLACIER),
+        SpecId::BERLIN => precompiles_for!(BERLIN),
+        SpecId::LONDON => precompiles_for!(LONDON),
+        SpecId::MERGE => precompiles_for!(MERGE),
+        SpecId::LATEST => precompiles_for!(LATEST),
+    }
+}
 
 /// wrapper type that displays byte as hex
 pub struct HexDisplay<'a>(&'a [u8]);

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -275,7 +275,7 @@ where
     pub async fn estimate(&self, builder_output: TxBuilderPeekOutput<'_>) -> Result<U256> {
         let (tx, _) = builder_output;
 
-        let res = self.provider.estimate_gas(tx).await?;
+        let res = self.provider.estimate_gas(tx, None).await?;
 
         Ok::<_, eyre::Error>(res)
     }

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -368,7 +368,7 @@ impl ScriptArgs {
     {
         tx.set_gas(
             provider
-                .estimate_gas(tx)
+                .estimate_gas(tx, None)
                 .await
                 .wrap_err_with(|| format!("Failed to estimate gas for tx: {}", tx.sighash()))
                 .map_err(|err| BroadcastError::Simple(err.to_string()))? *

--- a/evm/src/executor/inspector/access_list.rs
+++ b/evm/src/executor/inspector/access_list.rs
@@ -1,0 +1,96 @@
+use ethers::{
+    abi::{ethereum_types::BigEndianHash, Address},
+    types::{
+        transaction::eip2930::{AccessList, AccessListItem},
+        H256,
+    },
+};
+use hashbrown::{HashMap, HashSet};
+use revm::{opcode, Database, EVMData, Inspector, Interpreter, Return};
+
+/// An inspector that collects touched accounts and storage slots.
+#[derive(Default, Debug)]
+pub struct AccessListTracer {
+    excluded: HashSet<Address>,
+    access_list: HashMap<Address, HashSet<H256>>,
+}
+
+impl AccessListTracer {
+    pub fn new(
+        access_list: AccessList,
+        from: Address,
+        to: Address,
+        precompiles: Vec<Address>,
+    ) -> Self {
+        AccessListTracer {
+            excluded: vec![from, to].iter().chain(precompiles.iter()).copied().collect(),
+            access_list: access_list
+                .0
+                .iter()
+                .map(|v| (v.address, v.storage_keys.iter().copied().collect()))
+                .collect(),
+        }
+    }
+
+    pub fn access_list(&self) -> AccessList {
+        AccessList::from(
+            self.access_list
+                .iter()
+                .map(|(address, slots)| AccessListItem {
+                    address: *address,
+                    storage_keys: slots.iter().copied().collect(),
+                })
+                .collect::<Vec<AccessListItem>>(),
+        )
+    }
+}
+
+impl<DB> Inspector<DB> for AccessListTracer
+where
+    DB: Database,
+{
+    fn step(
+        &mut self,
+        interpreter: &mut Interpreter,
+        _data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        let pc = interpreter.program_counter();
+        let op = interpreter.contract.bytecode.bytecode()[pc];
+
+        match op {
+            opcode::SLOAD | opcode::SSTORE => {
+                if let Ok(slot) = interpreter.stack().peek(0) {
+                    let cur_contract = interpreter.contract.address;
+                    self.access_list
+                        .entry(cur_contract)
+                        .or_default()
+                        .insert(H256::from_uint(&slot));
+                }
+            }
+            opcode::EXTCODECOPY |
+            opcode::EXTCODEHASH |
+            opcode::EXTCODESIZE |
+            opcode::BALANCE |
+            opcode::SELFDESTRUCT => {
+                if let Ok(slot) = interpreter.stack().peek(0) {
+                    let addr: Address = H256::from_uint(&slot).into();
+                    if !self.excluded.contains(&addr) {
+                        self.access_list.entry(addr).or_default();
+                    }
+                }
+            }
+            opcode::DELEGATECALL | opcode::CALL | opcode::STATICCALL | opcode::CALLCODE => {
+                if let Ok(slot) = interpreter.stack().peek(1) {
+                    let addr: Address = H256::from_uint(&slot).into();
+                    if !self.excluded.contains(&addr) {
+                        self.access_list.entry(addr).or_default();
+                    }
+                }
+            }
+            _ => (),
+        }
+
+        Return::Continue
+    }
+}

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -4,6 +4,9 @@ mod utils;
 mod logs;
 pub use logs::LogCollector;
 
+mod access_list;
+pub use access_list::AccessListTracer;
+
 mod tracer;
 pub use tracer::Tracer;
 


### PR DESCRIPTION
## Motivation

The generated AccessList via `createAccessList` RPC call wasn't actually correct:
- It included the `coinbase` address (for which info was fetched, and thus added to the state diff)
- It didn't take into account for the `to` address whether storage was read or not
- The precompiles that should be excluded was a fixed list, not dependent on the fork
- Although not necessarily an issue, it kind of depended on `revm` implementation regarding the returned state-diff, which returned read accounts even though they weren't changed

## Solution

I implemented a custom tracer which checks for some opcodes was address/storage slot will be read/written to.
The trace was implemented based on Geth's one: https://github.com/ethereum/go-ethereum/blob/23ac8df15302bbde098cab6d711abdd24843d66a/eth/tracers/logger/access_list_tracer.go#L140-L160

It also returns the second execution's gas-used, instead of a gas estimation (which should be higher than the gas-used, since it has to include refunds).
