### PR TITLE
feat(anvil): Use `pending` as default block for estimateGas

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -865,6 +865,7 @@ impl EthApi {
     }
 
     /// Estimate gas needed for execution of given contract.
+    /// If no block parameter is given, it will use the pending block by default
     ///
     /// Handler for ETH RPC call: `eth_estimateGas`
     pub async fn estimate_gas(
@@ -873,7 +874,8 @@ impl EthApi {
         block_number: Option<BlockId>,
     ) -> Result<U256> {
         node_info!("eth_estimateGas");
-        self.do_estimate_gas(request, block_number).await
+        self.do_estimate_gas(request, block_number.or_else(|| Some(BlockNumber::Pending.into())))
+            .await
     }
 
     /// Get transaction by its hash.


### PR DESCRIPTION
## Motivation

Should fix https://github.com/foundry-rs/foundry/issues/3017

The `latest` block was the default block when None is passed for gas estimation; however it might make more sense to take into account pending txs.

## Solution

Set the block to Pending if None is given for gas estimation.

Note that this doesn't work when using `ethers-rs` since it overrides the None block parameter to `Latest`: cf. https://github.com/gakonst/ethers-rs/blob/13a0144abae32c45c01b1639929f612527994dd1/ethers-providers/src/provider.rs#L577
I think we might want to just not pass the block parameter if it's `None`
