### PR TITLE
Respect derivation path argument for mnemonic wallets in `cast`

### DIFF
--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -89,7 +89,17 @@ pub struct Wallet {
     pub mnemonic_path: Option<String>,
 
     #[clap(
+        long = "mnemonic-derivation-path",
+        alias = "hd-path",
+        help_heading = "WALLET OPTIONS - RAW",
+        help = "The wallet derivation path. Works with both --mnemonic-path and hardware wallets.",
+        value_name = "PATH"
+    )]
+    pub hd_path: Option<String>,
+
+    #[clap(
         long = "mnemonic-index",
+        conflicts_with = "hd-path",
         help_heading = "WALLET OPTIONS - RAW",
         help = "Use the private key from the given mnemonic index. Used with --mnemonic-path.",
         default_value = "0",
@@ -132,14 +142,6 @@ pub struct Wallet {
     pub trezor: bool,
 
     #[clap(
-        long = "hd-path",
-        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
-        help = "The derivation path to use with hardware wallets.",
-        value_name = "PATH"
-    )]
-    pub hd_path: Option<String>,
-
-    #[clap(
         env = "ETH_FROM",
         short,
         long = "from",
@@ -169,7 +171,7 @@ impl Wallet {
 
     pub fn mnemonic(&self) -> Result<Option<LocalWallet>> {
         Ok(if let Some(ref path) = self.mnemonic_path {
-            Some(self.get_from_mnemonic(path, self.mnemonic_index)?)
+            Some(self.get_from_mnemonic(path, self.hd_path.as_deref(), self.mnemonic_index)?)
         } else {
             None
         })
@@ -192,9 +194,24 @@ pub trait WalletTrait {
             .map_err(|x| eyre!("Failed to create wallet from private key: {x}"))
     }
 
-    fn get_from_mnemonic(&self, path: &str, index: u32) -> Result<LocalWallet> {
+    fn get_from_mnemonic(
+        &self,
+        path: &str,
+        derivation_path: Option<&str>,
+        index: u32,
+    ) -> Result<LocalWallet> {
         let mnemonic = fs::read_to_string(path)?.replace('\n', "");
-        Ok(MnemonicBuilder::<English>::default().phrase(mnemonic.as_str()).index(index)?.build()?)
+        if let Some(hd_path) = derivation_path {
+            Ok(MnemonicBuilder::<English>::default()
+                .phrase(mnemonic.as_str())
+                .derivation_path(hd_path)?
+                .build()?)
+        } else {
+            Ok(MnemonicBuilder::<English>::default()
+                .phrase(mnemonic.as_str())
+                .index(index)?
+                .build()?)
+        }
     }
 
     fn get_from_keystore(


### PR DESCRIPTION
Currently `--hd-path` argument works only for hardware wallets. But it makes sense to apply it to mnemonic based wallets too. This PR does exactly that.

I moved this argument from `WALLET OPTIONS - HARDWARE WALLET` to `WALLET OPTIONS - RAW` and renamed to `mnemonic-derivation-path` for consistency, older `hd-path` alias is still available for backwards compatibility. The motivation for the rename is that there is already `mnemonic-index` option that applies to hardware wallet address derivation, so now the options are more consistent.

Just like with hardware wallets, if `mnemonic-derivation-path` argument is specified it will override `mnemonic-index` arguments.

Please check the implementation and provide any comments. Also my implementation of `mnemonics()` in `multi_wallet.rs` looks very inefficient but I was unable to come up with a better solution due to my lack of rust skills.