### PR TITLE
feat(anvil): add fork IDs and blocks to Hardfork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,9 @@ dependencies = [
  "clap 3.2.16",
  "clap_complete",
  "clap_complete_fig",
+ "crc 3.0.0",
  "ctrlc",
+ "ethereum-forkid",
  "ethers",
  "ethers-solc",
  "fdlimit",
@@ -1038,6 +1040,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
+
+[[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1598,19 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-forkid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b823f6b913b97e58a2bd67a7beeb48b0338d4aa8e3cc21d9cdab457716e4d4"
+dependencies = [
+ "crc 1.8.1",
+ "fastrlp",
+ "maplit",
+ "primitive-types",
+ "thiserror",
 ]
 
 [[package]]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -75,12 +75,14 @@ auto_impl = "0.5.0"
 ctrlc = { version = "3", optional = true }
 fdlimit = { version = "0.2.1", optional = true }
 clap_complete_fig = "3.2.4"
+ethereum-forkid = "0.10.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", features = ["project-util", "full"] }
 pretty_assertions = "1.2.1"
 tokio = { version = "1", features = ["full"] }
+crc = "3.0.0"
 
 [features]
 default = ["cli"]

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -1,8 +1,6 @@
 use crate::{
-    config::{Hardfork, DEFAULT_MNEMONIC},
-    eth::pool::transactions::TransactionOrder,
-    genesis::Genesis,
-    AccountGenerator, NodeConfig, CHAIN_ID,
+    config::DEFAULT_MNEMONIC, eth::pool::transactions::TransactionOrder, genesis::Genesis,
+    AccountGenerator, Hardfork, NodeConfig, CHAIN_ID,
 };
 use anvil_server::ServerConfig;
 use clap::Parser;

--- a/anvil/src/hardfork.rs
+++ b/anvil/src/hardfork.rs
@@ -1,0 +1,236 @@
+use ethereum_forkid::{ForkHash, ForkId};
+use ethers::types::BlockNumber;
+use foundry_evm::revm::SpecId;
+use std::str::FromStr;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Hardfork {
+    Frontier,
+    Homestead,
+    Dao,
+    Tangerine,
+    SpuriousDragon,
+    Byzantium,
+    Constantinople,
+    Petersburg,
+    Istanbul,
+    Muirglacier,
+    Berlin,
+    London,
+    ArrowGlacier,
+    GrayGlacier,
+    Latest,
+}
+
+impl Hardfork {
+    /// Get the first block number of the hardfork.
+    pub fn fork_block(&self) -> u64 {
+        match *self {
+            Hardfork::Frontier => 0,
+            Hardfork::Homestead => 1150000,
+            Hardfork::Dao => 1920000,
+            Hardfork::Tangerine => 2463000,
+            Hardfork::SpuriousDragon => 2675000,
+            Hardfork::Byzantium => 4370000,
+            Hardfork::Constantinople | Hardfork::Petersburg => 7280000,
+            Hardfork::Istanbul => 9069000,
+            Hardfork::Muirglacier => 9200000,
+            Hardfork::Berlin => 12244000,
+            Hardfork::London => 12965000,
+            Hardfork::ArrowGlacier => 13773000,
+            Hardfork::GrayGlacier | Hardfork::Latest => 15050000,
+        }
+    }
+
+    /// Get the EIP-2124 fork id for a given hardfork
+    ///
+    /// The [`ForkId`](ethereum_forkid::ForkId) includes a CRC32 checksum of the all fork block
+    /// numbers from genesis, and the next upcoming fork block number.
+    /// If the next fork block number is not yet known, it is set to 0.
+    pub fn fork_id(&self) -> ForkId {
+        match *self {
+            Hardfork::Frontier => {
+                ForkId { hash: ForkHash([0xfc, 0x64, 0xec, 0x04]), next: 1150000 }
+            }
+            Hardfork::Homestead => {
+                ForkId { hash: ForkHash([0x97, 0xc2, 0xc3, 0x4c]), next: 1920000 }
+            }
+            Hardfork::Dao => ForkId { hash: ForkHash([0x91, 0xd1, 0xf9, 0x48]), next: 2463000 },
+            Hardfork::Tangerine => {
+                ForkId { hash: ForkHash([0x7a, 0x64, 0xda, 0x13]), next: 2675000 }
+            }
+            Hardfork::SpuriousDragon => {
+                ForkId { hash: ForkHash([0x3e, 0xdd, 0x5b, 0x10]), next: 4370000 }
+            }
+            Hardfork::Byzantium => {
+                ForkId { hash: ForkHash([0xa0, 0x0b, 0xc3, 0x24]), next: 7280000 }
+            }
+            Hardfork::Constantinople | Hardfork::Petersburg => {
+                ForkId { hash: ForkHash([0x66, 0x8d, 0xb0, 0xaf]), next: 9069000 }
+            }
+            Hardfork::Istanbul => {
+                ForkId { hash: ForkHash([0x87, 0x9d, 0x6e, 0x30]), next: 9200000 }
+            }
+            Hardfork::Muirglacier => {
+                ForkId { hash: ForkHash([0xe0, 0x29, 0xe9, 0x91]), next: 12244000 }
+            }
+            Hardfork::Berlin => ForkId { hash: ForkHash([0x0e, 0xb4, 0x40, 0xf6]), next: 12965000 },
+            Hardfork::London => ForkId { hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]), next: 13773000 },
+            Hardfork::ArrowGlacier => {
+                ForkId { hash: ForkHash([0x20, 0xc3, 0x27, 0xfc]), next: 15050000 }
+            }
+            Hardfork::Latest | Hardfork::GrayGlacier => {
+                // update `next` when another fork block num is known
+                ForkId { hash: ForkHash([0xf0, 0xaf, 0xd0, 0xe3]), next: 0 }
+            }
+        }
+    }
+}
+
+impl FromStr for Hardfork {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_lowercase();
+        let hardfork = match s.as_str() {
+            "frontier" | "1" => Hardfork::Frontier,
+            "homestead" | "2" => Hardfork::Homestead,
+            "dao" | "3" => Hardfork::Dao,
+            "tangerine" | "4" => Hardfork::Tangerine,
+            "spuriousdragon" | "5" => Hardfork::SpuriousDragon,
+            "byzantium" | "6" => Hardfork::Byzantium,
+            "constantinople" | "7" => Hardfork::Constantinople,
+            "petersburg" | "8" => Hardfork::Petersburg,
+            "istanbul" | "9" => Hardfork::Istanbul,
+            "muirglacier" | "10" => Hardfork::Muirglacier,
+            "berlin" | "11" => Hardfork::Berlin,
+            "london" | "12" => Hardfork::London,
+            "arrowglacier" | "13" => Hardfork::ArrowGlacier,
+            "grayglacier" => Hardfork::GrayGlacier,
+            "latest" | "14" => Hardfork::Latest,
+            _ => return Err(format!("Unknown hardfork {}", s)),
+        };
+        Ok(hardfork)
+    }
+}
+
+impl Default for Hardfork {
+    fn default() -> Self {
+        Hardfork::Latest
+    }
+}
+
+impl From<Hardfork> for SpecId {
+    fn from(fork: Hardfork) -> Self {
+        match fork {
+            Hardfork::Frontier => SpecId::FRONTIER,
+            Hardfork::Homestead => SpecId::HOMESTEAD,
+            Hardfork::Dao => SpecId::HOMESTEAD,
+            Hardfork::Tangerine => SpecId::TANGERINE,
+            Hardfork::SpuriousDragon => SpecId::SPURIOUS_DRAGON,
+            Hardfork::Byzantium => SpecId::BYZANTIUM,
+            Hardfork::Constantinople => SpecId::CONSTANTINOPLE,
+            Hardfork::Petersburg => SpecId::PETERSBURG,
+            Hardfork::Istanbul => SpecId::ISTANBUL,
+            Hardfork::Muirglacier => SpecId::MUIRGLACIER,
+            Hardfork::Berlin => SpecId::BERLIN,
+            Hardfork::London => SpecId::LONDON,
+            Hardfork::ArrowGlacier => SpecId::LONDON,
+            Hardfork::GrayGlacier | Hardfork::Latest => SpecId::LATEST,
+        }
+    }
+}
+
+impl<T: Into<BlockNumber>> From<T> for Hardfork {
+    fn from(block: T) -> Hardfork {
+        let num = match block.into() {
+            BlockNumber::Pending | BlockNumber::Latest => u64::MAX,
+            BlockNumber::Earliest => 0,
+            BlockNumber::Number(num) => num.as_u64(),
+        };
+
+        match num {
+            _i if num < 1_150_000 => Hardfork::Frontier,
+            _i if num < 1_920_000 => Hardfork::Dao,
+            _i if num < 2_463_000 => Hardfork::Homestead,
+            _i if num < 2_675_000 => Hardfork::Tangerine,
+            _i if num < 4_370_000 => Hardfork::SpuriousDragon,
+            _i if num < 7_280_000 => Hardfork::Byzantium,
+            _i if num < 9_069_000 => Hardfork::Constantinople,
+            _i if num < 9_200_000 => Hardfork::Istanbul,
+            _i if num < 12_244_000 => Hardfork::Muirglacier,
+            _i if num < 12_965_000 => Hardfork::Berlin,
+            _i if num < 13_773_000 => Hardfork::London,
+            _i if num < 15_050_000 => Hardfork::ArrowGlacier,
+
+            _ => Hardfork::Latest,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Hardfork;
+    use crc::{Crc, CRC_32_ISO_HDLC};
+    use ethers::utils::hex;
+
+    #[test]
+    fn test_hardfork_blocks() {
+        let hf: Hardfork = 12_965_000u64.into();
+        assert_eq!(hf, Hardfork::London);
+
+        let hf: Hardfork = 4370000u64.into();
+        assert_eq!(hf, Hardfork::Byzantium);
+
+        let hf: Hardfork = 12244000u64.into();
+        assert_eq!(hf, Hardfork::Berlin);
+    }
+
+    #[test]
+    // this test checks that the fork hash assigned to forks accurately map to the fork_id method
+    fn test_forkhash_from_fork_blocks() {
+        // set the genesis hash
+        let genesis =
+            hex::decode("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
+                .unwrap();
+
+        // instantiate the crc "hasher"
+        let crc_hasher = Crc::<u32>::new(&CRC_32_ISO_HDLC);
+        let mut crc_digest = crc_hasher.digest();
+
+        // check frontier forkhash
+        crc_digest.update(&genesis);
+
+        // now we go through enum members
+        let frontier_forkid = Hardfork::Frontier.fork_id();
+        let frontier_forkhash = u32::from_be_bytes(frontier_forkid.hash.0);
+        // clone the digest for finalization so we can update it again
+        assert_eq!(crc_digest.clone().finalize(), frontier_forkhash);
+
+        // list of the above hardforks
+        let hardforks = vec![
+            Hardfork::Homestead,
+            Hardfork::Dao,
+            Hardfork::Tangerine,
+            Hardfork::SpuriousDragon,
+            Hardfork::Byzantium,
+            Hardfork::Constantinople,
+            Hardfork::Istanbul,
+            Hardfork::Muirglacier,
+            Hardfork::Berlin,
+            Hardfork::London,
+            Hardfork::ArrowGlacier,
+            Hardfork::GrayGlacier,
+        ];
+
+        // now loop through each hardfork, conducting each forkhash test
+        for hardfork in hardforks {
+            // this could also be done with frontier_forkhash.next, but fork_block is used for more
+            // coverage
+            let fork_block = hardfork.fork_block().to_be_bytes();
+            crc_digest.update(&fork_block);
+            let fork_hash = u32::from_be_bytes(hardfork.fork_id().hash.0);
+            assert_eq!(crc_digest.clone().finalize(), fork_hash);
+        }
+    }
+}

--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -37,7 +37,9 @@ use tokio::{runtime::Handle, task::JoinError};
 mod service;
 
 mod config;
-pub use config::{AccountGenerator, Hardfork, NodeConfig, CHAIN_ID, VERSION_MESSAGE};
+pub use config::{AccountGenerator, NodeConfig, CHAIN_ID, VERSION_MESSAGE};
+mod hardfork;
+pub use hardfork::Hardfork;
 
 /// ethereum related implementations
 pub mod eth;


### PR DESCRIPTION
 ## Motivation

[Fork IDs](https://eips.ethereum.org/EIPS/eip-2124) are used in the p2p network to detect nodes that are not up to date, or on separate forks.

The `anvil::Hardfork` enum is a useful abstraction for working with hardforks. Adding a `fork_id` method allows for a status message to be constructed like this:
```rust
let status = Status {
    version: EthVersion::Eth67 as u8,
    chain: Chain::Id(1),
    total_difficulty: uint!(36206751599115524359527_U256), 
    blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
    genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
    forkid: Hardfork::Latest.fork_id(), // or Hardfork::Frontier.fork_id(), etc.
};
```

## Solution

 * Add missing hardforks `Dao` and `GrayGlacier`.
 * Add a `fork_block` method that returns a hardfork's fork block.
 * Return precomputed forkids for each hardfork.
 * Validate each forkid in tests by computing each forkid, using each hardfork's `fork_block` as input to the CRC32 hasher.