### PR TITLE
fix: don't fail on repeated installs

### DIFF
--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -828,7 +828,17 @@ forgetest!(can_reinstall_after_manual_remove, |prj: TestProject, mut cmd: TestCo
     install(&mut cmd);
 });
 
-// Tests that forge update doesn't break a working depencency by recursively updating nested
+// test that we can repeatedly install the same dependency without changes
+forgetest!(can_install_repeatedly, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.git_init();
+
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]);
+    for _ in 0..3 {
+        cmd.assert_success();
+    }
+});
+
+// Tests that forge update doesn't break a working dependency by recursively updating nested
 // dependencies
 forgetest!(
     can_update_library_with_outdated_nested_dependency,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
handles repeated forge install calls for the same dependency gracefully.
repeatedly installing the same repo doesn't have any side-effects but git returns an error if nothing has changed on git commit.

ref https://github.com/foundry-rs/foundry/issues/3321
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
