### PR TITLE
feat(invariant): collect logs & traces for last successful runs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-#debug = 0
+debug = 0
 
 # These speed up local tests
 [profile.dev.package.ethers-solc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much
-debug = 0
+#debug = 0
 
 # These speed up local tests
 [profile.dev.package.ethers-solc]

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -292,10 +292,6 @@ impl<'a> InvariantExecutor<'a> {
         self.executor.inspector_config_mut().fuzzer =
             Some(Fuzzer { call_generator, fuzz_state: fuzz_state.clone(), collect: true });
 
-        // Tracing should be off when running all runs. It will be turned on later for the failure
-        // cases.
-        self.executor.set_tracing(false);
-
         Ok((fuzz_state, targeted_contracts, strat))
     }
 

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -95,15 +95,17 @@ impl<'a> InvariantExecutor<'a> {
 
         let blank_executor = RefCell::new(&mut *self.executor);
 
+        let last_call_results = RefCell::new(
+            assert_invariants(
+                &invariant_contract,
+                &blank_executor.borrow(),
+                &[],
+                &mut failures.borrow_mut(),
+            )
+            .ok(),
+        );
         // Make sure invariants are sound even before starting to fuzz
-        if assert_invariants(
-            &invariant_contract,
-            &blank_executor.borrow(),
-            &[],
-            &mut failures.borrow_mut(),
-        )
-        .is_err()
-        {
+        if last_call_results.borrow().is_none() {
             fuzz_cases.borrow_mut().push(FuzzedCases::new(vec![]));
         }
 
@@ -179,16 +181,20 @@ impl<'a> InvariantExecutor<'a> {
                         stipend: call_result.stipend,
                     });
 
-                    if !can_continue(
+                    let (can_continue, call_results) = can_continue(
                         &invariant_contract,
                         call_result,
                         &executor,
                         &inputs,
                         &mut failures.borrow_mut(),
                         self.config.fail_on_revert,
-                    ) {
+                    );
+
+                    if !can_continue {
                         break 'fuzz_run
                     }
+
+                    *last_call_results.borrow_mut() = call_results;
 
                     // Generates the next call from the run using the recently updated
                     // dictionary.
@@ -218,7 +224,12 @@ impl<'a> InvariantExecutor<'a> {
 
         let (reverts, invariants) = failures.into_inner().into_inner();
 
-        Ok(Some(InvariantFuzzTestResult { invariants, cases: fuzz_cases.into_inner(), reverts }))
+        Ok(Some(InvariantFuzzTestResult {
+            invariants,
+            cases: fuzz_cases.into_inner(),
+            reverts,
+            last_call_results: last_call_results.take(),
+        }))
     }
 
     /// Prepares certain structures to execute the invariant tests:
@@ -562,10 +573,12 @@ fn can_continue(
     calldata: &[BasicTxDetails],
     failures: &mut InvariantFailures,
     fail_on_revert: bool,
-) -> bool {
+) -> (bool, Option<BTreeMap<String, RawCallResult>>) {
+    let mut call_results = None;
     if !call_result.reverted {
-        if assert_invariants(invariant_contract, executor, calldata, failures).is_err() {
-            return false
+        call_results = assert_invariants(invariant_contract, executor, calldata, failures).ok();
+        if call_results.is_none() {
+            return (false, None)
         }
     } else {
         failures.reverts += 1;
@@ -583,10 +596,10 @@ fn can_continue(
                 failures.failed_invariants.insert(invariant.name.clone(), Some(error.clone()));
             }
 
-            return false
+            return (false, None)
         }
     }
-    true
+    (true, call_results)
 }
 
 #[derive(Clone)]

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -562,6 +562,7 @@ fn collect_data(
 }
 
 /// Verifies that the invariant run execution can continue.
+/// Returns the mapping of (Invariant Function Name -> Call Result) if invariants were asserted.
 fn can_continue(
     invariant_contract: &InvariantContract,
     call_result: RawCallResult,

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -1,7 +1,7 @@
 //! Fuzzing support abstracted over the [`Evm`](crate::Evm) used
 use crate::{fuzz::*, CALLER};
 mod error;
-use error::*;
+pub use error::InvariantFuzzError;
 mod filters;
 pub use filters::{ArtifactFilters, SenderFilters};
 mod call_override;

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -36,6 +36,7 @@ pub struct InvariantContract<'a> {
 
 /// Given the executor state, asserts that no invariant has been broken. Otherwise, it fills the
 /// external `invariant_failures.failed_invariant` map and returns a generic error.
+/// Returns the mapping of (Invariant Function Name -> Call Result).
 pub fn assert_invariants(
     invariant_contract: &InvariantContract,
     executor: &Executor,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -459,12 +459,15 @@ impl<'a> ContractRunner<'a> {
                     let mut logs = logs.clone();
                     let mut traces = traces.clone();
 
-                    if let Some(last_call_logs) = last_call_results
+                    if let Some(last_call_result) = last_call_results
                         .as_mut()
                         .and_then(|call_results| call_results.remove(func_name))
-                        .map(|call_result| call_result.logs)
                     {
-                        logs.extend(last_call_logs);
+                        logs.extend(last_call_result.logs);
+
+                        if let Some(last_call_traces) = last_call_result.traces {
+                            traces.push((TraceKind::Execution, last_call_traces));
+                        }
                     }
 
                     if let Some(ref error) = test_error {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/2962

## Solution

### Cases

1. When invariant succeeds, we collect logs and traces from the last successful run
2. When invariant breaks, we replay the call to collect logs and traces from the last run that broke the invariant

### Demo
<details>
<summary>Code</summary>

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "forge-std/Test.sol";

contract NonceCounter {
  int256 public nonce = 1;

  function increment() public {
    nonce++;
  }
}

contract NonceCounterTest is Test {
  NonceCounter nonceCounter;
  int256 lastNonce;

  function setUp() public {
    nonceCounter = new NonceCounter();
  }

  function invariant_NonceGoUp() external {
    console2.log('lastNonce: ', vm.toString(lastNonce));

    int256 currentNonce = nonceCounter.nonce();
    console2.log('currentNonce: ', vm.toString(nonceCounter.nonce()));

    require(currentNonce > lastNonce, "Invariant violated: Nonce did not increase");
    lastNonce = currentNonce;
  }

  function invariant_NonceNotGoOver10() external {
    int256 currentNonce = nonceCounter.nonce();
    console2.log('currentNonce: ', vm.toString(nonceCounter.nonce()));

    require(currentNonce <= 10, "Invariant violated: Nonce went over 10");
  }
}
```
</details>

<details>
<summary>Before</summary>

```console
➜  invariant-bug git:(main) ✗ forge test -vvvv
[⠆] Compiling...
No files changed, compilation skipped

Running 2 tests for test/Counter.t.sol:NonceCounterTest
[PASS] invariant_NonceGoUp() (runs: 256, calls: 3835, reverts: 60)
[FAIL. Reason: Invariant violated: Nonce went over 10]
        [Sequence]
                sender=0x00000000000000000000000000000000000000e5 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x000000000000000000000000000000000000006d addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000ba414fa6 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x96c1077fbd1eeaae1ce08f75352cb0b424d9b481 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000000ad addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000f8ccbf47 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000006b3 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0xb568eabb1b0c6cfb2b32393b4aa98ca860b1b6bc addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x5c22070dafc36ad75f3dcf5e7237b22ade9aecc4 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x4defe99ade4fd21a9478cf81ef727aa847c0ab94 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]

 invariant_NonceNotGoOver10() (runs: 256, calls: 3835, reverts: 60)
Logs:
  currentNonce:  11

Traces:
  [118067] NonceCounterTest::setUp()
    ├─ [63599] → new NonceCounter@0xCe71065D4017F316EC606Fe4422e11eB2c47c246
    │   └─ ← 207 bytes of code
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [15130] NonceCounterTest::invariant_NonceNotGoOver10()
    ├─ [2261] NonceCounter::nonce() [staticcall]
    │   └─ ← 11
    ├─ [261] NonceCounter::nonce() [staticcall]
    │   └─ ← 11
    ├─ [0] VM::toString(11)
    │   └─ ← 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000023131000000000000000000000000000000000000000000000000000000000000
    ├─ [0] console::log(currentNonce: , 11) [staticcall]
    │   └─ ← ()
    └─ ← "Invariant violated: Nonce went over 10"

Test result: FAILED. 1 passed; 1 failed; finished in 284.39ms

Failing tests:
Encountered 1 failing test in test/Counter.t.sol:NonceCounterTest
[FAIL. Reason: Invariant violated: Nonce went over 10]
        [Sequence]
                sender=0x00000000000000000000000000000000000000e5 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x000000000000000000000000000000000000006d addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000ba414fa6 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x96c1077fbd1eeaae1ce08f75352cb0b424d9b481 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000000ad addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000f8ccbf47 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000006b3 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0xb568eabb1b0c6cfb2b32393b4aa98ca860b1b6bc addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x5c22070dafc36ad75f3dcf5e7237b22ade9aecc4 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x4defe99ade4fd21a9478cf81ef727aa847c0ab94 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]

 invariant_NonceNotGoOver10() (runs: 256, calls: 3835, reverts: 60)

Encountered a total of 1 failing tests, 1 tests succeeded
```
</details>

<details>
<summary>After</summary>

```console
➜  invariant-bug git:(main) ✗ /Users/shekhirin/Projects/foundry/target/debug/forge test -vvvv
[⠒] Compiling...
No files changed, compilation skipped

Running 2 tests for test/Counter.t.sol:NonceCounterTest
[PASS] invariant_NonceGoUp() (runs: 256, calls: 3835, reverts: 67)
Logs:
  lastNonce:  0
  currentNonce:  14

Traces:
  [38977] NonceCounterTest::invariant_NonceGoUp()
    ├─ [0] VM::toString(0)
    │   └─ ← 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000013000000000000000000000000000000000000000000000000000000000000000
    ├─ [0] console::log(lastNonce: , 0) [staticcall]
    │   └─ ← ()
    ├─ [2261] NonceCounter::nonce() [staticcall]
    │   └─ ← 14
    ├─ [261] NonceCounter::nonce() [staticcall]
    │   └─ ← 14
    ├─ [0] VM::toString(14)
    │   └─ ← 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000023134000000000000000000000000000000000000000000000000000000000000
    ├─ [0] console::log(currentNonce: , 14) [staticcall]
    │   └─ ← ()
    └─ ← ()

[FAIL. Reason: Invariant violated: Nonce went over 10]
        [Sequence]
                sender=0x0000000000000000000000000000000000000364 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x6f6c617465643a204e6f6e63652077656e74206f addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000003630b9ba2737b731b29d1 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x000000006c63430008100033a264697066735822 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x0000000000000000000000000000000000000040 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x92c9eba133ae5dc4287850bcf804f2b03cd3d776 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000001a0 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x1a9c76fa0d7d6a7f68dc6c539d18f9276fce81b5 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000000dc addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]

 invariant_NonceNotGoOver10() (runs: 256, calls: 3835, reverts: 67)
Logs:
  currentNonce:  11

Traces:
  [118067] NonceCounterTest::setUp()
    ├─ [63599] → new NonceCounter@0xCe71065D4017F316EC606Fe4422e11eB2c47c246
    │   └─ ← 207 bytes of code
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [5242] NonceCounter::increment()
    └─ ← ()

  [15130] NonceCounterTest::invariant_NonceNotGoOver10()
    ├─ [2261] NonceCounter::nonce() [staticcall]
    │   └─ ← 11
    ├─ [261] NonceCounter::nonce() [staticcall]
    │   └─ ← 11
    ├─ [0] VM::toString(11)
    │   └─ ← 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000023131000000000000000000000000000000000000000000000000000000000000
    ├─ [0] console::log(currentNonce: , 11) [staticcall]
    │   └─ ← ()
    └─ ← "Invariant violated: Nonce went over 10"

Test result: FAILED. 1 passed; 1 failed; finished in 6.01s

Failing tests:
Encountered 1 failing test in test/Counter.t.sol:NonceCounterTest
[FAIL. Reason: Invariant violated: Nonce went over 10]
        [Sequence]
                sender=0x0000000000000000000000000000000000000364 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x6f6c617465643a204e6f6e63652077656e74206f addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000003630b9ba2737b731b29d1 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x000000006c63430008100033a264697066735822 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x0000000000000000000000000000000000000040 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x92c9eba133ae5dc4287850bcf804f2b03cd3d776 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000001a0 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x1a9c76fa0d7d6a7f68dc6c539d18f9276fce81b5 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38 addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]
                sender=0x00000000000000000000000000000000000000dc addr=[test/Counter.t.sol:NonceCounter]0xce71065d4017f316ec606fe4422e11eb2c47c246 calldata=increment(), args=[]

 invariant_NonceNotGoOver10() (runs: 256, calls: 3835, reverts: 67)

Encountered a total of 1 failing tests, 1 tests succeeded
```
</details>