### PR TITLE
chore(cast): add 0x prefix to `cast wallet new` output

### DIFF
--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -106,7 +106,7 @@ impl WalletSubcommands {
                 } else {
                     let wallet = LocalWallet::new(&mut rng);
                     println!(
-                        "Successfully created new keypair.\nAddress: {}\nPrivate Key: {}",
+                        "Successfully created new keypair.\nAddress: {}\nPrivate Key: 0x{}",
                         SimpleCast::to_checksum_address(&wallet.address()),
                         hex::encode(wallet.signer().to_bytes()),
                     );

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -113,7 +113,7 @@ impl Cmd for VanityArgs {
         .expect("failed to generate vanity wallet");
 
         println!(
-            "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
+            "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: {}",
             timer.elapsed().as_secs(),
             if nonce.is_some() { "\nContract address: " } else { "" },
             if nonce.is_some() {

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -113,7 +113,7 @@ impl Cmd for VanityArgs {
         .expect("failed to generate vanity wallet");
 
         println!(
-            "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: {}",
+            "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
             timer.elapsed().as_secs(),
             if nonce.is_some() { "\nContract address: " } else { "" },
             if nonce.is_some() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

close #3635

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

add `0x` prefix to make `cast wallet new` output consistent with `cast wallet vanity`