### PR TITLE
chore: add .env in gitignore template

### DIFF
--- a/cli/assets/.gitignoreTemplate
+++ b/cli/assets/.gitignoreTemplate
@@ -6,3 +6,6 @@ out/
 !/broadcast
 /broadcast/*
 /broadcast/*/31337/
+
+# Dotenv file
+.env


### PR DESCRIPTION
Follow up on https://github.com/foundry-rs/foundry/pull/2587 by adding `.env` in `.gitignore` when generated by Forge.