### PR TITLE
fix(forge): decode traces when an onchain simulation fails

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -220,8 +220,7 @@ impl ScriptArgs {
                     .await
                     .map_err(|_| {
                         eyre::eyre!(
-                            "One or more transactions failed when simulating the
-                    on-chain version. Check the trace by re-running with `-vvv`"
+                            "Transaction failed when running the on-chain simulation. Check the trace above for more information."
                         )
                     })?
                 };

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -170,7 +170,9 @@ impl ScriptRunner {
                 Ok(DeployResult { address, gas, logs, traces, debug }) => {
                     (address, gas, logs, traces, debug)
                 }
-                Err(EvmError::Execution { traces, gas, logs, debug, .. }) => {
+                Err(EvmError::Execution { reason, traces, gas, logs, debug, .. }) => {
+                    println!("{}", Paint::red(format!("\nFailed with `{reason}`:\n")));
+
                     (Address::zero(), gas, logs, traces, debug)
                 }
                 e => eyre::bail!("Unrecoverable error: {:?}", e),

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -161,16 +161,24 @@ impl ScriptRunner {
         if let Some(NameOrAddress::Address(to)) = to {
             self.call(from, to, calldata.unwrap_or_default(), value.unwrap_or(U256::zero()), true)
         } else if to.is_none() {
-            let DeployResult { address, gas, logs, traces, debug } = self.executor.deploy(
+            let (address, gas, logs, traces, debug) = match self.executor.deploy(
                 from,
                 calldata.expect("No data for create transaction").0,
                 value.unwrap_or(U256::zero()),
                 None,
-            )?;
+            ) {
+                Ok(DeployResult { address, gas, logs, traces, debug }) => {
+                    (address, gas, logs, traces, debug)
+                }
+                Err(EvmError::Execution { traces, gas, logs, debug, .. }) => {
+                    (Address::zero(), gas, logs, traces, debug)
+                }
+                e => eyre::bail!("Unrecoverable error: {:?}", e),
+            };
 
             Ok(ScriptResult {
                 returned: bytes::Bytes::new(),
-                success: true,
+                success: address != Address::zero(),
                 gas,
                 logs,
                 traces: traces


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #2865 


## Solution

Doesn't panic, and decodes traces when an onchain simulation fails. Also, it fails early instead of going through the rest of transactions.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
