### PR TITLE
fix: prevent write access to foundry.toml

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/config.rs
+++ b/evm/src/executor/inspector/cheatcodes/config.rs
@@ -1,6 +1,7 @@
 use crate::executor::opts::EvmOpts;
 use bytes::Bytes;
 
+use ethers::solc::{utils::canonicalize, ProjectPathsConfig};
 use foundry_common::fs::normalize_path;
 use foundry_config::{cache::StorageCachingConfig, Config, ResolvedRpcEndpoints};
 use std::path::{Path, PathBuf};
@@ -11,20 +12,19 @@ use super::util;
 /// Additional, configurable context the `Cheatcodes` inspector has access to
 ///
 /// This is essentially a subset of various `Config` settings `Cheatcodes` needs to know.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CheatsConfig {
     pub ffi: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
     pub rpc_storage_caching: StorageCachingConfig,
     /// All known endpoints and their aliases
     pub rpc_endpoints: ResolvedRpcEndpoints,
-
+    /// the project's paths as configured
+    pub paths: ProjectPathsConfig,
     /// Project root
     pub root: PathBuf,
-
     /// Paths (directories) where file reading/writing is allowed
     pub allowed_paths: Vec<PathBuf>,
-
     /// How the evm was configured by the user
     pub evm_opts: EvmOpts,
 }
@@ -44,30 +44,67 @@ impl CheatsConfig {
             ffi: evm_opts.ffi,
             rpc_storage_caching: config.rpc_storage_caching.clone(),
             rpc_endpoints,
+            paths: config.project_paths(),
             root: config.__root.0.clone(),
             allowed_paths,
             evm_opts: evm_opts.clone(),
         }
     }
 
+    /// Attempts to canonicalize (see [std::fs::canonicalize]) the path.
+    ///
+    /// Canonicalization fails for non-existing paths, in which case we just normalize the path.
+    pub fn normalized_path(&self, path: impl AsRef<Path>) -> PathBuf {
+        let path = self.root.join(path);
+        canonicalize(&path).unwrap_or_else(|_| normalize_path(&path))
+    }
+
     /// Returns true if the given path is allowed, if any path `allowed_paths` is an ancestor of the
     /// path
     ///
     /// We only allow paths that are inside  allowed paths. To prevent path traversal
-    /// ("../../etc/passwd") we normalize the path first. We always join with the configured
-    /// root directory.
+    /// ("../../etc/passwd") we canonicalize/normalize the path first. We always join with the
+    /// configured root directory.
     pub fn is_path_allowed(&self, path: impl AsRef<Path>) -> bool {
-        let path = normalize_path(&self.root.join(path));
-        return self.allowed_paths.iter().any(|allowed_path| path.starts_with(allowed_path))
+        self.is_normalized_path_allowed(&self.normalized_path(path))
     }
 
