### PR TITLE
fix: make env cheatcodes during setup persistent

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -50,13 +50,13 @@ impl<'a> FuzzBackendWrapper<'a> {
     /// Executes the configured transaction of the `env` without committing state changes
     pub fn inspect_ref<INSP>(
         &mut self,
-        mut env: Env,
+        env: &mut Env,
         mut inspector: INSP,
     ) -> (ExecutionResult, Map<Address, Account>)
     where
         INSP: Inspector<Self>,
     {
-        revm::evm_inner::<Self, true>(&mut env, self, &mut inspector).transact()
+        revm::evm_inner::<Self, true>(env, self, &mut inspector).transact()
     }
 }
 

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -605,7 +605,7 @@ impl Backend {
     /// Executes the configured test call of the `env` without commiting state changes
     pub fn inspect_ref<INSP>(
         &mut self,
-        mut env: Env,
+        env: &mut Env,
         mut inspector: INSP,
     ) -> (ExecutionResult, Map<Address, Account>)
     where
@@ -616,7 +616,7 @@ impl Backend {
         if let TransactTo::Call(to) = env.tx.transact_to {
             self.set_test_contract(to);
         }
-        revm::evm_inner::<Self, true>(&mut env, self, &mut inspector).transact()
+        revm::evm_inner::<Self, true>(env, self, &mut inspector).transact()
     }
 
     /// Returns true if the address is a precompile

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -223,3 +223,25 @@ fn test_issue_3119() {
         }
     }
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3190>
+#[test]
+fn test_issue_3190() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3190"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}

--- a/testdata/cheats/ChainId.t.sol
+++ b/testdata/cheats/ChainId.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "./Cheats.sol";
+
+contract DealTest is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testChainId() public {
+        uint256 newChainId = 99;
+        vm.chainId(newChainId);
+        assertEq(newChainId, block.chainid);
+    }
+}

--- a/testdata/cheats/Fork.t.sol
+++ b/testdata/cheats/Fork.t.sol
@@ -103,4 +103,13 @@ contract ForkTest is DSTest {
         assertEq(val, 99);
         assertEq(testValue, 300);
     }
+
+    // ensures forks use different ids
+    function testCanChangeChainId() public {
+        cheats.selectFork(forkA);
+        uint256 newChainId = 1337;
+        cheats.chainId(newChainId);
+        uint256 expected = block.chainid;
+        assertEq(newChainId, expected);
+    }
 }

--- a/testdata/cheats/Setup.t.sol
+++ b/testdata/cheats/Setup.t.sol
@@ -18,6 +18,7 @@ contract CheatsSetupTest is DSTest {
         victim = new Victim();
 
         cheats.warp(10);
+        cheats.chainId(99);
         cheats.roll(100);
         cheats.fee(1000);
         cheats.difficulty(10000);
@@ -29,6 +30,7 @@ contract CheatsSetupTest is DSTest {
         assertEq(block.number, 100, "block number was not persisted from setup");
         assertEq(block.basefee, 1000, "basefee was not persisted from setup");
         assertEq(block.difficulty, 10000, "difficulty was not persisted from setup");
+        assertEq(block.chainid, 99, "chainid was not persisted from setup");
         victim.assertSender(address(1337));
     }
 }

--- a/testdata/repros/Issue3190.t.sol
+++ b/testdata/repros/Issue3190.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+import "../logs/console.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3190
+contract Issue3190Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function setUp() public {
+        vm.chainId(99);
+        assertEq(99, block.chainid);
+    }
+
+    function testChainId() public {
+        assertEq(99, block.chainid);
+        vm.chainId(100);
+        assertEq(100, block.chainid);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3190

changes to env during setup, (`vm.chainId`) weren't tracked properly so subsequent tests started with the default value again.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
update `env` after the `setup` call so any changes made during setup are recorded
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
