### PR TITLE
feat(forge): verify contracts created inside a call

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  doc:
+  live:
     name: goerli live tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - master
+
+name: live-test
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  doc:
+    name: goerli live tests
+    runs-on: ubuntu-latest
+    env:
+      GOERLI_RPC_URL: https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+      TEST_PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: cargo test
+        run: cargo test --package foundry-cli --test it -- verify::test_live_can_deploy_and_verify --exact --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,9 @@ jobs:
       matrix:
         job:
           - name: non-forking
-            filter: '!test(~fork)'
+            filter: '!test(~fork) & !test(~live)'
           - name: forking
-            filter: 'test(~fork)'
+            filter: 'test(~fork) & !test(~live)'
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:
@@ -85,9 +85,9 @@ jobs:
       matrix:
         job:
           - name: non-forking
-            filter: '!test(~fork)'
+            filter: '!test(~fork) & !test(~live)'
           - name: forking
-            filter: 'test(~fork)'
+            filter: 'test(~fork) & !test(~live)'
         partition: [1, 2]
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
@@ -124,9 +124,9 @@ jobs:
       matrix:
         job:
           - name: non-forking
-            filter: '!test(~fork_integration)'
+            filter: '!test(~fork_integration) & !test(~live)'
           - name: forking
-            filter: 'test(~fork_integration)'
+            filter: 'test(~fork_integration) & !test(~live)'
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
     steps:

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -168,6 +168,24 @@ fn is_git(root: &Path) -> eyre::Result<bool> {
     Ok(is_git.success())
 }
 
