### PR TITLE
fix(evm): improve journaledstate handling on reverts

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -33,6 +33,7 @@ pub use diagnostic::RevertDiagnostic;
 pub mod error;
 use crate::executor::backend::{error::NoCheatcodeAccessError, in_memory_db::FoundryEvmInMemoryDB};
 pub use error::{DatabaseError, DatabaseResult};
+use foundry_config::Config;
 
 mod in_memory_db;
 
@@ -504,8 +505,12 @@ impl Backend {
         self.storage(CHEATCODE_ADDRESS, index).map(|value| value == U256::one()).unwrap_or_default()
     }
 
-    /// when creating or switching forks, we update the AccountInfo of the contract
-    pub(crate) fn update_fork_db(&self, journaled_state: &mut JournaledState, fork: &mut Fork) {
+    /// When creating or switching forks, we update the AccountInfo of the contract
+    pub(crate) fn update_fork_db(
+        &self,
+        active_journaled_state: &mut JournaledState,
+        target_fork: &mut Fork,
+    ) {
         debug_assert!(
             self.inner.test_contract_address.is_some(),
             "Test contract address must be set"
@@ -513,23 +518,23 @@ impl Backend {
 
         self.update_fork_db_contracts(
             self.inner.persistent_accounts.iter().copied(),
-            journaled_state,
-            fork,
+            active_journaled_state,
+            target_fork,
         )
     }
 
-    /// Copies the state of all `accounts` from the currently active db into the given `fork`
+    /// Merges the state of all `accounts` from the currently active db into the given `fork`
     pub(crate) fn update_fork_db_contracts(
         &self,
         accounts: impl IntoIterator<Item = Address>,
-        journaled_state: &mut JournaledState,
-        fork: &mut Fork,
+        active_journaled_state: &mut JournaledState,
+        target_fork: &mut Fork,
     ) {
         if let Some((_, fork_idx)) = self.active_fork_ids.as_ref() {
             let active = self.inner.get_fork(*fork_idx);
-            clone_data(accounts, &active.db, journaled_state, fork)
+            merge_account_data(accounts, &active.db, active_journaled_state, target_fork)
         } else {
-            clone_data(accounts, &self.mem_db, journaled_state, fork)
+            merge_account_data(accounts, &self.mem_db, active_journaled_state, target_fork)
         }
     }
 
@@ -713,12 +718,12 @@ impl DatabaseExt for Backend {
                         if !fork.db.accounts.contains_key(&caller) {
                             // update the caller account which is required by the evm
                             fork.db.insert_account_info(caller, caller_account.clone());
-                            let _ = with_journaled_account(
-                                &mut fork.journaled_state,
-                                &mut fork.db,
-                                caller,
-                                |_| (),
-                            );
+                            // let _ = with_journaled_account(
+                            //     &mut fork.journaled_state,
+                            //     &mut fork.db,
+                            //     caller,
+                            //     |_| (),
+                            // );
                         }
                         journaled_state.state.insert(caller, caller_account.into());
                     }
@@ -767,7 +772,7 @@ impl DatabaseExt for Backend {
         &mut self,
         id: LocalForkId,
         env: &mut Env,
-        journaled_state: &mut JournaledState,
+        active_journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "select fork");
         if self.is_active_fork(id) {
@@ -787,7 +792,7 @@ impl DatabaseExt for Backend {
         // If we're currently in forking mode we need to update the journaled_state to this point,
         // this ensures the changes performed while the fork was active are recorded
         if let Some(active) = self.active_fork_mut() {
-            active.journaled_state = journaled_state.clone();
+            active.journaled_state = active_journaled_state.clone();
 
             // if the Backend was launched in forking mode, then we also need to adjust the depth of
             // the `JournalState` at this point
@@ -801,17 +806,18 @@ impl DatabaseExt for Backend {
                     // launched in forking mode there never is a `depth` that can be set for the
                     // `fork_init_journaled_state` instead we need to manually bump the depth to the
                     // current depth of the call _once_
-                    target_fork.journaled_state.depth = journaled_state.depth;
+                    target_fork.journaled_state.depth = active_journaled_state.depth;
 
                     // we also need to initialize and touch the caller
                     if let Some(acc) = caller_account {
-                        target_fork.db.insert_account_info(caller, acc);
-                        let _ = with_journaled_account(
-                            &mut target_fork.journaled_state,
-                            &mut target_fork.db,
-                            caller,
-                            |_| (),
-                        );
+                        target_fork.db.insert_account_info(caller, acc.clone());
+                        target_fork.journaled_state.state.insert(caller, acc.into());
+                        // let _ = with_journaled_account(
+                        //     &mut target_fork.journaled_state,
+                        //     &mut target_fork.db,
+                        //     caller,
+                        //     |_| (),
+                        // );
                     }
                 }
             }
@@ -822,7 +828,7 @@ impl DatabaseExt for Backend {
             // first fork is selected, we need to update it for all forks and use it as init state
             // for all future forks
             trace!("recording fork init journaled_state");
-            self.fork_init_journaled_state = journaled_state.clone();
+            self.fork_init_journaled_state = active_journaled_state.clone();
             self.prepare_init_journal_state()?;
         }
 
@@ -834,7 +840,7 @@ impl DatabaseExt for Backend {
         // the current sender
         let caller = env.tx.caller;
         if !fork.journaled_state.state.contains_key(&caller) {
-            let caller_account = journaled_state
+            let caller_account = active_journaled_state
                 .state
                 .get(&env.tx.caller)
                 .map(|acc| acc.info.clone())
@@ -843,18 +849,23 @@ impl DatabaseExt for Backend {
             if !fork.db.accounts.contains_key(&caller) {
                 // update the caller account which is required by the evm
                 fork.db.insert_account_info(caller, caller_account.clone());
-                let _ =
-                    with_journaled_account(&mut fork.journaled_state, &mut fork.db, caller, |_| ());
+                // let _ = with_journaled_account(
+                //     &mut fork.journaled_state,
+                //     &mut fork.db,
+                //     caller,
+                //     |_| (),
+                // );
             }
             fork.journaled_state.state.insert(caller, caller_account.into());
         }
 
-        self.update_fork_db(journaled_state, &mut fork);
+        self.update_fork_db(active_journaled_state, &mut fork);
         self.inner.set_fork(idx, fork);
 
         self.active_fork_ids = Some((id, idx));
         // update the environment accordingly
         update_current_env_with_fork_env(env, fork_env);
+
         Ok(())
     }
 
@@ -892,7 +903,7 @@ impl DatabaseExt for Backend {
                 active.journaled_state = self.fork_init_journaled_state.clone();
                 active.journaled_state.depth = journaled_state.depth;
                 for addr in persistent_addrs {
-                    clone_journaled_state_data(addr, journaled_state, &mut active.journaled_state);
+                    merge_journaled_state_data(addr, journaled_state, &mut active.journaled_state);
                 }
                 *journaled_state = active.journaled_state.clone();
             }
@@ -1287,7 +1298,7 @@ impl BackendInner {
             // we initialize a _new_ `ForkDB` but keep the state of persistent accounts
             let mut new_db = ForkDB::new(backend);
             for addr in self.persistent_accounts.iter().copied() {
-                clone_db_account_data(addr, &active.db, &mut new_db);
+                merge_db_account_data(addr, &active.db, &mut new_db);
             }
             active.db = new_db;
         }
@@ -1373,44 +1384,64 @@ pub(crate) fn update_current_env_with_fork_env(current: &mut Env, fork: Env) {
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`
-/// This includes the data held in storage (`CacheDB`) and kept in the `JournaledState`
-pub(crate) fn clone_data<ExtDB: DatabaseRef>(
+/// This includes the data held in storage (`CacheDB`) and kept in the `JournaledState`.
+pub(crate) fn merge_account_data<ExtDB: DatabaseRef>(
     accounts: impl IntoIterator<Item = Address>,
     active: &CacheDB<ExtDB>,
     active_journaled_state: &mut JournaledState,
-    fork: &mut Fork,
+    target_fork: &mut Fork,
 ) {
     for addr in accounts.into_iter() {
-        clone_db_account_data(addr, active, &mut fork.db);
-        clone_journaled_state_data(addr, active_journaled_state, &mut fork.journaled_state);
+        merge_db_account_data(addr, active, &mut target_fork.db);
+        merge_journaled_state_data(addr, active_journaled_state, &mut target_fork.journaled_state);
     }
 
-    *active_journaled_state = fork.journaled_state.clone();
+    // need to mock empty journal entries in case the current checkpoint is higher than the existing
+    // journal entries
+    while active_journaled_state.journal.len() > target_fork.journaled_state.journal.len() {
+        target_fork.journaled_state.journal.push(Default::default());
+    }
+
+    *active_journaled_state = target_fork.journaled_state.clone();
 }
 
 /// Clones the account data from the `active_journaled_state`  into the `fork_journaled_state`
-fn clone_journaled_state_data(
+fn merge_journaled_state_data(
     addr: Address,
     active_journaled_state: &JournaledState,
     fork_journaled_state: &mut JournaledState,
 ) {
-    if let Some(acc) = active_journaled_state.state.get(&addr).cloned() {
+    if let Some(mut acc) = active_journaled_state.state.get(&addr).cloned() {
         trace!(?addr, "updating journaled_state account data");
+        if let Some(fork_account) = fork_journaled_state.state.get_mut(&addr) {
+            // This will merge the fork's tracked storage with active storage and update values
+            fork_account.storage.extend(std::mem::take(&mut acc.storage));
+            // swap them so we can insert the account as whole in the next step
+            std::mem::swap(&mut fork_account.storage, &mut acc.storage);
+        }
         fork_journaled_state.state.insert(addr, acc);
     }
 }
 
 /// Clones the account data from the `active` db into the `ForkDB`
-fn clone_db_account_data<ExtDB: DatabaseRef>(
+fn merge_db_account_data<ExtDB: DatabaseRef>(
     addr: Address,
     active: &CacheDB<ExtDB>,
     fork_db: &mut ForkDB,
 ) {
     trace!(?addr, "cloning database data");
-    let acc = active.accounts.get(&addr).cloned().unwrap_or_default();
+    let mut acc = active.accounts.get(&addr).cloned().unwrap_or_default();
     if let Some(code) = active.contracts.get(&acc.info.code_hash).cloned() {
         fork_db.contracts.insert(acc.info.code_hash, code);
     }
+
+    if let Some(fork_account) = fork_db.accounts.get_mut(&addr) {
+        // This will merge the fork's tracked storage with active storage and update values
+        fork_account.storage.extend(std::mem::take(&mut acc.storage));
+        // swap them so we can insert the account as whole in the next step
+        std::mem::swap(&mut fork_account.storage, &mut acc.storage);
+    }
+
     fork_db.accounts.insert(addr, acc);
 }
 

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -128,3 +128,9 @@ fn test_issue_3223() {
         Address::from_str("0xF0959944122fb1ed4CfaBA645eA06EED30427BAA").unwrap()
     );
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3220>
+#[test]
+fn test_issue_3220() {
+    test_repro!("Issue3220");
+}

--- a/testdata/repros/Issue3220.t.sol
+++ b/testdata/repros/Issue3220.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3220
+contract Issue3220Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+    uint256 fork1;
+    uint256 fork2;
+
+    function setUp() public {
+        fork1 = vm.createFork("rpcAlias", 7475589);
+        fork2 = vm.createFork("rpcAlias", 12880747);
+        vm.selectFork(fork1);
+    }
+
+    function testForkSwapSelect() public {
+        assertEq(fork1, vm.activeFork());
+        vm.selectFork(fork2);
+    }
+}

--- a/testdata/repros/Issue3220.t.sol
+++ b/testdata/repros/Issue3220.t.sol
@@ -9,15 +9,35 @@ contract Issue3220Test is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
     uint256 fork1;
     uint256 fork2;
+    uint256 counter;
 
     function setUp() public {
         fork1 = vm.createFork("rpcAlias", 7475589);
-        fork2 = vm.createFork("rpcAlias", 12880747);
         vm.selectFork(fork1);
+        fork2 = vm.createFork("rpcAlias", 12880747);
+
     }
 
-    function testForkSwapSelect() public {
-        assertEq(fork1, vm.activeFork());
+    function testForkRevert() public {
         vm.selectFork(fork2);
+        vm.selectFork(fork1);
+
+        // do a bunch of work to increase the revm checkpoint counter
+        for (uint256 i = 0; i < 10; i++) {
+            mockCount();
+        }
+
+        vm.selectFork(fork2);
+
+        vm.expectRevert("This fails");
+        doRevert();
+    }
+
+    function doRevert() public {
+        revert("This fails");
+    }
+
+    function mockCount() public {
+        counter+=1;
     }
 }

--- a/testdata/repros/Issue3220.t.sol
+++ b/testdata/repros/Issue3220.t.sol
@@ -15,7 +15,6 @@ contract Issue3220Test is DSTest {
         fork1 = vm.createFork("rpcAlias", 7475589);
         vm.selectFork(fork1);
         fork2 = vm.createFork("rpcAlias", 12880747);
-
     }
 
     function testForkRevert() public {
@@ -38,6 +37,6 @@ contract Issue3220Test is DSTest {
     }
 
     function mockCount() public {
-        counter+=1;
+        counter += 1;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3220

There where a couple of issues with how multiple journaledstates would behave on reverts.

Revm uses checkpoints to track what to revert in case of a revert, these are tracked in the evm impl. But since we're replacing them on `selectFork` those checkpoints don't necessarily match if there's a revert after selecting another fork. which would lead to an underflow here https://github.com/bluealloy/revm/blob/1e25c99b544863d15610e9af8e623dd173397b48/crates/revm/src/journaled_state.rs#L430

This is fixed by simply adding empty JournalEntries when another fork is selected.

The other issue was with how the init `JournaledState` was determined:

https://github.com/foundry-rs/foundry/blob/233ba5c4da31c353cad44fbc067b8bb7028689c0/evm/src/executor/backend/mod.rs#L819-L825

however this not quite correct since this pattern is possible and used in #3220:

```solidity
    function setUp() public {
        fork1 = vm.createFork("rpcAlias", 7475589);
        vm.selectFork(fork1);
        fork2 = vm.createFork("rpcAlias", 12880747);
        // modify test contract state
    }
```

now the initial journaledstate would miss out on additional changes (missing `JournalEntry::StorageChanged`), which would lead to a panic on revert.

this is fixed by merging the state instead of cloning `active -> target fork`, this way we ensure we always have all storage entries for persistent accounts.

Another issue was that the caller was erroneously `touched` (`JournalEntry::AccountTouched`) which would result in another panic on revert.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
