### PR TITLE
fix: copy caller state when rolling active fork

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -825,11 +825,14 @@ impl DatabaseExt for Backend {
                 // same effect as selecting (`select_fork`) by discarding
                 // non-persistent storage from the journaled_state. This which will
                 // reset cached state from the previous block
-                let persitent_addrs = self.inner.persistent_accounts.clone();
+                let mut persistent_addrs = self.inner.persistent_accounts.clone();
+                // we also want to copy the caller state here
+                persistent_addrs.extend(self.caller_address());
+
                 let active = self.inner.get_fork_mut(active_idx);
                 active.journaled_state = self.fork_init_journaled_state.clone();
                 active.journaled_state.depth = journaled_state.depth;
-                for addr in persitent_addrs {
+                for addr in persistent_addrs {
                     clone_journaled_state_data(addr, journaled_state, &mut active.journaled_state);
                 }
                 *journaled_state = active.journaled_state.clone();

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -179,3 +179,25 @@ fn test_issue_3055() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3110>
+#[test]
+fn test_issue_3110() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3110"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue3110.t.sol
+++ b/testdata/repros/Issue3110.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3110
+abstract contract ZeroState is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    // deployer and users
+    address public deployer = vm.addr(1);
+    Token aaveToken;
+    uint256 public mainnetFork;
+
+    function setUp() public virtual {
+        vm.label(deployer, "Deployer");
+
+        vm.startPrank(deployer);
+        mainnetFork = vm.createFork("rpcAlias");
+        vm.selectFork(mainnetFork);
+
+        vm.rollFork(block.number - 20);
+
+        // deploy tokens
+        aaveToken = new Token();
+        vm.makePersistent(address(aaveToken));
+        vm.stopPrank();
+    }
+}
+
+abstract contract TestSate is ZeroState {
+    function setUp() public virtual override {
+        super.setUp();
+        aaveToken.balanceOf(deployer);
+    }
+}
+
+contract TestFork is TestSate {
+    function testFork() public {
+        vm.rollFork(block.number + 1);
+        emit log_uint(aaveToken.balanceOf(deployer));
+    }
+}
+
+contract Token {
+    mapping(address => uint256) private _balances;
+
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3110

when rolling the active fork, we also need to ensure the caller exists in the rolled journaledState
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
copy caller state
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
