### PR TITLE
feat: filter non bug panic section

### DIFF
--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -1,19 +1,63 @@
 use eyre::EyreHandler;
-use std::error::Error;
+use foundry_config::error::FAILED_TO_EXTRACT_CONFIG_PANIC_MSG;
+use once_cell::sync::OnceCell;
+use std::{error::Error, fmt};
 use yansi::Paint;
+
+const BUG_REPORT: &str =
+    "This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry";
+
+/// Contains the panic section if initialized
+static SECTION: OnceCell<BugPanicSection> = OnceCell::new();
+
+/// Responsible for displaying the panic section
+struct PanicSection;
+
+impl fmt::Display for PanicSection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        SECTION.get().copied().unwrap_or_default().fmt(f)
+    }
+}
+
+/// Represents the panic section
+#[derive(Debug, Copy, Clone)]
+struct BugPanicSection {
+    /// whether to display the `BUG_REPORT` section
+    is_bug: bool,
+}
+
+impl BugPanicSection {
+    const fn bug() -> Self {
+        Self { is_bug: true }
+    }
+    const fn no_bug() -> Self {
+        Self { is_bug: false }
+    }
+}
+
+impl Default for BugPanicSection {
+    fn default() -> Self {
+        BugPanicSection::bug()
+    }
+}
+
+impl fmt::Display for BugPanicSection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_bug {
+            f.write_str(BUG_REPORT)?;
+        }
+        Ok(())
+    }
+}
 
 /// A custom context type for Foundry specific error reporting via `eyre`
 #[derive(Debug)]
 pub struct Handler;
 
 impl EyreHandler for Handler {
-    fn debug(
-        &self,
-        error: &(dyn Error + 'static),
-        f: &mut core::fmt::Formatter<'_>,
-    ) -> core::fmt::Result {
+    fn debug(&self, error: &(dyn Error + 'static), f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            return core::fmt::Debug::fmt(error, f)
+            return fmt::Debug::fmt(error, f)
         }
         writeln!(f)?;
         write!(f, "{}", Paint::red(error))?;
@@ -38,11 +82,80 @@ impl EyreHandler for Handler {
     }
 }
 
+/// A wrapper around `color-eyre`'s PanicHook that's used to intercept the panic message
+struct PanicHook {
+    panic_hook: color_eyre::config::PanicHook,
+}
+
+// === impl PanicHook ===
+
+impl PanicHook {
+    /// Install self as a global panic hook via `std::panic::set_hook`.
+    pub fn install(self) {
+        std::panic::set_hook(self.into_panic_hook());
+    }
+
+    /// Convert self into the type expected by `std::panic::set_hook`.
+    pub fn into_panic_hook(
+        self,
+    ) -> Box<dyn Fn(&std::panic::PanicInfo<'_>) + Send + Sync + 'static> {
+        Box::new(move |panic_info| {
+            let payload = panic_info.payload();
+            install_panic_section(ErrorKind::NonRecoverable(payload));
+            eprintln!("{}", self.panic_hook.panic_report(panic_info));
+        })
+    }
+}
+
+/// The kind of type erased error being reported
+enum ErrorKind<'a> {
+    /// A non recoverable error aka `panic!`
+    NonRecoverable(&'a dyn std::any::Any),
+    /// A recoverable error aka `impl std::error::Error`
+    #[allow(unused)]
+    Recoverable(&'a (dyn Error + 'static)),
+}
+
+/// tries to reason whether this is an actual bug or something else, like invalid config etc
+fn is_no_bug_error(error: &(dyn Error + 'static)) -> bool {
+    // TODO additional errors to exclude
+    error.is::<foundry_config::figment::Error>()
+}
+
+/// Returns true if the `panic_message` is known and not a considered a bug
+fn is_no_bug_panic(panic_message: &str) -> bool {
+    panic_message.contains(FAILED_TO_EXTRACT_CONFIG_PANIC_MSG)
+}
+
+/// This installs the appropriate `BugReport` that links to the repo's issue section in the
+/// panic section. This circumvents the auto-generated issue content and title which would override
+/// foundry's template
+fn install_panic_section(kind: ErrorKind) {
+    let is_no_bug = match kind {
+        ErrorKind::NonRecoverable(payload) => {
+            let payload = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().cloned())
+                .unwrap_or("<non string panic payload>");
+
+            is_no_bug_panic(payload)
+        }
+        ErrorKind::Recoverable(error) => is_no_bug_error(error),
+    };
+
+    // if we determined that the issue is unrelated to a bug, like misconfigured config, then we set
+    // the panic section accordingly
+    if is_no_bug {
+        let _ = SECTION.set(BugPanicSection::no_bug());
+    }
+}
+
 /// Installs the Foundry eyre hook as the global error report hook.
 ///
 /// # Details
 ///
-/// By default a simple user-centric handler is installed, unless
+/// By default, a simple user-centric handler is installed, unless
 /// `FOUNDRY_DEBUG` is set in the environment, in which case a more
 /// verbose debug-centric handler is installed.
 ///
@@ -53,14 +166,23 @@ pub fn install() -> eyre::Result<()> {
     if debug_enabled {
         color_eyre::install()?;
     } else {
-        let (panic_hook, _) = color_eyre::config::HookBuilder::default()
-            .panic_section(
-                "This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry",
-            )
-            .into_hooks();
-        panic_hook.install();
+        let (panic_hook, _) =
+            color_eyre::config::HookBuilder::default().panic_section(PanicSection).into_hooks();
+        PanicHook { panic_hook }.install();
         eyre::set_hook(Box::new(move |_| Box::new(Handler)))?;
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_panic_hook() {
+        install().unwrap();
+        panic!("{}", FAILED_TO_EXTRACT_CONFIG_PANIC_MSG)
+    }
 }

--- a/config/src/error.rs
+++ b/config/src/error.rs
@@ -1,4 +1,9 @@
+//! Error handling including solc error codes
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The message shown upon panic if the config could not be extracted from the figment
+pub const FAILED_TO_EXTRACT_CONFIG_PANIC_MSG:&str = "failed to extract foundry config";
 
 /// A non-exhaustive list of solidity error codes
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/config/src/error.rs
+++ b/config/src/error.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// The message shown upon panic if the config could not be extracted from the figment
-pub const FAILED_TO_EXTRACT_CONFIG_PANIC_MSG:&str = "failed to extract foundry config";
+pub const FAILED_TO_EXTRACT_CONFIG_PANIC_MSG: &str = "failed to extract foundry config";
 
 /// A non-exhaustive list of solidity error codes
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -55,8 +55,9 @@ pub use chain::Chain;
 pub mod fmt;
 pub use fmt::FormatterConfig;
 
-mod error;
+pub mod error;
 pub use error::SolidityErrorCode;
+use crate::error::FAILED_TO_EXTRACT_CONFIG_PANIC_MSG;
 
 mod warning;
 pub use warning::*;
@@ -431,7 +432,7 @@ impl Config {
                 for error in errors {
                     eprintln!("{}", error);
                 }
-                panic!("failed to extract foundry config")
+                panic!("{}", FAILED_TO_EXTRACT_CONFIG_PANIC_MSG)
             }
         }
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -56,8 +56,8 @@ pub mod fmt;
 pub use fmt::FormatterConfig;
 
 pub mod error;
-pub use error::SolidityErrorCode;
 use crate::error::FAILED_TO_EXTRACT_CONFIG_PANIC_MSG;
+pub use error::SolidityErrorCode;
 
 mod warning;
 pub use warning::*;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2912

provides a way to inspect panic! messages and conditionally set the panic section with link to new issue
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add panichook wrapper that inspects the payload and set the panic section conditionally whether the message is considered a bug or not
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
