### PR TITLE
fix(anvil): use named arguments for timeout and retries

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -236,13 +236,23 @@ pub struct AnvilEvmArgs {
     /// Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
     ///
     /// Default value 45000
-    #[clap(name = "timeout", help_heading = "FORK CONFIG", requires = "fork-url")]
+    #[clap(
+        long = "timeout",
+        name = "timeout",
+        help_heading = "FORK CONFIG",
+        requires = "fork-url"
+    )]
     pub fork_request_timeout: Option<u64>,
 
     /// Number of retry requests for spurious networks (timed out requests)
     ///
     /// Default value 5
-    #[clap(name = "retries", help_heading = "FORK CONFIG", requires = "fork-url")]
+    #[clap(
+        long = "retries",
+        name = "retries",
+        help_heading = "FORK CONFIG",
+        requires = "fork-url"
+    )]
     pub fork_request_retries: Option<u32>,
 
     /// Fetch state from a specific block number over a remote endpoint.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
use named arguments for --timeout and --retries

cc @sunwrobert saw this on #2931 this was not intended and we should use named arguments here
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use long
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
