### PR TITLE
fix: update fork url when extracting evm opts

### DIFF
--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -247,8 +247,14 @@ where
     }
     fn load_config_and_evm_opts(self) -> eyre::Result<(Config, EvmOpts)> {
         let figment: Figment = self.into();
-        let evm_opts = figment.extract::<EvmOpts>()?;
+        let mut evm_opts = figment.extract::<EvmOpts>()?;
         let config = Config::from_provider(figment).sanitized();
+
+        // update the fork url if it was an alias
+        if let Some(fork_url) = config.get_rpc_url() {
+            evm_opts.fork_url = Some(fork_url?.into_owned());
+        }
+
         Ok((config, evm_opts))
     }
     fn load_config_unsanitized(self) -> Config {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #3195

when extracting the `EmvOpts` from the config we should also set the actual URL if it was an alias.

@devanonon you wanna try this? this should cover at least all of `script`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
