### PR TITLE
chore: run resource heavy tests in serial

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -413,7 +413,8 @@ forgetest_async!(can_deploy_with_create2, |prj: TestProject, cmd: TestCommand| a
 });
 
 forgetest_async!(
-    can_deploy_100_txes_concurrently,
+    #[serial_test::serial]
+    can_deploy_50_txes_concurrently,
     |prj: TestProject, cmd: TestCommand| async move {
         let (_api, handle) = spawn(NodeConfig::test()).await;
         let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
@@ -424,12 +425,13 @@ forgetest_async!(
             .add_sig("BroadcastTestNoLinking", "deployMany()")
             .simulate(ScriptOutcome::OkSimulation)
             .broadcast(ScriptOutcome::OkBroadcast)
-            .assert_nonce_increment(vec![(0, 100)])
+            .assert_nonce_increment(vec![(0, 50)])
             .await;
     }
 );
 
 forgetest_async!(
+    #[serial_test::serial]
     can_deploy_mixed_broadcast_modes,
     |prj: TestProject, cmd: TestCommand| async move {
         let (_api, handle) = spawn(NodeConfig::test()).await;

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -293,13 +293,17 @@ contract ContractTest is DSTest {
 
 // checks that we can test forge std successfully
 // `forgetest_init!` will install with `forge-std` under `lib/forge-std`
-forgetest_init!(can_test_forge_std, |prj: TestProject, mut cmd: TestCommand| {
-    let forge_std_dir = prj.root().join("lib/forge-std");
-    cmd.cmd().current_dir(forge_std_dir);
-    cmd.args(["test", "--root", "."]);
+forgetest_init!(
+    #[serial_test::serial]
+    can_test_forge_std,
+    |prj: TestProject, mut cmd: TestCommand| {
+        let forge_std_dir = prj.root().join("lib/forge-std");
+        cmd.cmd().current_dir(forge_std_dir);
+        cmd.args(["test", "--root", "."]);
 
-    cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]")
-});
+        cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]")
+    }
+);
 
 // tests that libraries are handled correctly in multiforking mode
 forgetest_init!(can_use_libs_in_multi_fork, |prj: TestProject, mut cmd: TestCommand| {

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -161,7 +161,7 @@ contract BroadcastTestNoLinking is DSTest {
 
         cheats.startBroadcast();
 
-        for (uint256 i; i < 100; i++) {
+        for (uint256 i; i < 50; i++) {
             NoLink test9 = new NoLink();
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
* running `forge test` on `forge-std` takes a lot of resources (fuzzing) so we run them exclusively in serial
* also decreases the 100tx test to more sensible 50tx and run them in serial as well
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