-    /// Returns an error
-    pub fn ensure_path_allowed(&self, path: impl AsRef<Path>) -> Result<(), String> {
+    fn is_normalized_path_allowed(&self, path: &Path) -> bool {
+        self.allowed_paths.iter().any(|allowed_path| path.starts_with(allowed_path))
+    }
+
+    /// Returns an error if no access is granted to access `path`, See also [Self::is_path_allowed]
+    ///
+    /// Returns the normalized version of `path`, see [`Self::normalized_path`]
+    pub fn ensure_path_allowed(&self, path: impl AsRef<Path>) -> Result<PathBuf, String> {
         let path = path.as_ref();
-        if !self.is_path_allowed(path) {
+        let normalized = self.normalized_path(path);
+        if !self.is_normalized_path_allowed(&normalized) {
             return Err(format!("Path {:?} is not allowed.", path))
         }
 
+        Ok(normalized)
+    }
+
+    /// Returns true if the given `path` is the project's foundry.toml file
+    ///
+    /// Note: this should be called with normalized path
+    pub fn is_foundry_toml(&self, path: impl AsRef<Path>) -> bool {
+        // path methods that do not access the filesystem are such as [`Path::starts_with`], are
+        // case-sensitive no matter the platform or filesystem. to make this case-sensitive
+        // we convert the underlying `OssStr` to lowercase checking that `path` and
+        // `foundry.toml` are the same file by comparing the FD, because it may not exist
+        let foundry_toml = self.root.join(Config::FILE_NAME);
+        Path::new(&foundry_toml.to_string_lossy().to_lowercase())
+            .starts_with(Path::new(&path.as_ref().to_string_lossy().to_lowercase()))
+    }
+
+    /// Same as [`Self::is_foundry_toml`] but returns an `Err` if [`Self::is_foundry_toml`] returns
+    /// true
+    pub fn ensure_not_foundry_toml(&self, path: impl AsRef<Path>) -> Result<(), String> {
+        if self.is_foundry_toml(path) {
+            return Err("Access to foundry.toml is not allowed.".to_string())
+        }
         Ok(())
     }
 
@@ -104,22 +141,53 @@ impl CheatsConfig {
     }
 }
 
+impl Default for CheatsConfig {
+    fn default() -> Self {
+        Self {
+            ffi: false,
+            rpc_storage_caching: Default::default(),
+            rpc_endpoints: Default::default(),
+            paths: ProjectPathsConfig::builder().build_with_root("./"),
+            root: Default::default(),
+            allowed_paths: vec![],
+            evm_opts: Default::default(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn config(root: &str) -> CheatsConfig {
+        CheatsConfig::new(
+            &Config { __root: PathBuf::from(root).into(), ..Default::default() },
+            &Default::default(),
+        )
+    }
+
     #[test]
     fn test_allowed_paths() {
         let root = "/my/project/root/";
-
-        let config = CheatsConfig::new(
-            &Config { __root: PathBuf::from(root).into(), ..Default::default() },
-            &Default::default(),
-        );
+        let config = config(root);
 
         assert!(config.ensure_path_allowed("./t.txt").is_ok());
         assert!(config.ensure_path_allowed("../root/t.txt").is_ok());
-
         assert!(config.ensure_path_allowed("../../root/t.txt").is_err());
+    }
+
+    #[test]
+    fn test_is_foundry_toml() {
+        let root = "/my/project/root/";
+        let config = config(root);
+
+        let f = format!("{}foundry.toml", root);
+        assert!(config.is_foundry_toml(&f));
+
+        let f = format!("{}Foundry.toml", root);
+        assert!(config.is_foundry_toml(&f));
+
+        let f = format!("{}lib/other/foundry.toml", root);
+        assert!(!config.is_foundry_toml(&f));
     }
 }

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -6,6 +6,7 @@ import "./Cheats.sol";
 
 contract FileTest is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    bytes constant FOUNDRY_TOML_ACCESS_ERR = "Access to foundry.toml is not allowed.";
 
     function testReadFile() public {
         string memory path = "../testdata/fixtures/File/read.txt";
@@ -80,5 +81,43 @@ contract FileTest is DSTest {
 
         cheats.expectRevert("Path \"/etc/hosts\" is not allowed.");
         cheats.removeFile("/etc/hosts");
+    }
+
+    function testWriteLineFoundrytoml() public {
+        string memory root = cheats.projectRoot();
+        string memory foundryToml = string.concat(root, "/", "foundry.toml");
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeLine(foundryToml, "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeLine("foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeLine("./foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeLine("./Foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeLine("./../foundry.toml", "\nffi = true\n");
+    }
+
+    function testWriteFoundrytoml() public {
+        string memory root = cheats.projectRoot();
+        string memory foundryToml = string.concat(root, "/", "foundry.toml");
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeFile(foundryToml, "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeFile("foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeFile("./foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeFile("./Foundry.toml", "\nffi = true\n");
+
+        cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
+        cheats.writeFile("./../foundry.toml", "\nffi = true\n");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
harden `writeFile|Line` cheatcodes and prevent write access to foundry.toml, otherwise it would be possible to modify the config (like `ffi`) via malicious cheatcodes.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* prevents write access to `foundry.toml` via cheatcodes.
* add additional check for `foundry.toml` in cheatcodes that write
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
