### PR TITLE
fix: redact private key in broadcast functions and env values

### DIFF
--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -12,6 +12,7 @@ use ethers::{
     abi::{Abi, Address, Event, Function, Param, ParamType, Token},
     types::H256,
 };
+use foundry_common::SELECTOR_LEN;
 use foundry_utils::get_indexed_event;
 use std::collections::{BTreeMap, HashMap};
 
@@ -250,14 +251,14 @@ impl CallTraceDecoder {
                 node.decode_precompile(precompile_fn, &self.labels);
             } else if let RawOrDecodedCall::Raw(ref bytes) = node.trace.data {
                 if bytes.len() >= 4 {
-                    if let Some(funcs) = self.functions.get(&bytes[0..4]) {
+                    if let Some(funcs) = self.functions.get(&bytes[..SELECTOR_LEN]) {
                         node.decode_function(funcs, &self.labels, &self.errors);
                     } else if node.trace.address == DEFAULT_CREATE2_DEPLOYER {
                         node.trace.data =
                             RawOrDecodedCall::Decoded("create2".to_string(), String::new(), vec![]);
                     } else if let Some(identifier) = &self.signature_identifier {
                         if let Some(function) =
-                            identifier.write().await.identify_function(&bytes[0..4]).await
+                            identifier.write().await.identify_function(&bytes[..SELECTOR_LEN]).await
                         {
                             node.decode_function(&[function], &self.labels, &self.errors);
                         }

--- a/evm/src/trace/node.rs
+++ b/evm/src/trace/node.rs
@@ -2,7 +2,8 @@ use crate::{
     decode,
     executor::CHEATCODE_ADDRESS,
     trace::{
-        utils, CallTrace, LogCallOrder, RawOrDecodedCall, RawOrDecodedLog, RawOrDecodedReturnData,
+        utils, utils::decode_cheatcode_outputs, CallTrace, LogCallOrder, RawOrDecodedCall,
+        RawOrDecodedLog, RawOrDecodedReturnData,
     },
     CallKind,
 };
@@ -132,6 +133,15 @@ impl CallTraceNode {
 
             if let RawOrDecodedReturnData::Raw(bytes) = &self.trace.output {
                 if !bytes.is_empty() && self.trace.success {
+                    if self.trace.address == CHEATCODE_ADDRESS {
+                        if let Some(decoded) =
+                            funcs.iter().find_map(|func| decode_cheatcode_outputs(func, bytes))
+                        {
+                            self.trace.output = RawOrDecodedReturnData::Decoded(decoded);
+                            return
+                        }
+                    }
+
                     if let Some(tokens) =
                         funcs.iter().find_map(|func| func.decode_output(bytes).ok())
                     {

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -5,6 +5,7 @@ use ethers::{
     abi::{Abi, Address, Function, ParamType, Token},
     core::utils::to_checksum,
 };
+use foundry_common::SELECTOR_LEN;
 use foundry_utils::format_token;
 use std::collections::HashMap;
 
@@ -35,8 +36,8 @@ pub(crate) fn decode_cheatcode_inputs(
         "expectRevert" => {
             decode::decode_revert(data, Some(errors), None).ok().map(|decoded| vec![decoded])
         }
-        "sign" | "startBroadcast" | "broadcast" => {
-            // sign and broadcast functions accept a private key as uint256, which should not be
+        "rememberKey" | "addr" | "startBroadcast" | "broadcast" => {
+            // these functions accept a private key as uint256, which should not be
             // converted to plain text
             if !func.inputs.is_empty() && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
                 // redact private key input
@@ -45,6 +46,15 @@ pub(crate) fn decode_cheatcode_inputs(
                 None
             }
         }
+        "sign" => {
+            // sign(uint256,bytes32)
+            let mut decoded = func.decode_input(&data[SELECTOR_LEN..]).ok()?;
+            if !decoded.is_empty() && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
+                decoded[0] = Token::String("<pk>".to_string());
+            }
+            Some(decoded.iter().map(format_token).collect())
+        }
+        "deriveKey" => Some(vec!["<pk>".to_string()]),
 
         _ => None,
     }
@@ -55,6 +65,10 @@ pub(crate) fn decode_cheatcode_outputs(func: &Function, _data: &[u8]) -> Option<
     if func.name.starts_with("env") {
         // redacts the value stored in the env var
         return Some("<env var value>".to_string())
+    }
+    if func.name == "deriveKey" {
+        // redacts derived private key
+        return Some("<pl>".to_string())
     }
     None
 }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -25,6 +25,7 @@ pub fn label(token: &Token, labels: &HashMap<Address, String>) -> String {
     }
 }
 
+/// Custom decoding of cheatcode calls
 pub(crate) fn decode_cheatcode_inputs(
     func: &Function,
     data: &[u8],
@@ -37,7 +38,7 @@ pub(crate) fn decode_cheatcode_inputs(
         "sign" | "startBroadcast" | "broadcast" => {
             // sign and broadcast functions accept a private key as uint256, which should not be
             // converted to plain text
-            if func.inputs.len() > 0 && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
+            if !func.inputs.is_empty() && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
                 // redact private key input
                 Some(vec!["<pk>".to_string()])
             } else {
@@ -47,4 +48,13 @@ pub(crate) fn decode_cheatcode_inputs(
 
         _ => None,
     }
+}
+
+/// Custom decoding of cheatcode return values
+pub(crate) fn decode_cheatcode_outputs(func: &Function, _data: &[u8]) -> Option<String> {
+    if func.name.starts_with("env") {
+        // redacts the value stored in the env var
+        return Some("<env var value>".to_string())
+    }
+    None
 }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -68,7 +68,7 @@ pub(crate) fn decode_cheatcode_outputs(func: &Function, _data: &[u8]) -> Option<
     }
     if func.name == "deriveKey" {
         // redacts derived private key
-        return Some("<pl>".to_string())
+        return Some("<pk>".to_string())
     }
     None
 }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -34,16 +34,17 @@ pub(crate) fn decode_cheatcode_inputs(
         "expectRevert" => {
             decode::decode_revert(data, Some(errors), None).ok().map(|decoded| vec![decoded])
         }
-        "startBroadcast" | "broadcast" => {
-            // broadcast function accept a private key as uint256, which should not be converted to
-            // plain text
-            if func.inputs.len() == 1 && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
+        "sign" | "startBroadcast" | "broadcast" => {
+            // sign and broadcast functions accept a private key as uint256, which should not be
+            // converted to plain text
+            if func.inputs.len() > 0 && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
                 // redact private key input
                 Some(vec!["<pk>".to_string()])
             } else {
                 None
             }
         }
+
         _ => None,
     }
 }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -2,7 +2,7 @@
 
 use crate::decode;
 use ethers::{
-    abi::{Abi, Address, Function, Token},
+    abi::{Abi, Address, Function, ParamType, Token},
     core::utils::to_checksum,
 };
 use foundry_utils::format_token;
@@ -33,6 +33,16 @@ pub(crate) fn decode_cheatcode_inputs(
     match func.name.as_str() {
         "expectRevert" => {
             decode::decode_revert(data, Some(errors), None).ok().map(|decoded| vec![decoded])
+        }
+        "startBroadcast" | "broadcast" => {
+            // broadcast function accept a private key as uint256, which should not be converted to
+            // plain text
+            if func.inputs.len() == 1 && matches!(&func.inputs[0].kind, ParamType::Uint(_)) {
+                // redact private key input
+                Some(vec!["<pk>".to_string()])
+            } else {
+                None
+            }
         }
         _ => None,
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3333

Redact input for cheatcodes that accept a private key:

```console
Traces:
  [27091] CounterScript::run() 
    ├─ [0] VM::startBroadcast(<pk>) 
    │   └─ ← ()
    └─ ← ()

```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
