### PR TITLE
refactor: allow project output dir read access

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -117,9 +117,10 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
 forgetest!(
     #[serial_test::serial]
     can_show_config,
-    |_prj: TestProject, mut cmd: TestCommand| {
+    |prj: TestProject, mut cmd: TestCommand| {
         cmd.arg("config");
-        let expected = Config::load().to_string_pretty().unwrap().trim().to_string();
+        let expected =
+            Config::load_with_root(prj.root()).to_string_pretty().unwrap().trim().to_string();
         assert_eq!(expected, cmd.stdout().trim().to_string());
     }
 );

--- a/config/README.md
+++ b/config/README.md
@@ -162,10 +162,10 @@ root = "root"
 #    `read` => only read access (`vm.readFile`)
 #    `write` => only write access (`vm.writeFile`)
 # The `allowed_paths` further lists the paths that are considered, e.g. `./` represents the project root directory
-# By default, only read access is granted to the project dir
+# By default, only read access is granted to the project's out dir, so generated artifacts can be read by default
 # following example enables read-write access for the project dir :
 #       `fs_permissions = [{ access = "read-write", path = "./"}]`
-fs_permissions = [{ access = "read", path = "./"}]
+fs_permissions = [{ access = "read", path = "./out"}]
 [fuzz]
 runs = 256
 max_test_rejects = 65536

--- a/config/README.md
+++ b/config/README.md
@@ -162,10 +162,10 @@ root = "root"
 #    `read` => only read access (`vm.readFile`)
 #    `write` => only write access (`vm.writeFile`)
 # The `allowed_paths` further lists the paths that are considered, e.g. `./` represents the project root directory
-# By default _no_ fs access permission is granted, and _no_ paths are allowed
-# following example enables read access for the project dir _only_:
-#       `fs_permissions = [{ access = "read", path = "./"}]`
-fs_permissions = []
+# By default, only read access is granted to the project dir
+# following example enables read-write access for the project dir :
+#       `fs_permissions = [{ access = "read-write", path = "./"}]`
+fs_permissions = [{ access = "read", path = "./"}]
 [fuzz]
 runs = 256
 max_test_rejects = 65536

--- a/config/src/fs_permissions.rs
+++ b/config/src/fs_permissions.rs
@@ -55,6 +55,22 @@ impl FsPermissions {
         self.join_all(root);
         self
     }
+
+    /// Removes all existing permissions for the given path
+    pub fn remove(&mut self, path: impl AsRef<Path>) {
+        let path = path.as_ref();
+        self.permissions.retain(|permission| permission.path != path)
+    }
+
+    /// Returns true if no permissions are configured
+    pub fn is_empty(&self) -> bool {
+        self.permissions.is_empty()
+    }
+
+    /// Returns the number of configured permissions
+    pub fn len(&self) -> usize {
+        self.permissions.len()
+    }
 }
 
 /// Represents an access permission to a single path

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1010,7 +1010,7 @@ impl Config {
         let root = root.into();
         let paths = ProjectPathsConfig::builder().build_with_root(&root);
         Config {
-            __root: paths.root.clone().into(),
+            __root: paths.root.into(),
             src: paths.sources.file_name().unwrap().into(),
             out: paths.artifacts.file_name().unwrap().into(),
             libs: paths.libraries.into_iter().map(|lib| lib.file_name().unwrap().into()).collect(),
@@ -1019,7 +1019,7 @@ impl Config {
                 .into_iter()
                 .map(|r| RelativeRemapping::new(r, &root))
                 .collect(),
-            fs_permissions: FsPermissions::new([PathPermission::read(paths.root)]),
+            fs_permissions: FsPermissions::new([PathPermission::read(paths.artifacts)]),
             ..Config::default()
         }
     }
@@ -1641,11 +1641,10 @@ impl Provider for Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let root: RootPath = Default::default();
         Self {
             profile: Self::DEFAULT_PROFILE,
-            fs_permissions: FsPermissions::new([PathPermission::read(root.as_ref())]),
-            __root: root,
+            fs_permissions: FsPermissions::new([PathPermission::read("out")]),
+            __root: Default::default(),
             src: "src".into(),
             test: "test".into(),
             script: "script".into(),

--- a/forge/tests/it/fs.rs
+++ b/forge/tests/it/fs.rs
@@ -16,7 +16,8 @@ fn test_fs_disabled() {
 }
 #[test]
 fn test_fs_default() {
-    let config = Config::with_root(PROJECT.root());
+    let mut config = Config::with_root(PROJECT.root());
+    config.fs_permissions = FsPermissions::new(vec![PathPermission::read("./fixtures")]);
     let runner = runner_with_config(config);
     let filter = Filter::new(".*", ".*", ".*fs/Default");
     TestConfig::with_filter(runner, filter).run();

--- a/forge/tests/it/fs.rs
+++ b/forge/tests/it/fs.rs
@@ -4,7 +4,6 @@ use crate::{
     config::*,
     test_helpers::{filter::Filter, PROJECT},
 };
-
 use foundry_config::{fs_permissions::PathPermission, Config, FsPermissions};
 
 #[test]
@@ -13,5 +12,12 @@ fn test_fs_disabled() {
     config.fs_permissions = FsPermissions::new(vec![PathPermission::none("./")]);
     let runner = runner_with_config(config);
     let filter = Filter::new(".*", ".*", ".*fs/Disabled");
+    TestConfig::with_filter(runner, filter).run();
+}
+#[test]
+fn test_fs_default() {
+    let config = Config::with_root(PROJECT.root());
+    let runner = runner_with_config(config);
+    let filter = Filter::new(".*", ".*", ".*fs/Default");
     TestConfig::with_filter(runner, filter).run();
 }

--- a/testdata/fs/Default.t.sol
+++ b/testdata/fs/Default.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+contract DefaultAccessTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    bytes constant FOUNDRY_WRITE_ERR =
+        "The path \"../testdata/fixtures/File/write_file.txt\" is not allowed to be accessed for write operations.";
+
+    function testReadFile() public {
+        string memory path = "../testdata/fixtures/File/read.txt";
+        cheats.readFile(path);
+    }
+
+    function testReadLine() public {
+        string memory path = "../testdata/fixtures/File/read.txt";
+        cheats.readLine(path);
+    }
+
+    function testWriteFile() public {
+        string memory path = "../testdata/fixtures/File/write_file.txt";
+        string memory data = "hello writable world";
+        cheats.expectRevert(FOUNDRY_WRITE_ERR);
+        cheats.writeFile(path, data);
+    }
+
+    function testWriteLine() public {
+        string memory path = "../testdata/fixtures/File/write_file.txt";
+        string memory data = "hello writable world";
+        cheats.expectRevert(FOUNDRY_WRITE_ERR);
+        cheats.writeLine(path, data);
+    }
+
+    function testRemoveFile() public {
+        string memory path = "../testdata/fixtures/File/write_file.txt";
+        cheats.expectRevert(FOUNDRY_WRITE_ERR);
+        cheats.removeFile(path);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
change `fs_permission` default from `None` to `read` from project's output dir.

This will unblock `getCode` cheatcodes restrictions and is a reasonable default now that cheatcode access is closed off.

~~alternatively, we could change it from root to `out` dir instead?~~
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
