### PR TITLE
fix(forge): improve fuzzing error message for assume rejections

### DIFF
--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -116,7 +116,7 @@ impl<'a> FuzzedExecutor<'a> {
 
             // When assume cheat code is triggered return a special string "FOUNDRY::ASSUME"
             if call.result.as_ref() == ASSUME_MAGIC_RETURN_CODE {
-                return Err(TestCaseError::reject("ASSUME cheatcode"));
+                return Err(TestCaseError::reject("ASSUME cheatcode"))
             }
 
             let success = self.executor.is_success(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
https://github.com/foundry-rs/foundry/issues/1202

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Show fuzzing run stats including rejection reason counts.

### Example
`Fuzz.t.sol`:
```solidity
pragma solidity 0.8.10;

import "forge-std/Test.sol";

contract ContractTest is Test {
    function setUp() public {
    }

    function testFuzzAssume(uint256 a) external {
        vm.assume(a % 2 == 0);
        require(a % 2 == 0);
    }
}
```
`fuzz.max_global_rejects = 16` in `foundry.toml`

#### Before

<img width="800" alt="Screenshot 2022-09-08 at 01 11 00" src="https://user-images.githubusercontent.com/86655648/188939064-b992afad-935d-4fe1-b113-a9c4cdff60c2.png">

#### After

<img width="510" alt="Screenshot 2022-09-08 at 01 12 31" src="https://user-images.githubusercontent.com/86655648/188939115-595c1f4a-c3f5-4914-8690-92d584acc796.png">
