### PR TITLE
refactor: use Config::try_from where possible

### DIFF
--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -201,7 +201,7 @@ impl Cmd for BindArgs {
             compile::compile(&project, false, false)?;
         }
 
-        let artifacts = self.load_config_emit_warnings().out;
+        let artifacts = self.try_load_config_emit_warnings()?.out;
 
         if !self.overwrite && self.bindings_exist(&artifacts) {
             println!("Bindings found. Checking for consistency.");

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -131,7 +131,7 @@ impl CoreBuildArgs {
     /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]
     pub fn project(&self) -> eyre::Result<Project> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         Ok(config.project()?)
     }
 

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -72,7 +72,7 @@ pub struct BuildArgs {
 impl Cmd for BuildArgs {
     type Output = ProjectCompileOutput;
     fn run(self) -> eyre::Result<Self::Output> {
-        let mut config = self.load_config_emit_warnings();
+        let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;
 
         if install::install_missing_dependencies(&mut config, &project, self.args.silent) &&

--- a/cli/src/cmd/forge/config.rs
+++ b/cli/src/cmd/forge/config.rs
@@ -34,7 +34,7 @@ impl Cmd for ConfigArgs {
             return Ok(())
         }
 
-        let config = self.load_config_unsanitized_emit_warnings();
+        let config = self.try_load_config_unsanitized_emit_warnings()?;
 
         let s = if self.basic {
             let config = config.into_basic();

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -116,7 +116,7 @@ impl CreateArgs {
         };
 
         // Add arguments to constructor
-        let config = self.eth.load_config_emit_warnings();
+        let config = self.eth.try_load_config_emit_warnings()?;
         let provider = Arc::new(get_http_provider(config.get_rpc_url_or_localhost_http()?));
         let params = match abi.constructor {
             Some(ref v) => {

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -48,7 +48,7 @@ impl Cmd for FlattenArgs {
             build_info_path: None,
         };
 
-        let config = build_args.load_config_emit_warnings();
+        let config = build_args.try_load_config_emit_warnings()?;
 
         let paths = config.project_paths();
         let target_path = dunce::canonicalize(target_path)?;

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -87,7 +87,7 @@ impl Cmd for FmtArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         let inputs = self.inputs(&config);
 
         if inputs.is_empty() {

--- a/cli/src/cmd/forge/geiger/mod.rs
+++ b/cli/src/cmd/forge/geiger/mod.rs
@@ -64,7 +64,7 @@ impl Cmd for GeigerArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         let sources = self.sources(&config).wrap_err("Failed to resolve files")?;
 
         if config.ffi {

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -63,7 +63,7 @@ impl Cmd for InstallArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let mut config = self.load_config_emit_warnings();
+        let mut config = self.try_load_config_emit_warnings()?;
         install(&mut config, self.dependencies, self.opts)?;
         Ok(())
     }

--- a/cli/src/cmd/forge/remappings.rs
+++ b/cli/src/cmd/forge/remappings.rs
@@ -22,7 +22,7 @@ impl Cmd for RemappingArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         config.remappings.iter().for_each(|x| println!("{x}"));
         Ok(())
     }

--- a/cli/src/cmd/forge/remove.rs
+++ b/cli/src/cmd/forge/remove.rs
@@ -27,7 +27,7 @@ impl Cmd for RemoveArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         let prj_root = config.__root.0.clone();
         let git_root =
             find_git_root_path(&prj_root).wrap_err("Unable to detect git root directory")?;

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -28,7 +28,7 @@ impl Cmd for TreeArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config = self.load_config_emit_warnings();
+        let config = self.try_load_config_emit_warnings()?;
         let graph = Graph::resolve(&config.project_paths())?;
         let opts = TreeOptions { charset: self.charset, no_dedupe: self.no_dedupe };
         graph.print_with_options(opts);

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -179,7 +179,7 @@ impl EtherscanVerificationProvider {
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
     async fn create_verify_request(&self, args: &VerifyArgs) -> eyre::Result<VerifyContract> {
-        let mut config = args.load_config_emit_warnings();
+        let mut config = args.try_load_config_emit_warnings()?;
         config.libraries.extend(args.libraries.clone());
 
         let project = config.project()?;

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -20,7 +20,7 @@ pub struct SourcifyVerificationProvider;
 #[async_trait]
 impl VerificationProvider for SourcifyVerificationProvider {
     async fn verify(&self, args: VerifyArgs) -> eyre::Result<()> {
-        let mut config = args.load_config_emit_warnings();
+        let mut config = args.try_load_config_emit_warnings()?;
         config.libraries.extend(args.libraries.clone());
 
         let project = config.project()?;

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -13,7 +13,7 @@ use ethers::{
 use eyre::WrapErr;
 use forge::executor::opts::EvmOpts;
 use foundry_common::{cli_warn, fs, TestFunctionExt};
-use foundry_config::{figment::Figment, Chain as ConfigChain, Config};
+use foundry_config::{error::ExtractConfigError, figment::Figment, Chain as ConfigChain, Config};
 use std::path::PathBuf;
 use yansi::Paint;
 
@@ -200,31 +200,49 @@ pub fn has_batch_support(chain: u64) -> bool {
 /// also prints `Config::__warnings` to stderr
 pub trait LoadConfig {
     /// Load and sanitize the [`Config`] based on the options provided in self
+    ///
+    /// Returns an error if loading the config failed
+    fn try_load_config(self) -> Result<Config, ExtractConfigError>;
+    /// Load and sanitize the [`Config`] based on the options provided in self
     fn load_config(self) -> Config;
     /// Load and sanitize the [`Config`], as well as extract [`EvmOpts`] from self
     fn load_config_and_evm_opts(self) -> eyre::Result<(Config, EvmOpts)>;
     /// Load [`Config`] but do not sanitize. See [`Config::sanitized`] for more information
     fn load_config_unsanitized(self) -> Config;
-
+    /// Load [`Config`] but do not sanitize. See [`Config::sanitized`] for more information.
+    ///
+    /// Returns an error if loading failed
+    fn try_load_config_unsanitized(self) -> Result<Config, ExtractConfigError>;
     /// Same as [`LoadConfig::load_config`] but also emits warnings generated
     fn load_config_emit_warnings(self) -> Config;
+    /// Same as [`LoadConfig::load_config`] but also emits warnings generated
+    ///
+    /// Returns an error if loading failed
+    fn try_load_config_emit_warnings(self) -> Result<Config, ExtractConfigError>;
     /// Same as [`LoadConfig::load_config_and_evm_opts`] but also emits warnings generated
     fn load_config_and_evm_opts_emit_warnings(self) -> eyre::Result<(Config, EvmOpts)>;
     /// Same as [`LoadConfig::load_config_unsanitized`] but also emits warnings generated
     fn load_config_unsanitized_emit_warnings(self) -> Config;
+    fn try_load_config_unsanitized_emit_warnings(self) -> Result<Config, ExtractConfigError>;
 }
 
 impl<T> LoadConfig for T
 where
     T: Into<Config> + Into<Figment>,
 {
+    fn try_load_config(self) -> Result<Config, ExtractConfigError> {
+        let figment: Figment = self.into();
+        Ok(Config::try_from(figment)?.sanitized())
+    }
+
     fn load_config(self) -> Config {
         self.into()
     }
+
     fn load_config_and_evm_opts(self) -> eyre::Result<(Config, EvmOpts)> {
         let figment: Figment = self.into();
         let mut evm_opts = figment.extract::<EvmOpts>()?;
-        let config = Config::from_provider(figment).sanitized();
+        let config = Config::try_from(figment)?.sanitized();
 
         // update the fork url if it was an alias
         if let Some(fork_url) = config.get_rpc_url() {
@@ -233,24 +251,45 @@ where
 
         Ok((config, evm_opts))
     }
+
     fn load_config_unsanitized(self) -> Config {
         let figment: Figment = self.into();
         Config::from_provider(figment)
     }
+
+    fn try_load_config_unsanitized(self) -> Result<Config, ExtractConfigError> {
+        let figment: Figment = self.into();
+        Config::try_from(figment)
+    }
+
     fn load_config_emit_warnings(self) -> Config {
         let config = self.load_config();
         config.__warnings.iter().for_each(|w| cli_warn!("{w}"));
         config
     }
+
+    fn try_load_config_emit_warnings(self) -> Result<Config, ExtractConfigError> {
+        let config = self.try_load_config()?;
+        config.__warnings.iter().for_each(|w| cli_warn!("{w}"));
+        Ok(config)
+    }
+
     fn load_config_and_evm_opts_emit_warnings(self) -> eyre::Result<(Config, EvmOpts)> {
         let (config, evm_opts) = self.load_config_and_evm_opts()?;
         config.__warnings.iter().for_each(|w| cli_warn!("{w}"));
         Ok((config, evm_opts))
     }
+
     fn load_config_unsanitized_emit_warnings(self) -> Config {
         let config = self.load_config_unsanitized();
         config.__warnings.iter().for_each(|w| cli_warn!("{w}"));
         config
+    }
+
+    fn try_load_config_unsanitized_emit_warnings(self) -> Result<Config, ExtractConfigError> {
+        let config = self.try_load_config_unsanitized()?;
+        config.__warnings.iter().for_each(|w| cli_warn!("{w}"));
+        Ok(config)
     }
 }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -423,7 +423,7 @@ impl Config {
     /// ```
     pub fn from_provider<T: Provider>(provider: T) -> Self {
         trace!("load config with provider: {:?}", provider.metadata());
-        Self::try_from(provider).unwrap()
+        Self::try_from(provider).unwrap_or_else(|err| panic!("{}", err))
     }
 
     /// Attempts to extract a `Config` from `provider`, returning the result.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/3259

this adds additional `try_from_*` `ConfigLoader` functions that don't panic

this also improves the config error message:


```toml
[profile.default]
etherscan_api_key = 5
```

```console
forge config                                                                                                            
Error: 
failed to extract foundry config:
foundry config error: invalid type: found signed int `5`, expected a string for setting `etherscan_api_key`
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
