### PR TITLE
fix(anvil): accept hex for evm_setNextBlockTimestamp

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -354,9 +354,9 @@ pub enum EthRequest {
     #[serde(
         rename = "anvil_setNextBlockTimestamp",
         alias = "evm_setNextBlockTimestamp",
-        with = "sequence"
+        deserialize_with = "deserialize_number_seq"
     )]
-    EvmSetNextBlockTimeStamp(u64),
+    EvmSetNextBlockTimeStamp(U256),
 
     /// Set the exact gas limit that you want in the next block
     #[serde(
@@ -820,6 +820,9 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
         let s = r#"{"method": "evm_setNextBlockTimestamp", "params": [100]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+        let s = r#"{"method": "evm_setNextBlockTimestamp", "params": ["0x64e0f308"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -292,7 +292,7 @@ impl EthApi {
             EthRequest::EvmRevert(id) => self.evm_revert(id).await.to_rpc_result(),
             EthRequest::EvmIncreaseTime(time) => self.evm_increase_time(time).await.to_rpc_result(),
             EthRequest::EvmSetNextBlockTimeStamp(time) => {
-                self.evm_set_next_block_timestamp(time).to_rpc_result()
+                self.evm_set_next_block_timestamp(time.as_u64()).to_rpc_result()
             }
             EthRequest::EvmSetBlockGasLimit(gas_limit) => {
                 self.evm_set_block_gas_limit(gas_limit).to_rpc_result()

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -292,7 +292,10 @@ impl EthApi {
             EthRequest::EvmRevert(id) => self.evm_revert(id).await.to_rpc_result(),
             EthRequest::EvmIncreaseTime(time) => self.evm_increase_time(time).await.to_rpc_result(),
             EthRequest::EvmSetNextBlockTimeStamp(time) => {
-                self.evm_set_next_block_timestamp(time.as_u64()).to_rpc_result()
+                match u64::try_from(time).map_err(BlockchainError::UintConversion) {
+                    Ok(time) => self.evm_set_next_block_timestamp(time).to_rpc_result(),
+                    err @ Err(_) => err.to_rpc_result(),
+                }
             }
             EthRequest::EvmSetBlockGasLimit(gas_limit) => {
                 self.evm_set_block_gas_limit(gas_limit).to_rpc_result()

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -64,6 +64,8 @@ pub enum BlockchainError {
     DataUnavailable,
     #[error("Trie error: {0}")]
     TrieError(String),
+    #[error("{0}")]
+    UintConversion(&'static str),
 }
 
 impl From<RpcError> for BlockchainError {
@@ -247,6 +249,7 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 err @ BlockchainError::TrieError(_) => {
                     RpcError::internal_error_with(err.to_string())
                 }
+                BlockchainError::UintConversion(err) => RpcError::invalid_params(err),
             }
             .into(),
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
hardhat will send evm_setNextBlockTimestamp as hex
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
support any numeric variant for `evm_setNextBlockTimestamp`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
