### PR TITLE
fix(config): fuzz rejects

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -60,8 +60,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         path_pattern_inverse: None,
         fuzz: FuzzConfig {
             runs: 1000,
-            max_local_rejects: 2000,
-            max_global_rejects: 100203,
+            max_test_rejects: 100203,
             seed: Some(1000.into()),
             ..Default::default()
         },

--- a/config/README.md
+++ b/config/README.md
@@ -12,7 +12,7 @@ in `FOUNDRY_PROFILE`. But all custom profiles inherit from the `default` profile
 
 ## foundry.toml
 
-Foundry's tools search for a `foundry.toml`  or the filename in a `FOUNDRY_CONFIG` environment variable starting at the
+Foundry's tools search for a `foundry.toml` or the filename in a `FOUNDRY_CONFIG` environment variable starting at the
 current working directory. If it is not found, the parent directory, its parent directory, and so on are searched until
 the file is found or the root is reached. But the typical location for the global `foundry.toml` would
 be `~/.foundry/foundry.toml`, which is also checked. If the path set in `FOUNDRY_CONFIG` is absolute, no such search
@@ -68,7 +68,7 @@ out = 'out'
 libs = ['lib']
 remappings = []
 # list of libraries to link in the form of `<path to lib>:<lib name>:<address>`: `"src/MyLib.sol:MyLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"`
-# the <path to lib> supports remappings 
+# the <path to lib> supports remappings
 libraries = []
 cache = true
 cache_path = 'cache'
@@ -166,8 +166,7 @@ root = "root"
 fs_permissions = []
 [fuzz]
 runs = 256
-max_local_rejects = 1024
-max_global_rejects = 65536
+max_test_rejects = 65536
 seed = '0x3e8'
 dictionary_weight = 40
 include_storage = true
@@ -232,7 +231,7 @@ The `etherscan` value accepts a list of `alias = "{key = "", url? ="", chain?= "
 
 the `key` attribute is always required and should contain the actual API key for that chain or an env var that holds the key in the form `${ENV_VAR}`
 The `chain` attribute is optional if the `alias` is the already the `chain` name, such as in `mainnet = { key = "${ETHERSCAN_MAINNET_KEY}"}`
-The optional `url` attribute can be used to explicitly set the Etherscan API url, this is the recommended setting for chains not natively supported by name. 
+The optional `url` attribute can be used to explicitly set the Etherscan API url, this is the recommended setting for chains not natively supported by name.
 
 ```toml
 [etherscan]

