### PR TITLE
fix: correct variable names in branch/version check

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -41,7 +41,7 @@ main() {
     need_cmd cargo
 
     # Ignore branches/versions as we do not want to modify local git state
-    if [ -n "$FOUNDRYUP_REPO" ] || [ -n "$FOUNDRY_BRANCH" ] || [ -n "$FOUNDRY_VERSION" ]; then
+    if [ -n "$FOUNDRYUP_REPO" ] || [ -n "$FOUNDRYUP_BRANCH" ] || [ -n "$FOUNDRYUP_VERSION" ]; then
       warn "--branch, --version, and --repo arguments are ignored during local install"
     fi
 


### PR DESCRIPTION
## Motivation

In `foundryup` we're not properly checking for whether the user has specified a branch or version when using a local repo. Instead of reading `FOUNDRYUP_BRANCH` and `FOUNDRYUP_VERSION` which is where we store the passed arguments, we instead read `FOUNDRY_BRANCH` and `FOUNDRY_VERSION`.

Instead of flagging up this error we instead silently install foundry using the current state of the local repo.

## Solution

I've replaced the faulty `FOUNDRY` prefix with `FOUNDRYUP`
