### PR TITLE
adding ash support to foundryup install.sh for easier install/use on busybox/alpine

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -32,6 +32,10 @@ case $SHELL in
     PROFILE=$HOME/.config/fish/config.fish
     PREF_SHELL=fish
     ;;
+*/ash)
+    PROFILE=$HOME/.profile
+    PREF_SHELL=ash
+    ;;
 *)
     echo "foundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
     exit 1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This adds support for ash (the Almquist shell, as in, on Alpine linux/busybox) in the installer. This allows you to use foundry in a busybox without installing another shell.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I add it as a shell option in the installer.


I tested this with this Dockerfile, and everything went fine :) have to do some futzing later on with paths for the forge binary, but it installs and runs.
```
FROM alpine

RUN apk add --no-cache bash curl jq git

# RUN curl -L https://foundry.paradigm.xyz | bash
# replace the previous line with the following to test my patched version :P
COPY ./integration-test/install.sh /install.sh
RUN chmod +x /install.sh
RUN /install.sh
ENV PATH="/root/.foundry/bin:${PATH}"
RUN foundryup
```
