### PR TITLE
perf(cast): improve vanity wallet generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,7 +106,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
- "clap 3.2.16",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
  "crc 3.0.0",
@@ -168,7 +174,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
- "clap 3.2.16",
+ "clap",
  "futures",
  "hyper",
  "parity-tokio-ipc",
@@ -328,7 +334,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.1",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -545,10 +551,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -716,6 +719,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,17 +766,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
@@ -760,7 +779,7 @@ dependencies = [
  "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.15.0",
+ "textwrap",
  "unicase",
 ]
 
@@ -770,7 +789,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
- "clap 3.2.16",
+ "clap",
 ]
 
 [[package]]
@@ -779,7 +798,7 @@ version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed37b4c0c1214673eba6ad8ea31666626bf72be98ffb323067d973c48b4964b9"
 dependencies = [
- "clap 3.2.16",
+ "clap",
  "clap_complete",
 ]
 
@@ -1071,15 +1090,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast 0.3.0",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -1088,7 +1108,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1097,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast 0.3.0",
  "itertools",
@@ -1242,28 +1261,6 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.6",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2123,7 +2120,7 @@ dependencies = [
  "atty",
  "bytes",
  "cast 0.2.0",
- "clap 3.2.16",
+ "clap",
  "clap_complete",
  "clap_complete_fig",
  "color-eyre",
