### PR TITLE
chore: prompt password

### DIFF
--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -105,8 +105,7 @@ impl WalletSubcommands {
                         password
                     } else {
                         // if no --unsafe-password was provided read via stdin
-                        println!("Insert secret:");
-                        rpassword::read_password()?
+                        rpassword::prompt_password("Enter secret: ")?
                     };
 
                     let (key, uuid) = LocalWallet::new_keystore(&path, &mut rng, password, None)?;

--- a/cli/src/opts/wallet.rs
+++ b/cli/src/opts/wallet.rs
@@ -196,8 +196,7 @@ impl WalletTrait for Wallet {}
 
 pub trait WalletTrait {
     fn get_from_interactive(&self) -> Result<LocalWallet> {
-        println!("Insert private key:");
-        let private_key = rpassword::read_password()?;
+        let private_key = rpassword::prompt_password("Enter private key: ")?;
         let private_key = private_key.strip_prefix("0x").unwrap_or(&private_key);
         Ok(LocalWallet::from_str(private_key)?)
     }
@@ -242,8 +241,7 @@ pub trait WalletTrait {
         Ok(match (keystore_path, keystore_password) {
             (Some(path), Some(password)) => Some(LocalWallet::decrypt_keystore(path, password)?),
             (Some(path), None) => {
-                println!("Insert keystore password:");
-                let password = rpassword::read_password().unwrap();
+                let password = rpassword::prompt_password("Enter keystore password:")?;
                 Some(LocalWallet::decrypt_keystore(path, password)?)
             }
             (None, _) => None,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #3046
use password prompt_password to show prompt directly

rpassword only uses hiddeninput 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
