### PR TITLE
perf(evm): only store changed storage entries

### DIFF
--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -50,6 +50,18 @@ impl Inspector {
 }
 
 impl<DB: Database> revm::Inspector<DB> for Inspector {
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        if let Some(tracer) = self.tracer.as_mut() {
+            tracer.step(interp, data, is_static);
+        }
+        Return::Continue
+    }
+
     fn log(
         &mut self,
         evm_data: &mut EVMData<'_, DB>,
@@ -61,6 +73,19 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             tracer.log(evm_data, address, topics, data);
         }
         self.logs.log(evm_data, address, topics, data);
+    }
+
+    fn step_end(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+        eval: Return,
+    ) -> Return {
+        if let Some(tracer) = self.tracer.as_mut() {
+            tracer.step_end(interp, data, is_static, eval);
+        }
+        eval
     }
 
     fn call(
@@ -117,31 +142,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             tracer.create_end(data, inputs, status, address, gas, retdata.clone());
         }
         (status, address, gas, retdata)
-    }
-
-    fn step(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-    ) -> Return {
-        if let Some(tracer) = self.tracer.as_mut() {
-            tracer.step(interp, data, is_static);
-        }
-        Return::Continue
-    }
-
-    fn step_end(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-        eval: Return,
-    ) -> Return {
-        if let Some(tracer) = self.tracer.as_mut() {
-            tracer.step_end(interp, data, is_static, eval);
-        }
-        eval
     }
 }
 

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -9,7 +9,6 @@ mod utils;
 
 use crate::{
     abi::CHEATCODE_ADDRESS, debug::Instruction, trace::identifier::LocalTraceIdentifier, CallKind,
-    H160,
 };
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use ethers::{
@@ -20,7 +19,7 @@ use ethers::{
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use hashbrown::HashMap;
 use node::CallTraceNode;
-use revm::{Account, CallContext, Memory, Return, Stack};
+use revm::{CallContext, Memory, Return, Stack};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
@@ -334,8 +333,8 @@ pub struct CallTraceStep {
     pub stack: Stack,
     /// Memory before step execution
     pub memory: Memory,
-    /// State before step execution
-    pub state: HashMap<H160, Account>,
+    /// The current state of the contract
+    pub state: HashMap<U256, U256>,
     /// Remaining gas before step execution
     pub gas: u64,
     /// Gas cost of step execution
@@ -360,12 +359,8 @@ impl From<&CallTraceStep> for StructLog {
             stack: Some(step.stack.data().clone()),
             storage: Some(
                 step.state
-                    .values()
-                    .flat_map(|acc| {
-                        acc.storage.iter().map(|(key, value)| {
-                            (H256::from_uint(key), H256::from_uint(&value.present_value()))
-                        })
-                    })
+                    .iter()
+                    .map(|(key, value)| (H256::from_uint(key), H256::from_uint(value)))
                     .collect(),
             ),
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Blocked by https://github.com/foundry-rs/foundry/pull/3183

## Motivation
only clone contract storage for step tracer
the `storage` entry in the geth `StructLog` is only the state of the contract, Ref https://docs.dcfsscan.io/docs/dapp/tracing

Therefor it's not necessary to clone the entire state. instead clone only the storage of the contract.

@shekhirin I think this is a significant factor for the recent mem issues
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
