### PR TITLE
fix(evm): refactor executor & detect `setUp` assertion failures

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -177,9 +177,11 @@ impl<'a> Database for FuzzBackendWrapper<'a> {
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         DatabaseRef::basic(self, address)
     }
+
     fn code_by_hash(&mut self, code_hash: H256) -> Result<Bytecode, Self::Error> {
         DatabaseRef::code_by_hash(self, code_hash)
     }
+
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         DatabaseRef::storage(self, address, index)
     }

--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -23,7 +23,7 @@ use tracing::trace;
 /// a clone-on-write `Backend`, where cloning is only necessary if cheatcodes will modify the
 /// `Backend`
 ///
-/// Entire purpose of this type is for fuzzing. A test function fuzzer will repeatedly execute  the
+/// Entire purpose of this type is for fuzzing. A test function fuzzer will repeatedly execute the
 /// function via immutable raw (no state changes) calls.
 ///
 /// **N.B.**: we're assuming cheatcodes that alter the state (like multi fork swapping) are niche.

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -230,16 +230,16 @@ impl Executor {
                     Err(EvmError::Execution {
                         reverted: res.reverted,
                         reason: "execution error".to_owned(),
-                        traces: res.traces.clone(),
+                        traces: res.traces,
                         gas_used: res.gas_used,
                         gas_refunded: res.gas_refunded,
                         stipend: res.stipend,
-                        logs: res.logs.clone(),
-                        debug: res.debug.clone(),
-                        labels: res.labels.clone(),
+                        logs: res.logs,
+                        debug: res.debug,
+                        labels: res.labels,
                         state_changeset: None,
                         transactions: None,
-                        script_wallets: res.script_wallets.clone(),
+                        script_wallets: res.script_wallets,
                     })
                 }
             }
@@ -298,9 +298,6 @@ impl Executor {
         let env = self.build_test_env(from, TransactTo::Call(test_contract), calldata, value);
         let call_result = self.call_raw_with_env(env)?;
 
-        // if there are multiple forks we need to merge them
-        // TODO: not used let logs = self.backend.merged_logs(logs);
-
         convert_call_result(abi, &func, call_result)
     }
 
@@ -338,7 +335,6 @@ impl Executor {
         let mut env = self.build_test_env(from, TransactTo::Call(to), calldata, value);
         let mut db = FuzzBackendWrapper::new(self.backend());
         let result = db.inspect_ref(&mut env, &mut inspector);
-        // TODO: let logs = db.backend.merged_logs(logs);
 
         convert_executed_result(env, inspector, result)
     }

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -358,11 +358,12 @@ impl Executor {
         convert_executed_result(env, inspector, result)
     }
 
-    /// TODO:
+    /// Commit the changeset to the database and adjust `self.inspector_config`
+    /// values according to the executed call result
     fn commit(&mut self, result: &mut RawCallResult) {
         // persist changes to db
-        if let Some(changes) = result.state_changeset.clone() {
-            self.backend.commit(changes);
+        if let Some(changes) = result.state_changeset.as_ref() {
+            self.backend_mut().commit(changes.clone());
         }
         // Persist the changed block environment
         self.inspector_config.block = result.env.block.clone();
@@ -370,7 +371,6 @@ impl Executor {
         let mut cheatcodes = result.cheatcodes.take();
         if let Some(cheats) = cheatcodes.as_mut() {
             if !cheats.broadcastable_transactions.is_empty() {
-                // TODO: validate
                 // Clear broadcast state from cheatcode state
                 cheats.broadcastable_transactions.clear();
                 cheats.corrected_nonce = false;
@@ -701,9 +701,9 @@ pub struct RawCallResult {
     pub script_wallets: Vec<LocalWallet>,
     /// The `revm::Env` after the call
     pub env: Env,
-    /// TODO:
+    /// The cheatcode states after execution
     pub cheatcodes: Option<Cheatcodes>,
-    /// TODO:
+    /// The raw output of the execution
     pub out: TransactOut,
 }
 

--- a/forge/tests/it/core.rs
+++ b/forge/tests/it/core.rs
@@ -67,6 +67,16 @@ fn test_core() {
                 ],
             ),
             ("core/Abstract.t.sol:AbstractTest", vec![("testSomething()", true, None, None, None)]),
+            (
+                "core/FailingTestAfterFailedSetup.t.sol:FailingTestAfterFailedSetupTest",
+                vec![(
+                    "setUp()",
+                    false,
+                    Some("Setup failed: execution error".to_string()),
+                    None,
+                    None,
+                )],
+            ),
         ]),
     );
 }

--- a/testdata/core/FailingTestAfterFailedSetup.t.sol
+++ b/testdata/core/FailingTestAfterFailedSetup.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 
 contract FailingTestAfterFailedSetupTest is DSTest {
-
     function setUp() public {
         assertTrue(false);
     }

--- a/testdata/core/FailingTestAfterFailedSetup.t.sol
+++ b/testdata/core/FailingTestAfterFailedSetup.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+
+contract FailingTestAfterFailedSetupTest is DSTest {
+
+    function setUp() public {
+        assertTrue(false);
+    }
+
+    function testAssertSuccess() public {
+        assertTrue(true);
+    }
+
+    function testAssertFailure() public {
+        assertTrue(false);
+    }
+}


### PR DESCRIPTION
close #1291

Refactoring according to @onbjerg's comment

> We can refactor Executor such that we only really have the call_raw/call variants that return state changesets - call_committing/call_raw_committing would then just be very thin wrappers around these that also call db.commit(changeset). This cleans up the executor code a bit, and seems like the right path forward. I think I did attempt this at some point, but there was some annoyances in some other parts of the code so I shelved it to get REVM over the line.