### PR TITLE
More accurate error message in check-verify

### DIFF
--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -127,6 +127,11 @@ impl VerificationProvider for EtherscanVerificationProvider {
                         .await
                         .wrap_err("Failed to request verification status")?;
 
+                    eprintln!(
+                        "Contract verification status:\nResponse: `{}`\nDetails: `{}`",
+                        resp.message, resp.result
+                    );
+
                     if resp.status == "0" {
                         if resp.result == "Already Verified" {
                             println!("Contract source code already verified");
@@ -137,14 +142,16 @@ impl VerificationProvider for EtherscanVerificationProvider {
                             return Err(eyre!("Verification is still pending...",))
                         }
 
-                        eprintln!(
-                            "Contract verification failed:\nResponse: `{}`\nDetails: `{}`",
-                            resp.message, resp.result
-                        );
+                        println!("Contract failed to verify.");
                         std::process::exit(1);
                     }
 
-                    println!("Contract successfully verified");
+                    if resp.status == "1" {
+                        if resp.result == "Unable to verify" {
+                            return Err(eyre!("Unable to verify.",))
+                        }
+                    }
+
                     Ok(())
                 }
                 .boxed()

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -132,24 +132,22 @@ impl VerificationProvider for EtherscanVerificationProvider {
                         resp.message, resp.result
                     );
 
-                    if resp.status == "0" {
-                        if resp.result == "Already Verified" {
-                            println!("Contract source code already verified");
-                            return Ok(())
-                        }
-
-                        if resp.result == "Pending in queue" {
-                            return Err(eyre!("Verification is still pending...",))
-                        }
-
-                        println!("Contract failed to verify.");
-                        std::process::exit(1);
+                    if resp.result == "Pending in queue" {
+                        return Err(eyre!("Verification is still pending...",))
                     }
 
-                    if resp.status == "1" {
-                        if resp.result == "Unable to verify" {
-                            return Err(eyre!("Unable to verify.",))
-                        }
+                    if resp.result == "Unable to verify" {
+                        return Err(eyre!("Unable to verify.",))
+                    }
+
+                    if resp.result == "Already Verified" {
+                        println!("Contract source code already verified");
+                        return Ok(())
+                    }
+
+                    if resp.status == "0" {
+                        println!("Contract failed to verify.");
+                        std::process::exit(1);
                     }
 
                     Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When running `check-verify` I kept getting `Contract successfully verified`, but the contract did not show up as verified on the block explorer. We dug into this deeper and when using a curl command to get more info, it turns out the response was `{"message":"OK","result":"Fail - Unable to verify","status":"1"}` . At the moment, if the status is 1 it says that the contract is successfully verified when it is not. Blockscout seems to always return 1 as the status, so we shouldn't rely on this.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Given that other errors like this could come up in the future, it seems best to display the whole message  / result that is returned, in order to give developers as much information as possible. I added a line to print this out. In addition, it now returns an error for this specific error I ran into.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
