### PR TITLE
fix: normalize paths

### DIFF
--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -12,7 +12,7 @@ contract FileTest is DSTest {
 
         assertEq(cheats.readFile(path), "hello readable world\nthis is the second line!");
 
-        cheats.expectRevert("Path is not allowed.");
+        cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.readFile("/etc/hosts");
     }
 
@@ -23,7 +23,7 @@ contract FileTest is DSTest {
         assertEq(cheats.readLine(path), "this is the second line!");
         assertEq(cheats.readLine(path), "");
 
-        cheats.expectRevert("Path is not allowed.");
+        cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.readLine("/etc/hosts");
     }
 
@@ -36,7 +36,7 @@ contract FileTest is DSTest {
 
         cheats.removeFile(path);
 
-        cheats.expectRevert("Path is not allowed.");
+        cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.writeFile("/etc/hosts", "malicious stuff");
     }
 
@@ -53,7 +53,7 @@ contract FileTest is DSTest {
 
         cheats.removeFile(path);
 
-        cheats.expectRevert("Path is not allowed.");
+        cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.writeLine("/etc/hosts", "malicious stuff");
     }
 
@@ -78,7 +78,7 @@ contract FileTest is DSTest {
 
         cheats.removeFile(path);
 
-        cheats.expectRevert("Path is not allowed.");
+        cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.removeFile("/etc/hosts");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2890

prevent path traversal
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add normalize path function, can't use `std::fs::canonicalize` as this only works for existing files
* normalize path when checking if a path is allowed
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
