### PR TITLE
Fixes multiarch docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add clang lld curl build-base linux-headers git \
     && chmod +x ./rustup.sh \
     && ./rustup.sh -y
 
-RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile
+RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true
 
 WORKDIR /opt/foundry
 COPY . .


### PR DESCRIPTION
Small addition to https://github.com/foundry-rs/foundry/commit/6dcc162fe0001f617d04c79933ef878b2ea86e72

## Motivation

Prev PR missed one small thing to work on github actions.

## Solution

Ignoring `if` statement exit code.
