### PR TITLE
feat(cast): Add integer radix (base) parsing, add --to-base

### DIFF
--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -196,6 +196,14 @@ pub struct NumberWithBase {
     base: Base,
 }
 
+impl std::ops::Deref for NumberWithBase {
+    type Target = U256;
+
+    fn deref(&self) -> &Self::Target {
+        &self.number
+    }
+}
+
 // Format using self.base
 impl Debug for NumberWithBase {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -44,12 +44,11 @@ impl FromStr for Base {
             "10" | "d" | "dec" | "decimal" => Ok(Self::Decimal),
             "16" | "h" | "hex" | "hexadecimal" => Ok(Self::Hexadecimal),
             s => Err(eyre::eyre!(
-                r#"Invalid base "{}". Possible options:
+                r#"Invalid base "{}". Possible values:
 2, b, bin, binary
 8, o, oct, octal
 10, d, dec, decimal
-16, h, hex, hexadecimal
-                "#,
+16, h, hex, hexadecimal"#,
                 s
             )),
         }
@@ -73,7 +72,7 @@ impl TryFrom<u32> for Base {
             8 => Ok(Self::Octal),
             10 => Ok(Self::Decimal),
             16 => Ok(Self::Hexadecimal),
-            n => Err(eyre::eyre!("Invalid base \"{}\". Possible options: 2, 8, 10, 16", n)),
+            n => Err(eyre::eyre!("Invalid base \"{}\". Possible values: 2, 8, 10, 16", n)),
         }
     }
 }

