### PR TITLE
fix(forge, coverage): versioned path source

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -129,15 +129,13 @@ impl CoverageArgs {
             }
 
             if let Some(ast) = source_file.ast.take() {
-                let path = project_paths.root.join(path).to_string_lossy().to_string();
-
                 versioned_asts
                     .entry(version.clone())
                     .or_default()
                     .insert(source_file.id as usize, ast);
                 versioned_sources.entry(version.clone()).or_default().insert(
                     source_file.id as usize,
-                    fs::read_to_string(&path)
+                    fs::read_to_string(project_paths.root.join(&path))
                         .wrap_err("Could not read source code for analysis")?,
                 );
                 report.add_source(version, source_file.id as usize, path);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/3072

## Solution

```console
/Users/shekhirin/.cargo/bin/cargo run --color=always --bin forge -- coverage --root /Users/shekhirin/Projects/solmate
    Finished dev [unoptimized] target(s) in 0.26s
     Running `target/debug/forge coverage --root /Users/shekhirin/Projects/solmate`
Compiling 51 files with 0.8.15
Solc 0.8.15 finished in 2.39s
Compiler run successful
Analysing contracts...
Running tests...
+-------------------------------------------------------+------------------+------------------+-----------------+------------------+
| File                                                  | % Lines          | % Statements     | % Branches      | % Funcs          |
+==================================================================================================================================+
| src/auth/Auth.sol                                     | 100.00% (7/7)    | 100.00% (7/7)    | 100.00% (2/2)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/auth/Owned.sol                                    | 100.00% (2/2)    | 100.00% (2/2)    | 100.00% (0/0)   | 100.00% (1/1)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/auth/authorities/MultiRolesAuthority.sol          | 100.00% (17/17)  | 100.00% (16/16)  | 100.00% (6/6)   | 100.00% (7/7)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/auth/authorities/RolesAuthority.sol               | 100.00% (13/13)  | 100.00% (11/11)  | 100.00% (4/4)   | 100.00% (6/6)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/mixins/ERC4626.sol                                | 80.00% (32/40)   | 76.19% (32/42)   | 33.33% (4/12)   | 50.00% (8/16)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/Auth.t.sol                                   | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/ERC1155.t.sol                                | 100.00% (18/18)  | 100.00% (18/18)  | 100.00% (0/0)   | 100.00% (8/8)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/ERC20.t.sol                                  | 0.00% (0/11)     | 0.00% (0/11)     | 100.00% (0/0)   | 0.00% (0/7)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/ERC721.t.sol                                 | 100.00% (7/7)    | 100.00% (7/7)    | 100.00% (0/0)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/ReentrancyGuard.t.sol                        | 100.00% (6/6)    | 100.00% (8/8)    | 100.00% (4/4)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/WETH.t.sol                                   | 0.00% (0/7)      | 0.00% (0/7)      | 100.00% (0/0)   | 0.00% (0/5)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/DSInvariantTest.sol                    | 0.00% (0/3)      | 0.00% (0/3)      | 0.00% (0/2)     | 0.00% (0/2)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/DSTestPlus.sol                         | 0.00% (0/48)     | 0.00% (0/59)     | 0.00% (0/16)    | 0.00% (0/16)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockAuthChild.sol                | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockAuthority.sol                | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockERC1155.sol                  | 100.00% (4/4)    | 100.00% (4/4)    | 100.00% (0/0)   | 80.00% (4/5)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockERC20.sol                    | 100.00% (2/2)    | 100.00% (2/2)    | 100.00% (0/0)   | 100.00% (2/2)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockERC4626.sol                  | 100.00% (3/3)    | 100.00% (3/3)    | 100.00% (0/0)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockERC721.sol                   | 100.00% (4/4)    | 100.00% (4/4)    | 100.00% (0/0)   | 80.00% (4/5)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/mocks/MockOwned.sol                    | 100.00% (1/1)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/MissingReturnToken.sol    | 100.00% (10/10)  | 100.00% (11/11)  | 100.00% (2/2)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/ReturnsFalseToken.sol     | 0.00% (0/3)      | 0.00% (0/3)      | 100.00% (0/0)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/ReturnsGarbageToken.sol   | 100.00% (14/14)  | 100.00% (15/15)  | 100.00% (2/2)   | 100.00% (4/4)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/ReturnsTooLittleToken.sol | 100.00% (0/0)    | 100.00% (0/0)    | 100.00% (0/0)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/ReturnsTooMuchToken.sol   | 100.00% (10/10)  | 100.00% (11/11)  | 100.00% (2/2)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/ReturnsTwoToken.sol       | 100.00% (3/3)    | 100.00% (3/3)    | 100.00% (0/0)   | 100.00% (3/3)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/test/utils/weird-tokens/RevertingToken.sol        | 66.67% (2/3)     | 66.67% (2/3)     | 100.00% (0/0)   | 66.67% (2/3)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/tokens/ERC1155.sol                                | 93.18% (41/44)   | 93.88% (46/49)   | 90.00% (18/20)  | 72.73% (8/11)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/tokens/ERC20.sol                                  | 96.15% (25/26)   | 96.43% (27/28)   | 100.00% (6/6)   | 87.50% (7/8)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/tokens/ERC721.sol                                 | 94.74% (36/38)   | 94.74% (36/38)   | 96.15% (25/26)  | 84.62% (11/13)   |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/tokens/WETH.sol                                   | 100.00% (5/5)    | 100.00% (5/5)    | 100.00% (0/0)   | 100.00% (2/2)    |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/Bytes32AddressLib.sol                       | 0.00% (0/2)      | 0.00% (0/2)      | 100.00% (0/0)   | 0.00% (0/2)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/CREATE3.sol                                 | 0.00% (0/9)      | 0.00% (0/11)     | 0.00% (0/4)     | 0.00% (0/2)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/FixedPointMathLib.sol                       | 0.00% (0/40)     | 0.00% (0/30)     | 0.00% (0/10)    | 0.00% (0/8)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/SSTORE2.sol                                 | 0.00% (0/12)     | 0.00% (0/14)     | 0.00% (0/4)     | 0.00% (0/5)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/SafeCastLib.sol                             | 0.00% (0/22)     | 0.00% (0/22)     | 0.00% (0/22)    | 0.00% (0/11)     |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| src/utils/SafeTransferLib.sol                         | 0.00% (0/12)     | 0.00% (0/12)     | 0.00% (0/8)     | 0.00% (0/4)      |
|-------------------------------------------------------+------------------+------------------+-----------------+------------------|
| Total                                                 | 59.02% (265/449) | 58.92% (274/465) | 49.34% (75/152) | 57.07% (105/184) |
+-------------------------------------------------------+------------------+------------------+-----------------+------------------+

Process finished with exit code 0
```
