### PR TITLE
bump ethers and fix BlockNumber issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.17.0"
-source = "git+https://github.com/gakonst/ethers-rs#2c28fa47e7bebab87587181cd2868d09b724ed0a"
+source = "git+https://github.com/gakonst/ethers-rs#a9dd53da810d8eff82aa77e0f9297b4a453028e6"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -4369,9 +4369,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1039,10 +1039,15 @@ impl EthApi {
         node_info!("eth_feeHistory");
         // max number of blocks in the requested range
 
+        let current = self.backend.best_number().as_u64();
+        let slots_in_an_epoch = 32u64;
+
         let number = match newest_block {
-            BlockNumber::Latest | BlockNumber::Pending => self.backend.best_number().as_u64(),
+            BlockNumber::Latest | BlockNumber::Pending => current,
             BlockNumber::Earliest => 0,
             BlockNumber::Number(n) => n.as_u64(),
+            BlockNumber::Safe => current.saturating_sub(slots_in_an_epoch),
+            BlockNumber::Finalized => current.saturating_sub(slots_in_an_epoch * 2),
         };
 
         // check if the number predates the fork, if in fork mode

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -210,11 +210,26 @@ impl BlockchainStorage {
 impl BlockchainStorage {
     /// Returns the hash for [BlockNumber]
     pub fn hash(&self, number: BlockNumber) -> Option<H256> {
+        let slots_in_an_epoch = U64::from(32u64);
         match number {
             BlockNumber::Latest => Some(self.best_hash),
             BlockNumber::Earliest => Some(self.genesis_hash),
             BlockNumber::Pending => None,
             BlockNumber::Number(num) => self.hashes.get(&num).copied(),
+            BlockNumber::Safe => {
+                if self.best_number > (slots_in_an_epoch) {
+                    self.hashes.get(&(self.best_number - (slots_in_an_epoch))).copied()
+                } else {
+                    Some(self.genesis_hash) // treat the genesis block as safe "by definition"
+                }
+            }
+            BlockNumber::Finalized => {
+                if self.best_number > (slots_in_an_epoch * 2) {
+                    self.hashes.get(&(self.best_number - (slots_in_an_epoch * 2))).copied()
+                } else {
+                    Some(self.genesis_hash)
+                }
+            }
         }
     }
 }

--- a/anvil/src/hardfork.rs
+++ b/anvil/src/hardfork.rs
@@ -144,9 +144,9 @@ impl From<Hardfork> for SpecId {
 impl<T: Into<BlockNumber>> From<T> for Hardfork {
     fn from(block: T) -> Hardfork {
         let num = match block.into() {
-            BlockNumber::Pending | BlockNumber::Latest => u64::MAX,
             BlockNumber::Earliest => 0,
             BlockNumber::Number(num) => num.as_u64(),
+            _ => u64::MAX,
         };
 
         match num {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Folks trying to upgrade anvil and ethers are running into a problem with the BlockNumber enum (in the latest version of ethers).

This PR fixes that problem at brings anvil up to parity with the latest version of ethers-rs.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

After the merge, there is a notion of "safe" and "finalized" blocks (in addition to "latest", "pending", etc). We need to support all of the block number functionality for these new tags, which are described in more detail here: 

**https://www.alchemy.com/overviews/ethereum-commitment-levels**
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
