### PR TITLE
fix: ensure caller exists

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -179,6 +179,27 @@ fn test_issue_3055() {
         }
     }
 }
+// <https://github.com/foundry-rs/foundry/issues/3192>
+#[test]
+fn test_issue_3192() {
+    let mut runner = runner();
+    let suite_result =
+        runner.test(&Filter::new(".*", ".*", ".*repros/Issue3192"), None, TEST_OPTS).unwrap();
+    assert!(!suite_result.is_empty());
+
+    for (_, SuiteResult { test_results, .. }) in suite_result {
+        for (test_name, result) in test_results {
+            let logs = decode_console_logs(&result.logs);
+            assert!(
+                result.success,
+                "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                test_name,
+                result.reason,
+                logs.join("\n")
+            );
+        }
+    }
+}
 
 // <https://github.com/foundry-rs/foundry/issues/3110>
 #[test]

--- a/testdata/repros/Issue3192.t.sol
+++ b/testdata/repros/Issue3192.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3192
+contract Issue3192Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+    uint256 fork1;
+    uint256 fork2;
+
+    function setUp() public {
+        fork1 = vm.createFork("rpcAlias", 7475589);
+        fork2 = vm.createFork("rpcAlias", 12880747);
+        vm.selectFork(fork1);
+    }
+
+    function testForkSwapSelect() public {
+        assertEq(fork1, vm.activeFork());
+        vm.selectFork(fork2);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3192

revm will panic if the `caller` account does not exist in the final journaled state.
There was another edge case where this could have happened.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Ensure that the caller account always exists in the fork's journaled state when selecting another fork.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
