### PR TITLE
fix(anvil): Fix wrong timestamp after manually set

### DIFF
--- a/anvil/src/eth/backend/time.rs
+++ b/anvil/src/eth/backend/time.rs
@@ -120,7 +120,7 @@ impl TimeManager {
         if next_timestamp <= last_timestamp {
             next_timestamp = last_timestamp + 1;
         }
-        let next_offset = if update_offset { Some(current - next_timestamp as i128) } else { None };
+        let next_offset = update_offset.then_some((next_timestamp as i128) - current);
         (next_timestamp, next_offset)
     }
 


### PR DESCRIPTION
## Motivation

I actually introduced a bug in https://github.com/foundry-rs/foundry/pull/2920 ; sorry :/
So the issue is that after setting the next block timestamp manually, the following block will have a timestamp way in the future.

## Solution

I had the order wrong in the subtraction between the new block timestamp and the current time...
I also added a test that ensures the issue is fixed.
