### PR TITLE
feat(verify): add --show-standard-json-input

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -284,6 +284,7 @@ impl CreateArgs {
             libraries: vec![],
             root: None,
             verifier: self.verifier,
+            show_standard_json_input: false,
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await

--- a/cli/src/cmd/forge/script/verify.rs
+++ b/cli/src/cmd/forge/script/verify.rs
@@ -114,6 +114,7 @@ impl VerifyBundle {
                     libraries: libraries.to_vec(),
                     root: None,
                     verifier: self.verifier.clone(),
+                    show_standard_json_input: false,
                 };
 
                 return Some(verify)

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -194,7 +194,7 @@ impl EtherscanVerificationProvider {
     ///
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
-    async fn create_verify_request(&self, args: &VerifyArgs) -> eyre::Result<VerifyContract> {
+    pub async fn create_verify_request(&self, args: &VerifyArgs) -> eyre::Result<VerifyContract> {
         let mut config = args.try_load_config_emit_warnings()?;
         config.libraries.extend(args.libraries.clone());
 

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -1,6 +1,6 @@
 //! Verify contract source
 
-use crate::cmd::retry::RetryArgs;
+use crate::cmd::{forge::verify::etherscan::EtherscanVerificationProvider, retry::RetryArgs};
 use clap::{Parser, ValueHint};
 use ethers::{abi::Address, solc::info::ContractInfo};
 use foundry_config::{figment, impl_figment_convert, Chain, Config};
@@ -137,6 +137,13 @@ pub struct VerifyArgs {
 
     #[clap(flatten)]
     pub verifier: VerifierArgs,
+
+    #[clap(
+        help = "Prints the standard json compiler input.",
+        long,
+        long_help = "The standard json compiler input can be used to manually submit contract verification in the browser."
+    )]
+    pub show_standard_json_input: bool,
 }
 
 impl_figment_convert!(VerifyArgs);
@@ -166,6 +173,13 @@ impl figment::Provider for VerifyArgs {
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> eyre::Result<()> {
+        if self.show_standard_json_input {
+            let args =
+                EtherscanVerificationProvider::default().create_verify_request(&self).await?;
+            println!("{}", args.source);
+            return Ok(())
+        }
+
         self.verifier.verifier.client(&self.etherscan_key)?.verify(self).await
     }
 }

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -141,7 +141,8 @@ pub struct VerifyArgs {
     #[clap(
         help = "Prints the standard json compiler input.",
         long,
-        long_help = "The standard json compiler input can be used to manually submit contract verification in the browser."
+        long_help = "The standard json compiler input can be used to manually submit contract verification in the browser.",
+        conflicts_with = "flatten"
     )]
     pub show_standard_json_input: bool,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Add new `--show-standard-json-input` to print the standard-json forge would send to etherscan verifyContract endpoint.

This can be useful when changes have to applied manually to the input and verify via browser.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
