### PR TITLE
fix(anvil): always exit on ctrl-c

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -189,8 +189,8 @@ impl NodeArgs {
                 fork.database.read().await.flush_cache();
                 // cleaning up and shutting down
                 // this will make sure that the fork RPC cache is flushed if caching is configured
-                std::process::exit(0);
             }
+            std::process::exit(0);
         });
 
         ctrlc::set_handler(move || {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the `std::process::exit(0);` installed via the ctrl-c handler only fired in forking mode
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
always exist
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
