### PR TITLE
chore: flip unresolved interpolated and env var in err message

### DIFF
--- a/config/src/resolve.rs
+++ b/config/src/resolve.rs
@@ -33,7 +33,7 @@ impl fmt::Display for UnresolvedEnvVarError {
         write!(
             f,
             "Failed to resolve env var `{}` in `{}`: {}",
-            self.unresolved, self.var, self.source
+            self.var, self.unresolved, self.source
         )
     }
 }

--- a/testdata/cheats/RpcUrls.t.sol
+++ b/testdata/cheats/RpcUrls.t.sol
@@ -16,7 +16,7 @@ contract RpcUrlTest is DSTest {
     // returns an error if env alias does not exist
     function testRevertsOnMissingEnv() public {
         cheats.expectRevert(
-            "Failed to resolve env var `${RPC_ENV_ALIAS}` in `RPC_ENV_ALIAS`: environment variable not found"
+            "Failed to resolve env var `RPC_ENV_ALIAS` in `${RPC_ENV_ALIAS}`: environment variable not found"
         );
         string memory url = cheats.rpcUrl("rpcEnvAlias");
     }
@@ -25,7 +25,7 @@ contract RpcUrlTest is DSTest {
     function testCanSetAndGetURLAndAllUrls() public {
         // this will fail because alias is not set
         cheats.expectRevert(
-            "Failed to resolve env var `${RPC_ENV_ALIAS}` in `RPC_ENV_ALIAS`: environment variable not found"
+            "Failed to resolve env var `RPC_ENV_ALIAS` in `${RPC_ENV_ALIAS}`: environment variable not found"
         );
         string[2][] memory _urls = cheats.rpcUrls();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Flip env name and unresolved value in error message so we print

```
Failed to resolve env var `ABC` in `https://polygon-mumbai.g.alchemy.com/v2/${ABC}`: environment variable not found
```

instead of

```
Failed to resolve env var `https://polygon-mumbai.g.alchemy.com/v2/${ABC}` in `ABC`: environment variable not found
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
