### PR TITLE
fix: breaking changes geth trace data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,12 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1620,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1635,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1646,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1664,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1687,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1701,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1732,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1748,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1773,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1809,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1832,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#91d8c21b216b097d7acb624f566a4a0d43989acf"
+source = "git+https://github.com/gakonst/ethers-rs#5a18059b141c07789425c5d055210886721656c9"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -2084,11 +2087,10 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -2808,11 +2810,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -3830,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -5854,9 +5855,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
~~Blocked by https://github.com/gakonst/ethers-rs/pull/1690~~

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3179

fix geth types breaking changes
encode memory like geth does https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
