### PR TITLE
feat(forge): add `excludeSenders()` on invariant testing

### DIFF
--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -1,7 +1,8 @@
 use super::{
-    assert_invariants, filters::ArtifactFilters, BasicTxDetails, FuzzRunIdentifiedContracts,
-    InvariantContract, InvariantFuzzError, InvariantFuzzTestResult, InvariantTestOptions,
-    RandomCallGenerator, TargetedContracts,
+    assert_invariants,
+    filters::{ArtifactFilters, SenderFilters},
+    BasicTxDetails, FuzzRunIdentifiedContracts, InvariantContract, InvariantFuzzError,
+    InvariantFuzzTestResult, InvariantTestOptions, RandomCallGenerator, TargetedContracts,
 };
 use crate::{
     executor::{
@@ -378,9 +379,9 @@ impl<'a> InvariantExecutor<'a> {
         &self,
         invariant_address: Address,
         abi: &Abi,
-    ) -> eyre::Result<(Vec<Address>, TargetedContracts)> {
-        let [senders, selected, excluded] =
-            ["targetSenders", "targetContracts", "excludeContracts"]
+    ) -> eyre::Result<(SenderFilters, TargetedContracts)> {
+        let [targeted_senders, excluded_senders, selected, excluded] =
+            ["targetSenders", "excludeSenders", "targetContracts", "excludeContracts"]
                 .map(|method| self.get_list::<Address>(invariant_address, abi, method));
 
         let mut contracts: TargetedContracts = self
@@ -403,7 +404,7 @@ impl<'a> InvariantExecutor<'a> {
 
         self.select_selectors(invariant_address, abi, &mut contracts)?;
 
-        Ok((senders, contracts))
+        Ok((SenderFilters::new(targeted_senders, excluded_senders), contracts))
     }
 
     /// Selects the functions to fuzz based on the contract method `targetSelectors()` and

--- a/evm/src/fuzz/invariant/filters.rs
+++ b/evm/src/fuzz/invariant/filters.rs
@@ -1,6 +1,6 @@
 use crate::utils::get_function;
 use ethers::{
-    abi::{Abi, FixedBytes, Function},
+    abi::{Abi, Address, FixedBytes, Function},
     solc::ArtifactId,
 };
 use std::collections::BTreeMap;
@@ -48,5 +48,28 @@ impl ArtifactFilters {
         }
 
         Ok(None)
+    }
+}
+
+/// Filter for acceptable senders to use for invariant testing. Exclusion takes priority if
+/// clashing.
+///
+/// `address(0)` is excluded by default.
+#[derive(Default)]
+pub struct SenderFilters {
+    pub targeted: Vec<Address>,
+    pub excluded: Vec<Address>,
+}
+
+impl SenderFilters {
+    pub fn new(mut targeted: Vec<Address>, mut excluded: Vec<Address>) -> Self {
+        let addr_0 = Address::zero();
+        if !excluded.contains(&addr_0) {
+            excluded.push(addr_0);
+        }
+
+        targeted.retain(|addr| !excluded.contains(addr));
+
+        SenderFilters { targeted, excluded }
     }
 }

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -3,7 +3,7 @@ use crate::{fuzz::*, CALLER};
 mod error;
 use error::*;
 mod filters;
-pub use filters::ArtifactFilters;
+pub use filters::{ArtifactFilters, SenderFilters};
 mod call_override;
 pub use call_override::{set_up_inner_replay, RandomCallGenerator};
 mod executor;

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -45,6 +45,9 @@ fn test_invariant() {
                 vec![("invariantTrueWorld", false, Some("false world.".into()), None, None)],
             ),
             (
+                "fuzz/invariant/target/ExcludeSenders.t.sol:ExcludeSenders",
+                vec![("invariantTrueWorld", true, None, None, None)],
+            )(
                 "fuzz/invariant/target/TargetSelectors.t.sol:TargetSelectors",
                 vec![("invariantTrueWorld", true, None, None, None)],
             ),

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -47,7 +47,8 @@ fn test_invariant() {
             (
                 "fuzz/invariant/target/ExcludeSenders.t.sol:ExcludeSenders",
                 vec![("invariantTrueWorld", true, None, None, None)],
-            )(
+            ),
+            (
                 "fuzz/invariant/target/TargetSelectors.t.sol:TargetSelectors",
                 vec![("invariantTrueWorld", true, None, None, None)],
             ),

--- a/testdata/fuzz/invariant/target/ExcludeSenders.t.sol
+++ b/testdata/fuzz/invariant/target/ExcludeSenders.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+
+contract Hello {
+    address seed_address = address(0xdeadbeef);
+    bool public world = true;
+
+    function changeBeef() public {
+        require(msg.sender == address(0xdeadbeef));
+        world = false;
+    }
+
+    // address(0) should be automatically excluded
+    function change0() public {
+        require(msg.sender == address(0));
+        world = false;
+    }
+}
+
+contract ExcludeSenders is DSTest {
+    Hello hello;
+
+    function setUp() public {
+        hello = new Hello();
+    }
+
+    function excludeSenders() public returns (address[] memory) {
+        address[] memory addrs = new address[](1);
+        addrs[0] = address(0xdeadbeef);
+        return addrs;
+    }
+
+    function invariantTrueWorld() public {
+        require(hello.world() == true, "false world.");
+    }
+}

--- a/testdata/fuzz/invariant/target/ExcludeSenders.t.sol
+++ b/testdata/fuzz/invariant/target/ExcludeSenders.t.sol
@@ -32,6 +32,13 @@ contract ExcludeSenders is DSTest {
         return addrs;
     }
 
+    // Tests clashing. Exclusion takes priority.
+    function targetSenders() public returns (address[] memory) {
+        address[] memory addrs = new address[](1);
+        addrs[0] = address(0xdeadbeef);
+        return addrs;
+    }
+
     function invariantTrueWorld() public {
         require(hello.world() == true, "false world.");
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

It's important to have a way to exclude senders. 


## Solution

Similar to other filter methods: `excludeSenders()`. Exclusion takes priority on clashing.

`address(0)` is excluded by default (should we add more?)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
