### PR TITLE
fix: trim private keys

### DIFF
--- a/cli/src/opts/multi_wallet.rs
+++ b/cli/src/opts/multi_wallet.rs
@@ -253,7 +253,7 @@ impl MultiWallet {
         if let Some(private_keys) = &self.private_keys {
             let mut wallets = vec![];
             for private_key in private_keys.iter() {
-                wallets.push(self.get_from_private_key(private_key)?);
+                wallets.push(self.get_from_private_key(private_key.trim())?);
             }
             return Ok(Some(wallets))
         }


### PR DESCRIPTION
Same as https://github.com/foundry-rs/foundry/pull/2099 but for `forge script`

Closes #2976 and closes #2978