### PR TITLE
fix(verify): json input sanitization 

### DIFF
--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -437,6 +437,9 @@ To skip this solc dry, pass `--force`.
             .map(|(f, libs)| (f.strip_prefix(project.root()).unwrap_or(&f).to_path_buf(), libs))
             .collect();
 
+        // TODO: make sanitization logic shared between types in ethers
+        let input: StandardJsonCompilerInput = CompilerInput::from(input).sanitized(version).into();
+
         let source =
             serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;
         let name = format!(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently, the verification is broken on master, because JSON standard input is not sanitized during construction

## Solution

Temp fix: convert to compiler input, sanitize & convert back to JSON standard input