### PR TITLE
fix(forge/script): deployment size check

### DIFF
--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -165,10 +165,7 @@ impl ScriptArgs {
 
                 verify.known_contracts = unwrap_contracts(&highlevel_known_contracts, false);
 
-                self.check_contract_sizes(
-                    result.transactions.as_ref(),
-                    &highlevel_known_contracts,
-                )?;
+                self.check_contract_sizes(&result, &highlevel_known_contracts)?;
 
                 self.handle_broadcastable_transactions(
                     &target,

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -495,6 +495,7 @@ impl ScriptArgs {
             unreachable!("Create data was not raw");
         }
 
+        let mut prompt_user = false;
         for (data, to) in result.transactions.iter().flat_map(|txes| {
             txes.iter().filter_map(|tx| {
                 tx.data().filter(|data| data.len() > CONTRACT_MAX_SIZE).map(|data| (data, tx.to()))
@@ -519,6 +520,7 @@ impl ScriptArgs {
                 let deployment_size = deployed_code.len();
 
                 if deployment_size > CONTRACT_MAX_SIZE {
+                    prompt_user = self.broadcast;
                     println!(
                         "{}",
                         Paint::red(format!(
@@ -526,17 +528,16 @@ impl ScriptArgs {
                             name, deployment_size, CONTRACT_MAX_SIZE
                         ))
                     );
-
-                    if self.broadcast &&
-                        !Confirm::new()
-                            .with_prompt("Do you wish to continue?".to_string())
-                            .interact()?
-                    {
-                        eyre::bail!("User canceled the script.");
-                    }
                 }
             }
         }
+
+        if prompt_user &&
+            !Confirm::new().with_prompt("Do you wish to continue?".to_string()).interact()?
+        {
+            eyre::bail!("User canceled the script.");
+        }
+
         Ok(())
     }
 }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -492,7 +492,7 @@ impl ScriptArgs {
                 }
             }
             // Both should be raw and not decoded since it's just bytecode
-            unreachable!("Create data was not raw");
+            eyre::bail!("Create node returned decoded data: {:?}", node);
         }
 
         let mut prompt_user = false;

--- a/cli/tests/it/create.rs
+++ b/cli/tests/it/create.rs
@@ -148,7 +148,7 @@ forgetest_async!(
         let (_api, handle) = spawn(NodeConfig::test()).await;
         let rpc = handle.http_endpoint();
         let wallet = handle.dev_wallets().next().unwrap();
-        let pk = hex::encode(&wallet.signer().to_bytes());
+        let pk = hex::encode(wallet.signer().to_bytes());
         cmd.args(["init", "--force"]);
         cmd.assert_non_empty_stdout();
 

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -684,9 +684,7 @@ contract Script0 is Script {
         assert!(cmd.stdout_lossy().contains("SIMULATION COMPLETE"));
 
         let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast"))
-            .into_iter()
-            .filter(|file| file.ends_with("run-latest.json"))
-            .next()
+            .into_iter().find(|file| file.ends_with("run-latest.json"))
             .expect("No broadcast artifacts");
 
         let content = foundry_common::fs::read_to_string(run_latest).unwrap();
@@ -774,9 +772,7 @@ contract Script0 is Script {
         assert!(cmd.stdout_lossy().contains("SIMULATION COMPLETE"));
 
         let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast"))
-            .into_iter()
-            .filter(|file| file.ends_with("run-latest.json"))
-            .next()
+            .into_iter().find(|file| file.ends_with("run-latest.json"))
             .expect("No broadcast artifacts");
 
         let content = foundry_common::fs::read_to_string(run_latest).unwrap();

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -684,7 +684,8 @@ contract Script0 is Script {
         assert!(cmd.stdout_lossy().contains("SIMULATION COMPLETE"));
 
         let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast"))
-            .into_iter().find(|file| file.ends_with("run-latest.json"))
+            .into_iter()
+            .find(|file| file.ends_with("run-latest.json"))
             .expect("No broadcast artifacts");
 
         let content = foundry_common::fs::read_to_string(run_latest).unwrap();
@@ -772,7 +773,8 @@ contract Script0 is Script {
         assert!(cmd.stdout_lossy().contains("SIMULATION COMPLETE"));
 
         let run_latest = foundry_common::fs::json_files(prj.root().join("broadcast"))
-            .into_iter().find(|file| file.ends_with("run-latest.json"))
+            .into_iter()
+            .find(|file| file.ends_with("run-latest.json"))
             .expect("No broadcast artifacts");
 
         let content = foundry_common::fs::read_to_string(run_latest).unwrap();

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -11,7 +11,7 @@ use foundry_config::Config;
 use foundry_utils::Retry;
 use std::{fs, path::PathBuf};
 
-const VERIFICATION_PROVIDERS: &'static [&'static str] = &["etherscan", "sourcify"];
+const VERIFICATION_PROVIDERS: &[&str] = &["etherscan", "sourcify"];
 
 /// Adds a `Unique` contract to the source directory of the project that can be imported as
 /// `import {Unique} from "./unique.sol";`
@@ -366,7 +366,7 @@ forgetest_async!(
         assert!(stdout.contains("Sending transactions [0 - 4]"), "{}", err);
 
         // ensure all transactions are successful
-        assert_eq!(5, stdout.matches("✅").count(), "{}", err);
+        assert_eq!(5, stdout.matches('✅').count(), "{}", err);
 
         // ensure verified all deployments
         // Note: the 5th tx creates contracts internally, which are little flaky at times because


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Deployment sizes check introduced in #2619 would not work for arbitrary bytecode deployed without an artifact and thus pass without errors.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Check against bytecodes from both artifacts and traces

Tested with, closes #2923:

Before: https://mumbai.polygonscan.com/tx/0xcf74fcecf15120bcf703598b4f47411f46210a5b6ffcef46a3e3919fd04f629b
(max codesize exceeded revert)

After: 
![image](https://user-images.githubusercontent.com/57450786/190080204-e6e80225-4d50-4d4e-a38c-342514c50750.png)
