### PR TITLE
fix(verify): extract all settings from etherscan table

### DIFF
--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -44,9 +44,14 @@ pub struct EtherscanVerificationProvider;
 #[async_trait]
 impl VerificationProvider for EtherscanVerificationProvider {
     async fn verify(&self, args: VerifyArgs) -> eyre::Result<()> {
-        let etherscan =
-            self.client(&args.chain, &args.verifier.verifier_url, &args.etherscan_key)?;
-        let verify_args = self.create_verify_request(&args).await?;
+        let config = args.try_load_config_emit_warnings()?;
+        let etherscan = self.client(
+            args.chain,
+            args.verifier.verifier_url.as_deref(),
+            args.etherscan_key.as_deref(),
+            &config,
+        )?;
+        let verify_args = self.create_verify_request(&args, Some(config)).await?;
 
         trace!(?verify_args, target = "forge::verify", "submitting verification request");
 
@@ -118,8 +123,13 @@ impl VerificationProvider for EtherscanVerificationProvider {
 
     /// Executes the command to check verification status on Etherscan
     async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()> {
-        let etherscan =
-            self.client(&args.chain, &args.verifier.verifier_url, &args.etherscan_key)?;
+        let config = args.try_load_config_emit_warnings()?;
+        let etherscan = self.client(
+            args.chain,
+            args.verifier.verifier_url.as_deref(),
+            args.etherscan_key.as_deref(),
+            &config,
+        )?;
         let retry: Retry = args.retry.into();
         retry
             .run_async(|| {
@@ -169,12 +179,20 @@ impl VerificationProvider for EtherscanVerificationProvider {
 
 impl EtherscanVerificationProvider {
     /// Create an etherscan client
-    fn client(
+    pub(crate) fn client(
         &self,
-        chain: &Chain,
-        url: &Option<String>,
-        etherscan_key: &Option<String>,
+        chain: Chain,
+        verifier_url: Option<&str>,
+        etherscan_key: Option<&str>,
+        config: &Config,
     ) -> eyre::Result<Client> {
+        let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
+        dbg!(&etherscan_config);
+
+        let url = verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
+        let etherscan_key =
+            etherscan_key.or_else(|| etherscan_config.as_ref().map(|c| c.key.as_str()));
+
         let mut builder = Client::builder();
 
         builder = if let Some(url) = url {
@@ -189,12 +207,18 @@ impl EtherscanVerificationProvider {
             .wrap_err("Failed to create etherscan client")
     }
 
-    /// Creates the `VerifyContract` etherescan request in order to verify the contract
+    /// Creates the `VerifyContract` etherscan request in order to verify the contract
     ///
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
-    pub async fn create_verify_request(&self, args: &VerifyArgs) -> eyre::Result<VerifyContract> {
-        let mut config = args.try_load_config_emit_warnings()?;
+    pub async fn create_verify_request(
+        &self,
+        args: &VerifyArgs,
+        config: Option<Config>,
+    ) -> eyre::Result<VerifyContract> {
+        let mut config =
+            if let Some(config) = config { config } else { args.try_load_config_emit_warnings()? };
+
         config.libraries.extend(args.libraries.clone());
 
         let project = config.project()?;

--- a/cli/src/cmd/forge/verify/etherscan.rs
+++ b/cli/src/cmd/forge/verify/etherscan.rs
@@ -187,7 +187,6 @@ impl EtherscanVerificationProvider {
         config: &Config,
     ) -> eyre::Result<Client> {
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
-        dbg!(&etherscan_config);
 
         let url = verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
         let etherscan_key =
@@ -202,7 +201,7 @@ impl EtherscanVerificationProvider {
         };
 
         builder
-            .with_api_key(etherscan_key.clone().unwrap_or_default())
+            .with_api_key(etherscan_key.unwrap_or_default())
             .build()
             .wrap_err("Failed to create etherscan client")
     }

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -151,7 +151,7 @@ impl_figment_convert!(VerifyArgs);
 
 impl figment::Provider for VerifyArgs {
     fn metadata(&self) -> figment::Metadata {
-        figment::Metadata::named(stringify!($name))
+        figment::Metadata::named("Verify Provider")
     }
     fn data(
         &self,
@@ -176,7 +176,7 @@ impl VerifyArgs {
     pub async fn run(self) -> eyre::Result<()> {
         if self.show_standard_json_input {
             let args =
-                EtherscanVerificationProvider::default().create_verify_request(&self).await?;
+                EtherscanVerificationProvider::default().create_verify_request(&self, None).await?;
             println!("{}", args.source);
             return Ok(())
         }
@@ -225,5 +225,103 @@ impl VerifyCheckArgs {
     pub async fn run(self) -> eyre::Result<()> {
         println!("Checking verification status on {}", self.chain);
         self.verifier.verifier.client(&self.etherscan_key)?.check(self).await
+    }
+}
+
+impl figment::Provider for VerifyCheckArgs {
+    fn metadata(&self) -> figment::Metadata {
+        figment::Metadata::named("Verify Check Provider")
+    }
+    fn data(
+        &self,
+    ) -> Result<figment::value::Map<figment::Profile, figment::value::Dict>, figment::Error> {
+        Ok(figment::value::Map::from([(Config::selected_profile(), figment::value::Dict::new())]))
+    }
+}
+impl<'a> From<&'a VerifyCheckArgs> for figment::Figment {
+    fn from(args: &'a VerifyCheckArgs) -> Self {
+        Config::figment_with_root(foundry_config::find_project_root_path().unwrap()).merge(args)
+    }
+}
+
+impl<'a> From<&'a VerifyCheckArgs> for Config {
+    fn from(args: &'a VerifyCheckArgs) -> Self {
+        let figment: figment::Figment = args.into();
+        Config::from_provider(figment).sanitized()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::LoadConfig;
+    use foundry_cli_test_utils::tempfile::tempdir;
+    use foundry_common::fs;
+
+    #[test]
+    fn can_extract_etherscan_verify_config() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+
+        let config = r#"
+                [profile.default]
+
+                [etherscan]
+                mumbai = { key = "dummykey", chain = 80001, url = "https://api-testnet.polygonscan.com/" }
+            "#;
+
+        let toml_file = root.join(Config::FILE_NAME);
+        fs::write(toml_file, config).unwrap();
+
+        let args: VerifyArgs = VerifyArgs::parse_from([
+            "foundry-cli",
+            "0xd8509bee9c9bf012282ad33aba0d87241baf5064",
+            "src/Counter.sol:Counter",
+            "--chain",
+            "mumbai",
+            "--root",
+            root.as_os_str().to_str().unwrap(),
+        ]);
+
+        let config = args.load_config();
+
+        let etherscan = EtherscanVerificationProvider::default();
+        let client = etherscan
+            .client(
+                args.chain,
+                args.verifier.verifier_url.as_deref(),
+                args.etherscan_key.as_deref(),
+                &config,
+            )
+            .unwrap();
+        assert_eq!(client.etherscan_api_url().as_str(), "https://api-testnet.polygonscan.com/");
+
+        assert!(format!("{:?}", client).contains("dummykey"));
+
+        let args: VerifyArgs = VerifyArgs::parse_from([
+            "foundry-cli",
+            "0xd8509bee9c9bf012282ad33aba0d87241baf5064",
+            "src/Counter.sol:Counter",
+            "--chain",
+            "mumbai",
+            "--verifier-url",
+            "https://verifier-url.com/",
+            "--root",
+            root.as_os_str().to_str().unwrap(),
+        ]);
+
+        let config = args.load_config();
+
+        let etherscan = EtherscanVerificationProvider::default();
+        let client = etherscan
+            .client(
+                args.chain,
+                args.verifier.verifier_url.as_deref(),
+                args.etherscan_key.as_deref(),
+                &config,
+            )
+            .unwrap();
+        assert_eq!(client.etherscan_api_url().as_str(), "https://verifier-url.com/");
+        assert!(format!("{:?}", client).contains("dummykey"));
     }
 }

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -296,7 +296,7 @@ mod tests {
             .unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://api-testnet.polygonscan.com/");
 
-        assert!(format!("{:?}", client).contains("dummykey"));
+        assert!(format!("{client:?}").contains("dummykey"));
 
         let args: VerifyArgs = VerifyArgs::parse_from([
             "foundry-cli",
@@ -322,6 +322,6 @@ mod tests {
             )
             .unwrap();
         assert_eq!(client.etherscan_api_url().as_str(), "https://verifier-url.com/");
-        assert!(format!("{:?}", client).contains("dummykey"));
+        assert!(format!("{client:?}").contains("dummykey"));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3597

This fixes two bugs:

1. when extracting an etherscan config from the table, use the `url` if configured and not replace with the hardcoded API url
2. merge config settings when creating the etherscan client, but prefer command line args.


this ensures:

```toml
arbitrum-goerli = { key = "${ARBITRUM_ETHERSCAN_API_KEY}", url = "https://api-goerli.arbiscan.io/api" }

```
all values in the etherscan config table entry are used in verify when provided with matching `--chain` id as argument

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
