### PR TITLE
Add solc option to remove metadata hash from the bytecode.

### DIFF
--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -97,6 +97,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         },
         no_storage_caching: true,
         bytecode_hash: Default::default(),
+        cbor_metadata: true,
         revert_strings: Some(RevertStrings::Strip),
         sparse_mode: true,
         allow_paths: vec![],


### PR DESCRIPTION
Solidity 0.8.18 (unreleased) will introduce an option to completely remove the CBOR metadata from the bytecode. This PR adds that option here.

See `appendCBOR` in https://docs.soliditylang.org/en/develop/using-the-compiler.html#input-description

Depends on https://github.com/gakonst/ethers-rs/pull/1782