### PR TITLE
fix(forge): ensure accounts are touched in cheatcodes

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -1,13 +1,14 @@
 use std::collections::BTreeMap;
 
 use super::Cheatcodes;
-use crate::abi::HEVMCalls;
+use crate::{abi::HEVMCalls, executor::inspector::cheatcodes::util::with_journaled_account};
 use bytes::Bytes;
 use ethers::{
     abi::{self, AbiEncode, RawLog, Token, Tokenizable, Tokenize},
     types::{Address, U256},
 };
 use revm::{Bytecode, Database, EVMData};
+use tracing::trace;
 
 #[derive(Clone, Debug, Default)]
 pub struct Broadcast {
@@ -114,7 +115,7 @@ fn start_record_logs(state: &mut Cheatcodes) {
 
 fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
     if let Some(recorded_logs) = state.recorded_logs.replace(Default::default()) {
-        ethers::abi::encode(
+        abi::encode(
             &recorded_logs
                 .entries
                 .iter()
@@ -129,7 +130,7 @@ fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
         )
         .into()
     } else {
-        ethers::abi::encode(&[Token::Array(vec![])]).into()
+        abi::encode(&[Token::Array(vec![])]).into()
     }
 }
 
@@ -183,10 +184,11 @@ pub fn apply<DB: Database>(
         HEVMCalls::Deal(inner) => {
             let who = inner.0;
             let value = inner.1;
+            trace!(?who, ?value, "deal cheatcode");
 
-            data.journaled_state.load_account(who, data.db);
-            let account = data.journaled_state.state.get_mut(&who).expect("account loaded;");
-            account.info.balance = value;
+            with_journaled_account(&mut data.journaled_state, data.db, who, |account| {
+                account.info.balance = value;
+            });
             Ok(Bytes::new())
         }
         HEVMCalls::Prank0(inner) => prank(
@@ -240,22 +242,18 @@ pub fn apply<DB: Database>(
         }
         HEVMCalls::GetRecordedLogs(_) => Ok(get_recorded_logs(state)),
         HEVMCalls::SetNonce(inner) => {
-            // TODO:  this is probably not a good long-term solution since it might mess up the gas
-            // calculations
-            data.journaled_state.load_account(inner.0, data.db);
-
-            // we can safely unwrap because `load_account` insert inner.0 to DB.
-            let account = data.journaled_state.state().get_mut(&inner.0).unwrap();
-            // nonce must increment only
-            if account.info.nonce < inner.1 {
-                account.info.nonce = inner.1;
-                Ok(Bytes::new())
-            } else {
-                Err(format!("Nonce lower than account's current nonce. Please provide a higher nonce than {}", account.info.nonce).encode().into())
-            }
+            with_journaled_account(&mut data.journaled_state, data.db, inner.0, |account| {
+                // nonce must increment only
+                if account.info.nonce < inner.1 {
+                    account.info.nonce = inner.1;
+                    Ok(Bytes::new())
+                } else {
+                    Err(format!("Nonce lower than account's current nonce. Please provide a higher nonce than {}", account.info.nonce).encode().into())
+                }
+            })
         }
         HEVMCalls::GetNonce(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            correct_sender_nonce(data.env.tx.caller, &mut data.journaled_state, state);
 
             // TODO:  this is probably not a good long-term solution since it might mess up the gas
             // calculations
@@ -270,19 +268,19 @@ pub fn apply<DB: Database>(
             Ok(Bytes::new())
         }
         HEVMCalls::Broadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            correct_sender_nonce(data.env.tx.caller, &mut data.journaled_state, state);
             broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::Broadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            correct_sender_nonce(data.env.tx.caller, &mut data.journaled_state, state);
             broadcast(state, inner.0, caller, data.journaled_state.depth(), true)
         }
         HEVMCalls::StartBroadcast0(_) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            correct_sender_nonce(data.env.tx.caller, &mut data.journaled_state, state);
             broadcast(state, data.env.tx.caller, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StartBroadcast1(inner) => {
-            correct_sender_nonce(&data.env.tx.caller, &mut data.journaled_state, state);
+            correct_sender_nonce(data.env.tx.caller, &mut data.journaled_state, state);
             broadcast(state, inner.0, caller, data.journaled_state.depth(), false)
         }
         HEVMCalls::StopBroadcast(_) => {
@@ -297,13 +295,12 @@ pub fn apply<DB: Database>(
 /// That leads to its nonce being incremented by `call_raw`. In a `broadcast` scenario this is
 /// undesirable. Therefore, we make sure to fix the sender's nonce **once**.
 fn correct_sender_nonce(
-    sender: &Address,
+    sender: Address,
     journaled_state: &mut revm::JournaledState,
     state: &mut Cheatcodes,
 ) {
     if !state.corrected_nonce {
-        let account = journaled_state.state().get_mut(sender).unwrap();
-        account.info.nonce -= 1;
+        journaled_state.inc_nonce(sender);
         state.corrected_nonce = true;
     }
 }

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -138,6 +138,7 @@ impl Cheatcodes {
         }
     }
 
+    #[tracing::instrument(skip_all, name = "applying cheatcode")]
     fn apply_cheatcode<DB: DatabaseExt>(
         &mut self,
         data: &mut EVMData<'_, DB>,

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -195,6 +195,7 @@ impl Executor {
         from: Option<Address>,
         to: Address,
     ) -> Result<CallResult<()>, EvmError> {
+        trace!(?from, ?to, "setting up contract");
         let from = from.unwrap_or(CALLER);
         self.backend_mut().set_test_contract(to).set_caller(from);
         self.call_committing::<(), _, _>(from, to, "setUp()", (), 0.into(), None)

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -69,3 +69,25 @@ fn test_issue_2723() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/2898>
+#[test]
+fn test_issue_2898() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue2898"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue2898.t.sol
+++ b/testdata/repros/Issue2898.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+import "../logs/console.sol";
+
+// https://github.com/foundry-rs/foundry/issues/2898
+contract Issue2898Test is DSTest {
+    address private constant BRIDGE = address(10);
+    address private constant BENEFICIARY = address(11);
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function setUp() public {
+        vm.deal(BRIDGE, 100);
+        vm.deal(BENEFICIARY, 99);
+
+        vm.setNonce(BRIDGE, 10);
+    }
+
+    function testDealBalance() public {
+        assertEq(BRIDGE.balance, 100);
+        assertEq(BENEFICIARY.balance, 99);
+    }
+
+    function testSetNonce() public {
+        assertEq(vm.getNonce(BRIDGE), 10);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2898 

this was a regression introduced by the latest revm bump.

when modifying account data directly, we need to ensure the account gets loaded _and_ `touched`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add helper function that loads and marks the account as touched
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