--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -1,0 +1,465 @@
+use ethers_core::{
+    abi::ethereum_types::{FromStrRadixErr, FromStrRadixErrKind},
+    types::{Sign, I256, U256},
+};
+use eyre::{Context, ContextCompat, Result};
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    iter::FromIterator,
+    str::FromStr,
+};
+
+/* -------------------------------------------- Base -------------------------------------------- */
+
+// TODO: UpperHex and LowerHex
+/// Represents a number's [radix] or base. Currently it supports the same bases that [std::fmt]
+/// supports.
+///
+/// [Radix] = (https://en.wikipedia.org/wiki/Radix)
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Base {
+    Binary = 2,
+    Octal = 8,
+    #[default]
+    Decimal = 10,
+    Hexadecimal = 16,
+}
+
+impl Display for Base {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&(*self as u32), f)
+    }
+}
+
+impl FromStr for Base {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "2" | "b" | "bin" | "binary" => Ok(Self::Binary),
+            "8" | "o" | "oct" | "octal" => Ok(Self::Octal),
+            "10" | "d" | "dec" | "decimal" => Ok(Self::Decimal),
+            "16" | "h" | "hex" | "hexadecimal " => Ok(Self::Hexadecimal),
+            _ => Err(eyre::eyre!(
+                r#"Invalid base. Possible options:
+2, b, bin, binary
+8, o, oct, octal
+10, d, dec, decimal
+16, h, hex, hexadecimal
+                "#
+            )),
+        }
+    }
+}
+
+impl TryFrom<String> for Base {
+    type Error = eyre::Report;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}
+
+impl TryFrom<u32> for Base {
+    type Error = eyre::Report;
+
+    fn try_from(n: u32) -> Result<Self, Self::Error> {
+        match n {
+            2 => Ok(Self::Binary),
+            8 => Ok(Self::Octal),
+            10 => Ok(Self::Decimal),
+            16 => Ok(Self::Hexadecimal),
+            _ => Err(eyre::eyre!("Invalid base. Possible options: 2, 8, 10, 16")),
+        }
+    }
+}
+
+impl TryFrom<I256> for Base {
+    type Error = eyre::Report;
+
+    fn try_from(n: I256) -> Result<Self, Self::Error> {
+        Self::try_from(n.low_u32())
+    }
+}
+
+impl TryFrom<U256> for Base {
+    type Error = eyre::Report;
+
+    fn try_from(n: U256) -> Result<Self, Self::Error> {
+        Self::try_from(n.low_u32())
+    }
+}
+
+impl From<Base> for u32 {
+    fn from(b: Base) -> Self {
+        b as u32
+    }
+}
+
+impl From<Base> for I256 {
+    fn from(b: Base) -> Self {
+        Self::from(b as u32)
+    }
+}
+
+impl From<Base> for U256 {
+    fn from(b: Base) -> Self {
+        Self::from(b as u32)
+    }
+}
+
+impl From<Base> for String {
+    fn from(b: Base) -> Self {
+        b.to_string()
+    }
+}
+
+impl Base {
+    pub fn unwrap_or_detect(base: Option<Self>, s: impl AsRef<str>) -> Result<Self> {
+        base.map_or_else(|| Self::detect(s), |base| Ok(base))
+    }
+
+    /// Try parsing a number's base from a string.
+    pub fn detect(s: impl AsRef<str>) -> Result<Self> {
+        let s = s.as_ref();
+        match s {
+            _ if s.starts_with("0b") => Ok(Self::Binary),
+            _ if s.starts_with("0o") => Ok(Self::Octal),
+            _ if s.starts_with("0x") => Ok(Self::Hexadecimal),
+            // No prefix => first try parsing as decimal
+            _ => match U256::from_str_radix(s, 10) {
+                Ok(_) => {
+                    match U256::from_str_radix(s, 16) {
+                        // Can be both, ambiguous
+                        Ok(_) => Err(eyre::eyre!("Could not autodetect base: input could be decimal or hexadecimal. Please prepend with 0x if the input is hexadecimal, or specify a --base-in parameter.")),
+                        // Can only be decimal
+                        Err(_) => Ok(Self::Decimal),
+                    }
+                }
+                Err(_) => match U256::from_str_radix(s, 16) {
+                    Ok(_) => Ok(Self::Hexadecimal),
+                    Err(e) => Err(eyre::eyre!(
+                        "Could not autodetect base neither as decimal nor as hexadecimal: {}",
+                        e
+                    )),
+                },
+            },
+        }
+    }
+
+    /// Returns the Rust standard prefix for a base
+    pub const fn prefix(&self) -> &str {
+        match self {
+            Base::Binary => "0b",
+            Base::Octal => "0o",
+            Base::Hexadecimal => "0x",
+            _ => "",
+        }
+    }
+}
+
+/* --------------------------------------- NumberWithBase --------------------------------------- */
+
+#[derive(Clone, Copy)]
+pub struct NumberWithBase {
+    number: U256,
+    is_positive: bool,
+    base: Base,
+}
+
+impl Debug for NumberWithBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for NumberWithBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let prefix = self.base.prefix();
+        if self.number.is_zero() {
+            f.pad_integral(true, prefix, "0")
+        } else {
+            f.pad_integral(self.is_positive, prefix, &self.format(false))
+        }
+    }
+}
+
+impl FromStr for NumberWithBase {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse_int(s, None)
+    }
+}
+
+impl From<I256> for NumberWithBase {
+    fn from(number: I256) -> Self {
+        // both is_positive and is_negative return false for 0
+        Self::new(number.into_raw(), !number.is_negative(), Base::default())
+    }
+}
+
+impl From<U256> for NumberWithBase {
+    fn from(number: U256) -> Self {
+        Self::new(number, true, Base::default())
+    }
+}
+
+impl From<NumberWithBase> for I256 {
+    fn from(n: NumberWithBase) -> Self {
+        I256::from_raw(n.number)
+    }
+}
+
+impl From<NumberWithBase> for U256 {
+    fn from(n: NumberWithBase) -> Self {
+        n.number
+    }
+}
+
+impl From<NumberWithBase> for String {
+    /// Formats the number into the specified base with its prefix
+    fn from(n: NumberWithBase) -> Self {
+        n.format(true)
+    }
+}
+
+impl NumberWithBase {
+    pub fn new(number: impl Into<U256>, is_positive: bool, base: impl Into<Base>) -> Self {
+        Self { number: number.into(), is_positive, base: base.into() }
+    }
+
+    /// Parses a string slice into a signed integer. If base is None then it tries to determine base
+    /// from the prefix, otherwise defaults to Decimal.
+    pub fn parse_int(s: &str, base: Option<Base>) -> Result<Self> {
+        let base = Base::unwrap_or_detect(base, s)/*.unwrap_or_default()*/?;
+        let (number, is_positive) = Self::_parse_int(s, base)?;
+        Ok(Self { number, is_positive, base })
+    }
+
+    /// Parses a string slice into an unsigned integer. If base is None then it tries to determine
+    /// base from the prefix, otherwise defaults to Decimal.
+    pub fn parse_uint(s: &str, base: Option<Base>) -> Result<Self> {
+        let base = Base::unwrap_or_detect(base, s)/*.unwrap_or_default()*/?;
+        let number = Self::_parse_uint(s, base)?;
+        Ok(Self { number, is_positive: true, base })
+    }
+
+    /// Returns the underlying number as an unsigned integer. If the value is negative then the
+    /// two's complement of its absolute value will be returned.
+    pub fn number(&self) -> U256 {
+        self.number
+    }
+
+    /// Returns whether the underlying number is to be treated as a signed integer.
+    pub fn is_positive(&self) -> bool {
+        self.is_positive
+    }
+
+    /// Returns the underlying base. Defaults to [`Decimal`][Base].
+    pub fn base(&self) -> Base {
+        self.base
+    }
+
+    /// Returns the Rust standard prefix for the base.
+    pub const fn prefix(&self) -> &str {
+        self.base.prefix()
+    }
+
+    /// Sets the number's base to format to.
+    pub fn set_base(&mut self, base: Base) -> &mut Self {
+        self.base = base;
+        self
+    }
+
+    /// Formats the number into the specified base.
+    pub fn format(&self, add_prefix: bool) -> String {
+        let prefix = if add_prefix { self.prefix() } else { "" };
+        let s = match self.base {
+            // Binary and Octal traits are not implemented for primitive-types types, so we're using
+            // a custom formatter
+            Base::Binary | Base::Octal => self.format_radix(),
+            Base::Decimal => {
+                if self.is_positive {
+                    self.number.to_string()
+                } else {
+                    I256::from_raw(self.number).to_string()
+                }
+            }
+            Base::Hexadecimal => format!("{:x}", self.number),
+        };
+        format!("{}{}", prefix, s)
+    }
+
+    /// Iterates over every digit and calls [std::char::from_digit] to create a String.
+    ///
+    /// Modified from: https://stackoverflow.com/a/50278316
+    fn format_radix(&self) -> String {
+        let mut x = self.number;
+        let radix = self.base as u32;
+        let r = U256::from(radix);
+
+        let mut buf = ['\0'; 256];
+        let mut i = 255;
+        loop {
+            let m = (x % r).low_u64() as u32;
+            // radix is always less than 37 so from_digit cannot panic
+            // m is always in the radix's range so unwrap cannot panic
+            buf[i] = char::from_digit(m, radix).unwrap();
+            x /= r;
+            if x.is_zero() {
+                break
+            }
+            i -= 1;
+        }
+        String::from_iter(&buf[i..])
+    }
+
+    fn _parse_int(s: &str, base: Base) -> Result<(U256, bool)> {
+        let (s, sign) = get_sign(s);
+        let mut n = Self::_parse_uint(s, base)?;
+
+        let is_neg = matches!(sign, Sign::Negative);
+        if is_neg {
+            n = (!n).overflowing_add(U256::one()).0;
+        }
+
+        Ok((n, !is_neg))
+    }
+
+    fn _parse_uint(s: &str, base: Base) -> Result<U256> {
+        // TODO: Parse from binary or octal str into U256
+        U256::from_str_radix(s, base as u32).map_err(|e| {
+            if matches!(e.kind(), FromStrRadixErrKind::UnsupportedRadix) {
+                eyre::eyre!("numbers in base {} are currently not supported as input", base)
+            } else {
+                eyre::eyre!(e)
+            }
+        })
+    }
+}
+
+/* ------------------------------------------- ToBase ------------------------------------------- */
+
+/// Facilitates formatting an integer into a [Base].
+pub trait ToBase {
+    fn to_base(&self, base: Base, add_prefix: bool) -> String;
+}
+
+impl ToBase for I256 {
+    fn to_base(&self, base: Base, add_prefix: bool) -> String {
+        NumberWithBase::from(*self).set_base(base).format(add_prefix)
+    }
+}
+
+impl ToBase for U256 {
+    fn to_base(&self, base: Base, add_prefix: bool) -> String {
+        NumberWithBase::from(*self).set_base(base).format(add_prefix)
+    }
+}
+
+fn get_sign(s: &str) -> (&str, Sign) {
+    match s.as_bytes().first() {
+        Some(b'+') => (&s[1..], Sign::Positive),
+        Some(b'-') => (&s[1..], Sign::Negative),
+        _ => (s, Sign::Positive),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Base::*;
+
+    const POS_NUM: [i32; 14] = [1, 2, 8, 10, 16, 32, 64, 100, 128, 200, 500, 1000, 10000, i32::MAX];
+
+    const NEG_NUM: [i32; 14] =
+        [-1, -2, -8, -10, -16, -32, -64, -100, -128, -200, -500, -1000, -10000, i32::MIN];
+
+    #[test]
+    fn test_defaults() {
+        let def: Base = Default::default();
+        assert!(matches!(def, Decimal));
+
+        let n: NumberWithBase = U256::zero().into();
+        assert!(matches!(n.base, Decimal));
+        let n: NumberWithBase = I256::zero().into();
+        assert!(matches!(n.base, Decimal));
+    }
+
+    #[test]
+    fn test_detect() {
+        assert_eq!(Base::detect("0b100").unwrap(), Binary);
+        assert_eq!(Base::detect("0o100").unwrap(), Octal);
+        assert_eq!(Base::detect("100").unwrap(), Decimal);
+        assert_eq!(Base::detect("0x100").unwrap(), Hexadecimal);
+
+        Base::detect("0b234abc").unwrap_err();
+        Base::detect("0o89cba").unwrap_err();
+        Base::detect("123456abcdef").unwrap_err();
+        Base::detect("0x123abclpmk").unwrap_err();
+        Base::detect("hello world").unwrap_err();
+    }
+
+    #[test]
+    fn test_fmt_pos() {
+        let expected_2: Vec<_> = POS_NUM.iter().map(|n| format!("{:b}", n)).collect();
+        let expected_2_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#b}", n)).collect();
+        let expected_8: Vec<_> = POS_NUM.iter().map(|n| format!("{:o}", n)).collect();
+        let expected_8_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#o}", n)).collect();
+        let expected_10: Vec<_> = POS_NUM.iter().map(|n| format!("{:}", n)).collect();
+        let expected_10_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#}", n)).collect();
+        let expected_16: Vec<_> = POS_NUM.iter().map(|n| format!("{:x}", n)).collect();
+        let expected_16_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#x}", n)).collect();
+
+        let mut alt = false;
+        for (i, n) in POS_NUM.into_iter().enumerate() {
+            let mut num: NumberWithBase = I256::from(n).into();
+
+            alt = false;
+            assert_eq!(num.set_base(Binary).format(alt), expected_2[i]);
+            assert_eq!(num.set_base(Octal).format(alt), expected_8[i]);
+            assert_eq!(num.set_base(Decimal).format(alt), expected_10[i]);
+            assert_eq!(num.set_base(Hexadecimal).format(alt), expected_16[i]);
+
+            alt = true;
+            assert_eq!(num.set_base(Binary).format(alt), expected_2_alt[i]);
+            assert_eq!(num.set_base(Octal).format(alt), expected_8_alt[i]);
+            assert_eq!(num.set_base(Decimal).format(alt), expected_10_alt[i]);
+            assert_eq!(num.set_base(Hexadecimal).format(alt), expected_16_alt[i]);
+        }
+    }
+
+    #[test]
+    fn test_fmt_neg() {
+        // underlying is 256 bits so we have to pad left manually
+        let expected_2: Vec<_> = NEG_NUM.iter().map(|n| format!("{:1>256b}", n)).collect();
+        let expected_2_alt: Vec<_> = NEG_NUM.iter().map(|n| format!("0b{:1>256b}", n)).collect();
+        // TODO: create expected for octal
+        // let expected_8: Vec<_> = NEG_NUM.iter().map(|n| format!("1{:7>85o}", n)).collect();
+        // let expected_8_alt: Vec<_> = NEG_NUM.iter().map(|n| format!("0o1{:7>85o}", n)).collect();
+        let expected_10: Vec<_> = NEG_NUM.iter().map(|n| format!("{:}", n)).collect();
+        let expected_10_alt: Vec<_> = NEG_NUM.iter().map(|n| format!("{:#}", n)).collect();
+        let expected_16: Vec<_> = NEG_NUM.iter().map(|n| format!("{:f>64x}", n)).collect();
+        let expected_16_alt: Vec<_> = NEG_NUM.iter().map(|n| format!("0x{:f>64x}", n)).collect();
+
+        let mut alt = false;
+        for (i, n) in NEG_NUM.into_iter().enumerate() {
+            let mut num: NumberWithBase = I256::from(n).into();
+
+            alt = false;
+            assert_eq!(num.set_base(Binary).format(alt), expected_2[i]);
+            // assert_eq!(num.set_base(Octal).format(alt), expected_8[i]);
+            assert_eq!(num.set_base(Decimal).format(alt), expected_10[i]);
+            assert_eq!(num.set_base(Hexadecimal).format(alt), expected_16[i]);
+
+            alt = true;
+            assert_eq!(num.set_base(Binary).format(alt), expected_2_alt[i]);
+            // assert_eq!(num.set_base(Octal).format(alt), expected_8_alt[i]);
+            assert_eq!(num.set_base(Decimal).format(alt), expected_10_alt[i]);
+            assert_eq!(num.set_base(Hexadecimal).format(alt), expected_16_alt[i]);
+        }
+    }
+}

--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -160,8 +160,10 @@ impl Base {
             _ => match U256::from_str_radix(s, 10) {
                 Ok(_) => {
                     // Can be both, ambiguous but default to Decimal
-                    #[cfg_attr(rustfmt, rustfmt_skip)]
-                    // Err(eyre::eyre!("Could not autodetect base: input could be decimal or hexadecimal. Please prepend with 0x if the input is hexadecimal, or specify a --base-in parameter."))
+
+                    // Err(eyre::eyre!("Could not autodetect base: input could be decimal or
+                    // hexadecimal. Please prepend with 0x if the input is hexadecimal, or specify a
+                    // --base-in parameter."))
                     Ok(Self::Decimal)
                 }
                 Err(_) => match U256::from_str_radix(s, 16) {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -26,7 +26,7 @@ use std::{path::PathBuf, str::FromStr};
 pub use tx::TxBuilder;
 use tx::{TxBuilderOutput, TxBuilderPeekOutput};
 
-mod base;
+pub mod base;
 mod rlp_converter;
 mod tx;
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1059,7 +1059,7 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn to_base(value: &str, base_in: Option<String>, base_out: &str) -> Result<String> {
-        let base_in = get_base_or_from_str(&value, base_in.clone())?;
+        let base_in = get_base_or_from_str(value, base_in)?;
         let base_out = get_base(base_out)?;
         if base_in == base_out {
             return Ok(value.to_string())
@@ -1405,7 +1405,7 @@ impl SimpleCast {
         base_in: Option<String>,
         base_out: &str,
     ) -> Result<String> {
-        let base_in = get_base_or_from_str(&value, base_in.clone())?;
+        let base_in = get_base_or_from_str(value, base_in)?;
         let base_out = get_base(base_out)?;
 
         let value = parse_num(value, base_in)?;
@@ -1438,7 +1438,7 @@ impl SimpleCast {
         base_in: Option<String>,
         base_out: &str,
     ) -> Result<String> {
-        let base_in = get_base_or_from_str(&value, base_in.clone())?;
+        let base_in = get_base_or_from_str(value, base_in)?;
         let base_out = get_base(base_out)?;
 
         let value = parse_num(value, base_in)?;
@@ -1593,7 +1593,7 @@ fn get_base_from_str(s: &str) -> Result<u32> {
 fn get_base_or_from_str(s: &str, base: Option<String>) -> Result<u32> {
     match base {
         Some(base) => get_base(&base),
-        None => get_base_from_str(&s),
+        None => get_base_from_str(s),
     }
 }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1615,7 +1615,7 @@ fn format_uint(val: impl Into<U256>, base: u32, add_prefix: bool) -> eyre::Resul
             let mut s = String::new();
             let mut latch = false;
             let is_b = base == 2;
-            let f = if is_b { |v: u8| format!("{:b}", v) } else { |v: u8| format!("{:o}", v) };
+            let f = if is_b { |v: u8| format!("{:08b}", v) } else { |v: u8| format!("{:o}", v) };
             // little endian so rev
             for ch in val.0.iter().rev() {
                 let bytes = ch.to_be_bytes();

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -11,8 +11,8 @@ use ethers_core::{
     },
     types::{Chain, *},
     utils::{
-        self, format_bytes32_string, get_contract_address, keccak256, parse_bytes32_string,
-        parse_units, rlp,
+        self, format_bytes32_string, format_units, get_contract_address, keccak256,
+        parse_bytes32_string, parse_units, rlp, Units,
     },
 };
 use ethers_etherscan::Client;
@@ -733,13 +733,13 @@ impl SimpleCast {
     /// use ethers_core::types::U256;
     ///
     /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(U256::from_dec_str("424242")?, Cast::to_dec("0x67932")?);
-    ///     assert_eq!(U256::from_dec_str("1234")?, Cast::to_dec("0x4d2")?);
+    ///     assert_eq!(Cast::to_dec("0x67932")?, "424242");
+    ///     assert_eq!(Cast::to_dec("0x4d2")?, "1234");
     ///
     ///     Ok(())
     /// }
-    pub fn to_dec(hex: &str) -> Result<U256> {
-        Ok(U256::from_str(hex)?)
+    pub fn to_dec(value: &str) -> Result<String> {
+        Ok(Self::to_base(value, None, "dec")?)
     }
 
     /// Converts decimal input to hex
@@ -960,11 +960,11 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn from_wei(value: &str, unit: &str) -> Result<String> {
-        let value = U256::from_dec_str(value)?;
+        let value = NumberWithBase::parse_int(value, None)?.number();
 
         Ok(match unit {
-            "gwei" => ethers_core::utils::format_units(value, 9),
-            _ => ethers_core::utils::format_units(value, 18),
+            "gwei" => format_units(value, 9),
+            _ => format_units(value, 18),
         }?)
     }
 
@@ -985,11 +985,11 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn to_wei(value: &str, unit: &str) -> Result<String> {
-        Ok(match unit {
-            "gwei" => ethers_core::utils::parse_units(value, 9),
-            _ => ethers_core::utils::parse_units(value, 18),
-        }?
-        .to_string())
+        let wei = match unit {
+            "gwei" => parse_units(value, 9),
+            _ => parse_units(value, 18),
+        }?;
+        Ok(wei.to_string())
     }
 
     /// Decodes rlp encoded list with hex data

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1106,7 +1106,7 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn to_unit(value: &str, unit: &str) -> Result<String> {
-        let value = U256::from(LenientTokenizer::tokenize_uint(&value)?);
+        let value = U256::from(LenientTokenizer::tokenize_uint(value)?);
 
         Ok(match unit {
             "eth" | "ether" => ethers_core::utils::format_units(value, 18)?

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -831,7 +831,7 @@ impl SimpleCast {
             values
                 .into_iter()
                 .map(|s| s.strip_prefix("0x").unwrap_or(&s).to_string())
-                .collect::<Vec::<String>>()
+                .collect::<Vec<String>>()
                 .join("")
         )
     }
@@ -848,14 +848,14 @@ impl SimpleCast {
     ///
     /// # fn main() -> eyre::Result<()> {
     /// let addr = Address::from_str("0xb7e390864a90b7b923c9f9310c6f98aafe43f707")?;
-    /// let addr = Cast::to_checksum_address(&addr)?;
+    /// let addr = Cast::to_checksum_address(&addr);
     /// assert_eq!(addr, "0xB7e390864a90b7b923C9f9310C6F98aafE43F707");
     ///
     /// # Ok(())
     /// # }
     /// ```
-    pub fn to_checksum_address(address: &Address) -> Result<String> {
-        Ok(utils::to_checksum(address, None))
+    pub fn to_checksum_address(address: &Address) -> String {
+        utils::to_checksum(address, None)
     }
 
     /// Converts a number into uint256 hex string with 0x prefix

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -958,7 +958,7 @@ impl SimpleCast {
                 .trim_end_matches(".000000000")
                 .to_string(),
             "wei" => ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string(),
-            _ => eyre::bail!("invalid unit"),
+            _ => eyre::bail!("invalid unit: \"{}\"", unit),
         })
     }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -40,6 +40,8 @@ where
 {
     /// Creates a new Cast instance from the provided client
     ///
+    /// # Example
+    ///
     /// ```
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -56,6 +58,8 @@ where
     }
 
     /// Makes a read-only call to the specified address
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use cast::{Cast, TxBuilder};
@@ -107,6 +111,8 @@ where
 
     /// Generates an access list for the specified transaction
     ///
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
@@ -142,7 +148,7 @@ where
             let mut s =
                 vec![format!("gas used: {}", access_list.gas_used), "access list:".to_string()];
             for al in access_list.access_list.0 {
-                s.push(format!("- address: {}", SimpleCast::checksum_address(&al.address)?));
+                s.push(format!("- address: {}", SimpleCast::to_checksum_address(&al.address)?));
                 if !al.storage_keys.is_empty() {
                     s.push("  keys:".to_string());
                     for key in al.storage_keys {
@@ -165,6 +171,8 @@ where
     }
 
     /// Sends a transaction to the specified address
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use cast::{Cast, TxBuilder};
@@ -206,6 +214,8 @@ where
 
     /// Publishes a raw transaction to the network
     ///
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -230,6 +240,8 @@ where
     }
 
     /// Estimates the gas cost of a transaction
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use cast::{Cast, TxBuilder};
@@ -263,6 +275,8 @@ where
         Ok::<_, eyre::Error>(res)
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -423,6 +437,8 @@ where
         Ok(self.provider.get_gas_price().await?)
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -446,6 +462,8 @@ where
         Ok(self.provider.get_transaction_count(who, block).await?)
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -478,6 +496,8 @@ where
         Ok(get_contract_address(address, unpacked))
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -501,6 +521,8 @@ where
         Ok(format!("{}", self.provider.get_code(who, block).await?))
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -547,6 +569,8 @@ where
         Ok(transaction)
     }
 
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -616,6 +640,8 @@ where
 
     /// Perform a raw JSON-RPC request
     ///
+    /// # Example
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -651,9 +677,529 @@ pub enum InterfacePath {
 
 pub struct SimpleCast;
 impl SimpleCast {
+    /// Converts UTF-8 text input to hex
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::from_utf8("yo"), "0x796f");
+    ///     assert_eq!(Cast::from_utf8("Hello, World!"), "0x48656c6c6f2c20576f726c6421");
+    ///     assert_eq!(Cast::from_utf8("TurboDappTools"), "0x547572626f44617070546f6f6c73");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_utf8(s: &str) -> String {
+        let s: String = s.as_bytes().to_hex();
+        format!("0x{s}")
+    }
+
+    /// Converts hex data into text data
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_ascii("0x796f")?, "yo");
+    ///     assert_eq!(Cast::to_ascii("48656c6c6f2c20576f726c6421")?, "Hello, World!");
+    ///     assert_eq!(Cast::to_ascii("0x547572626f44617070546f6f6c73")?, "TurboDappTools");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_ascii(hex: &str) -> Result<String> {
+        let hex_trimmed = hex.trim_start_matches("0x");
+        let iter = FromHexIter::new(hex_trimmed);
+        let mut ascii = String::new();
+        for letter in iter.collect::<Vec<_>>() {
+            ascii.push(letter.unwrap() as char);
+        }
+        Ok(ascii)
+    }
+
+    /// Converts hex input to decimal
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// use ethers_core::types::U256;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(U256::from_dec_str("424242")?, Cast::to_dec("0x67932")?);
+    ///     assert_eq!(U256::from_dec_str("1234")?, Cast::to_dec("0x4d2")?);
+    ///
+    ///     Ok(())
+    /// }
+    pub fn to_dec(hex: &str) -> Result<U256> {
+        Ok(U256::from_str(hex)?)
+    }
+
+    /// Converts decimal input to hex
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// use ethers_core::types::U256;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("424242")?), "0x67932");
+    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("1234")?), "0x4d2");
+    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("115792089237316195423570985008687907853269984665640564039457584007913129639935")?), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_hex(u: U256) -> String {
+        format!("{:#x}", u)
+    }
+
+    /// Converts fixed point number into specified number of decimals
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// use ethers_core::types::U256;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::from_fix(0, "10")?, 10.into());
+    ///     assert_eq!(Cast::from_fix(1, "1.0")?, 10.into());
+    ///     assert_eq!(Cast::from_fix(2, "0.10")?, 10.into());
+    ///     assert_eq!(Cast::from_fix(3, "0.010")?, 10.into());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_fix(decimals: u32, value: &str) -> Result<U256> {
+        Ok(parse_units(value, decimals).unwrap())
+    }
+
+    /// Converts integers with specified decimals into fixed point numbers
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// use ethers_core::types::U256;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_fix(0, 10.into())?, "10.");
+    ///     assert_eq!(Cast::to_fix(1, 10.into())?, "1.0");
+    ///     assert_eq!(Cast::to_fix(2, 10.into())?, "0.10");
+    ///     assert_eq!(Cast::to_fix(3, 10.into())?, "0.010");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_fix(decimals: u128, value: U256) -> Result<String> {
+        let mut value: String = value.to_string();
+        let decimals = decimals as usize;
+
+        if decimals >= value.len() {
+            // {0}.{0 * (number_of_decimals - value.len())}{value}
+            Ok(format!("0.{:0>1$}", value, decimals))
+        } else {
+            // Insert decimal at -idx (i.e 1 => decimal idx = -1)
+            value.insert(value.len() - decimals, '.');
+            Ok(value)
+        }
+    }
+
+    /// Concatencates hex strings
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::concat_hex(vec!["0x00".to_string(), "0x01".to_string()]), "0x0001");
+    ///     assert_eq!(Cast::concat_hex(vec!["1".to_string(), "2".to_string()]), "0x12");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn concat_hex(values: Vec<String>) -> String {
+        format!(
+            "0x{}",
+            values
+                .into_iter()
+                .map(|s| s.strip_prefix("0x").unwrap_or(&s).to_string())
+                .collect::<Vec::<String>>()
+                .join("")
+        )
+    }
+
+    /// Converts an Ethereum address to its checksum format
+    /// according to [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// use ethers_core::types::Address;
+    /// use std::str::FromStr;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    /// let addr = Address::from_str("0xb7e390864a90b7b923c9f9310c6f98aafe43f707")?;
+    /// let addr = Cast::checksum_address(&addr)?;
+    /// assert_eq!(addr, "0xB7e390864a90b7b923C9f9310C6F98aafE43F707");
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn to_checksum_address(address: &Address) -> Result<String> {
+        Ok(utils::to_checksum(address, None))
+    }
+
+    /// Converts a number into uint256 hex string with 0x prefix
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_uint256("100")?, "0x0000000000000000000000000000000000000000000000000000000000000064");
+    ///     assert_eq!(Cast::to_uint256("192038293923")?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
+    ///     assert_eq!(
+    ///         Cast::to_uint256("115792089237316195423570985008687907853269984665640564039457584007913129639935")?,
+    ///         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    ///     );
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_uint256(value: &str) -> Result<String> {
+        let n = U256::from_str_radix(value, 10)?;
+        Ok(format!("0x{:064x}", n))
+    }
+
+    /// Converts a number into int256 hex string with 0x prefix
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_int256("0")?, "0x0000000000000000000000000000000000000000000000000000000000000000");
+    ///     assert_eq!(Cast::to_int256("100")?, "0x0000000000000000000000000000000000000000000000000000000000000064");
+    ///     assert_eq!(Cast::to_int256("-100")?, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9c");
+    ///     assert_eq!(Cast::to_int256("192038293923")?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
+    ///     assert_eq!(Cast::to_int256("-192038293923")?, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffd349a02e5d");
+    ///     assert_eq!(
+    ///         Cast::to_int256("57896044618658097711785492504343953926634992332820282019728792003956564819967")?,
+    ///         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    ///     );
+    ///     assert_eq!(
+    ///         Cast::to_int256("-57896044618658097711785492504343953926634992332820282019728792003956564819968")?,
+    ///         "0x8000000000000000000000000000000000000000000000000000000000000000"
+    ///     );
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_int256(value: &str) -> Result<String> {
+        let (sign, value) = match value.as_bytes().first() {
+            Some(b'+') => (Sign::Positive, &value[1..]),
+            Some(b'-') => (Sign::Negative, &value[1..]),
+            _ => (Sign::Positive, value),
+        };
+        let mut n = U256::from_str_radix(value, 10)?;
+
+        if matches!(sign, Sign::Negative) {
+            n = (!n).overflowing_add(U256::one()).0;
+        }
+
+        // same as to_uint256
+        Ok(format!("0x{:064x}", n))
+    }
+
+    /// Converts an eth amount into a specified unit
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_unit("1 wei", "wei")?, "1");
+    ///     assert_eq!(Cast::to_unit("1", "wei")?, "1");
+    ///     assert_eq!(Cast::to_unit("1ether", "wei")?, "1000000000000000000");
+    ///     assert_eq!(Cast::to_unit("100 gwei", "gwei")?, "100");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_unit(value: &str, unit: &str) -> Result<String> {
+        let value = U256::from(LenientTokenizer::tokenize_uint(value)?);
+
+        Ok(match unit {
+            "eth" | "ether" => ethers_core::utils::format_units(value, 18)?
+                .trim_end_matches(".000000000000000000")
+                .to_string(),
+            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?
+                .trim_end_matches(".000000000")
+                .to_string(),
+            "wei" => ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string(),
+            _ => eyre::bail!("invalid unit"),
+        })
+    }
+
+    /// Converts wei into an eth amount
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::from_wei("1", "gwei")?, "0.000000001");
+    ///     assert_eq!(Cast::from_wei("12340000005", "gwei")?, "12.340000005");
+    ///     assert_eq!(Cast::from_wei("10", "ether")?, "0.000000000000000010");
+    ///     assert_eq!(Cast::from_wei("100", "eth")?, "0.000000000000000100");
+    ///     assert_eq!(Cast::from_wei("17", "")?, "0.000000000000000017");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_wei(value: &str, unit: &str) -> Result<String> {
+        let value = U256::from_dec_str(value)?;
+
+        Ok(match unit {
+            "gwei" => ethers_core::utils::format_units(value, 9),
+            _ => ethers_core::utils::format_units(value, 18),
+        }?)
+    }
+
+    /// Converts an eth amount into wei
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_wei("1", "")?, "1000000000000000000");
+    ///     assert_eq!(Cast::to_wei("100", "gwei")?, "100000000000");
+    ///     assert_eq!(Cast::to_wei("100", "eth")?, "100000000000000000000");
+    ///     assert_eq!(Cast::to_wei("1000", "ether")?, "1000000000000000000000");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_wei(value: &str, unit: &str) -> Result<String> {
+        Ok(match unit {
+            "gwei" => ethers_core::utils::parse_units(value, 9),
+            _ => ethers_core::utils::parse_units(value, 18),
+        }?
+        .to_string())
+    }
+
+    /// Decodes rlp encoded list with hex data
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::from_rlp("0xc0".to_string()).unwrap(), "[]");
+    ///     assert_eq!(Cast::from_rlp("0x0f".to_string()).unwrap(), "\"0x0f\"");
+    ///     assert_eq!(Cast::from_rlp("0x33".to_string()).unwrap(), "\"0x33\"");
+    ///     assert_eq!(Cast::from_rlp("0xc161".to_string()).unwrap(), "[\"0x61\"]");
+    ///     assert_eq!(Cast::from_rlp("0xc26162".to_string()).unwrap(), "[\"0x61\",\"0x62\"]");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_rlp(value: impl AsRef<str>) -> Result<String> {
+        let value = value.as_ref();
+        let striped_value = strip_0x(value);
+        let bytes = hex::decode(striped_value).expect("Could not decode hex");
+        let item = rlp::decode::<Item>(&bytes).expect("Could not decode rlp");
+        Ok(format!("{}", item))
+    }
+
+    /// Encodes hex data or list of hex data to hexadecimal rlp
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_rlp("[]").unwrap(),"0xc0".to_string());
+    ///     assert_eq!(Cast::to_rlp("0x22").unwrap(),"0x22".to_string());
+    ///     assert_eq!(Cast::to_rlp("[\"0x61\"]",).unwrap(), "0xc161".to_string());
+    ///     assert_eq!(Cast::to_rlp( "[\"0xf1\",\"f2\"]").unwrap(), "0xc481f181f2".to_string());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_rlp(value: &str) -> Result<String> {
+        let val = serde_json::from_str(value).unwrap_or(serde_json::Value::String(value.parse()?));
+        let item = Item::value_to_item(&val)?;
+        Ok(format!("0x{}", hex::encode(rlp::encode(&item))))
+    }
+
+    /// Converts hexdata into bytes32 value
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    /// let bytes = Cast::to_bytes32("1234")?;
+    /// assert_eq!(bytes, "0x1234000000000000000000000000000000000000000000000000000000000000");
+    ///
+    /// let bytes = Cast::to_bytes32("0x1234")?;
+    /// assert_eq!(bytes, "0x1234000000000000000000000000000000000000000000000000000000000000");
+    ///
+    /// let err = Cast::to_bytes32("0x123400000000000000000000000000000000000000000000000000000000000011").unwrap_err();
+    /// assert_eq!(err.to_string(), "string >32 bytes");
+    ///
+    /// # Ok(())
+    /// # }
+    pub fn to_bytes32(s: &str) -> Result<String> {
+        let s = strip_0x(s);
+        if s.len() > 64 {
+            eyre::bail!("string >32 bytes");
+        }
+
+        let padded = format!("{:0<64}", s);
+        // need to use the Debug implementation
+        Ok(format!("{:?}", H256::from_str(&padded)?))
+    }
+
+    /// Encodes string into bytes32 value
+    pub fn format_bytes32_string(s: &str) -> Result<String> {
+        let formatted = format_bytes32_string(s)?;
+        Ok(format!("0x{}", hex::encode(formatted)))
+    }
+
+    /// Decodes string from bytes32 value
+    pub fn parse_bytes32_string(s: &str) -> Result<String> {
+        let s = strip_0x(s);
+        if s.len() != 64 {
+            eyre::bail!("string not 32 bytes");
+        }
+
+        let bytes = hex::decode(s)?;
+        let mut buffer = [0u8; 32];
+        buffer.copy_from_slice(&bytes);
+
+        Ok(parse_bytes32_string(&buffer)?.to_owned())
+    }
+
+    /// Decodes abi-encoded hex input or output
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     // Passing `input = false` will decode the data as the output type.
+    ///     // The input data types and the full function sig are ignored, i.e.
+    ///     // you could also pass `balanceOf()(uint256)` and it'd still work.
+    ///     let data = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    ///     let sig = "balanceOf(address, uint256)(uint256)";
+    ///     let decoded = Cast::abi_decode(sig, data, false)?[0].to_string();
+    ///     assert_eq!(decoded, "1");
+    ///
+    ///     // Passing `input = true` will decode the data with the input function signature.
+    ///     let data = "0xf242432a0000000000000000000000008dbd1b711dc621e1404633da156fcc779e1c6f3e000000000000000000000000d9f3c9cc99548bf3b44a43e0a2d07399eb918adc000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000";
+    ///     let sig = "safeTransferFrom(address, address, uint256, uint256, bytes)";
+    ///     let decoded = Cast::abi_decode(sig, data, true)?;
+    ///     let decoded = decoded.iter().map(ToString::to_string).collect::<Vec<_>>();
+    ///     assert_eq!(
+    ///         decoded,
+    ///         vec!["8dbd1b711dc621e1404633da156fcc779e1c6f3e", "d9f3c9cc99548bf3b44a43e0a2d07399eb918adc", "2a", "1", ""]
+    ///     );
+    ///
+    ///
+    ///     # Ok(())
+    /// }
+    /// ```
+    pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {
+        foundry_utils::abi_decode(sig, calldata, input)
+    }
+
+    /// Performs ABI encoding based off of the function signature. Does not include
+    /// the function selector in the result.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use cast::SimpleCast as Cast;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    ///     assert_eq!(
+    ///         "0x0000000000000000000000000000000000000000000000000000000000000001",
+    ///         Cast::abi_encode("f(uint a)", &["1"]).unwrap().as_str()
+    ///     );
+    ///     assert_eq!(
+    ///         "0x0000000000000000000000000000000000000000000000000000000000000001",
+    ///         Cast::abi_encode("constructor(uint a)", &["1"]).unwrap().as_str()
+    ///     );
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn abi_encode(sig: &str, args: &[impl AsRef<str>]) -> Result<String> {
+        let func = match HumanReadableParser::parse_function(sig) {
+            Ok(func) => func,
+            Err(err) => {
+                if let Ok(constructor) = HumanReadableParser::parse_constructor(sig) {
+                    #[allow(deprecated)]
+                    Function {
+                        name: "constructor".to_string(),
+                        inputs: constructor.inputs,
+                        outputs: vec![],
+                        constant: None,
+                        state_mutability: Default::default(),
+                    }
+                } else {
+                    // we return the `Function` parse error as this case is more likely
+                    return Err(err.into())
+                }
+            }
+        };
+        let calldata = encode_args(&func, args)?.to_hex::<String>();
+        let encoded = &calldata[8..];
+        Ok(format!("0x{encoded}"))
+    }
+
+    /// Performs ABI encoding to produce the hexadecimal calldata with the given arguments.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use cast::SimpleCast as Cast;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    ///     assert_eq!(
+    ///         "0xb3de648b0000000000000000000000000000000000000000000000000000000000000001",
+    ///         Cast::calldata_encode("f(uint a)", &["1"]).unwrap().as_str()
+    ///     );
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn calldata_encode(sig: impl AsRef<str>, args: &[impl AsRef<str>]) -> Result<String> {
+        let func = HumanReadableParser::parse_function(sig.as_ref())?;
+        let calldata = encode_args(&func, args)?;
+        Ok(format!("0x{}", calldata.to_hex::<String>()))
+    }
+
     /// Generates an interface in solidity from either a local file ABI or a verified contract on
     /// Etherscan. It returns a vector of [`InterfaceSource`] structs that contain the source of the
     /// interface and their name.
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use cast::SimpleCast as Cast;
@@ -723,565 +1269,35 @@ impl SimpleCast {
             .collect::<Result<Vec<InterfaceSource>>>()
     }
 
