### PR TITLE
feat: add deployedCode cheatcode

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -66,6 +66,7 @@ ethers::contract::abigen!(
             expectCall(address,bytes)
             expectCall(address,uint256,bytes)
             getCode(string)
+            getDeployedCode(string)
             label(address,string)
             assume(bool)
             setNonce(address,uint64)

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -228,7 +228,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::Etch(inner) => {
             let code = inner.1.clone();
-
+            trace!(address=?inner.0, code=?hex::encode(&code.0), "etch cheatcode");
             // TODO: Does this increase gas usage?
             data.journaled_state
                 .load_account(inner.0, data.db)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I started this while investigating why patching code for a precompile via

```solidity
  vm.etch(arbSys, vm.getCode("ArbitrumDomain.sol:ArbSysOverride"));
```

didn't work.

This doesn't work, simply because `getCode` returns the _deployment_ code

the books's example is:


```solidity
bytes memory args = abi.encode(arg1, arg2);
bytes memory bytecode = abi.encodePacked(vm.getCode("ArbitrumDomain.sol:ArbSysOverride"), args);
address deployedAddress;
assembly {
    deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
}
```

The same result could then be achieved by adding:

```solidity
bytes memory code = address(deployedAddress).code;
vm.etch(arbSys, code);
```

for stateless contracts this would be equal to

```solidity
 vm.etch(arbSys, vm.getDeployedCode("ArbitrumDomain.sol:ArbSysOverride"));
```

I don't have a strong opinion about whether we need a `getDeployedCode` cheatcode, but since patching precompiles is a legitimate use case, this would make it easier.

will definitely add an example to the book 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
