### PR TITLE
fix(forge): verify-contract encode args from constructor-args-path

### DIFF
--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -55,7 +55,13 @@ pub struct VerifyArgs {
     )]
     pub contract: ContractInfo,
 
-    #[clap(long, help = "the encoded constructor arguments", value_name = "ARGS")]
+    #[clap(
+        long,
+        help = "The ABI-encoded constructor arguments.",
+        name = "constructor_args",
+        conflicts_with = "constructor_args_path",
+        value_name = "ARGS"
+    )]
     pub constructor_args: Option<String>,
 
     #[clap(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes the implementation in https://github.com/foundry-rs/foundry/pull/3078. Apologies for the oversight in the previous PR.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
To provide ABI-encoded arguments for verification, we'll need the constructor signature in order to encode the arguments in the file.  Currently I'm using ABI info from the cached artifact to do this. But if there's more elegant way, please let me know.