### PR TITLE
✨ Add a decoded_logs field to TestResult structs

### DIFF
--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     coverage::HitMaps,
-    decode,
+    decode::{self, decode_console_logs},
     executor::{Executor, RawCallResult},
     trace::CallTraceArena,
 };
@@ -173,6 +173,7 @@ impl<'a> FuzzedExecutor<'a> {
             success: run_result.is_ok(),
             reason: None,
             counterexample: None,
+            decoded_logs: decode_console_logs(&call.logs),
             logs: call.logs,
             labeled_addresses: call.labels,
             traces: if run_result.is_ok() { traces.into_inner() } else { call.traces.clone() },
@@ -321,6 +322,9 @@ pub struct FuzzTestResult {
     /// Any captured & parsed as strings logs along the test's execution which should
     /// be printed to the user.
     pub logs: Vec<Log>,
+
+    /// The decoded DSTest logging events and Hardhat's `console.log` from [logs](Self::logs).
+    pub decoded_logs: Vec<String>,
 
     /// Labeled addresses
     pub labeled_addresses: BTreeMap<Address, String>,

--- a/forge/src/result.rs
+++ b/forge/src/result.rs
@@ -75,6 +75,9 @@ pub struct TestResult {
     /// be printed to the user.
     pub logs: Vec<Log>,
 
+    /// The decoded DSTest logging events and Hardhat's `console.log` from [logs](Self::logs).
+    pub decoded_logs: Vec<String>,
+
     /// What kind of test this was
     pub kind: TestKind,
 

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -12,6 +12,7 @@ use foundry_common::{
     TestFunctionExt,
 };
 use foundry_evm::{
+    decode::decode_console_logs,
     executor::{CallResult, DeployResult, EvmError, Executor},
     fuzz::{
         invariant::{
@@ -216,6 +217,7 @@ impl<'a> ContractRunner<'a> {
                         reason: Some("Multiple setUp functions".to_string()),
                         counterexample: None,
                         logs: vec![],
+                        decoded_logs: vec![],
                         kind: TestKind::Standard(0),
                         traces: vec![],
                         coverage: None,
@@ -249,6 +251,7 @@ impl<'a> ContractRunner<'a> {
                         success: false,
                         reason: setup.reason,
                         counterexample: None,
+                        decoded_logs: decode_console_logs(&setup.logs),
                         logs: setup.logs,
                         kind: TestKind::Standard(0),
                         traces: setup.traces,
@@ -417,6 +420,7 @@ impl<'a> ContractRunner<'a> {
             success,
             reason,
             counterexample: None,
+            decoded_logs: decode_console_logs(&logs),
             logs,
             kind: TestKind::Standard(gas.overflowing_sub(stipend).0),
             traces,
@@ -495,6 +499,7 @@ impl<'a> ContractRunner<'a> {
                             (!err.revert_reason.is_empty()).then(|| err.revert_reason.clone())
                         }),
                         counterexample,
+                        decoded_logs: decode_console_logs(&logs),
                         logs,
                         kind: TestKind::Invariant(cases.clone(), reverts),
                         coverage: None, // todo?
@@ -543,6 +548,7 @@ impl<'a> ContractRunner<'a> {
             success: result.success,
             reason: result.reason,
             counterexample: result.counterexample,
+            decoded_logs: decode_console_logs(&logs),
             logs,
             kind: TestKind::Fuzz(result.cases),
             traces,

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -216,7 +216,7 @@ pub fn assert_multiple(
             contract_name
         );
         for (test_name, should_pass, reason, expected_logs, expected_warning_count) in tests {
-            let logs = decode_console_logs(&actuals[*contract_name].test_results[*test_name].logs);
+            let logs = &actuals[*contract_name].test_results[*test_name].decoded_logs;
 
             let warnings_count = &actuals[*contract_name].warnings.len();
 

--- a/forge/tests/it/fuzz.rs
+++ b/forge/tests/it/fuzz.rs
@@ -3,7 +3,6 @@
 use crate::{config::*, test_helpers::filter::Filter};
 use ethers::types::U256;
 use forge::result::SuiteResult;
-use foundry_evm::decode::decode_console_logs;
 use std::collections::BTreeMap;
 
 #[test]
@@ -24,7 +23,6 @@ fn test_fuzz() {
 
     for (_, SuiteResult { test_results, .. }) in suite_result {
         for (test_name, result) in test_results {
-            let logs = decode_console_logs(&result.logs);
             match test_name.as_str() {
                 "testPositive(uint256)" |
                 "testPositive(int256)" |
@@ -34,14 +32,14 @@ fn test_fuzz() {
                     "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
-                    logs.join("\n")
+                    result.decoded_logs.join("\n")
                 ),
                 _ => assert!(
                     !result.success,
                     "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
-                    logs.join("\n")
+                    result.decoded_logs.join("\n")
                 ),
             }
         }


### PR DESCRIPTION
## Motivation

> It would be nice if it could also include the decoded/interpreted logs, as commands consuming this json are not likely to have the ability to decode these logs - Willyham

Closes #3002 

## Solution

I added a simple `decoded_logs` field on the `TestResult` and `FuzzTestResult` structs.