### PR TITLE
fix: optimism goerli scripts default to --slow

### DIFF
--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -184,7 +184,11 @@ pub fn has_batch_support(chain: u64) -> bool {
     if let ConfigChain::Named(chain) = ConfigChain::from(chain) {
         return !matches!(
             chain,
-            Chain::Arbitrum | Chain::ArbitrumTestnet | Chain::Optimism | Chain::OptimismKovan
+            Chain::Arbitrum |
+                Chain::ArbitrumTestnet |
+                Chain::Optimism |
+                Chain::OptimismKovan |
+                Chain::OptimismGoerli
         )
     }
     true


### PR DESCRIPTION
Just tried deploying to optimism goerli and got a nonce too low error since it did not default to `--slow` like the other optimism chains.