### PR TITLE
fix(anvil): store state cache in anvil specific location

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -974,6 +974,16 @@ impl AccountGenerator {
     }
 }
 
+/// Returns the path to anvil dir `~/.foundry/anvil`
+pub fn anvil_dir() -> Option<PathBuf> {
+    Config::foundry_dir().map(|p| p.join("anvil"))
+}
+
+/// Returns the root path to anvil's temporary storage `~/.foundry/anvil/`
+pub fn anvil_tmp_dir() -> Option<PathBuf> {
+    anvil_dir().map(|p| p.join("tmp"))
+}
+
 /// Finds the latest appropriate block to fork
 ///
 /// This fetches the "latest" block and checks whether the `Block` is fully populated (`hash` field

--- a/anvil/src/eth/backend/mem/cache.rs
+++ b/anvil/src/eth/backend/mem/cache.rs
@@ -1,16 +1,20 @@
+use crate::config::anvil_tmp_dir;
 use ethers::prelude::H256;
-
 use foundry_evm::executor::backend::snapshot::StateSnapshot;
-
-use std::path::PathBuf;
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 use tracing::{error, trace};
 
 /// On disk state cache
 ///
 /// A basic tempdir which stores states on disk
-#[derive(Default)]
 pub struct DiskStateCache {
+    /// The path where to create the tempdir in
+    pub(crate) temp_path: Option<PathBuf>,
+    /// Holds the temp dir object.
     pub(crate) temp_dir: Option<TempDir>,
 }
 
@@ -21,7 +25,16 @@ impl DiskStateCache {
         F: FnOnce(PathBuf) -> R,
     {
         if self.temp_dir.is_none() {
-            match TempDir::new() {
+            let tmp_dir = self
+                .temp_path
+                .as_ref()
+                .map(|p| -> io::Result<TempDir> {
+                    std::fs::create_dir_all(p)?;
+                    build_tmp_dir(Some(p))
+                })
+                .unwrap_or_else(|| build_tmp_dir(None));
+
+            match tmp_dir {
                 Ok(temp_dir) => {
                     trace!(target: "backend", path=?temp_dir.path(), "created disk state cache dir");
                     self.temp_dir = Some(temp_dir);
@@ -76,5 +89,55 @@ impl DiskStateCache {
             }
         })
         .flatten()
+    }
+}
+
+impl Default for DiskStateCache {
+    fn default() -> Self {
+        DiskStateCache { temp_path: anvil_tmp_dir(), temp_dir: None }
+    }
+}
+
+/// Returns the temporary dir for the cached state
+///
+/// This will create a prefixed temp dir with `anvil-state-06-11-2022-12-50`
+fn build_tmp_dir(p: Option<&Path>) -> io::Result<TempDir> {
+    let mut builder = tempfile::Builder::new();
+    let now = chrono::offset::Utc::now();
+    let prefix = now.format("anvil-state-%d-%m-%Y-%H-%M").to_string();
+    builder.prefix(&prefix);
+
+    if let Some(p) = p {
+        builder.tempdir_in(p)
+    } else {
+        builder.tempdir()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn can_build_temp_dir() {
+        let dir = tempdir().unwrap();
+        let p = dir.path();
+        let cache_dir = build_tmp_dir(Some(p)).unwrap();
+        assert!(cache_dir
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("anvil-state-"));
+        let cache_dir = build_tmp_dir(None).unwrap();
+        assert!(cache_dir
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("anvil-state-"));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #3623

Add dedicated anvil folder in `~/.foundry/anvil` and store state cache in `~/.foundry/anvil/tmp`, also prefix the tmp dir with current timestamp.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
