### PR TITLE
feat: support string aliases for error codes

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -102,7 +102,9 @@ eth_rpc_url = "https://example.com/"
 # Setting this option enables decoding of error traces from mainnet deployed / verfied contracts via etherscan
 etherscan_api_key = "YOURETHERSCANAPIKEY"
 # ignore solc warnings for missing license and exceeded contract size
-ignored_error_codes = [1878, 5574]
+# known error codes are: ["unreachable", "unused-return", "unused-param", "unused-var", "code-size", "shadowing", "func-mutability", "license", "pragma-solidity", "virtual-interfaces", "same-varname"]
+# additional warnings can be added using their numeric error code: ["license", 1337]
+ignored_error_codes = ["license", "code-size"]
 match_test = "Foo"
 no_match_test = "Bar"
 match_contract = "Foo"

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -3958,4 +3958,29 @@ mod tests {
         chain_dir.close()?;
         Ok(())
     }
+
+    #[test]
+    fn test_parse_error_codes() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [default]
+                ignored_error_codes = ["license", "unreachable", 1337]
+            "#,
+            )?;
+
+            let config = Config::load();
+            assert_eq!(
+                config.ignored_error_codes,
+                vec![
+                    SolidityErrorCode::SpdxLicenseNotProvided,
+                    SolidityErrorCode::Unreachable,
+                    SolidityErrorCode::Other(1337)
+                ]
+            );
+
+            Ok(())
+        });
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3159

supports error code string identifiers and numbers for error codes, uses string identifiers in serialize
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
