### PR TITLE
fix(evm): handover depth in multifork

### DIFF
--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -30,7 +30,6 @@ pub struct Tracer {
 impl Tracer {
     pub fn with_steps_recording(mut self) -> Self {
         self.record_steps = true;
-
         self
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3237

In multifork, each fork has its own `State` that tracks the current depth separately.
which could result in out of bounds errors in the tracer that uses the depth to populate the tree. 

Under normal circumstances there are no gaps in depth, however, in multifork that could end up happening.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
When selecting a different fork, handover the current depth, this ensures there are no gaps and the selected fork starts at the same depth 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
