### PR TITLE
fix: format tuples and arrays

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -101,23 +101,12 @@ where
             format!("{res}\n")
         } else {
             // seth compatible user-friendly return type conversions
-            let out = decoded
+            decoded
                 .iter()
-                .map(|item| {
-                    match item {
-                        Token::Address(inner) => utils::to_checksum(inner, None),
-                        // add 0x
-                        Token::Bytes(inner) => format!("0x{}", hex::encode(inner)),
-                        Token::FixedBytes(inner) => format!("0x{}", hex::encode(inner)),
-                        // print as decimal
-                        Token::Uint(inner) => inner.to_string(),
-                        Token::Int(inner) => format!("{}", I256::from_raw(*inner)),
-                        _ => format!("{item}"),
-                    }
-                })
-                .collect::<Vec<_>>();
-
-            out.join("\n")
+                .map(TokenDisplay)
+                .map(|token| token.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
         })
     }
 

--- a/common/src/fmt/mod.rs
+++ b/common/src/fmt/mod.rs
@@ -1,0 +1,7 @@
+//! Helpers for formatting ethereum types
+
+mod ui;
+pub use ui::*;
+
+mod token;
+pub use token::*;

--- a/common/src/fmt/token.rs
+++ b/common/src/fmt/token.rs
@@ -1,0 +1,50 @@
+//! Formatting helpers for [`Token`](ethers_core::abi::Token)
+
+use ethers_core::{abi::Token, types::I256, utils, utils::hex};
+use std::{fmt, fmt::Write};
+
+/// Wrapper that pretty formats a token
+pub struct TokenDisplay<'a>(pub &'a Token);
+
+impl<'a> fmt::Display for TokenDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_token(f, self.0)
+    }
+}
+
+fn fmt_token(f: &mut fmt::Formatter, item: &Token) -> fmt::Result {
+    match item {
+        Token::Address(inner) => {
+            write!(f, "{}", utils::to_checksum(inner, None))
+        }
+        // add 0x
+        Token::Bytes(inner) => write!(f, "0x{}", hex::encode(inner)),
+        Token::FixedBytes(inner) => write!(f, "0x{}", hex::encode(inner)),
+        // print as decimal
+        Token::Uint(inner) => write!(f, "{}", inner),
+        Token::Int(inner) => write!(f, "{}", I256::from_raw(*inner)),
+        Token::Array(tokens) | Token::FixedArray(tokens) => {
+            f.write_char('[')?;
+            let mut tokens = tokens.iter().peekable();
+            while let Some(token) = tokens.next() {
+                fmt_token(f, token)?;
+                if tokens.peek().is_some() {
+                    f.write_char(',')?
+                }
+            }
+            f.write_char(']')
+        }
+        Token::Tuple(tokens) => {
+            f.write_char('(')?;
+            let mut tokens = tokens.iter().peekable();
+            while let Some(token) = tokens.next() {
+                fmt_token(f, token)?;
+                if tokens.peek().is_some() {
+                    f.write_char(',')?
+                }
+            }
+            f.write_char(')')
+        }
+        _ => write!(f, "{item}"),
+    }
+}

--- a/common/src/fmt/ui.rs
+++ b/common/src/fmt/ui.rs
@@ -19,7 +19,7 @@ const NAME_COLUMN_LEN: usize = 20usize;
 /// let string = boolean.pretty();
 /// ```
 pub trait UIfmt {
-    /// Return a pretty-fied string version of the value
+    /// Return a prettified string version of the value
     fn pretty(&self) -> String;
 }
 
@@ -465,7 +465,7 @@ mod tests {
 
         let tx: Transaction = serde_json::from_str(s).unwrap();
         assert_eq!(tx.pretty().trim(),
-       r#"
+                   r#"
 blockHash            0x02b853cf50bc1c335b70790f93d5a390a35a166bea9c895e685cc866e4961cae
 blockNumber          436
 from                 0x3b179DcfC5fAa677044c27dCe958e4BC0ad696A6
@@ -489,7 +489,7 @@ queueOrigin          sequencer
 rawTransaction       0xf86681a28084011cbbdc944a16a42407aa491564643e1dfc1fd50af29794ef8084d294f09338a06fca94073a0cf3381978662d46cf890602d3e9ccf6a31e4b69e8ecbd995e2beea00e804161a2b56a37ca1f6f4c4b8bce926587afa0d9b1acc5165e6556c959d583
 txType
 "#.trim()
-       );
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
add missing tuple + array return type formatting for `cast call`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `TokenDisplay` helper type that formats
   * tuples: `(,,,)`
   * arrays `[,,,,,]`

turn `common::fmt` into a standalone module
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