-    /// Returns maximum I256 value
+    /// Prints the slot number for the specified mapping type and input data
+    /// Uses abi_encode to pad the data to 32 bytes.
+    /// For value types v, slot number of v is keccak256(concat(h(v) , p)) where h is the padding
+    /// function and p is slot number of the mapping.
     ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::I256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(I256::MAX, Cast::max_int()?);
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub const fn max_int() -> Result<I256> {
-        Ok(I256::MAX)
-    }
-
-    /// Returns maximum U256 value
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(U256::MAX, Cast::max_uint()?);
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub const fn max_uint() -> Result<U256> {
-        Ok(U256::MAX)
-    }
-
-    /// Returns minimum I256 value
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::I256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(I256::MIN, Cast::min_int()?);
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub const fn min_int() -> Result<I256> {
-        Ok(I256::MIN)
-    }
-
-    /// Converts UTF-8 text input to hex
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::from_utf8("yo"), "0x796f");
-    ///     assert_eq!(Cast::from_utf8("Hello, World!"), "0x48656c6c6f2c20576f726c6421");
-    ///     assert_eq!(Cast::from_utf8("TurboDappTools"), "0x547572626f44617070546f6f6c73");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn from_utf8(s: &str) -> String {
-        let s: String = s.as_bytes().to_hex();
-        format!("0x{s}")
-    }
-
-    /// Converts hex data into text data
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_ascii("0x796f")?, "yo");
-    ///     assert_eq!(Cast::to_ascii("48656c6c6f2c20576f726c6421")?, "Hello, World!");
-    ///     assert_eq!(Cast::to_ascii("0x547572626f44617070546f6f6c73")?, "TurboDappTools");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_ascii(hex: &str) -> Result<String> {
-        let hex_trimmed = hex.trim_start_matches("0x");
-        let iter = FromHexIter::new(hex_trimmed);
-        let mut ascii = String::new();
-        for letter in iter.collect::<Vec<_>>() {
-            ascii.push(letter.unwrap() as char);
-        }
-        Ok(ascii)
-    }
-
-    /// Converts hex input to decimal
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(U256::from_dec_str("424242")?, Cast::to_dec("0x67932")?);
-    ///     assert_eq!(U256::from_dec_str("1234")?, Cast::to_dec("0x4d2")?);
-    ///
-    ///     Ok(())
-    /// }
-    pub fn to_dec(hex: &str) -> Result<U256> {
-        Ok(U256::from_str(hex)?)
-    }
-
-    /// Converts decimal input to hex
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("424242")?), "0x67932");
-    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("1234")?), "0x4d2");
-    ///     assert_eq!(Cast::to_hex(U256::from_dec_str("115792089237316195423570985008687907853269984665640564039457584007913129639935")?), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_hex(u: U256) -> String {
-        format!("{:#x}", u)
-    }
-
-    /// Converts fixed point number into specified number of decimals
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::from_fix(0, "10")?, 10.into());
-    ///     assert_eq!(Cast::from_fix(1, "1.0")?, 10.into());
-    ///     assert_eq!(Cast::from_fix(2, "0.10")?, 10.into());
-    ///     assert_eq!(Cast::from_fix(3, "0.010")?, 10.into());
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn from_fix(decimals: u32, value: &str) -> Result<U256> {
-        Ok(parse_units(value, decimals).unwrap())
-    }
-
-    /// Converts integers with specified decimals into fixed point numbers
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_fix(0, 10.into())?, "10.");
-    ///     assert_eq!(Cast::to_fix(1, 10.into())?, "1.0");
-    ///     assert_eq!(Cast::to_fix(2, 10.into())?, "0.10");
-    ///     assert_eq!(Cast::to_fix(3, 10.into())?, "0.010");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_fix(decimals: u128, value: U256) -> Result<String> {
-        let mut value: String = value.to_string();
-        let decimals = decimals as usize;
-
-        if decimals >= value.len() {
-            // {0}.{0 * (number_of_decimals - value.len())}{value}
-            Ok(format!("0.{:0>1$}", value, decimals))
-        } else {
-            // Insert decimal at -idx (i.e 1 => decimal idx = -1)
-            value.insert(value.len() - decimals, '.');
-            Ok(value)
-        }
-    }
-
-    /// Decodes abi-encoded hex input or output
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     // Passing `input = false` will decode the data as the output type.
-    ///     // The input data types and the full function sig are ignored, i.e.
-    ///     // you could also pass `balanceOf()(uint256)` and it'd still work.
-    ///     let data = "0x0000000000000000000000000000000000000000000000000000000000000001";
-    ///     let sig = "balanceOf(address, uint256)(uint256)";
-    ///     let decoded = Cast::abi_decode(sig, data, false)?[0].to_string();
-    ///     assert_eq!(decoded, "1");
-    ///
-    ///     // Passing `input = true` will decode the data with the input function signature.
-    ///     let data = "0xf242432a0000000000000000000000008dbd1b711dc621e1404633da156fcc779e1c6f3e000000000000000000000000d9f3c9cc99548bf3b44a43e0a2d07399eb918adc000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000";
-    ///     let sig = "safeTransferFrom(address, address, uint256, uint256, bytes)";
-    ///     let decoded = Cast::abi_decode(sig, data, true)?;
-    ///     let decoded = decoded.iter().map(ToString::to_string).collect::<Vec<_>>();
-    ///     assert_eq!(
-    ///         decoded,
-    ///         vec!["8dbd1b711dc621e1404633da156fcc779e1c6f3e", "d9f3c9cc99548bf3b44a43e0a2d07399eb918adc", "2a", "1", ""]
-    ///     );
-    ///
-    ///
-    ///     # Ok(())
-    /// }
-    /// ```
-    pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {
-        foundry_utils::abi_decode(sig, calldata, input)
-    }
-
-    /// Performs ABI encoding based off of the function signature. Does not include
-    /// the function selector in the result.
+    /// # Example
     ///
     /// ```
     /// # use cast::SimpleCast as Cast;
     ///
     /// # fn main() -> eyre::Result<()> {
