### PR TITLE
fix: patch empty event args

### DIFF
--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -46,6 +46,11 @@ impl TestConfig {
         self
     }
 
+    /// Executes the test runner
+    pub fn test(&mut self) -> BTreeMap<String, SuiteResult> {
+        self.runner.test(&self.filter, None, self.opts).unwrap()
+    }
+
     #[track_caller]
     pub fn run(&mut self) {
         self.try_run().unwrap()

--- a/testdata/repros/Issue3347.sol
+++ b/testdata/repros/Issue3347.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3347
+contract Issue3347Test is DSTest {
+    event log2(uint256, uint256);
+
+    function test() public {
+        emit log2(1, 2);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3347

This is a known bug in ethabi, https://github.com/rust-ethereum/ethabi/issues/206. the decoding impl is a bit cryptic...

Instead, this is fixed by temporarily patching empty event args:

```
forge test -vvvvv                                                                                                        
[⠆] Compiling...
No files changed, compilation skipped

Running 1 test for test/Counter.t.sol:LogTest
[PASS] test() (gas: 1497)
Traces:
  [1497] LogTest::test() 
    ├─ emit log2(: 1, : 2)
    └─ ← ()

```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
