### PR TITLE
fix(anvil): move old state to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "revm_precompiles",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -61,6 +61,7 @@ serde_json = "1.0.67"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 yansi = "0.5.1"
+tempfile = "3.3.0"
 
 # cli
 clap = { version = "3.0.10", features = [

--- a/anvil/src/eth/backend/db.rs
+++ b/anvil/src/eth/backend/db.rs
@@ -27,7 +27,7 @@ use std::collections::BTreeMap;
 pub type AsHashDB = Box<dyn HashDB<KeccakHasher, Vec<u8>>>;
 
 /// Helper trait get access to the data in `HashDb` form
-#[auto_impl::auto_impl(&, Box)]
+#[auto_impl::auto_impl(Box)]
 pub trait MaybeHashDatabase: DatabaseRef {
     /// Return the DB as read-only hashdb and the root key
     fn maybe_as_hash_db(&self) -> Option<(AsHashDB, H256)> {
@@ -37,6 +37,20 @@ pub trait MaybeHashDatabase: DatabaseRef {
     fn maybe_account_db(&self, _addr: Address) -> Option<(AsHashDB, H256)> {
         None
     }
+
+    /// Clear the state and move it into a new `StateSnapshot`
+    fn clear_into_snapshot(&mut self) -> StateSnapshot;
+
+    /// Reverses `clear_into_snapshot` by initializing the db's state with the snapshot
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot);
+}
+
+impl MaybeHashDatabase for &dyn Db {
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        unimplemented!()
+    }
+
+    fn init_from_snapshot(&mut self, _: StateSnapshot) {}
 }
 
 /// This bundles all required revm traits
@@ -76,12 +90,6 @@ pub trait Db: DatabaseRef + Database + DatabaseCommit + MaybeHashDatabase + Send
 
     /// inserts a blockhash for the given number
     fn insert_block_hash(&mut self, number: U256, hash: H256);
-
-    /// Clear the state and move it into a new `StateSnapshot`
-    fn clear_into_snapshot(&mut self) -> StateSnapshot;
-
-    /// Reverses `clear_into_snapshot` by initializing the db's state with the snapshot
-    fn init_from_snapshot(&mut self, snapshot: StateSnapshot);
 
     /// Write all chain data to serialized bytes buffer
     fn dump_state(&self) -> Option<SerializableState>;
@@ -123,40 +131,6 @@ impl<T: DatabaseRef + Send + Sync + Clone> Db for CacheDB<T> {
         self.block_hashes.insert(number, hash);
     }
 
-    fn clear_into_snapshot(&mut self) -> StateSnapshot {
-        let db_accounts = std::mem::take(&mut self.accounts);
-        let mut accounts = BTreeMap::new();
-        let mut account_storage = BTreeMap::new();
-
-        for (addr, mut acc) in db_accounts {
-            account_storage.insert(addr, std::mem::take(&mut acc.storage));
-            let mut info = acc.info;
-            info.code = self.contracts.remove(&info.code_hash);
-            accounts.insert(addr, info);
-        }
-        let block_hashes = std::mem::take(&mut self.block_hashes);
-        StateSnapshot { accounts, storage: account_storage, block_hashes }
-    }
-
-    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
-        let StateSnapshot { accounts, mut storage, block_hashes } = snapshot;
-
-        for (addr, mut acc) in accounts {
-            if let Some(code) = acc.code.take() {
-                self.contracts.insert(acc.code_hash, code);
-            }
-            self.accounts.insert(
-                addr,
-                DbAccount {
-                    info: acc.info,
-                    storage: storage.remove(&addr).unwrap_or_default(),
-                    ..Default::default()
-                },
-            );
-        }
-        self.block_hashes = block_hashes;
-    }
-
     fn dump_state(&self) -> Option<SerializableState> {
         None
     }
@@ -182,10 +156,43 @@ impl<T: DatabaseRef> MaybeHashDatabase for CacheDB<T> {
     fn maybe_as_hash_db(&self) -> Option<(AsHashDB, H256)> {
         Some(trie_hash_db(&self.accounts))
     }
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        let db_accounts = std::mem::take(&mut self.accounts);
+        let mut accounts = BTreeMap::new();
+        let mut account_storage = BTreeMap::new();
+
+        for (addr, mut acc) in db_accounts {
+            account_storage.insert(addr, std::mem::take(&mut acc.storage));
+            let mut info = acc.info;
+            info.code = self.contracts.remove(&info.code_hash);
+            accounts.insert(addr, info);
+        }
+        let block_hashes = std::mem::take(&mut self.block_hashes);
+        StateSnapshot { accounts, storage: account_storage, block_hashes }
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        let StateSnapshot { accounts, mut storage, block_hashes } = snapshot;
+
+        for (addr, mut acc) in accounts {
+            if let Some(code) = acc.code.take() {
+                self.contracts.insert(acc.code_hash, code);
+            }
+            self.accounts.insert(
+                addr,
+                DbAccount {
+                    info: acc,
+                    storage: storage.remove(&addr).unwrap_or_default(),
+                    ..Default::default()
+                },
+            );
+        }
+        self.block_hashes = block_hashes;
+    }
 }
 
 /// Represents a state at certain point
