### PR TITLE
fix(forge): incorrect endianness used parsing uints

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -246,7 +246,7 @@ pub fn value_to_abi(
     let parse_uint = |v: &str| {
         if v.starts_with("0x") {
             let v = Vec::from_hex(v.strip_prefix("0x").unwrap()).map_err(|e| e.to_string())?;
-            Ok(U256::from_little_endian(&v))
+            Ok(U256::from_big_endian(&v))
         } else {
             U256::from_dec_str(v).map_err(|e| e.to_string())
         }

--- a/testdata/cheats/Env.t.sol
+++ b/testdata/cheats/Env.t.sol
@@ -26,18 +26,26 @@ contract EnvTest is DSTest {
         }
     }
 
-    uint256 constant numEnvUintTests = 4;
+    uint256 constant numEnvUintTests = 6;
 
     function testEnvUint() public {
         string memory key = "_foundryCheatcodeEnvUintTestKey";
         string[numEnvUintTests] memory values = [
             "0",
             "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+            "0x01",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
         ];
-        uint256[numEnvUintTests] memory expected =
-            [type(uint256).min, type(uint256).max, type(uint256).min, type(uint256).max];
+        uint256[numEnvUintTests] memory expected = [
+            type(uint256).min,
+            type(uint256).max,
+            1,
+            77814517325470205911140941194401928579557062014761831930645393041380819009408,
+            type(uint256).min,
+            type(uint256).max
+        ];
         for (uint256 i = 0; i < numEnvUintTests; ++i) {
             cheats.setEnv(key, values[i]);
             uint256 output = cheats.envUint(key);


### PR DESCRIPTION
## Motivation

This bug was found in the Telegram group: https://t.me/foundry_support/23118

## Solution

uints should be read as big-endian from environment or strings.

Added more tests. I think these tests were only passing before because the hex strings were symmetrical! 😄 