### PR TITLE
fix(anvil): poll receiver until pending

### DIFF
--- a/anvil/src/filter.rs
+++ b/anvil/src/filter.rs
@@ -94,7 +94,13 @@ impl Filters {
         trace!(target: "node::filter", "Evicting stale filters");
         let now = Instant::now();
         let mut active_filters = self.active_filters.lock().await;
-        active_filters.retain(|_, (_, deadline)| *deadline > now);
+        active_filters.retain(|id, (_, deadline)| {
+            if now > *deadline {
+                trace!(target: "node::filter",?id, "Evicting stale filter");
+                return false
+            }
+            true
+        });
     }
 }
 

--- a/anvil/src/pubsub.rs
+++ b/anvil/src/pubsub.rs
@@ -47,7 +47,14 @@ impl LogsSubscription {
                 let b = self.storage.block(block.hash);
                 let receipts = self.storage.receipts(block.hash);
                 if let (Some(receipts), Some(block)) = (receipts, b) {
-                    self.queued.extend(filter_logs(block, receipts, &self.filter))
+                    let logs = filter_logs(block, receipts, &self.filter);
+                    if logs.is_empty() {
+                        // this ensures we poll the until it is pending, in which case the
+                        // underlying `UnboundedReceiver` will register the new waker, see
+                        // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
+                        continue
+                    }
+                    self.queued.extend(logs)
                 }
             } else {
                 return Poll::Ready(None)
@@ -98,18 +105,21 @@ impl EthSubscription {
         match self {
             EthSubscription::Logs(listener) => listener.poll(cx),
             EthSubscription::Header(blocks, storage, id) => {
-                if let Some(block) = ready!(blocks.poll_next_unpin(cx)) {
-                    if let Some(block) = storage.eth_block(block.hash) {
-                        let params = EthSubscriptionParams {
-                            subscription: id.clone(),
-                            result: to_rpc_result(block),
-                        };
-                        Poll::Ready(Some(EthSubscriptionResponse::new(params)))
+                // this loop ensures we poll the until it is pending, in which case the underlying
+                // `UnboundedReceiver` will register the new waker, see
+                // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
+                loop {
+                    if let Some(block) = ready!(blocks.poll_next_unpin(cx)) {
+                        if let Some(block) = storage.eth_block(block.hash) {
+                            let params = EthSubscriptionParams {
+                                subscription: id.clone(),
+                                result: to_rpc_result(block),
+                            };
+                            return Poll::Ready(Some(EthSubscriptionResponse::new(params)))
+                        }
                     } else {
-                        Poll::Pending
+                        return Poll::Ready(None)
                     }
-                } else {
-                    Poll::Ready(None)
                 }
             }
             EthSubscription::PendingTransactions(tx, id) => {

--- a/anvil/src/pubsub.rs
+++ b/anvil/src/pubsub.rs
@@ -49,7 +49,7 @@ impl LogsSubscription {
                 if let (Some(receipts), Some(block)) = (receipts, b) {
                     let logs = filter_logs(block, receipts, &self.filter);
                     if logs.is_empty() {
-                        // this ensures we poll the until it is pending, in which case the
+                        // this ensures we poll the receiver until it is pending, in which case the
                         // underlying `UnboundedReceiver` will register the new waker, see
                         // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
                         continue
@@ -105,8 +105,8 @@ impl EthSubscription {
         match self {
             EthSubscription::Logs(listener) => listener.poll(cx),
             EthSubscription::Header(blocks, storage, id) => {
-                // this loop ensures we poll the until it is pending, in which case the underlying
-                // `UnboundedReceiver` will register the new waker, see
+                // this loop ensures we poll the receiver until it is pending, in which case the
+                // underlying `UnboundedReceiver` will register the new waker, see
                 // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
                 loop {
                     if let Some(block) = ready!(blocks.poll_next_unpin(cx)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The `NewBlockNotification` stream is an `UnboundedReceiver` which poll_next fn looks like

```rust
        match self.next_message() {
            Poll::Ready(msg) => {
                if msg.is_none() {
                    self.inner = None;
                }
                Poll::Ready(msg)
            }
            Poll::Pending => {
                // There are no messages to read, in this case, park.
                self.inner.as_ref().unwrap().recv_task.register(cx.waker());
                // Check queue again after parking to prevent race condition:
                // a message could be added to the queue after previous `next_message`
                // before `register` call.
                self.next_message()
            }
        }

```

this means only if the receiver half of the channel is pending is the new waker registered.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

always poll `NewBlockNotification` until it's pending in subscriptions this prevents cases where the `NewBlockNotification` returns `Ready(Some)` but the eth sub stream returns `Pending`, e.g. if the filter didn't match

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