-pub struct StateDb(Box<dyn MaybeHashDatabase + Send + Sync>);
+pub struct StateDb(pub(crate) Box<dyn MaybeHashDatabase + Send + Sync>);
 
 // === impl StateDB ===
 
@@ -217,6 +224,26 @@ impl MaybeHashDatabase for StateDb {
     fn maybe_as_hash_db(&self) -> Option<(AsHashDB, H256)> {
         self.0.maybe_as_hash_db()
     }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        self.0.clear_into_snapshot()
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        self.0.init_from_snapshot(snapshot)
+    }
+}
+
+impl<'a> MaybeHashDatabase for &'a StateDb {
+    fn maybe_as_hash_db(&self) -> Option<(AsHashDB, H256)> {
+        self.0.maybe_as_hash_db()
+    }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        unimplemented!()
+    }
+
+    fn init_from_snapshot(&mut self, _snapshot: StateSnapshot) {}
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/anvil/src/eth/backend/db.rs
+++ b/anvil/src/eth/backend/db.rs
@@ -9,12 +9,19 @@ use ethers::{
 };
 use forge::revm::KECCAK_EMPTY;
 use foundry_evm::{
-    executor::{backend::MemDb, DatabaseRef},
-    revm::{db::CacheDB, Bytecode, Database, DatabaseCommit},
+    executor::{
+        backend::{snapshot::StateSnapshot, MemDb},
+        DatabaseRef,
+    },
+    revm::{
+        db::{CacheDB, DbAccount},
+        Bytecode, Database, DatabaseCommit,
+    },
     HashMap,
 };
 use hash_db::HashDB;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Type alias for the `HashDB` representation of the Database
 pub type AsHashDB = Box<dyn HashDB<KeccakHasher, Vec<u8>>>;
@@ -70,6 +77,12 @@ pub trait Db: DatabaseRef + Database + DatabaseCommit + MaybeHashDatabase + Send
     /// inserts a blockhash for the given number
     fn insert_block_hash(&mut self, number: U256, hash: H256);
 
+    /// Clear the state and move it into a new `StateSnapshot`
+    fn clear_into_snapshot(&mut self) -> StateSnapshot;
+
+    /// Reverses `clear_into_snapshot` by initializing the db's state with the snapshot
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot);
+
     /// Write all chain data to serialized bytes buffer
     fn dump_state(&self) -> Option<SerializableState>;
 
