### PR TITLE
feat(anvil, evm): make steps tracing configurable

### DIFF
--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -237,8 +237,8 @@ impl<'a, 'b, DB: Db + ?Sized, Validator: TransactionValidator> Iterator
         evm.env = env;
         evm.database(&mut self.db);
 
-        // records all call traces
-        let mut inspector = Inspector::default().with_tracing();
+        // records all call and step traces
+        let mut inspector = Inspector::default().with_tracing().with_steps_tracing();
 
         trace!(target: "backend", "[{:?}] executing", transaction.hash());
         // transact and commit the transaction

--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -36,6 +36,17 @@ impl Inspector {
         self.tracer = Some(Default::default());
         self
     }
+
+    /// Enables steps recording for `Tracer`
+    /// If `Tracer` wasn't configured before, configures it automatically
+    pub fn with_steps_tracing(mut self) -> Self {
+        if self.tracer.is_none() {
+            self = self.with_tracing()
+        }
+        self.tracer = self.tracer.map(|tracer| tracer.with_steps_recording());
+
+        self
+    }
 }
 
 impl<DB: Database> revm::Inspector<DB> for Inspector {

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -129,6 +129,8 @@ impl CoverageArgs {
             }
 
             if let Some(ast) = source_file.ast.take() {
+                let path = project_paths.root.join(path).to_string_lossy().to_string();
+
                 versioned_asts
                     .entry(version.clone())
                     .or_default()

--- a/cli/src/opts/multi_wallet.rs
+++ b/cli/src/opts/multi_wallet.rs
@@ -294,13 +294,13 @@ impl MultiWallet {
         if let Some(mnemonic_paths) = self.mnemonic_paths.as_ref() {
             let mut wallets = vec![];
             let hd_paths: Vec<_> = if let Some(ref hd_paths) = self.hd_paths {
-                hd_paths.into_iter().map(String::as_str).map(Some).collect()
+                hd_paths.iter().map(String::as_str).map(Some).collect()
             } else {
                 repeat(None).take(mnemonic_paths.len()).collect()
             };
             let mnemonic_indexes: Vec<_> = if let Some(ref mnemonic_indexes) = self.mnemonic_indexes
             {
-                mnemonic_indexes.into_iter().copied().collect()
+                mnemonic_indexes.to_vec()
             } else {
                 repeat(0).take(mnemonic_paths.len()).collect()
             };

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -20,12 +20,20 @@ use revm::{
 /// An inspector that collects call traces.
 #[derive(Default, Debug, Clone)]
 pub struct Tracer {
+    pub record_steps: bool,
+
     pub trace_stack: Vec<usize>,
     pub traces: CallTraceArena,
     pub step_stack: Vec<(usize, usize)>, // (trace_idx, step_idx)
 }
 
 impl Tracer {
+    pub fn with_steps_recording(mut self) -> Self {
+        self.record_steps = true;
+
+        self
+    }
+
     pub fn start_trace(
         &mut self,
         depth: usize,
@@ -204,6 +212,10 @@ where
         data: &mut EVMData<'_, DB>,
         _is_static: bool,
     ) -> Return {
+        if !self.record_steps {
+            return Return::Continue
+        }
+
         let depth = data.journaled_state.depth();
         let pc = interp.program_counter();
         let op = OpCode(interp.contract.bytecode.bytecode()[pc]);
@@ -236,6 +248,10 @@ where
         _is_static: bool,
         status: Return,
     ) -> Return {
+        if !self.record_steps {
+            return Return::Continue
+        }
+
         self.fill_step(interp.gas.remaining(), status);
 
         status


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/3067

## Solution

Steps tracing in coverage with `-vvv` resulted in enormous memory growth but we don't really need such granular tracing in there. So now we only enable steps tracing in Anvil, when we're executing only a bunch of transactions (instead of lots of tests in parallel) and really care about using these traces later.

Memory usage before/after changes during running `forge coverage -vvv` in Solmate:
<img width="250" alt="Screenshot 2022-09-03 at 10 02 42" src="https://user-images.githubusercontent.com/5773434/188263812-f51a3bc7-58c8-4069-9f8e-05cfc2670caf.png">

---

If, for some reason, we may want to have steps tracing in any of the `forge` commands, we can make it configurable here: https://github.com/foundry-rs/foundry/blob/4b9cca1790096c8bfdd50922bf22244983ad6e4f/evm/src/executor/builder.rs#L36-L41
and maybe enable with even higher verbosity.