### PR TITLE
test: add more etherscan api key tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "serde",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "thiserror",
 ]
 
@@ -845,7 +845,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "thiserror",
 ]
 
@@ -865,7 +865,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "sha3",
  "thiserror",
 ]
@@ -919,17 +919,6 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
 ]
 
 [[package]]
@@ -1564,7 +1553,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "sha3",
  "thiserror",
  "uuid",
@@ -1630,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1645,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1656,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1674,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1697,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1711,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1742,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1758,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1783,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1819,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1834,7 +1823,7 @@ dependencies = [
  "home",
  "rand 0.8.5",
  "semver",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "thiserror",
  "trezor-client",
 ]
@@ -1842,10 +1831,9 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#13a0144abae32c45c01b1639929f612527994dd1"
+source = "git+https://github.com/gakonst/ethers-rs#fca8f997fa8ac3663dae19149ae6c2b6d93ae574"
 dependencies = [
  "cfg-if 1.0.0",
- "colored",
  "dunce",
  "ethers-core",
  "fs_extra",
@@ -1864,7 +1852,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "solang-parser",
  "svm-rs",
  "svm-rs-builds",
@@ -1874,6 +1862,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
+ "yansi",
 ]
 
 [[package]]
@@ -3050,7 +3039,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "sha3",
 ]
 
@@ -3232,9 +3221,9 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
 dependencies = [
  "digest 0.10.3",
 ]
@@ -3798,7 +3787,7 @@ dependencies = [
  "digest 0.10.3",
  "hmac",
  "password-hash 0.3.2",
- "sha2 0.10.2",
+ "sha2 0.10.5",
 ]
 
 [[package]]
@@ -3810,7 +3799,7 @@ dependencies = [
  "digest 0.10.3",
  "hmac",
  "password-hash 0.4.2",
- "sha2 0.10.2",
+ "sha2 0.10.5",
 ]
 
 [[package]]
@@ -4503,7 +4492,7 @@ dependencies = [
  "primitive-types",
  "ripemd",
  "secp256k1 0.23.4",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "sha3",
  "substrate-bn",
 ]
@@ -4519,7 +4508,7 @@ dependencies = [
  "primitive-types",
  "ripemd",
  "secp256k1 0.24.0",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "sha3",
  "substrate-bn",
 ]
@@ -4732,7 +4721,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.2",
+ "sha2 0.10.5",
 ]
 
 [[package]]
@@ -4985,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -5350,18 +5339,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -542,6 +542,8 @@ pub struct ScriptConfig {
 mod tests {
     use super::*;
     use crate::cmd::LoadConfig;
+    use foundry_cli_test_utils::tempfile::tempdir;
+    use std::fs;
 
     #[test]
     fn can_merge_script_config() {
@@ -553,5 +555,34 @@ mod tests {
         ]);
         let config = args.load_config();
         assert_eq!(config.etherscan_api_key, Some("goerli".to_string()));
+    }
+
+    #[test]
+    fn can_extract_script_etherscan_key() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+
+        let config = r#"
+                [profile.default]
+                etherscan_api_key = "mumbai"
+
+                [etherscan]
+                mumbai = { key = "https://etherscan-mumbai.com/" }
+            "#;
+
+        let toml_file = root.join(Config::FILE_NAME);
+        fs::write(toml_file, config).unwrap();
+        let args: ScriptArgs = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--etherscan-api-key",
+            "mumbai",
+            "--root",
+            root.as_os_str().to_str().unwrap(),
+        ]);
+
+        let config = args.load_config();
+        let mumbai = config.get_etherscan_api_key(Some(ethers::types::Chain::PolygonMumbai));
+        assert_eq!(mumbai, Some("https://etherscan-mumbai.com/".to_string()));
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2772,6 +2772,36 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_etherscan_config() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                etherscan_api_key = "optimism"
+
+                [etherscan]
+                optimism = { key = "https://etherscan-optimism.com/" }
+                mumbai = { key = "https://etherscan-mumbai.com/" }
+            "#,
+            )?;
+
+            let mut config = Config::load();
+
+            let optimism = config.get_etherscan_api_key(Some(ethers_core::types::Chain::Optimism));
+            assert_eq!(optimism, Some("https://etherscan-optimism.com/".to_string()));
+
+            config.etherscan_api_key = Some("mumbai".to_string());
+
+            let mumbai =
+                config.get_etherscan_api_key(Some(ethers_core::types::Chain::PolygonMumbai));
+            assert_eq!(mumbai, Some("https://etherscan-mumbai.com/".to_string()));
+
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_toml_file() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

~~Blocked by https://github.com/gakonst/ethers-rs/pull/1656~~

## Motivation
it was reported `--etherscan-api-key mumbai` results in invalid API key even if specified in table.
This was an issue because `Chain` only matched: `polygon-mumbai`:

https://github.com/gakonst/ethers-rs/pull/1656


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* Add additional etherscan-api-key tests
* bump ethers
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
