### PR TITLE
fix: use relative path for fs permissions

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1018,17 +1018,18 @@ impl Config {
         // autodetect paths
         let root = root.into();
         let paths = ProjectPathsConfig::builder().build_with_root(&root);
+        let artifacts: PathBuf = paths.artifacts.file_name().unwrap().into();
         Config {
             __root: paths.root.into(),
             src: paths.sources.file_name().unwrap().into(),
-            out: paths.artifacts.file_name().unwrap().into(),
+            out: artifacts.clone(),
             libs: paths.libraries.into_iter().map(|lib| lib.file_name().unwrap().into()).collect(),
             remappings: paths
                 .remappings
                 .into_iter()
                 .map(|r| RelativeRemapping::new(r, &root))
                 .collect(),
-            fs_permissions: FsPermissions::new([PathPermission::read(paths.artifacts)]),
+            fs_permissions: FsPermissions::new([PathPermission::read(artifacts)]),
             ..Config::default()
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
fixes an issue where the default read permission would be set to an absolute path

```
[[profile.default.fs_permissions]]
access = 'read'
path = '/Users/Matthias/git/rust/foundry-integration-tests/testdata/foundry-playground/out'

``` 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
