### PR TITLE
feat(forge): decodes external event/function signatures on `forge test`

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -17,7 +17,7 @@ use forge::{
     gas_report::GasReport,
     result::{SuiteResult, TestKind, TestResult},
     trace::{
-        identifier::{EtherscanIdentifier, LocalTraceIdentifier},
+        identifier::{EtherscanIdentifier, LocalTraceIdentifier, SignaturesIdentifier},
         CallTraceDecoderBuilder, TraceKind,
     },
     MultiContractRunner, MultiContractRunnerBuilder, TestOptions,
@@ -522,6 +522,10 @@ fn test(
                         .with_labels(result.labeled_addresses.clone())
                         .with_events(local_identifier.events())
                         .build();
+
+                    decoder.add_signature_identifier(SignaturesIdentifier::new(
+                        Config::foundry_cache_dir(),
+                    )?);
 
                     // Decode the traces
                     let mut decoded_traces = Vec::new();


### PR DESCRIPTION
Adds the `SignaturesIdentifier` (4byte/sig.sam) to `forge test` traces as well, since I've seen more people asking for it lately. 

