### PR TITLE
fix(forge): script non-zero exit code on no inputs

### DIFF
--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -185,6 +185,10 @@ impl ScriptArgs {
     ) -> eyre::Result<(Project, ProjectCompileOutput)> {
         let project = script_config.config.project()?;
 
+        if !project.paths.has_input_files() {
+            eyre::bail!("No input files detected.")
+        }
+
         // We received a file path.
         if let Ok(target_contract) = dunce::canonicalize(&self.path) {
             let output = compile::compile_target(


### PR DESCRIPTION
## Motivation

close #3454 

## Solution

Currently, on no input files provided forge script exits with code `0` upon calling `compile::compile_target`. Exit with non-zero code and an error message 