### PR TITLE
feat(forge): constructor-args-path option for verify-contract

### DIFF
--- a/cli/src/cmd/forge/script/verify.rs
+++ b/cli/src/cmd/forge/script/verify.rs
@@ -97,6 +97,7 @@ impl VerifyBundle {
                     contract,
                     compiler_version: Some(version.to_string()),
                     constructor_args: Some(hex::encode(&constructor_args)),
+                    constructor_args_path: None,
                     num_of_optimizations: self.num_of_optimizations,
                     chain: self.chain,
                     etherscan_key: self.etherscan_key.clone(),

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -1,4 +1,4 @@
-use crate::cmd::{retry::RETRY_CHECK_ON_VERIFY, LoadConfig};
+use crate::cmd::{read_constructor_args_file, retry::RETRY_CHECK_ON_VERIFY, LoadConfig};
 use async_trait::async_trait;
 use cast::SimpleCast;
 use ethers::{
@@ -217,9 +217,14 @@ impl EtherscanVerificationProvider {
 
         let compiler_version = ensure_solc_build_metadata(compiler_version).await?;
         let compiler_version = format!("v{}", compiler_version);
+        let constructor_args = if let Some(ref constructor_args_path) = args.constructor_args_path {
+            Some(read_constructor_args_file(constructor_args_path.to_path_buf())?.join(" "))
+        } else {
+            args.constructor_args.clone()
+        };
         let mut verify_args =
             VerifyContract::new(args.address, contract_name, source, compiler_version)
-                .constructor_arguments(args.constructor_args.clone())
+                .constructor_arguments(constructor_args)
                 .code_format(code_format);
 
         if code_format == CodeFormat::SingleFile {

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -60,6 +60,16 @@ pub struct VerifyArgs {
 
     #[clap(
         long,
+        help = "The path to a file containing the constructor arguments.",
+        value_hint = ValueHint::FilePath,
+        name = "constructor_args_path",
+        conflicts_with = "constructor_args",
+        value_name = "FILE"
+    )]
+    pub constructor_args_path: Option<PathBuf>,
+
+    #[clap(
+        long,
         help = "The compiler version used to build the smart contract.",
         value_name = "VERSION"
     )]

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -94,7 +94,7 @@ pub fn get_cached_entry_by_name(
     }
 
     if let Some(entry) = cached_entry {
-        return Ok(entry);
+        return Ok(entry)
     }
 
     let mut err = format!("could not find artifact: `{}`", name);
@@ -161,7 +161,7 @@ pub fn unwrap_contracts(
                 };
 
                 if let Some(bytecode) = bytecode {
-                    return Some((id.clone(), (c.abi.clone(), bytecode.to_vec())));
+                    return Some((id.clone(), (c.abi.clone(), bytecode.to_vec())))
                 }
                 None
             })
@@ -197,7 +197,7 @@ macro_rules! update_progress {
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain: u64) -> bool {
     if let ConfigChain::Named(chain) = ConfigChain::from(chain) {
-        return matches!(chain, Chain::Arbitrum | Chain::ArbitrumTestnet);
+        return matches!(chain, Chain::Arbitrum | Chain::ArbitrumTestnet)
     }
     false
 }
@@ -208,7 +208,7 @@ pub fn has_batch_support(chain: u64) -> bool {
         return !matches!(
             chain,
             Chain::Arbitrum | Chain::ArbitrumTestnet | Chain::Optimism | Chain::OptimismKovan
-        );
+        )
     }
     true
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Closes https://github.com/foundry-rs/foundry/issues/3065.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Extract `read_constructor_args_file` from `create` as a util function and reuse it in `verify-contract`.
