### PR TITLE
chore: use try_get_http_provider and prevent unwrap

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -15,7 +15,7 @@ use foundry_cli::{
     utils,
     utils::consume_config_rpc_url,
 };
-use foundry_common::{fs, get_http_provider};
+use foundry_common::{fs, try_get_http_provider};
 use foundry_config::{Chain, Config};
 use foundry_utils::{
     format_tokens,
@@ -188,7 +188,7 @@ async fn main() -> eyre::Result<()> {
         // Blockchain & RPC queries
         Subcommands::AccessList { eth, address, sig, args, block, to_json } => {
             let config = Config::from(&eth);
-            let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
+            let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
             let chain: Chain = if let Some(chain) = eth.chain {
                 chain
@@ -205,7 +205,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Age { block, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!(
                 "{}",
                 Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
@@ -213,13 +213,13 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Balance { block, who, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).balance(who, block).await?);
         }
         Subcommands::BaseFee { block, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!(
                 "{}",
                 Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
@@ -227,48 +227,48 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Block { rpc_url, block, full, field, to_json } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);
         }
         Subcommands::BlockNumber { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).block_number().await?);
         }
         Subcommands::Chain { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).chain().await?);
         }
         Subcommands::ChainId { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).chain_id().await?);
         }
         Subcommands::Client { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", provider.client_version().await?);
         }
         Subcommands::Code { block, who, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).code(who, block).await?);
         }
         Subcommands::ComputeAddress { rpc_url, address, nonce } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
             let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             let addr = Cast::new(&provider).compute_address(pubkey, nonce).await?;
             println!("Computed Address: {}", SimpleCast::to_checksum_address(&addr));
         }
         Subcommands::FindBlock(cmd) => cmd.run()?.await?,
         Subcommands::GasPrice { rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).gas_price().await?);
         }
         Subcommands::Index { key_type, key, slot_number } => {
@@ -278,13 +278,13 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Nonce { block, who, rpc_url } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
         Subcommands::Proof { address, slots, rpc_url, block } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             let value = provider.get_proof(address, slots, block).await?;
             println!("{}", serde_json::to_string(&value)?);
         }
@@ -292,7 +292,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Storage { address, slot, rpc_url, block } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
 
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             let value = provider.get_storage_at(address, slot, block).await?;
             println!("{:?}", value);
         }
