### PR TITLE
feat: decode custom errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "futures",
  "hashbrown 0.12.0",
  "hex",
+ "itertools",
  "jsonpath-rust",
  "once_cell",
  "parking_lot 0.12.0",
@@ -2997,9 +2998,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -55,6 +55,7 @@ yansi = "0.5.1"
 # Misc
 url = "2.2.2"
 auto_impl = "1.0.1"
+itertools = "0.10.5"
 
 # Coverage
 semver = "1.0.5"

--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -4,12 +4,14 @@ use crate::{
     error::ERROR_PREFIX,
 };
 use ethers::{
-    abi::{AbiDecode, Contract as Abi, RawLog},
+    abi::{decode, AbiDecode, Contract as Abi, ParamType, RawLog, Token},
     contract::EthLogDecode,
     prelude::U256,
     types::Log,
 };
-use foundry_common::SELECTOR_LEN;
+use foundry_common::{abi::format_token, SELECTOR_LEN};
+use itertools::Itertools;
+use once_cell::sync::Lazy;
 use revm::Return;
 
 /// Decode a set of logs, only returning logs from DSTest logging events and Hardhat's `console.log`
@@ -194,7 +196,117 @@ pub fn decode_revert(
                         .map(|err_str| format!("{}:{}", hex::encode(&err[..SELECTOR_LEN]), err_str))
                         .ok()
                 })
+                .or_else(|| {
+                    // try to decode possible variations of custom error types
+                    decode_custom_error(err).map(|token| {
+                        let s = format!("Custom Error {}:", hex::encode(&err[..SELECTOR_LEN]));
+
+                        let err_str = format_token(&token);
+                        if err_str.starts_with('(') {
+                            format!("{}{}", s, err_str)
+                        } else {
+                            format!("{}({})", s, err_str)
+                        }
+                    })
+                })
                 .ok_or_else(|| eyre::eyre!("Non-native error and not string"))
         }
+    }
+}
+
+/// Tries to optimistically decode a custom solc error, with at most 4 arguments
+pub fn decode_custom_error(err: &[u8]) -> Option<Token> {
+    decode_custom_error_args(err, 4)
+}
+
+/// Tries to optimistically decode a custom solc error with a maximal amount of arguments
+///
+/// This will brute force decoding of custom errors with up to `args` arguments
+pub fn decode_custom_error_args(err: &[u8], args: usize) -> Option<Token> {
+    if err.len() <= SELECTOR_LEN {
+        return None
+    }
+
+    let err = &err[SELECTOR_LEN..];
+    /// types we check against
+    static TYPES: Lazy<Vec<ParamType>> = Lazy::new(|| {
+        vec![
+            ParamType::Address,
+            ParamType::Bool,
+            ParamType::Uint(256),
+            ParamType::Int(256),
+            ParamType::Bytes,
+            ParamType::String,
+        ]
+    });
+
+    macro_rules! try_decode {
+        ($ty:ident) => {
+            if let Ok(mut decoded) = decode(&[$ty], err) {
+                return Some(decoded.remove(0))
+            }
+        };
+    }
+
+    // check if single param, but only if it's a single word
+    if err.len() == 32 {
+        for ty in TYPES.iter().cloned() {
+            try_decode!(ty);
+        }
+        return None
+    }
+
+    // brute force decode all possible combinations
+    for num in (2..=args).rev() {
+        for candidate in TYPES.iter().cloned().combinations(num) {
+            if let Ok(decoded) = decode(&candidate, err) {
+                return Some(Token::Tuple(decoded))
+            }
+        }
+    }
+
+    // try as array
+    for ty in TYPES.iter().cloned().map(|ty| ParamType::Array(Box::new(ty))) {
+        try_decode!(ty);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::{
+        abi::{AbiEncode, Address},
+        contract::EthError,
+    };
+
+    #[test]
+    fn test_decode_custom_error_address() {
+        #[derive(Debug, Clone, EthError)]
+        struct AddressErr(Address);
+        let err = AddressErr(Address::random());
+
+        let encoded = err.clone().encode();
+        let decoded = decode_custom_error(&encoded).unwrap();
+        assert_eq!(decoded, Token::Address(err.0));
+    }
+
+    #[test]
+    fn test_decode_custom_error_args3() {
+        #[derive(Debug, Clone, EthError)]
+        struct MyError(Address, bool, U256);
+        let err = MyError(Address::random(), true, 100u64.into());
+
+        let encoded = err.clone().encode();
+        let decoded = decode_custom_error(&encoded).unwrap();
+        assert_eq!(
+            decoded,
+            Token::Tuple(vec![
+                Token::Address(err.0),
+                Token::Bool(err.1),
+                Token::Uint(100u64.into()),
+            ])
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3399

Brute forces custom error decoding.

```solidity
  error MyError(address);
```

will be decoded and printed to console as:

` Error: reverted with 'Custom Error 73ea2a7f:(0x0000000000000000000000000000000000000001)'`


Note: the decoding impl could be further optimized by manually counting words but this should be sufficient 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
