### PR TITLE
Use consistent casing

### DIFF
--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -764,7 +764,7 @@ pub trait OutputExt {
 ///
 /// This should strip everything that can vary from run to run, like elapsed time, file paths
 static IGNORE_IN_FIXTURES: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(\r|finished in (.*)?s|-->(.*).sol|Location(.|\n)*\.rs(.|\n)*Backtrace|installing solc version(.*?)\n|Successfully installed solc(.*?)\n|runs: \d+, μ: \d+, ~: \d+)").unwrap()
+    Regex::new(r"(\r|finished in (.*)?s|-->(.*).sol|Location(.|\n)*\.rs(.|\n)*Backtrace|Installing solc version(.*?)\n|Successfully installed solc(.*?)\n|runs: \d+, μ: \d+, ~: \d+)").unwrap()
 });
 
 impl OutputExt for process::Output {

--- a/common/src/term.rs
+++ b/common/src/term.rs
@@ -203,7 +203,7 @@ impl Reporter for SpinnerReporter {
 
     /// Invoked before a new [`Solc`] bin is installed
     fn on_solc_installation_start(&self, version: &Version) {
-        self.send_msg(format!("Installing solc version \"{version}\""));
+        self.send_msg(format!("Installing solc version {version}"));
     }
 
     /// Invoked before a new [`Solc`] bin was successfully installed

--- a/common/src/term.rs
+++ b/common/src/term.rs
@@ -203,7 +203,7 @@ impl Reporter for SpinnerReporter {
 
     /// Invoked before a new [`Solc`] bin is installed
     fn on_solc_installation_start(&self, version: &Version) {
-        self.send_msg(format!("installing solc version \"{version}\""));
+        self.send_msg(format!("Installing solc version \"{version}\""));
     }
 
     /// Invoked before a new [`Solc`] bin was successfully installed


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Terminal output uses title case almost everywhere, except when installing solc:
```logs
[⠊] Compiling...
[⠆] installing solc version "0.8.17"
[⠒] Successfully installed solc 0.8.17
[⠑] Compiling 10 files with 0.8.17
[⠃] Solc 0.8.17 finished in 1.05s
Compiler run successful
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adjust case for `installing solc version` message.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
