### PR TITLE
feat: no random target senders if `targetSenders()` is used

### DIFF
--- a/evm/src/fuzz/strategies/invariants.rs
+++ b/evm/src/fuzz/strategies/invariants.rs
@@ -90,8 +90,7 @@ fn generate_call(
 
 /// Strategy to select a sender address:
 /// * If `senders` is empty, then it's either a random address (10%) or from the dictionary (90%).
-/// * If `senders` is not empty, then there's an 80% chance that one from the list is selected. The
-///   remaining 20% will either be a random address (10%) or from the dictionary (90%).
+/// * If `senders` is not empty, a random address is chosen from the list of senders.
 fn select_random_sender(
     fuzz_state: EvmFuzzState,
     senders: Rc<SenderFilters>,

--- a/evm/src/fuzz/strategies/invariants.rs
+++ b/evm/src/fuzz/strategies/invariants.rs
@@ -117,9 +117,8 @@ fn select_random_sender(
     .boxed();
 
     if !senders.targeted.is_empty() {
-        let selector = any::<prop::sample::Selector>()
-            .prop_map(move |selector| *selector.select(&*senders.targeted));
-        proptest::strategy::Union::new_weighted(vec![(80, selector.boxed()), (20, fuzz_strategy)])
+        any::<prop::sample::Selector>()
+            .prop_map(move |selector| *selector.select(&*senders.targeted))
             .boxed()
     } else {
         fuzz_strategy


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/3400

I'm unsure why we originally decided to choose random addresses 20% of the time even when `targetSenders()` is used. I agree with @lucas-manuel that isn't ideal. Curious to hear from @joshieDo why we currently do this, but if there's value in it we can always add this back with a new config flag to determine how `targetSenders()` behaves