### PR TITLE
fix(forge): record snapshot failures correctly

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -380,10 +380,19 @@ impl Backend {
         self.inner.caller
     }
 
+    /// Failures occurred in snapshots are tracked when the snapshot is reverted
+    ///
+    /// If an error occurs in a restored snapshot, the test is considered failed.
+    ///
+    /// This returns whether there was a reverted snapshot that recorded an error
+    pub fn has_snapshot_failure(&self) -> bool {
+        self.inner.has_snapshot_failure
+    }
+
     /// Checks if the test contract associated with this backend failed, See
     /// [Self::is_failed_test_contract]
     pub fn is_failed(&self) -> bool {
-        self.inner.has_failure_snapshot ||
+        self.has_snapshot_failure() ||
             self.test_contract_address()
                 .map(|addr| self.is_failed_test_contract(addr))
                 .unwrap_or_default()
@@ -403,8 +412,27 @@ impl Backend {
          }
         */
         let value = self.storage(address, U256::zero());
-
         value.byte(1) != 0
+    }
+
+    /// Checks if the given test function failed by looking at the present value of the test
+    /// contract's `JournaledState`
+    ///
+    /// See [`Self::is_failed_test_contract()]`
+    ///
+    /// Note: we assume the test contract is either `forge-std/Test` or `DSTest`
+    pub fn is_failed_test_contract_state(
+        &self,
+        address: Address,
+        current_state: &JournaledState,
+    ) -> bool {
+        if let Some(account) = current_state.state.get(&address) {
+            let value =
+                account.storage.get(&U256::zero()).cloned().unwrap_or_default().present_value();
+            return value.byte(1) != 0
+        }
+
+        false
     }
 
     /// In addition to the `_failed` variable, `DSTest::fail()` stores a failure
@@ -589,8 +617,12 @@ impl DatabaseExt for Backend {
         if let Some(mut snapshot) = self.inner.snapshots.remove(id) {
             // need to check whether DSTest's `failed` variable is set to `true` which means an
             // error occurred either during the snapshot or even before
-            if self.is_failed() {
-                self.inner.has_failure_snapshot = true;
+            if self
+                .test_contract_address()
+                .map(|addr| self.is_failed_test_contract_state(addr, current_state))
+                .unwrap_or_default()
+            {
+                self.inner.has_snapshot_failure = true;
             }
 
             // merge additional logs
@@ -1024,7 +1056,7 @@ pub struct BackendInner {
     /// reverted we get the _current_ `revm::JournaledState` which contains the state that we can
     /// check if the `_failed` variable is set,
     /// additionally
-    pub has_failure_snapshot: bool,
+    pub has_snapshot_failure: bool,
     /// Tracks the address of a Test contract
     ///
     /// This address can be used to inspect the state of the contract when a test is being

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -541,6 +541,11 @@ impl Executor {
         state_changeset: StateChangeset,
         should_fail: bool,
     ) -> bool {
+        if self.backend().has_snapshot_failure() {
+            // a failure occurred in a reverted snapshot, which is considered a failed test
+            return should_fail
+        }
+
         // Construct a new VM with the state changeset
         let mut backend = self.backend().clone_empty();
         backend.insert_account_info(address, self.backend().basic(address));

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -135,3 +135,25 @@ fn test_issue_2984() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3055>
+#[test]
+fn test_issue_3055() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3055"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                !result.success,
+                "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue3055.t.sol
+++ b/testdata/repros/Issue3055.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3055
+contract Issue3055Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function test_snapshot() external {
+        uint256 snapId = vm.snapshot();
+        assertEq(uint256(0), uint256(1));
+        vm.revertTo(snapId);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3055

there were some changes in revm state recording, so we need to check the `JournaledState`'s present value of the slot that contains the `failed` variable when we revert a snapshot to record if there was a failure in a reverted snapshot
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
