### PR TITLE
chore: better private key error diagnostic

### DIFF
--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -4,13 +4,11 @@ pub mod forge;
 mod chain;
 mod dependency;
 mod ethereum;
-mod multi_wallet;
 mod transaction;
 mod wallet;
 
 pub use chain::*;
 pub use dependency::*;
 pub use ethereum::*;
-pub use multi_wallet::*;
 pub use transaction::*;
 pub use wallet::*;

--- a/cli/src/opts/wallet/error.rs
+++ b/cli/src/opts/wallet/error.rs
@@ -1,0 +1,11 @@
+//! Errors when working with wallets
+
+use hex::FromHexError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivateKeyError {
+    #[error("Failed to create wallet from private key. Private key is invalid hex: {0}")]
+    InvalidHex(#[from] FromHexError),
+    #[error("Failed to create wallet from private key. Invalid private key. But env var {0} exists. Is the `$` anchor missing?")]
+    ExistsAsEnvVar(String),
+}

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -1,10 +1,4 @@
-use itertools::izip;
-use std::{
-    collections::{HashMap, HashSet},
-    iter::repeat,
-    sync::Arc,
-};
-
+use super::{WalletTrait, WalletType};
 use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
@@ -13,12 +7,15 @@ use ethers::{
     types::Address,
 };
 use eyre::{Context, Result};
-
 use foundry_common::RetryProvider;
 use foundry_config::Config;
+use itertools::izip;
 use serde::Serialize;
-
-use super::{wallet::WalletTrait, WalletType};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::repeat,
+    sync::Arc,
+};
 
 macro_rules! get_wallets {
     ($id:ident, [ $($wallets:expr),+ ], $call:expr) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2978

better error when parsing private key failed.

it can fail if:
* pk is invalid hex
* invalid signature, in which case we check if it's actually an env var (pk env var names can be valid hex)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
