### PR TITLE
feat(anvil): make steps tracing optional in cmd

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -160,6 +160,7 @@ impl NodeArgs {
             .with_chain_id(self.evm_opts.chain_id)
             .with_transaction_order(self.order)
             .with_genesis(self.init)
+            .with_steps_tracing(self.evm_opts.steps_tracing)
     }
 
     fn account_generator(&self) -> AccountGenerator {
@@ -312,6 +313,9 @@ pub struct AnvilEvmArgs {
     /// The chain ID.
     #[clap(long, alias = "chain", value_name = "CHAIN_ID", help_heading = "ENVIRONMENT CONFIG")]
     pub chain_id: Option<Chain>,
+
+    #[clap(long, help = "Enable steps tracing used for debug calls returning geth-style traces")]
+    pub steps_tracing: bool,
 }
 
 /// Represents the input URL for a fork with an optional trailing block number:

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -127,6 +127,8 @@ pub struct NodeConfig {
     pub fork_retry_backoff: Duration,
     /// available CUPS
     pub compute_units_per_second: u64,
+    /// Enable transaction/call steps tracing for debug calls returning geth-style traces
+    pub enable_steps_tracing: bool,
 }
 
 impl NodeConfig {
@@ -328,6 +330,7 @@ impl Default for NodeConfig {
             account_generator: None,
             base_fee: None,
             enable_tracing: true,
+            enable_steps_tracing: false,
             no_storage_caching: false,
             server_config: Default::default(),
             host: None,
@@ -581,6 +584,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets whether to enable steps tracing
+    #[must_use]
+    pub fn with_steps_tracing(mut self, enable_steps_tracing: bool) -> Self {
+        self.enable_steps_tracing = enable_steps_tracing;
+        self
+    }
+
     #[must_use]
     pub fn with_server_config(mut self, config: ServerConfig) -> Self {
         self.server_config = config;
@@ -804,7 +814,15 @@ impl NodeConfig {
         };
 
         // only memory based backend for now
-        mem::Backend::with_genesis(db, Arc::new(RwLock::new(env)), genesis, fees, fork).await
+        mem::Backend::with_genesis(
+            db,
+            Arc::new(RwLock::new(env)),
+            genesis,
+            fees,
+            fork,
+            self.enable_steps_tracing,
+        )
+        .await
     }
 }
 

--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -98,6 +98,7 @@ pub struct TransactionExecutor<'a, Db: ?Sized, Validator: TransactionValidator> 
     pub parent_hash: H256,
     /// Cumulative gas used by all executed transactions
     pub gas_used: U256,
+    pub enable_steps_tracing: bool,
 }
 
 impl<'a, DB: Db + ?Sized, Validator: TransactionValidator> TransactionExecutor<'a, DB, Validator> {
@@ -251,7 +252,10 @@ impl<'a, 'b, DB: Db + ?Sized, Validator: TransactionValidator> Iterator
         evm.database(&mut self.db);
 
         // records all call and step traces
-        let mut inspector = Inspector::default().with_tracing().with_steps_tracing();
+        let mut inspector = Inspector::default().with_tracing();
+        if self.enable_steps_tracing {
+            inspector = inspector.with_steps_tracing();
+        }
 
         trace!(target: "backend", "[{:?}] executing", transaction.hash());
         // transact and commit the transaction

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -139,6 +139,7 @@ pub struct Backend {
     new_block_listeners: Arc<Mutex<Vec<UnboundedSender<NewBlockNotification>>>>,
     /// keeps track of active snapshots at a specific block
     active_snapshots: Arc<Mutex<HashMap<U256, (u64, H256)>>>,
+    enable_steps_tracing: bool,
 }
 
 impl Backend {
@@ -149,6 +150,7 @@ impl Backend {
         genesis: GenesisConfig,
         fees: FeeManager,
         fork: Option<ClientFork>,
+        enable_steps_tracing: bool,
     ) -> Self {
         // if this is a fork then adjust the blockchain storage
         let blockchain = if let Some(ref fork) = fork {
@@ -176,6 +178,7 @@ impl Backend {
             fees,
             genesis,
             active_snapshots: Arc::new(Mutex::new(Default::default())),
+            enable_steps_tracing,
         };
 
         // Note: this can only fail in forking mode, in which case we can't recover
@@ -593,6 +596,7 @@ impl Backend {
             cfg_env: env.cfg,
             parent_hash: storage.best_hash,
             gas_used: U256::zero(),
+            enable_steps_tracing: self.enable_steps_tracing,
         };
 
         // create a new pending block
@@ -642,6 +646,7 @@ impl Backend {
                     cfg_env: env.cfg.clone(),
                     parent_hash: best_hash,
                     gas_used: U256::zero(),
+                    enable_steps_tracing: self.enable_steps_tracing,
                 };
                 let executed_tx = executor.execute();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/3133

## Solution

Hotfix introducing the cmd option to enable steps tracing (disabled by default). Afterwards, we can implement lazy geth-style traces calculation on `debug_traceTransaction` and `debug_traceCall` requests.
