### PR TITLE
fix: use revm patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.9.0"
-source = "git+https://github.com/bluealloy/revm#1069e3f689db756170e0e2fc4d148a8226dc135b"
+source = "git+https://github.com/bluealloy/revm#97b16315c307e8ace22a56f4d2a574216fea77de"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "1.1.0"
-source = "git+https://github.com/bluealloy/revm#1069e3f689db756170e0e2fc4d148a8226dc135b"
+source = "git+https://github.com/bluealloy/revm#97b16315c307e8ace22a56f4d2a574216fea77de"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.9.0"
-source = "git+https://github.com/bluealloy/revm#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
+source = "git+https://github.com/bluealloy/revm#1069e3f689db756170e0e2fc4d148a8226dc135b"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "1.1.0"
-source = "git+https://github.com/bluealloy/revm#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
+source = "git+https://github.com/bluealloy/revm#1069e3f689db756170e0e2fc4d148a8226dc135b"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "memory-db",
  "parking_lot 0.12.0",
  "pretty_assertions",
- "revm_precompiles",
+ "revm_precompiles 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "thiserror",
@@ -4401,8 +4401,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab402ae244afdd560b2aa710df5af557bc791b1cca6fec174ced0cf781e13134"
+source = "git+https://github.com/bluealloy/revm#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4411,7 +4410,7 @@ dependencies = [
  "hex",
  "num_enum",
  "primitive-types",
- "revm_precompiles",
+ "revm_precompiles 1.1.0 (git+https://github.com/bluealloy/revm)",
  "rlp",
  "serde",
  "sha3",
