### PR TITLE
fix(cast): --to-base aliases

### DIFF
--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -324,13 +324,13 @@ impl From<NumberWithBase> for String {
 }
 
 impl NumberWithBase {
-    pub fn new(number: impl Into<U256>, is_nonnegative: bool, base: impl Into<Base>) -> Self {
-        Self { number: number.into(), is_nonnegative, base: base.into() }
+    pub fn new(number: impl Into<U256>, is_nonnegative: bool, base: Base) -> Self {
+        Self { number: number.into(), is_nonnegative, base }
     }
 
     /// Creates a copy of the number with the provided base.
-    pub fn with_base(&self, base: impl Into<Base>) -> Self {
-        Self::new(self.number, self.is_nonnegative, base)
+    pub fn with_base(&self, base: Base) -> Self {
+        Self { number: self.number, is_nonnegative: self.is_nonnegative, base }
     }
 
     /// Parses a string slice into a signed integer. If base is None then it tries to determine base

--- a/cast/src/base.rs
+++ b/cast/src/base.rs
@@ -5,7 +5,7 @@ use ethers_core::{
 use eyre::Result;
 use std::{
     convert::{Infallible, TryFrom, TryInto},
-    fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, Result as FmtResult},
+    fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, Result as FmtResult, UpperHex},
     iter::FromIterator,
     num::IntErrorKind,
     str::FromStr,
@@ -13,7 +13,6 @@ use std::{
 
 /* -------------------------------------------- Base -------------------------------------------- */
 
-// TODO: Split Hexadecimal into UpperHex and LowerHex and implement formatting
 /// Represents a number's [radix] or base. Currently it supports the same bases that [std::fmt]
 /// supports.
 ///
@@ -272,6 +271,13 @@ impl Display for NumberWithBase {
 impl LowerHex for NumberWithBase {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Debug::fmt(&self.with_base(Base::Hexadecimal), f)
+    }
+}
+
+impl UpperHex for NumberWithBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let n = format!("{:X}", self.number);
+        f.pad_integral(true, Base::Hexadecimal.prefix(), &n)
     }
 }
 
@@ -677,9 +683,8 @@ mod tests {
 
         assert_eq!(Base::detect("0123456789abcdef").unwrap(), Hexadecimal);
 
-        // See Base::detect comments
-        // Base::detect("0b234abc").unwrap_err();
-        // Base::detect("0o89cba").unwrap_err();
+        let _ = Base::detect("0b234abc").unwrap_err();
+        let _ = Base::detect("0o89cba").unwrap_err();
         let _ = Base::detect("0123456789abcdefg").unwrap_err();
         let _ = Base::detect("0x123abclpmk").unwrap_err();
         let _ = Base::detect("hello world").unwrap_err();
@@ -691,7 +696,7 @@ mod tests {
         let expected_8: Vec<_> = POS_NUM.iter().map(|n| format!("{:o}", n)).collect();
         let expected_10: Vec<_> = POS_NUM.iter().map(|n| format!("{:}", n)).collect();
         let expected_l16: Vec<_> = POS_NUM.iter().map(|n| format!("{:x}", n)).collect();
-        // let expected_u16: Vec<_> = POS_NUM.iter().map(|n| format!("{:X}", n)).collect();
+        let expected_u16: Vec<_> = POS_NUM.iter().map(|n| format!("{:X}", n)).collect();
 
         for (i, n) in POS_NUM.into_iter().enumerate() {
             let mut num: NumberWithBase = I256::from(n).into();
@@ -700,23 +705,22 @@ mod tests {
             assert_eq!(num.set_base(Octal).format(), expected_8[i]);
             assert_eq!(num.set_base(Decimal).format(), expected_10[i]);
             assert_eq!(num.set_base(Hexadecimal).format(), expected_l16[i]);
+            assert_eq!(num.set_base(Hexadecimal).format().to_uppercase(), expected_u16[i]);
         }
     }
 
+    // TODO: test for octal
     #[test]
     fn test_format_neg() {
         // underlying is 256 bits so we have to pad left manually
 
         let expected_2: Vec<_> = NEG_NUM.iter().map(|n| format!("{:1>256b}", n)).collect();
-
-        // TODO: create expected for octal
         // let expected_8: Vec<_> = NEG_NUM.iter().map(|n| format!("1{:7>85o}", n)).collect();
-
         // Sign not included, see NumberWithBase::format
         let expected_10: Vec<_> =
             NEG_NUM.iter().map(|n| format!("{:}", n).trim_matches('-').to_string()).collect();
-
-        let expected_16: Vec<_> = NEG_NUM.iter().map(|n| format!("{:f>64x}", n)).collect();
+        let expected_l16: Vec<_> = NEG_NUM.iter().map(|n| format!("{:f>64x}", n)).collect();
+        let expected_u16: Vec<_> = NEG_NUM.iter().map(|n| format!("{:F>64X}", n)).collect();
 
         for (i, n) in NEG_NUM.into_iter().enumerate() {
             let mut num: NumberWithBase = I256::from(n).into();
@@ -724,7 +728,8 @@ mod tests {
             assert_eq!(num.set_base(Binary).format(), expected_2[i]);
             // assert_eq!(num.set_base(Octal).format(), expected_8[i]);
             assert_eq!(num.set_base(Decimal).format(), expected_10[i]);
-            assert_eq!(num.set_base(Hexadecimal).format(), expected_16[i]);
+            assert_eq!(num.set_base(Hexadecimal).format(), expected_l16[i]);
+            assert_eq!(num.set_base(Hexadecimal).format().to_uppercase(), expected_u16[i]);
         }
     }
 
@@ -739,8 +744,10 @@ mod tests {
         let actual_8_alt: Vec<_> = nums.iter().map(|n| format!("{:#o}", n)).collect();
         let actual_10: Vec<_> = nums.iter().map(|n| format!("{:}", n)).collect();
         let actual_10_alt: Vec<_> = nums.iter().map(|n| format!("{:#}", n)).collect();
-        let actual_16: Vec<_> = nums.iter().map(|n| format!("{:x}", n)).collect();
-        let actual_16_alt: Vec<_> = nums.iter().map(|n| format!("{:#x}", n)).collect();
+        let actual_l16: Vec<_> = nums.iter().map(|n| format!("{:x}", n)).collect();
+        let actual_l16_alt: Vec<_> = nums.iter().map(|n| format!("{:#x}", n)).collect();
+        let actual_u16: Vec<_> = nums.iter().map(|n| format!("{:X}", n)).collect();
+        let actual_u16_alt: Vec<_> = nums.iter().map(|n| format!("{:#X}", n)).collect();
 
         let expected_2: Vec<_> = POS_NUM.iter().map(|n| format!("{:b}", n)).collect();
         let expected_2_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#b}", n)).collect();
@@ -748,8 +755,10 @@ mod tests {
         let expected_8_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#o}", n)).collect();
         let expected_10: Vec<_> = POS_NUM.iter().map(|n| format!("{:}", n)).collect();
         let expected_10_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#}", n)).collect();
-        let expected_16: Vec<_> = POS_NUM.iter().map(|n| format!("{:x}", n)).collect();
-        let expected_16_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#x}", n)).collect();
+        let expected_l16: Vec<_> = POS_NUM.iter().map(|n| format!("{:x}", n)).collect();
+        let expected_l16_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#x}", n)).collect();
+        let expected_u16: Vec<_> = POS_NUM.iter().map(|n| format!("{:X}", n)).collect();
+        let expected_u16_alt: Vec<_> = POS_NUM.iter().map(|n| format!("{:#X}", n)).collect();
 
         for (i, _) in POS_NUM.iter().enumerate() {
             assert_eq!(actual_2[i], expected_2[i]);
@@ -761,8 +770,11 @@ mod tests {
             assert_eq!(actual_10[i], expected_10[i]);
             assert_eq!(actual_10_alt[i], expected_10_alt[i]);
 
-            assert_eq!(actual_16[i], expected_16[i]);
-            assert_eq!(actual_16_alt[i], expected_16_alt[i]);
+            assert_eq!(actual_l16[i], expected_l16[i]);
+            assert_eq!(actual_l16_alt[i], expected_l16_alt[i]);
+
+            assert_eq!(actual_u16[i], expected_u16[i]);
+            assert_eq!(actual_u16_alt[i], expected_u16_alt[i]);
         }
     }
 }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -138,8 +138,14 @@ async fn main() -> eyre::Result<()> {
             let value = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_rlp(&value)?);
         }
-        Subcommands::ToBase { value, base_in, base_out } => {
-            println!("{}", SimpleCast::to_base(&value, base_in, &base_out)?);
+        Subcommands::ToHex(base) => {
+            println!("{}", SimpleCast::to_base(&base.value, base.base_in, "hex")?);
+        }
+        Subcommands::ToDec(base) => {
+            println!("{}", SimpleCast::to_base(&base.value, base.base_in, "dec")?);
+        }
+        Subcommands::ToBase { base, base_out } => {
+            println!("{}", SimpleCast::to_base(&base.value, base.base_in, &base_out)?);
         }
         Subcommands::ToBytes32 { bytes } => {
             let value = unwrap_or_stdin(bytes)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -208,16 +208,22 @@ Examples:
     #[clap(name = "--from-rlp")]
     #[clap(about = "Decodes RLP encoded data. Input must be hexadecimal.")]
     FromRlp { value: Option<String> },
+    #[clap(name = "--to-hex")]
+    #[clap(visible_aliases = &["to-hex", "th", "2h"])]
+    #[clap(about = "Converts a number of one base to another")]
+    ToHex(ToBaseArgs),
+    #[clap(name = "--to-dec")]
+    #[clap(visible_aliases = &["to-dec", "td", "2d"])]
+    #[clap(about = "Converts a number of one base to decimal")]
+    ToDec(ToBaseArgs),
     #[clap(name = "--to-base")]
-    #[clap(visible_aliases = &["--to-radix", "to-radix", "to-base", "tr", "2r", "--to-hex", "to-hex", "th", "2h", "--to-dec", "to-dec", "td", "2d"])]
+    #[clap(visible_aliases = &["to-base", "--to-radix", "to-radix", "tr", "2r"])]
     #[clap(about = "Converts a number of one base to another")]
     ToBase {
-        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
-        value: String,
+        #[clap(flatten)]
+        base: ToBaseArgs,
         #[clap(value_name = "BASE", help = "The output base")]
         base_out: String,
-        #[clap(long = "base-in", help = "The input base")]
-        base_in: Option<String>,
     },
     #[clap(name = "access-list")]
     #[clap(visible_aliases = &["ac", "acl"])]
@@ -750,6 +756,15 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
     },
+}
+
+/// Common args for ToHex, ToDec, ToBase
+#[derive(Debug, Parser)]
+pub struct ToBaseArgs {
+    #[clap(allow_hyphen_values = true, value_name = "VALUE")]
+    pub value: String,
+    #[clap(long = "base-in", short = 'i', help = "The input base")]
+    pub base_in: Option<String>,
 }
 
 pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -239,3 +239,31 @@ casttest!(cast_run_succeeds, |_: TestProject, mut cmd: TestCommand| {
     assert!(output.contains("Transaction successfully executed"));
     assert!(!output.contains("Revert"));
 });
+
+// tests that `cast --to-base` commands are working correctly.
+casttest!(cast_to_base, |_: TestProject, mut cmd: TestCommand| {
+    let values = [
+        "1",
+        "100",
+        "100000",
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "-1",
+        "-100",
+        "-100000",
+        "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+    ];
+    for value in values {
+        for subcmd in ["--to-base", "--to-hex", "--to-dec"] {
+            if subcmd == "--to-base" {
+                for base in ["bin", "oct", "dec", "hex"] {
+                    cmd.cast_fuse().args([subcmd, value, base]);
+                    assert!(!cmd.stdout_lossy().trim().is_empty());
+                }
+            } else {
+                cmd.cast_fuse().args([subcmd, value]);
+                assert!(!cmd.stdout_lossy().trim().is_empty());
+            }
+        }
+    }
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

closes: #3506

## Solution

re-add `ToHex`, `ToDec` commands which just use `ToBase` with always the same `base_out`

maybe there's a better way to do this by using using clap, without creating new commands?

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
