### PR TITLE
Updated output for cast publish --async from debug data to tx_hash

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -314,7 +314,7 @@ async fn main() -> eyre::Result<()> {
             let tx_hash = *pending_tx;
 
             if cast_async {
-                println!("{pending_tx:?}");
+                println!("{tx_hash:#x}");
             } else {
                 let receipt =
                     pending_tx.await?.ok_or_else(|| eyre::eyre!("tx {tx_hash} not found"))?;


### PR DESCRIPTION
Related to https://github.com/foundry-rs/foundry/issues/3544

Outputs `tx_hash` rather than unstructured debug info from `PendingTransaction` on `cast publish --async`

## Motivation

`cast send --async` output is raw `tx_hash` but for `cast publish --async` output is raw Debug `PendingTransaction`.

## Solution

Return `tx_hash` only.

Output example:

```
cast publish --async --rpc-url http://geth.local:8545  $TX
0xa29a3a8527e2da1a9eb5241fbbae245c0b069291f15d7f59e7d4af3267c4a098
```