### PR TITLE
feat(cast): resolve rpc aliases if foundry.toml is present

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -12,7 +12,7 @@ use foundry_cli::{
     handler,
     opts::cast::{Opts, Subcommands},
     utils,
-    utils::consume_config_rpc_url,
+    utils::try_consume_config_rpc_url,
 };
 use foundry_common::{
     abi::format_tokens,
@@ -204,7 +204,7 @@ async fn main() -> eyre::Result<()> {
             println!("{}", Cast::new(&provider).access_list(builder_output, block, to_json).await?);
         }
         Subcommands::Age { block, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!(
                 "{}",
@@ -212,12 +212,12 @@ async fn main() -> eyre::Result<()> {
             );
         }
         Subcommands::Balance { block, who, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).balance(who, block).await?);
         }
         Subcommands::BaseFee { block, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             println!(
@@ -226,39 +226,39 @@ async fn main() -> eyre::Result<()> {
             );
         }
         Subcommands::Block { rpc_url, block, full, field, to_json } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);
         }
         Subcommands::BlockNumber { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).block_number().await?);
         }
         Subcommands::Chain { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).chain().await?);
         }
         Subcommands::ChainId { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).chain_id().await?);
         }
         Subcommands::Client { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", provider.client_version().await?);
         }
         Subcommands::Code { block, who, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).code(who, block).await?);
         }
         Subcommands::ComputeAddress { rpc_url, address, nonce } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
             let provider = try_get_http_provider(rpc_url)?;
@@ -267,7 +267,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::FindBlock(cmd) => cmd.run()?.await?,
         Subcommands::GasPrice { rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).gas_price().await?);
         }
@@ -276,13 +276,13 @@ async fn main() -> eyre::Result<()> {
             println!("{encoded}");
         }
         Subcommands::Nonce { block, who, rpc_url } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
         Subcommands::Proof { address, slots, rpc_url, block } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             let value = provider.get_proof(address, slots, block).await?;
@@ -290,7 +290,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Rpc(cmd) => cmd.run()?.await?,
         Subcommands::Storage { address, slot, rpc_url, block } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 
             let provider = try_get_http_provider(rpc_url)?;
             let value = provider.get_storage_at(address, slot, block).await?;
@@ -316,7 +316,7 @@ async fn main() -> eyre::Result<()> {
             }
         }
         Subcommands::Receipt { hash, field, to_json, rpc_url, cast_async, confirmations } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!(
                 "{}",
@@ -328,7 +328,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Run(cmd) => cmd.run()?,
         Subcommands::SendTx(cmd) => cmd.run().await?,
         Subcommands::Tx { rpc_url, hash, field, to_json } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
@@ -377,7 +377,7 @@ async fn main() -> eyre::Result<()> {
 
         // ENS
         Subcommands::LookupAddress { who, rpc_url, verify } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             let who = unwrap_or_stdin(who)?;
             let name = provider.lookup_address(who).await?;
@@ -395,7 +395,7 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::namehash(&name)?);
         }
         Subcommands::ResolveName { who, rpc_url, verify } => {
-            let rpc_url = consume_config_rpc_url(rpc_url);
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
             let who = unwrap_or_stdin(who)?;
             let address = provider.resolve_name(&who).await?;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -97,14 +97,19 @@ pub fn parse_u256(s: &str) -> eyre::Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
 }
 
-/// Return `rpc-url` cli argument if given, or consume `eth-rpc-url` from foundry.toml. Default to
+/// Returns `rpc-url` cli argument if given, or consume `eth-rpc-url` from foundry.toml. Default to
 /// `localhost:8545`
+///
+/// This also supports rpc aliases and try to load the current foundry.toml file if it exists
+pub fn try_consume_config_rpc_url(rpc_url: Option<String>) -> eyre::Result<String> {
+    let mut config = Config::load();
+    config.eth_rpc_url = rpc_url;
+    let url = config.get_rpc_url_or_localhost_http()?;
+    Ok(url.into_owned())
+}
+
 pub fn consume_config_rpc_url(rpc_url: Option<String>) -> String {
-    if let Some(rpc_url) = rpc_url {
-        rpc_url
-    } else {
-        Config::load().get_rpc_url_or_localhost_http().expect("Invalid rpc url").into_owned()
-    }
+    try_consume_config_rpc_url(rpc_url).expect("Invalid rpc url")
 }
 
 /// Parses an ether value from a string.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3433

use new alias helpers when resolving rpc URL in cast
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
