### PR TITLE
test(config): fuzz profile sections

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1322,7 +1322,6 @@ impl Config {
         }
         // merge special keys into config
         for standalone_key in Config::STANDALONE_SECTIONS {
-            // let standalone_provider =
             if let Some(fallback) = STANDALONE_FALLBACK_SECTIONS.get(standalone_key) {
                 figment = figment.merge(
                     provider
@@ -3328,6 +3327,9 @@ mod tests {
 
                 [invariant]
                 runs = 420
+
+                [profile.ci.fuzz]
+                dictionary_weight = 5
             "#,
             )?;
 
@@ -3343,8 +3345,47 @@ mod tests {
             assert_ne!(config.fuzz.dictionary_weight, invariant_default.dictionary_weight);
             assert_eq!(config.invariant.dictionary_weight, config.fuzz.dictionary_weight);
 
+            jail.set_env("FOUNDRY_PROFILE", "ci");
+            let ci_config = Config::load();
+            assert_eq!(ci_config.invariant.runs, 420);
+            assert_eq!(ci_config.fuzz.dictionary_weight, 5);
+            assert_eq!(ci_config.invariant.dictionary_weight, config.fuzz.dictionary_weight);
+
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_standalone_profile_sections() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [fuzz]
+                runs = 100
+
+                [invariant]
+                runs = 120
+
+                [profile.ci.fuzz]
+                runs = 420
+
+                [profile.ci.invariant]
+                runs = 500
+            "#,
+            )?;
+
+            let config = Config::load();
+            assert_eq!(config.fuzz.runs, 100);
+            assert_eq!(config.invariant.runs, 120);
+
+            jail.set_env("FOUNDRY_PROFILE", "ci");
+            let config = Config::load();
+            assert_eq!(config.fuzz.runs, 420);
+            assert_eq!(config.invariant.runs, 500);
+
+            Ok(())
+        });
     }
 
     #[test]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -3330,6 +3330,9 @@ mod tests {
 
                 [profile.ci.fuzz]
                 dictionary_weight = 5
+
+                [profile.ci.invariant]
+                runs = 400
             "#,
             )?;
 
@@ -3347,7 +3350,8 @@ mod tests {
 
             jail.set_env("FOUNDRY_PROFILE", "ci");
             let ci_config = Config::load();
-            assert_eq!(ci_config.invariant.runs, 420);
+            assert_eq!(ci_config.fuzz.runs, 1);
+            assert_eq!(ci_config.invariant.runs, 400);
             assert_eq!(ci_config.fuzz.dictionary_weight, 5);
             assert_eq!(ci_config.invariant.dictionary_weight, config.fuzz.dictionary_weight);
 


### PR DESCRIPTION
added more tests to cover current fallback behavior with profiles. the logic is the following
1. if the selected profile is `default` and no `invariant` config values were set, then common values (`runs`, `dictionary_weight` etc) will be taken from `fuzz` section if present or `InvariantConfig::default`
2. if the selected profile is other than `default` and no `invariant` section present, the common values will be taken from `[profile.default.invariant]` (which in turn falls back to `[profile.default.fuzz]`)

open for comments. happy to change/revert the fallback if it's too confusing 

cc @mds1 @devtooligan @transmissions11 @gakonst 