### PR TITLE
chore: improve verify output with chain info

### DIFF
--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -117,7 +117,6 @@ impl VerificationProvider for EtherscanVerificationProvider {
     async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()> {
         let etherscan =
             self.client(&args.chain, &args.verifier.verifier_url, &args.etherscan_key)?;
-        println!("Waiting for verification result...");
         let retry: Retry = args.retry.into();
         retry
             .run_async(|| {

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -166,6 +166,7 @@ impl figment::Provider for VerifyArgs {
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> eyre::Result<()> {
+        println!("Start verifying contract `{:?}` deployed on {}", self.address, self.chain);
         self.verifier.verifier.client(&self.etherscan_key)?.verify(self).await
     }
 }
@@ -207,6 +208,7 @@ pub struct VerifyCheckArgs {
 impl VerifyCheckArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> eyre::Result<()> {
+        println!("Checking verification status on {}", self.chain);
         self.verifier.verifier.client(&self.etherscan_key)?.check(self).await
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
If the chain argument is committed, then mainnet is the default, which may not be the actual network the contract is deployed on.

Add chain info to output so user can see what chain is targeted.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