-    ///     assert_eq!(
-    ///         "0x0000000000000000000000000000000000000000000000000000000000000001",
-    ///         Cast::abi_encode("f(uint a)", &["1"]).unwrap().as_str()
-    ///     );
-    ///     assert_eq!(
-    ///         "0x0000000000000000000000000000000000000000000000000000000000000001",
-    ///         Cast::abi_encode("constructor(uint a)", &["1"]).unwrap().as_str()
-    ///     );
+    ///
+    ///    assert_eq!(Cast::index("address", "0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
+    ///    assert_eq!(Cast::index("uint256","42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
     /// #    Ok(())
     /// # }
     /// ```
-    pub fn abi_encode(sig: &str, args: &[impl AsRef<str>]) -> Result<String> {
-        let func = match HumanReadableParser::parse_function(sig) {
-            Ok(func) => func,
-            Err(err) => {
-                if let Ok(constructor) = HumanReadableParser::parse_constructor(sig) {
-                    #[allow(deprecated)]
-                    Function {
-                        name: "constructor".to_string(),
-                        inputs: constructor.inputs,
-                        outputs: vec![],
-                        constant: None,
-                        state_mutability: Default::default(),
-                    }
-                } else {
-                    // we return the `Function` parse error as this case is more likely
-                    return Err(err.into())
-                }
-            }
-        };
-        let calldata = encode_args(&func, args)?.to_hex::<String>();
-        let encoded = &calldata[8..];
-        Ok(format!("0x{encoded}"))
-    }
-
-    /// Concatencates hex strings
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::concat_hex(vec!["0x00".to_string(), "0x01".to_string()]), "0x0001");
-    ///     assert_eq!(Cast::concat_hex(vec!["1".to_string(), "2".to_string()]), "0x12");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn concat_hex(values: Vec<String>) -> String {
-        format!(
-            "0x{}",
-            values
-                .into_iter()
-                .map(|s| s.strip_prefix("0x").unwrap_or(&s).to_string())
-                .collect::<Vec::<String>>()
-                .join("")
-        )
-    }
-
-    /// Converts a number into uint256 hex string with 0x prefix
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_uint256("100")?, "0x0000000000000000000000000000000000000000000000000000000000000064");
-    ///     assert_eq!(Cast::to_uint256("192038293923")?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
-    ///     assert_eq!(
-    ///         Cast::to_uint256("115792089237316195423570985008687907853269984665640564039457584007913129639935")?,
-    ///         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-    ///     );
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_uint256(value: &str) -> Result<String> {
-        let n = U256::from_str_radix(value, 10)?;
-        Ok(format!("0x{:064x}", n))
-    }
-
-    /// Converts a number into int256 hex string with 0x prefix
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_int256("0")?, "0x0000000000000000000000000000000000000000000000000000000000000000");
-    ///     assert_eq!(Cast::to_int256("100")?, "0x0000000000000000000000000000000000000000000000000000000000000064");
-    ///     assert_eq!(Cast::to_int256("-100")?, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9c");
-    ///     assert_eq!(Cast::to_int256("192038293923")?, "0x0000000000000000000000000000000000000000000000000000002cb65fd1a3");
-    ///     assert_eq!(Cast::to_int256("-192038293923")?, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffd349a02e5d");
-    ///     assert_eq!(
-    ///         Cast::to_int256("57896044618658097711785492504343953926634992332820282019728792003956564819967")?,
-    ///         "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-    ///     );
-    ///     assert_eq!(
-    ///         Cast::to_int256("-57896044618658097711785492504343953926634992332820282019728792003956564819968")?,
-    ///         "0x8000000000000000000000000000000000000000000000000000000000000000"
-    ///     );
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_int256(value: &str) -> Result<String> {
-        let (sign, value) = match value.as_bytes().first() {
-            Some(b'+') => (Sign::Positive, &value[1..]),
-            Some(b'-') => (Sign::Negative, &value[1..]),
-            _ => (Sign::Positive, value),
-        };
-        let mut n = U256::from_str_radix(value, 10)?;
-
-        if matches!(sign, Sign::Negative) {
-            n = (!n).overflowing_add(U256::one()).0;
-        }
-
-        // same as to_uint256
-        Ok(format!("0x{:064x}", n))
-    }
-
-    /// Performs the left shift operation (<<) on a number
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::left_shift("16", "10", 10)?, 0x4000.into());
-    ///     assert_eq!(Cast::left_shift("255", "16", 10)?, 0xff0000.into());
-    ///     assert_eq!(Cast::left_shift("0xff", "16", 16)?, 0xff0000.into());
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn left_shift(value: &str, bits: &str, base_in: u32) -> Result<U256> {
-        let value = U256::from_str_radix(value, base_in)
-            .wrap_err(format!("Cannot parse input as base {}", base_in))?;
-        let bits = U256::from_dec_str(bits).wrap_err("Cannot parse bits input")?;
-
-        Ok(value << bits)
-    }
-
-    /// Performs the right shift operation (>>) on a number
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::right_shift("0x4000", "10", 16)?, 16.into());
-    ///     assert_eq!(Cast::right_shift("16711680", "16", 10)?, 0xff.into());
-    ///     assert_eq!(Cast::right_shift("0xff0000", "16", 16)?, 0xff.into());
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn right_shift(value: &str, bits: &str, base_in: u32) -> Result<U256> {
-        let value = U256::from_str_radix(value, base_in)
-            .wrap_err(format!("Cannot parse input as base {}", base_in))?;
-        let bits = U256::from_dec_str(bits).wrap_err("Cannot parse bits input")?;
-
-        Ok(value >> bits)
-    }
-
-    /// Converts an eth amount into a specified unit
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_unit("1 wei", "wei")?, "1");
-    ///     assert_eq!(Cast::to_unit("1", "wei")?, "1");
-    ///     assert_eq!(Cast::to_unit("1ether", "wei")?, "1000000000000000000");
-    ///     assert_eq!(Cast::to_unit("100 gwei", "gwei")?, "100");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_unit(value: &str, unit: &str) -> Result<String> {
-        let value = U256::from(LenientTokenizer::tokenize_uint(value)?);
-
-        Ok(match unit {
-            "eth" | "ether" => ethers_core::utils::format_units(value, 18)?
-                .trim_end_matches(".000000000000000000")
-                .to_string(),
-            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?
-                .trim_end_matches(".000000000")
-                .to_string(),
-            "wei" => ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string(),
-            _ => eyre::bail!("invalid unit"),
-        })
-    }
-
-    /// Converts wei into an eth amount
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::from_wei("1", "gwei")?, "0.000000001");
-    ///     assert_eq!(Cast::from_wei("12340000005", "gwei")?, "12.340000005");
-    ///     assert_eq!(Cast::from_wei("10", "ether")?, "0.000000000000000010");
-    ///     assert_eq!(Cast::from_wei("100", "eth")?, "0.000000000000000100");
-    ///     assert_eq!(Cast::from_wei("17", "")?, "0.000000000000000017");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn from_wei(value: &str, unit: &str) -> Result<String> {
-        let value = U256::from_dec_str(value)?;
-
-        Ok(match unit {
-            "gwei" => ethers_core::utils::format_units(value, 9),
-            _ => ethers_core::utils::format_units(value, 18),
-        }?)
-    }
-
-    /// Converts an eth amount into wei
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_wei("1", "")?, "1000000000000000000");
-    ///     assert_eq!(Cast::to_wei("100", "gwei")?, "100000000000");
-    ///     assert_eq!(Cast::to_wei("100", "eth")?, "100000000000000000000");
-    ///     assert_eq!(Cast::to_wei("1000", "ether")?, "1000000000000000000000");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_wei(value: &str, unit: &str) -> Result<String> {
-        Ok(match unit {
-            "gwei" => ethers_core::utils::parse_units(value, 9),
-            _ => ethers_core::utils::parse_units(value, 18),
-        }?
-        .to_string())
-    }
-
-    /// Decodes rlp encoded list with hex data
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::from_rlp("0xc0".to_string()).unwrap(), "[]");
-    ///     assert_eq!(Cast::from_rlp("0x0f".to_string()).unwrap(), "\"0x0f\"");
-    ///     assert_eq!(Cast::from_rlp("0x33".to_string()).unwrap(), "\"0x33\"");
-    ///     assert_eq!(Cast::from_rlp("0xc161".to_string()).unwrap(), "[\"0x61\"]");
-    ///     assert_eq!(Cast::from_rlp("0xc26162".to_string()).unwrap(), "[\"0x61\",\"0x62\"]");
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn from_rlp(value: impl AsRef<str>) -> Result<String> {
-        let value = value.as_ref();
-        let striped_value = strip_0x(value);
-        let bytes = hex::decode(striped_value).expect("Could not decode hex");
-        let item = rlp::decode::<Item>(&bytes).expect("Could not decode rlp");
-        Ok(format!("{}", item))
-    }
-
-    /// Encodes hex data or list of hex data to hexadecimal rlp
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_rlp("[]").unwrap(),"0xc0".to_string());
-    ///     assert_eq!(Cast::to_rlp("0x22").unwrap(),"0x22".to_string());
-    ///     assert_eq!(Cast::to_rlp("[\"0x61\"]",).unwrap(), "0xc161".to_string());
-    ///     assert_eq!(Cast::to_rlp( "[\"0xf1\",\"f2\"]").unwrap(), "0xc481f181f2".to_string());
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_rlp(value: &str) -> Result<String> {
-        let val = serde_json::from_str(value).unwrap_or(serde_json::Value::String(value.parse()?));
-        let item = Item::value_to_item(&val)?;
-        Ok(format!("0x{}", hex::encode(rlp::encode(&item))))
-    }
-
-    /// Converts an Ethereum address to its checksum format
-    /// according to [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::Address;
-    /// use std::str::FromStr;
-    ///
-    /// # fn main() -> eyre::Result<()> {
-    /// let addr = Address::from_str("0xb7e390864a90b7b923c9f9310c6f98aafe43f707")?;
-    /// let addr = Cast::checksum_address(&addr)?;
-    /// assert_eq!(addr, "0xB7e390864a90b7b923C9f9310C6F98aafE43F707");
-    ///
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn checksum_address(address: &Address) -> Result<String> {
-        Ok(utils::to_checksum(address, None))
-    }
-
-    /// Converts hexdata into bytes32 value
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// # fn main() -> eyre::Result<()> {
-    /// let bytes = Cast::bytes32("1234")?;
-    /// assert_eq!(bytes, "0x1234000000000000000000000000000000000000000000000000000000000000");
-    ///
-    /// let bytes = Cast::bytes32("0x1234")?;
-    /// assert_eq!(bytes, "0x1234000000000000000000000000000000000000000000000000000000000000");
-    ///
-    /// let err = Cast::bytes32("0x123400000000000000000000000000000000000000000000000000000000000011").unwrap_err();
-    /// assert_eq!(err.to_string(), "string >32 bytes");
-    ///
-    /// # Ok(())
-    /// # }
-    pub fn bytes32(s: &str) -> Result<String> {
-        let s = strip_0x(s);
-        if s.len() > 64 {
-            eyre::bail!("string >32 bytes");
-        }
-
-        let padded = format!("{:0<64}", s);
-        // need to use the Debug implementation
-        Ok(format!("{:?}", H256::from_str(&padded)?))
-    }
-
-    /// Keccak-256 hashes arbitrary data
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::keccak("foo")?, "0x41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d");
-    ///     assert_eq!(Cast::keccak("123abc")?, "0xb1f1c74a1ba56f07a892ea1110a39349d40f66ca01d245e704621033cb7046a4");
-    ///     assert_eq!(Cast::keccak("0x12")?, "0x5fa2358263196dbbf23d1ca7a509451f7a2f64c15837bfbb81298b1e3e24e4fa");
-    ///     assert_eq!(Cast::keccak("12")?, "0x7f8b6b088b6d74c2852fc86c796dca07b44eed6fb3daf5e6b59f7c364db14528");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn keccak(data: &str) -> Result<String> {
-        let hash = match data.as_bytes() {
-            // 0x prefix => read as hex data
-            [b'0', b'x', rest @ ..] => keccak256(hex::decode(rest)?),
-            // No 0x prefix => read as text
-            _ => keccak256(data),
-        };
-
-        Ok(format!("{:?}", H256(hash)))
+    pub fn index(from_type: &str, from_value: &str, slot_number: &str) -> Result<String> {
+        let sig = format!("x({from_type},uint256)");
+        let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
+        let location: String = Self::keccak(&encoded)?;
+        Ok(location)
     }
 
     /// Converts ENS names to their namehash representation
     /// [Namehash reference](https://docs.ens.domains/contract-api-reference/name-processing#hashing-names)
     /// [namehash-rust reference](https://github.com/InstateDev/namehash-rust/blob/master/src/lib.rs)