@@ -2203,7 +2200,7 @@ name = "foundry-common"
 version = "0.1.0"
 dependencies = [
  "atty",
- "clap 3.2.16",
+ "clap",
  "comfy-table",
  "dunce",
  "ethers-core",
@@ -2724,7 +2721,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -2771,7 +2768,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3002,12 +2999,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -4837,16 +4828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4863,7 +4844,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -4885,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -5193,7 +5174,7 @@ source = "git+https://github.com/roynalnaruto/svm-rs#3d55c338c61939641a18b56ffe7
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "clap 3.2.16",
+ "clap",
  "console 0.14.1",
  "dialoguer 0.8.0",
  "fs2",
@@ -5323,15 +5304,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
@@ -5385,7 +5357,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "num_threads",
  "time-macros",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,11 @@ repository = "https://github.com/foundry-rs/foundry"
 keywords = ["ethereum", "web3"]
 
 [build-dependencies]
-vergen = { version = "7.0", default-features = false, features = ["build", "rustc", "git"] }
+vergen = { version = "7.0", default-features = false, features = [
+    "build",
+    "rustc",
+    "git",
+] }
 
 [dependencies]
 # foundry internal
@@ -25,7 +29,12 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = fals
 solang-parser = "0.1.11"
 
 # cli
-clap = { version = "3.0.10", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "3.0.10", features = [
+    "derive",
+    "env",
+    "unicode",
+    "wrap_help",
+] }
 clap_complete = "3.0.4"
 clap_complete_fig = "3.2.4"
 yansi = "0.5.1"
@@ -36,11 +45,7 @@ console = "0.15.0"
 watchexec = "2.0.0"
 atty = "0.2.14"
 comfy-table = "6.0.0"
-reqwest = { version = "0.11.8", default-features = false, features = [
-    "json",
-    "rustls",
-    "rustls-native-certs"
-] }
+reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls", "rustls-native-certs"] }
 dotenv = "0.15.0"
 dialoguer = { version = "0.10.2", default-features = false }
 
@@ -65,7 +70,7 @@ serde_json = "1.0.67"
 regex = { version = "1.5.4", default-features = false }
 rpassword = "7.0.0"
 hex = "0.4.3"
-serde = { version = "1.0.133", features = ["derive"] }
+serde = { version="1.0.133", features = ["derive"] }
 itertools = "0.10.3"
 proptest = "1.0.0"
 semver = "1.0.5"
@@ -85,7 +90,7 @@ foundry-cli-test-utils = { path = "./test-utils" }
 pretty_assertions = "1.0.0"
 toml = "0.5"
 serial_test = "0.9.0"
-criterion = "0.3"
+criterion = "0.4.0"
 svm = { package = "svm-rs", version = "0.2.16", default-features = false, features = ["rustls"] }
 
 [features]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,11 +8,7 @@ repository = "https://github.com/foundry-rs/foundry"
 keywords = ["ethereum", "web3"]
 
 [build-dependencies]
-vergen = { version = "7.0", default-features = false, features = [
-    "build",
-    "rustc",
-    "git",
-] }
+vergen = { version = "7.0", default-features = false, features = ["build", "rustc", "git"] }
 
 [dependencies]
 # foundry internal
@@ -29,12 +25,7 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = fals
 solang-parser = "0.1.11"
 
 # cli
-clap = { version = "3.0.10", features = [
-    "derive",
-    "env",
-    "unicode",
-    "wrap_help",
-] }
+clap = { version = "3.0.10", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "3.0.4"
 clap_complete_fig = "3.2.4"
 yansi = "0.5.1"
@@ -45,7 +36,11 @@ console = "0.15.0"
 watchexec = "2.0.0"
 atty = "0.2.14"
 comfy-table = "6.0.0"
-reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls", "rustls-native-certs"] }
+reqwest = { version = "0.11.8", default-features = false, features = [
+    "json",
+    "rustls",
+    "rustls-native-certs"
+] }
 dotenv = "0.15.0"
 dialoguer = { version = "0.10.2", default-features = false }
 
@@ -70,7 +65,7 @@ serde_json = "1.0.67"
 regex = { version = "1.5.4", default-features = false }
 rpassword = "7.0.0"
 hex = "0.4.3"
-serde = { version="1.0.133", features = ["derive"] }
+serde = { version = "1.0.133", features = ["derive"] }
 itertools = "0.10.3"
 proptest = "1.0.0"
 semver = "1.0.5"
@@ -114,4 +109,8 @@ doc = false
 
 [[bench]]
 name = "forge_test"
+harness = false
+
+[[bench]]
+name = "cast"
 harness = false

--- a/cli/benches/cast.rs
+++ b/cli/benches/cast.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use foundry_cli::cmd::cast::wallet::vanity::*;
+use rayon::prelude::*;
+use std::time::Duration;
+
+/// Benches `cast wallet vanity`
+///
+/// Left or right matchers, with or without nonce do not change the outcome.
+///
+/// Regex matchers get optimised away even with a black_box.
+fn vanity(c: &mut Criterion) {
+    let mut g = c.benchmark_group("vanity");
+
+    g.sample_size(500);
+    g.noise_threshold(0.04);
+    g.measurement_time(Duration::from_secs(30));
+
+    g.bench_function("wallet generator", |b| b.iter(|| black_box(generate_wallet())));
+
+    // 1
+
+    g.sample_size(150);
+    g.noise_threshold(0.02);
+
+    g.bench_function("match 1", |b| {
+        let m = LeftHexMatcher { left: v(0, 1) };
+        let matcher = matcher(m);
+        b.iter(|| wallet_generator().find_any(|x| black_box(matcher(x))))
+    });
+
+    // 2
+
+    g.sample_size(10);
+    g.noise_threshold(0.01);
+    g.measurement_time(Duration::from_secs(60));
+
+    g.bench_function("match 2", |b| {
+        let m = LeftHexMatcher { left: v(0, 2) };
+        let matcher = matcher(m);
+        b.iter(|| wallet_generator().find_any(|x| black_box(matcher(x))))
+    });
+
+    g.finish();
+}
+
+fn v(byte: u8, times: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(times);
+    for _ in 0..times {
+        v.push(byte)
+    }
+    v
+}
+
+// fn r(byte: u8, times: usize) -> Regex {
+//     Regex::new(format!("{}{{{}}}", byte, times).as_str()).unwrap()
+// }
+
+criterion_group!(vanity_benches, vanity);
+criterion_main!(vanity_benches);

--- a/cli/benches/cast.rs
+++ b/cli/benches/cast.rs
@@ -24,7 +24,7 @@ fn vanity(c: &mut Criterion) {
 
     g.bench_function("match 1", |b| {
         let m = LeftHexMatcher { left: v(0, 1) };
-        let matcher = matcher(m);
+        let matcher = create_matcher(m);
         b.iter(|| wallet_generator().find_any(|x| black_box(matcher(x))))
     });
 
@@ -36,7 +36,7 @@ fn vanity(c: &mut Criterion) {
 
     g.bench_function("match 2", |b| {
         let m = LeftHexMatcher { left: v(0, 2) };
-        let matcher = matcher(m);
+        let matcher = create_matcher(m);
         b.iter(|| wallet_generator().find_any(|x| black_box(matcher(x))))
     });
 

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -12,7 +12,8 @@ use ethers::{
     types::{Address, Chain, Signature},
 };
 use std::str::FromStr;
-mod vanity;
+
+pub mod vanity;
 
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -132,12 +132,13 @@ impl Cmd for VanityArgs {
     }
 }
 
-/// Uses [wallet_generator] to find a match by using `matcher`, returning the Wallet.
+/// Generates random wallets until `matcher` matches the wallet address, returning the wallet.
 pub fn find_vanity_address<T: VanityMatcher>(matcher: T) -> Option<LocalWallet> {
     wallet_generator().find_any(create_matcher(matcher)).map(|(key, _)| key.into())
 }
 
-/// Generates random wallets until a match is found by using `matcher`, returning the Wallet.
+/// Generates random wallets until `matcher` matches the contract address created at `nonce`,
+/// returning the wallet.
 pub fn find_vanity_address_with_nonce<T: VanityMatcher>(
     matcher: T,
     nonce: u64,
@@ -146,15 +147,15 @@ pub fn find_vanity_address_with_nonce<T: VanityMatcher>(
     wallet_generator().find_any(create_nonce_matcher(matcher, nonce)).map(|(key, _)| key.into())
 }
 
-/// Creates a nonce matcher function, which takes a [GeneratedWallet] and returns whether it found a
-/// match or not by using `matcher`.
+/// Creates a nonce matcher function, which takes a reference to a [GeneratedWallet] and returns
+/// whether it found a match or not by using `matcher`.
 #[inline]
 pub fn create_matcher<T: VanityMatcher>(matcher: T) -> impl Fn(&GeneratedWallet) -> bool {
     move |(_, addr)| matcher.is_match(addr)
 }
 
-/// Creates a nonce matcher function, which takes a [GeneratedWallet] and a nonce and returns
-/// whether it found a match or not by using `matcher`.
+/// Creates a nonce matcher function, which takes a reference to a [GeneratedWallet] and a nonce and
+/// returns whether it found a match or not by using `matcher`.
 #[inline]
 pub fn create_nonce_matcher<T: VanityMatcher>(
     matcher: T,
@@ -172,7 +173,7 @@ pub fn wallet_generator() -> impl ParallelIterator<Item = GeneratedWallet> {
     std::iter::repeat(()).par_bridge().map(|_| generate_wallet())
 }
 
-/// Generates a random private key and derives its Ethereum address using [thread_rng].
+/// Generates a random K-256 signing key and derives its Ethereum address.
 pub fn generate_wallet() -> GeneratedWallet {
     let key = SigningKey::random(&mut thread_rng());
     let address = secret_key_to_address(&key);


### PR DESCRIPTION
## Motivation

`iter::repeat_with`'s function is not executed in parallel and is 20x slower than when called with any other constant time iterator (ranges etc) paired with a parallel map

## Solution

- fix: hex_address_validator in the wrong spot
- perf: use `iter::repeat` (interchangeable with `(0..)`) with a parallel map instead of `iter::repeat_with`

## Benches

### System info

- Using CPU
  - OS: Ubuntu 22.04.1 LTS x86_64
  - Kernel: 5.15.0-47-generic
  - CPU: AMD Ryzen 9 5900X (24) @ 3.700GHz

- Using GPU
  - OS: Windows 10 Pro
  - Build: 19041.1.amd64fre.vb_release.191206-1406
  - GPU: NVIDIA GeForce RTX 3060

- Rust: latest nightly
- Browser: Brave

---

### [profanity](https://github.com/johguse/profanity) (old README.md benches)
- GTX 1070 OC: 179M/s
- GTX 1070: 163M/s
- RX 480: 120M/s

### [vanity-eth.tk](https://github.com/bokub/vanity-eth) (prefix, case insensitive)
~2K/s per thread, with diminishing returns

### cast wallet vanity
- Local benches:
  - (master) iter::repeat_with, 10K
    - local: in ~1310ms ~= 7.7K/s
  - range iter / iter::repeat + par map, 100K
    - debug: in ~4300ms ~= 23.2K/s
    - local: in ~610ms ~= 165K/s
    - release: in ~440ms ~= 227K/s

- Criterion, using `black_box` so equivalent to debug mode:
  - range iter / iter::repeat + par map
 
 ![image](https://user-images.githubusercontent.com/57450786/191239226-5822d291-0ad9-496b-9f76-8e54b428b9cf.png)

---

### [create2crunch](https://github.com/0age/create2crunch) (`-r`, `WORK_SIZE = 0x40000000` (one extra '0'))
CREATE2 salt calculations are way cheaper, but wanted to include it anyway
- CPU: 10M in ~295ms ~= 10M/s
- GPU: ~650M/s

---

### Benchmarking code

```rust
use std::{
    sync::atomic::{AtomicU64, Ordering},
    time::{Duration, SystemTime, UNIX_EPOCH},
};

const STEP: u64 = 100_000;
static PREVIOUS: AtomicU64 = AtomicU64::new(0);
static I: AtomicU64 = AtomicU64::new(0);

#[inline]
fn setup() {
    let start = now().as_millis() as u64;
    PREVIOUS.store(start, Ordering::Release);
}

#[inline]
fn bench() {
    let i = I.fetch_add(1, Ordering::AcqRel);
    if i % STEP == 0 {
        let now = now().as_millis() as u64;
        let previous =
            PREVIOUS.fetch_update(Ordering::Release, Ordering::Acquire, |_| Some(now)).unwrap();
        println!("{} in {} ms", STEP, now - previous);
    };
}

#[inline]
fn now() -> Duration {
    SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
}
```
