### PR TITLE
fix(forge): set depth on roll fork correctly

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -768,6 +768,7 @@ impl DatabaseExt for Backend {
                 let persitent_addrs = self.inner.persistent_accounts.clone();
                 let active = self.inner.get_fork_mut(active_idx);
                 active.journaled_state = self.fork_init_journaled_state.clone();
+                active.journaled_state.depth = journaled_state.depth;
                 for addr in persitent_addrs {
                     clone_journaled_state_data(addr, journaled_state, &mut active.journaled_state);
                 }
@@ -810,6 +811,7 @@ impl DatabaseExt for Backend {
             // no contract for `callee` available on current fork, check if available on other forks
             let mut available_on = Vec::new();
             for (id, fork) in self.inner.forks_iter().filter(|(id, _)| *id != active_id) {
+                trace!(?id, address=?callee, "checking if account exists");
                 if fork.is_contract(callee) {
                     available_on.push(id);
                 }

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -135,3 +135,27 @@ fn test_issue_2984() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3077>
+#[test]
+fn test_issue_3077() {
+    foundry_utils::init_tracing_subscriber();
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3077"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}
+

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -139,7 +139,6 @@ fn test_issue_2984() {
 // <https://github.com/foundry-rs/foundry/issues/3077>
 #[test]
 fn test_issue_3077() {
-    foundry_utils::init_tracing_subscriber();
     let mut runner = runner();
     let suite_result =
         runner.test(&Filter::new(".*", ".*", ".*repros/Issue3077"), None, TEST_OPTS).unwrap();

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -139,6 +139,7 @@ fn test_issue_2984() {
 // <https://github.com/foundry-rs/foundry/issues/3077>
 #[test]
 fn test_issue_3077() {
+    foundry_utils::init_tracing_subscriber();
     let mut runner = runner();
     let suite_result =
         runner.test(&Filter::new(".*", ".*", ".*repros/Issue3077"), None, TEST_OPTS).unwrap();

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -139,7 +139,6 @@ fn test_issue_2984() {
 // <https://github.com/foundry-rs/foundry/issues/3077>
 #[test]
 fn test_issue_3077() {
-    foundry_utils::init_tracing_subscriber();
     let mut runner = runner();
     let suite_result =
         runner.test(&Filter::new(".*", ".*", ".*repros/Issue3077"), None, TEST_OPTS).unwrap();
@@ -158,4 +157,3 @@ fn test_issue_3077() {
         }
     }
 }
-

--- a/testdata/repros/Issue3077.t.sol
+++ b/testdata/repros/Issue3077.t.sol
@@ -5,16 +5,32 @@ import "ds-test/test.sol";
 import "../cheats/Cheats.sol";
 
 // https://github.com/foundry-rs/foundry/issues/3077
-contract Issue3077Test is DSTest {
+abstract contract ZeroState is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
 
-    function testRollFork() public {
-        uint256 fork = vm.createFork("rpcAlias", 10);
-        vm.selectFork(fork);
+    // deployer and users
+    address public deployer = vm.addr(1);
 
-        assertEq(block.number, 10);
-        assertEq(block.timestamp, 1438270128);
+    uint256 public mainnetFork;
 
-        vm.rollFork(15471120);
+    function setUp() public virtual {
+        vm.startPrank(deployer);
+        mainnetFork = vm.createFork("rpcAlias");
+        vm.selectFork(mainnetFork);
+        vm.stopPrank();
+    }
+}
+
+abstract contract rollfork is ZeroState {
+    function setUp() public virtual override {
+        super.setUp();
+        emit log_uint(15471105);
+        vm.rollFork(block.number - 15);
+    }
+}
+
+contract testing is rollfork {
+    function testFork() public {
+        assert(true);
     }
 }

--- a/testdata/repros/Issue3077.t.sol
+++ b/testdata/repros/Issue3077.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3077
+contract Issue3077Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testRollFork() public {
+        uint256 fork = vm.createFork("rpcAlias", 10);
+        vm.selectFork(fork);
+
+        assertEq(block.number, 10);
+        assertEq(block.timestamp, 1438270128);
+
+        vm.rollFork(15471120);
+    }
+}

--- a/testdata/repros/Issue3077.t.sol
+++ b/testdata/repros/Issue3077.t.sol
@@ -10,13 +10,16 @@ abstract contract ZeroState is DSTest {
 
     // deployer and users
     address public deployer = vm.addr(1);
-
+    Token aaveToken;
     uint256 public mainnetFork;
 
     function setUp() public virtual {
         vm.startPrank(deployer);
         mainnetFork = vm.createFork("rpcAlias");
         vm.selectFork(mainnetFork);
+        vm.rollFork(block.number - 20);
+        // deploy tokens
+        aaveToken = new Token();
         vm.stopPrank();
     }
 }
@@ -24,13 +27,20 @@ abstract contract ZeroState is DSTest {
 abstract contract rollfork is ZeroState {
     function setUp() public virtual override {
         super.setUp();
-        emit log_uint(15471105);
-        vm.rollFork(block.number - 15);
+        vm.rollFork(block.number + 1);
+        aaveToken.balanceOf(deployer);
     }
 }
 
 contract testing is rollfork {
     function testFork() public {
         assert(true);
+    }
+}
+
+contract Token {
+    mapping(address => uint256) private _balances;
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
     }
 }

--- a/testdata/repros/Issue3077.t.sol
+++ b/testdata/repros/Issue3077.t.sol
@@ -20,6 +20,7 @@ abstract contract ZeroState is DSTest {
         vm.rollFork(block.number - 20);
         // deploy tokens
         aaveToken = new Token();
+        vm.makePersistent(address(aaveToken));
         vm.stopPrank();
     }
 }
@@ -34,12 +35,13 @@ abstract contract rollfork is ZeroState {
 
 contract testing is rollfork {
     function testFork() public {
-        assert(true);
+        emit log_uint(block.number);
     }
 }
 
 contract Token {
     mapping(address => uint256) private _balances;
+
     function balanceOf(address account) public view returns (uint256) {
         return _balances[account];
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3077

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use the current depth when `rollFork` is called
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
