### PR TITLE
fix(evm, cheatcodes): prevent early filesystem commits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-debug = 0
+#debug = 0
 
 [profile.dev.package]
 # These speed up local tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-#debug = 0
+debug = 0
 
 [profile.dev.package]
 # These speed up local tests

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -214,6 +214,15 @@ impl ScriptRunner {
         value: U256,
         commit: bool,
     ) -> eyre::Result<ScriptResult> {
+        let fs_commit_changed =
+            if let Some(ref mut cheatcodes) = self.executor.inspector_config_mut().cheatcodes {
+                let original_fs_commit = cheatcodes.fs_commit;
+                cheatcodes.fs_commit = false;
+                original_fs_commit != cheatcodes.fs_commit
+            } else {
+                false
+            };
+
         let mut res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
         let mut gas_used = res.gas_used;
         if matches!(res.exit_reason, return_ok!()) {
@@ -257,6 +266,14 @@ impl ScriptRunner {
             }
             // reset gas limit in the
             self.executor.env_mut().tx.gas_limit = init_gas_limit;
+        }
+
+        if fs_commit_changed {
+            if let Some(ref mut cheatcodes) = self.executor.inspector_config_mut().cheatcodes {
+                cheatcodes.fs_commit = !cheatcodes.fs_commit;
+            }
+
+            res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
         }
 
         if commit {

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -268,6 +268,8 @@ impl ScriptRunner {
             self.executor.env_mut().tx.gas_limit = init_gas_limit;
         }
 
+        // if we changed `fs_commit` during gas limit search, re-execute the call with original
+        // value
         if fs_commit_changed {
             if let Some(ref mut cheatcodes) = self.executor.inspector_config_mut().cheatcodes {
                 cheatcodes.fs_commit = !cheatcodes.fs_commit;

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -201,7 +201,9 @@ fn write_file(state: &Cheatcodes, path: impl AsRef<Path>, content: &str) -> Resu
     // write access to foundry.toml is not allowed
     state.config.ensure_not_foundry_toml(&path).map_err(util::encode_error)?;
 
-    fs::write(path, content).map_err(util::encode_error)?;
+    if state.fs_commit {
+        fs::write(path, content).map_err(util::encode_error)?;
+    }
 
     Ok(Bytes::new())
 }
@@ -214,13 +216,15 @@ fn write_line(state: &Cheatcodes, path: impl AsRef<Path>, line: &str) -> Result<
         state.config.ensure_path_allowed(&path, FsAccessKind::Write).map_err(util::encode_error)?;
     state.config.ensure_not_foundry_toml(&path).map_err(util::encode_error)?;
 
-    let mut file = std::fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(path)
-        .map_err(util::encode_error)?;
+    if state.fs_commit {
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+            .map_err(util::encode_error)?;
 
-    writeln!(file, "{line}").map_err(util::encode_error)?;
+        writeln!(file, "{line}").map_err(util::encode_error)?;
+    }
 
     Ok(Bytes::new())
 }
@@ -247,7 +251,9 @@ fn remove_file(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, 
     // also remove from the set if opened previously
     state.context.opened_read_files.remove(&path);
 
-    fs::remove_file(&path).map_err(util::encode_error)?;
+    if state.fs_commit {
+        fs::remove_file(&path).map_err(util::encode_error)?;
+    }
 
     Ok(Bytes::new())
 }

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -113,6 +113,8 @@ pub struct Cheatcodes {
     /// Test-scoped context holding data that needs to be reset every test run
     pub context: Context,
 
+    // Commit FS changes such as file creations, writes and deletes.
+    // Used to prevent duplicate changes file executing non-committing calls.
     pub fs_commit: bool,
 }
 

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -112,6 +112,8 @@ pub struct Cheatcodes {
 
     /// Test-scoped context holding data that needs to be reset every test run
     pub context: Context,
+
+    pub fs_commit: bool,
 }
 
 #[derive(Debug, Default)]
@@ -134,6 +136,7 @@ impl Cheatcodes {
             block: Some(block),
             gas_price: Some(gas_price),
             config: Arc::new(config),
+            fs_commit: true,
             ..Default::default()
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/3069

## Solution

### Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/5773434/188435154-604bf1f5-f66d-4249-8be1-8a052ba07d5b.png">

### After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/5773434/188435282-d4366adf-fa8d-40b6-b37e-31df511995da.png">

