### PR TITLE
fix(cast): allow hyphens for negative numbers in --to-base

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -212,7 +212,7 @@ Examples:
     #[clap(visible_aliases = &["--to-radix", "to-radix", "to-base", "tr", "2r", "--to-hex", "to-hex", "th", "2h", "--to-dec", "to-dec", "td", "2d"])]
     #[clap(about = "Converts a number of one base to another")]
     ToBase {
-        #[clap(value_name = "VALUE")]
+        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         value: String,
         #[clap(value_name = "BASE", help = "The output base")]
         base_out: String,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Small oversight, negative numbers are already supported but clap was not allowing them

## Solution

Add `allow_hyphen_values = true`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
