### PR TITLE
fix: collect push bytes from test setup in fuzzer

### DIFF
--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -90,6 +90,17 @@ pub fn build_initial_state<DB: DatabaseRef>(
         // Insert basic account information
         state.insert(H256::from(*address).into());
 
+        // Insert push bytes
+        if let Some(code) = &account.info.code {
+            if !state.cache.contains(address) {
+                state.cache.insert(*address);
+
+                for push_byte in collect_push_bytes(code.bytes().clone()) {
+                    state.insert(push_byte);
+                }
+            }
+        }
+
         if include_storage {
             // Insert storage
             for (slot, value) in &account.storage {

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -93,7 +93,6 @@ pub fn build_initial_state<DB: DatabaseRef>(
         // Insert push bytes
         if let Some(code) = &account.info.code {
             if state.cache.insert(*address) {
-
                 for push_byte in collect_push_bytes(code.bytes().clone()) {
                     state.insert(push_byte);
                 }

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -92,8 +92,7 @@ pub fn build_initial_state<DB: DatabaseRef>(
 
         // Insert push bytes
         if let Some(code) = &account.info.code {
-            if !state.cache.contains(address) {
-                state.cache.insert(*address);
+            if state.cache.insert(*address) {
 
                 for push_byte in collect_push_bytes(code.bytes().clone()) {
                     state.insert(push_byte);


### PR DESCRIPTION
## Motivation

There's an old report that immutables were not collected in the fuzzer. Immutables are sections in the bytecode of contracts that are replaced by constant values, so we *should* be collecting them (since we collect push bytes), but it turns out that we were not collecting push bytes in the initial fuzzer DB (i.e. from the state right after `setUp`).

See https://github.com/foundry-rs/foundry/issues/1168

## Solution

Also collect push bytes after `setUp`. Closes https://github.com/foundry-rs/foundry/issues/1168

Note: The state dict after `setUp` for the test in #1168 contains about ~120 values. It seems that either one of the tests fail every time (which is what we want), but not super reliably. Increasing the fuzzer runs to 512 makes them both fail reliably, though.