### PR TITLE
fix(forge): remove metadata requirement for sourcify verifier

### DIFF
--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, fs, path::PathBuf};
 
 use async_trait::async_trait;
 use cast::SimpleCast;
-use ethers::solc::artifacts::output_selection::ContractOutputSelection;
 use foundry_utils::Retry;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -47,10 +47,6 @@ impl VerificationProvider for SourcifyVerificationProvider {
             eyre::bail!("Cache is required for sourcify verification.")
         }
 
-        if !config.extra_output_files.contains(&ContractOutputSelection::Metadata) {
-            eyre::bail!("Metadata is required for sourcify verification. Try adding `extra_output_files = [\"metadata\"]` to `foundry.toml`")
-        }
-
         let cache = project.read_cache_file()?;
         let (path, entry) = crate::cmd::get_cached_entry_by_name(&cache, &args.contract.name)?;
 


### PR DESCRIPTION
metadata is outputted by default now #2798 