### PR TITLE
chore: run script remember key test in serial

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -330,26 +330,31 @@ forgetest_async!(can_deploy_script_with_lib, |prj: TestProject, cmd: TestCommand
         .await;
 });
 
-forgetest_async!(can_deploy_script_remember_key, |prj: TestProject, cmd: TestCommand| async move {
-    let (_api, handle) = spawn(NodeConfig::test()).await;
-    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+forgetest_async!(
+    #[serial_test::serial]
+    can_deploy_script_remember_key,
+    |prj: TestProject, cmd: TestCommand| async move {
+        let (_api, handle) = spawn(NodeConfig::test()).await;
+        let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
 
-    tester
-        .load_addresses(vec![
-            Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()
-        ])
-        .await
-        .add_sig("BroadcastTest", "deployRememberKey()")
-        .simulate(ScriptOutcome::OkSimulation)
-        .broadcast(ScriptOutcome::OkBroadcast)
-        .assert_nonce_increment_addresses(vec![(
-            Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap(),
-            2,
-        )])
-        .await;
-});
+        tester
+            .load_addresses(vec![
+                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()
+            ])
+            .await
+            .add_sig("BroadcastTest", "deployRememberKey()")
+            .simulate(ScriptOutcome::OkSimulation)
+            .broadcast(ScriptOutcome::OkBroadcast)
+            .assert_nonce_increment_addresses(vec![(
+                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap(),
+                2,
+            )])
+            .await;
+    }
+);
 
 forgetest_async!(
+    #[serial_test::serial]
     can_deploy_script_remember_key_and_resume,
     |prj: TestProject, cmd: TestCommand| async move {
         let (_api, handle) = spawn(NodeConfig::test()).await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
script test can be a bit flaky expensive on smol runners: https://github.com/foundry-rs/foundry/runs/8196349472?check_suite_focus=true
better to run them in serial
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
