### PR TITLE
fix: use `get_deployed_bytecode_bytes` for codesize

### DIFF
--- a/cli/src/compile.rs
+++ b/cli/src/compile.rs
@@ -183,7 +183,7 @@ impl ProjectCompiler {
                 for (_, contracts) in compiled_contracts.into_iter() {
                     for (name, contract) in contracts {
                         let size = contract
-                            .get_bytecode_bytes()
+                            .get_deployed_bytecode_bytes()
                             .map(|bytes| bytes.0.len())
                             .unwrap_or_default();
 


### PR DESCRIPTION

## Motivation

The EVM contract size limit applies to runtime bytecode, NOT constructor code.

Source:

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md

https://github.com/ethereum/go-ethereum/blob/d30e39b2f833fb75f1e529cd405061fb6b548b8d/core/vm/evm.go#L453-L458 (shoutout @mds1 for this link)

## Solution

Using `get_deployed_bytecode_bytes` should measure runtime bytecode instead.