### PR TITLE
fix(cast): interface struct member access

### DIFF
--- a/utils/src/abi.rs
+++ b/utils/src/abi.rs
@@ -295,6 +295,8 @@ fn format_struct_types(structs: &InternalStructs) -> String {
 }
 
 fn format_struct_field(name: &str, sol_struct: &SolStruct) -> String {
+    // strip member access if any
+    let name = name.split('.').last().unwrap();
     let mut def = format!("struct {} {{\n", name);
     for field in sol_struct.fields.iter() {
         let ty = match &field.ty {


### PR DESCRIPTION
## Motivation

close #3260. `cast interface` breaks if it encounters member accessed struct internal type like `struct Lib.StructType`

## Solution

strip top-level identifiers in struct name