### PR TITLE
chore: use retry provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "ethers",
  "ethers-solc",
  "eyre",
+ "foundry-common",
  "foundry-config",
  "once_cell",
  "parking_lot 0.12.0",

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -16,6 +16,7 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = fals
 walkdir = "2.3.2"
 once_cell = "1.13"
 foundry-config = { path = "../../config" }
+foundry-common = { path = "../../common" }
 serde_json = "1.0.67"
 parking_lot = "0.12.0"
 eyre = "0.6"

--- a/cli/test-utils/src/script.rs
+++ b/cli/test-utils/src/script.rs
@@ -1,3 +1,4 @@
+use crate::TestCommand;
 use ethers::{
     abi::Address,
     prelude::{Middleware, NameOrAddress, U256},
@@ -5,7 +6,6 @@ use ethers::{
 };
 use foundry_common::{get_http_provider, RetryProvider};
 use std::{collections::BTreeMap, path::Path, str::FromStr};
-use crate::TestCommand;
 
 pub const BROADCAST_TEST_PATH: &str = "src/Broadcast.t.sol";
 

--- a/cli/test-utils/src/script.rs
+++ b/cli/test-utils/src/script.rs
@@ -1,11 +1,10 @@
 use ethers::{
     abi::Address,
-    prelude::{Http, Middleware, NameOrAddress, Provider, U256},
+    prelude::{Middleware, NameOrAddress, U256},
     utils::hex,
 };
-
+use foundry_common::{get_http_provider, RetryProvider};
 use std::{collections::BTreeMap, path::Path, str::FromStr};
-
 use crate::TestCommand;
 
 pub const BROADCAST_TEST_PATH: &str = "src/Broadcast.t.sol";
@@ -14,7 +13,7 @@ pub const BROADCAST_TEST_PATH: &str = "src/Broadcast.t.sol";
 pub struct ScriptTester {
     pub accounts_pub: Vec<Address>,
     pub accounts_priv: Vec<String>,
-    pub provider: Provider<Http>,
+    pub provider: RetryProvider,
     pub nonces: BTreeMap<u32, U256>,
     pub cmd: TestCommand,
 }
@@ -53,7 +52,7 @@ impl ScriptTester {
                 "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d".to_string(),
                 "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a".to_string(),
             ],
-            provider: Provider::<Http>::try_from(endpoint).unwrap(),
+            provider: get_http_provider(endpoint),
             nonces: BTreeMap::default(),
             cmd,
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
use `RetryProvider` in script, this prevents any hanging requests in spurious networks
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
