### PR TITLE
fix: use invariant signatures instead of names in resuts

### DIFF
--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -503,4 +503,18 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn can_parse_invariant_snapshot_entry2() {
+        let s = "ERC20Invariants:invariantBalanceSum() (runs: 256, calls: 3840, reverts: 2388)";
+        let entry = SnapshotEntry::from_str(s).unwrap();
+        assert_eq!(
+            entry,
+            SnapshotEntry {
+                contract_name: "ERC20Invariants".to_string(),
+                signature: "invariantBalanceSum()".to_string(),
+                gas_used: TestKindReport::Invariant { runs: 256, calls: 3840, reverts: 2388 }
+            }
+        );
+    }
 }

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -313,7 +313,7 @@ impl<'a> ContractRunner<'a> {
             results.into_iter().zip(functions.iter()).for_each(|(result, function)| {
                 match result.kind {
                     TestKind::Invariant(ref _cases, _) => {
-                        test_results.insert(function.name.clone(), result);
+                        test_results.insert(function.signature(), result);
                     }
                     _ => unreachable!(),
                 }

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -110,6 +110,7 @@ pub fn rpc_endpoints() -> RpcEndpoints {
 }
 
 /// A helper to assert the outcome of multiple tests with helpful assert messages
+#[track_caller]
 pub fn assert_multiple(
     actuals: &BTreeMap<String, SuiteResult>,
     expecteds: BTreeMap<

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -22,54 +22,54 @@ fn test_invariant() {
         BTreeMap::from([
             (
                 "fuzz/invariant/common/InvariantInnerContract.t.sol:InvariantInnerContract",
-                vec![("invariantHideJesus", false, Some("jesus betrayed.".into()), None, None)],
+                vec![("invariantHideJesus()", false, Some("jesus betrayed.".into()), None, None)],
             ),
             (
                 "fuzz/invariant/common/InvariantReentrancy.t.sol:InvariantReentrancy",
-                vec![("invariantNotStolen", true, None, None, None)],
+                vec![("invariantNotStolen()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/common/InvariantTest1.t.sol:InvariantTest",
-                vec![("invariant_neverFalse", false, Some("false.".into()), None, None)],
+                vec![("invariant_neverFalse()", false, Some("false.".into()), None, None)],
             ),
             (
                 "fuzz/invariant/target/ExcludeContracts.t.sol:ExcludeContracts",
-                vec![("invariantTrueWorld", true, None, None, None)],
+                vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/target/TargetContracts.t.sol:TargetContracts",
-                vec![("invariantTrueWorld", true, None, None, None)],
+                vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/target/TargetSenders.t.sol:TargetSenders",
-                vec![("invariantTrueWorld", false, Some("false world.".into()), None, None)],
+                vec![("invariantTrueWorld()", false, Some("false world.".into()), None, None)],
             ),
             (
                 "fuzz/invariant/target/ExcludeSenders.t.sol:ExcludeSenders",
-                vec![("invariantTrueWorld", true, None, None, None)],
+                vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/target/TargetSelectors.t.sol:TargetSelectors",
-                vec![("invariantTrueWorld", true, None, None, None)],
+                vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/targetAbi/ExcludeArtifacts.t.sol:ExcludeArtifacts",
-                vec![("invariantShouldPass", true, None, None, None)],
+                vec![("invariantShouldPass()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/targetAbi/TargetArtifacts.t.sol:TargetArtifacts",
                 vec![
-                    ("invariantShouldPass", true, None, None, None),
-                    ("invariantShouldFail", false, Some("false world.".into()), None, None),
+                    ("invariantShouldPass()", true, None, None, None),
+                    ("invariantShouldFail()", false, Some("false world.".into()), None, None),
                 ],
             ),
             (
                 "fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol:TargetArtifactSelectors",
-                vec![("invariantShouldPass", true, None, None, None)],
+                vec![("invariantShouldPass()", true, None, None, None)],
             ),
             (
                 "fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol:TargetArtifactSelectors2",
-                vec![("invariantShouldFail", false, Some("its false.".into()), None, None)],
+                vec![("invariantShouldFail()", false, Some("its false.".into()), None, None)],
             ),
         ]),
     );
@@ -95,7 +95,7 @@ fn test_invariant_override() {
         &results,
         BTreeMap::from([(
             "fuzz/invariant/common/InvariantReentrancy.t.sol:InvariantReentrancy",
-            vec![("invariantNotStolen", false, Some("stolen.".into()), None, None)],
+            vec![("invariantNotStolen()", false, Some("stolen.".into()), None, None)],
         )]),
     );
 }
@@ -122,10 +122,10 @@ fn test_invariant_storage() {
         BTreeMap::from([(
             "fuzz/invariant/storage/InvariantStorageTest.t.sol:InvariantStorageTest",
             vec![
-                ("invariantChangeAddress", false, Some("changedAddr".into()), None, None),
-                ("invariantChangeString", false, Some("changedStr".into()), None, None),
-                ("invariantChangeUint", false, Some("changedUint".into()), None, None),
-                ("invariantPush", false, Some("pushUint".into()), None, None),
+                ("invariantChangeAddress()", false, Some("changedAddr".into()), None, None),
+                ("invariantChangeString()", false, Some("changedStr".into()), None, None),
+                ("invariantChangeUint()", false, Some("changedUint".into()), None, None),
+                ("invariantPush()", false, Some("pushUint".into()), None, None),
             ],
         )]),
     );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
use function signatures as identifiers for invariant tests

fixes a snapshot bug where entries are formatted as `WETHInvariants:invariantTotalSupplyEqualsBalance (runs: 256, calls: 3840, reverts: 1860)`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