@@ -108,6 +121,40 @@ impl<T: DatabaseRef + Send + Sync + Clone> Db for CacheDB<T> {
 
     fn insert_block_hash(&mut self, number: U256, hash: H256) {
         self.block_hashes.insert(number, hash);
+    }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        let db_accounts = std::mem::take(&mut self.accounts);
+        let mut accounts = BTreeMap::new();
+        let mut account_storage = BTreeMap::new();
+
+        for (addr, mut acc) in db_accounts {
+            account_storage.insert(addr, std::mem::take(&mut acc.storage));
+            let mut info = acc.info;
+            info.code = self.contracts.remove(&info.code_hash);
+            accounts.insert(addr, info);
+        }
+        let block_hashes = std::mem::take(&mut self.block_hashes);
+        StateSnapshot { accounts, storage: account_storage, block_hashes }
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        let StateSnapshot { accounts, mut storage, block_hashes } = snapshot;
+
+        for (addr, mut acc) in accounts {
+            if let Some(code) = acc.code.take() {
+                self.contracts.insert(acc.code_hash, code);
+            }
+            self.accounts.insert(
+                addr,
+                DbAccount {
+                    info: acc.info,
+                    storage: storage.remove(&addr).unwrap_or_default(),
+                    ..Default::default()
+                },
+            );
+        }
+        self.block_hashes = block_hashes;
     }
 
     fn dump_state(&self) -> Option<SerializableState> {

--- a/anvil/src/eth/backend/mem/cache.rs
+++ b/anvil/src/eth/backend/mem/cache.rs
@@ -1,0 +1,60 @@
+use crate::eth::backend::db::StateDb;
+use ethers::{
+    prelude::H256,
+    types::{Address, U256},
+};
+use forge::revm::AccountInfo;
+use foundry_evm::HashMap as Map;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
+use tempfile::TempDir;
+use tracing::{error, trace};
+use foundry_evm::executor::backend::snapshot::StateSnapshot;
+
+/// On disk state cache
+///
+/// A basic tempdir which stores states on disk
+#[derive(Default)]
+pub struct DiskStateCache {
+    temp_dir: Option<TempDir>,
+}
+
+impl DiskStateCache {
+    /// Returns the cache file for the given hash
+    fn with_cache_file<F, R>(&mut self, hash: H256, f: F) -> Option<R>
+    where
+        F: FnOnce(PathBuf) -> R,
+    {
+        if self.temp_dir.is_none() {
+            match TempDir::new() {
+                Ok(temp_dir) => {
+                    trace!(path=?temp_dir.path(), "created disk state cache dir");
+                    self.temp_dir = Some(temp_dir);
+                }
+                Err(err) => {
+                    error!(?err, "failed to create disk state cache dir");
+                }
+            }
+        }
+        if let Some(ref temp_dir) = self.temp_dir {
+            let path = temp_dir.path().join(format!("{:?}.json", hash));
+            Some(f(path))
+        } else {
+            None
+        }
+    }
+
+    fn store(&mut self, hash: H256, state: StateSnapshot) {
+        self.with_cache_file(hash, |file| ());
+    }
+
+    fn load(&mut self, hash: H256, state: StateDb) -> Option<StateSnapshot> {
+        self.with_cache_file(hash, |file| {
+           match foundry_common::fs::read_
+
+        });
+    }
+}

--- a/anvil/src/eth/backend/mem/fork_db.rs
+++ b/anvil/src/eth/backend/mem/fork_db.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use ethers::prelude::H256;
 use forge::revm::Database;
-use foundry_evm::executor::fork::database::ForkDbSnapshot;
 pub use foundry_evm::executor::fork::database::ForkedDatabase;
+use foundry_evm::executor::{backend::snapshot::StateSnapshot, fork::database::ForkDbSnapshot};
 
 /// Implement the helper for the fork database
 impl Db for ForkedDatabase {
@@ -21,7 +21,23 @@ impl Db for ForkedDatabase {
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: H256) {
-        self.inner().block_hashes().write().insert(number.as_u64(), hash);
+        self.inner().block_hashes().write().insert(number, hash);
+    }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        let db = self.inner().db();
+        let accounts = std::mem::take(&mut *db.accounts.write());
+        let storage = std::mem::take(&mut *db.storage.write());
+        let block_hashes = std::mem::take(&mut *db.block_hashes.write());
+        StateSnapshot { accounts, storage, block_hashes }
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        let db = self.inner().db();
+        let StateSnapshot { accounts, storage, block_hashes } = snapshot;
+        *db.accounts.write() = accounts;
+        *db.storage.write() = storage;
+        *db.block_hashes.write() = block_hashes;
     }
 
     fn dump_state(&self) -> Option<SerializableState> {

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -30,14 +30,6 @@ impl Db for MemDb {
         self.inner.block_hashes.insert(number, hash);
     }
 
-    fn clear_into_snapshot(&mut self) -> StateSnapshot {
-        self.inner.clear_into_snapshot()
-    }
-
-    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
-        self.inner.init_from_snapshot(snapshot)
-    }
-
     fn dump_state(&self) -> Option<SerializableState> {
         let accounts = self
             .inner
@@ -134,6 +126,14 @@ impl MaybeHashDatabase for MemDb {
         } else {
             Some(storage_trie_db(&Default::default()))
         }
+    }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        self.inner.clear_into_snapshot()
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        self.inner.init_from_snapshot(snapshot)
     }
 }
 

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -14,6 +14,7 @@ use tracing::{trace, warn};
 
 // reexport for convenience
 use crate::mem::state::storage_trie_db;