+/// Returns the commit hash of the project if it exists
+pub fn get_commit_hash(root: &Path) -> Option<String> {
+    if is_git(root).ok()? {
+        let output = Command::new("git")
+            .args(&["rev-parse", "--short", "HEAD"])
+            .current_dir(&root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .ok()?
+            .wait_with_output()
+            .ok()?;
+
+        return Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+    None
+}
+
 /// Initialises the `root` as git repository if it's not a git repository yet
 fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
     if !is_git(root)? {

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{sequence::AdditionalContract, *};
 use crate::{
     cmd::{
         ensure_clean_constructor,
@@ -136,7 +136,10 @@ impl ScriptArgs {
                         .flat_map(|(_, traces)| {
                             traces.arena.iter().filter_map(|node| {
                                 if node.kind() == CallKind::Create {
-                                    return Some((node.trace.address, node.trace.data.to_raw()))
+                                    return Some(AdditionalContract {
+                                        address: node.trace.address,
+                                        init_code: node.trace.data.to_raw(),
+                                    })
                                 }
                                 None
                             })

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -130,15 +130,18 @@ impl ScriptArgs {
                         )
                     }
 
-                    let mut created_contracts = vec![];
-                    for (_, trace) in &mut result.traces {
-                        trace.arena.iter().for_each(|node| {
-                            if node.kind() == CallKind::Create {
-                                created_contracts
-                                    .push((node.trace.address, node.trace.data.to_raw()));
-                            }
-                        });
-                    }
+                    let created_contracts = result
+                        .traces
+                        .iter()
+                        .flat_map(|(_, traces)| {
+                            traces.arena.iter().filter_map(|node| {
+                                if node.kind() == CallKind::Create {
+                                    return Some((node.trace.address, node.trace.data.to_raw()))
+                                }
+                                None
+                            })
+                        })
+                        .collect();
 
                     // Simulate mining the transaction if the user passes `--slow`.
                     if self.slow {

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -135,8 +135,9 @@ impl ScriptArgs {
                         .iter()
                         .flat_map(|(_, traces)| {
                             traces.arena.iter().filter_map(|node| {
-                                if node.kind() == CallKind::Create {
+                                if matches!(node.kind(), CallKind::Create | CallKind::Create2) {
                                     return Some(AdditionalContract {
+                                        opcode: node.kind(),
                                         address: node.trace.address,
                                         init_code: node.trace.data.to_raw(),
                                     })

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -1,5 +1,5 @@
 use super::{NestedValue, ScriptResult, VerifyBundle};
-use crate::cmd::forge::verify;
+use crate::cmd::forge::verify::{self, VerifyArgs};
 use cast::executor::inspector::DEFAULT_CREATE2_DEPLOYER;
 use ethers::{
     abi::{Abi, Address},
@@ -158,7 +158,7 @@ impl ScriptSequence {
             // Make sure the receipts have the right order first.
             self.sort_receipts();
 
-            'receipts: for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
+            for (receipt, tx) in self.receipts.iter_mut().zip(self.transactions.iter()) {
                 let mut create2_offset = 0;
 
                 if tx.is_create2() {
@@ -166,58 +166,40 @@ impl ScriptSequence {
                     create2_offset = 32;
                 }
 
+                // Verify contract created directly from the transaction
                 if let (Some(contract_address), Some(data)) =
                     (receipt.contract_address, tx.typed_tx().data())
                 {
-                    for (artifact, (_contract, bytecode)) in verify.known_contracts.iter() {
-                        // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
-                        // of the transaction
-                        if data.0.split_at(create2_offset).1.starts_with(bytecode) {
-                            let constructor_args =
-                                data.0.split_at(create2_offset + bytecode.len()).1.to_vec();
-
-                            let contract = ContractInfo {
-                                path: Some(
-                                    artifact
-                                        .source
-                                        .to_str()
-                                        .expect("There should be an artifact.")
-                                        .to_string(),
-                                ),
-                                name: artifact.name.clone(),
-                            };
-
-                            // We strip the build metadadata information, since it can lead to
-                            // etherscan not identifying it correctly. eg:
-                            // `v0.8.10+commit.fc410830.Linux.gcc` != `v0.8.10+commit.fc410830`
-                            let version = Version::new(
-                                artifact.version.major,
-                                artifact.version.minor,
-                                artifact.version.patch,
-                            );
-
-                            let verify = verify::VerifyArgs {
-                                address: contract_address,
-                                contract,
-                                compiler_version: Some(version.to_string()),
-                                constructor_args: Some(hex::encode(&constructor_args)),
-                                num_of_optimizations: verify.num_of_optimizations,
-                                chain: chain.into(),
-                                etherscan_key: Some(etherscan_key.clone()),
-                                flatten: false,
-                                force: false,
-                                watch: true,
-                                retry: verify.retry.clone(),
-                                libraries: self.libraries.clone(),
-                                root: None,
-                                verifier: VerificationProviderType::Etherscan,
-                            };
-
-                            future_verifications.push(verify.run());
-                            continue 'receipts
-                        }
+                    if let Some(verify) = try_verify_contract(
+                        contract_address,
+                        create2_offset,
+                        &data.0,
+                        &verify,
+                        chain,
+                        etherscan_key,
+                        &self.libraries,
+                    ) {
+                        future_verifications.push(verify.run());
+                    } else {
+                        unverifiable_contracts.push(contract_address);
                     }
-                    unverifiable_contracts.push(contract_address);
+                }
+
+                // Verify potential contracts created during the transaction execution
+                for AdditionalContract { address, init_code } in &tx.additional_contracts {
+                    if let Some(verify) = try_verify_contract(
+                        *address,
+                        0,
+                        init_code,
+                        &verify,
+                        chain,
+                        etherscan_key,
+                        &self.libraries,
+                    ) {
+                        future_verifications.push(verify.run());
+                    } else {
+                        unverifiable_contracts.push(*address);
+                    }
                 }
             }
 
@@ -248,11 +230,75 @@ impl ScriptSequence {
     }
 }
 
+/// Given a verify bundle and contract details, it tries to generate a valid `VerifyArgs` to use
+/// against the `contract_address`.
+fn try_verify_contract(
+    contract_address: Address,
+    create2_offset: usize,
+    data: &[u8],
+    verify: &VerifyBundle,
+    chain: u64,
+    etherscan_key: &str,
+    libraries: &[String],
+) -> Option<VerifyArgs> {
+    for (artifact, (_contract, bytecode)) in verify.known_contracts.iter() {
+        // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
+        // of the transaction
+        if data.split_at(create2_offset).1.starts_with(bytecode) {
+            let constructor_args = data.split_at(create2_offset + bytecode.len()).1.to_vec();
+
+            let contract = ContractInfo {
+                path: Some(
+                    artifact.source.to_str().expect("There should be an artifact.").to_string(),
+                ),
+                name: artifact.name.clone(),
+            };
+
+            // We strip the build metadadata information, since it can lead to
+            // etherscan not identifying it correctly. eg:
+            // `v0.8.10+commit.fc410830.Linux.gcc` != `v0.8.10+commit.fc410830`
+            let version = Version::new(
+                artifact.version.major,
+                artifact.version.minor,
+                artifact.version.patch,
+            );
+
+            let verify = verify::VerifyArgs {
+                address: contract_address,
+                contract,
+                compiler_version: Some(version.to_string()),
+                constructor_args: Some(hex::encode(&constructor_args)),
+                num_of_optimizations: verify.num_of_optimizations,
+                chain: chain.into(),
+                etherscan_key: Some(etherscan_key.to_owned()),
+                flatten: false,
+                force: false,
+                watch: true,
+                retry: verify.retry.clone(),
+                libraries: libraries.to_vec(),
+                root: None,
+                verifier: VerificationProviderType::Etherscan,
+            };
+
+            return Some(verify)
+        }
+    }
+    None
+}
+
 impl Drop for ScriptSequence {
     fn drop(&mut self) {
         self.sort_receipts();
         self.save().expect("not able to save deployment sequence");
     }
+}
+
+#[derive(Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AdditionalContract {
+    pub address: Address,
+    #[serde(with = "hex")]
+    pub init_code: Vec<u8>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Default)]
@@ -270,6 +316,7 @@ pub struct TransactionWithMetadata {
     #[serde(default = "default_vec_of_strings")]
     pub arguments: Option<Vec<String>>,
     pub transaction: TypedTransaction,
+    pub additional_contracts: Vec<AdditionalContract>,
 }
 
 fn default_string() -> Option<String> {
@@ -294,9 +341,11 @@ impl TransactionWithMetadata {
         result: &ScriptResult,
         local_contracts: &BTreeMap<Address, (String, &Abi)>,
         decoder: &CallTraceDecoder,
+        additional_contracts: Vec<(Address, Vec<u8>)>,
     ) -> eyre::Result<Self> {
         let mut metadata = Self { transaction, ..Default::default() };
 
+        // Specify if any contract was directly created with this transaction
         if let Some(NameOrAddress::Address(to)) = metadata.transaction.to().cloned() {
             if to == DEFAULT_CREATE2_DEPLOYER {
                 metadata.set_create(true, Address::from_slice(&result.returned), local_contracts)
@@ -310,6 +359,21 @@ impl TransactionWithMetadata {
                 local_contracts,
             );
         }
+
+        // Add the additional contracts created in this transaction, so we can verify them later
+        if let Some(tx_address) = metadata.contract_address {
+            metadata.additional_contracts = additional_contracts
+                .into_iter()
+                .filter_map(|(address, init_code)| {
+                    if address != tx_address {
+                        Some(AdditionalContract { address, init_code })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        }
+
         Ok(metadata)
     }
 

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -170,7 +170,7 @@ impl ScriptSequence {
                 if let (Some(contract_address), Some(data)) =
                     (receipt.contract_address, tx.typed_tx().data())
                 {
-                    if let Some(verify) = try_verify_contract(
+                    if let Some(verify) = get_verify_args(
                         contract_address,
                         create2_offset,
                         &data.0,
@@ -187,7 +187,7 @@ impl ScriptSequence {
                 // Verify potential contracts created during the transaction execution
                 for AdditionalContract { address, init_code } in &tx.additional_contracts {
                     if let Some(verify) =
-                        try_verify_contract(*address, 0, init_code, &verify, chain, &self.libraries)
+                        get_verify_args(*address, 0, init_code, &verify, chain, &self.libraries)
                     {
                         future_verifications.push(verify.run());
                     } else {
@@ -225,7 +225,7 @@ impl ScriptSequence {
 
 /// Given a verify bundle and contract details, it tries to generate a valid `VerifyArgs` to use
 /// against the `contract_address`.
-fn try_verify_contract(
+fn get_verify_args(
     contract_address: Address,
     create2_offset: usize,
     data: &[u8],

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -329,7 +329,7 @@ impl TransactionWithMetadata {
         result: &ScriptResult,
         local_contracts: &BTreeMap<Address, (String, &Abi)>,
         decoder: &CallTraceDecoder,
-        additional_contracts: Vec<(Address, Vec<u8>)>,
+        additional_contracts: Vec<AdditionalContract>,
     ) -> eyre::Result<Self> {
         let mut metadata = Self { transaction, ..Default::default() };
 
@@ -348,13 +348,14 @@ impl TransactionWithMetadata {
             );
         }
 
-        // Add the additional contracts created in this transaction, so we can verify them later
+        // Add the additional contracts created in this transaction, so we can verify them later.
         if let Some(tx_address) = metadata.contract_address {
             metadata.additional_contracts = additional_contracts
                 .into_iter()
-                .filter_map(|(address, init_code)| {
-                    if address != tx_address {
-                        Some(AdditionalContract { address, init_code })
+                .filter_map(|contract| {
+                    // Filter out the transaction contract repeated init_code.
+                    if contract.address != tx_address {
+                        Some(contract)
                     } else {
                         None
                     }

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -277,12 +277,7 @@ fn get_verify_args(
                 constructor_args: Some(hex::encode(&constructor_args)),
                 num_of_optimizations: verify.num_of_optimizations,
                 chain: chain.into(),
-                etherscan_key: Some(
-                    verify
-                        .etherscan_key
-                        .clone()
-                        .expect("Should have already verified key existence."),
-                ),
+                etherscan_key: verify.etherscan_key.clone(),
                 flatten: false,
                 force: false,
                 watch: true,

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -195,10 +195,13 @@ impl ScriptSequence {
 
             self.check_unverified(unverifiable_contracts, verify);
 
-            println!("##\nStart verification for ({}) contracts", future_verifications.len());
+            let num_verifications = future_verifications.len();
+            println!("##\nStart verification for ({num_verifications}) contracts",);
             for verification in future_verifications {
                 verification.await?;
             }
+
+            println!("All ({num_verifications}) contracts were verified!");
         }
 
         Ok(())

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -195,7 +195,7 @@ impl ScriptSequence {
 
             self.check_unverified(unverifiable_contracts, verify);
 
-            println!("##\nStart Contract Verification");
+            println!("##\nStart verification for ({}) contracts", future_verifications.len());
             for verification in future_verifications {
                 verification.await?;
             }

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -155,7 +155,9 @@ impl EtherscanVerificationProvider {
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
     async fn create_verify_request(&self, args: &VerifyArgs) -> eyre::Result<VerifyContract> {
-        let config = args.load_config_emit_warnings();
+        let mut config = args.load_config_emit_warnings();
+        config.libraries.extend(args.libraries.clone());
+
         let project = config.project()?;
 
         if args.contract.path.is_none() && !config.cache {

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -40,7 +40,9 @@ pub struct SourcifyVerificationProvider;
 #[async_trait]
 impl VerificationProvider for SourcifyVerificationProvider {
     async fn verify(&self, args: VerifyArgs) -> eyre::Result<()> {
-        let config = args.load_config_emit_warnings();
+        let mut config = args.load_config_emit_warnings();
+        config.libraries.extend(args.libraries.clone());
+
         let project = config.project()?;
 
         if !config.cache {

--- a/cli/tests/fixtures/ScriptVerify.sol
+++ b/cli/tests/fixtures/ScriptVerify.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.16;
+
+import {Unique} from "./unique.sol";
+
+interface HEVM {
+    function startBroadcast() external;
+}
+
+library F {
+    function f() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+library C {
+    function c() public pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract Hello {
+    function world() public {
+        F.f();
+        C.c();
+    }
+}
+
+contract CC1 is Unique {
+    uint256 a;
+
+    constructor(uint256 _a) {
+        a = _a;
+    }
+}
+
+contract CC2 is Unique {
+    uint8 b;
+
+    constructor(uint256 _b) {
+        b = uint8(_b);
+        new CC3("hello");
+    }
+}
+
+contract CC3 is Unique {
+    string c;
+
+    constructor(string memory _c) {
+        c = _c;
+    }
+}
+
+contract InnerContracts is Unique {
+    constructor(uint256 _a) public {
+        CC1 c1 = new CC1(_a);
+    }
+
+    function c2(uint256 _b) public {
+        CC2 c2 = new CC2{salt: bytes32(uint256(1))}(_b);
+    }
+}
+
+contract ScriptVerify {
+    function run() public {
+        address vm = address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+        HEVM(vm).startBroadcast();
+        new Hello();
+        InnerContracts contracts = new InnerContracts(1);
+        contracts.c2(3);
+    }
+}

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -2,11 +2,14 @@
 //! and sourcify
 
 use crate::utils::{self, EnvExternalities};
+use ethers::solc::artifacts::BytecodeHash;
 use foundry_cli_test_utils::{
-    forgetest,
+    forgetest, forgetest_async,
     util::{TestCommand, TestProject},
 };
+use foundry_config::Config;
 use foundry_utils::Retry;
+use std::{fs, path::PathBuf};
 
 const VERIFICATION_PROVIDERS: &'static [&'static str] = &["etherscan", "sourcify"];
 
@@ -300,5 +303,66 @@ forgetest!(
 
             parse_verification_result(&mut cmd, 1).expect("Failed to verify check")
         }
+    }
+);
+
+// tests `script --verify` by deploying on goerli and verifying live goerli etherscan
+// Uses predeployed libs and contract creations inside constructors and calls
+forgetest_async!(
+    test_live_can_deploy_and_verify,
+    |prj: TestProject, mut cmd: TestCommand| async move {
+        let info = EnvExternalities::goerli().expect("Goerli secrets not set.");
+
+        add_unique(&prj);
+
+        prj.inner()
+            .add_source(
+                "ScriptVerify.sol",
+                fs::read_to_string(
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                        .join("tests/fixtures/ScriptVerify.sol"),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        // explicitly byte code hash for consistent checks
+        let config = Config { bytecode_hash: BytecodeHash::None, ..Default::default() };
+        prj.write_config(config);
+
+        let contract_path = "src/ScriptVerify.sol:ScriptVerify";
+        cmd.args(vec![
+            "script",
+            "--rpc-url",
+            &info.rpc,
+            "--private-key",
+            &info.pk,
+            "--broadcast",
+            "-vvvv",
+            "--optimize",
+            "--verify",
+            "--optimizer-runs",
+            "200",
+            "--use",
+            "0.8.16",
+            "--retries",
+            "10",
+            "--delay",
+            "20",
+            contract_path,
+        ]);
+
+        let output = cmd.unchecked_output();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            stdout.contains("All (7) contracts were verified!"),
+            "{}",
+            format!(
+                "Failed to get verification, stdout: {}, stderr: {}",
+                stdout,
+                String::from_utf8_lossy(&output.stderr)
+            )
+        );
     }
 );

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -306,7 +306,7 @@ forgetest!(
     }
 );
 
-// tests `script --verify` by deploying on goerli and verifying live goerli etherscan
+// tests `script --verify` by deploying on goerli and verifying it on etherscan
 // Uses predeployed libs and contract creations inside constructors and calls
 forgetest_async!(
     test_live_can_deploy_and_verify,

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -137,7 +137,7 @@ where
             get_create_address(call, nonce),
             call.init_code.to_vec(),
             call.value,
-            CallKind::Create,
+            call.scheme.into(),
             call.caller,
         );
 

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -47,12 +47,14 @@ pub const TEST_CONTRACT_ADDRESS: Address = H160([
 ]);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum CallKind {
     Call,
     StaticCall,
     CallCode,
     DelegateCall,
     Create,
+    Create2,
 }
 
 impl Default for CallKind {
@@ -73,8 +75,11 @@ impl From<CallScheme> for CallKind {
 }
 
 impl From<CreateScheme> for CallKind {
-    fn from(_: CreateScheme) -> Self {
-        CallKind::Create
+    fn from(create: CreateScheme) -> Self {
+        match create {
+            CreateScheme::Create => CallKind::Create,
+            CreateScheme::Create2 { .. } => CallKind::Create2,
+        }
     }
 }
 
@@ -85,6 +90,7 @@ impl From<CallKind> for ActionType {
                 ActionType::Call
             }
             CallKind::Create => ActionType::Create,
+            CallKind::Create2 => ActionType::Create,
         }
     }
 }
@@ -97,6 +103,7 @@ impl From<CallKind> for CallType {
             CallKind::CallCode => CallType::CallCode,
             CallKind::DelegateCall => CallType::DelegateCall,
             CallKind::Create => CallType::None,
+            CallKind::Create2 => CallType::None,
         }
     }
 }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -330,7 +330,7 @@ pub struct CallTrace {
 impl CallTrace {
     /// Whether this is a contract creation or not
     pub fn created(&self) -> bool {
-        matches!(self.kind, CallKind::Create)
+        matches!(self.kind, CallKind::Create | CallKind::Create2)
     }
 }
 

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -306,7 +306,7 @@ pub struct CallTrace {
     pub label: Option<String>,
     /// caller of this call
     pub caller: Address,
-    /// The destination address of the call
+    /// The destination address of the call or the address from the created contract
     pub address: Address,
     /// The kind of call this is
     pub kind: CallKind,

--- a/evm/src/trace/node.rs
+++ b/evm/src/trace/node.rs
@@ -53,7 +53,7 @@ impl CallTraceNode {
                     output: self.trace.output.to_raw().into(),
                 })
             }
-            CallKind::Create => Res::Create(CreateResult {
+            CallKind::Create | CallKind::Create2 => Res::Create(CreateResult {
                 gas_used: self.trace.gas_cost.into(),
                 code: self.trace.output.to_raw().into(),
                 address: self.trace.address,
@@ -82,7 +82,7 @@ impl CallTraceNode {
                     call_type: self.kind().into(),
                 })
             }
-            CallKind::Create => Action::Create(Create {
+            CallKind::Create | CallKind::Create2 => Action::Create(Create {
                 from: self.trace.caller,
                 value: self.trace.value,
                 gas: self.trace.gas_cost.into(),

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -370,7 +370,7 @@ impl Tui {
     ) {
         let block_source_code = Block::default()
             .title(match call_kind {
-                CallKind::Create => "Contract creation",
+                CallKind::Create | CallKind::Create2 => "Contract creation",
                 CallKind::Call => "Contract call",
                 CallKind::StaticCall => "Contract staticcall",
                 CallKind::CallCode => "Contract callcode",
@@ -384,17 +384,19 @@ impl Tui {
             if let Some(known) = known_contracts.get(contract_name) {
                 let pc_ic_map = pc_ic_maps.get(contract_name);
                 // grab either the creation source map or runtime sourcemap
-                if let Some((sourcemap, ic)) = if matches!(call_kind, CallKind::Create) {
-                    known.bytecode.source_map().zip(pc_ic_map.and_then(|(c, _)| c.get(&pc)))
-                } else {
-                    known
-                        .deployed_bytecode
-                        .bytecode
-                        .as_ref()
-                        .expect("no bytecode")
-                        .source_map()
-                        .zip(pc_ic_map.and_then(|(_, r)| r.get(&pc)))
-                } {
+                if let Some((sourcemap, ic)) =
+                    if matches!(call_kind, CallKind::Create | CallKind::Create2) {
+                        known.bytecode.source_map().zip(pc_ic_map.and_then(|(c, _)| c.get(&pc)))
+                    } else {
+                        known
+                            .deployed_bytecode
+                            .bytecode
+                            .as_ref()
+                            .expect("no bytecode")
+                            .source_map()
+                            .zip(pc_ic_map.and_then(|(_, r)| r.get(&pc)))
+                    }
+                {
                     match sourcemap {
                         Ok(sourcemap) => {
                             // we are handed a vector of SourceElements that give


### PR DESCRIPTION
## Motivation

Identifies and verifies contracts created during a `call` or `deploy`.
ref https://github.com/foundry-rs/foundry/issues/2518#issuecomment-1199961233

## Solution

Since we recently enabled the traces for all scripts, independently of verbosity, we can get all the contracts through `CallKind::Create` and `CallKind::Create2` traces.

Also:
* Fix verification regression where libraries were not being used. And thus, failing any contract verification that required them
* Added a CI job that only happens on push to master since it requires the following repository secrets: `${{ secrets.ETHERSCAN_API_KEY }}` `${{ secrets.TEST_PRIVATE_KEY }}`. It deploys and verifies a script which uses predeployed libraries and contracts create inside contracts.
