### PR TITLE
fix: detect global failures

### DIFF
--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -3,5 +3,5 @@ Solc 0.8.10 finished in 185.25ms
 Compiler run successful
 
 Running 1 test for src/Contract.t.sol:ContractTest
-[PASS] testExample() (gas: 120)
+[PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; finished in 1.89ms

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -3,5 +3,5 @@ Solc 0.8.13 finished in 185.25ms
 Compiler run successful
 
 Running 1 test for src/Contract.t.sol:ContractTest
-[PASS] testExample() (gas: 120)
+[PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; finished in 1.89ms

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -204,10 +204,12 @@ pub fn apply<DB: DatabaseExt>(
             Bytes::new()
         }
         HEVMCalls::Store(inner) => {
-            // TODO: Does this increase gas usage?
             data.journaled_state
                 .load_account(inner.0, data.db)
                 .map_err(|err| err.encode_string())?;
+            // ensure the account is touched
+            data.journaled_state.touch(&inner.0);
+
             data.journaled_state
                 .sstore(inner.0, inner.1.into(), inner.2.into(), data.db)
                 .map_err(|err| err.encode_string())?;

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -547,13 +547,19 @@ impl Executor {
 
     /// Check if a call to a test contract was successful.
     ///
-    /// This function checks both the VM status of the call and DSTest's `failed`.
+    /// This function checks both the VM status of the call, DSTest's `failed` status and the
+    /// `globalFailed` flag which is stored in `failed` inside the `CHEATCODE_ADDRESS` contract.
     ///
     /// DSTest will not revert inside its `assertEq`-like functions which allows
     /// to test multiple assertions in 1 test function while also preserving logs.
     ///
-    /// Instead, it sets `failed` to `true` which we must check.
-    // TODO(mattsse): check if safe to replace with `Backend::is_failed()`
+    /// If an `assert` is violated, the contract's `failed` variable is set to true, and the
+    /// `globalFailure` flag inside the `CHEATCODE_ADDRESS` is also set to true, this way, failing
+    /// asserts from any contract are tracked as well.
+    ///
+    /// In order to check whether a test failed, we therefore need to evaluate the contract's
+    /// `failed` variable and the `globalFailure` flag, which happens by calling
+    /// `contract.failed()`.
     pub fn is_success(
         &self,
         address: Address,
@@ -575,9 +581,20 @@ impl Executor {
             // a failure occurred in a reverted snapshot, which is considered a failed test
             return Ok(should_fail)
         }
+
         // Construct a new VM with the state changeset
         let mut backend = self.backend().clone_empty();
-        backend.insert_account_info(address, self.backend().basic(address)?.unwrap_or_default());
+
+        // we only clone the test contract and cheatcode accounts, that's all we need to evaluate
+        // success
+        for addr in [address, CHEATCODE_ADDRESS] {
+            let acc = self.backend().basic(addr)?.unwrap_or_default();
+            backend.insert_account_info(addr, acc);
+        }
+
+        // If this test failed any asserts, then this changeset will contain changes `false -> true`
+        // for the contract's `failed` variable and the `globalFailure` flag in the state of the
+        // cheatcode address which are both read when call `"failed()(bool)"` in the next step
         backend.commit(state_changeset);
         let executor =
             Executor::new(backend, self.env.clone(), self.inspector_config.clone(), self.gas_limit);

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -202,6 +202,28 @@ fn test_issue_3110() {
     }
 }
 
+// <https://github.com/foundry-rs/foundry/issues/3189>
+#[test]
+fn test_issue_3189() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3189"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                !result.success,
+                "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}
+
 // <https://github.com/foundry-rs/foundry/issues/3119>
 #[test]
 fn test_issue_3119() {

--- a/testdata/repros/Issue3189.t.sol
+++ b/testdata/repros/Issue3189.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3189
+contract MyContract {
+    function foo(uint256 arg) public returns (uint256) {
+        return arg + 2;
+    }
+}
+
+contract MyContractUser is DSTest {
+    MyContract immutable myContract;
+
+    constructor() {
+        myContract = new MyContract();
+    }
+
+    function foo(uint256 arg) public returns (uint256 ret) {
+        ret = myContract.foo(arg);
+        assertEq(ret, arg + 1, "Invariant failed");
+    }
+}
+
+contract Issue3189Test is DSTest {
+    function testFoo() public {
+        MyContractUser user = new MyContractUser();
+        uint256 fooRet = user.foo(123);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3189

previously we effectively only checked the contract's own `failed` variable when evaluating success. This wouldn't detect failures like #3189.

DSTest also records failures by storing true inside the cheatcode's state. this way failing asserts from any contract are recorded
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This contains two fixes:
* touch the account in `store` cheatcode, this ensures the change (`globalFailure`) shows up in the final changeset
* also clone the CHEATCODE_ADDRESS' state when evaluating success, so the `failed` function can lookup the `globalFailure` flag inside the cheatcode_address' state.
* update DSTest calls 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
