### PR TITLE
Fix chain ID overflow

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -287,6 +287,9 @@ pub fn apply<DB: DatabaseExt>(
             abi::encode(&[Token::Uint(account.info.nonce.into())]).into()
         }
         HEVMCalls::ChainId(inner) => {
+            if inner.0 > U256::from(u64::MAX) {
+                return Err("Chain ID must be less than 2^64".to_string().encode().into())
+            }
             data.env.cfg.chain_id = inner.0;
             Bytes::new()
         }

--- a/testdata/cheats/Travel.t.sol
+++ b/testdata/cheats/Travel.t.sol
@@ -12,9 +12,8 @@ contract ChainIdTest is DSTest {
         assertEq(block.chainid, 10, "chainId switch failed");
     }
 
-    function testChainIdFuzzed(uint128 jump) public {
-        uint256 pre = block.chainid;
-        cheats.chainId(block.chainid + jump);
-        assertEq(block.chainid, pre + jump, "chainId switch failed");
+    function testChainIdFuzzed(uint64 chainId) public {
+        cheats.chainId(chainId);
+        assertEq(block.chainid, chainId, "chainId switch failed");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Resolves #3098 

Since chain ID is handled as `u64` internally, setting a value greater or equal to 2^64 by `cheats.chainId` cause the error because `cheats.sign`, etc. casting from `U256` to `u64`.

## Solution

Unlike `cheats.chainId`, it is not allowed to set chain ID to a value greater or equal to 2^64 in config files and the `--chain-id` option. (Strictly speaking, in config files, setting a value greater or equal to 2^63 throws the error due to [this bug in toml-rs](https://github.com/alexcrichton/toml-rs/issues/256). )

This PR also disallows setting chain ID to a value greater or equal to 2^64 using `cheats.chainId`. 

