### PR TITLE
fix(script): file path arg

### DIFF
--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -185,11 +185,9 @@ impl ScriptArgs {
     ) -> eyre::Result<(Project, ProjectCompileOutput)> {
         let project = script_config.config.project()?;
 
-        if !project.paths.has_input_files() {
-            eyre::bail!("No input files detected.")
-        }
-
-        // We received a file path.
+        // We received a valid file path.
+        // If this file does not exist, `dunce::canonicalize` will
+        // result in an error and it will be handled below.
         if let Ok(target_contract) = dunce::canonicalize(&self.path) {
             let output = compile::compile_target(
                 &target_contract,
@@ -198,6 +196,10 @@ impl ScriptArgs {
                 self.verify,
             )?;
             return Ok((project, output))
+        }
+
+        if !project.paths.has_input_files() {
+            eyre::bail!("The project doesn't have any input files. Make sure the `script` directory is configured properly in foundry.toml. Otherwise, provide the path to the file.")
         }
 
         let contract = ContractInfo::from_str(&self.path)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Sometimes, users have the a non-traditional script project layout. e.g. multiple script dirs for tutorials like
```
- exercise_1/
-- *.sol
- exercise_2/
-- *.sol
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Check if the project contains any files only after checking the input file path. Improve the error message.
