### PR TITLE
Update `revm` to latest `main`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "memory-db",
  "parking_lot 0.12.0",
  "pretty_assertions",
- "revm_precompiles",
+ "revm_precompiles 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "thiserror",
@@ -4401,8 +4401,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab402ae244afdd560b2aa710df5af557bc791b1cca6fec174ced0cf781e13134"
+source = "git+https://github.com/bluealloy/revm?rev=24622a4c9e450217f6a723008a75e3faa3b7cc5d#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4411,7 +4410,7 @@ dependencies = [
  "hex",
  "num_enum",
  "primitive-types",
- "revm_precompiles",
+ "revm_precompiles 1.1.0 (git+https://github.com/bluealloy/revm?rev=24622a4c9e450217f6a723008a75e3faa3b7cc5d)",
  "rlp",
  "serde",
  "sha3",
@@ -4424,11 +4423,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af88e7e9feb30cc4ed64645f09b966e84a1f6be56551ce5f1691105def45705d"
 dependencies = [
  "bytes",
+ "num 0.4.0",
+ "primitive-types",
+ "ripemd",
+ "secp256k1 0.23.4",
+ "sha2 0.10.2",
+ "sha3",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm_precompiles"
+version = "1.1.0"
+source = "git+https://github.com/bluealloy/revm?rev=24622a4c9e450217f6a723008a75e3faa3b7cc5d#24622a4c9e450217f6a723008a75e3faa3b7cc5d"
+dependencies = [
+ "bytes",
  "k256",
  "num 0.4.0",
  "primitive-types",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.24.0",
  "sha2 0.10.2",
  "sha3",
  "substrate-bn",
@@ -4663,6 +4677,15 @@ name = "secp256k1"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ece73253dd9e1fb540ff324eae554113a31c25fb598d22fd13b088a6a03f90d"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
  "secp256k1-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ debug = 0
 
 [patch.crates-io]
 #revm = { path = "../../revm/crates/revm" }
+revm = { git="https://github.com/bluealloy/revm", rev = "24622a4c9e450217f6a723008a75e3faa3b7cc5d" }

--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -8,8 +8,8 @@ use crate::{
 use ethers::prelude::{H160, H256, U256};
 use hashbrown::HashMap as Map;
 use revm::{
-    db::DatabaseRef, Account, AccountInfo, Bytecode, Database, Env, Inspector, Log, Return,
-    SubRoutine, TransactOut,
+    db::DatabaseRef, Account, AccountInfo, Bytecode, Database, Env, ExecutionResult, Inspector,
+    JournaledState,
 };
 use std::borrow::Cow;
 use tracing::trace;
@@ -50,7 +50,7 @@ impl<'a> FuzzBackendWrapper<'a> {
         &mut self,
         mut env: Env,
         mut inspector: INSP,
-    ) -> (Return, TransactOut, u64, Map<Address, Account>, Vec<Log>)
+    ) -> (ExecutionResult, Map<Address, Account>)
     where
         INSP: Inspector<Self>,
     {
@@ -59,38 +59,38 @@ impl<'a> FuzzBackendWrapper<'a> {
 }
 
 impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
-    fn snapshot(&mut self, subroutine: &SubRoutine, env: &Env) -> U256 {
+    fn snapshot(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {
         trace!("fuzz: create snapshot");
-        self.backend.to_mut().snapshot(subroutine, env)
+        self.backend.to_mut().snapshot(journaled_state, env)
     }
 
     fn revert(
         &mut self,
         id: U256,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
         current: &mut Env,
-    ) -> Option<SubRoutine> {
+    ) -> Option<JournaledState> {
         trace!(?id, "fuzz: revert snapshot");
-        self.backend.to_mut().revert(id, subroutine, current)
+        self.backend.to_mut().revert(id, journaled_state, current)
     }
 
     fn create_fork(
         &mut self,
         fork: CreateFork,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
     ) -> eyre::Result<LocalForkId> {
         trace!("fuzz: create fork");
-        self.backend.to_mut().create_fork(fork, subroutine)
+        self.backend.to_mut().create_fork(fork, journaled_state)
     }
 
     fn select_fork(
         &mut self,
         id: LocalForkId,
         env: &mut Env,
-        subroutine: &mut SubRoutine,
+        journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "fuzz: select fork");
-        self.backend.to_mut().select_fork(id, env, subroutine)
+        self.backend.to_mut().select_fork(id, env, journaled_state)
     }
 
     fn roll_fork(
@@ -98,10 +98,10 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         id: Option<LocalForkId>,
         block_number: U256,
         env: &mut Env,
-        subroutine: &mut SubRoutine,
+        journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "fuzz: roll fork");
-        self.backend.to_mut().roll_fork(id, block_number, env, subroutine)
+        self.backend.to_mut().roll_fork(id, block_number, env, journaled_state)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {
@@ -119,9 +119,9 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn diagnose_revert(
         &self,
         callee: Address,
-        subroutine: &SubRoutine,
+        journaled_state: &JournaledState,
     ) -> Option<RevertDiagnostic> {
-        self.backend.diagnose_revert(callee, subroutine)
+        self.backend.diagnose_revert(callee, journaled_state)
     }
 
     fn is_persistent(&self, acc: &Address) -> bool {

--- a/evm/src/executor/backend/snapshot.rs
+++ b/evm/src/executor/backend/snapshot.rs
@@ -1,11 +1,11 @@
-use revm::{Env, SubRoutine};
+use revm::{Env, JournaledState};
 
 /// Represents a snapshot taken during evm execution
 #[derive(Clone, Debug)]
 pub struct BackendSnapshot<T> {
     pub db: T,
-    /// The subroutine state at a specific point
-    pub subroutine: SubRoutine,
+    /// The journaled state at a specific point
+    pub journaled_state: JournaledState,
     /// Contains the env at the time of the snapshot
     pub env: Env,
 }
@@ -14,17 +14,18 @@ pub struct BackendSnapshot<T> {
 
 impl<T> BackendSnapshot<T> {
     /// Takes a new snapshot
-    pub fn new(db: T, subroutine: SubRoutine, env: Env) -> Self {
-        Self { db, subroutine, env }
+    pub fn new(db: T, journaled_state: JournaledState, env: Env) -> Self {
+        Self { db, journaled_state, env }
     }
 
     /// Called when this snapshot is reverted.
     ///
     /// Since we want to keep all additional logs that were emitted since the snapshot was taken
-    /// we'll merge additional logs into the snapshot's `revm::Subroutine`. Additional logs are
-    /// those logs that are missing in the snapshot's subroutine, since the current subroutine
-    /// includes the same logs, we can simply replace use that See also `DatabaseExt::revert`
-    pub fn merge(&mut self, current: &SubRoutine) {
-        self.subroutine.logs = current.logs.clone();
+    /// we'll merge additional logs into the snapshot's `revm::JournaledState`. Additional logs are
+    /// those logs that are missing in the snapshot's JournaledState, since the current
+    /// JournaledState includes the same logs, we can simply replace use that See also
+    /// `DatabaseExt::revert`
+    pub fn merge(&mut self, current: &JournaledState) {
+        self.journaled_state.logs = current.logs.clone();
     }
 }

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -1,7 +1,7 @@
 //! Cache related abstraction
 use ethers::types::{Address, H256, U256};
 use parking_lot::RwLock;
-use revm::{Account, AccountInfo, DatabaseCommit, Filth, KECCAK_EMPTY};
+use revm::{Account, AccountInfo, DatabaseCommit, KECCAK_EMPTY};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -189,7 +189,7 @@ impl MemDb {
         let mut storage = self.storage.write();
         let mut accounts = self.accounts.write();
         for (add, mut acc) in changes {
-            if acc.is_empty() || matches!(acc.filth, Filth::Destroyed) {
+            if acc.is_empty() || acc.is_destroyed {
                 accounts.remove(&add);
                 storage.remove(&add);
             } else {
@@ -204,10 +204,11 @@ impl MemDb {
                 accounts.insert(add, acc.info);
 
                 let acc_storage = storage.entry(add).or_default();
-                if acc.filth.abandon_old_storage() {
+                if acc.storage_cleared {
                     acc_storage.clear();
                 }
                 for (index, value) in acc.storage {
+                    let value = value.present_value();
                     if value.is_zero() {
                         acc_storage.remove(&index);
                     } else {

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -162,22 +162,22 @@ pub fn apply<DB: Database>(
         }
         HEVMCalls::Store(inner) => {
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            data.subroutine.sstore(inner.0, inner.1.into(), inner.2.into(), data.db);
+            data.journaled_state.load_account(inner.0, data.db);
+            data.journaled_state.sstore(inner.0, inner.1.into(), inner.2.into(), data.db);
             Ok(Bytes::new())
         }
         HEVMCalls::Load(inner) => {
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            let (val, _) = data.subroutine.sload(inner.0, inner.1.into(), data.db);
+            data.journaled_state.load_account(inner.0, data.db);
+            let (val, _) = data.journaled_state.sload(inner.0, inner.1.into(), data.db);
             Ok(val.encode().into())
         }
         HEVMCalls::Etch(inner) => {
             let code = inner.1.clone();
 
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(inner.0, data.db);
-            data.subroutine.set_code(inner.0, Bytecode::new_raw(code.0).to_checked());
+            data.journaled_state.load_account(inner.0, data.db);
+            data.journaled_state.set_code(inner.0, Bytecode::new_raw(code.0).to_checked());
             Ok(Bytes::new())
         }
         HEVMCalls::Deal(inner) => {
@@ -185,39 +185,46 @@ pub fn apply<DB: Database>(
             let value = inner.1;
 
             // TODO: Does this increase gas usage?
-            data.subroutine.load_account(who, data.db);
-            let balance = data.subroutine.account(inner.0).info.balance;
-
-            // TODO: We should probably upstream a `set_balance` function
-            if balance < value {
-                data.subroutine.balance_add(who, value - balance);
-            } else {
-                data.subroutine.balance_sub(who, balance - value);
-            }
+            data.journaled_state.load_account(who, data.db);
+            data.journaled_state.touch(&who);
+            // we can safely unwrap because `load_account` insert `who` to DB.
+            data.journaled_state.state().get_mut(&who).unwrap().info.balance = value;
             Ok(Bytes::new())
         }
-        HEVMCalls::Prank0(inner) => {
-            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), true)
-        }
+        HEVMCalls::Prank0(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            None,
+            data.journaled_state.depth(),
+            true,
+        ),
         HEVMCalls::Prank1(inner) => prank(
             state,
             caller,
             data.env.tx.caller,
             inner.0,
             Some(inner.1),
-            data.subroutine.depth(),
+            data.journaled_state.depth(),
             true,
         ),
-        HEVMCalls::StartPrank0(inner) => {
-            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), false)
-        }
+        HEVMCalls::StartPrank0(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            None,
+            data.journaled_state.depth(),
+            false,
+        ),
         HEVMCalls::StartPrank1(inner) => prank(
             state,
             caller,
             data.env.tx.caller,
             inner.0,
             Some(inner.1),
-            data.subroutine.depth(),
+            data.journaled_state.depth(),
             false,
         ),
         HEVMCalls::StopPrank(_) => {
@@ -237,10 +244,11 @@ pub fn apply<DB: Database>(
         HEVMCalls::SetNonce(inner) => {
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
-            data.subroutine.load_account(inner.0, data.db);
+            data.journaled_state.load_account(inner.0, data.db);
+            data.journaled_state.touch(&inner.0);
 
             // we can safely unwrap because `load_account` insert inner.0 to DB.
-            let account = data.subroutine.state().get_mut(&inner.0).unwrap();
+            let account = data.journaled_state.state().get_mut(&inner.0).unwrap();
             // nonce must increment only
             if account.info.nonce < inner.1 {
                 account.info.nonce = inner.1;
@@ -250,14 +258,14 @@ pub fn apply<DB: Database>(
             }
         }
         HEVMCalls::GetNonce(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
 
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
-            data.subroutine.load_account(inner.0, data.db);
+            data.journaled_state.load_account(inner.0, data.db);
 
             // we can safely unwrap because `load_account` insert inner.0 to DB.
-            let account = data.subroutine.state().get(&inner.0).unwrap();
+            let account = data.journaled_state.state().get(&inner.0).unwrap();
             Ok(abi::encode(&[Token::Uint(account.info.nonce.into())]).into())
         }
         HEVMCalls::ChainId(inner) => {
@@ -265,20 +273,20 @@ pub fn apply<DB: Database>(
             Ok(Bytes::new())
         }
         HEVMCalls::Broadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, data.env.tx.caller, caller, data.subroutine.depth(), true)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::Broadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, inner.0, caller, data.subroutine.depth(), true)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, inner.0, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::StartBroadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, data.env.tx.caller, caller, data.subroutine.depth(), false)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StartBroadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.subroutine, state);
-            broadcast(state, inner.0, caller, data.subroutine.depth(), false)
+            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            broadcast(state, inner.0, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StopBroadcast(_) => {
             state.broadcast = None;
@@ -293,11 +301,11 @@ pub fn apply<DB: Database>(
 /// undesirable. Therefore, we make sure to fix the sender's nonce **once**.
 fn correct_sender_nonce(
     sender: &Address,
-    subroutine: &mut revm::SubRoutine,
+    journaled_state: &mut revm::JournaledState,
     state: &mut Cheatcodes,
 ) {
     if !state.corrected_nonce {
-        let account = subroutine.state().get_mut(sender).unwrap();
+        let account = journaled_state.state().get_mut(sender).unwrap();
         account.info.nonce -= 1;
         state.corrected_nonce = true;
     }

--- a/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -65,14 +65,14 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::RollFork0(fork) => {
             let block_number = fork.0;
             data.db
-                .roll_fork(None, block_number, data.env, &mut data.subroutine)
+                .roll_fork(None, block_number, data.env, &mut data.journaled_state)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }
         HEVMCalls::RollFork1(fork) => {
             let block_number = fork.1;
             data.db
-                .roll_fork(Some(fork.0), block_number, data.env, &mut data.subroutine)
+                .roll_fork(Some(fork.0), block_number, data.env, &mut data.journaled_state)
                 .map(|_| Default::default())
                 .map_err(util::encode_error)
         }
@@ -98,7 +98,7 @@ pub fn apply<DB: DatabaseExt>(
 /// Selects the given fork id
 fn select_fork<DB: DatabaseExt>(data: &mut EVMData<DB>, fork_id: U256) -> Result<Bytes, Bytes> {
     data.db
-        .select_fork(fork_id, data.env, &mut data.subroutine)
+        .select_fork(fork_id, data.env, &mut data.journaled_state)
         .map(|_| Default::default())
         .map_err(util::encode_error)
 }
@@ -111,7 +111,9 @@ fn create_select_fork<DB: DatabaseExt>(
     block: Option<u64>,
 ) -> Result<U256, Bytes> {
     let fork = create_fork_request(state, url_or_alias, block, data)?;
-    data.db.create_select_fork(fork, data.env, &mut data.subroutine).map_err(util::encode_error)
+    data.db
+        .create_select_fork(fork, data.env, &mut data.journaled_state)
+        .map_err(util::encode_error)
 }
 
 /// Creates a new fork
@@ -122,7 +124,7 @@ fn create_fork<DB: DatabaseExt>(
     block: Option<u64>,
 ) -> Result<U256, Bytes> {
     let fork = create_fork_request(state, url_or_alias, block, data)?;
-    data.db.create_fork(fork, &data.subroutine).map_err(util::encode_error)
+    data.db.create_fork(fork, &data.journaled_state).map_err(util::encode_error)
 }
 
 /// Creates the request object for a new fork request

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -275,11 +275,11 @@ where
 
             // Apply our prank
             if let Some(prank) = &self.prank {
-                if data.subroutine.depth() >= prank.depth &&
+                if data.journaled_state.depth() >= prank.depth &&
                     call.context.caller == prank.prank_caller
                 {
                     // At the target depth we set `msg.sender`
-                    if data.subroutine.depth() == prank.depth {
+                    if data.journaled_state.depth() == prank.depth {
                         call.context.caller = prank.new_caller;
                         call.transfer.source = prank.new_caller;
                     }
@@ -297,7 +297,7 @@ where
                 //
                 // We do this because any subsequent contract calls *must* exist on chain and
                 // we only want to grab *this* call, not internal ones
-                if data.subroutine.depth() == broadcast.depth &&
+                if data.journaled_state.depth() == broadcast.depth &&
                     call.context.caller == broadcast.original_caller
                 {
                     // At the target depth we set `msg.sender` & tx.origin.
@@ -310,8 +310,9 @@ where
                     // into 1559, in the cli package, relatively easily once we
                     // know the target chain supports EIP-1559.
                     if !is_static {
-                        data.subroutine.load_account(broadcast.origin, data.db);
-                        let account = data.subroutine.state().get_mut(&broadcast.origin).unwrap();
+                        data.journaled_state.load_account(broadcast.origin, data.db);
+                        let account =
+                            data.journaled_state.state().get_mut(&broadcast.origin).unwrap();
 
                         self.broadcastable_transactions.push_back(TypedTransaction::Legacy(
                             TransactionRequest {
@@ -360,7 +361,7 @@ where
 
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() == prank.depth {
+            if data.journaled_state.depth() == prank.depth {
                 data.env.tx.caller = prank.prank_origin;
             }
             if prank.single_call {
@@ -377,7 +378,7 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
-            if data.subroutine.depth() <= expected_revert.depth {
+            if data.journaled_state.depth() <= expected_revert.depth {
                 let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match handle_expect_revert(false, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, remaining_gas, retdata),
@@ -390,7 +391,7 @@ where
         if !self
             .expected_emits
             .iter()
-            .filter(|expected| expected.depth == data.subroutine.depth())
+            .filter(|expected| expected.depth == data.journaled_state.depth())
             .all(|expected| expected.found)
         {
             return (
@@ -404,7 +405,7 @@ where
         }
 
         // If the depth is 0, then this is the root call terminating
-        if data.subroutine.depth() == 0 {
+        if data.journaled_state.depth() == 0 {
             // Handle expected calls that were not fulfilled
             if let Some((address, expecteds)) =
                 self.expected_calls.iter().find(|(_, expecteds)| !expecteds.is_empty())
@@ -456,7 +457,7 @@ where
             if data.db.is_forked_mode() && status == Return::Stop && call.contract != test_contract
             {
                 self.fork_revert_diagnostic =
-                    data.db.diagnose_revert(call.contract, &data.subroutine);
+                    data.db.diagnose_revert(call.contract, &data.journaled_state);
             }
         }
 
@@ -470,9 +471,9 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // Apply our prank
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() >= prank.depth && call.caller == prank.prank_caller {
+            if data.journaled_state.depth() >= prank.depth && call.caller == prank.prank_caller {
                 // At the target depth we set `msg.sender`
-                if data.subroutine.depth() == prank.depth {
+                if data.journaled_state.depth() == prank.depth {
                     call.caller = prank.new_caller;
                 }
 
@@ -485,10 +486,10 @@ where
 
         // Apply our broadcast
         if let Some(broadcast) = &self.broadcast {
-            if data.subroutine.depth() == broadcast.depth &&
+            if data.journaled_state.depth() == broadcast.depth &&
                 call.caller == broadcast.original_caller
             {
-                data.subroutine.load_account(broadcast.origin, data.db);
+                data.journaled_state.load_account(broadcast.origin, data.db);
 
                 let (bytecode, to, nonce) =
                     process_create(broadcast.origin, call.init_code.clone(), data, call);
@@ -520,7 +521,7 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            if data.subroutine.depth() == prank.depth {
+            if data.journaled_state.depth() == prank.depth {
                 data.env.tx.caller = prank.prank_origin;
             }
             if prank.single_call {
@@ -537,7 +538,7 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
-            if data.subroutine.depth() <= expected_revert.depth {
+            if data.journaled_state.depth() <= expected_revert.depth {
                 let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match handle_expect_revert(true, &expected_revert.reason, status, retdata) {
                     Err(retdata) => (Return::Revert, None, remaining_gas, retdata),

--- a/evm/src/executor/inspector/cheatcodes/snapshot.rs
+++ b/evm/src/executor/inspector/cheatcodes/snapshot.rs
@@ -11,16 +11,19 @@ pub fn apply<DB: DatabaseExt>(
     call: &HEVMCalls,
 ) -> Option<Result<Bytes, Bytes>> {
     Some(match call {
-        HEVMCalls::Snapshot(_) => Ok(data.db.snapshot(&data.subroutine, data.env).encode().into()),
+        HEVMCalls::Snapshot(_) => {
+            Ok(data.db.snapshot(&data.journaled_state, data.env).encode().into())
+        }
         HEVMCalls::RevertTo(snapshot) => {
-            let res =
-                if let Some(subroutine) = data.db.revert(snapshot.0, &data.subroutine, data.env) {
-                    // we reset the evm's subroutine to the state of the snapshot previous state
-                    data.subroutine = subroutine;
-                    true
-                } else {
-                    false
-                };
+            let res = if let Some(journaled_state) =
+                data.db.revert(snapshot.0, &data.journaled_state, data.env)
+            {
+                // we reset the evm's journaled state to the state of the snapshot previous state
+                data.journaled_state = journaled_state;
+                true
+            } else {
+                false
+            };
             Ok(res.encode().into())
         }
         _ => return None,

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -137,13 +137,13 @@ pub fn process_create<DB: Database>(
         revm::CreateScheme::Create => {
             call.caller = broadcast_sender;
 
-            (bytecode, None, data.subroutine.account(broadcast_sender).info.nonce)
+            (bytecode, None, data.journaled_state.account(broadcast_sender).info.nonce)
         }
         revm::CreateScheme::Create2 { salt } => {
             // Sanity checks for our CREATE2 deployer
-            data.subroutine.load_account(DEFAULT_CREATE2_DEPLOYER, data.db);
+            data.journaled_state.load_account(DEFAULT_CREATE2_DEPLOYER, data.db);
 
-            let info = &data.subroutine.account(DEFAULT_CREATE2_DEPLOYER).info;
+            let info = &data.journaled_state.account(DEFAULT_CREATE2_DEPLOYER).info;
             match &info.code {
                 Some(code) => {
                     if code.is_empty() {
@@ -162,7 +162,7 @@ pub fn process_create<DB: Database>(
 
             // We have to increment the nonce of the user address, since this create2 will be done
             // by the create2_deployer
-            let account = data.subroutine.state().get_mut(&broadcast_sender).unwrap();
+            let account = data.journaled_state.state().get_mut(&broadcast_sender).unwrap();
             let nonce = account.info.nonce;
             account.info.nonce += 1;
 

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -70,8 +70,8 @@ where
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.enter(get_create_address(call, nonce));
 
         (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -68,7 +68,7 @@ where
         _: bool,
     ) -> (Return, Gas, Bytes) {
         self.enter(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             call.context.code_address,
             call.context.scheme.into(),
         );
@@ -164,10 +164,10 @@ where
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.enter(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             get_create_address(call, nonce),
             CallKind::Create,
         );

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -94,7 +94,7 @@ where
         };
 
         self.start_trace(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             to,
             call.input.to_vec(),
             call.transfer.value,
@@ -130,10 +130,10 @@ where
         call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
-        data.subroutine.load_account(call.caller, data.db);
-        let nonce = data.subroutine.account(call.caller).info.nonce;
+        data.journaled_state.load_account(call.caller, data.db);
+        let nonce = data.journaled_state.account(call.caller).info.nonce;
         self.start_trace(
-            data.subroutine.depth() as usize,
+            data.journaled_state.depth() as usize,
             get_create_address(call, nonce),
             call.init_code.to_vec(),
             call.value,
@@ -155,7 +155,7 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         let code = match address {
             Some(address) => data
-                .subroutine
+                .journaled_state
                 .account(address)
                 .info
                 .code

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -15,7 +15,7 @@ use parking_lot::RwLock;
 use proptest::prelude::{BoxedStrategy, Strategy};
 use revm::{
     db::{CacheDB, DatabaseRef},
-    opcode, spec_opcode_gas, Filth, SpecId,
+    opcode, spec_opcode_gas, SpecId,
 };
 use std::{
     collections::BTreeSet,
@@ -119,7 +119,7 @@ pub fn collect_state_from_call(
         // Insert storage
         for (slot, value) in &account.storage {
             state.insert(utils::u256_to_h256_be(*slot).into());
-            state.insert(utils::u256_to_h256_be(*value).into());
+            state.insert(utils::u256_to_h256_be(value.present_value()).into());
         }
 
         // Insert push bytes
@@ -201,7 +201,7 @@ pub fn collect_created_contracts(
 
     for (address, account) in state_changeset {
         if !setup_contracts.contains_key(address) {
-            if let (Filth::NewlyCreated, Some(code)) = (&account.filth, &account.info.code) {
+            if let (true, Some(code)) = (&account.storage_cleared, &account.info.code) {
                 if !code.is_empty() {
                     if let Some((artifact, (abi, _))) = project_contracts.find_by_code(code.bytes())
                     {


### PR DESCRIPTION
## Motivation

I needed some new functionalities from `revm`'s latest `main` branch, so I figured I'd create a draft PR until there is a new release, or if you want to use the latest version from `git` this could be merged.

## Solution

The updates are mostly internal. Externally it's mostly about renaming `subroutine` to `journaled_state`, replacing the `Account::Filth` flag with the corresponding boolean getters, and replacing the execution results from a tuple into a struct.