@@ -4424,11 +4423,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af88e7e9feb30cc4ed64645f09b966e84a1f6be56551ce5f1691105def45705d"
 dependencies = [
  "bytes",
+ "num 0.4.0",
+ "primitive-types",
+ "ripemd",
+ "secp256k1 0.23.4",
+ "sha2 0.10.2",
+ "sha3",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm_precompiles"
+version = "1.1.0"
+source = "git+https://github.com/bluealloy/revm#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
+dependencies = [
+ "bytes",
  "k256",
  "num 0.4.0",
  "primitive-types",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.24.0",
  "sha2 0.10.2",
  "sha3",
  "substrate-bn",
@@ -4663,6 +4677,15 @@ name = "secp256k1"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ece73253dd9e1fb540ff324eae554113a31c25fb598d22fd13b088a6a03f90d"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
  "secp256k1-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ debug = 0
 
 [patch.crates-io]
 #revm = { path = "../../revm/crates/revm" }
+revm = { git = "https://github.com/bluealloy/revm" }

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -50,7 +50,7 @@ use ethers::{
 };
 use forge::{
     executor::inspector::AccessListTracer,
-    revm::{return_ok, return_revert, BlockEnv, Return},
+    revm::{return_ok, return_revert, BlockEnv, ExecutionResult, Return},
 };
 use foundry_evm::{
     decode::decode_revert,
@@ -555,9 +555,10 @@ impl Backend {
         let mut evm = revm::EVM::new();
         evm.env = env;
         evm.database(&*db);
-        let out = evm.inspect_ref(&mut inspector);
+        let (ExecutionResult { exit_reason, out, gas_used, logs, .. }, state) =
+            evm.inspect_ref(&mut inspector);
         inspector.print_logs();
-        out
+        (exit_reason, out, gas_used, state, logs)
     }
 
     /// Creates the pending block
@@ -814,9 +815,10 @@ impl Backend {
         let mut evm = revm::EVM::new();
         evm.env = self.build_call_env(request, fee_details, block_env);
         evm.database(state);
-        let (exit, out, gas, state, _) = evm.inspect_ref(&mut inspector);
+        let (ExecutionResult { exit_reason, out, gas_used, .. }, state) =
+            evm.inspect_ref(&mut inspector);
         inspector.print_logs();
-        Ok((exit, out, gas, state))
+        Ok((exit_reason, out, gas_used, state))
     }
 
     pub fn build_access_list_with_state<D>(
@@ -845,9 +847,9 @@ impl Backend {
         let mut evm = revm::EVM::new();
         evm.env = self.build_call_env(request, fee_details, block_env);
         evm.database(state);
-        let (exit, out, gas, _, _) = evm.inspect_ref(&mut tracer);
+        let (ExecutionResult { exit_reason, out, gas_used, .. }, _) = evm.inspect_ref(&mut tracer);
         let access_list = tracer.access_list();
-        Ok((exit, out, gas, access_list))
+        Ok((exit_reason, out, gas_used, access_list))
     }
 
     /// returns all receipts for the given transactions

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -850,7 +850,7 @@ async fn test_tx_access_list() {
 /// returns a String representation of the AccessList, with sorted
 /// keys (address) and storage slots
 fn access_list_to_sorted_string(a: AccessList) -> String {
-    let mut a = a.0.clone();
+    let mut a = a.0;
     a.sort_by_key(|v| v.address);
 
     let a = a

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -139,24 +139,29 @@ impl RunArgs {
                 if let Some(to) = tx.to {
                     env.tx.transact_to = TransactTo::Call(to);
                     let RawCallResult {
-                        reverted, gas, traces, debug: run_debug, status: _, ..
+                        reverted,
+                        gas_used: gas,
+                        traces,
+                        debug: run_debug,
+                        exit_reason: _,
+                        ..
                     } = executor.commit_tx_with_env(env).unwrap();
 
                     RunResult {
                         success: !reverted,
                         traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
                         debug: run_debug.unwrap_or_default(),
-                        gas,
+                        gas_used: gas,
                     }
                 } else {
-                    let DeployResult { gas, traces, debug: run_debug, .. }: DeployResult =
+                    let DeployResult { gas_used, traces, debug: run_debug, .. }: DeployResult =
                         executor.deploy_with_env(env, None).unwrap();
 
                     RunResult {
                         success: true,
                         traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
                         debug: run_debug.unwrap_or_default(),
-                        gas,
+                        gas_used,
                     }
                 }
             };
@@ -253,7 +258,7 @@ async fn print_traces(
         println!("{}", Paint::red("Transaction failed."));
     }
 
-    println!("Gas used: {}", result.gas);
+    println!("Gas used: {}", result.gas_used);
     Ok(())
 }
 
@@ -261,5 +266,5 @@ struct RunResult {
     pub success: bool,
     pub traces: Vec<(TraceKind, CallTraceArena)>,
     pub debug: DebugArena,
-    pub gas: u64,
+    pub gas_used: u64,
 }

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -55,7 +55,7 @@ impl ScriptArgs {
             let script_result = runner.script(address, calldata)?;
 
             result.success &= script_result.success;
-            result.gas = script_result.gas;
+            result.gas_used = script_result.gas_used;
             result.logs.extend(script_result.logs);
             result.traces.extend(script_result.traces);
             result.debug = script_result.debug;
@@ -153,7 +153,7 @@ impl ScriptArgs {
                     }
 
                     // We inflate the gas used by the user specified percentage
-                    tx.gas = Some(U256::from(result.gas * self.gas_estimate_multiplier / 100));
+                    tx.gas = Some(U256::from(result.gas_used * self.gas_estimate_multiplier / 100));
 
                     if !result.success {
                         failed = true;

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -250,7 +250,7 @@ impl ScriptArgs {
         }
 
         if script_config.evm_opts.fork_url.is_none() {
-            println!("Gas used: {}", result.gas);
+            println!("Gas used: {}", result.gas_used);
         }
 
         if result.success && !result.returned.is_empty() {
@@ -301,7 +301,7 @@ impl ScriptArgs {
         let returns = self.get_returns(script_config, &result.returned)?;
 
         let console_logs = decode_console_logs(&result.logs);
-        let output = JsonResult { logs: console_logs, gas_used: result.gas, returns };
+        let output = JsonResult { logs: console_logs, gas_used: result.gas_used, returns };
         let j = serde_json::to_string(&output)?;
         println!("{}", j);
 
@@ -488,7 +488,7 @@ pub struct ScriptResult {
     pub logs: Vec<Log>,
     pub traces: Vec<(TraceKind, CallTraceArena)>,
     pub debug: Option<Vec<DebugArena>>,
-    pub gas: u64,
+    pub gas_used: u64,
     pub labeled_addresses: BTreeMap<Address, String>,
     pub transactions: Option<VecDeque<TypedTransaction>>,
     pub returned: bytes::Bytes,

--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -8,8 +8,8 @@ use crate::{
 use ethers::prelude::{H160, H256, U256};
 use hashbrown::HashMap as Map;
 use revm::{
-    db::DatabaseRef, Account, AccountInfo, Bytecode, Database, Env, Inspector, Log, Return,
-    SubRoutine, TransactOut,
+    db::DatabaseRef, Account, AccountInfo, Bytecode, Database, Env, ExecutionResult, Inspector,
+    JournaledState,
 };
 use std::borrow::Cow;
 use tracing::trace;
@@ -50,7 +50,7 @@ impl<'a> FuzzBackendWrapper<'a> {
         &mut self,
         mut env: Env,
         mut inspector: INSP,
-    ) -> (Return, TransactOut, u64, Map<Address, Account>, Vec<Log>)
+    ) -> (ExecutionResult, Map<Address, Account>)
     where
         INSP: Inspector<Self>,
     {
@@ -59,38 +59,38 @@ impl<'a> FuzzBackendWrapper<'a> {
 }
 
 impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
-    fn snapshot(&mut self, subroutine: &SubRoutine, env: &Env) -> U256 {
+    fn snapshot(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {
         trace!("fuzz: create snapshot");
-        self.backend.to_mut().snapshot(subroutine, env)
+        self.backend.to_mut().snapshot(journaled_state, env)
     }
 
     fn revert(
         &mut self,
         id: U256,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
         current: &mut Env,
-    ) -> Option<SubRoutine> {
+    ) -> Option<JournaledState> {
         trace!(?id, "fuzz: revert snapshot");
-        self.backend.to_mut().revert(id, subroutine, current)
+        self.backend.to_mut().revert(id, journaled_state, current)
     }
 
     fn create_fork(
         &mut self,
         fork: CreateFork,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
     ) -> eyre::Result<LocalForkId> {
         trace!("fuzz: create fork");
-        self.backend.to_mut().create_fork(fork, subroutine)
+        self.backend.to_mut().create_fork(fork, journaled_state)
     }
 
     fn select_fork(
         &mut self,
         id: LocalForkId,
         env: &mut Env,
-        subroutine: &mut SubRoutine,
+        journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "fuzz: select fork");
-        self.backend.to_mut().select_fork(id, env, subroutine)
+        self.backend.to_mut().select_fork(id, env, journaled_state)
     }
 
     fn roll_fork(
@@ -98,10 +98,10 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         id: Option<LocalForkId>,
         block_number: U256,
         env: &mut Env,
-        subroutine: &mut SubRoutine,
+        journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "fuzz: roll fork");
-        self.backend.to_mut().roll_fork(id, block_number, env, subroutine)
+        self.backend.to_mut().roll_fork(id, block_number, env, journaled_state)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {
@@ -119,9 +119,9 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn diagnose_revert(
         &self,
         callee: Address,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
     ) -> Option<RevertDiagnostic> {
-        self.backend.diagnose_revert(callee, subroutine)
+        self.backend.diagnose_revert(callee, journaled_state)
     }
 
     fn is_persistent(&self, acc: &Address) -> bool {

--- a/evm/src/executor/backend/snapshot.rs
+++ b/evm/src/executor/backend/snapshot.rs
@@ -1,11 +1,11 @@
-use revm::{Env, SubRoutine};
+use revm::{Env, JournaledState};
 
 /// Represents a snapshot taken during evm execution
 #[derive(Clone, Debug)]
 pub struct BackendSnapshot<T> {
     pub db: T,
-    /// The subroutine state at a specific point
-    pub subroutine: SubRoutine,
+    /// The journaled_state state at a specific point
+    pub journaled_state: JournaledState,
     /// Contains the env at the time of the snapshot
     pub env: Env,
 }
@@ -14,17 +14,18 @@ pub struct BackendSnapshot<T> {
 
 impl<T> BackendSnapshot<T> {
     /// Takes a new snapshot
-    pub fn new(db: T, subroutine: SubRoutine, env: Env) -> Self {
-        Self { db, subroutine, env }
+    pub fn new(db: T, journaled_state: JournaledState, env: Env) -> Self {
+        Self { db, journaled_state, env }
     }
 
     /// Called when this snapshot is reverted.
     ///
     /// Since we want to keep all additional logs that were emitted since the snapshot was taken
-    /// we'll merge additional logs into the snapshot's `revm::Subroutine`. Additional logs are
-    /// those logs that are missing in the snapshot's subroutine, since the current subroutine
-    /// includes the same logs, we can simply replace use that See also `DatabaseExt::revert`
-    pub fn merge(&mut self, current: &SubRoutine) {
-        self.subroutine.logs = current.logs.clone();
+    /// we'll merge additional logs into the snapshot's `revm::JournaledState`. Additional logs are
+    /// those logs that are missing in the snapshot's journaled_state, since the current
+    /// journaled_state includes the same logs, we can simply replace use that See also
+    /// `DatabaseExt::revert`
+    pub fn merge(&mut self, current: &JournaledState) {
+        self.journaled_state.logs = current.logs.clone();
     }
 }

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -204,7 +204,7 @@ impl MemDb {
                 accounts.insert(add, acc.info);
 
                 let acc_storage = storage.entry(add).or_default();
-                if acc.is_destroyed || acc.is_touched {
+                if acc.storage_cleared {
                     acc_storage.clear();
                 }
                 for (index, value) in acc.storage {

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -1,7 +1,7 @@
 //! Cache related abstraction
 use ethers::types::{Address, H256, U256};
 use parking_lot::RwLock;
-use revm::{Account, AccountInfo, DatabaseCommit, Filth, KECCAK_EMPTY};
+use revm::{Account, AccountInfo, DatabaseCommit, KECCAK_EMPTY};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -189,7 +189,7 @@ impl MemDb {
         let mut storage = self.storage.write();
         let mut accounts = self.accounts.write();
         for (add, mut acc) in changes {
-            if acc.is_empty() || matches!(acc.filth, Filth::Destroyed) {
+            if acc.is_empty() || acc.is_destroyed {
                 accounts.remove(&add);
                 storage.remove(&add);
             } else {
@@ -204,14 +204,14 @@ impl MemDb {
                 accounts.insert(add, acc.info);
 
                 let acc_storage = storage.entry(add).or_default();
-                if acc.filth.abandon_old_storage() {
+                if acc.is_destroyed || acc.is_touched {
                     acc_storage.clear();
                 }
                 for (index, value) in acc.storage {
-                    if value.is_zero() {
+                    if value.present_value().is_zero() {
                         acc_storage.remove(&index);
                     } else {
-                        acc_storage.insert(index, value);
+                        acc_storage.insert(index, value.present_value());
                     }
                 }
                 if acc_storage.is_empty() {

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -162,62 +162,67 @@ pub fn apply<DB: Database>(
         }
         HEVMCalls::Store(inner) => {
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            data.subroutine.sstore(inner.0, inner.1.into(), inner.2.into(), data.db);
+            data.journaled_state.load_account(inner.0, data.db);
+            data.journaled_state.sstore(inner.0, inner.1.into(), inner.2.into(), data.db);
             Ok(Bytes::new())
         }
         HEVMCalls::Load(inner) => {
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            let (val, _) = data.subroutine.sload(inner.0, inner.1.into(), data.db);
+            data.journaled_state.load_account(inner.0, data.db);
+            let (val, _) = data.journaled_state.sload(inner.0, inner.1.into(), data.db);
             Ok(val.encode().into())
         }
         HEVMCalls::Etch(inner) => {
             let code = inner.1.clone();
 
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            data.subroutine.set_code(inner.0, Bytecode::new_raw(code.0).to_checked());
+            data.journaled_state.load_account(inner.0, data.db);
+            data.journaled_state.set_code(inner.0, Bytecode::new_raw(code.0).to_checked());
             Ok(Bytes::new())
         }
         HEVMCalls::Deal(inner) => {
             let who = inner.0;
             let value = inner.1;
 
-            // TODO: Does this increase gas usage?
-            data.subroutine.load_account(who, data.db);
-            let balance = data.subroutine.account(inner.0).info.balance;
-
-            // TODO: We should probably upstream a `set_balance` function
-            if balance < value {
-                data.subroutine.balance_add(who, value - balance);
-            } else {
-                data.subroutine.balance_sub(who, balance - value);
-            }
+            data.journaled_state.load_account(who, data.db);
+            let account = data.journaled_state.state.get_mut(&who).expect("account loaded;");
+            account.info.balance = value;
             Ok(Bytes::new())
         }
-        HEVMCalls::Prank0(inner) => {
-            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), true)
-        }
+        HEVMCalls::Prank0(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            None,
+            data.journaled_state.depth(),
+            true,
+        ),
         HEVMCalls::Prank1(inner) => prank(
             state,
             caller,
             data.env.tx.caller,
             inner.0,
             Some(inner.1),
-            data.subroutine.depth(),
+            data.journaled_state.depth(),
             true,
         ),
-        HEVMCalls::StartPrank0(inner) => {
-            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), false)
-        }
+        HEVMCalls::StartPrank0(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            None,
+            data.journaled_state.depth(),
+            false,
+        ),
         HEVMCalls::StartPrank1(inner) => prank(
             state,
             caller,
             data.env.tx.caller,
             inner.0,
             Some(inner.1),
-            data.subroutine.depth(),
+            data.journaled_state.depth(),
             false,
         ),
         HEVMCalls::StopPrank(_) => {
@@ -237,10 +242,10 @@ pub fn apply<DB: Database>(
         HEVMCalls::SetNonce(inner) => {
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
-            data.subroutine.load_account(inner.0, data.db);
+            data.journaled_state.load_account(inner.0, data.db);
 
             // we can safely unwrap because `load_account` insert inner.0 to DB.
-            let account = data.subroutine.state().get_mut(&inner.0).unwrap();
+            let account = data.journaled_state.state().get_mut(&inner.0).unwrap();
             // nonce must increment only
             if account.info.nonce < inner.1 {
                 account.info.nonce = inner.1;
@@ -250,14 +255,14 @@ pub fn apply<DB: Database>(
             }
         }
         HEVMCalls::GetNonce(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
 
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
-            data.subroutine.load_account(inner.0, data.db);
+            data.journaled_state.load_account(inner.0, data.db);
 
             // we can safely unwrap because `load_account` insert inner.0 to DB.
-            let account = data.subroutine.state().get(&inner.0).unwrap();
+            let account = data.journaled_state.state().get(&inner.0).unwrap();
             Ok(abi::encode(&[Token::Uint(account.info.nonce.into())]).into())
         }
         HEVMCalls::ChainId(inner) => {
@@ -265,20 +270,20 @@ pub fn apply<DB: Database>(
             Ok(Bytes::new())
         }
         HEVMCalls::Broadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, data.env.tx.caller, caller, data.subroutine.depth(), true)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::Broadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, inner.0, caller, data.subroutine.depth(), true)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, inner.0, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::StartBroadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, data.env.tx.caller, caller, data.subroutine.depth(), false)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StartBroadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, inner.0, caller, data.subroutine.depth(), false)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, inner.0, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StopBroadcast(_) => {
             state.broadcast = None;
@@ -293,11 +298,11 @@ pub fn apply<DB: Database>(
 /// undesirable. Therefore, we make sure to fix the sender's nonce **once**.
 fn correct_sender_nonce(
     sender: &Address,
-    subroutine: &mut revm::SubRoutine,
+    journaled_state: &mut revm::JournaledState,
     state: &mut Cheatcodes,
 ) {
     if !state.corrected_nonce {
-        let account = subroutine.state().get_mut(sender).unwrap();
+        let account = journaled_state.state().get_mut(sender).unwrap();
         account.info.nonce -= 1;
         state.corrected_nonce = true;
     }

--- a/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -65,14 +65,14 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::RollFork0(fork) => {
             let block_number = fork.0;
             data.db
-                .roll_fork(None, block_number, data.env, &mut data.subroutine)
+                .roll_fork(None, block_number, data.env, &mut data.journaled_state)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }
         HEVMCalls::RollFork1(fork) => {
             let block_number = fork.1;
             data.db
-                .roll_fork(Some(fork.0), block_number, data.env, &mut data.subroutine)
+                .roll_fork(Some(fork.0), block_number, data.env, &mut data.journaled_state)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }
@@ -98,7 +98,7 @@ pub fn apply<DB: DatabaseExt>(
 /// Selects the given fork id
 fn select_fork<DB: DatabaseExt>(data: &mut EVMData<DB>, fork_id: U256) -> Result<Bytes, Bytes> {
     data.db
-        .select_fork(fork_id, data.env, &mut data.subroutine)
+        .select_fork(fork_id, data.env, &mut data.journaled_state)
         .map(|_| Default::default())
         .map_err(util::encode_error)
 }
@@ -111,7 +111,9 @@ fn create_select_fork<DB: DatabaseExt>(
     block: Option<u64>,
 ) -> Result<U256, Bytes> {
     let fork = create_fork_request(state, url_or_alias, block, data)?;
-    data.db.create_select_fork(fork, data.env, &mut data.subroutine).map_err(util::encode_error)
+    data.db
+        .create_select_fork(fork, data.env, &mut data.journaled_state)
+        .map_err(util::encode_error)
 }
 
 /// Creates a new fork
@@ -122,7 +124,7 @@ fn create_fork<DB: DatabaseExt>(
     block: Option<u64>,
 ) -> Result<U256, Bytes> {
     let fork = create_fork_request(state, url_or_alias, block, data)?;
-    data.db.create_fork(fork, &data.subroutine).map_err(util::encode_error)
+    data.db.create_fork(fork, &data.journaled_state).map_err(util::encode_error)
 }
 
 /// Creates the request object for a new fork request

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -275,11 +275,11 @@ where
 
             // Apply our prank
             if let Some(prank) = &self.prank {
-                if data.subroutine.depth() >= prank.depth &&
+                if data.journaled_state.depth() >= prank.depth &&
                     call.context.caller == prank.prank_caller
                 {
                     // At the target depth we set `msg.sender`
-                    if data.subroutine.depth() == prank.depth {
+                    if data.journaled_state.depth() == prank.depth {
                         call.context.caller = prank.new_caller;
                         call.transfer.source = prank.new_caller;
                     }
@@ -297,7 +297,7 @@ where
                 //
                 // We do this because any subsequent contract calls *must* exist on chain and
                 // we only want to grab *this* call, not internal ones
-                if data.subroutine.depth() == broadcast.depth &&
+                if data.journaled_state.depth() == broadcast.depth &&
                     call.context.caller == broadcast.original_caller
                 {
                     // At the target depth we set `msg.sender` & tx.origin.
@@ -310,8 +310,9 @@ where
                     // into 1559, in the cli package, relatively easily once we
                     // know the target chain supports EIP-1559.
                     if !is_static {
-                        data.subroutine.load_account(broadcast.origin, data.db);
-                        let account = data.subroutine.state().get_mut(&broadcast.origin).unwrap();
+                        data.journaled_state.load_account(broadcast.origin, data.db);
+                        let account =
+                            data.journaled_state.state().get_mut(&broadcast.origin).unwrap();
 
                         self.broadcastable_transactions.push_back(TypedTransaction::Legacy(
                             TransactionRequest {
@@ -360,7 +361,7 @@ where
 
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() == prank.depth {
+            if data.journaled_state.depth() == prank.depth {
                 data.env.tx.caller = prank.prank_origin;
             }
             if prank.single_call {
@@ -377,7 +378,7 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
-            if data.subroutine.depth() <= expected_revert.depth {
+            if data.journaled_state.depth() <= expected_revert.depth {
                 let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match handle_expect_revert(false, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, remaining_gas, retdata),
@@ -390,7 +391,7 @@ where
         if !self
             .expected_emits
             .iter()
-            .filter(|expected| expected.depth == data.subroutine.depth())
+            .filter(|expected| expected.depth == data.journaled_state.depth())
             .all(|expected| expected.found)
         {
             return (
@@ -404,7 +405,7 @@ where
         }
 
         // If the depth is 0, then this is the root call terminating
-        if data.subroutine.depth() == 0 {
+        if data.journaled_state.depth() == 0 {
             // Handle expected calls that were not fulfilled
             if let Some((address, expecteds)) =
                 self.expected_calls.iter().find(|(_, expecteds)| !expecteds.is_empty())
@@ -456,7 +457,7 @@ where
             if data.db.is_forked_mode() && status == Return::Stop && call.contract != test_contract
             {
                 self.fork_revert_diagnostic =
-                    data.db.diagnose_revert(call.contract, &data.subroutine);
+                    data.db.diagnose_revert(call.contract, &data.journaled_state);
             }
         }
 
@@ -470,9 +471,9 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // Apply our prank
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() >= prank.depth && call.caller == prank.prank_caller {
+            if data.journaled_state.depth() >= prank.depth && call.caller == prank.prank_caller {
                 // At the target depth we set `msg.sender`
-                if data.subroutine.depth() == prank.depth {
+                if data.journaled_state.depth() == prank.depth {
                     call.caller = prank.new_caller;
                 }
 
@@ -485,10 +486,10 @@ where
 
         // Apply our broadcast
         if let Some(broadcast) = &self.broadcast {
-            if data.subroutine.depth() == broadcast.depth &&
+            if data.journaled_state.depth() == broadcast.depth &&
                 call.caller == broadcast.original_caller
             {
-                data.subroutine.load_account(broadcast.origin, data.db);
+                data.journaled_state.load_account(broadcast.origin, data.db);
 
                 let (bytecode, to, nonce) =
                     process_create(broadcast.origin, call.init_code.clone(), data, call);
@@ -520,7 +521,7 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() == prank.depth {
+            if data.journaled_state.depth() == prank.depth {
                 data.env.tx.caller = prank.prank_origin;
             }
             if prank.single_call {
@@ -537,7 +538,7 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
-            if data.subroutine.depth() <= expected_revert.depth {
+            if data.journaled_state.depth() <= expected_revert.depth {
                 let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match handle_expect_revert(true, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, None, remaining_gas, retdata),

--- a/evm/src/executor/inspector/cheatcodes/snapshot.rs
+++ b/evm/src/executor/inspector/cheatcodes/snapshot.rs
@@ -11,16 +11,19 @@ pub fn apply<DB: DatabaseExt>(
     call: &HEVMCalls,
 ) -> Option<Result<Bytes, Bytes>> {
     Some(match call {
-        HEVMCalls::Snapshot(_) => Ok(data.db.snapshot(&data.subroutine, data.env).encode().into()),
+        HEVMCalls::Snapshot(_) => {
+            Ok(data.db.snapshot(&data.journaled_state, data.env).encode().into())
+        }
         HEVMCalls::RevertTo(snapshot) => {
-            let res =
-                if let Some(subroutine) = data.db.revert(snapshot.0, &data.subroutine, data.env) {
-                    // we reset the evm's subroutine to the state of the snapshot previous state
-                    data.subroutine = subroutine;
-                    true
-                } else {
-                    false
-                };
+            let res = if let Some(journaled_state) =
+                data.db.revert(snapshot.0, &data.journaled_state, data.env)
+            {
+                // we reset the evm's journaled_state to the state of the snapshot previous state
+                data.journaled_state = journaled_state;
+                true
+            } else {
+                false
+            };
             Ok(res.encode().into())
         }
         _ => return None,

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -137,13 +137,13 @@ pub fn process_create<DB: Database>(
         revm::CreateScheme::Create => {
             call.caller = broadcast_sender;
 
-            (bytecode, None, data.subroutine.account(broadcast_sender).info.nonce)
+            (bytecode, None, data.journaled_state.account(broadcast_sender).info.nonce)
         }
         revm::CreateScheme::Create2 { salt } => {
             // Sanity checks for our CREATE2 deployer
-            data.subroutine.load_account(DEFAULT_CREATE2_DEPLOYER, data.db);
+            data.journaled_state.load_account(DEFAULT_CREATE2_DEPLOYER, data.db);
 
-            let info = &data.subroutine.account(DEFAULT_CREATE2_DEPLOYER).info;
+            let info = &data.journaled_state.account(DEFAULT_CREATE2_DEPLOYER).info;
             match &info.code {
                 Some(code) => {
                     if code.is_empty() {
@@ -162,7 +162,7 @@ pub fn process_create<DB: Database>(
 
             // We have to increment the nonce of the user address, since this create2 will be done
             // by the create2_deployer
-            let account = data.subroutine.state().get_mut(&broadcast_sender).unwrap();
+            let account = data.journaled_state.state().get_mut(&broadcast_sender).unwrap();
             let nonce = account.info.nonce;
             account.info.nonce += 1;
 

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -69,9 +69,8 @@ where
         data: &mut EVMData<'_, DB>,
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
-        // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.enter(get_create_address(call, nonce));
 
         (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -68,7 +68,7 @@ where
         _: bool,
     ) -> (Return, Gas, Bytes) {
         self.enter(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             call.context.code_address,
             call.context.scheme.into(),
         );
@@ -164,10 +164,10 @@ where
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.enter(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             get_create_address(call, nonce),
             CallKind::Create,
         );

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -94,7 +94,7 @@ where
         };
 
         self.start_trace(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             to,
             call.input.to_vec(),
             call.transfer.value,
@@ -130,10 +130,10 @@ where
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.start_trace(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             get_create_address(call, nonce),
             call.init_code.to_vec(),
             call.value,
@@ -155,7 +155,7 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         let code = match address {
             Some(address) => data
-                .subroutine
+                .journaled_state
                 .account(address)
                 .info
                 .code

--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -53,7 +53,7 @@ impl InvariantFuzzError {
                     match decode_revert(
                         call_result.result.as_ref(),
                         Some(invariant_contract.abi),
-                        Some(call_result.status)
+                        Some(call_result.exit_reason)
                     ) {
                         Ok(e) => e,
                         Err(e) => e.to_string(),
@@ -66,7 +66,7 @@ impl InvariantFuzzError {
             revert_reason: decode_revert(
                 call_result.result.as_ref(),
                 Some(invariant_contract.abi),
-                Some(call_result.status),
+                Some(call_result.exit_reason),
             )
             .unwrap_or_default(),
             addr: invariant_contract.address,

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -165,7 +165,7 @@ impl<'a> InvariantExecutor<'a> {
 
                     fuzz_runs.push(FuzzCase {
                         calldata: calldata.clone(),
-                        gas: call_result.gas,
+                        gas: call_result.gas_used,
                         stipend: call_result.stipend,
                     });
 

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -103,7 +103,7 @@ impl<'a> FuzzedExecutor<'a> {
             if success {
                 cases.borrow_mut().push(FuzzCase {
                     calldata,
-                    gas: call.gas,
+                    gas: call.gas_used,
                     stipend: call.stipend,
                 });
 
@@ -111,7 +111,7 @@ impl<'a> FuzzedExecutor<'a> {
 
                 Ok(())
             } else {
-                let status = call.status;
+                let status = call.exit_reason;
                 // We cannot use the calldata returned by the test runner in `TestError::Fail`,
                 // since that input represents the last run case, which may not correspond with our
                 // failure - when a fuzz case fails, proptest will try to run at least one more

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -15,7 +15,7 @@ use parking_lot::RwLock;
 use proptest::prelude::{BoxedStrategy, Strategy};
 use revm::{
     db::{CacheDB, DatabaseRef},
-    opcode, spec_opcode_gas, Filth, SpecId,
+    opcode, spec_opcode_gas, SpecId,
 };
 use std::{
     collections::BTreeSet,
@@ -119,7 +119,7 @@ pub fn collect_state_from_call(
         // Insert storage
         for (slot, value) in &account.storage {
             state.insert(utils::u256_to_h256_be(*slot).into());
-            state.insert(utils::u256_to_h256_be(*value).into());
+            state.insert(utils::u256_to_h256_be(value.present_value()).into());
         }
 
         // Insert push bytes
@@ -201,7 +201,7 @@ pub fn collect_created_contracts(
 
     for (address, account) in state_changeset {
         if !setup_contracts.contains_key(address) {
-            if let (Filth::NewlyCreated, Some(code)) = (&account.filth, &account.info.code) {
+            if let (true, Some(code)) = (&account.is_touched, &account.info.code) {
                 if !code.is_empty() {
                     if let Some((artifact, (abi, _))) = project_contracts.find_by_code(code.bytes())
                     {

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -364,7 +364,7 @@ impl<'a> ContractRunner<'a> {
             ) {
                 Ok(CallResult {
                     reverted,
-                    gas,
+                    gas_used: gas,
                     stipend,
                     logs: execution_logs,
                     traces: execution_trace,
@@ -380,7 +380,7 @@ impl<'a> ContractRunner<'a> {
                 Err(EvmError::Execution {
                     reverted,
                     reason,
-                    gas,
+                    gas_used: gas,
                     stipend,
                     logs: execution_logs,
                     traces: execution_trace,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

~~Blocked by https://github.com/bluealloy/revm/pull/182~~

## Motivation
this should fix the recent debugger issues 

https://github.com/bluealloy/revm/commit/136555437e1c410508aafdd9948a43477c0d64ee

ref https://github.com/foundry-rs/foundry/issues/2870
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
patch until new revm released

> The updates are mostly internal. Externally it's mostly about renaming subroutine to journaled_state, replacing the Account::Filth flag with the corresponding boolean getters, and replacing the execution results from a tuple into a struct. ref #2878


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