+use foundry_evm::executor::backend::snapshot::StateSnapshot;
 pub use foundry_evm::executor::{backend::MemDb, DatabaseRef};
 
 impl Db for MemDb {
@@ -27,6 +28,14 @@ impl Db for MemDb {
 
     fn insert_block_hash(&mut self, number: U256, hash: H256) {
         self.inner.block_hashes.insert(number, hash);
+    }
+
+    fn clear_into_snapshot(&mut self) -> StateSnapshot {
+        self.inner.clear_into_snapshot()
+    }
+
+    fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
+        self.inner.init_from_snapshot(snapshot)
     }
 
     fn dump_state(&self) -> Option<SerializableState> {

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -70,6 +70,7 @@ use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{trace, warn};
 use trie_db::{Recorder, Trie};
 
+pub mod cache;
 pub mod fork_db;
 pub mod in_memory_db;
 pub mod inspector;

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1250,7 +1250,7 @@ impl Backend {
         let block_number: U256 = self.convert_block_number(block_number).into();
 
         if block_number < self.env.read().block.number {
-            let states = self.states.read();
+            let mut states = self.states.write();
             return if let Some((state, block)) = self
                 .get_block(block_number.as_u64())
                 .and_then(|block| Some((states.get(&block.header.hash())?, block)))

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -301,7 +301,7 @@ mod tests {
         let mut state = MemDb::default();
         let addr = Address::random();
         let info = AccountInfo::from_balance(1337.into());
-        state.insert_account(addr, info.clone());
+        state.insert_account(addr, info);
         storage.insert(one, StateDb::new(state));
         storage.insert(two, StateDb::new(MemDb::default()));
 

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -850,7 +850,7 @@ async fn test_tx_access_list() {
 /// returns a String representation of the AccessList, with sorted
 /// keys (address) and storage slots
 fn access_list_to_sorted_string(a: AccessList) -> String {
-    let mut a = a.0.clone();
+    let mut a = a.0;
     a.sort_by_key(|v| v.address);
 
     let a = a

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
-tempfile = "3.2.0"
+tempfile = "3.3.0"
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["project-util"] }
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -33,6 +33,8 @@ pub enum FsPathError {
     Open { source: io::Error, path: PathBuf },
     #[error("failed to parse json file: {path:?}: {source}")]
     ReadJson { source: serde_json::Error, path: PathBuf },
+    #[error("failed to write to json file: {path:?}: {source}")]
+    WriteJson { source: serde_json::Error, path: PathBuf },
 }
 
 impl FsPathError {
@@ -83,6 +85,7 @@ impl AsRef<Path> for FsPathError {
             FsPathError::RemoveFile { path, .. } => path,
             FsPathError::Open { path, .. } => path,
             FsPathError::ReadJson { path, .. } => path,
+            FsPathError::WriteJson { path, .. } => path,
         }
     }
 }
@@ -98,6 +101,7 @@ impl From<FsPathError> for io::Error {
             FsPathError::RemoveFile { source, .. } => source,
             FsPathError::Open { source, .. } => source,
             FsPathError::ReadJson { source, .. } => source.into(),
+            FsPathError::WriteJson { source, .. } => source.into(),
         }
     }
 }

--- a/common/src/fs.rs
+++ b/common/src/fs.rs
@@ -1,6 +1,6 @@
 //! Contains various `std::fs` wrapper functions that also contain the target path in their errors
 use crate::errors::FsPathError;
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{fs, path::Path};
 
 type Result<T> = std::result::Result<T, FsPathError>;
@@ -35,6 +35,15 @@ pub fn read_json_file<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> 
     let file = std::io::BufReader::new(file);
     serde_json::from_reader(file)
         .map_err(|source| FsPathError::ReadJson { source, path: path.to_path_buf() })
+}
+
+/// Writes the object as a json object
+pub fn write_json_file<T: Serialize>(path: impl AsRef<Path>, obj: &T) -> Result<()> {
+    let path = path.as_ref();
+    let file = create_file(path)?;
+    let file = std::io::BufWriter::new(file);
+    serde_json::to_writer(file, obj)
+        .map_err(|source| FsPathError::WriteJson { source, path: path.to_path_buf() })
 }
 
 /// Wrapper for `std::fs::write`

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use tracing::{trace, warn};
 
 mod fuzz;
-mod snapshot;
+pub mod snapshot;
 pub use fuzz::FuzzBackendWrapper;
 mod diagnostic;
 pub use diagnostic::RevertDiagnostic;

--- a/evm/src/executor/backend/snapshot.rs
+++ b/evm/src/executor/backend/snapshot.rs
@@ -1,7 +1,6 @@
-use revm::{Env, JournaledState};
 use ethers::types::{Address, H256, U256};
 use hashbrown::HashMap as Map;
-use revm::{AccountInfo};
+use revm::{AccountInfo, Env, JournaledState};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/evm/src/executor/backend/snapshot.rs
+++ b/evm/src/executor/backend/snapshot.rs
@@ -1,4 +1,16 @@
-use revm::{Env, SubRoutine};
+use ethers::types::{Address, H256, U256};
+use hashbrown::HashMap as Map;
+use revm::{AccountInfo, Env, SubRoutine};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A minimal abstraction of a state at a certain point in time
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct StateSnapshot {
+    pub accounts: BTreeMap<Address, AccountInfo>,
+    pub storage: BTreeMap<Address, BTreeMap<U256, U256>>,
+    pub block_hashes: Map<U256, H256>,
+}
 
 /// Represents a snapshot taken during evm execution
 #[derive(Clone, Debug)]

--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -115,7 +115,7 @@ where
                 }
             }
             BackendRequest::BlockHash(number, sender) => {
-                let hash = self.db.block_hashes().read().get(&number).cloned();
+                let hash = self.db.block_hashes().read().get(&U256::from(number)).cloned();
                 if let Some(hash) = hash {
                     let _ = sender.send(hash);
                 } else {
@@ -321,7 +321,7 @@ where
                             });
 
                             // update the cache