@@ -302,7 +302,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Estimate(cmd) => cmd.run().await?,
         Subcommands::PublishTx { eth, raw_tx, cast_async } => {
             let config = Config::from(&eth);
-            let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
+            let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
             let cast = Cast::new(&provider);
             let pending_tx = cast.publish(raw_tx).await?;
             let tx_hash = *pending_tx;
@@ -317,7 +317,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Receipt { hash, field, to_json, rpc_url, cast_async, confirmations } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!(
                 "{}",
                 Cast::new(provider)
@@ -329,7 +329,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::SendTx(cmd) => cmd.run().await?,
         Subcommands::Tx { rpc_url, hash, field, to_json } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
 
@@ -378,7 +378,7 @@ async fn main() -> eyre::Result<()> {
         // ENS
         Subcommands::LookupAddress { who, rpc_url, verify } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             let who = unwrap_or_stdin(who)?;
             let name = provider.lookup_address(who).await?;
             if verify {
@@ -396,7 +396,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::ResolveName { who, rpc_url, verify } => {
             let rpc_url = consume_config_rpc_url(rpc_url);
-            let provider = get_http_provider(rpc_url);
+            let provider = try_get_http_provider(rpc_url)?;
             let who = unwrap_or_stdin(who)?;
             let address = provider.resolve_name(&who).await?;
             if verify {

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -12,7 +12,7 @@ use ethers::{
     providers::Middleware,
     types::{BlockId, NameOrAddress, U256},
 };
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
 
 #[derive(Debug, Parser)]
@@ -60,7 +60,7 @@ impl CallArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let CallArgs { to, sig, args, tx, eth, command, block } = self;
         let config = Config::from(&eth);
-        let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
+        let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -9,7 +9,7 @@ use ethers::{
     providers::Middleware,
     types::{NameOrAddress, U256},
 };
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
 
 #[derive(Debug, Parser)]
@@ -63,7 +63,7 @@ impl EstimateArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let EstimateArgs { to, sig, args, value, eth, command } = self;
         let config = Config::from(&eth);
-        let provider = get_http_provider(config.get_rpc_url_or_localhost_http()?);
+        let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -5,7 +5,7 @@ use cast::Cast;
 use clap::Parser;
 use ethers::prelude::*;
 use eyre::Result;
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use futures::{future::BoxFuture, join};
 
 #[derive(Debug, Clone, Parser)]
@@ -30,7 +30,7 @@ impl FindBlockArgs {
         let ts_target = U256::from(timestamp);
         let rpc_url = consume_config_rpc_url(rpc_url);
 
-        let provider = get_http_provider(rpc_url);
+        let provider = try_get_http_provider(rpc_url)?;
         let last_block_num = provider.get_block_number().await?;
         let cast_provider = Cast::new(provider);
 

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -2,7 +2,7 @@ use crate::{cmd::Cmd, utils::consume_config_rpc_url};
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 
@@ -53,7 +53,7 @@ impl RpcArgs {
         params: Vec<String>,
     ) -> Result<()> {
         let rpc_url = consume_config_rpc_url(rpc_url);
-        let provider = get_http_provider(rpc_url);
+        let provider = try_get_http_provider(rpc_url)?;
         let params = if raw {
             if params.is_empty() {
                 serde_json::Deserializer::from_reader(std::io::stdin())

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -16,7 +16,7 @@ use forge::{
     },
     trace::{identifier::EtherscanIdentifier, CallTraceArena, CallTraceDecoderBuilder, TraceKind},
 };
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use foundry_config::{find_project_root_path, Config};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::{collections::BTreeMap, str::FromStr};
@@ -67,7 +67,7 @@ impl RunArgs {
         let config = Config::from_provider(figment).sanitized();
 
         let rpc_url = consume_config_rpc_url(self.rpc_url);
-        let provider = get_http_provider(rpc_url.as_str());
+        let provider = try_get_http_provider(rpc_url.as_str())?;
 
         if let Some(tx) = provider
             .get_transaction(

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -3,7 +3,7 @@ use crate::opts::{cast::parse_name_or_address, EthereumOpts, TransactionOpts, Wa
 use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{providers::Middleware, types::NameOrAddress};
-use foundry_common::get_http_provider;
+use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
 use std::sync::Arc;
 
@@ -80,7 +80,7 @@ impl SendTxArgs {
             command,
         } = self;
         let config = Config::from(&eth);
-        let provider = Arc::new(get_http_provider(config.get_rpc_url_or_localhost_http()?));
+        let provider = Arc::new(try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?);
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
         let mut sig = sig.unwrap_or_default();

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -16,7 +16,7 @@ use ethers::{
     types::{transaction::eip2718::TypedTransaction, Chain},
 };
 use eyre::Context;
-use foundry_common::{compile, get_http_provider};
+use foundry_common::{compile, try_get_http_provider};
 use foundry_utils::parse_tokens;
 use rustc_hex::ToHex;
 use serde_json::json;
@@ -117,7 +117,7 @@ impl CreateArgs {
 
         // Add arguments to constructor
         let config = self.eth.try_load_config_emit_warnings()?;
-        let provider = Arc::new(get_http_provider(config.get_rpc_url_or_localhost_http()?));
+        let provider = Arc::new(try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?);
         let params = match abi.constructor {
             Some(ref v) => {
                 let constructor_args =

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -17,7 +17,7 @@ use ethers::{
     utils::format_units,
 };
 use eyre::{ContextCompat, WrapErr};
-use foundry_common::{get_http_provider, RetryProvider};
+use foundry_common::{try_get_http_provider, RetryProvider};
 use foundry_config::Chain;
 use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -31,7 +31,7 @@ impl ScriptArgs {
         fork_url: &str,
         script_wallets: Vec<LocalWallet>,
     ) -> eyre::Result<()> {
-        let provider = Arc::new(get_http_provider(fork_url));
+        let provider = Arc::new(try_get_http_provider(fork_url)?);
         let already_broadcasted = deployment_sequence.receipts.len();
 
         if already_broadcasted < deployment_sequence.transactions.len() {
@@ -245,7 +245,7 @@ impl ScriptArgs {
                     })?
                 };
 
-                let provider = Arc::new(get_http_provider(&fork_url));
+                let provider = Arc::new(try_get_http_provider(&fork_url)?);
                 let chain = provider.get_chainid().await?.as_u64();
 
                 verify.set_chain(&script_config.config, chain.into());

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -4,7 +4,7 @@ use ethers::{
     prelude::{Middleware, Signer},
     types::{transaction::eip2718::TypedTransaction, U256},
 };
-use foundry_common::{contracts::flatten_contracts, get_http_provider};
+use foundry_common::{contracts::flatten_contracts, try_get_http_provider};
 use std::sync::Arc;
 use tracing::trace;
 
@@ -67,7 +67,7 @@ impl ScriptArgs {
                 .clone()
                 .ok_or_else(|| eyre::eyre!("You must provide an RPC URL (see --fork-url)."))?;
 
-            let provider = Arc::new(get_http_provider(&fork_url));
+            let provider = Arc::new(try_get_http_provider(&fork_url)?);
             let chain = provider.get_chainid().await?.as_u64();
 
             verify.set_chain(&script_config.config, chain.into());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
replace `get_http_provider` usage with `try_get_http_provider` preventing an unwrap/panic
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
