### PR TITLE
refactor: move compile mod to common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,7 +2202,10 @@ dependencies = [
 name = "foundry-common"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "clap 3.2.16",
+ "comfy-table",
+ "dunce",
  "ethers-core",
  "ethers-providers",
  "ethers-solc",
@@ -2210,10 +2213,14 @@ dependencies = [
  "foundry-config",
  "once_cell",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
+ "tracing",
  "walkdir",
+ "yansi",
 ]
 
 [[package]]

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -277,7 +277,7 @@ mod tests {
         let wallet = args.run().unwrap();
         let addr = wallet.address();
         let addr = format!("{addr:x}");
-        assert!(addr.starts_with("9"));
+        assert!(addr.starts_with('9'));
     }
 
     #[test]

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -1,9 +1,9 @@
 use crate::cmd::utils::{Cmd, LoadConfig};
 
-use crate::{cmd::forge::build::CoreBuildArgs, compile};
+use crate::cmd::forge::build::CoreBuildArgs;
 use clap::{Parser, ValueHint};
 use ethers::contract::{Abigen, ContractFilter, ExcludeContracts, MultiAbigen, SelectContracts};
-use foundry_common::fs::json_files;
+use foundry_common::{compile, fs::json_files};
 use foundry_config::{
     figment::{
         self,

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -1,16 +1,14 @@
 //! Build command
-use crate::{
-    cmd::{
-        forge::{
-            install::{self},
-            watch::WatchArgs,
-        },
-        Cmd, LoadConfig,
+use crate::cmd::{
+    forge::{
+        install::{self},
+        watch::WatchArgs,
     },
-    compile,
+    Cmd, LoadConfig,
 };
 use clap::Parser;
 use ethers::solc::{Project, ProjectCompileOutput};
+use foundry_common::compile;
 use foundry_config::{
     figment::{
         self,

--- a/cli/src/cmd/forge/config.rs
+++ b/cli/src/cmd/forge/config.rs
@@ -1,11 +1,8 @@
 //! config command
 
-use crate::{
-    cmd::{forge::build::BuildArgs, utils::Cmd, LoadConfig},
-    term::cli_warn,
-};
+use crate::cmd::{forge::build::BuildArgs, utils::Cmd, LoadConfig};
 use clap::Parser;
-use foundry_common::evm::EvmArgs;
+use foundry_common::{evm::EvmArgs, term::cli_warn};
 use foundry_config::fix::fix_tomls;
 
 foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -4,7 +4,6 @@ use crate::{
         forge::{build::CoreBuildArgs, test::Filter},
         Cmd, LoadConfig,
     },
-    compile::ProjectCompiler,
     utils::{self, p_println, STATIC_FUZZ_SEED},
 };
 use clap::{AppSettings, ArgEnum, Parser};
@@ -28,7 +27,7 @@ use forge::{
     utils::{build_ic_pc_map, ICPCMap},
     MultiContractRunnerBuilder, TestOptions,
 };
-use foundry_common::{evm::EvmArgs, fs, ContractsByArtifact};
+use foundry_common::{compile::ProjectCompiler, evm::EvmArgs, fs, ContractsByArtifact};
 use foundry_config::Config;
 use semver::Version;
 use std::{collections::HashMap, sync::mpsc::channel, thread};

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -5,7 +5,6 @@ use crate::{
         forge::build::CoreBuildArgs, read_constructor_args_file, remove_contract,
         retry::RETRY_VERIFY_ON_CREATE, LoadConfig,
     },
-    compile,
     opts::{EthereumOpts, TransactionOpts, WalletType},
 };
 use cast::SimpleCast;
@@ -17,7 +16,7 @@ use ethers::{
     types::{transaction::eip2718::TypedTransaction, Chain},
 };
 use eyre::Context;
-use foundry_common::get_http_provider;
+use foundry_common::{compile, get_http_provider};
 use foundry_utils::parse_tokens;
 use rustc_hex::ToHex;
 use serde_json::json;

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -1,12 +1,11 @@
 use crate::{
     cmd::{Cmd, LoadConfig},
-    term::cli_warn,
     utils::FoundryPathExt,
 };
 use clap::{Parser, ValueHint};
 use console::{style, Style};
 use forge_fmt::{format, parse};
-use foundry_common::fs;
+use foundry_common::{fs, term::cli_warn};
 use foundry_config::{impl_figment_convert_basic, Config};
 use rayon::prelude::*;
 use similar::{ChangeTag, TextDiff};

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -1,10 +1,10 @@
 use crate::{
     cmd::forge::build::{CoreBuildArgs, ProjectPathsArgs},
-    compile,
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
 use ethers::prelude::artifacts::output_selection::ContractOutputSelection;
+use foundry_common::compile;
 use foundry_utils::selectors::{import_selectors, SelectorImportData};
 
 #[derive(Debug, Clone, Parser)]

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -3,7 +3,6 @@ use crate::{
         forge::build::{self, CoreBuildArgs},
         Cmd,
     },
-    compile,
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
@@ -18,6 +17,7 @@ use ethers::{
     },
     solc::utils::canonicalize,
 };
+use foundry_common::compile;
 
 use serde_json::{to_value, Value};
 use std::{fmt, str::FromStr};

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{cmd::get_cached_entry_by_name, compile};
+use crate::cmd::get_cached_entry_by_name;
 use ethers::{
     prelude::{
         artifacts::Libraries, cache::SolFilesCache, ArtifactId, Graph, Project,
@@ -12,6 +12,7 @@ use ethers::{
     types::{Address, U256},
 };
 use eyre::{Context, ContextCompat};
+use foundry_common::compile;
 use foundry_utils::PostLinkInput;
 use std::{collections::BTreeMap, fs, str::FromStr};
 use tracing::warn;

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -4,8 +4,6 @@ use crate::{
         forge::{build::CoreBuildArgs, debug::DebugArgs, install, watch::WatchArgs},
         Cmd, LoadConfig,
     },
-    compile,
-    compile::ProjectCompiler,
     suggestions, utils,
 };
 use cast::fuzz::CounterExample;
@@ -22,7 +20,10 @@ use forge::{
     },
     MultiContractRunner, MultiContractRunnerBuilder, TestOptions,
 };
-use foundry_common::evm::EvmArgs;
+use foundry_common::{
+    compile::{self, ProjectCompiler},
+    evm::EvmArgs,
+};
 use foundry_config::{figment, Config};
 use regex::Regex;
 use std::{collections::BTreeMap, path::PathBuf, sync::mpsc::channel, thread, time::Duration};

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -1,4 +1,4 @@
-use crate::{suggestions, term::cli_warn};
+use crate::suggestions;
 use ethers::{
     abi::Abi,
     core::types::Chain,
@@ -13,7 +13,7 @@ use ethers::{
 };
 use eyre::WrapErr;
 use forge::executor::opts::EvmOpts;
-use foundry_common::{fs, ContractsByArtifact, TestFunctionExt};
+use foundry_common::{cli_warn, fs, ContractsByArtifact, TestFunctionExt};
 use foundry_config::{figment::Figment, Chain as ConfigChain, Config};
 use std::{collections::BTreeMap, path::PathBuf};
 use yansi::Paint;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,5 @@
 pub mod cmd;
-pub mod compile;
 pub mod handler;
 pub mod opts;
 pub mod suggestions;
-pub mod term;
 pub mod utils;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -28,6 +28,12 @@ clap = { version = "3.0.10", features = [
     "unicode",
     "wrap_help",
 ] }
+comfy-table = "6.0.0"
+tracing = "0.1"
+atty = "0.2.14"
+yansi = "0.5.1"
+tempfile = "3.3.0"
+
 
 #  misc
 serde = "1.0.133"
@@ -35,4 +41,6 @@ serde_json = "1.0.67"
 thiserror = "1.0.31"
 eyre = "0.6"
 walkdir = "2.3.2"
+semver = "1.0.5"
 once_cell = "1.13.1"
+dunce = "1.0.2"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,9 +1,9 @@
 //! Common utilities for building and using foundry's tools.
-
 #![deny(missing_docs, unused_crate_dependencies)]
 
 pub mod calc;
 pub mod clap_helpers;
+pub mod compile;
 pub mod constants;
 pub mod contracts;
 pub mod errors;
@@ -13,6 +13,7 @@ pub mod fs;
 pub mod provider;
 pub mod shell;
 pub use provider::*;
+pub mod term;
 pub mod traits;
 pub use constants::*;
 pub use contracts::*;

--- a/common/src/term.rs
+++ b/common/src/term.rs
@@ -1,7 +1,6 @@
 //! terminal utils
-
 use atty::{self, Stream};
-use ethers::solc::{
+use ethers_solc::{
     remappings::Remapping,
     report::{self, BasicStdoutReporter, Reporter, SolcCompilerIoReporter},
     CompilerInput, CompilerOutput, Solc,
@@ -38,6 +37,7 @@ pub struct TermSettings {
 }
 
 impl TermSettings {
+    #[allow(missing_docs)]
     pub fn from_env() -> TermSettings {
         if atty::is(Stream::Stdout) {
             TermSettings { indicate_progress: true }
@@ -47,6 +47,7 @@ impl TermSettings {
     }
 }
 
+#[allow(missing_docs)]
 pub struct Spinner {
     indicator: &'static [&'static str],
     no_progress: bool,
@@ -55,6 +56,7 @@ pub struct Spinner {
 }
 
 #[allow(unused)]
+#[allow(missing_docs)]
 impl Spinner {
     pub fn new(msg: impl Into<String>) -> Self {
         Self::with_indicator(SPINNERS[0], msg)
@@ -231,6 +233,8 @@ pub fn with_spinner_reporter<T>(f: impl FnOnce() -> T) -> T {
     report::with_scoped(&reporter, f)
 }
 
+#[macro_export]
+/// Displays warnings on the cli
 macro_rules! cli_warn {
     ($($arg:tt)*) => {
         eprintln!(
@@ -242,7 +246,7 @@ macro_rules! cli_warn {
     }
 }
 
-pub(crate) use cli_warn;
+pub use cli_warn;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
extracts `cli::compile --> foundry_common::compile` from #3006
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
