### PR TITLE
chore: handle etherscan blocked by cloudflare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#9773a76dd422ed8c625ac994f0ffbb5f7c20fc1c"
+source = "git+https://github.com/gakonst/ethers-rs#78e406b2619340053d3d55d504621b6077add7b9"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",

--- a/evm/src/trace/identifier/etherscan.rs
+++ b/evm/src/trace/identifier/etherscan.rs
@@ -187,7 +187,13 @@ impl Stream for EtherscanFetcher {
                         Err(EtherscanError::InvalidApiKey) => {
                             warn!(target: "etherscanidentifier", "invalid api key");
                             // mark key as invalid
-                            pin.invalid_api_key.store(false, Ordering::Relaxed);
+                            pin.invalid_api_key.store(true, Ordering::Relaxed);
+                            return Poll::Ready(None)
+                        }
+                        Err(EtherscanError::BlockedByCloudflare) => {
+                            warn!(target: "etherscanidentifier", "blocked by cloudflare");
+                            // mark key as invalid
+                            pin.invalid_api_key.store(true, Ordering::Relaxed);
                             return Poll::Ready(None)
                         }
                         Err(err) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
treat `BlockedByCloudflare` same as `InvalidApiKey` -> no more requests.

also fixes that we store the correct value `true`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
