### PR TITLE
chore: exclude file related tests

### DIFF
--- a/forge/tests/it/cheats.rs
+++ b/forge/tests/it/cheats.rs
@@ -14,9 +14,9 @@ fn test_cheats_local() {
     let filter =
         Filter::new(".*", ".*", &format!(".*cheats{}*", RE_PATH_SEPARATOR)).exclude_paths("Fork");
 
-    // exclude ffi tests on windows since no echo
+    // on windows exclude ffi tests since no echo and file test that expect a certain file path
     #[cfg(windows)]
-    let filter = filter.exclude_tests("Ffi");
+    let filter = filter.exclude_tests("(Ffi|File|Line)");
 
     let suite_result = runner.test(&filter, None, TEST_OPTS).unwrap();
     assert!(!suite_result.is_empty());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
this excludes tests that use `expectRevert` with a specific file pah, which is different on windows

ref https://github.com/foundry-rs/foundry/pull/2867
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
