### PR TITLE
fix: put metadata in artifact instead separate file

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -294,7 +294,7 @@ impl CreateArgs {
             root: None,
             verifier: self.verifier,
         };
-        println!("Waiting for etherscan to detect contract deployment...");
+        println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await
     }
 

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -4,15 +4,14 @@ use crate::cmd::retry::RetryArgs;
 use async_trait::async_trait;
 use clap::{Parser, ValueHint};
 use ethers::{abi::Address, solc::info::ContractInfo};
+use etherscan::EtherscanVerificationProvider;
 use foundry_config::{impl_figment_convert_basic, Chain};
+use sourcify::SourcifyVerificationProvider;
 use std::{
     fmt::{Display, Formatter},
     path::PathBuf,
     str::FromStr,
 };
-
-use etherscan::EtherscanVerificationProvider;
-use sourcify::SourcifyVerificationProvider;
 
 mod etherscan;
 mod sourcify;

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -1,39 +1,19 @@
-use std::{collections::HashMap, fs, path::PathBuf};
-
+use super::{VerificationProvider, VerifyArgs, VerifyCheckArgs};
+use crate::cmd::LoadConfig;
 use async_trait::async_trait;
 use cast::SimpleCast;
+use ethers::solc::ConfigurableContractArtifact;
+
+use foundry_common::fs;
 use foundry_utils::Retry;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::PathBuf};
 use tracing::{trace, warn};
-
-use crate::cmd::LoadConfig;
-
-use super::{VerificationProvider, VerifyArgs, VerifyCheckArgs};
 
 pub static SOURCIFY_URL: &str = "https://sourcify.dev/server/";
 
-#[derive(Serialize, Debug)]
-pub struct SourcifyVerifyRequest {
-    address: String,
-    chain: String,
-    files: HashMap<String, String>,
-    #[serde(rename = "chosenContract", skip_serializing_if = "Option::is_none")]
-    chosen_contract: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct SourcifyVerificationResponse {
-    result: Vec<SourcifyResponseElement>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct SourcifyResponseElement {
-    status: String,
-    #[serde(rename = "storageTimestamp")]
-    storage_timestamp: Option<String>,
-}
-
+/// The type that can verify a contract on `sourcify`
 pub struct SourcifyVerificationProvider;
 
 #[async_trait]
@@ -51,19 +31,37 @@ impl VerificationProvider for SourcifyVerificationProvider {
         let cache = project.read_cache_file()?;
         let (path, entry) = crate::cmd::get_cached_entry_by_name(&cache, &args.contract.name)?;
 
-        let path = args.contract.path.map_or(path, PathBuf::from);
+        if entry.solc_config.settings.metadata.is_none() {
+            eyre::bail!(
+                r#"Contract {} was compiled without the solc `metadata` setting.
+Sourcify requires contract metadata for verification.
+metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
+                args.contract.name
+            )
+        }
 
-        let mut files = HashMap::new();
+        let mut files = HashMap::with_capacity(2 + entry.imports.len());
 
-        let filename = path.file_name().unwrap().to_str().unwrap().to_owned();
-        let metadata_path =
-            config.out.join(&filename).join(format!("{}.metadata.json", args.contract.name));
+        let artifact_path = args.contract.path.map_or(path, PathBuf::from);
+        let artifact: ConfigurableContractArtifact = fs::read_json_file(&artifact_path)?;
+        if let Some(metadata) = artifact.metadata {
+            let metadata = serde_json::to_string_pretty(&metadata)?;
+            files.insert("metadata.json".to_string(), metadata);
+        } else {
+            eyre::bail!(
+                r#"No metadata found in artifact `{}` for contract {}.
+Sourcify requires contract metadata for verification.
+metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
+                artifact_path.display(),
+                args.contract.name
+            )
+        }
 
-        files.insert("metadata.json".to_owned(), fs::read_to_string(&metadata_path)?);
-        files.insert(filename, fs::read_to_string(&path)?);
+        let filename = artifact_path.file_name().unwrap().to_string_lossy().to_string();
+        files.insert(filename, fs::read_to_string(&artifact_path)?);
 
         for import in entry.imports {
-            let import_entry = import.clone().into_os_string().into_string().unwrap();
+            let import_entry = format!("{}", import.display());
             files.insert(import_entry, fs::read_to_string(&import)?);
         }
 
@@ -168,4 +166,25 @@ impl SourcifyVerificationProvider {
             std::process::exit(1);
         }
     }
+}
+
+#[derive(Serialize, Debug)]
+pub struct SourcifyVerifyRequest {
+    address: String,
+    chain: String,
+    files: HashMap<String, String>,
+    #[serde(rename = "chosenContract", skip_serializing_if = "Option::is_none")]
+    chosen_contract: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SourcifyVerificationResponse {
+    result: Vec<SourcifyResponseElement>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SourcifyResponseElement {
+    status: String,
+    #[serde(rename = "storageTimestamp")]
+    storage_timestamp: Option<String>,
 }

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -164,7 +164,8 @@ fn verify_flag_on_create_on_chain(
                 .args(info.create_args())
                 .arg("--verify")
                 .arg(contract_path)
-                .arg(format!("--verification-provider {}", verifier));
+                .arg("--verifier")
+                .arg(verifier);
             parse_verification_result(&mut cmd, 1).expect("Failed to verify check")
         }
     }
@@ -237,7 +238,8 @@ forgetest!(
                     ])
                     .arg("--verify")
                     .arg(contract_path)
-                    .arg(format!("--verification-provider {}", verifier));
+                    .arg("--verifier")
+                    .arg(verifier);
 
                 parse_verification_result(&mut cmd, 1).expect("Failed to verify check")
             }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -798,15 +798,16 @@ impl Config {
     /// returns the [`ethers_solc::ConfigurableArtifacts`] for this config, that includes the
     /// `extra_output` fields
     pub fn configured_artifacts_handler(&self) -> ConfigurableArtifacts {
-        let mut extra_output_files = self.extra_output_files.clone();
+        let mut extra_output = self.extra_output.clone();
         // Sourcify verification requires solc metadata output. Since, it doesn't
         // affect the UX & performance of the compiler, output the metadata files
         // by default.
         // For more info see: https://github.com/foundry-rs/foundry/issues/2795
-        if !extra_output_files.contains(&ContractOutputSelection::Metadata) {
-            extra_output_files.push(ContractOutputSelection::Metadata);
+        if !extra_output.contains(&ContractOutputSelection::Metadata) {
+            extra_output.push(ContractOutputSelection::Metadata);
         }
-        ConfigurableArtifacts::new(self.extra_output.clone(), extra_output_files)
+
+        ConfigurableArtifacts::new(extra_output, self.extra_output_files.clone())
     }
 
     /// Parses all libraries in the form of

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -802,7 +802,8 @@ impl Config {
         // Sourcify verification requires solc metadata output. Since, it doesn't
         // affect the UX & performance of the compiler, output the metadata files
         // by default.
-        // For more info see: https://github.com/foundry-rs/foundry/issues/2795
+        // For more info see: <https://github.com/foundry-rs/foundry/issues/2795>
+        // Metadata is not emitted as separate file because this breaks typechain support: <https://github.com/foundry-rs/foundry/issues/2969>
         if !extra_output.contains(&ContractOutputSelection::Metadata) {
             extra_output.push(ContractOutputSelection::Metadata);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2969

@rkrasiuk do we have a sourcify test?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
instead of emitting the metadata as separate file, we put it in the artifact itself

sourcify verification is then still possible by extracting the metadata from the artifact
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
