### PR TITLE
deps(fmt): bump ethers, solang-parser 0.1.18 & support for overriding function selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.6",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#f208fb9cd348cd7749db126e08054d0c3b88d866"
+source = "git+https://github.com/gakonst/ethers-rs#f0aceb86b546999e4d2a9604f48a132fc720a961"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd659de36c2a8ce8cba4627e2304121acbf57d00589779a5ec3ab24569dc684"
+checksum = "ac8ac4bfef383f368bd9bb045107a501cd9cd0b64ad1983e1b7e839d6a44ecad"
 dependencies = [
  "itertools",
  "lalrpop",
@@ -5188,8 +5188,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.17"
-source = "git+https://github.com/roynalnaruto/svm-rs#3d55c338c61939641a18b56ffe77095ab74d46cd"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4cdcf91153dc0e4e0637f26f042ada32a3b552bc8115935c7bf96f80132b0a"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5231,9 +5232,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6348,3 +6349,8 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[patch.unused]]
+name = "svm-rs"
+version = "0.2.17"
+source = "git+https://github.com/roynalnaruto/svm-rs#3d55c338c61939641a18b56ffe77095ab74d46cd"

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ethereum", "web3", "solidity", "linter"]
 
 [dependencies]
 semver = "1.0.4"
-solang-parser = "=0.1.17"
+solang-parser = "=0.1.18"
 itertools = "0.10.3"
 thiserror = "1.0.30"
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -2195,6 +2195,11 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                     self.write_chunk(&base_or_modifier)?;
                 }
             }
+            // substrate compatibility
+            FunctionAttribute::NameValue(loc, ident, expr) => {
+                let expr = self.simulate_to_string(|fmt| expr.visit(fmt))?;
+                write_chunk!(self, loc.start(), loc.end(), "{}={}", ident.name, expr)?;
+            }
         };
 
         Ok(())
@@ -3415,4 +3420,5 @@ mod tests {
     test_directory! { NumberLiteralUnderscore }
     test_directory! { FunctionCall }
     test_directory! { TrailingComma }
+    test_directory! { SelectorOverride }
 }

--- a/fmt/src/solang_ext/ast_eq.rs
+++ b/fmt/src/solang_ext/ast_eq.rs
@@ -462,6 +462,7 @@ derive_ast_eq! { enum FunctionAttribute {
     Immutable(loc),
     Override(loc, idents),
     BaseOrModifier(loc, base),
+    NameValue(loc, ident, expr),
     _
 }}
 derive_ast_eq! { enum StorageLocation {

--- a/fmt/src/solang_ext/attr_sort_key.rs
+++ b/fmt/src/solang_ext/attr_sort_key.rs
@@ -24,7 +24,7 @@ impl AttrSortKey for FunctionAttribute {
             FunctionAttribute::Mutability(..) => 1,
             FunctionAttribute::Virtual(..) => 2,
             FunctionAttribute::Immutable(..) => 3,
-            FunctionAttribute::Override(..) => 4,
+            FunctionAttribute::Override(..) | FunctionAttribute::NameValue(..) => 4,
             FunctionAttribute::BaseOrModifier(..) => 5,
         }
     }

--- a/fmt/src/solang_ext/loc.rs
+++ b/fmt/src/solang_ext/loc.rs
@@ -397,7 +397,8 @@ impl LineOfCode for FunctionAttribute {
             FunctionAttribute::Virtual(loc) |
             FunctionAttribute::Immutable(loc) |
             FunctionAttribute::Override(loc, _) |
-            FunctionAttribute::BaseOrModifier(loc, _) => *loc,
+            FunctionAttribute::BaseOrModifier(loc, _) |
+            FunctionAttribute::NameValue(loc, _, _) => *loc,
         }
     }
 }

--- a/fmt/testdata/SelectorOverride/fmt.sol
+++ b/fmt/testdata/SelectorOverride/fmt.sol
@@ -1,0 +1,13 @@
+// https://github.com/hyperledger/solang/blob/b867c8a6c7a1ee89d405993abef458fc59e9b0fb/tests/contract_testcases/ewasm/selector_override.sol
+contract SelectorOverride {
+    constructor() selector=hex"abcd" {}
+
+    modifier m() selector=hex"" {
+        _;
+    }
+
+    receive() external payable selector=hex"1" {}
+    fallback() external selector=hex"abc" {}
+    function i() internal selector=hex"abdd" {}
+    function p() private selector=hex"abdd" {}
+}

--- a/fmt/testdata/SelectorOverride/original.sol
+++ b/fmt/testdata/SelectorOverride/original.sol
@@ -1,0 +1,9 @@
+// https://github.com/hyperledger/solang/blob/b867c8a6c7a1ee89d405993abef458fc59e9b0fb/tests/contract_testcases/ewasm/selector_override.sol
+contract SelectorOverride {
+	constructor() selector=hex"abcd" {}
+	modifier m() selector=hex"" {_;}
+	receive() payable external selector=hex"1" {}
+	fallback() external selector=hex"abc" {}
+	function i() internal selector = hex"ab_dd" {}
+	function p() private selector = hex"ab_dd" {}
+}


### PR DESCRIPTION
close #3276

tangent: [tracking issue](https://github.com/ethereum/solidity/issues/11819) for overriding function selector in solidity