### PR TITLE
fix: don't force snake case standalone sections

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -615,6 +615,7 @@ mod tests {
     use super::*;
     use crate::cmd::LoadConfig;
     use foundry_cli_test_utils::tempfile::tempdir;
+    use foundry_config::UnresolvedEnvVarError;
     use std::fs;
 
     #[test]
@@ -670,5 +671,41 @@ mod tests {
         let config = args.load_config();
         let mumbai = config.get_etherscan_api_key(Some(ethers::types::Chain::PolygonMumbai));
         assert_eq!(mumbai, Some("https://etherscan-mumbai.com/".to_string()));
+    }
+
+    #[test]
+    fn can_extract_script_rpc_alias() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+
+        let config = r#"
+                [profile.default]
+
+                [rpc_endpoints]
+                polygonMumbai = "https://polygon-mumbai.g.alchemy.com/v2/${_EXTRACT_RPC_ALIAS}"
+            "#;
+
+        let toml_file = root.join(Config::FILE_NAME);
+        fs::write(toml_file, config).unwrap();
+        let args: ScriptArgs = ScriptArgs::parse_from([
+            "foundry-cli",
+            "DeployV1",
+            "--rpc-url",
+            "polygonMumbai",
+            "--root",
+            root.as_os_str().to_str().unwrap(),
+        ]);
+
+        let err = args.clone().load_config_and_evm_opts().unwrap_err();
+
+        assert!(err.downcast::<UnresolvedEnvVarError>().is_ok());
+
+        std::env::set_var("_EXTRACT_RPC_ALIAS", "123456");
+        let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
+        assert_eq!(config.eth_rpc_url, Some("polygonMumbai".to_string()));
+        assert_eq!(
+            evm_opts.fork_url,
+            Some("https://polygon-mumbai.g.alchemy.com/v2/123456".to_string())
+        );
     }
 }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -708,4 +708,49 @@ mod tests {
             Some("https://polygon-mumbai.g.alchemy.com/v2/123456".to_string())
         );
     }
+
+    #[test]
+    fn can_extract_script_rpc_and_etherscan_alias() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+
+        let config = r#"
+                [profile.default]
+
+               [rpc_endpoints]
+                mumbai = "https://polygon-mumbai.g.alchemy.com/v2/${_EXTRACT_RPC_ALIAS}"
+
+                [etherscan]
+                mumbai = { key = "${_POLYSCAN_API_KEY}", chain = 80001, url = "https://api-testnet.polygonscan.com/" }
+            "#;
+
+        let toml_file = root.join(Config::FILE_NAME);
+        fs::write(toml_file, config).unwrap();
+        let args: ScriptArgs = ScriptArgs::parse_from([
+            "foundry-cli",
+            "DeployV1",
+            "--rpc-url",
+            "mumbai",
+            "--etherscan-api-key",
+            "mumbai",
+            "--root",
+            root.as_os_str().to_str().unwrap(),
+        ]);
+        let err = args.clone().load_config_and_evm_opts().unwrap_err();
+
+        assert!(err.downcast::<UnresolvedEnvVarError>().is_ok());
+
+        std::env::set_var("_EXTRACT_RPC_ALIAS", "123456");
+        std::env::set_var("_POLYSCAN_API_KEY", "polygonkey");
+        let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
+        assert_eq!(config.eth_rpc_url, Some("mumbai".to_string()));
+        assert_eq!(
+            evm_opts.fork_url,
+            Some("https://polygon-mumbai.g.alchemy.com/v2/123456".to_string())
+        );
+        let etherscan = config.get_etherscan_api_key(Some(80001u64));
+        assert_eq!(etherscan, Some("polygonkey".to_string()));
+        let etherscan = config.get_etherscan_api_key(Option::<u64>::None);
+        assert_eq!(etherscan, Some("polygonkey".to_string()));
+    }
 }

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -15,6 +15,7 @@ use forge::executor::opts::EvmOpts;
 use foundry_common::{cli_warn, fs, TestFunctionExt};
 use foundry_config::{error::ExtractConfigError, figment::Figment, Chain as ConfigChain, Config};
 use std::path::PathBuf;
+use tracing::trace;
 use yansi::Paint;
 
 /// Common trait for all cli commands
@@ -250,6 +251,7 @@ where
 
         // update the fork url if it was an alias
         if let Some(fork_url) = config.get_rpc_url() {
+            trace!(target: "forge::config", ?fork_url, "Update EvmOpts fork url");
             evm_opts.fork_url = Some(fork_url?.into_owned());
         }
 

--- a/common/src/provider.rs
+++ b/common/src/provider.rs
@@ -41,7 +41,7 @@ pub fn try_get_http_provider(builder: impl Into<ProviderBuilder>) -> eyre::Resul
 #[derive(Debug)]
 pub struct ProviderBuilder {
     // Note: this is a result, so we can easily chain builder calls
-    url: reqwest::Result<Url>,
+    url: eyre::Result<Url>,
     chain: Chain,
     max_retry: u32,
     timeout_retry: u32,
@@ -62,9 +62,9 @@ impl ProviderBuilder {
             // prefix
             return Self::new(format!("http://{}", url_str))
         }
-
+        let err = format!("Invalid provider url: {}", url_str);
         Self {
-            url: url.into_url(),
+            url: url.into_url().wrap_err(err),
             chain: Chain::Mainnet,
             max_retry: 100,
             timeout_retry: 5,
@@ -150,7 +150,7 @@ impl ProviderBuilder {
             timeout,
             compute_units_per_second,
         } = self;
-        let url = url.wrap_err("Invalid provider url")?;
+        let url = url?;
 
         let client = reqwest::Client::builder().timeout(timeout).build()?;
         let is_local = is_local_endpoint(url.as_str());

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -9,7 +9,7 @@ use ethers_core::{
     utils::to_checksum,
 };
 use ethers_etherscan::Client;
-use ethers_providers::{Middleware, Provider, ProviderError};
+use ethers_providers::{Middleware, Provider};
 use ethers_solc::{
     artifacts::{BytecodeObject, CompactBytecode, CompactContractBytecode, Libraries},
     contracts::ArtifactContracts,
@@ -606,9 +606,10 @@ pub async fn next_nonce(
     caller: Address,
     provider_url: &str,
     block: Option<BlockId>,
-) -> Result<U256, ProviderError> {
-    let provider = Provider::try_from(provider_url).expect("Bad fork_url provider");
-    provider.get_transaction_count(caller, block).await
+) -> Result<U256> {
+    let provider = Provider::try_from(provider_url)
+        .wrap_err_with(|| format!("Bad fork_url provider: {}", provider_url))?;
+    Ok(provider.get_transaction_count(caller, block).await?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3195

don't use forced snake case case for entries in standalone sections like `rpc_endpoints`

also improves error message for invalid URLs, ref https://github.com/foundry-rs/foundry/issues/3178
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