--- a/config/src/fuzz.rs
+++ b/config/src/fuzz.rs
@@ -14,7 +14,7 @@ pub struct FuzzConfig {
     /// `max_local_rejects` option isn't exposed here since we're not using
     /// `prop_filter`.
     pub max_test_rejects: u32,
-    /// Beging deprecated in favor of `max_test_rejects`. Will be removed in future versions.
+    /// Being deprecated in favor of `max_test_rejects`. Will be removed in future versions.
     pub max_global_rejects: u32,
     /// Optional seed for the fuzzing RNG algorithm
     #[serde(

--- a/config/src/fuzz.rs
+++ b/config/src/fuzz.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 pub struct FuzzConfig {
     /// The number of test cases that must execute for each property test
     pub runs: u32,
-    /// The maximum number of local test case rejections allowed
-    /// by proptest, to be encountered during usage of `vm.assume`
-    /// cheatcode.
-    pub max_local_rejects: u32,
-    /// The maximum number of global test case rejections allowed
-    /// by proptest, to be encountered during usage of `vm.assume`
-    /// cheatcode.
+    /// The maximum number of test case rejections allowed by proptest, to be
+    /// encountered during usage of `vm.assume` cheatcode. This will be used
+    /// to set the `max_global_rejects` value in proptest test runner config.
+    /// `max_local_rejects` option isn't exposed here since we're not using
+    /// `prop_filter`.
+    pub max_test_rejects: u32,
+    /// Beging deprecated in favor of `max_test_rejects`. Will be removed in future versions.
     pub max_global_rejects: u32,
     /// Optional seed for the fuzzing RNG algorithm
     #[serde(
@@ -34,7 +34,7 @@ impl Default for FuzzConfig {
     fn default() -> Self {
         FuzzConfig {
             runs: 256,
-            max_local_rejects: 1024,
+            max_test_rejects: 65536,
             max_global_rejects: 65536,
             seed: None,
             dictionary_weight: 40,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2352,6 +2352,12 @@ mod tests {
     use std::{collections::BTreeMap, fs::File, io::Write, str::FromStr};
     use tempfile::tempdir;
 
+    // Helper function to clear `__warnings` in config, since it will be populated during loading
+    // from file, causing testing problem when comparing to those created from `default()`, etc.
+    fn clear_warning(config: &mut Config) {
+        config.__warnings = vec![];
+    }
+
     #[test]
     fn default_sender() {
         assert_eq!(
@@ -3054,8 +3060,7 @@ mod tests {
                 [fuzz]
                 runs = 256
                 seed = '0x3e8'
-                max_global_rejects = 65536
-                max_local_rejects = 1024
+                max_test_rejects = 65536
 
                 [invariant]
                 runs = 256
@@ -3516,14 +3521,16 @@ mod tests {
             let basic = default.clone().into_basic();
             jail.create_file("foundry.toml", &basic.to_string_pretty().unwrap())?;
 
-            let other = Config::load();
+            let mut other = Config::load();
+            clear_warning(&mut other);
             assert_eq!(default, other);
 
             let other = other.into_basic();
             assert_eq!(basic, other);
 
             jail.create_file("foundry.toml", &default.to_string_pretty().unwrap())?;
-            let other = Config::load();
+            let mut other = Config::load();
+            clear_warning(&mut other);
             assert_eq!(default, other);
 
             Ok(())
@@ -3577,7 +3584,8 @@ mod tests {
                 stackAllocation = true
             "#,
             )?;
-            let loaded = Config::load();
+            let mut loaded = Config::load();
+            clear_warning(&mut loaded);
             assert_eq!(
                 loaded.optimizer_details,
                 Some(OptimizerDetails {
@@ -3593,7 +3601,8 @@ mod tests {
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
 
-            let reloaded = Config::load();
+            let mut reloaded = Config::load();
+            clear_warning(&mut reloaded);
             assert_eq!(loaded, reloaded);
 
             Ok(())
@@ -3615,7 +3624,8 @@ mod tests {
                 timeout = 10000
             "#,
             )?;
-            let loaded = Config::load();
+            let mut loaded = Config::load();
+            clear_warning(&mut loaded);
             assert_eq!(
                 loaded.model_checker,
                 Some(ModelCheckerSettings {
@@ -3635,7 +3645,8 @@ mod tests {
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
 
-            let reloaded = Config::load();
+            let mut reloaded = Config::load();
+            clear_warning(&mut reloaded);
             assert_eq!(loaded, reloaded);
 
             Ok(())

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -353,6 +353,11 @@ pub struct Config {
 pub static STANDALONE_FALLBACK_SECTIONS: Lazy<HashMap<&'static str, &'static str>> =
     Lazy::new(|| HashMap::from([("invariant", "fuzz")]));
 
+/// Deprecated keys.
+pub static DEPRECATIONS: Lazy<HashMap<String, String>> = Lazy::new(|| {
+    HashMap::from([("fuzz.max_global_rejects".into(), "fuzz.max_test_rejects".into())])
+});
+
 impl Config {
     /// The default profile: "default"
     pub const DEFAULT_PROFILE: Profile = Profile::const_new("default");

--- a/config/src/providers/mod.rs
+++ b/config/src/providers/mod.rs
@@ -51,8 +51,8 @@ impl<P: Provider> WarningsProvider<P> {
                 .unwrap_or_default()
                 .keys()
                 .filter(|k| {
-                    k != &Config::PROFILE_SECTION
-                        && !Config::STANDALONE_SECTIONS.iter().any(|s| s == k)
+                    k != &Config::PROFILE_SECTION &&
+                        !Config::STANDALONE_SECTIONS.iter().any(|s| s == k)
                 })
                 .map(|unknown_section| {
                     let source = self.provider.metadata().source.map(|s| s.to_string());

--- a/config/src/warning.rs
+++ b/config/src/warning.rs
@@ -38,6 +38,14 @@ pub enum Warning {
         /// The error message that occured
         err: String,
     },
+    /// Deprecated key.
+    DeprecatedKey {
+        /// The key being deprecated
+        old: String,
+        /// The new key replacing the deprecated one if not empty, otherwise, meaning the old one
+        /// is being removed completely without replacement
+        new: String,
+    },
 }
 
 impl fmt::Display for Warning {
@@ -62,6 +70,12 @@ impl fmt::Display for Warning {
                 profile,
                 path.display(),
                 err
+            )),
+            Self::DeprecatedKey { old, new } if new.is_empty() => f.write_fmt(format_args!(
+                "Key `{old}` is being deprecated and will be removed in future versions.",
+            )),
+            Self::DeprecatedKey { old, new } => f.write_fmt(format_args!(
+                "Key `{old}` is being deprecated in favor of `{new}`. It will be removed in future versions.",
             )),
         }
     }

--- a/evm/src/executor/inspector/cheatcodes/fuzz.rs
+++ b/evm/src/executor/inspector/cheatcodes/fuzz.rs
@@ -1,4 +1,4 @@
-use crate::{abi::HEVMCalls, fuzz::ASSUME_MAGIC_RETURN_CODE};
+use crate::{abi::HEVMCalls, fuzz::error::ASSUME_MAGIC_RETURN_CODE};
 use bytes::Bytes;
 use revm::{Database, EVMData};
 

--- a/evm/src/fuzz/error.rs
+++ b/evm/src/fuzz/error.rs
@@ -1,0 +1,21 @@
+//! errors related to fuzz tests
+
+/// Magic return code for the `assume` cheatcode
+pub const ASSUME_MAGIC_RETURN_CODE: &[u8] = b"FOUNDRY::ASSUME";
+
+/// Possible errors when running fuzz tests
+#[derive(Debug, thiserror::Error)]
+pub enum FuzzError {
+    #[error("Couldn't call unknown contract")]
+    UnknownContract,
+    #[error("Couldn't find function")]
+    UnknownFunction,
+    #[error("Failed to decode fuzzer inputs")]
+    FailedDecodeInput,
+    #[error("Failed contract call")]
+    FailedContractCall,
+    #[error("Empty state changeset")]
+    EmptyChangeset,
+    #[error("The `vm.assume` cheatcode rejected too many inputs ({0} allowed)")]
+    TooManyRejects(u32),
+}

--- a/evm/src/fuzz/error.rs
+++ b/evm/src/fuzz/error.rs
@@ -1,4 +1,5 @@
 //! errors related to fuzz tests
+use proptest::test_runner::Reason;
 
 /// Magic return code for the `assume` cheatcode
 pub const ASSUME_MAGIC_RETURN_CODE: &[u8] = b"FOUNDRY::ASSUME";
@@ -16,6 +17,14 @@ pub enum FuzzError {
     FailedContractCall,
     #[error("Empty state changeset")]
     EmptyChangeset,
+    #[error("`vm.assume` reject")]
+    AssumeReject,
     #[error("The `vm.assume` cheatcode rejected too many inputs ({0} allowed)")]
     TooManyRejects(u32),
+}
+
+impl From<FuzzError> for Reason {
+    fn from(error: FuzzError) -> Self {
+        error.to_string().into()
+    }
 }

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -96,8 +96,7 @@ impl<'a> FuzzedExecutor<'a> {
             (self.config.dictionary_weight, fuzz_calldata_from_state(func.clone(), state.clone())),
         ]);
         tracing::debug!(func = ?func.name, should_fail, "fuzzing");
-        let mut runner = self.runner.clone();
-        let run_result = runner.run(&strat, |calldata| {
+        let run_result = self.runner.clone().run(&strat, |calldata| {
             let call = self
                 .executor
                 .call_raw(self.sender, address, calldata.0.clone(), 0.into())

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -116,7 +116,7 @@ impl<'a> FuzzedExecutor<'a> {
 
             // When assume cheat code is triggered return a special string "FOUNDRY::ASSUME"
             if call.result.as_ref() == ASSUME_MAGIC_RETURN_CODE {
-                return Err(TestCaseError::reject("ASSUME: Too many rejects"));
+                return Err(TestCaseError::reject("ASSUME: Too many rejects"))
             }
 
             let success = self.executor.is_success(

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -116,7 +116,7 @@ impl<'a> FuzzedExecutor<'a> {
 
             // When assume cheat code is triggered return a special string "FOUNDRY::ASSUME"
             if call.result.as_ref() == ASSUME_MAGIC_RETURN_CODE {
-                return Err(TestCaseError::reject("ASSUME cheatcode"));
+                return Err(TestCaseError::reject("ASSUME cheatcode"))
             }
 
             let success = self.executor.is_success(

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -42,12 +42,18 @@ impl TestOptions {
     }
 
     pub fn fuzzer_with_cases(&self, cases: u32) -> TestRunner {
+        let max_global_rejects = if self.fuzz.max_test_rejects !=
+            foundry_config::FuzzConfig::default().max_test_rejects
+        {
+            self.fuzz.max_test_rejects
+        } else {
+            self.fuzz.max_global_rejects
+        };
         // TODO: Add Options to modify the persistence
         let cfg = proptest::test_runner::Config {
             failure_persistence: None,
             cases,
-            max_local_rejects: self.fuzz.max_local_rejects,
-            max_global_rejects: self.fuzz.max_global_rejects,
+            max_global_rejects,
             ..Default::default()
         };
 

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -15,7 +15,7 @@ use std::{
 pub static TEST_OPTS: TestOptions = TestOptions {
     fuzz: FuzzConfig {
         runs: 256,
-        max_local_rejects: 1024,
+        max_test_rejects: 65536,
         max_global_rejects: 65536,
         seed: None,
         include_storage: true,

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -44,5 +44,4 @@ endpoints = 'all'
 
 [fuzz]
 runs = 256
-max_global_rejects = 65536
-max_local_rejects = 1024
+max_test_rejects = 65536


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes https://github.com/foundry-rs/foundry/issues/1202.

Related discussion about the `vm.assume` error message formatting: https://github.com/foundry-rs/foundry/pull/3123.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
1. Display clearer error message when fuzzing aborts due to too many rejects caused by `vm.assume`.
2. Remove `fuzz.max_local_rejects` in config.
3. Deprecate and replace `fuzz.max_global_rejects` with `fuzz.max_test_rejects` in config.
4. Also took this chance to revamp error handling in fuzz test module.

### Example
`foundry.toml`:
```toml
[profile.default]
src = 'src'
out = 'out'
libs = ['lib']

[fuzz]
max_global_rejects = 16
```
`test/Fuzz.t.sol`:
```solidity
pragma solidity 0.8.10;

import "forge-std/Test.sol";

contract ContractTest is Test {
    function setUp() public {
    }

    function testFuzzAssume(uint256 a) external {
        vm.assume(a % 2 == 0);
        require(a % 2 == 0);
    }
}
```

<img width="690" alt="Screenshot 2022-09-09 at 02 14 38" src="https://user-images.githubusercontent.com/86655648/189196083-d5f3b198-9128-4b4d-9a6a-7c4311c564b8.png">
