### PR TITLE
Fixes multiarch docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine as build-environment
-ENV CFLAGS=-mno-outline-atomics
+ARG TARGETARCH
 WORKDIR /opt
 RUN apk add clang lld curl build-base linux-headers git \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
     && chmod +x ./rustup.sh \
     && ./rustup.sh -y
+
+RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile
 
 WORKDIR /opt/foundry
 COPY . .


### PR DESCRIPTION
Resolves docker build for multiarch `arm64` and `amd64` 

## Motivation

Related to https://github.com/foundry-rs/foundry/issues/3545 and https://github.com/foundry-rs/foundry/issues/3513

## Solution

Configure `CFLAGS`  dependent on image arch.

Note:
`ARG TARGETARCH` is provided by docker itself on build stage.
