### PR TITLE
feat: patch svm-rs with 0.8.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,12 @@ jobs:
         with:
           path: "$HOME/.foundry/cache"
           key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
+
+      - name: Setup git config
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "<>"
+
       - name: Force use of HTTPS for submodules
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,9 +5166,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9da7be4aa3d6b944579b66af0cfdca48f2682de7d5b85cf40449805e2e93db9"
+version = "0.2.17"
+source = "git+https://github.com/roynalnaruto/svm-rs#3d55c338c61939641a18b56ffe77095ab74d46cd"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,4 @@ debug = 0
 [patch.crates-io]
 #revm = { path = "../revm/crates/revm" }
 #revm = { git = "https://github.com/bluealloy/revm" }
+svm-rs = { git = "https://github.com/roynalnaruto/svm-rs" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3141

contains svm-rs patch with 0.8.17 support

patch can be phased out after published and upstreamed in ethers-rs
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* added new test to ensure `forge test` works with latest version
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
