### PR TITLE
fix(anvil): Ensure timestamp is always increasing

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -601,7 +601,6 @@ impl NodeConfig {
             tx: TxEnv { chain_id: self.get_chain_id().into(), ..Default::default() },
         };
         let fees = FeeManager::new(env.cfg.spec_id, self.get_base_fee(), self.get_gas_price());
-        let mut fork_timestamp = None;
 
         let (db, fork): (Arc<tokio::sync::RwLock<dyn Db>>, Option<ClientFork>) =
             if let Some(eth_rpc_url) = self.eth_rpc_url.clone() {
@@ -657,7 +656,6 @@ impl NodeConfig {
                     coinbase: env.block.coinbase,
                     basefee: env.block.basefee,
                 };
-                fork_timestamp = Some(block.timestamp);
 
                 // if not set explicitly we use the base fee of the latest block
                 if self.base_fee.is_none() {
@@ -747,15 +745,7 @@ impl NodeConfig {
         };
 
         // only memory based backend for now
-        let backend =
-            mem::Backend::with_genesis(db, Arc::new(RwLock::new(env)), genesis, fees, fork).await;
-
-        if let Some(timestamp) = fork_timestamp {
-            backend.time().set_start_timestamp(timestamp.as_u64());
-        } else {
-            backend.time().set_start_timestamp(self.get_genesis_timestamp());
-        }
-        backend
+        mem::Backend::with_genesis(db, Arc::new(RwLock::new(env)), genesis, fees, fork).await
     }
 }
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1401,7 +1401,7 @@ impl EthApi {
     /// Handler for RPC call: `evm_revert`
     pub async fn evm_revert(&self, id: U256) -> Result<bool> {
         node_info!("evm_revert");
-        Ok(self.backend.revert_snapshot(id).await)
+        self.backend.revert_snapshot(id).await
     }
 
     /// Jump forward in time by the given amount of time, in seconds.
@@ -1417,8 +1417,7 @@ impl EthApi {
     /// Handler for RPC call: `evm_setNextBlockTimestamp`
     pub fn evm_set_next_block_timestamp(&self, seconds: u64) -> Result<()> {
         node_info!("evm_setNextBlockTimestamp");
-        self.backend.time().set_next_block_timestamp(seconds);
-        Ok(())
+        self.backend.time().set_next_block_timestamp(seconds)
     }
 
     /// Set the next block gas limit

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -68,6 +68,8 @@ pub enum BlockchainError {
     UintConversion(&'static str),
     #[error("State override error: {0}")]
     StateOverrideError(String),
+    #[error("Timestamp error: {0}")]
+    TimestampError(String),
 }
 
 impl From<RpcError> for BlockchainError {
@@ -253,6 +255,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 }
                 BlockchainError::UintConversion(err) => RpcError::invalid_params(err),
                 err @ BlockchainError::StateOverrideError(_) => {
+                    RpcError::invalid_params(err.to_string())
+                }
+                err @ BlockchainError::TimestampError(_) => {
                     RpcError::invalid_params(err.to_string())
                 }
             }

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -424,16 +424,17 @@ async fn get_blocktimestamp_works() {
     assert_eq!(timestamp, latest_block.timestamp);
 
     // mock timestamp
-    api.evm_set_next_block_timestamp(1337).unwrap();
+    let next_timestamp = timestamp.as_u64() + 1337;
+    api.evm_set_next_block_timestamp(next_timestamp).unwrap();
 
     let timestamp =
         contract.get_current_block_timestamp().block(BlockNumber::Pending).call().await.unwrap();
-    assert_eq!(timestamp, 1337u64.into());
+    assert_eq!(timestamp, next_timestamp.into());
 
     // repeat call same result
     let timestamp =
         contract.get_current_block_timestamp().block(BlockNumber::Pending).call().await.unwrap();
-    assert_eq!(timestamp, 1337u64.into());
+    assert_eq!(timestamp, next_timestamp.into());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

So the initial goal of this PR was to fix an issue when reverting snapshots, that the timestamp wouldn't be reset (even though it could be done with `setNextBlockTimestamp` I guess).

I also found out that the timestamps aren't always increasing, which is kind of not-spec compliant (but this isn't necessarily an issue since setting state/code/etc. isn't), but doesn't follow what Hardhat is doing for example, and thus could break a few things (at least it broke some assumptions on my side).

## Solution

I mainly reworked a bit the `TimeManager` implementation. First, it should always be able to know what was the last block timestamp: in fork mode it's easy, otherwise the genesis block already have a timestamp. I also factorized the `next_timestamp` and `current_call_timestamp` methods' computation part.

I also removed `Backend::new` and `Backend::empty` since it wasn't used anywhere, and I don't think it really make sense to create a Backend without a genesis.. ?


Edit: I forgot, I also modified the `evm_set_next_block_timestamp` method so that it fails if it's called with a past timestamp. I think it's the right approach *if we want to have always increasing timestamps*