### PR TITLE
fix(forge): fmt doc comment spacing

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -404,11 +404,12 @@ impl<'a, W: Write> Formatter<'a, W> {
                     .strip_suffix("*/")
                     .unwrap()
                     .trim();
-                let lines = content.lines().map(|line| line.trim_start());
+                let lines = content.lines();
                 writeln!(self.buf(), "/**")?;
                 for line in lines {
-                    let line = line.trim().trim_start_matches('*').trim_start();
-                    writeln!(self.buf(), "{}", format!(" * {line}").trim_end())?;
+                    let line = line.trim().trim_start_matches('*');
+                    let needs_space = line.chars().next().map_or(false, |ch| !ch.is_whitespace());
+                    writeln!(self.buf(), " *{}{}", if needs_space { " " } else { "" }, line)?;
                 }
                 write!(self.buf(), " */")?;
             } else {

--- a/fmt/testdata/DocComments/fmt.sol
+++ b/fmt/testdata/DocComments/fmt.sol
@@ -45,4 +45,13 @@ contract HelloWorld {
         s = w * h;
         p = 2 * (w + h);
     }
+
+    /**
+     * @notice Here is my comment
+     *       - item 1
+     *       - item 2
+     * Some equations:
+     *     y = mx + b
+     */
+    function anotherExample() external {}
 }

--- a/fmt/testdata/DocComments/original.sol
+++ b/fmt/testdata/DocComments/original.sol
@@ -42,4 +42,13 @@ contract HelloWorld {
         s = w * h;
         p = 2 * (w + h);
     }
+
+    /**
+     * @notice Here is my comment
+     *       - item 1
+     *       - item 2
+     * Some equations:
+     *     y = mx + b
+     */
+    function anotherExample() external {}
 }

--- a/fmt/testdata/SimpleComments/fmt.sol
+++ b/fmt/testdata/SimpleComments/fmt.sol
@@ -30,3 +30,12 @@ contract SimpleComments {
         // line comment
     }
 }
+
+/*
+ * @notice Here is my comment
+ *       - item 1
+ *       - item 2
+ * Some equations:
+ *     y = mx + b
+ */
+function test() {}

--- a/fmt/testdata/SimpleComments/original.sol
+++ b/fmt/testdata/SimpleComments/original.sol
@@ -30,3 +30,12 @@ contract SimpleComments {
         // line comment
     }
 }
+
+/*
+ * @notice Here is my comment
+ *       - item 1
+ *       - item 2
+ * Some equations:
+ *     y = mx + b
+ */
+function test() {}


### PR DESCRIPTION
## Motivation

ref #3184

## Solution

don't trim doc comment line whitespaces