### PR TITLE
fix(etherscan): remappings

### DIFF
--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -4,9 +4,10 @@ use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, *};
 use ethers_etherscan::contract::Metadata;
 use ethers_solc::{
     artifacts::{BytecodeObject, ContractBytecodeSome},
+    remappings::Remapping,
     report::NoReporter,
     Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig,
-    Solc,
+    Solc, SolcConfig,
 };
 use eyre::Result;
 use std::{
@@ -365,13 +366,45 @@ pub async fn compile_from_source(
 /// Creates a [Project] from an Etherscan source.
 pub fn etherscan_project(metadata: &Metadata, target_path: impl AsRef<Path>) -> Result<Project> {
     let target_path = dunce::canonicalize(target_path.as_ref())?;
+    let sources_path = target_path.join(&metadata.contract_name);
     metadata.source_tree().write_to(&target_path)?;
 
-    let paths = ProjectPathsConfig::builder().build_with_root(target_path);
+    let mut settings = metadata.source_code.settings()?.unwrap_or_default();
+
+    // make remappings absolute
+    for remapping in settings.remappings.iter_mut() {
+        let mut path = Path::new(&remapping.path);
+        if path.is_absolute() {
+            path = path.strip_prefix("/").unwrap_or(path);
+        }
+        let new_path = target_path.join(path);
+        remapping.path = new_path.display().to_string();
+    }
+
+    // add missing remappings
+    let oz = Remapping {
+        name: "@openzeppelin/".into(),
+        path: sources_path.join("@openzeppelin").display().to_string(),
+    };
+    settings.remappings.push(oz);
+
+    // root/
+    //   ContractName/
+    //     [source code]
+    let paths = ProjectPathsConfig::builder()
+        .sources(sources_path)
+        .remappings(settings.remappings.clone())
+        .build_with_root(target_path);
 
     let v = metadata.compiler_version()?;
     let v = format!("{}.{}.{}", v.major, v.minor, v.patch);
     let solc = Solc::find_or_install_svm_version(v)?;
 
-    Ok(metadata.project_builder()?.paths(paths).solc(solc).ephemeral().no_artifacts().build()?)
+    Ok(Project::builder()
+        .solc_config(SolcConfig::builder().settings(settings).build())
+        .paths(paths)
+        .solc(solc)
+        .ephemeral()
+        .no_artifacts()
+        .build()?)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Remappings from settings don't get included in the project paths struct, are absolute, and sometimes are not even there!!!
example, in [this case](https://api.etherscan.io/api?module=contract&action=getsourcecode&address=0xf4d2888d29D722226FafA5d9B24F9164c092421E) `@openzeppelin` is referenced in the source code but the settings contain no remappings

Not sure about whether the common libraries (like `@openzeppelin`) are always under `root/ContractName` but it's what I've seen in the contracts I looked at

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
