### PR TITLE
fix: diagnose forking reverts only in multifork mode

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -1107,6 +1107,13 @@ impl DatabaseExt for Backend {
     ) -> Option<RevertDiagnostic> {
         let active_id = self.active_fork_id()?;
         let active_fork = self.active_fork()?;
+
+        if self.inner.forks.len() == 1 {
+            // we only want to provide additional diagnostics here when in multifork mode with > 1
+            // forks
+            return None
+        }
+
         if !active_fork.is_contract(callee) && !is_contract_in_state(journaled_state, callee) {
             // no contract for `callee` available on current fork, check if available on other forks
             let mut available_on = Vec::new();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #3424

when we encounter a revert in forking mode we check if the account of the call recipient actually exists. this is useful in multi forking mode, but only really in multiforking mode.

This will only try to diagnose a revert if there are more than 1 forks created.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
