### PR TITLE
fix: ensure caller is always set

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -113,3 +113,25 @@ fn test_issue_2956() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/2984>
+#[test]
+fn test_issue_2984() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue2984"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue2984.t.sol
+++ b/testdata/repros/Issue2984.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/2984
+contract Issue2984Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+    uint256 fork;
+    uint256 snapshot;
+
+    function setUp() public {
+        fork = vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc", 12880747);
+        snapshot = vm.snapshot();
+    }
+
+    function testForkRevertSnapshot() public {
+        vm.revertTo(snapshot);
+    }
+
+    function testForkSelectSnapshot() public {
+        uint256 fork2 = vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc", 12880749);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #2984
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
ensure the caller account is always set to prevent panic in revm finalize
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
