### PR TITLE
perf(evm): only store storage slot diffs and reconstruct full storage on request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "memory-db",
  "parking_lot 0.12.0",
  "pretty_assertions",
- "revm_precompiles",
+ "revm_precompiles 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "tempfile",
@@ -4470,8 +4470,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca8a6f68427a4a11f0652c1562484dcf9a153087441ad254e8e2b6398232f3d"
+source = "git+https://github.com/bluealloy/revm#1e25c99b544863d15610e9af8e623dd173397b48"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",
@@ -4480,7 +4479,7 @@ dependencies = [
  "hex",
  "num_enum",
  "primitive-types",
- "revm_precompiles",
+ "revm_precompiles 1.1.1 (git+https://github.com/bluealloy/revm)",
  "rlp",
  "serde",
  "sha3",
@@ -4491,6 +4490,23 @@ name = "revm_precompiles"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e68901326fe20437526cb6d64a2898d2976383b7d222329dfce1717902da50"
+dependencies = [
+ "bytes",
+ "hashbrown 0.12.0",
+ "num",
+ "once_cell",
+ "primitive-types",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.5",
+ "sha3",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm_precompiles"
+version = "1.1.1"
+source = "git+https://github.com/bluealloy/revm#1e25c99b544863d15610e9af8e623dd173397b48"
 dependencies = [
  "bytes",
  "hashbrown 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,5 +66,5 @@ debug = 0
 
 [patch.crates-io]
 #revm = { path = "../revm/crates/revm" }
-#revm = { git = "https://github.com/bluealloy/revm" }
+revm = { git = "https://github.com/bluealloy/revm" }
 svm-rs = { git = "https://github.com/roynalnaruto/svm-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-debug = 0
+#debug = 0
 
 [profile.dev.package]
 # These speed up local tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-#debug = 0
+debug = 0
 
 [profile.dev.package]
 # These speed up local tests

--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -50,6 +50,18 @@ impl Inspector {
 }
 
 impl<DB: Database> revm::Inspector<DB> for Inspector {
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        if let Some(tracer) = self.tracer.as_mut() {
+            tracer.step(interp, data, is_static);
+        }
+        Return::Continue
+    }
+
     fn log(
         &mut self,
         evm_data: &mut EVMData<'_, DB>,
@@ -61,6 +73,19 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             tracer.log(evm_data, address, topics, data);
         }
         self.logs.log(evm_data, address, topics, data);
+    }
+
+    fn step_end(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+        eval: Return,
+    ) -> Return {
+        if let Some(tracer) = self.tracer.as_mut() {
+            tracer.step_end(interp, data, is_static, eval);
+        }
+        eval
     }
 
     fn call(
@@ -117,31 +142,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             tracer.create_end(data, inputs, status, address, gas, retdata.clone());
         }
         (status, address, gas, retdata)
-    }
-
-    fn step(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-    ) -> Return {
-        if let Some(tracer) = self.tracer.as_mut() {
-            tracer.step(interp, data, is_static);
-        }
-        Return::Continue
-    }
-
-    fn step_end(
-        &mut self,
-        interp: &mut Interpreter,
-        data: &mut EVMData<'_, DB>,
-        is_static: bool,
-        eval: Return,
-    ) -> Return {
-        if let Some(tracer) = self.tracer.as_mut() {
-            tracer.step_end(interp, data, is_static, eval);
-        }
-        eval
     }
 }
 

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -123,12 +123,15 @@ impl Tracer {
             .journaled_state
             .journal
             .last()
-            .expect("not enough contract journal entries")
-            .last()
-            .expect("not enough call journal entries");
+            // This should always work because revm initializes it as `vec![vec![]]`
+            .unwrap()
+            .last();
 
         step.state_diff = match (op, journal_entry) {
-            (opcode::SLOAD | opcode::SSTORE, JournalEntry::StorageChage { address, key, .. }) => {
+            (
+                opcode::SLOAD | opcode::SSTORE,
+                Some(JournalEntry::StorageChage { address, key, .. }),
+            ) => {
                 let value = data.journaled_state.state[address].storage[key].present_value();
                 Some((*key, value))
             }

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -117,6 +117,7 @@ impl Tracer {
             _ => None,
         };
 
+        // TODO: calculate spent gas as in `Debugger::step`
         step.gas_cost = step.gas - interp.gas.remaining();
 
         // Error codes only

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -149,10 +149,10 @@ where
             contract: interp.contract.address,
             stack: interp.stack.clone(),
             memory: interp.memory.clone(),
-            state_diff: None,
             gas: interp.gas.remaining(),
             gas_refund_counter: interp.gas.refunded() as u64,
             gas_cost: 0,
+            state_diff: None,
             error: None,
         });
 

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -102,9 +102,6 @@ impl CallTraceArena {
                     let contract_storage = storage.entry(step.contract).or_default();
                     if let Some((key, value)) = step.state_diff {
                         contract_storage.insert(H256::from_uint(&key), H256::from_uint(&value));
-                    }
-
-                    if !contract_storage.is_empty() {
                         log.storage = Some(contract_storage.clone());
                     }
                 }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -329,6 +329,8 @@ impl fmt::Display for RawOrDecodedReturnData {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CallTraceStep {
+    // Fields filled in `step`
+    /// Call depth
     pub depth: u64,
     /// Program counter before step execution
     pub pc: usize,
@@ -340,14 +342,16 @@ pub struct CallTraceStep {
     pub stack: Stack,
     /// Memory before step execution
     pub memory: Memory,
-    /// State of the contract after step execution (effect of the SLOAD/SSTORE instructions)
-    pub state_diff: Option<(U256, U256)>,
     /// Remaining gas before step execution
     pub gas: u64,
-    /// Gas cost of step execution
-    pub gas_cost: u64,
     /// Gas refund counter before step execution
     pub gas_refund_counter: u64,
+
+    // Fields filled in `step_end`
+    /// Gas cost of step execution
+    pub gas_cost: u64,
+    /// Change of the contract state after step execution (effect of the SLOAD/SSTORE instructions)
+    pub state_diff: Option<(U256, U256)>,
     /// Error (if any) after after step execution
     pub error: Option<String>,
 }
@@ -364,6 +368,7 @@ impl From<&CallTraceStep> for StructLog {
             pc: step.pc as u64,
             refund_counter: Some(step.gas_refund_counter),
             stack: Some(step.stack.data().clone()),
+            // Filled in `CallTraceArena::geth_trace` as a result of compounding all slot changes
             storage: None,
         }
     }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -9,7 +9,6 @@ mod utils;
 
 use crate::{
     abi::CHEATCODE_ADDRESS, debug::Instruction, trace::identifier::LocalTraceIdentifier, CallKind,
-    H160,
 };
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use ethers::{
@@ -20,7 +19,7 @@ use ethers::{
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use hashbrown::HashMap;
 use node::CallTraceNode;
-use revm::{Account, CallContext, Memory, Return, Stack};
+use revm::{CallContext, Memory, Return, Stack};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
@@ -334,8 +333,8 @@ pub struct CallTraceStep {
     pub stack: Stack,
     /// Memory before step execution
     pub memory: Memory,
-    /// State before step execution
-    pub state: HashMap<H160, Account>,
+    /// The current state of the contract
+    pub state: HashMap<U256, U256>,
     /// Remaining gas before step execution
     pub gas: u64,
     /// Gas cost of step execution
@@ -360,12 +359,8 @@ impl From<&CallTraceStep> for StructLog {
             stack: Some(step.stack.data().clone()),
             storage: Some(
                 step.state
-                    .values()
-                    .flat_map(|acc| {
-                        acc.storage.iter().map(|(key, value)| {
-                            (H256::from_uint(key), H256::from_uint(&value.present_value()))
-                        })
-                    })
+                    .iter()
+                    .map(|(key, value)| (H256::from_uint(key), H256::from_uint(value)))
                     .collect(),
             ),
         }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -103,7 +103,10 @@ impl CallTraceArena {
                     if let Some((key, value)) = step.state_diff {
                         contract_storage.insert(H256::from_uint(&key), H256::from_uint(&value));
                     }
-                    log.storage = Some(contract_storage.clone());
+
+                    if !contract_storage.is_empty() {
+                        log.storage = Some(contract_storage.clone());
+                    }
                 }
                 if opts.disable_stack.unwrap_or_default() {
                     log.stack = None;

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -366,7 +366,11 @@ impl From<&CallTraceStep> for StructLog {
             memory: Some(convert_memory(step.memory.data())),
             op: step.op.to_string(),
             pc: step.pc as u64,
-            refund_counter: Some(step.gas_refund_counter),
+            refund_counter: if step.gas_refund_counter > 0 {
+                Some(step.gas_refund_counter)
+            } else {
+                None
+            },
             stack: Some(step.stack.data().clone()),
             // Filled in `CallTraceArena::geth_trace` as a result of compounding all slot changes
             storage: None,


### PR DESCRIPTION
## Motivation

continued work on top of https://github.com/foundry-rs/foundry/pull/3187
relevant piece of geth code: https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L181-L206

## Demo

Deposit WETH and debug this transaction
```bash
➜  ~ cast send --rpc-url http://localhost:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 deposit --value 1 --json |
jq -r .transactionHash |
xargs -I{} cast rpc --rpc-url http://localhost:8545 --raw debug_traceTransaction '["{}", {"enableMemory": true, "enableReturnData": true}]'
```

Check `SLOAD` instruction and storage slots associated with it (before, during, after)
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/5773434/190136876-5541dca4-143e-41b3-8f77-4b982dffa305.png">

Check `SSTORE` instruction and storage slots associated with it (before, during, after)
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/5773434/190136960-5bff0a6d-04db-4ca4-bf71-70faa05f8921.png">
