### PR TITLE
Disable Yul compilation pipeline along with optimizer in coverage command

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -97,7 +97,7 @@ impl CoverageArgs {
             // Disable the optimizer for more accurate source maps
             project.solc_config.settings.optimizer.disable();
             project.solc_config.settings.via_ir = Some(false);
-            
+
             project
         };
 

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -96,7 +96,8 @@ impl CoverageArgs {
 
             // Disable the optimizer for more accurate source maps
             project.solc_config.settings.optimizer.disable();
-
+            project.solc_config.settings.via_ir = Some(false);
+            
             project
         };
 


### PR DESCRIPTION
## Motivation

When compiling contracts for coverage reporting, the optimizer is set to disabled. However, the yul IR pipeline is not. It isn't intended to be run without the optimizer, and doing so can frequently cause stack too deep errors in many codebases.

## Solution

Set via_ir in the solc config settings to false before the project is built 
