### PR TITLE
feat(evm): Compile Etherscan Sources for use in Debugger

### DIFF
--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -18,7 +18,6 @@ use ethers::{
     solc::utils::canonicalize,
 };
 use foundry_common::compile;
-
 use serde_json::{to_value, Value};
 use std::{fmt, str::FromStr};
 

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -495,10 +495,10 @@ fn test(
         Ok(TestOutcome::new(results, allow_failure))
     } else {
         // Set up identifiers
-        let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
+        let mut local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
         let remote_chain_id = runner.evm_opts.get_remote_chain_id();
         // Do not re-query etherscan for contracts that you've already queried today.
-        let etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
+        let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
 
         // Set up test reporter channel
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -552,8 +552,8 @@ fn test(
                     let mut decoded_traces = Vec::new();
                     let rt = RuntimeOrHandle::new();
                     for (kind, trace) in &mut result.traces {
-                        decoder.identify(trace, &local_identifier);
-                        decoder.identify(trace, &etherscan_identifier);
+                        decoder.identify(trace, &mut local_identifier);
+                        decoder.identify(trace, &mut etherscan_identifier);
 
                         let should_include = match kind {
                             // At verbosity level 3, we only display traces for failed tests

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -187,7 +187,7 @@ impl CallTraceDecoder {
     /// Identify unknown addresses in the specified call trace using the specified identifier.
     ///
     /// Unknown contracts are contracts that either lack a label or an ABI.
-    pub fn identify(&mut self, trace: &CallTraceArena, identifier: &impl TraceIdentifier) {
+    pub fn identify(&mut self, trace: &CallTraceArena, identifier: &mut impl TraceIdentifier) {
         let unidentified_addresses = trace
             .addresses()
             .into_iter()

--- a/evm/src/trace/identifier/local.rs
+++ b/evm/src/trace/identifier/local.rs
@@ -29,7 +29,7 @@ impl LocalTraceIdentifier {
 
 impl TraceIdentifier for LocalTraceIdentifier {
     fn identify_addresses(
-        &self,
+        &mut self,
         addresses: Vec<(&Address, Option<&Vec<u8>>)>,
     ) -> Vec<AddressIdentity> {
         addresses

--- a/evm/src/trace/identifier/mod.rs
+++ b/evm/src/trace/identifier/mod.rs
@@ -35,7 +35,7 @@ pub trait TraceIdentifier {
     /// Attempts to identify an address in one or more call traces.
     #[allow(clippy::type_complexity)]
     fn identify_addresses(
-        &self,
+        &mut self,
         addresses: Vec<(&Address, Option<&Vec<u8>>)>,
     ) -> Vec<AddressIdentity>;
 }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -527,10 +527,10 @@ pub fn load_contracts(
     known_contracts: Option<&ContractsByArtifact>,
 ) -> ContractsByAddress {
     if let Some(contracts) = known_contracts {
-        let local_identifier = LocalTraceIdentifier::new(contracts);
+        let mut local_identifier = LocalTraceIdentifier::new(contracts);
         let mut decoder = CallTraceDecoderBuilder::new().build();
         for (_, trace) in &traces {
-            decoder.identify(trace, &local_identifier);
+            decoder.identify(trace, &mut local_identifier);
         }
 
         decoder

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Tui {
     current_step: usize,
     identified_contracts: HashMap<Address, String>,
     known_contracts: HashMap<String, ContractBytecodeSome>,
-    source_code: BTreeMap<u32, String>,
+    known_contracts_sources: HashMap<String, BTreeMap<u32, String>>,
     /// A mapping of source -> (PC -> IC map for deploy code, PC -> IC map for runtime code)
     pc_ic_maps: BTreeMap<String, (PCICMap, PCICMap)>,
 }
@@ -69,7 +69,7 @@ impl Tui {
         current_step: usize,
         identified_contracts: HashMap<Address, String>,
         known_contracts: HashMap<String, ContractBytecodeSome>,
-        source_code: BTreeMap<u32, String>,
+        known_contracts_sources: HashMap<String, BTreeMap<u32, String>>,
     ) -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
@@ -108,7 +108,7 @@ impl Tui {
             current_step,
             identified_contracts,
             known_contracts,
-            source_code,
+            known_contracts_sources,
             pc_ic_maps,
         })
     }
@@ -134,7 +134,7 @@ impl Tui {
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
         pc_ic_maps: &BTreeMap<String, (PCICMap, PCICMap)>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -151,7 +151,7 @@ impl Tui {
                 identified_contracts,
                 known_contracts,
                 pc_ic_maps,
-                source_code,
+                known_contracts_sources,
                 debug_steps,
                 opcode_list,
                 current_step,
@@ -167,7 +167,7 @@ impl Tui {
                 identified_contracts,
                 known_contracts,
                 pc_ic_maps,
-                source_code,
+                known_contracts_sources,
                 debug_steps,
                 opcode_list,
                 current_step,
@@ -186,7 +186,7 @@ impl Tui {
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
         pc_ic_maps: &BTreeMap<String, (PCICMap, PCICMap)>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -221,7 +221,7 @@ impl Tui {
                     identified_contracts,
                     known_contracts,
                     pc_ic_maps,
-                    source_code,
+                    known_contracts_sources,
                     debug_steps[current_step].pc,
                     call_kind,
                     src_pane,
@@ -259,7 +259,7 @@ impl Tui {
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
         pc_ic_maps: &BTreeMap<String, (PCICMap, PCICMap)>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         debug_steps: &[DebugStep],
         opcode_list: &[String],
         current_step: usize,
@@ -300,7 +300,7 @@ impl Tui {
                             identified_contracts,
                             known_contracts,
                             pc_ic_maps,
-                            source_code,
+                            known_contracts_sources,
                             debug_steps[current_step].pc,
                             call_kind,
                             src_pane,
@@ -363,7 +363,7 @@ impl Tui {
         identified_contracts: &HashMap<Address, String>,
         known_contracts: &HashMap<String, ContractBytecodeSome>,
         pc_ic_maps: &BTreeMap<String, (PCICMap, PCICMap)>,
-        source_code: &BTreeMap<u32, String>,
+        known_contracts_sources: &HashMap<String, BTreeMap<u32, String>>,
         pc: usize,
         call_kind: CallKind,
         area: Rect,
@@ -381,7 +381,9 @@ impl Tui {
         let mut text_output: Text = Text::from("");
 
         if let Some(contract_name) = identified_contracts.get(&address) {
-            if let Some(known) = known_contracts.get(contract_name) {
+            if let (Some(known), Some(source_code)) =
+                (known_contracts.get(contract_name), known_contracts_sources.get(contract_name))
+            {
                 let pc_ic_map = pc_ic_maps.get(contract_name);
                 // grab either the creation source map or runtime sourcemap
                 if let Some((sourcemap, ic)) =
@@ -1225,7 +1227,7 @@ impl Ui for Tui {
                     &self.identified_contracts,
                     &self.known_contracts,
                     &self.pc_ic_maps,
-                    &self.source_code,
+                    &self.known_contracts_sources,
                     &debug_call[draw_memory.inner_call_index].1[..],
                     &opcode_list,
                     current_step,


### PR DESCRIPTION
## Motivation
Debugging with sources is helpful, pulling sources from etherscan expands amount of source code available. Built off of [this PR](https://github.com/foundry-rs/foundry/pull/1413). 

## Solution
1 . When identifying addresses for traces, collect addresses & sources.
2. Compile each contract address [and downloads the solc version required)
3. Provide them to the TUI debugger. 

Still can't handle vyper, `--via-ir`, or multifile sources.


In order to make these changes, we migrate the `compile` module to the common module. This makes the dependecy pattern more obvious and removes cyclical imports. The compile from etherscan function is now in this module and can be imported into other crates.

Example from ethereum mainnet: 

`cargo run --bin cast -- run 0x1a3223af00bbbf09db3b84dcd7ed281e0b5fcc2a74c9afb04eb8a2f2289b529b --debug`