### PR TITLE
fix: check current state for calle on revert diagnose

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -866,11 +866,11 @@ impl DatabaseExt for Backend {
     fn diagnose_revert(
         &self,
         callee: Address,
-        _journaled_state: &JournaledState,
+        journaled_state: &JournaledState,
     ) -> Option<RevertDiagnostic> {
         let active_id = self.active_fork_id()?;
         let active_fork = self.active_fork()?;
-        if !active_fork.is_contract(callee) {
+        if !active_fork.is_contract(callee) && !is_contract_in_state(journaled_state, callee) {
             // no contract for `callee` available on current fork, check if available on other forks
             let mut available_on = Vec::new();
             for (id, fork) in self.inner.forks_iter().filter(|(id, _)| *id != active_id) {
@@ -1056,11 +1056,7 @@ impl Fork {
                 return true
             }
         }
-        self.journaled_state
-            .state
-            .get(&acc)
-            .map(|acc| acc.info.code_hash != KECCAK_EMPTY)
-            .unwrap_or_default()
+        is_contract_in_state(&self.journaled_state, acc)
     }
 }
 
@@ -1334,4 +1330,13 @@ fn clone_db_account_data<ExtDB: DatabaseRef>(
         fork_db.contracts.insert(acc.info.code_hash, code);
     }
     fork_db.accounts.insert(addr, acc);
+}
+
+/// Returns true of the address is a contract
+fn is_contract_in_state(journaled_state: &JournaledState, acc: Address) -> bool {
+    journaled_state
+        .state
+        .get(&acc)
+        .map(|acc| acc.info.code_hash != KECCAK_EMPTY)
+        .unwrap_or_default()
 }

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -201,3 +201,25 @@ fn test_issue_3110() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3119>
+#[test]
+fn test_issue_3119() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3119"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/repros/Issue3119.t.sol
+++ b/testdata/repros/Issue3119.t.sol
@@ -22,14 +22,13 @@ contract Issue3119Test is DSTest {
 }
 
 contract FortressSwap {
-
     address owner;
 
-    constructor(address _owner ) {
+    constructor(address _owner) {
         owner = _owner;
     }
 
-    function updateOwner(address new_owner)  public {
+    function updateOwner(address new_owner) public {
         require(msg.sender == owner, "must be owner");
         owner = new_owner;
     }

--- a/testdata/repros/Issue3119.t.sol
+++ b/testdata/repros/Issue3119.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3119
+contract Issue3119Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    address public owner = vm.addr(1);
+    address public alice = vm.addr(2);
+
+    function testRollFork() public {
+        uint256 fork = vm.createFork("rpcAlias");
+        vm.selectFork(fork);
+
+        FortressSwap fortressSwap = new FortressSwap(address(owner));
+        vm.prank(owner);
+        fortressSwap.updateOwner(alice);
+    }
+}
+
+contract FortressSwap {
+
+    address owner;
+
+    constructor(address _owner ) {
+        owner = _owner;
+    }
+
+    function updateOwner(address new_owner)  public {
+        require(msg.sender == owner, "must be owner");
+        owner = new_owner;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
likely fixes #3119

wasn't able to reproduce this but, I think what happened was that a call reverted and we wrongly diagnosed this related to missing account
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
also check the current state if the address is a contract
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
