### PR TITLE
chore: try to find by chain

### DIFF
--- a/config/src/etherscan.rs
+++ b/config/src/etherscan.rs
@@ -44,6 +44,11 @@ impl EtherscanConfigs {
         self.configs.is_empty()
     }
 
+    /// Returns the first config that matches the chain
+    pub fn find_chain(&self, chain: Chain) -> Option<&EtherscanConfig> {
+        self.configs.values().find(|config| config.chain == Some(chain))
+    }
+
     /// Returns all (alias -> url) pairs
     pub fn resolved(self) -> ResolvedEtherscanConfigs {
         ResolvedEtherscanConfigs {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
previously we required exact matching entries in the table: `Chain::to_string`

this also compares chain id, if set and returns the first matching entry with matching chain id
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
