### PR TITLE
feat(create): add retry args to create

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -2,8 +2,8 @@
 use super::verify;
 use crate::{
     cmd::{
-        forge::build::CoreBuildArgs, read_constructor_args_file, remove_contract,
-        retry::RETRY_VERIFY_ON_CREATE, LoadConfig,
+        forge::build::CoreBuildArgs, read_constructor_args_file, remove_contract, retry::RetryArgs,
+        LoadConfig,
     },
     opts::{EthereumOpts, TransactionOpts, WalletType},
 };
@@ -78,6 +78,9 @@ pub struct CreateArgs {
 
     #[clap(flatten)]
     pub verifier: verify::VerifierArgs,
+
+    #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
+    retry: RetryArgs,
 }
 
 impl CreateArgs {
@@ -280,7 +283,7 @@ impl CreateArgs {
             flatten: false,
             force: false,
             watch: true,
-            retry: RETRY_VERIFY_ON_CREATE,
+            retry: self.retry,
             libraries: vec![],
             root: None,
             verifier: self.verifier,
@@ -303,5 +306,25 @@ impl CreateArgs {
             .collect::<Vec<_>>();
 
         parse_tokens(params, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse_create() {
+        let args: CreateArgs = CreateArgs::parse_from([
+            "foundry-cli",
+            "src/Domains.sol:Domains",
+            "--verify",
+            "--retries",
+            "10",
+            "--delay",
+            "30",
+        ]);
+        assert_eq!(args.retry.retries, 10);
+        assert_eq!(args.retry.delay, 30);
     }
 }

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -40,7 +40,7 @@ impl ScriptArgs {
             &build_output.project,
             &script_config.config,
             flatten_contracts(&build_output.highlevel_known_contracts, false),
-            self.retry.clone(),
+            self.retry,
             self.verifier.clone(),
         );
 

--- a/cli/src/cmd/forge/script/verify.rs
+++ b/cli/src/cmd/forge/script/verify.rs
@@ -110,7 +110,7 @@ impl VerifyBundle {
                     flatten: false,
                     force: false,
                     watch: true,
-                    retry: self.retry.clone(),
+                    retry: self.retry,
                     libraries: libraries.to_vec(),
                     root: None,
                     verifier: self.verifier.clone(),

--- a/cli/src/cmd/retry.rs
+++ b/cli/src/cmd/retry.rs
@@ -8,7 +8,7 @@ pub const RETRY_CHECK_ON_VERIFY: RetryArgs = RetryArgs { retries: 6, delay: 10 }
 pub const RETRY_VERIFY_ON_CREATE: RetryArgs = RetryArgs { retries: 15, delay: 3 };
 
 /// A type that keeps track of attempts
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, Copy, Parser)]
 pub struct RetryArgs {
     #[clap(
         long,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
add support for retry args (--retries, --delay) used by `forge verify-contract` to `forge create` as well
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
