### PR TITLE
do not fix '@openzeppelin' alias to 'openzeppelin'

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -233,21 +233,10 @@ const GITHUB: &str = "github.com";
 const VERSION_SEPARATOR: char = '@';
 const ALIAS_SEPARATOR: char = '=';
 
-/// Commonly used aliases for solidity repos,
-const COMMON_ORG_ALIASES: &[(&str, &str); 1] = &[("@openzeppelin", "openzeppelin")];
-
 impl FromStr for Dependency {
     type Err = eyre::Error;
     fn from_str(dependency: &str) -> Result<Self, Self::Err> {
-        let mut dependency = dependency.to_string();
-
-        // this will update wrong conventional aliases
-        for (alias, real_org) in COMMON_ORG_ALIASES.iter() {
-            if dependency.starts_with(alias) {
-                dependency = dependency.replacen(alias, real_org, 1);
-                break
-            }
-        }
+        let dependency = dependency.to_string();
 
         // everything before "=" should be considered the alias
         let (mut alias, dependency) = if let Some(split) = dependency.split_once(ALIAS_SEPARATOR) {


### PR DESCRIPTION
## Motivation

If I specify '@openzeppelin' as an alias, I want to get exactly this
alias, not the latter. The current behavior is counterintuitive and
is forcing users to use a certain alias, not the one they want or might
have had before migrating to foundry.

Besides, is 'openzeppelin' really a conventional alias? The
'@openzeppelin' variant is the one promoted on the openzeppelin repo.

## Solution

Just don't do that substitution.