### PR TITLE
feat: resolve rpc url aliases

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -181,9 +181,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::AccessList { eth, address, sig, args, block, to_json } => {
             let config = Config::from(&eth);
-            let provider = get_http_provider(
-                config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-            );
+            let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
 
             let chain: Chain = if let Some(chain) = eth.chain {
                 chain
@@ -253,9 +251,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::SendTx(cmd) => cmd.run().await?,
         Subcommands::PublishTx { eth, raw_tx, cast_async } => {
             let config = Config::from(&eth);
-            let provider = get_http_provider(
-                config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-            );
+            let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
             let cast = Cast::new(&provider);
             let pending_tx = cast.publish(raw_tx).await?;
             let tx_hash = *pending_tx;

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -59,10 +59,8 @@ Examples: 1ether, 10gwei, 0.01ether"#,
 impl CallArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let CallArgs { to, sig, args, tx, eth, command, block } = self;
-        let mut config = Config::from(&eth);
-        let provider = get_http_provider(
-            config.eth_rpc_url.take().unwrap_or_else(|| "http://localhost:8545".to_string()),
-        );
+        let config = Config::from(&eth);
+        let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
 
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -62,10 +62,8 @@ Examples: 1ether, 10gwei, 0.01ether"#,
 impl EstimateArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let EstimateArgs { to, sig, args, value, eth, command } = self;
-        let mut config = Config::from(&eth);
-        let provider = get_http_provider(
-            config.eth_rpc_url.take().unwrap_or_else(|| "http://localhost:8545".to_string()),
-        );
+        let config = Config::from(&eth);
+        let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
 
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -80,9 +80,7 @@ impl SendTxArgs {
             command,
         } = self;
         let config = Config::from(&eth);
-        let provider = Arc::new(get_http_provider(
-            &config.eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string()),
-        ));
+        let provider = Arc::new(get_http_provider(config.get_rpc_url_or_localhost_http()?));
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
         let mut sig = sig.unwrap_or_default();

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -118,9 +118,7 @@ impl CreateArgs {
 
         // Add arguments to constructor
         let config = self.eth.load_config_emit_warnings();
-        let provider = Arc::new(get_http_provider(
-            config.eth_rpc_url.as_deref().unwrap_or("http://localhost:8545"),
-        ));
+        let provider = Arc::new(get_http_provider(config.get_rpc_url_or_localhost_http()?));
         let params = match abi.constructor {
             Some(ref v) => {
                 let constructor_args =

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -138,7 +138,7 @@ pub fn consume_config_rpc_url(rpc_url: Option<String>) -> String {
     if let Some(rpc_url) = rpc_url {
         rpc_url
     } else {
-        Config::load().eth_rpc_url.unwrap_or_else(|| "http://localhost:8545".to_string())
+        Config::load().get_rpc_url_or_localhost_http().expect("Invalid rpc url").into_owned()
     }
 }
 

--- a/common/src/provider.rs
+++ b/common/src/provider.rs
@@ -8,7 +8,7 @@ use ethers_providers::{
 };
 use eyre::WrapErr;
 use reqwest::{IntoUrl, Url};
-use std::time::Duration;
+use std::{borrow::Cow, time::Duration};
 
 /// Helper type alias for a retry provider
 pub type RetryProvider = Provider<RetryClient<Http>>;
@@ -190,6 +190,12 @@ impl<'a> From<&'a String> for ProviderBuilder {
 impl From<String> for ProviderBuilder {
     fn from(url: String) -> Self {
         url.as_str().into()
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for ProviderBuilder {
+    fn from(url: Cow<'a, str>) -> Self {
+        url.as_ref().into()
     }
 }
 

--- a/config/src/endpoints.rs
+++ b/config/src/endpoints.rs
@@ -2,7 +2,11 @@
 
 use crate::resolve::{interpolate, UnresolvedEnvVarError, RE_PLACEHOLDER};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{collections::BTreeMap, fmt, ops::Deref};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 /// Container type for API endpoints, like various RPC endpoints
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -152,5 +156,11 @@ impl Deref for ResolvedRpcEndpoints {
 
     fn deref(&self) -> &Self::Target {
         &self.endpoints
+    }
+}
+
+impl DerefMut for ResolvedRpcEndpoints {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.endpoints
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3021

this allows aliases in place of `--eth-rpc-url "mainnet"` if `"mainnet"` is an entry in [rpc_endpoints]
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add helper functions `Config::get_rpc_url` that looks up if `eth_rpc_url` is an alias in the [rpc_endpoints] table and returns that instead
* `Config::get_rpc_url_or_localhost_http` will return "http://localhost:8545" if `eth_rpc_url` is None
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
