### PR TITLE
refactor(anvil): depend on revm directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "hash256-std-hasher",
  "keccak-hasher",
  "reference-trie",
+ "revm",
  "serde",
  "serde_json",
  "triehash",

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../../evm" }
+revm = { version = "2.0", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
 
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/anvil/core/src/eth/proof.rs
+++ b/anvil/core/src/eth/proof.rs
@@ -6,7 +6,7 @@ use ethers_core::{
     utils::rlp,
 };
 use fastrlp::{RlpDecodable, RlpEncodable};
-use foundry_evm::revm::KECCAK_EMPTY;
+use revm::KECCAK_EMPTY;
 // reexport for convenience
 pub use ethers_core::types::{EIP1186ProofResponse as AccountProof, StorageProof};
 

--- a/anvil/core/src/eth/receipt.rs
+++ b/anvil/core/src/eth/receipt.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use crate::eth::utils::enveloped;
 use bytes::Buf;
 use ethers_core::{
@@ -10,8 +8,8 @@ use ethers_core::{
     },
 };
 use fastrlp::{length_of_length, Header, RlpDecodable, RlpEncodable};
-use foundry_evm::revm;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, RlpEncodable, RlpDecodable)]
 pub struct Log {

--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -1,7 +1,5 @@
 //! transaction related data
 
-use std::cmp::Ordering;
-
 use crate::eth::{
     receipt::Log,
     utils::{enveloped, to_access_list},
@@ -18,12 +16,12 @@ use ethers_core::{
     },
 };
 use fastrlp::{length_of_length, Header, RlpDecodable, RlpEncodable};
-use foundry_evm::{
-    revm::{CreateScheme, Return, TransactTo, TxEnv},
-    trace::CallTraceArena,
-};
+use foundry_evm::trace::CallTraceArena;
+use revm::{CreateScheme, Return, TransactTo, TxEnv};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
+/// compatibility with `ethers-rs` types
 mod ethers_compat;
 
 /// Container type for various Ethereum transaction requests


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
first step towards isolating `anvil-core`.

still depends on tracing support provided by `foundry-evm`.

~~Suggesting we extract some core types/features from `foundry-evm` and move it to a new crate (foundry-evm-core) perhaps.~~

Or better we flip it and extract all things ethereum only from anvil-core to a generic ethereum crate.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
