### PR TITLE
fix: add `include_push_bytes` flag on initial state

### DIFF
--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -239,8 +239,11 @@ impl<'a> InvariantExecutor<'a> {
         }
 
         // Stores fuzz state for use with [fuzz_calldata_from_state].
-        let fuzz_state: EvmFuzzState =
-            build_initial_state(self.executor.backend().mem_db(), self.config.include_storage);
+        let fuzz_state: EvmFuzzState = build_initial_state(
+            self.executor.backend().mem_db(),
+            self.config.include_storage,
+            self.config.include_push_bytes,
+        );
 
         // During execution, any newly created contract is added here and used through the rest of
         // the fuzz run.

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -73,9 +73,17 @@ impl<'a> FuzzedExecutor<'a> {
 
         // Stores fuzz state for use with [fuzz_calldata_from_state]
         let state: EvmFuzzState = if let Some(fork_db) = self.executor.backend().active_fork_db() {
-            build_initial_state(fork_db, self.config.include_storage)
+            build_initial_state(
+                fork_db,
+                self.config.include_storage,
+                self.config.include_push_bytes,
+            )
         } else {
-            build_initial_state(self.executor.backend().mem_db(), self.config.include_storage)
+            build_initial_state(
+                self.executor.backend().mem_db(),
+                self.config.include_storage,
+                self.config.include_push_bytes,
+            )
         };
 
         let strat = proptest::strategy::Union::new_weighted(vec![

--- a/evm/src/fuzz/strategies/param.rs
+++ b/evm/src/fuzz/strategies/param.rs
@@ -142,7 +142,7 @@ mod tests {
         let func = HumanReadableParser::parse_function(f).unwrap();
 
         let db = CacheDB::new(EmptyDB());
-        let state = build_initial_state(&db, true);
+        let state = build_initial_state(&db, true, true);
 
         let strat = proptest::strategy::Union::new_weighted(vec![
             (60, fuzz_calldata(func.clone())),

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -83,6 +83,7 @@ This is a bug, please open an issue: https://github.com/foundry-rs/foundry/issue
 pub fn build_initial_state<DB: DatabaseRef>(
     db: &CacheDB<DB>,
     include_storage: bool,
+    include_push_bytes: bool,
 ) -> EvmFuzzState {
     let mut state = FuzzDictionary::default();
 
@@ -91,10 +92,12 @@ pub fn build_initial_state<DB: DatabaseRef>(
         state.insert(H256::from(*address).into());
 
         // Insert push bytes
-        if let Some(code) = &account.info.code {
-            if state.cache.insert(*address) {
-                for push_byte in collect_push_bytes(code.bytes().clone()) {
-                    state.insert(push_byte);
+        if include_push_bytes {
+            if let Some(code) = &account.info.code {
+                if state.cache.insert(*address) {
+                    for push_byte in collect_push_bytes(code.bytes().clone()) {
+                        state.insert(push_byte);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

A follow-up PR resolving inconsistencies between #2929 and #2882 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

add `include_push_bytes` flag on building initial fuzz state
