### PR TITLE
fix: shrink memory for step tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "memory-db",
  "parking_lot 0.12.0",
  "pretty_assertions",
- "revm_precompiles",
+ "revm_precompiles 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "tempfile",
@@ -4469,8 +4469,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca8a6f68427a4a11f0652c1562484dcf9a153087441ad254e8e2b6398232f3d"
+source = "git+https://github.com/bluealloy/revm#aa39d64fc3f14ba381c5d244edb3a1f02805e521"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4479,7 +4478,7 @@ dependencies = [
  "hex",
  "num_enum",
  "primitive-types",
- "revm_precompiles",
+ "revm_precompiles 1.1.1 (git+https://github.com/bluealloy/revm)",
  "rlp",
  "serde",
  "sha3",
@@ -4490,6 +4489,23 @@ name = "revm_precompiles"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e68901326fe20437526cb6d64a2898d2976383b7d222329dfce1717902da50"
+dependencies = [
+ "bytes",
+ "hashbrown 0.12.0",
+ "num",
+ "once_cell",
+ "primitive-types",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.5",
+ "sha3",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm_precompiles"
+version = "1.1.1"
+source = "git+https://github.com/bluealloy/revm#aa39d64fc3f14ba381c5d244edb3a1f02805e521"
 dependencies = [
  "bytes",
  "hashbrown 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ debug = 0
 
 [patch.crates-io]
 #revm = { path = "../revm/crates/revm" }
-#revm = { git = "https://github.com/bluealloy/revm" }
+revm = { git = "https://github.com/bluealloy/revm" }

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -110,10 +110,13 @@ where
             self.current_gas_block += opcode_info.get_gas() as u64;
         }
 
+        let mut memory = interpreter.memory.clone();
+        memory.shrink_to_fit();
+
         self.arena.arena[self.head].steps.push(DebugStep {
             pc,
             stack: interpreter.stack().data().clone(),
-            memory: interpreter.memory.clone(),
+            memory,
             instruction: Instruction::OpCode(op),
             push_bytes,
             total_gas_used: gas_used(data.env.cfg.spec_id, total_gas_spent, gas.refunded() as u64),

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -220,7 +220,8 @@ where
         let pc = interp.program_counter();
         let op = OpCode(interp.contract.bytecode.bytecode()[pc]);
         let stack = interp.stack.clone();
-        let memory = interp.memory.clone();
+        let mut memory = interp.memory.clone();
+        memory.shrink_to_fit();
         let state = data.journaled_state.state.clone();
         let gas = interp.gas.remaining();
         let gas_refund_counter = interp.gas.refunded() as u64;

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -342,7 +342,7 @@ pub struct CallTraceStep {
     pub gas_cost: u64,
     /// Gas refund counter before step execution
     pub gas_refund_counter: u64,
-    /// Error (if any) after after step execution
+    /// Error (if any) after step execution
     pub error: Option<String>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

~~Blocked by https://github.com/bluealloy/revm/pull/215~~

## Motivation
the default memory allocates [`4 *1024`](https://github.com/bluealloy/revm/blob/24622a4c9e450217f6a723008a75e3faa3b7cc5d/crates/revm/src/interpreter/memory.rs#L26) bytes, we need to record this _per_ step for geth traces https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L413-L426

which blows up memory rather quickly.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
shrink memory down to what's actually used.

this could be optimized by only recording diffs, but would require some work...

cc @shekhirin 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
