### PR TITLE
feat(forge): error hints

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -690,7 +690,7 @@ impl Backend {
                         return_revert!() => {
                             if let Some(ref r) = info.out {
                                 if let Ok(reason) = decode_revert(r.as_ref(), None, None) {
-                                    node_info!("    Error: reverted with '{}'", reason);
+                                    node_info!("    Error: reverted with '{}'", reason.message);
                                 } else {
                                     node_info!("    Error: reverted without a reason string");
                                 }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -296,7 +296,7 @@ impl ScriptArgs {
 
         if !result.success {
             let revert_msg = decode::decode_revert(&result.returned[..], None, None)
-                .map(|err| format!("{}\n", err))
+                .map(|err| format!("{}\n", err.message))
                 .unwrap_or_else(|_| "Script failed.\n".to_string());
 
             eyre::bail!("{}", Paint::red(revert_msg));

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -185,7 +185,7 @@ impl ScriptRunner {
                     (address, gas_used, logs, traces, debug)
                 }
                 Err(EvmError::Execution { reason, traces, gas_used, logs, debug, .. }) => {
-                    println!("{}", Paint::red(format!("\nFailed with `{reason}`:\n")));
+                    println!("{}", Paint::red(format!("\nFailed with `{}`:\n", reason.message)));
 
                     (Address::zero(), gas_used, logs, traces, debug)
                 }

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -509,9 +509,9 @@ fn test(
                 // We always display hints if the revert had any.
                 if let Some(reason) = &result.reason {
                     if !reason.hints.is_empty() {
-                        println!("Hints:");
+                        println!("{}", Paint::blue("Hints:"));
                         for hint in &reason.hints {
-                            println!("  {hint}");
+                            println!("  - {hint}");
                         }
                         println!();
                     }

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -292,7 +292,7 @@ fn short_test_result(name: &str, result: &TestResult) {
         let reason = result
             .reason
             .as_ref()
-            .map(|reason| format!("Reason: {reason}"))
+            .map(|reason| format!("Reason: {}", reason.message))
             .unwrap_or_else(|| "Reason: Assertion failed.".to_string());
 
         let counterexample = result
@@ -505,6 +505,17 @@ fn test(
             }
             for (name, result) in &mut tests {
                 short_test_result(name, result);
+
+                // We always display hints if the revert had any.
+                if let Some(reason) = &result.reason {
+                    if !reason.hints.is_empty() {
+                        println!("Hints:");
+                        for hint in &reason.hints {
+                            println!("  {hint}");
+                        }
+                        println!();
+                    }
+                }
 
                 // We only display logs at level 2 and above
                 if verbosity >= 2 {

--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -1,12 +1,11 @@
 //! Various utilities to decode test results
 use crate::{
     abi::ConsoleEvents::{self, *},
-    error::ERROR_PREFIX,
+    error::DecodedError,
 };
 use ethers::{
-    abi::{AbiDecode, Contract as Abi, RawLog},
+    abi::{Abi, AbiDecode, RawLog},
     contract::EthLogDecode,
-    prelude::U256,
     types::Log,
 };
 use foundry_common::SELECTOR_LEN;
@@ -63,138 +62,27 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
     Some(decoded)
 }
 
-/// Given an ABI encoded error string with the function signature `Error(string)`, it decodes
-/// it and returns the revert error message.
+/// Decodes a revert given some error data, the final status of the VM, and optionally an ABI.
 pub fn decode_revert(
-    err: &[u8],
-    maybe_abi: Option<&Abi>,
+    data: &[u8],
+    abi: Option<&Abi>,
     status: Option<Return>,
-) -> eyre::Result<String> {
-    if err.len() < SELECTOR_LEN {
-        if let Some(status) = status {
-            if !matches!(status, revm::return_ok!()) {
-                return Ok(format!("EvmError: {:?}", status))
-            }
+) -> eyre::Result<DecodedError> {
+    if data.len() < SELECTOR_LEN {
+        if status.map_or(false, |status| !matches!(status, revm::return_ok!())) {
+            return Ok(DecodedError {
+                message: format!("EvmError: {:?}", status.unwrap()),
+                hints: Vec::new(),
+            })
         }
-        eyre::bail!("Not enough error data to decode")
-    }
-    match err[..SELECTOR_LEN] {
-        // keccak(Panic(uint256))
-        [78, 72, 123, 113] => {
-            // ref: https://soliditydeveloper.com/solidity-0.8
-            match err[err.len() - 1] {
-                1 => {
-                    // assert
-                    Ok("Assertion violated".to_string())
-                }
-                17 => {
-                    // safemath over/underflow
-                    Ok("Arithmetic over/underflow".to_string())
-                }
-                18 => {
-                    // divide by 0
-                    Ok("Division or modulo by 0".to_string())
-                }
-                33 => {
-                    // conversion into non-existent enum type
-                    Ok("Conversion into non-existent enum type".to_string())
-                }
-                34 => {
-                    // incorrectly encoded storage byte array
-                    Ok("Incorrectly encoded storage byte array".to_string())
-                }
-                49 => {
-                    // pop() on empty array
-                    Ok("`pop()` on empty array".to_string())
-                }
-                50 => {
-                    // index out of bounds
-                    Ok("Index out of bounds".to_string())
-                }
-                65 => {
-                    // allocating too much memory or creating too large array
-                    Ok("Memory allocation overflow".to_string())
-                }
-                81 => {
-                    // calling a zero initialized variable of internal function type
-                    Ok("Calling a zero initialized variable of internal function type".to_string())
-                }
-                _ => {
-                    eyre::bail!("Unsupported solidity builtin panic")
-                }
-            }
-        }
-        // keccak(Error(string))
-        [8, 195, 121, 160] => {
-            String::decode(&err[SELECTOR_LEN..]).map_err(|_| eyre::eyre!("Bad string decode"))
-        }
-        // keccak(expectRevert(bytes))
-        [242, 141, 206, 179] => {
-            let err_data = &err[SELECTOR_LEN..];
-            if err_data.len() > 64 {
-                let len = U256::from(&err_data[32..64]).as_usize();
-                if err_data.len() > 64 + len {
-                    let actual_err = &err_data[64..64 + len];
-                    if let Ok(decoded) = decode_revert(actual_err, maybe_abi, None) {
-                        // check if it's a builtin
-                        return Ok(decoded)
-                    } else if let Ok(as_str) = String::from_utf8(actual_err.to_vec()) {
-                        // check if it's a true string
-                        return Ok(as_str)
-                    }
-                }
-            }
-            eyre::bail!("Non-native error and not string")
-        }
-        // keccak(expectRevert(bytes4))
-        [195, 30, 176, 224] => {
-            let err_data = &err[SELECTOR_LEN..];
-            if err_data.len() == 32 {
-                let actual_err = &err_data[..SELECTOR_LEN];
-                if let Ok(decoded) = decode_revert(actual_err, maybe_abi, None) {
-                    // it's a known selector
-                    return Ok(decoded)
-                }
-            }
-            eyre::bail!("Unknown error selector")
-        }
-        _ => {
-            // try to decode a custom error if provided an abi
-            if let Some(abi) = maybe_abi {
-                for abi_error in abi.errors() {
-                    if abi_error.signature()[..SELECTOR_LEN] == err[..SELECTOR_LEN] {
-                        // if we don't decode, don't return an error, try to decode as a
-                        // string later
-                        if let Ok(decoded) = abi_error.decode(&err[SELECTOR_LEN..]) {
-                            let inputs = decoded
-                                .iter()
-                                .map(foundry_utils::format_token)
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            return Ok(format!("{}({})", abi_error.name, inputs))
-                        }
-                    }
-                }
-            }
 
-            // optimistically try to decode as string, unkown selector or `CheatcodeError`
-            String::decode(err)
-                .ok()
-                .or_else(|| {
-                    // try decoding as cheatcode error
-                    if err.starts_with(ERROR_PREFIX.as_slice()) {
-                        String::decode(&err[ERROR_PREFIX.len()..]).ok()
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| {
-                    // try decoding as unknown err
-                    String::decode(&err[SELECTOR_LEN..])
-                        .map(|err_str| format!("{}:{}", hex::encode(&err[..SELECTOR_LEN]), err_str))
-                        .ok()
-                })
-                .ok_or_else(|| eyre::eyre!("Non-native error and not string"))
-        }
+        eyre::bail!("Not enough data to decode error.")
     }
+
+    (if let Some(abi) = abi {
+        DecodedError::decode_with_abi(data, abi)
+    } else {
+        DecodedError::decode(data)
+    })
+    .map_err(|_| eyre::eyre!("Could not decode error."))
 }

--- a/evm/src/error.rs
+++ b/evm/src/error.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use ethers::{
-    abi::{self, Abi, AbiDecode, AbiEncode, AbiError, ParamType},
+    abi::{self, Abi, AbiDecode, AbiEncode, AbiError, ParamType, Tokenizable},
     prelude::U256,
     utils::keccak256,
 };
@@ -47,8 +47,7 @@ pub fn encode_error(reason: impl Display) -> Bytes {
 pub fn encode_error_with_hints(reason: impl Display, hints: Vec<String>) -> Bytes {
     [
         CHEATCODE_ERROR_SELECTOR.as_slice(),
-        reason.to_string().encode().as_slice(),
-        hints.encode().as_slice(),
+        abi::encode(&[reason.to_string().into_token(), hints.into_token()]).as_slice(),
     ]
     .concat()
     .into()
@@ -179,7 +178,7 @@ impl AbiDecode for DecodedError {
                 } else {
                     let mut tokens = abi::decode(
                         &[ParamType::String, ParamType::Array(Box::new(ParamType::String))],
-                        bytes.as_ref(),
+                        &bytes.as_ref()[32..],
                     )?
                     .into_iter();
 

--- a/evm/src/error.rs
+++ b/evm/src/error.rs
@@ -1,15 +1,25 @@
 //! error handling and support
 
 use bytes::Bytes;
-use ethers::{abi::AbiEncode, utils::keccak256};
+use ethers::{
+    abi::{self, Abi, AbiDecode, AbiEncode, AbiError, ParamType},
+    prelude::U256,
+    utils::keccak256,
+};
+use foundry_common::SELECTOR_LEN;
 use once_cell::sync::Lazy;
-use std::fmt::Display;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
 
-// keccak(Error(string))
-pub static REVERT_PREFIX: [u8; 4] = [8, 195, 121, 160];
+/// The selector of `keccak(Error(string))` used by Solidity string reverts
+pub const SOLIDITY_REVERT_SELECTOR: [u8; 4] = [8, 195, 121, 160];
 
-/// Custom error prefiix
-pub static ERROR_PREFIX: Lazy<[u8; 32]> = Lazy::new(|| keccak256("CheatCodeError"));
+/// The selector of a Solidity panic
+pub const SOLIDITY_PANIC_SELECTOR: [u8; 4] = [78, 72, 123, 113];
+
+/// The selector of a cheatcode-related error (`CheatCodeError(string error, string[] hints)`)
+pub static CHEATCODE_ERROR_SELECTOR: Lazy<[u8; 32]> =
+    Lazy::new(|| keccak256("CheatCodeError(string,string[])"));
 
 /// An extension trait for `std::error::Error` that can abi-encode itself
 pub trait SolError: std::error::Error {
@@ -28,7 +38,209 @@ pub trait SolError: std::error::Error {
     }
 }
 
-/// Encodes the given messages as solidity custom error
+/// Encodes the given message as a Solidity custom error
 pub fn encode_error(reason: impl Display) -> Bytes {
-    [ERROR_PREFIX.as_slice(), reason.to_string().encode().as_slice()].concat().into()
+    encode_error_with_hints(reason, Vec::new())
+}
+
+/// Encodes the given message and hints as a Solidity custom error
+pub fn encode_error_with_hints(reason: impl Display, hints: Vec<String>) -> Bytes {
+    [
+        CHEATCODE_ERROR_SELECTOR.as_slice(),
+        reason.to_string().encode().as_slice(),
+        hints.encode().as_slice(),
+    ]
+    .concat()
+    .into()
+}
+
+/// A Solidity panic.
+#[derive(Debug)]
+pub enum SolidityPanic {
+    /// 0x00: Generic compiler inserted panics.
+    Generic,
+    /// 0x01: If you call `assert` with an argument that evaluates to false
+    Assert,
+    /// 0x11: If an arithmetic operation results in underflow or overflow outside of an `unchecked
+    /// { ... }` block.
+    OverUnderFlow,
+    /// 0x12: Divide by zero.
+    DivideByZero,
+    /// 0x21: If you convert a value that is too big or negative into an enum type.
+    InvalidEnumCast,
+    /// 0x22: If you access a storage byte array that is incorrectly encoded.
+    InvalidStorageByteArray,
+    /// 0x31: If you call `.pop()` on an empty array
+    PopOnEmptyArray,
+    /// 0x32: If you access an array, `bytesN` or an array slice at an out-of-bounds or negative
+    /// index.
+    IndexOutOfBounds,
+    /// 0x41: If you allocate too much memory or create an array that is too large.
+    Alloc,
+    /// 0x51: If you call a zero-initialized variable of internal function type.
+    InvalidPointer,
+    /// An unknown Solidity panic.
+    Unknown(usize),
+}
+
+impl AbiDecode for SolidityPanic {
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, AbiError> {
+        if !bytes.as_ref().starts_with(&SOLIDITY_PANIC_SELECTOR) {
+            Err(AbiError::WrongSelector)
+        } else {
+            let code = U256::decode(&bytes.as_ref()[SELECTOR_LEN..])?.as_usize();
+
+            Ok(match code {
+                0x00 => SolidityPanic::Generic,
+                0x01 => SolidityPanic::Assert,
+                0x11 => SolidityPanic::OverUnderFlow,
+                0x12 => SolidityPanic::DivideByZero,
+                0x21 => SolidityPanic::InvalidEnumCast,
+                0x22 => SolidityPanic::InvalidStorageByteArray,
+                0x31 => SolidityPanic::PopOnEmptyArray,
+                0x32 => SolidityPanic::IndexOutOfBounds,
+                0x41 => SolidityPanic::Alloc,
+                0x51 => SolidityPanic::InvalidPointer,
+                code => SolidityPanic::Unknown(code),
+            })
+        }
+    }
+}
+
+impl Display for SolidityPanic {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                SolidityPanic::Generic => "Generic compiler panic encountered",
+                SolidityPanic::Assert => "Assertion violated",
+                SolidityPanic::OverUnderFlow => "Arithmetic over/underflow",
+                SolidityPanic::DivideByZero => "Division or modulo by zero",
+                SolidityPanic::InvalidEnumCast => "Conversion into non-existent enum variant",
+                SolidityPanic::InvalidStorageByteArray => "Incorrectly encoded byte storage array",
+                SolidityPanic::PopOnEmptyArray => "Called pop on an empty array",
+                SolidityPanic::IndexOutOfBounds => "Index out of bounds",
+                SolidityPanic::Alloc => "Memory allocation overflow",
+                SolidityPanic::InvalidPointer =>
+                    "Called a zero-initialized variable of type internal function",
+                SolidityPanic::Unknown(_) => "Unknown Solidity panic encountered",
+            }
+        )
+    }
+}
+
+/// A Solidity string revert (e.g. from `require(cond, msg)`)
+#[derive(Debug)]
+pub struct StringRevert(pub String);
+
+impl AbiDecode for StringRevert {
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, AbiError> {
+        if !bytes.as_ref().starts_with(&SOLIDITY_REVERT_SELECTOR) {
+            Err(AbiError::WrongSelector)
+        } else {
+            Ok(StringRevert(String::decode(&bytes.as_ref()[SELECTOR_LEN..])?))
+        }
+    }
+}
+
+impl Display for StringRevert {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A wrapper around a decoded error with potential hints.
+///
+/// Using the [AbiDecode] trait it is possible to decode:
+///
+/// - Solidity panic codes
+/// - Solidity string reverts
+/// - Forge-specific cheatcode errors
+///
+/// It is also possible to decode custom user-defined errors using [DecodedError::decode_with_abi].
+// TODO: Does this name kind of suck?
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DecodedError {
+    pub message: String,
+    pub hints: Vec<String>,
+}
+
+impl AbiDecode for DecodedError {
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, AbiError> {
+        SolidityPanic::decode(&bytes)
+            .map(Into::into)
+            .or_else(|_| StringRevert::decode(&bytes).map(Into::into))
+            .or_else(|_| String::decode(&bytes).map(Into::into))
+            .or_else(|_| {
+                // Try decoding cheatcode errors
+                if !bytes.as_ref().starts_with(CHEATCODE_ERROR_SELECTOR.as_ref()) {
+                    Err(AbiError::WrongSelector)
+                } else {
+                    let mut tokens = abi::decode(
+                        &[ParamType::String, ParamType::Array(Box::new(ParamType::String))],
+                        bytes.as_ref(),
+                    )?
+                    .into_iter();
+
+                    let message = tokens
+                        .next()
+                        .and_then(|token| token.into_string())
+                        .ok_or(AbiError::DecodingError(ethers::abi::Error::InvalidData))?;
+                    let hints = tokens
+                        .next()
+                        .and_then(|token| token.into_array())
+                        .ok_or(AbiError::DecodingError(ethers::abi::Error::InvalidData))?
+                        .into_iter()
+                        .map(|hint| {
+                            hint.into_string()
+                                .ok_or(AbiError::DecodingError(ethers::abi::Error::InvalidData))
+                        })
+                        .collect::<Result<Vec<String>, AbiError>>()?;
+                    Ok(DecodedError { message, hints })
+                }
+            })
+            .or_else(|_| {
+                // Try decoding unknown errors
+                if bytes.as_ref().len() < SELECTOR_LEN {
+                    return Err(AbiError::WrongSelector)
+                }
+
+                Ok(DecodedError::from(format!(
+                    "{}:{}",
+                    hex::encode(&bytes.as_ref()[..SELECTOR_LEN]),
+                    String::decode(&bytes.as_ref()[SELECTOR_LEN..])?
+                )))
+            })
+    }
+}
+
+impl<T> From<T> for DecodedError
+where
+    T: Display,
+{
+    fn from(message: T) -> Self {
+        DecodedError { message: message.to_string(), hints: Vec::new() }
+    }
+}
+
+impl DecodedError {
+    /// Decode an error from some return data, accounting for custom errors defined in an ABI
+    pub fn decode_with_abi(data: &[u8], abi: &Abi) -> Result<Self, AbiError> {
+        if data.len() < SELECTOR_LEN {
+            return Err(AbiError::WrongSelector)
+        }
+
+        let error =
+            abi.errors().find(|error| error.signature()[..SELECTOR_LEN] == data[..SELECTOR_LEN]);
+        if let Some(error) = error {
+            if let Ok(decoded) = error.decode(&data[SELECTOR_LEN..]) {
+                let inputs =
+                    decoded.iter().map(foundry_utils::format_token).collect::<Vec<_>>().join(", ");
+                return Ok(DecodedError::from(format!("{}({})", error.name, inputs)))
+            }
+        }
+
+        DecodedError::decode(data)
+    }
 }

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -1,7 +1,7 @@
 use super::Cheatcodes;
 use crate::{
     abi::HEVMCalls,
-    error::{SolError, ERROR_PREFIX, REVERT_PREFIX},
+    error::{SolError, CHEATCODE_ERROR_SELECTOR, SOLIDITY_REVERT_SELECTOR},
     executor::backend::DatabaseExt,
 };
 use bytes::Bytes;
@@ -59,15 +59,16 @@ pub fn handle_expect_revert(
     }
 
     let string_data = match retdata {
-        _ if retdata.len() >= REVERT_PREFIX.len() &&
-            retdata[..REVERT_PREFIX.len()] == REVERT_PREFIX =>
+        _ if retdata.len() >= SOLIDITY_REVERT_SELECTOR.len() &&
+            retdata[..SOLIDITY_REVERT_SELECTOR.len()] == SOLIDITY_REVERT_SELECTOR =>
         {
             Some(&retdata[4..])
         }
-        _ if retdata.len() >= ERROR_PREFIX.len() &&
-            &retdata[..ERROR_PREFIX.len()] == ERROR_PREFIX.as_slice() =>
+        _ if retdata.len() >= CHEATCODE_ERROR_SELECTOR.len() &&
+            &retdata[..CHEATCODE_ERROR_SELECTOR.len()] ==
+                CHEATCODE_ERROR_SELECTOR.as_slice() =>
         {
-            Some(&retdata[ERROR_PREFIX.len()..])
+            Some(&retdata[CHEATCODE_ERROR_SELECTOR.len()..])
         }
         _ => None,
     };

--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -1,6 +1,7 @@
 use super::{BasicTxDetails, InvariantContract};
 use crate::{
     decode::decode_revert,
+    error::DecodedError,
     executor::{Executor, RawCallResult},
     fuzz::{invariant::set_up_inner_replay, *},
     trace::{load_contracts, TraceKind},
@@ -18,7 +19,7 @@ pub struct InvariantFuzzError {
     /// The return reason of the offending call.
     pub return_reason: Reason,
     /// The revert string of the offending call.
-    pub revert_reason: String,
+    pub revert_reason: Option<DecodedError>,
     /// Address of the invariant asserter.
     pub addr: Address,
     /// Function data for invariant check.
@@ -55,7 +56,7 @@ impl InvariantFuzzError {
                         Some(invariant_contract.abi),
                         Some(call_result.exit_reason)
                     ) {
-                        Ok(e) => e,
+                        Ok(e) => e.message,
                         Err(e) => e.to_string(),
                     }
                 )
@@ -68,7 +69,7 @@ impl InvariantFuzzError {
                 Some(invariant_contract.abi),
                 Some(call_result.exit_reason),
             )
-            .unwrap_or_default(),
+            .ok(),
             addr: invariant_contract.address,
             func,
             inner_sequence: inner_sequence.to_vec(),

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -5,6 +5,7 @@ use super::{
     InvariantFuzzTestResult, RandomCallGenerator, TargetedContracts,
 };
 use crate::{
+    error::DecodedError,
     executor::{
         inspector::Fuzzer, Executor, RawCallResult, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS,
     },
@@ -576,7 +577,7 @@ fn can_continue(
             let error =
                 InvariantFuzzError::new(invariant_contract, None, calldata, call_result, &[]);
 
-            failures.revert_reason = Some(error.revert_reason.clone());
+            failures.revert_reason = error.revert_reason.clone();
 
             // Hacky to provide the full error to the user.
             for invariant in invariant_contract.invariant_functions.iter() {
@@ -593,7 +594,7 @@ fn can_continue(
 /// Stores information about failures and reverts of the invariant tests.
 pub struct InvariantFailures {
     /// The latest revert reason of a run.
-    pub revert_reason: Option<String>,
+    pub revert_reason: Option<DecodedError>,
     /// Total number of reverts.
     pub reverts: usize,
     /// How many different invariants have been broken.

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -278,7 +278,7 @@ impl CallTraceDecoder {
                             ) {
                                 node.trace.output = RawOrDecodedReturnData::Decoded(format!(
                                     r#""{}""#,
-                                    decoded_error
+                                    decoded_error.message
                                 ));
                             }
                         }

--- a/evm/src/trace/node.rs
+++ b/evm/src/trace/node.rs
@@ -151,7 +151,7 @@ impl CallTraceNode {
                     decode::decode_revert(bytes, Some(errors), Some(self.trace.status))
                 {
                     self.trace.output =
-                        RawOrDecodedReturnData::Decoded(format!(r#""{}""#, decoded_error));
+                        RawOrDecodedReturnData::Decoded(format!(r#""{}""#, decoded_error.message));
                 }
             }
         }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -1,7 +1,11 @@
 //! utilities used within tracing
 
 use crate::decode;
-use ethers::abi::{Abi, Address, Function, Token};
+use ethers::{
+    abi::{Abi, Address, Function, Token},
+    prelude::U256,
+};
+use foundry_common::SELECTOR_LEN;
 use foundry_utils::format_token;
 use std::collections::HashMap;
 
@@ -29,7 +33,35 @@ pub(crate) fn decode_cheatcode_inputs(
 ) -> Option<Vec<String>> {
     match func.name.as_str() {
         "expectRevert" => {
-            decode::decode_revert(data, Some(errors), None).ok().map(|decoded| vec![decoded])
+            let err_data = &data[SELECTOR_LEN..];
+            match data[..SELECTOR_LEN] {
+                // `expectRevert(bytes)`
+                [242, 141, 206, 179] if err_data.len() > 64 => {
+                    let len = U256::from(&err_data[32..64]).as_usize();
+                    if err_data.len() > 64 + len {
+                        let actual_err = &err_data[64..64 + len];
+
+                        // check if it's a builtin
+                        return decode::decode_revert(actual_err, Some(errors), None)
+                            .ok()
+                            .map(|decoded| decoded.message)
+                            // check if it's a string
+                            .or_else(|| String::from_utf8(actual_err.to_vec()).ok())
+                            .map(|decoded| vec![decoded])
+                    }
+                }
+                // `expectRevert(bytes4)`
+                [195, 30, 176, 224] if err_data.len() == 32 => {
+                    let actual_err = &data[..SELECTOR_LEN];
+
+                    return decode::decode_revert(actual_err, Some(errors), None)
+                        .ok()
+                        .map(|decoded| vec![decoded.message])
+                }
+                _ => (),
+            }
+
+            None
         }
         _ => None,
     }

--- a/forge/src/result.rs
+++ b/forge/src/result.rs
@@ -4,6 +4,7 @@ use crate::Address;
 use ethers::prelude::Log;
 use foundry_evm::{
     coverage::HitMaps,
+    error::DecodedError,
     fuzz::{CounterExample, FuzzedCases},
     trace::{CallTraceArena, TraceKind},
 };
@@ -66,7 +67,7 @@ pub struct TestResult {
 
     /// If there was a revert, this field will be populated. Note that the test can
     /// still be successful (i.e self.success == true) when it's expected to fail.
-    pub reason: Option<String>,
+    pub reason: Option<DecodedError>,
 
     /// Minimal reproduction test case for failing test
     pub counterexample: Option<CounterExample>,
@@ -178,5 +179,5 @@ pub struct TestSetup {
     /// Whether the setup failed
     pub setup_failed: bool,
     /// The reason the setup failed
-    pub reason: Option<String>,
+    pub reason: Option<DecodedError>,
 }

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -1,7 +1,10 @@
 //! Test setup
 
 use crate::test_helpers::{COMPILED, COMPILED_WITH_LIBS, EVM_OPTS, LIBS_PROJECT, PROJECT};
-use forge::{result::SuiteResult, MultiContractRunner, MultiContractRunnerBuilder, TestOptions};
+use forge::{
+    error::DecodedError, result::SuiteResult, MultiContractRunner, MultiContractRunnerBuilder,
+    TestOptions,
+};
 use foundry_config::{
     fs_permissions::PathPermission, Config, FsPermissions, FuzzConfig, InvariantConfig,
     RpcEndpoint, RpcEndpoints,
@@ -152,7 +155,8 @@ pub fn assert_multiple(
                     logs.join("\n")
                 );
                 assert_eq!(
-                    actuals[*contract_name].test_results[*test_name].reason, *reason,
+                    actuals[*contract_name].test_results[*test_name].reason,
+                    reason.clone().map(DecodedError::from),
                     "Failure reason for test {} did not match what we expected.",
                     test_name
                 );

--- a/forge/tests/it/fork.rs
+++ b/forge/tests/it/fork.rs
@@ -27,7 +27,7 @@ fn test_cheats_fork_revert() {
     for (_, SuiteResult { test_results, .. }) in suite_result {
         for (_, result) in test_results {
             assert_eq!(
-                result.reason.unwrap(),
+                result.reason.unwrap().message,
                 "Contract 0xCe71065D4017F316EC606Fe4422e11eB2c47c246 does not exist on active fork with id `1`\n        But exists on non active forks: `[0]`"
             );
         }


### PR DESCRIPTION
## Motivation

Some cheatcodes lack context when they fail, but our current setup does not allow us to add very much context without the output of `forge test` becoming super cluttered

## Solution

Allow reverts from our backend and our inspectors to include optional hints

Effectively closes https://github.com/foundry-rs/foundry/issues/928 as some of the more annoying cheatcode reverts are documented in other issues