-                            pin.db.block_hashes().write().insert(number, value);
+                            pin.db.block_hashes().write().insert(number.into(), value);
 
                             // notify all listeners
                             if let Some(listeners) = pin.block_requests.remove(&number) {
@@ -572,7 +572,7 @@ mod tests {
 
         let num = U256::from(10u64);
         let hash = backend.block_hash(num);
-        let mem_hash = *db.block_hashes().read().get(&num.as_u64()).unwrap();
+        let mem_hash = *db.block_hashes().read().get(&num).unwrap();
         assert_eq!(hash, mem_hash);
 
         let max_slots = 5;

--- a/evm/src/executor/fork/database.rs
+++ b/evm/src/executor/fork/database.rs
@@ -195,8 +195,8 @@ impl DatabaseCommit for ForkedDatabase {
 /// This mimics `revm::CacheDB`
 #[derive(Debug)]
 pub struct ForkDbSnapshot {
-    local: CacheDB<SharedBackend>,
-    snapshot: StateSnapshot,
+    pub local: CacheDB<SharedBackend>,
+    pub snapshot: StateSnapshot,
 }
 
 // === impl DbSnapshot ===

--- a/evm/src/executor/fork/database.rs
+++ b/evm/src/executor/fork/database.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     executor::{
+        backend::snapshot::StateSnapshot,
         fork::{BlockchainDb, SharedBackend},
         snapshot::Snapshots,
     },
@@ -14,7 +15,7 @@ use ethers::{
 use hashbrown::HashMap as Map;
 use parking_lot::Mutex;
 use revm::{db::DatabaseRef, Account, AccountInfo, Bytecode, Database, DatabaseCommit};
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 use tracing::{trace, warn};
 
 /// a [revm::Database] that's forked off another client
@@ -96,12 +97,12 @@ impl ForkedDatabase {
 
     pub fn create_snapshot(&self) -> ForkDbSnapshot {
         let db = self.db.db();
-        ForkDbSnapshot {
-            local: self.cache_db.clone(),
+        let snapshot = StateSnapshot {
             accounts: db.accounts.read().clone(),
             storage: db.storage.read().clone(),
             block_hashes: db.block_hashes.read().clone(),
-        }
+        };
+        ForkDbSnapshot { local: self.cache_db.clone(), snapshot }
     }
 
     pub fn insert_snapshot(&self) -> U256 {
@@ -115,7 +116,10 @@ impl ForkedDatabase {
     pub fn revert_snapshot(&mut self, id: U256) -> bool {
         let snapshot = { self.snapshots().lock().remove(id) };
         if let Some(snapshot) = snapshot {
-            let ForkDbSnapshot { accounts, storage, block_hashes, local } = snapshot;
+            let ForkDbSnapshot {
+                local,
+                snapshot: StateSnapshot { accounts, storage, block_hashes },
+            } = snapshot;
             let db = self.inner().db();
             {
                 let mut accounts_lock = db.accounts.write();
@@ -187,12 +191,12 @@ impl DatabaseCommit for ForkedDatabase {
 }
 
 /// Represents a snapshot of the database
+///
+/// This mimics `revm::CacheDB`
 #[derive(Debug)]
 pub struct ForkDbSnapshot {
     local: CacheDB<SharedBackend>,
-    accounts: BTreeMap<Address, AccountInfo>,
-    storage: BTreeMap<Address, BTreeMap<U256, U256>>,
-    block_hashes: BTreeMap<u64, H256>,
+    snapshot: StateSnapshot,
 }
 
 // === impl DbSnapshot ===
@@ -210,9 +214,12 @@ impl DatabaseRef for ForkDbSnapshot {
     fn basic(&self, address: Address) -> AccountInfo {
         match self.local.accounts.get(&address) {
             Some(account) => account.info.clone(),
-            None => {
-                self.accounts.get(&address).cloned().unwrap_or_else(|| self.local.basic(address))
-            }
+            None => self
+                .snapshot
+                .accounts
+                .get(&address)
+                .cloned()
+                .unwrap_or_else(|| self.local.basic(address)),
         }
     }
 
@@ -235,8 +242,9 @@ impl DatabaseRef for ForkDbSnapshot {
     }
 
     fn block_hash(&self, number: U256) -> H256 {
-        self.block_hashes
-            .get(&number.as_u64())
+        self.snapshot
+            .block_hashes
+            .get(&number)
             .copied()
             .unwrap_or_else(|| self.local.block_hash(number))
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2880

previously we had an unbounded mem map that stored _all_ previous states

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
this will lower the limit to 1_000 blocks, roughly 30mins with 1s interval and extract the state of older blocks and write that in a temp dir until requested again.

This extract and init step is necessary because the state is essentially a `dyn Database` so instead this adds new functions to `clear` and `init` a `StateSnapshot`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
