### PR TITLE
fix(anvil): avoid mutable/immutable borrow conflict

### DIFF
--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -60,8 +60,8 @@ impl Db for MemDb {
 
     fn load_state(&mut self, state: SerializableState) -> DatabaseResult<bool> {
         for (addr, account) in state.accounts.into_iter() {
-            let old_account = self.inner.accounts.get(&addr);
-            let old_account_nonce = old_account.map(|a| a.info.nonce).unwrap_or_default();
+            let old_account_nonce =
+                self.inner.accounts.get(&addr).map(|a| a.info.nonce).unwrap_or_default();
 
             self.insert_account(
                 addr,

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -61,6 +61,7 @@ impl Db for MemDb {
     fn load_state(&mut self, state: SerializableState) -> DatabaseResult<bool> {
         for (addr, account) in state.accounts.into_iter() {
             let old_account = self.inner.accounts.get(&addr);
+            let old_account_nonce = old_account.map(|a| a.info.nonce).unwrap_or_default();
 
             self.insert_account(
                 addr,
@@ -74,10 +75,7 @@ impl Db for MemDb {
                     },
                     // use max nonce in case account is imported multiple times with difference
                     // nonces to prevent collisions
-                    nonce: std::cmp::max(
-                        old_account.map(|a| a.info.nonce).unwrap_or_default(),
-                        account.nonce,
-                    ),
+                    nonce: std::cmp::max(old_account_nonce, account.nonce),
                 },
             );
 

--- a/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -62,6 +62,9 @@ impl Db for MemDb {
         for (addr, account) in state.accounts.into_iter() {
             let old_account_nonce =
                 self.inner.accounts.get(&addr).map(|a| a.info.nonce).unwrap_or_default();
+            // use max nonce in case account is imported multiple times with difference
+            // nonces to prevent collisions
+            let nonce = std::cmp::max(old_account_nonce, account.nonce);
 
             self.insert_account(
                 addr,
@@ -73,9 +76,7 @@ impl Db for MemDb {
                     } else {
                         Some(Bytecode::new_raw(account.code.0).to_checked())
                     },
-                    // use max nonce in case account is imported multiple times with difference
-                    // nonces to prevent collisions
-                    nonce: std::cmp::max(old_account_nonce, account.nonce),
+                    nonce,
                 },
             );
 


### PR DESCRIPTION
```
warning: cannot borrow `*self` as mutable because it is also borrowed as immutable
  --> anvil/src/eth/backend/mem/in_memory_db.rs:65:13
   |
63 |               let old_account = self.inner.accounts.get(&addr);
   |                                 ------------------------------ immutable borrow occurs here
64 | 
65 | /             self.insert_account(
66 | |                 addr,
67 | |                 AccountInfo {
68 | |                     balance: account.balance,
...  |
78 | |                         old_account.map(|a| a.info.nonce).unwrap_or_default(),
   | |                         ----------- immutable borrow later used here
...  |
81 | |                 },
82 | |             );
   | |_____________^ mutable borrow occurs here
   |
   = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
   = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
   = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
 ```

This just fixes this warning, which may become an error in later Rust versions.
