### PR TITLE
feat(anvil): Add `stateOverride` to `eth_call`

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -19,11 +19,14 @@ pub mod block;
 pub mod proof;
 pub mod receipt;
 pub mod serde_helpers;
+pub mod state;
 pub mod subscription;
 pub mod transaction;
 pub mod trie;
 pub mod utils;
 use serde_helpers::*;
+
+use self::state::StateOverride;
 
 /// Represents ethereum JSON-RPC API
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -117,7 +120,11 @@ pub enum EthRequest {
     EthSendRawTransaction(Bytes),
 
     #[serde(rename = "eth_call")]
-    EthCall(EthTransactionRequest, #[serde(default)] Option<BlockId>),
+    EthCall(
+        EthTransactionRequest,
+        #[serde(default)] Option<BlockId>,
+        #[serde(default)] Option<StateOverride>,
+    ),
 
     #[serde(rename = "eth_createAccessList")]
     EthCreateAccessList(EthTransactionRequest, #[serde(default)] Option<BlockId>),

--- a/anvil/core/src/eth/state.rs
+++ b/anvil/core/src/eth/state.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use ethers_core::types::{Address, Bytes, H256, U256};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountOverride {
+    pub nonce: Option<u64>,
+    pub code: Option<Bytes>,
+    pub balance: Option<U256>,
+    pub state: Option<HashMap<H256, H256>>,
+    pub state_diff: Option<HashMap<H256, H256>>,
+}
+
+pub type StateOverride = HashMap<Address, AccountOverride>;

--- a/anvil/src/eth/backend/mem/state.rs
+++ b/anvil/src/eth/backend/mem/state.rs
@@ -1,14 +1,21 @@
 //! Support for generating the state root for memdb storage
 use std::collections::BTreeMap;
 
-use crate::eth::backend::db::AsHashDB;
-use anvil_core::eth::trie::RefSecTrieDBMut;
+use crate::eth::{backend::db::AsHashDB, error::BlockchainError};
+use anvil_core::eth::{state::StateOverride, trie::RefSecTrieDBMut};
 use bytes::Bytes;
 use ethers::{
+    abi::ethereum_types::BigEndianHash,
     types::{Address, H256, U256},
     utils::{rlp, rlp::RlpStream},
 };
-use forge::revm::db::DbAccount;
+use forge::{
+    executor::DatabaseRef,
+    revm::{
+        db::{CacheDB, DbAccount},
+        Bytecode,
+    },
+};
 use foundry_evm::revm::{AccountInfo, Log};
 use memory_db::HashKey;
 use trie_db::TrieMut;
@@ -97,4 +104,57 @@ pub fn trie_account_rlp(info: &AccountInfo, storage: &BTreeMap<U256, U256>) -> B
     stream.append(&storage_trie_db(storage).1);
     stream.append(&info.code_hash.as_bytes());
     stream.out().freeze()
+}
+
+/// Applies the given state overrides to the state, returning a new CacheDB state
+pub fn apply_state_override<D>(
+    overrides: StateOverride,
+    state: D,
+) -> Result<CacheDB<D>, BlockchainError>
+where
+    D: DatabaseRef,
+{
+    let mut cache_db = CacheDB::new(state);
+    for (account, account_overrides) in overrides.iter() {
+        let mut account_info = cache_db.basic(*account);
+
+        if let Some(nonce) = account_overrides.nonce {
+            account_info.nonce = nonce;
+        }
+        if let Some(code) = &account_overrides.code {
+            account_info.code = Some(Bytecode::new_raw(code.to_vec().into()));
+        }
+        if let Some(balance) = account_overrides.balance {
+            account_info.balance = balance;
+        }
+
+        cache_db.insert_account_info(*account, account_info);
+
+        // We ensure that not both state and state_diff are set.
+        // If state is set, we must mark the account as "NewlyCreated", so that the old storage
+        // isn't read from
+        match (&account_overrides.state, &account_overrides.state_diff) {
+            (Some(_), Some(_)) => {
+                return Err(BlockchainError::StateOverrideError(
+                    "state and state_diff can't be used together".into(),
+                ))
+            }
+            (None, None) => (),
+            (Some(new_account_state), None) => {
+                cache_db.replace_account_storage(
+                    *account,
+                    new_account_state
+                        .iter()
+                        .map(|(key, value)| (key.into_uint(), value.into_uint()))
+                        .collect(),
+                );
+            }
+            (None, Some(account_state_diff)) => {
+                for (key, value) in account_state_diff.iter() {
+                    cache_db.insert_account_storage(*account, key.into_uint(), value.into_uint());
+                }
+            }
+        };
+    }
+    Ok(cache_db)
 }

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -66,6 +66,8 @@ pub enum BlockchainError {
     TrieError(String),
     #[error("{0}")]
     UintConversion(&'static str),
+    #[error("State override error: {0}")]
+    StateOverrideError(String),
 }
 
 impl From<RpcError> for BlockchainError {
@@ -250,6 +252,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                     RpcError::internal_error_with(err.to_string())
                 }
                 BlockchainError::UintConversion(err) => RpcError::invalid_params(err),
+                err @ BlockchainError::StateOverrideError(_) => {
+                    RpcError::invalid_params(err.to_string())
+                }
             }
             .into(),
         }

--- a/anvil/tests/it/api.rs
+++ b/anvil/tests/it/api.rs
@@ -1,16 +1,20 @@
 //! general eth api tests
 
-use anvil::{eth::api::CLIENT_VERSION, spawn, NodeConfig, CHAIN_ID};
+use anvil::{
+    eth::{api::CLIENT_VERSION, EthApi},
+    spawn, NodeConfig, CHAIN_ID,
+};
+use anvil_core::eth::{state::AccountOverride, transaction::EthTransactionRequest};
 use ethers::{
-    abi::Address,
-    prelude::{Middleware, SignerMiddleware},
+    abi::{Address, Tokenizable},
+    prelude::{builders::ContractCall, decode_function_data, Middleware, SignerMiddleware},
     signers::Signer,
-    types::{Block, BlockNumber, Chain, Transaction, TransactionRequest, U256},
+    types::{Block, BlockNumber, Chain, Transaction, TransactionRequest, H256, U256},
     utils::get_contract_address,
 };
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use crate::abi::MulticallContract;
+use crate::abi::{MulticallContract, SimpleStorage};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_block_number() {
@@ -210,4 +214,122 @@ async fn can_call_on_pending_block() {
             pending_contract.get_current_block_coinbase().block(block_number).call().await.unwrap();
         assert_eq!(block.author.unwrap(), block_coinbase);
     }
+}
+
+async fn call_with_override<M, D>(
+    api: &EthApi,
+    call: ContractCall<M, D>,
+    to: Address,
+    overrides: HashMap<Address, AccountOverride>,
+) -> D
+where
+    D: Tokenizable,
+{
+    let result = api
+        .call(
+            EthTransactionRequest {
+                data: call.tx.data().map(|d| d.clone()),
+                to: Some(to),
+                ..Default::default()
+            },
+            None,
+            Some(overrides),
+        )
+        .await
+        .unwrap();
+    decode_function_data(&call.function, result.as_ref(), false).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_call_with_state_override() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(true).await.unwrap();
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let account = wallet.address();
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    let init_value = "toto".to_string();
+    let multicall =
+        MulticallContract::deploy(Arc::clone(&client), ()).unwrap().send().await.unwrap();
+    let simple_storage = SimpleStorage::deploy(Arc::clone(&client), init_value.clone())
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    // Test the `balance` account override
+    let balance = 42u64.into();
+    let result = call_with_override(
+        &api,
+        multicall.get_eth_balance(account),
+        multicall.address(),
+        HashMap::from([(
+            account,
+            AccountOverride { balance: Some(balance), ..Default::default() },
+        )]),
+    )
+    .await;
+    assert_eq!(result, balance);
+
+    // Test the `state_diff` account override
+    let overrides = HashMap::from([(
+        simple_storage.address(),
+        AccountOverride {
+            // The `lastSender` is in the first storage slot
+            state_diff: Some(HashMap::from([(H256::from_low_u64_be(0), account.into())])),
+            ..Default::default()
+        },
+    )]);
+
+    let last_sender = call_with_override(
+        &api,
+        simple_storage.last_sender(),
+        simple_storage.address(),
+        Default::default(),
+    )
+    .await;
+    // No `sender` set without override
+    assert_eq!(last_sender, Address::zero());
+    let last_sender = call_with_override(
+        &api,
+        simple_storage.last_sender(),
+        simple_storage.address(),
+        overrides.clone(),
+    )
+    .await;
+    // `sender` *is* set with override
+    assert_eq!(last_sender, account);
+    let value =
+        call_with_override(&api, simple_storage.get_value(), simple_storage.address(), overrides)
+            .await;
+    // `value` *is not* changed with state-diff
+    assert_eq!(value, init_value);
+
+    // Test the `state` account override
+    let overrides = HashMap::from([(
+        simple_storage.address(),
+        AccountOverride {
+            // The `lastSender` is in the first storage slot
+            state: Some(HashMap::from([(H256::from_low_u64_be(0), account.into())])),
+            ..Default::default()
+        },
+    )]);
+
+    let last_sender = call_with_override(
+        &api,
+        simple_storage.last_sender(),
+        simple_storage.address(),
+        overrides.clone(),
+    )
+    .await;
+    // `sender` *is* set with override
+    assert_eq!(last_sender, account);
+    let value =
+        call_with_override(&api, simple_storage.get_value(), simple_storage.address(), overrides)
+            .await;
+    // `value` *is* changed with state
+    assert_eq!(value, "");
 }

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -576,7 +576,11 @@ async fn test_fork_call() {
     let (api, _) = spawn(fork_config().with_fork_block_number(Some(block_number))).await;
 
     let res1 = api
-        .call(EthTransactionRequest { to: Some(to), data: Some(input), ..Default::default() }, None)
+        .call(
+            EthTransactionRequest { to: Some(to), data: Some(input), ..Default::default() },
+            None,
+            None,
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
## Motivation

In `go-ethereum` (and maybe other clients too?), there is an additional optional parameter to `eth_call` which is called "StateOverride", cf. https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set

It is useful in some conditions, for setting code/balance/etc. temporarily for a single call.

## Solution

I implemented this new optional parameter, with added tests for most of the usages