### PR TITLE
fix(forge): fmt pragma directive newlines

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -1506,6 +1506,9 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             loc,
             source_unit.0.iter_mut(),
             |last_unit, unit| match last_unit {
+                SourceUnitPart::PragmaDirective(..) => {
+                    !matches!(unit, SourceUnitPart::PragmaDirective(..))
+                }
                 SourceUnitPart::ImportDirective(_) => {
                     !matches!(unit, SourceUnitPart::ImportDirective(_))
                 }
@@ -3485,4 +3488,5 @@ mod tests {
     test_directory! { FunctionCall }
     test_directory! { TrailingComma }
     test_directory! { SelectorOverride }
+    test_directory! { PragmaDirective }
 }

--- a/fmt/testdata/PragmaDirective/fmt.sol
+++ b/fmt/testdata/PragmaDirective/fmt.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.8.17;
+pragma experimental ABIEncoderV2;
+
+contract Contract {}
+
+// preserves lines
+pragma solidity 0.8.17;
+
+pragma experimental ABIEncoderV2;

--- a/fmt/testdata/PragmaDirective/original.sol
+++ b/fmt/testdata/PragmaDirective/original.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.8.17;
+pragma experimental ABIEncoderV2;
+
+contract Contract {}
+
+// preserves lines
+pragma solidity 0.8.17;
+
+pragma experimental ABIEncoderV2;


### PR DESCRIPTION
## Motivation

close #3472

## Solution

Currently, the formatter forces a newline between two pragma directives. The expected behavior is that the newlines would be preserved (2 at most) between multiple consecutive pragma directives