+    ///
+    /// # Example
     ///
     /// ```
     /// use cast::SimpleCast as Cast;
@@ -1316,26 +1332,82 @@ impl SimpleCast {
         Ok(format!("0x{namehash}"))
     }
 
-    /// Performs ABI encoding to produce the hexadecimal calldata with the given arguments.
+    /// Keccak-256 hashes arbitrary data
+    ///
+    /// # Example
     ///
     /// ```
-    /// # use cast::SimpleCast as Cast;
+    /// use cast::SimpleCast as Cast;
     ///
-    /// # fn main() -> eyre::Result<()> {
-    ///     assert_eq!(
-    ///         "0xb3de648b0000000000000000000000000000000000000000000000000000000000000001",
-    ///         Cast::calldata("f(uint a)", &["1"]).unwrap().as_str()
-    ///     );
-    /// #    Ok(())
-    /// # }
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::keccak("foo")?, "0x41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d");
+    ///     assert_eq!(Cast::keccak("123abc")?, "0xb1f1c74a1ba56f07a892ea1110a39349d40f66ca01d245e704621033cb7046a4");
+    ///     assert_eq!(Cast::keccak("0x12")?, "0x5fa2358263196dbbf23d1ca7a509451f7a2f64c15837bfbb81298b1e3e24e4fa");
+    ///     assert_eq!(Cast::keccak("12")?, "0x7f8b6b088b6d74c2852fc86c796dca07b44eed6fb3daf5e6b59f7c364db14528");
+    ///
+    ///     Ok(())
+    /// }
     /// ```
-    pub fn calldata(sig: impl AsRef<str>, args: &[impl AsRef<str>]) -> Result<String> {
-        let func = HumanReadableParser::parse_function(sig.as_ref())?;
-        let calldata = encode_args(&func, args)?;
-        Ok(format!("0x{}", calldata.to_hex::<String>()))
+    pub fn keccak(data: &str) -> Result<String> {
+        let hash = match data.as_bytes() {
+            // 0x prefix => read as hex data
+            [b'0', b'x', rest @ ..] => keccak256(hex::decode(rest)?),
+            // No 0x prefix => read as text
+            _ => keccak256(data),
+        };
+
+        Ok(format!("{:?}", H256(hash)))
+    }
+
+    /// Performs the left shift operation (<<) on a number
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::left_shift("16", "10", 10)?, 0x4000.into());
+    ///     assert_eq!(Cast::left_shift("255", "16", 10)?, 0xff0000.into());
+    ///     assert_eq!(Cast::left_shift("0xff", "16", 16)?, 0xff0000.into());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn left_shift(value: &str, bits: &str, base_in: u32) -> Result<U256> {
+        let value = U256::from_str_radix(value, base_in)
+            .wrap_err(format!("Cannot parse input as base {}", base_in))?;
+        let bits = U256::from_dec_str(bits).wrap_err("Cannot parse bits input")?;
+
+        Ok(value << bits)
+    }
+
+    /// Performs the right shift operation (>>) on a number
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::right_shift("0x4000", "10", 16)?, 16.into());
+    ///     assert_eq!(Cast::right_shift("16711680", "16", 10)?, 0xff.into());
+    ///     assert_eq!(Cast::right_shift("0xff0000", "16", 16)?, 0xff.into());
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn right_shift(value: &str, bits: &str, base_in: u32) -> Result<U256> {
+        let value = U256::from_str_radix(value, base_in)
+            .wrap_err(format!("Cannot parse input as base {}", base_in))?;
+        let bits = U256::from_dec_str(bits).wrap_err("Cannot parse bits input")?;
+
+        Ok(value >> bits)
     }
 
     /// Fetches source code of verified contracts from etherscan.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use cast::SimpleCast as Cast;
