### PR TITLE
feat(anvil): Add some missing RPC implementations

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -345,14 +345,14 @@ impl EthApi {
         Ok(self.backend.gas_limit())
     }
 
-    fn block_request(&self, block_number: Option<BlockId>) -> Result<BlockRequest> {
+    async fn block_request(&self, block_number: Option<BlockId>) -> Result<BlockRequest> {
         let block_request = match block_number {
             Some(BlockId::Number(BlockNumber::Pending)) => {
                 let pending_txs = self.pool.ready_transactions().collect();
                 BlockRequest::Pending(pending_txs)
             }
             _ => {
-                let number = self.backend.ensure_block_number(block_number)?;
+                let number = self.backend.ensure_block_number(block_number).await?;
                 BlockRequest::Number(number.into())
             }
         };
@@ -470,7 +470,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `eth_getBalance`
     pub async fn balance(&self, address: Address, block_number: Option<BlockId>) -> Result<U256> {
         node_info!("eth_getBalance");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         self.backend.get_balance(address, Some(block_request)).await
     }
 
@@ -484,7 +484,7 @@ impl EthApi {
         block_number: Option<BlockId>,
     ) -> Result<H256> {
         node_info!("eth_getStorageAt");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         self.backend.storage_at(address, index, Some(block_request)).await
     }
 
@@ -582,7 +582,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `eth_getCode`
     pub async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> Result<Bytes> {
         node_info!("eth_getCode");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         self.backend.get_code(address, Some(block_request)).await
     }
 
@@ -597,7 +597,7 @@ impl EthApi {
         block_number: Option<BlockId>,
     ) -> Result<AccountProof> {
         node_info!("eth_getProof");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
 
         if let BlockRequest::Number(number) = &block_request {
             if let Some(fork) = self.get_fork() {
@@ -752,7 +752,7 @@ impl EthApi {
         overrides: Option<StateOverride>,
     ) -> Result<Bytes> {
         node_info!("eth_call");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = &block_request {
             if let Some(fork) = self.get_fork() {
@@ -800,7 +800,7 @@ impl EthApi {
         block_number: Option<BlockId>,
     ) -> Result<AccessListWithGasUsed> {
         node_info!("eth_createAccessList");
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = &block_request {
             if let Some(fork) = self.get_fork() {
@@ -1651,7 +1651,7 @@ impl EthApi {
         request: EthTransactionRequest,
         block_number: Option<BlockId>,
     ) -> Result<U256> {
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = &block_request {
             if let Some(fork) = self.get_fork() {
@@ -1967,7 +1967,7 @@ impl EthApi {
         address: Address,
         block_number: Option<BlockId>,
     ) -> Result<U256> {
-        let block_request = self.block_request(block_number)?;
+        let block_request = self.block_request(block_number).await?;
         let nonce = self.backend.get_nonce(address, Some(block_request)).await?;
 
         Ok(nonce)

--- a/anvil/src/eth/backend/fork.rs
+++ b/anvil/src/eth/backend/fork.rs
@@ -396,6 +396,52 @@ impl ClientFork {
         Ok(None)
     }
 
+    pub async fn uncle_by_block_hash_and_index(
+        &self,
+        hash: H256,
+        index: usize,
+    ) -> Result<Option<Block<TxHash>>, ProviderError> {
+        if let Some(block) = self.block_by_hash(hash).await? {
+            return self.uncles_by_block_and_index(block, index).await
+        }
+        Ok(None)
+    }
+
+    pub async fn uncle_by_block_number_and_index(
+        &self,
+        number: u64,
+        index: usize,
+    ) -> Result<Option<Block<TxHash>>, ProviderError> {
+        if let Some(block) = self.block_by_number(number).await? {
+            return self.uncles_by_block_and_index(block, index).await
+        }
+        Ok(None)
+    }
+
+    async fn uncles_by_block_and_index(
+        &self,
+        block: Block<H256>,
+        index: usize,
+    ) -> Result<Option<Block<TxHash>>, ProviderError> {
+        let block_hash = block
+            .hash
+            .ok_or_else(|| ProviderError::CustomError("missing block-hash".to_string()))?;
+        if let Some(uncles) = self.storage_read().uncles.get(&block_hash) {
+            return Ok(uncles.get(index).cloned())
+        }
+
+        let mut uncles = Vec::with_capacity(block.uncles.len());
+        for (uncle_idx, _) in block.uncles.iter().enumerate() {
+            let uncle = match self.provider().get_uncle(block_hash, uncle_idx.into()).await? {
+                Some(u) => u,
+                None => return Ok(None),
+            };
+            uncles.push(uncle);
+        }
+        self.storage_write().uncles.insert(block_hash, uncles.clone());
+        Ok(uncles.get(index).cloned())
+    }
+
     /// Converts a block of hashes into a full block
     fn convert_to_full_block(&self, block: Block<TxHash>) -> Block<Transaction> {
         let storage = self.storage.read();
@@ -472,6 +518,7 @@ impl ClientForkConfig {
 /// Contains cached state fetched to serve EthApi requests
 #[derive(Debug, Clone, Default)]
 pub struct ForkedStorage {
+    pub uncles: HashMap<H256, Vec<Block<TxHash>>>,
     pub blocks: HashMap<H256, Block<TxHash>>,
     pub hashes: HashMap<u64, H256>,
     pub transactions: HashMap<H256, Transaction>,

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -89,8 +89,13 @@ async fn test_fork_eth_get_code() {
     }
 
     for address in utils::contract_addresses(Chain::Mainnet) {
+        let prev_code = api
+            .get_code(address, Some(BlockNumber::Number((BLOCK_NUMBER - 10).into()).into()))
+            .await
+            .unwrap();
         let code = api.get_code(address, None).await.unwrap();
         let provider_code = provider.get_code(address, None).await.unwrap();
+        assert_eq!(code, prev_code);
         assert_eq!(code, provider_code);
         assert!(!code.as_ref().is_empty());
     }

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -656,3 +656,54 @@ async fn test_fork_uncles_fetch() {
         assert_eq!(*uncle_hash, uncle.hash.unwrap());
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_block_transaction_count() {
+    let (api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    let sender = accounts[0].address();
+
+    // disable automine (so there are pending transactions)
+    api.anvil_set_auto_mine(false).await.unwrap();
+    // transfer: impersonate real sender
+    api.anvil_impersonate_account(sender).await.unwrap();
+
+    let tx = TransactionRequest::new().from(sender).value(42u64).gas(100_000);
+    provider.send_transaction(tx, None).await.unwrap();
+
+    let pending_txs =
+        api.block_transaction_count_by_number(BlockNumber::Pending).await.unwrap().unwrap();
+    assert_eq!(pending_txs.as_usize(), 1);
+
+    // mine a new block
+    api.anvil_mine(None, None).await.unwrap();
+
+    let pending_txs =
+        api.block_transaction_count_by_number(BlockNumber::Pending).await.unwrap().unwrap();
+    assert_eq!(pending_txs.as_usize(), 0);
+    let latest_txs =
+        api.block_transaction_count_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+    assert_eq!(latest_txs.as_usize(), 1);
+    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+    let latest_txs =
+        api.block_transaction_count_by_hash(latest_block.hash.unwrap()).await.unwrap().unwrap();
+    assert_eq!(latest_txs.as_usize(), 1);
+
+    // check txs count on an older block: 420000 has 3 txs on mainnet
+    let count_txs = api
+        .block_transaction_count_by_number(BlockNumber::Number(420000.into()))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(count_txs.as_usize(), 3);
+    let count_txs = api
+        .block_transaction_count_by_hash(
+            "0xb3b0e3e0c64e23fb7f1ccfd29245ae423d2f6f1b269b63b70ff882a983ce317c".parse().unwrap(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(count_txs.as_usize(), 3);
+}


### PR DESCRIPTION
## Motivation

This PR fixes several things (split into different commits which should make reviewing easier):

1. The `backend.ensure_block_number` wouldn't return the right block number in fork mode, if called with a block-hash of a block preceding the fork. This would be breaking some RPC calls which accept a block hash as a parameter
2. The `*uncles*` RPC calls are now implemented (by adding an `uncles` cache in `forking`)
3. The `eth_getCode` works on blocks preceding a fork (in fork mode)
4. The ` eth_getBlockTransactionCountBy*` methods are implemented

Note that (2) was needing when fetching a block with uncles with geth's `ethclient`, which would request it if it finds a block header with uncles; and (4) is useful to get the number of pending transactions (which is its own method in geth's `ethclient`)

## Solution

I added some tests with each implementation, or edited existing ones.
