### PR TITLE
fix: correct line col calc

### DIFF
--- a/cli/src/cmd/forge/geiger/find.rs
+++ b/cli/src/cmd/forge/geiger/find.rs
@@ -56,7 +56,7 @@ impl<'a, 'b> fmt::Display for SolFileMetricsPrinter<'a, 'b> {
                         let mut iter = metrics.cheatcodes.$field.iter().peekable();
                         while let Some(loc) = iter.next() {
                             let function_call = &metrics.content.as_bytes()[loc.start().. loc.end()];
-                            let (line, col) = offset_to_line_column(&metrics.content, loc.start(), loc.end());
+                            let (line, col) = offset_to_line_column(&metrics.content, loc.start());
                             let pos = format!("  --> {}:{}:{}", file.display(),  line, col);
                             writeln!(f,"{}", Paint::red(pos))?;
                             let content = String::from_utf8_lossy(function_call);

--- a/fmt/src/helpers.rs
+++ b/fmt/src/helpers.rs
@@ -51,20 +51,20 @@ pub fn fmt(src: &str) -> Result<String, FormatterError> {
     Ok(output)
 }
 
-/// Converts the offset of a `Loc` to `(line, col)`
-pub fn offset_to_line_column(content: &str, start: usize, end: usize) -> (usize, usize) {
-    let mut line_num = 0;
-    let mut offset = 0;
-    let mut col = 0;
-    for (idx, line) in content.lines().enumerate() {
-        let next_offset = offset + line.len();
-        if start < next_offset {
-            col = if next_offset > end { end - offset } else { end - next_offset };
-            // we let line count from 1
-            line_num = idx + 1;
-            break
+/// Converts the start offset of a `Loc` to `(line, col)`
+pub fn offset_to_line_column(content: &str, start: usize) -> (usize, usize) {
+    debug_assert!(content.len() > start);
+
+    // first line is `1`
+    let mut line_counter = 1;
+    for (offset, c) in content.chars().enumerate() {
+        if c == '\n' {
+            line_counter += 1;
         }
-        offset = next_offset;
+        if offset > start {
+            return (line_counter, offset - start)
+        }
     }
-    (line_num, col)
+
+    unreachable!("content.len() > start")
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3180

Calculate line and column correctly.
Only `start` offset is required:
count all line breaks until `offset > start`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
