### PR TITLE
perf(anvil): flush historic state in new task

### DIFF
--- a/anvil/src/eth/backend/mem/cache.rs
+++ b/anvil/src/eth/backend/mem/cache.rs
@@ -40,16 +40,22 @@ impl DiskStateCache {
     }
 
     /// Stores the snapshot for the given hash
-    pub fn write(&mut self, hash: H256, state: &StateSnapshot) {
+    ///
+    /// Note: this writes the state on a new spawned task
+    ///
+    /// Caution: this requires a running tokio Runtime.
+    pub fn write(&mut self, hash: H256, state: StateSnapshot) {
         self.with_cache_file(hash, |file| {
-            match foundry_common::fs::write_json_file(&file, state) {
-                Ok(_) => {
-                    trace!(target: "backend", ?hash, "wrote state json file");
-                }
-                Err(err) => {
-                    error!(target: "backend", ?err, ?hash, "Failed to load state snapshot");
-                }
-            }
+            tokio::task::spawn(async move {
+                match foundry_common::fs::write_json_file(&file, &state) {
+                    Ok(_) => {
+                        trace!(target: "backend", ?hash, "wrote state json file");
+                    }
+                    Err(err) => {
+                        error!(target: "backend", ?err, ?hash, "Failed to load state snapshot");
+                    }
+                };
+            });
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
flushing historic cached state to file in sync could be a performance bottleneck once the state reached a certain size.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
flush historic state to file in separate task.

there's the possibility that a request for historic data that is currently in the process of being flushed returns nothing. But since only old state is flushed to disk, I think we can neglect that here and rather focus on block mining perf.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