@@ -1369,6 +1441,9 @@ impl SimpleCast {
 
     /// Fetches the source code of verified contracts from etherscan and expands the resulting
     /// files to a directory for easy perusal.
+    ///
+    /// # Example
+    ///
     /// ```
     /// # use cast::SimpleCast as Cast;
     /// # use ethers_core::types::Chain;
@@ -1391,47 +1466,6 @@ impl SimpleCast {
         source_tree.write_to(&output_directory)?;
         Ok(())
     }
-
-    /// Prints the slot number for the specified mapping type and input data
-    /// Uses abi_encode to pad the data to 32 bytes.
-    /// For value types v, slot number of v is keccak256(concat(h(v) , p)) where h is the padding
-    /// function and p is slot number of the mapping.
-    /// ```
-    /// # use cast::SimpleCast as Cast;
-    ///
-    /// # fn main() -> eyre::Result<()> {
-    ///
-    ///    assert_eq!(Cast::index("address", "0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
-    ///    assert_eq!(Cast::index("uint256","42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
-    /// #    Ok(())
-    /// # }
-    /// ```
-    pub fn index(from_type: &str, from_value: &str, slot_number: &str) -> Result<String> {
-        let sig = format!("x({from_type},uint256)");
-        let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
-        let location: String = Self::keccak(&encoded)?;
-        Ok(location)
-    }
-
-    /// Encodes string into bytes32 value
-    pub fn format_bytes32_string(s: &str) -> Result<String> {
-        let formatted = format_bytes32_string(s)?;
-        Ok(format!("0x{}", hex::encode(formatted)))
-    }
-
-    /// Decodes string from bytes32 value
-    pub fn parse_bytes32_string(s: &str) -> Result<String> {
-        let s = strip_0x(s);
-        if s.len() != 64 {
-            eyre::bail!("string not 32 bytes");
-        }
-
-        let bytes = hex::decode(s)?;
-        let mut buffer = [0u8; 32];
-        buffer.copy_from_slice(&bytes);
-
-        Ok(parse_bytes32_string(&buffer)?.to_owned())
-    }
 }
 
 fn strip_0x(s: &str) -> &str {
@@ -1446,7 +1480,7 @@ mod tests {
     fn calldata_uint() {
         assert_eq!(
             "0xb3de648b0000000000000000000000000000000000000000000000000000000000000001",
-            Cast::calldata("f(uint a)", &["1"]).unwrap().as_str()
+            Cast::calldata_encode("f(uint a)", &["1"]).unwrap().as_str()
         );
     }
 
@@ -1455,7 +1489,7 @@ mod tests {
     fn calldata_array() {
         assert_eq!(
             "0xcde2baba0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000",
-            Cast::calldata("propose(string[])", &["[\"\"]"]).unwrap().as_str()
+            Cast::calldata_encode("propose(string[])", &["[\"\"]"]).unwrap().as_str()
         );
     }
 
@@ -1463,7 +1497,7 @@ mod tests {
     fn calldata_bool() {
         assert_eq!(
             "0x6fae94120000000000000000000000000000000000000000000000000000000000000000",
-            Cast::calldata("bar(bool)", &["false"]).unwrap().as_str()
+            Cast::calldata_encode("bar(bool)", &["false"]).unwrap().as_str()
         );
     }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -38,7 +38,7 @@ impl<M: Middleware> Cast<M>
 where
     M::Error: 'static,
 {
-    /// Converts ASCII text input to hex
+    /// Creates a new Cast instance from the provided client
     ///
     /// ```
     /// use cast::Cast;
@@ -58,7 +58,6 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -109,7 +108,6 @@ where
     /// Generates an access list for the specified transaction
     ///
     /// ```no_run
-    ///
     /// use cast::{Cast, TxBuilder};
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -739,7 +739,7 @@ impl SimpleCast {
     ///     Ok(())
     /// }
     pub fn to_dec(value: &str) -> Result<String> {
-        Ok(Self::to_base(value, None, "dec")?)
+        Self::to_base(value, None, "dec")
     }
 
     /// Converts decimal input to hex
@@ -759,7 +759,7 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn to_hex(value: &str) -> Result<String> {
-        Ok(Self::to_base(value, None, "hex")?)
+        Self::to_base(value, None, "hex")
     }
 
     /// Converts fixed point number into specified number of decimals

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -724,44 +724,6 @@ impl SimpleCast {
         Ok(ascii)
     }
 
-    /// Converts hex input to decimal
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_dec("0x67932")?, "424242");
-    ///     assert_eq!(Cast::to_dec("0x4d2")?, "1234");
-    ///
-    ///     Ok(())
-    /// }
-    pub fn to_dec(value: &str) -> Result<String> {
-        Self::to_base(value, None, "dec")
-    }
-
-    /// Converts decimal input to hex
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use cast::SimpleCast as Cast;
-    /// use ethers_core::types::U256;
-    ///
-    /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_hex("424242")?, "0x67932");
-    ///     assert_eq!(Cast::to_hex("1234")?, "0x4d2");
-    ///     assert_eq!(Cast::to_hex("115792089237316195423570985008687907853269984665640564039457584007913129639935")?, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn to_hex(value: &str) -> Result<String> {
-        Self::to_base(value, None, "hex")
-    }
-
     /// Converts fixed point number into specified number of decimals
     /// ```
     /// use cast::SimpleCast as Cast;

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -150,7 +150,7 @@ where
             let mut s =
                 vec![format!("gas used: {}", access_list.gas_used), "access list:".to_string()];
             for al in access_list.access_list.0 {
-                s.push(format!("- address: {}", SimpleCast::to_checksum_address(&al.address)?));
+                s.push(format!("- address: {}", SimpleCast::to_checksum_address(&al.address)));
                 if !al.storage_keys.is_empty() {
                     s.push("  keys:".to_string());
                     for key in al.storage_keys {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -65,14 +65,6 @@ async fn main() -> eyre::Result<()> {
             let value = unwrap_or_stdin(hexdata)?;
             println!("{}", SimpleCast::to_ascii(&value)?);
         }
-        Subcommands::ToDec { hexvalue } => {
-            let value = unwrap_or_stdin(hexvalue)?;
-            println!("{}", SimpleCast::to_dec(&value)?);
-        }
-        Subcommands::ToHex { decimal } => {
-            let value = unwrap_or_stdin(decimal)?;
-            println!("{}", SimpleCast::to_hex(&value)?);
-        }
         Subcommands::FromFixedPoint { decimals, value } => {
             let value = unwrap_or_stdin(value)?;
             let decimals = unwrap_or_stdin(decimals)?;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -147,6 +147,9 @@ async fn main() -> eyre::Result<()> {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_rlp(&val)?);
         }
+        Subcommands::ToBase { value, base_in, base_out } => {
+            println!("{}", SimpleCast::to_base(&value, base_in, &base_out)?);
+        }
         Subcommands::ToBytes32 { bytes } => {
             let val = unwrap_or_stdin(bytes)?;
             println!("{}", SimpleCast::to_bytes32(&val)?);
@@ -421,22 +424,24 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::keccak(&data)?);
         }
         Subcommands::LeftShift { value, bits, base_in, base_out } => {
-            println!(
-                "{}",
-                format_uint(
-                    SimpleCast::left_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-                    det_base_out(&base_out)?
-                )?
-            );
+            // println!(
+            //     "{}",
+            //     format_uint(
+            //         SimpleCast::left_shift(&value, &bits, det_base_in(&value, base_in)?)?,
+            //         det_base_out(&base_out)?
+            //     )?
+            // );
+            todo!()
         }
         Subcommands::RightShift { value, bits, base_in, base_out } => {
-            println!(
-                "{}",
-                format_uint(
-                    SimpleCast::right_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-                    det_base_out(&base_out)?
-                )?
-            );
+            // println!(
+            //     "{}",
+            //     format_uint(
+            //         SimpleCast::right_shift(&value, &bits, det_base_in(&value, base_in)?)?,
+            //         det_base_out(&base_out)?
+            //     )?
+            // );
+            todo!()
         }
         Subcommands::EtherscanSource { chain, address, directory, etherscan_api_key } => {
             let api_key = match etherscan_api_key {
@@ -495,60 +500,4 @@ where
             T::from_str(&what.replace('\n', ""))?
         }
     })
-}
-
-// TODO: Integrate det_base_out and move to SimpleCast as get_base(&str,Option<String>)->Result<u32>
-fn det_base_in(value: &str, base_in: Option<String>) -> eyre::Result<u32> {
-    match base_in {
-        Some(base_in) => match base_in.as_str() {
-            "10" | "dec" => Ok(10),
-            "16" | "hex" => Ok(16),
-            _ => eyre::bail!("Unknown input base: {base_in}"),
-        },
-        None if value.starts_with("0x") => Ok(16),
-        None => match U256::from_str_radix(value, 10) {
-            Ok(_) => {
-                eyre::bail!("Could not autodetect input base: input could be decimal or hexadecimal. Please prepend with 0x if the input is hexadecimal, or specify a --base-in parameter.");
-            }
-            Err(_) => {
-                U256::from_str_radix(value, 16).expect("Could not autodetect input base.");
-                Ok(16)
-            }
-        },
-    }
-}
-
-fn det_base_out(base_out: &str) -> eyre::Result<u32> {
-    match base_out {
-        "2" | "bin" | "binary" => Ok(2),
-        "8" | "oct" | "octal" => Ok(8),
-        "10" | "dec" | "decimal" => Ok(10),
-        "16" | "hex" | "hexadecimal " => Ok(16),
-        _ => Err(eyre::eyre!(
-            r#"Invalid output base. Possible options:
-2, bin, binary
-8, oct, octal
-10, dec, decimal
-16, hex, hexadecimal
-            "#
-        )),
-    }
-}
-
-// TODO: Move to SimpleCast as to_base(&str, &str) -> Result<String>
-fn format_uint(val: U256, base: u32) -> eyre::Result<String> {
-    match base {
-        // Binary and Octal traits are not implemented for primitive-types types
-        2 | 8 => {
-            let arr = val.0;
-            let is_b = base == 2;
-            let prefix = if is_b { "0b" } else { "0o" };
-            let f = if is_b { |v: u64| format!("{:b}", v) } else { |v: u64| format!("{:o}", v) };
-            // little endian
-            Ok(format!("{}{}{}{}{}", prefix, f(arr[3]), f(arr[2]), f(arr[1]), f(arr[0])))
-        }
-        10 => Ok(format!("{}", val)),
-        16 => Ok(format!("{:#x}", val)),
-        _ => Err(eyre::eyre!("Invalid output base: {base}")),
-    }
 }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -272,7 +272,7 @@ async fn main() -> eyre::Result<()> {
             let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
             let provider = get_http_provider(rpc_url);
             let addr = Cast::new(&provider).compute_address(pubkey, nonce).await?;
-            println!("Computed Address: {}", SimpleCast::to_checksum_address(&addr)?);
+            println!("Computed Address: {}", SimpleCast::to_checksum_address(&addr));
         }
         Subcommands::FindBlock(cmd) => cmd.run()?.await?,
         Subcommands::GasPrice { rpc_url } => {
@@ -342,7 +342,7 @@ async fn main() -> eyre::Result<()> {
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
 
-        // Sigethsamczsuncom & 4Byte
+        // 4Byte
         Subcommands::FourByte { selector } => {
             let sigs = decode_function_selector(&selector).await?;
             sigs.iter().for_each(|sig| println!("{}", sig));
@@ -416,7 +416,7 @@ async fn main() -> eyre::Result<()> {
                     name, who
                 );
             }
-            println!("{}", SimpleCast::to_checksum_address(&address)?);
+            println!("{}", SimpleCast::to_checksum_address(&address));
         }
 
         // Misc

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -58,31 +58,30 @@ async fn main() -> eyre::Result<()> {
 
         // Conversions & transformations
         Subcommands::FromUtf8 { text } => {
-            let val = unwrap_or_stdin(text)?;
-            println!("{}", SimpleCast::from_utf8(&val));
+            let value = unwrap_or_stdin(text)?;
+            println!("{}", SimpleCast::from_utf8(&value));
         }
         Subcommands::ToAscii { hexdata } => {
-            let val = unwrap_or_stdin(hexdata)?;
-            println!("{}", SimpleCast::to_ascii(&val)?);
+            let value = unwrap_or_stdin(hexdata)?;
+            println!("{}", SimpleCast::to_ascii(&value)?);
         }
         Subcommands::ToDec { hexvalue } => {
-            let val = unwrap_or_stdin(hexvalue)?;
-            println!("{}", SimpleCast::to_dec(&val)?);
+            let value = unwrap_or_stdin(hexvalue)?;
+            println!("{}", SimpleCast::to_dec(&value)?);
         }
         Subcommands::ToHex { decimal } => {
-            let val = unwrap_or_stdin(decimal)?;
-            println!("{}", SimpleCast::to_hex(U256::from_dec_str(&val)?));
+            let value = unwrap_or_stdin(decimal)?;
+            println!("{}", SimpleCast::to_hex(&value)?);
         }
-        Subcommands::FromFix { decimals, value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::from_fix(unwrap_or_stdin(decimals)? as u32, &val)?);
+        Subcommands::FromFixedPoint { decimals, value } => {
+            let value = unwrap_or_stdin(value)?;
+            let decimals = unwrap_or_stdin(decimals)?;
+            println!("{}", SimpleCast::from_fixed_point(&value, &decimals)?);
         }
-        Subcommands::ToFix { decimals, value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!(
-                "{}",
-                SimpleCast::to_fix(unwrap_or_stdin(decimals)?, U256::from_dec_str(&val)?)?
-            );
+        Subcommands::ToFixedPoint { decimals, value } => {
+            let value = unwrap_or_stdin(value)?;
+            let decimals = unwrap_or_stdin(decimals)?;
+            println!("{}", SimpleCast::to_fixed_point(&value, &decimals)?);
         }
         Subcommands::ConcatHex { data } => {
             println!("{}", SimpleCast::concat_hex(data))
@@ -95,8 +94,8 @@ async fn main() -> eyre::Result<()> {
             println!("0x{hex}");
         }
         Subcommands::ToHexdata { input } => {
-            let val = unwrap_or_stdin(input)?;
-            let output = match val {
+            let value = unwrap_or_stdin(input)?;
+            let output = match value {
                 s if s.starts_with('@') => {
                     let var = std::env::var(&s[1..])?;
                     var.as_bytes().to_hex()
@@ -116,16 +115,16 @@ async fn main() -> eyre::Result<()> {
             println!("0x{output}");
         }
         Subcommands::ToCheckSumAddress { address } => {
-            let val = unwrap_or_stdin(address)?;
-            println!("{}", SimpleCast::to_checksum_address(&val)?);
+            let value = unwrap_or_stdin(address)?;
+            println!("{}", SimpleCast::to_checksum_address(&value));
         }
         Subcommands::ToUint256 { value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_uint256(&val)?);
+            let value = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_uint256(&value)?);
         }
         Subcommands::ToInt256 { value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_int256(&val)?);
+            let value = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_int256(&value)?);
         }
         Subcommands::ToUnit { value, unit } => {
             let value = unwrap_or_stdin(value)?;
@@ -140,27 +139,27 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::to_wei(&value, &unit)?);
         }
         Subcommands::FromRlp { value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::from_rlp(val)?);
+            let value = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::from_rlp(value)?);
         }
         Subcommands::ToRlp { value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_rlp(&val)?);
+            let value = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_rlp(&value)?);
         }
         Subcommands::ToBase { value, base_in, base_out } => {
             println!("{}", SimpleCast::to_base(&value, base_in, &base_out)?);
         }
         Subcommands::ToBytes32 { bytes } => {
-            let val = unwrap_or_stdin(bytes)?;
-            println!("{}", SimpleCast::to_bytes32(&val)?);
+            let value = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleCast::to_bytes32(&value)?);
         }
         Subcommands::FormatBytes32String { string } => {
-            let val = unwrap_or_stdin(string)?;
-            println!("{}", SimpleCast::format_bytes32_string(&val)?);
+            let value = unwrap_or_stdin(string)?;
+            println!("{}", SimpleCast::format_bytes32_string(&value)?);
         }
         Subcommands::ParseBytes32String { bytes } => {
-            let val = unwrap_or_stdin(bytes)?;
-            println!("{}", SimpleCast::parse_bytes32_string(&val)?);
+            let value = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleCast::parse_bytes32_string(&value)?);
         }
 
         // ABI encoding & decoding

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -5,7 +5,7 @@ use ethers::{
     abi::HumanReadableParser,
     core::types::{BlockId, BlockNumber::Latest, H256},
     providers::Middleware,
-    types::{Address, U256},
+    types::{Address, I256, U256},
 };
 
 use foundry_cli::{
@@ -39,14 +39,15 @@ async fn main() -> eyre::Result<()> {
 
     let opts = Opts::parse();
     match opts.sub {
+        // Constants
         Subcommands::MaxInt => {
-            println!("{}", SimpleCast::max_int()?);
-        }
-        Subcommands::MinInt => {
-            println!("{}", SimpleCast::min_int()?);
+            println!("{}", U256::MAX);
         }
         Subcommands::MaxUint => {
-            println!("{}", SimpleCast::max_uint()?);
+            println!("{}", U256::MAX);
+        }
+        Subcommands::MinInt => {
+            println!("{}", I256::MIN);
         }
         Subcommands::AddressZero => {
             println!("{:?}", Address::zero());
@@ -54,13 +55,34 @@ async fn main() -> eyre::Result<()> {
         Subcommands::HashZero => {
             println!("{:?}", H256::zero());
         }
+
+        // Conversions & transformations
         Subcommands::FromUtf8 { text } => {
             let val = unwrap_or_stdin(text)?;
             println!("{}", SimpleCast::from_utf8(&val));
         }
+        Subcommands::ToAscii { hexdata } => {
+            let val = unwrap_or_stdin(hexdata)?;
+            println!("{}", SimpleCast::to_ascii(&val)?);
+        }
+        Subcommands::ToDec { hexvalue } => {
+            let val = unwrap_or_stdin(hexvalue)?;
+            println!("{}", SimpleCast::to_dec(&val)?);
+        }
         Subcommands::ToHex { decimal } => {
             let val = unwrap_or_stdin(decimal)?;
             println!("{}", SimpleCast::to_hex(U256::from_dec_str(&val)?));
+        }
+        Subcommands::FromFix { decimals, value } => {
+            let val = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::from_fix(unwrap_or_stdin(decimals)? as u32, &val)?);
+        }
+        Subcommands::ToFix { decimals, value } => {
+            let val = unwrap_or_stdin(value)?;
+            println!(
+                "{}",
+                SimpleCast::to_fix(unwrap_or_stdin(decimals)?, U256::from_dec_str(&val)?)?
+            );
         }
         Subcommands::ConcatHex { data } => {
             println!("{}", SimpleCast::concat_hex(data))
@@ -72,7 +94,6 @@ async fn main() -> eyre::Result<()> {
                 .collect();
             println!("0x{hex}");
         }
-
         Subcommands::ToHexdata { input } => {
             let val = unwrap_or_stdin(input)?;
             let output = match val {
@@ -96,30 +117,11 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::ToCheckSumAddress { address } => {
             let val = unwrap_or_stdin(address)?;
-            println!("{}", SimpleCast::checksum_address(&val)?);
-        }
-        Subcommands::ToAscii { hexdata } => {
-            let val = unwrap_or_stdin(hexdata)?;
-            println!("{}", SimpleCast::to_ascii(&val)?);
-        }
-        Subcommands::FromFix { decimals, value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::from_fix(unwrap_or_stdin(decimals)? as u32, &val)?);
+            println!("{}", SimpleCast::to_checksum_address(&val)?);
         }
         Subcommands::ToBytes32 { bytes } => {
             let val = unwrap_or_stdin(bytes)?;
-            println!("{}", SimpleCast::bytes32(&val)?);
-        }
-        Subcommands::ToDec { hexvalue } => {
-            let val = unwrap_or_stdin(hexvalue)?;
-            println!("{}", SimpleCast::to_dec(&val)?);
-        }
-        Subcommands::ToFix { decimals, value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!(
-                "{}",
-                SimpleCast::to_fix(unwrap_or_stdin(decimals)?, U256::from_dec_str(&val)?)?
-            );
+            println!("{}", SimpleCast::to_bytes32(&val)?);
         }
         Subcommands::ToUint256 { value } => {
             let val = unwrap_or_stdin(value)?;
@@ -129,44 +131,67 @@ async fn main() -> eyre::Result<()> {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_int256(&val)?);
         }
-        Subcommands::LeftShift { value, bits, base_in, base_out } => {
-            println!(
-                "{}",
-                format_uint(
-                    SimpleCast::left_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-                    det_base_out(&base_out)?
-                )?
-            );
-        }
-        Subcommands::RightShift { value, bits, base_in, base_out } => {
-            println!(
-                "{}",
-                format_uint(
-                    SimpleCast::right_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-                    det_base_out(&base_out)?
-                )?
-            );
-        }
         Subcommands::ToUnit { value, unit } => {
             let value = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_unit(&value, &unit)?);
-        }
-        Subcommands::ToWei { value, unit } => {
-            let value = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_wei(&value, &unit)?);
         }
         Subcommands::FromWei { value, unit } => {
             let value = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::from_wei(&value, &unit)?);
         }
-        Subcommands::ToRlp { value } => {
-            let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_rlp(&val)?);
+        Subcommands::ToWei { value, unit } => {
+            let value = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_wei(&value, &unit)?);
         }
         Subcommands::FromRlp { value } => {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::from_rlp(val)?);
         }
+        Subcommands::ToRlp { value } => {
+            let val = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_rlp(&val)?);
+        }
+        Subcommands::FormatBytes32String { string } => {
+            let val = unwrap_or_stdin(string)?;
+            println!("{}", SimpleCast::format_bytes32_string(&val)?);
+        }
+        Subcommands::ParseBytes32String { bytes } => {
+            let val = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleCast::parse_bytes32_string(&val)?);
+        }
+
+        // ABI encoding & decoding
+        Subcommands::AbiDecode { sig, calldata, input } => {
+            let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
+            let tokens = format_tokens(&tokens);
+            tokens.for_each(|t| println!("{t}"));
+        }
+        Subcommands::AbiEncode { sig, args } => {
+            println!("{}", SimpleCast::abi_encode(&sig, &args)?);
+        }
+        Subcommands::CalldataDecode { sig, calldata } => {
+            let tokens = SimpleCast::abi_decode(&sig, &calldata, true)?;
+            let tokens = format_tokens(&tokens);
+            tokens.for_each(|t| println!("{t}"));
+        }
+        Subcommands::CalldataEncode { sig, args } => {
+            println!("{}", SimpleCast::calldata_encode(sig, &args)?);
+        }
+        Subcommands::Interface(cmd) => cmd.run()?.await?,
+        Subcommands::PrettyCalldata { calldata, offline } => {
+            if !calldata.starts_with("0x") {
+                eprintln!("Expected calldata hex string, received \"{calldata}\"");
+                std::process::exit(0)
+            }
+            let pretty_data = pretty_calldata(&calldata, offline).await?;
+            println!("{pretty_data}");
+        }
+        Subcommands::Sig { sig } => {
+            let selector = HumanReadableParser::parse_function(&sig)?.short_signature();
+            println!("0x{}", hex::encode(selector));
+        }
+
+        // Blockchain & RPC queries
         Subcommands::AccessList { eth, address, sig, args, block, to_json } => {
             let config = Config::from(&eth);
             let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
@@ -184,6 +209,28 @@ async fn main() -> eyre::Result<()> {
 
             println!("{}", Cast::new(&provider).access_list(builder_output, block, to_json).await?);
         }
+        Subcommands::Age { block, rpc_url } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+            let provider = get_http_provider(rpc_url);
+            println!(
+                "{}",
+                Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
+            );
+        }
+        Subcommands::Balance { block, who, rpc_url } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+            let provider = get_http_provider(rpc_url);
+            println!("{}", Cast::new(provider).balance(who, block).await?);
+        }
+        Subcommands::BaseFee { block, rpc_url } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+
+            let provider = get_http_provider(rpc_url);
+            println!(
+                "{}",
+                Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
+            );
+        }
         Subcommands::Block { rpc_url, block, full, field, to_json } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
             let provider = get_http_provider(rpc_url);
@@ -193,10 +240,6 @@ async fn main() -> eyre::Result<()> {
             let rpc_url = consume_config_rpc_url(rpc_url);
             let provider = get_http_provider(rpc_url);
             println!("{}", Cast::new(provider).block_number().await?);
-        }
-        Subcommands::Call(cmd) => cmd.run().await?,
-        Subcommands::Calldata { sig, args } => {
-            println!("{}", SimpleCast::calldata(sig, &args)?);
         }
         Subcommands::Chain { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
@@ -215,28 +258,54 @@ async fn main() -> eyre::Result<()> {
             let provider = get_http_provider(rpc_url);
             println!("{}", provider.client_version().await?);
         }
+        Subcommands::Code { block, who, rpc_url } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+            let provider = get_http_provider(rpc_url);
+            println!("{}", Cast::new(provider).code(who, block).await?);
+        }
         Subcommands::ComputeAddress { rpc_url, address, nonce } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
             let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
             let provider = get_http_provider(rpc_url);
             let addr = Cast::new(&provider).compute_address(pubkey, nonce).await?;
