### PR TITLE
fix(anvil): return time offset in `evm_increase_time`

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1393,9 +1393,7 @@ impl EthApi {
     /// Handler for RPC call: `evm_increaseTime`
     pub async fn evm_increase_time(&self, seconds: U256) -> Result<i128> {
         node_info!("evm_increaseTime");
-        let time = self.backend.time();
-        time.increase_time(seconds.try_into().unwrap_or(u64::MAX));
-        Ok(time.offset())
+        Ok(self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX)))
     }
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1391,9 +1391,9 @@ impl EthApi {
     /// Jump forward in time by the given amount of time, in seconds.
     ///
     /// Handler for RPC call: `evm_increaseTime`
-    pub async fn evm_increase_time(&self, seconds: U256) -> Result<i128> {
+    pub async fn evm_increase_time(&self, seconds: U256) -> Result<i64> {
         node_info!("evm_increaseTime");
-        Ok(self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX)))
+        Ok(self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX)) as i64)
     }
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1393,8 +1393,9 @@ impl EthApi {
     /// Handler for RPC call: `evm_increaseTime`
     pub async fn evm_increase_time(&self, seconds: U256) -> Result<U256> {
         node_info!("evm_increaseTime");
-        self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX));
-        Ok(seconds)
+        let time = self.backend.time();
+        time.increase_time(seconds.try_into().unwrap_or(u64::MAX));
+        Ok(time.offset().into())
     }
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1391,11 +1391,11 @@ impl EthApi {
     /// Jump forward in time by the given amount of time, in seconds.
     ///
     /// Handler for RPC call: `evm_increaseTime`
-    pub async fn evm_increase_time(&self, seconds: U256) -> Result<U256> {
+    pub async fn evm_increase_time(&self, seconds: U256) -> Result<i128> {
         node_info!("evm_increaseTime");
         let time = self.backend.time();
         time.increase_time(seconds.try_into().unwrap_or(u64::MAX));
-        Ok(time.offset().into())
+        Ok(time.offset())
     }
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1391,10 +1391,10 @@ impl EthApi {
     /// Jump forward in time by the given amount of time, in seconds.
     ///
     /// Handler for RPC call: `evm_increaseTime`
-    pub async fn evm_increase_time(&self, seconds: U256) -> Result<()> {
+    pub async fn evm_increase_time(&self, seconds: U256) -> Result<U256> {
         node_info!("evm_increaseTime");
         self.backend.time().increase_time(seconds.try_into().unwrap_or(u64::MAX));
-        Ok(())
+        Ok(seconds)
     }
 
     /// Similar to `evm_increaseTime` but takes the exact timestamp that you want in the next block

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -28,7 +28,7 @@ pub struct TimeManager {
 // === impl TimeManager ===
 
 impl TimeManager {
-    fn offset(&self) -> i128 {
+    pub fn offset(&self) -> i128 {
         *self.offset.read()
     }
 

--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -32,12 +32,13 @@ impl TimeManager {
         *self.offset.read()
     }
 
-    /// Adds the given `offset` to the already tracked offset
-    fn add_offset(&self, offset: i128) {
+    /// Adds the given `offset` to the already tracked offset and returns the result
+    fn add_offset(&self, offset: i128) -> i128 {
         let mut current = self.offset.write();
         let next = current.saturating_add(offset);
         trace!(target: "time", "adding timestamp offset={}, total={}", offset, next);
         *current = next;
+        next
     }
 
     /// Sets the timestamp we should base further timestamps on
@@ -49,7 +50,7 @@ impl TimeManager {
     /// Jumps forward in time by the given seconds
     ///
     /// This will apply a permanent offset to the natural UNIX Epoch timestamp
-    pub fn increase_time(&self, seconds: u64) {
+    pub fn increase_time(&self, seconds: u64) -> i128 {
         self.add_offset(seconds as i128)
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Ganache's [`evm_increaseTime`](https://github.com/trufflesuite/ganache/blob/d48d998bd057a82b78c15ce197de06abc3487d2c/src/chains/ethereum/ethereum/RPC-METHODS.md#evm_increasetime) returns the time offset in seconds while Anvil's returns nothing, which leads to unexpected errors. Example: [eth-brownie/brownie](https://github.com/eth-brownie/brownie) uses it to track the time offset of the provider, but it raises an error when trying to parse the call's result since it is not a number:

https://github.com/eth-brownie/brownie/blob/4ae5f527ea86eb95766fe225a0f67620ffd36022/brownie/network/state.py#L375

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Return the input seconds in `EthApi::evm_increase_time`.
