### PR TITLE
fix(forge): avoid mutable/immutable borrow conflict

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -292,11 +292,12 @@ impl CoverageArgs {
                 artifact_id.version.clone(),
                 artifact_id.source.to_string_lossy().to_string(),
             ) {
+                let source_id = *source_id;
                 // TODO: Distinguish between creation/runtime in a smart way
                 report.add_hit_map(
                     &ContractId {
                         version: artifact_id.version.clone(),
-                        source_id: *source_id,
+                        source_id,
                         contract_name: artifact_id.name.clone(),
                     },
                     &hits,


### PR DESCRIPTION
Sorry I did not intend to spam with tiny PRs, but there's another one of these (and no more warnings after this).

```
warning: cannot borrow `report` as mutable because it is also borrowed as immutable
   --> cli/src/cmd/forge/coverage.rs:296:17
    |
291 |               if let Some(source_id) = report.get_source_id(
    |  ______________________________________-
292 | |                 artifact_id.version.clone(),
293 | |                 artifact_id.source.to_string_lossy().to_string(),
294 | |             ) {
    | |_____________- immutable borrow occurs here
295 |                   // TODO: Distinguish between creation/runtime in a smart way
296 | /                 report.add_hit_map(
297 | |                     &ContractId {
298 | |                         version: artifact_id.version.clone(),
299 | |                         source_id: *source_id,
    | |                                    ---------- immutable borrow later used here
...   |
302 | |                     &hits,
303 | |                 );
    | |_________________^ mutable borrow occurs here
    |
    = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
```

The "fix" is a bit ugly, but basically does the de-referencing outside. I suppose `get_source_id` returns `Option<&usize>` only to tie the lifecycle of the `usize` to the coverage state, as for copy-avoiding reasons it wouldn't make any sense.