-            println!("Computed Address: {}", SimpleCast::checksum_address(&addr)?);
+            println!("Computed Address: {}", SimpleCast::to_checksum_address(&addr)?);
         }
-        Subcommands::Code { block, who, rpc_url } => {
+        Subcommands::FindBlock(cmd) => cmd.run()?.await?,
+        Subcommands::GasPrice { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
             let provider = get_http_provider(rpc_url);
-            println!("{}", Cast::new(provider).code(who, block).await?);
+            println!("{}", Cast::new(provider).gas_price().await?);
         }
-        Subcommands::Namehash { name } => {
-            println!("{}", SimpleCast::namehash(&name)?);
+        Subcommands::Index { key_type, key, slot_number } => {
+            let encoded = SimpleCast::index(&key_type, &key, &slot_number)?;
+            println!("{encoded}");
         }
-        Subcommands::Tx { rpc_url, hash, field, to_json } => {
+        Subcommands::Nonce { block, who, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
+
             let provider = get_http_provider(rpc_url);
-            println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
+            println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
-        Subcommands::SendTx(cmd) => cmd.run().await?,
+        Subcommands::Proof { address, slots, rpc_url, block } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+
+            let provider = get_http_provider(rpc_url);
+            let value = provider.get_proof(address, slots, block).await?;
+            println!("{}", serde_json::to_string(&value)?);
+        }
+        Subcommands::Rpc(cmd) => cmd.run()?.await?,
+        Subcommands::Storage { address, slot, rpc_url, block } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+
+            let provider = get_http_provider(rpc_url);
+            let value = provider.get_storage_at(address, slot, block).await?;
+            println!("{:?}", value);
+        }
+
+        // Calls & transactions
+        Subcommands::Call(cmd) => cmd.run().await?,
+        Subcommands::Estimate(cmd) => cmd.run().await?,
         Subcommands::PublishTx { eth, raw_tx, cast_async } => {
             let config = Config::from(&eth);
             let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
@@ -252,23 +321,25 @@ async fn main() -> eyre::Result<()> {
                 println!("{}", serde_json::json!(receipt));
             }
         }
-        Subcommands::CalldataDecode { sig, calldata } => {
-            let tokens = SimpleCast::abi_decode(&sig, &calldata, true)?;
-            let tokens = format_tokens(&tokens);
-            tokens.for_each(|t| println!("{t}"));
+        Subcommands::Receipt { hash, field, to_json, rpc_url, cast_async, confirmations } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+            let provider = get_http_provider(rpc_url);
+            println!(
+                "{}",
+                Cast::new(provider)
+                    .receipt(hash, field, confirmations, cast_async, to_json)
+                    .await?
+            );
         }
-        Subcommands::AbiDecode { sig, calldata, input } => {
-            let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
-            let tokens = format_tokens(&tokens);
-            tokens.for_each(|t| println!("{t}"));
+        Subcommands::Run(cmd) => cmd.run()?,
+        Subcommands::SendTx(cmd) => cmd.run().await?,
+        Subcommands::Tx { rpc_url, hash, field, to_json } => {
+            let rpc_url = consume_config_rpc_url(rpc_url);
+            let provider = get_http_provider(rpc_url);
+            println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
-        Subcommands::AbiEncode { sig, args } => {
-            println!("{}", SimpleCast::abi_encode(&sig, &args)?);
-        }
-        Subcommands::Index { key_type, key, slot_number } => {
-            let encoded = SimpleCast::index(&key_type, &key, &slot_number)?;
-            println!("{encoded}");
-        }
+
+        // Sigethsamczsuncom & 4Byte
         Subcommands::FourByte { selector } => {
             let sigs = decode_function_selector(&selector).await?;
             sigs.iter().for_each(|sig| println!("{}", sig));
@@ -300,7 +371,6 @@ async fn main() -> eyre::Result<()> {
             let sigs = decode_event_topic(&topic).await?;
             sigs.iter().for_each(|sig| println!("{}", sig));
         }
-
         Subcommands::UploadSignature { signatures } => {
             let ParsedSignatures { signatures, abis } = parse_signatures(signatures);
             if !abis.is_empty() {
@@ -311,61 +381,7 @@ async fn main() -> eyre::Result<()> {
             }
         }
 
-        Subcommands::PrettyCalldata { calldata, offline } => {
-            if !calldata.starts_with("0x") {
-                eprintln!("Expected calldata hex string, received \"{calldata}\"");
-                std::process::exit(0)
-            }
-            let pretty_data = pretty_calldata(&calldata, offline).await?;
-            println!("{pretty_data}");
-        }
-        Subcommands::Age { block, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
-            println!(
-                "{}",
-                Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
-            );
-        }
-        Subcommands::Balance { block, who, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
-            println!("{}", Cast::new(provider).balance(who, block).await?);
-        }
-        Subcommands::BaseFee { block, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-
-            let provider = get_http_provider(rpc_url);
-            println!(
-                "{}",
-                Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
-            );
-        }
-        Subcommands::GasPrice { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
-            println!("{}", Cast::new(provider).gas_price().await?);
-        }
-        Subcommands::Keccak { data } => {
-            println!("{}", SimpleCast::keccak(&data)?);
-        }
-
-        Subcommands::Interface(cmd) => cmd.run()?.await?,
-        Subcommands::ResolveName { who, rpc_url, verify } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
-            let who = unwrap_or_stdin(who)?;
-            let address = provider.resolve_name(&who).await?;
-            if verify {
-                let name = provider.lookup_address(address).await?;
-                assert_eq!(
-                    name, who,
-                    "forward lookup verification failed. got {}, expected {}",
-                    name, who
-                );
-            }
-            println!("{}", SimpleCast::checksum_address(&address)?);
-        }
+        // ENS
         Subcommands::LookupAddress { who, rpc_url, verify } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
             let provider = get_http_provider(rpc_url);
@@ -381,35 +397,46 @@ async fn main() -> eyre::Result<()> {
             }
             println!("{name}");
         }
-        Subcommands::Storage { address, slot, rpc_url, block } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-
-            let provider = get_http_provider(rpc_url);
-            let value = provider.get_storage_at(address, slot, block).await?;
-            println!("{:?}", value);
+        Subcommands::Namehash { name } => {
+            println!("{}", SimpleCast::namehash(&name)?);
         }
-        Subcommands::Proof { address, slots, rpc_url, block } => {
+        Subcommands::ResolveName { who, rpc_url, verify } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-
             let provider = get_http_provider(rpc_url);
-            let value = provider.get_proof(address, slots, block).await?;
-            println!("{}", serde_json::to_string(&value)?);
+            let who = unwrap_or_stdin(who)?;
+            let address = provider.resolve_name(&who).await?;
+            if verify {
+                let name = provider.lookup_address(address).await?;
+                assert_eq!(
+                    name, who,
+                    "forward lookup verification failed. got {}, expected {}",
+                    name, who
+                );
+            }
+            println!("{}", SimpleCast::to_checksum_address(&address)?);
         }
-        Subcommands::Receipt { hash, field, to_json, rpc_url, cast_async, confirmations } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+
+        // Misc
+        Subcommands::Keccak { data } => {
+            println!("{}", SimpleCast::keccak(&data)?);
+        }
+        Subcommands::LeftShift { value, bits, base_in, base_out } => {
             println!(
                 "{}",
-                Cast::new(provider)
-                    .receipt(hash, field, confirmations, cast_async, to_json)
-                    .await?
+                format_uint(
+                    SimpleCast::left_shift(&value, &bits, det_base_in(&value, base_in)?)?,
+                    det_base_out(&base_out)?
+                )?
             );
         }
-        Subcommands::Nonce { block, who, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
-
-            let provider = get_http_provider(rpc_url);
-            println!("{}", Cast::new(provider).nonce(who, block).await?);
+        Subcommands::RightShift { value, bits, base_in, base_out } => {
+            println!(
+                "{}",
+                format_uint(
+                    SimpleCast::right_shift(&value, &bits, det_base_in(&value, base_in)?)?,
+                    det_base_out(&base_out)?
+                )?
+            );
         }
         Subcommands::EtherscanSource { chain, address, directory, etherscan_api_key } => {
             let api_key = match etherscan_api_key {
@@ -440,12 +467,6 @@ async fn main() -> eyre::Result<()> {
                 }
             }
         }
-        Subcommands::Sig { sig } => {
-            let selector = HumanReadableParser::parse_function(&sig)?.short_signature();
-            println!("0x{}", hex::encode(selector));
-        }
-        Subcommands::FindBlock(cmd) => cmd.run()?.await?,
-        Subcommands::Estimate(cmd) => cmd.run().await?,
         Subcommands::Wallet { command } => command.run().await?,
         Subcommands::Completions { shell } => {
             generate(shell, &mut Opts::command(), "cast", &mut std::io::stdout())
@@ -456,16 +477,6 @@ async fn main() -> eyre::Result<()> {
             "cast",
             &mut std::io::stdout(),
         ),
-        Subcommands::Run(cmd) => cmd.run()?,
-        Subcommands::Rpc(cmd) => cmd.run()?.await?,
-        Subcommands::FormatBytes32String { string } => {
-            let val = unwrap_or_stdin(string)?;
-            println!("{}", SimpleCast::format_bytes32_string(&val)?);
-        }
-        Subcommands::ParseBytes32String { bytes } => {
-            let val = unwrap_or_stdin(bytes)?;
-            println!("{}", SimpleCast::parse_bytes32_string(&val)?);
-        }
     };
     Ok(())
 }
@@ -486,7 +497,7 @@ where
     })
 }
 
-// TODO: Integrate det_base_out and move to CastSimple as get_base(&str,Option<String>)->Result<u32>
+// TODO: Integrate det_base_out and move to SimpleCast as get_base(&str,Option<String>)->Result<u32>
 fn det_base_in(value: &str, base_in: Option<String>) -> eyre::Result<u32> {
     match base_in {
         Some(base_in) => match base_in.as_str() {
@@ -524,7 +535,7 @@ fn det_base_out(base_out: &str) -> eyre::Result<u32> {
     }
 }
 
-// TODO: Move to CastSimple as to_base(&str, &str) -> Result<String>
+// TODO: Move to SimpleCast as to_base(&str, &str) -> Result<String>
 fn format_uint(val: U256, base: u32) -> eyre::Result<String> {
     match base {
         // Binary and Octal traits are not implemented for primitive-types types

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -424,24 +424,10 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::keccak(&data)?);
         }
         Subcommands::LeftShift { value, bits, base_in, base_out } => {
-            // println!(
-            //     "{}",
-            //     format_uint(
-            //         SimpleCast::left_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-            //         det_base_out(&base_out)?
-            //     )?
-            // );
-            todo!()
+            println!("{}", SimpleCast::left_shift(&value, &bits, base_in, &base_out)?);
         }
         Subcommands::RightShift { value, bits, base_in, base_out } => {
-            // println!(
-            //     "{}",
-            //     format_uint(
-            //         SimpleCast::right_shift(&value, &bits, det_base_in(&value, base_in)?)?,
-            //         det_base_out(&base_out)?
-            //     )?
-            // );
-            todo!()
+            println!("{}", SimpleCast::right_shift(&value, &bits, base_in, &base_out)?);
         }
         Subcommands::EtherscanSource { chain, address, directory, etherscan_api_key } => {
             let api_key = match etherscan_api_key {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -119,10 +119,6 @@ async fn main() -> eyre::Result<()> {
             let val = unwrap_or_stdin(address)?;
             println!("{}", SimpleCast::to_checksum_address(&val)?);
         }
-        Subcommands::ToBytes32 { bytes } => {
-            let val = unwrap_or_stdin(bytes)?;
-            println!("{}", SimpleCast::to_bytes32(&val)?);
-        }
         Subcommands::ToUint256 { value } => {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_uint256(&val)?);
@@ -150,6 +146,10 @@ async fn main() -> eyre::Result<()> {
         Subcommands::ToRlp { value } => {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_rlp(&val)?);
+        }
+        Subcommands::ToBytes32 { bytes } => {
+            let val = unwrap_or_stdin(bytes)?;
+            println!("{}", SimpleCast::to_bytes32(&val)?);
         }
         Subcommands::FormatBytes32String { string } => {
             let val = unwrap_or_stdin(string)?;

--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -109,7 +109,7 @@ impl WalletSubcommands {
                     };
 
                     let (key, uuid) = LocalWallet::new_keystore(&path, &mut rng, password, None)?;
-                    let address = SimpleCast::checksum_address(&key.address())?;
+                    let address = SimpleCast::to_checksum_address(&key.address())?;
                     let filepath = path.join(uuid);
 
                     println!(
@@ -121,7 +121,7 @@ impl WalletSubcommands {
                     let wallet = LocalWallet::new(&mut rng);
                     println!(
                         "Successfully created new keypair.\nAddress: {}\nPrivate Key: {}",
-                        SimpleCast::checksum_address(&wallet.address())?,
+                        SimpleCast::to_checksum_address(&wallet.address())?,
                         hex::encode(wallet.signer().to_bytes()),
                     );
                 }
@@ -171,8 +171,8 @@ impl WalletSubcommands {
                     "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
                     timer.elapsed().as_secs(),
                     if match_contract {"\nContract address: "} else {""},
-                    if match_contract {SimpleCast::checksum_address(&get_contract_address(wallet.address(), nonce.unwrap()))?} else {"".to_string()},
-                    SimpleCast::checksum_address(&wallet.address())?,
+                    if match_contract {SimpleCast::to_checksum_address(&get_contract_address(wallet.address(), nonce.unwrap()))?} else {"".to_string()},
+                    SimpleCast::to_checksum_address(&wallet.address())?,
                     hex::encode(wallet.signer().to_bytes()),
                 );
             }
@@ -194,7 +194,7 @@ impl WalletSubcommands {
                     WalletType::Local(signer) => signer.address(),
                     WalletType::Trezor(signer) => signer.address(),
                 };
-                println!("Address: {}", SimpleCast::checksum_address(&addr)?);
+                println!("Address: {}", SimpleCast::to_checksum_address(&addr)?);
             }
             WalletSubcommands::Sign { message, wallet } => {
                 let wallet = EthereumOpts {

--- a/cli/src/cmd/cast/wallet.rs
+++ b/cli/src/cmd/cast/wallet.rs
@@ -109,7 +109,7 @@ impl WalletSubcommands {
                     };
 
                     let (key, uuid) = LocalWallet::new_keystore(&path, &mut rng, password, None)?;
-                    let address = SimpleCast::to_checksum_address(&key.address())?;
+                    let address = SimpleCast::to_checksum_address(&key.address());
                     let filepath = path.join(uuid);
 
                     println!(
@@ -121,7 +121,7 @@ impl WalletSubcommands {
                     let wallet = LocalWallet::new(&mut rng);
                     println!(
                         "Successfully created new keypair.\nAddress: {}\nPrivate Key: {}",
-                        SimpleCast::to_checksum_address(&wallet.address())?,
+                        SimpleCast::to_checksum_address(&wallet.address()),
                         hex::encode(wallet.signer().to_bytes()),
                     );
                 }
@@ -171,8 +171,8 @@ impl WalletSubcommands {
                     "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
                     timer.elapsed().as_secs(),
                     if match_contract {"\nContract address: "} else {""},
-                    if match_contract {SimpleCast::to_checksum_address(&get_contract_address(wallet.address(), nonce.unwrap()))?} else {"".to_string()},
-                    SimpleCast::to_checksum_address(&wallet.address())?,
+                    if match_contract {SimpleCast::to_checksum_address(&get_contract_address(wallet.address(), nonce.unwrap()))} else {"".to_string()},
+                    SimpleCast::to_checksum_address(&wallet.address()),
                     hex::encode(wallet.signer().to_bytes()),
                 );
             }
@@ -194,7 +194,7 @@ impl WalletSubcommands {
                     WalletType::Local(signer) => signer.address(),
                     WalletType::Trezor(signer) => signer.address(),
                 };
-                println!("Address: {}", SimpleCast::to_checksum_address(&addr)?);
+                println!("Address: {}", SimpleCast::to_checksum_address(&addr));
             }
             WalletSubcommands::Sign { message, wallet } => {
                 let wallet = EthereumOpts {

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -227,14 +227,14 @@ impl CreateArgs {
         let address = deployed_contract.address();
         if self.json {
             let output = json!({
-                "deployer": SimpleCast::to_checksum_address(&deployer_address)?,
-                "deployedTo": SimpleCast::to_checksum_address(&address)?,
+                "deployer": SimpleCast::to_checksum_address(&deployer_address),
+                "deployedTo": SimpleCast::to_checksum_address(&address),
                 "transactionHash": receipt.transaction_hash
             });
             println!("{output}");
         } else {
-            println!("Deployer: {}", SimpleCast::to_checksum_address(&deployer_address)?);
-            println!("Deployed to: {}", SimpleCast::to_checksum_address(&address)?);
+            println!("Deployer: {}", SimpleCast::to_checksum_address(&deployer_address));
+            println!("Deployed to: {}", SimpleCast::to_checksum_address(&address));
             println!("Transaction hash: {:?}", receipt.transaction_hash);
         };
 

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -227,14 +227,14 @@ impl CreateArgs {
         let address = deployed_contract.address();
         if self.json {
             let output = json!({
-                "deployer": SimpleCast::checksum_address(&deployer_address)?,
-                "deployedTo": SimpleCast::checksum_address(&address)?,
+                "deployer": SimpleCast::to_checksum_address(&deployer_address)?,
+                "deployedTo": SimpleCast::to_checksum_address(&address)?,
                 "transactionHash": receipt.transaction_hash
             });
             println!("{output}");
         } else {
-            println!("Deployer: {}", SimpleCast::checksum_address(&deployer_address)?);
-            println!("Deployed to: {}", SimpleCast::checksum_address(&address)?);
+            println!("Deployer: {}", SimpleCast::to_checksum_address(&deployer_address)?);
+            println!("Deployed to: {}", SimpleCast::to_checksum_address(&address)?);
             println!("Transaction hash: {:?}", receipt.transaction_hash);
         };
 

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -48,7 +48,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
         let retry: Retry = args.retry.into();
         let resp = retry.run_async(|| {
             async {
-                println!("\nSubmitting verification for [{}] {:?}.", verify_args.contract_name, SimpleCast::checksum_address(&verify_args.address));
+                println!("\nSubmitting verification for [{}] {:?}.", verify_args.contract_name, SimpleCast::to_checksum_address(&verify_args.address));
                 let resp = etherscan
                     .submit_contract_verification(&verify_args)
                     .await

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -88,7 +88,7 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
                     println!(
                         "\nSubmitting verification for [{}] {:?}.",
                         args.contract.name,
-                        SimpleCast::to_checksum_address(&args.address)?
+                        SimpleCast::to_checksum_address(&args.address)
                     );
                     let response = client
                         .post(args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL))

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -88,7 +88,7 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
                     println!(
                         "\nSubmitting verification for [{}] {:?}.",
                         args.contract.name,
-                        SimpleCast::checksum_address(&args.address)?
+                        SimpleCast::to_checksum_address(&args.address)?
                     );
                     let response = client
                         .post(args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL))

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -104,9 +104,9 @@ The input can be:
     #[clap(name = "--from-fix")]
     #[clap(visible_aliases = &["from-fix", "ff"])]
     #[clap(about = "Convert a fixed point number into an integer.")]
-    FromFix {
+    FromFixedPoint {
         #[clap(value_name = "DECIMALS")]
-        decimals: Option<u128>,
+        decimals: Option<String>,
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
@@ -128,11 +128,10 @@ The input can be:
     #[clap(name = "--to-fix")]
     #[clap(visible_aliases = &["to-fix", "tf", "2f"])]
     #[clap(about = "Convert an integer into a fixed point number.")]
-    ToFix {
+    ToFixedPoint {
         #[clap(value_name = "DECIMALS")]
-        decimals: Option<u128>,
+        decimals: Option<String>,
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
-        // negative values not yet supported internally
         value: Option<String>,
     },
     #[clap(name = "--to-uint256")]
@@ -188,6 +187,7 @@ Examples:
     )]
     ToUnit {
         #[clap(value_name = "VALUE")]
+        // negative values not yet supported internally
         value: Option<String>,
         #[clap(
             help = "The unit to convert to (ether, gwei, wei).",
@@ -223,7 +223,8 @@ Examples:
     #[clap(about = "Decodes RLP encoded data. Input must be hexadecimal.")]
     FromRlp { value: Option<String> },
     #[clap(name = "--to-base")]
-    #[clap(about = "")]
+    #[clap(visible_aliases = &["--to-radix", "to-radix", "to-base", "tr", "2r"])]
+    #[clap(about = "Converts a number of one base to another")]
     ToBase {
         #[clap(value_name = "VALUE")]
         value: String,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -203,8 +203,8 @@ Examples:
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
-        #[clap(value_name = "UNIT")]
-        unit: Option<String>,
+        #[clap(value_name = "UNIT", default_value = "eth")]
+        unit: String,
     },
     #[clap(name = "--from-wei")]
     #[clap(visible_aliases = &["from-wei", "fw"])]
@@ -213,8 +213,8 @@ Examples:
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
-        #[clap(value_name = "UNIT")]
-        unit: Option<String>,
+        #[clap(value_name = "UNIT", default_value = "eth")]
+        unit: String,
     },
     #[clap(name = "--to-rlp")]
     #[clap(about = "RLP encodes hex data, or an array of hex data")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -281,9 +281,10 @@ Examples:
     #[clap(visible_alias = "c")]
     #[clap(about = "Perform a call on an account without publishing a transaction.")]
     Call(CallArgs),
+    #[clap(name = "calldata")]
     #[clap(visible_alias = "cd")]
     #[clap(about = "ABI-encode a function with arguments.")]
-    Calldata {
+    CalldataEncode {
         #[clap(
             help = "The function signature.",
             long_help = "The function signature in the form <name>(<types...>)",

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -222,6 +222,16 @@ Examples:
     #[clap(name = "--from-rlp")]
     #[clap(about = "Decodes RLP encoded data. Input must be hexadecimal.")]
     FromRlp { value: Option<String> },
+    #[clap(name = "--to-base")]
+    #[clap(about = "")]
+    ToBase {
+        #[clap(value_name = "VALUE")]
+        value: String,
+        #[clap(value_name = "BASE", help = "The output base")]
+        base_out: String,
+        #[clap(long = "--base-in", help = "The input base")]
+        base_in: Option<String>,
+    },
     #[clap(name = "access-list")]
     #[clap(visible_aliases = &["ac", "acl"])]
     #[clap(about = "Create an access list for a transaction.")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -780,6 +780,5 @@ pub fn parse_block_id(s: &str) -> eyre::Result<BlockId> {
 
 fn parse_slot(s: &str) -> eyre::Result<H256> {
     Numeric::from_str(s)
-        .map_err(|e| eyre::eyre!("Could not parse slot number: {e}"))
-        .and_then(|n| Ok(H256::from_uint(&n.into())))
+        .map_err(|e| eyre::eyre!("Could not parse slot number: {e}")).map(|n| H256::from_uint(&n.into()))
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -158,12 +158,7 @@ The input can be:
         bits: String,
         #[clap(long = "--base-in", help = "The input base")]
         base_in: Option<String>,
-        #[clap(
-            long = "--base-out",
-            help = "The output base",
-            default_value = "16",
-            parse(try_from_str = parse_base)
-        )]
+        #[clap(long = "--base-out", help = "The output base", default_value = "16")]
         base_out: String,
     },
     #[clap(name = "shr")]
@@ -175,12 +170,7 @@ The input can be:
         bits: String,
         #[clap(long = "--base-in", help = "The input base")]
         base_in: Option<String>,
-        #[clap(
-            long = "--base-out",
-            help = "The output base",
-            default_value = "16",
-            parse(try_from_str = parse_base)
-        )]
+        #[clap(long = "--base-out", help = "The output base", default_value = "16")]
         base_out: String,
     },
     #[clap(name = "--to-unit")]
@@ -761,7 +751,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
 
 pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {
     Ok(if s.starts_with("0x") {
-        NameOrAddress::Address(s.parse::<Address>()?)
+        NameOrAddress::Address(s.parse()?)
     } else {
         NameOrAddress::Name(s.into())
     })
@@ -778,15 +768,7 @@ pub fn parse_block_id(s: &str) -> eyre::Result<BlockId> {
 }
 
 fn parse_slot(s: &str) -> eyre::Result<H256> {
-    Ok(H256::from_uint(&U256::from(
-        Numeric::from_str(s).map_err(|e| eyre::eyre!("Could not parse slot number: {e}"))?,
-    )))
-}
-
-fn parse_base(s: &str) -> eyre::Result<String> {
-    Ok(match s {
-        "10" | "dec" => "10".to_string(),
-        "16" | "hex" => "16".to_string(),
-        _ => eyre::bail!("Provided base is not a valid."),
-    })
+    Numeric::from_str(s)
+        .map_err(|e| eyre::eyre!("Could not parse slot number: {e}"))
+        .and_then(|n| Ok(H256::from_uint(&n.into())))
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -53,13 +53,6 @@ pub enum Subcommands {
         #[clap(value_name = "TEXT")]
         text: Option<String>,
     },
-    #[clap(name = "--to-hex")]
-    #[clap(visible_aliases = &["to-hex", "th", "2h"])]
-    #[clap(about = "Convert an integer to hex.")]
-    ToHex {
-        #[clap(value_name = "DECIMAL")]
-        decimal: Option<String>,
-    },
     #[clap(name = "--concat-hex")]
     #[clap(visible_aliases = &["concat-hex", "ch"])]
     #[clap(about = "Concatenate hex strings.")]
@@ -117,13 +110,6 @@ The input can be:
     ToBytes32 {
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
-    },
-    #[clap(name = "--to-dec")]
-    #[clap(visible_aliases = &["to-dec", "td", "2d"])]
-    #[clap(about = "Convert hex value into a decimal number.")]
-    ToDec {
-        #[clap(value_name = "HEXVALUE")]
-        hexvalue: Option<String>,
     },
     #[clap(name = "--to-fix")]
     #[clap(visible_aliases = &["to-fix", "tf", "2f"])]
@@ -223,7 +209,7 @@ Examples:
     #[clap(about = "Decodes RLP encoded data. Input must be hexadecimal.")]
     FromRlp { value: Option<String> },
     #[clap(name = "--to-base")]
-    #[clap(visible_aliases = &["--to-radix", "to-radix", "to-base", "tr", "2r"])]
+    #[clap(visible_aliases = &["--to-radix", "to-radix", "to-base", "tr", "2r", "--to-hex", "to-hex", "th", "2h", "--to-dec", "to-dec", "td", "2d"])]
     #[clap(about = "Converts a number of one base to another")]
     ToBase {
         #[clap(value_name = "VALUE")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -780,5 +780,6 @@ pub fn parse_block_id(s: &str) -> eyre::Result<BlockId> {
 
 fn parse_slot(s: &str) -> eyre::Result<H256> {
     Numeric::from_str(s)
-        .map_err(|e| eyre::eyre!("Could not parse slot number: {e}")).map(|n| H256::from_uint(&n.into()))
+        .map_err(|e| eyre::eyre!("Could not parse slot number: {e}"))
+        .map(|n| H256::from_uint(&n.into()))
 }

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -245,7 +245,7 @@ contract DeployScript is Script {
         let run_log =
             std::fs::read_to_string("broadcast/DeployScript.sol/1/run-latest.json").unwrap();
         let run_object: Value = serde_json::from_str(&run_log).unwrap();
-        let contract_address = SimpleCast::checksum_address(
+        let contract_address = SimpleCast::to_checksum_address(
             &ethers::prelude::H160::from_str(
                 run_object["receipts"][0]["contractAddress"].as_str().unwrap(),
             )

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -250,8 +250,7 @@ contract DeployScript is Script {
                 run_object["receipts"][0]["contractAddress"].as_str().unwrap(),
             )
             .unwrap(),
-        )
-        .unwrap();
+        );
 
         let run_code = r#"
 // SPDX-License-Identifier: UNLICENSED

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -3096,7 +3096,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         Ok(())
     }
 
-    #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_peekable)]
     fn visit_try(
         &mut self,
         loc: Loc,

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -3096,7 +3096,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         Ok(())
     }
 
-    #[allow(clippy::unused_peekable)]
+    #[allow(clippy::unused_self)]
     fn visit_try(
         &mut self,
         loc: Loc,


### PR DESCRIPTION
## Motivation

Initially wanted to add a `to_base`, then saw there already was some kind of base parsing implemented for shl/shr, so I seized the opportunity to do some more stuff

## Solution

- added `cast --to-base <number> <base_out> [--base-in <base>]`, which tries to match `<number>` to a base (binary, hex...) by looking at prefix or parsing it directly, and convert it to `<to_base>`, with an optional `--base in` in ambiguous cases, similar to how it is currently done in `SimpleCast::{shl, shr}`
- added `base.rs`, includes:
  - `Base` enum for parsing radix from strings or numbers' bases;
  - `NumberWithBase` struct for parsing numbers and formatting them into bases;
  - `ToBase` trait for easy one function conversion by using the above items;
- ordering/grouping functions: matching a from/to pair where possible, eg. `{from,to}_fix` etc;
- standardizing names: `--to-asci`'s matching `SimpleCast` function was `ascii()` while most others have the same name as the flag;
- standardizing function args: `from_wei`, `to_wei`, `to_unit` all had different args from every other function;
- refactoring some weird hex formatting: in `to_{uint256,int256}`

Any suggestion is welcome!