### PR TITLE
feat(anvil): allow setting custom compute units per second

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -149,6 +149,7 @@ impl NodeArgs {
             .fork_request_timeout(self.evm_opts.fork_request_timeout.map(Duration::from_millis))
             .fork_request_retries(self.evm_opts.fork_request_retries)
             .fork_retry_backoff(self.evm_opts.fork_retry_backoff.map(Duration::from_millis))
+            .fork_compute_units_per_second(self.evm_opts.compute_units_per_second)
             .with_eth_rpc_url(self.evm_opts.fork_url.map(|fork| fork.url))
             .with_base_fee(self.evm_opts.block_base_fee_per_gas)
             .with_storage_caching(self.evm_opts.no_storage_caching)
@@ -265,6 +266,21 @@ pub struct AnvilEvmArgs {
     /// See --fork-url.
     #[clap(long, requires = "fork-url", value_name = "BACKOFF", help_heading = "FORK CONFIG")]
     pub fork_retry_backoff: Option<u64>,
+
+    /// Sets the number of assumed available compute units per second for this provider
+    ///
+    /// default value: 330
+    ///
+    /// See --fork-url.
+    /// See also, https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups
+    #[clap(
+        long,
+        requires = "fork-url",
+        alias = "cups",
+        value_name = "CUPS",
+        help_heading = "FORK CONFIG"
+    )]
+    pub compute_units_per_second: Option<u64>,
 
     /// Explicitly disables the use of RPC caching.
     ///

--- a/anvil/src/eth/backend/fork.rs
+++ b/anvil/src/eth/backend/fork.rs
@@ -492,6 +492,8 @@ pub struct ClientForkConfig {
     pub retries: u32,
     /// request retries for spurious networks
     pub backoff: Duration,
+    /// available CUPS
+    pub compute_units_per_second: u64,
 }
 
 // === impl ClientForkConfig ===
@@ -510,6 +512,7 @@ impl ClientForkConfig {
                 .timeout_retry(self.retries)
                 .max_retry(10)
                 .initial_backoff(self.backoff.as_millis() as u64)
+                .compute_units_per_second(self.compute_units_per_second)
                 .build()
                 .map_err(|_| BlockchainError::InvalidUrl(url.clone()))?
                 .interval(interval),

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -17,3 +17,6 @@ pub const CONTRACT_MAX_SIZE: usize = 24576;
 /// open forever. We assume some nodes may have some backoff baked into them and will delay some
 /// responses. This timeout should be a reasonable amount of time to wait for a request.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Alchemy free tier cups <https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups>
+pub const ALCHEMY_FREE_TIER_CUPS: u64 = 330;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Allow to configure a custom compute unit per second budget.

The alchemy free tier allows 330 CUPS which is used by the provider to anticipate retries

Ref https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
allows setting a custom CUPS value, for example Growth/Enterprise 

cc @sunwrobert

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
