### PR TITLE
feat(forge): add emitter addr to log (#2921)

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -148,7 +148,13 @@ fn accesses(state: &mut Cheatcodes, address: Address) -> Bytes {
 
 #[derive(Clone, Debug, Default)]
 pub struct RecordedLogs {
-    pub entries: Vec<RawLog>,
+    pub entries: Vec<Log>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Log {
+    pub emitter: Address,
+    pub inner: RawLog,
 }
 
 fn start_record_logs(state: &mut Cheatcodes) {
@@ -163,8 +169,9 @@ fn get_recorded_logs(state: &mut Cheatcodes) -> Bytes {
                 .iter()
                 .map(|entry| {
                     Token::Tuple(vec![
-                        entry.topics.clone().into_token(),
-                        Token::Bytes(entry.data.clone()),
+                        entry.inner.topics.clone().into_token(),
+                        Token::Bytes(entry.inner.data.clone()),
+                        entry.emitter.into_token(),
                     ])
                 })
                 .collect::<Vec<Token>>()

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -34,7 +34,7 @@ use std::{
 
 /// Cheatcodes related to the execution environment.
 mod env;
-pub use env::{Prank, RecordAccess};
+pub use env::{Log, Prank, RecordAccess};
 /// Assertion helpers (such as `expectEmit`)
 mod expect;
 pub use expect::{ExpectedCallData, ExpectedEmit, ExpectedRevert, MockCallDataContext};
@@ -271,9 +271,10 @@ where
 
         // Stores this log if `recordLogs` has been called
         if let Some(storage_recorded_logs) = &mut self.recorded_logs {
-            storage_recorded_logs
-                .entries
-                .push(RawLog { topics: topics.to_vec(), data: data.to_vec() });
+            storage_recorded_logs.entries.push(Log {
+                emitter: *address,
+                inner: RawLog { topics: topics.to_vec(), data: data.to_vec() },
+            });
         }
     }
 

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -6,6 +6,7 @@ interface Cheats {
     struct Log {
         bytes32[] topics;
         bytes data;
+        address emitter;
     }
     // Set block.timestamp (newTimestamp)
 

--- a/testdata/cheats/RecordLogs.t.sol
+++ b/testdata/cheats/RecordLogs.t.sol
@@ -42,6 +42,10 @@ contract Emitterv2 {
     function emitEvent(uint256 topic1, uint256 topic2, uint256 topic3, bytes memory data) public {
         emitter.emitEvent(topic1, topic2, topic3, data);
     }
+
+    function getEmitterAddr() public view returns (address) {
+        return address(emitter);
+    }
 }
 
 contract RecordLogsTest is DSTest {
@@ -97,6 +101,7 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[0].topics[2], bytes32(uint256(2)));
         assertEq(entries[0].topics[3], bytes32(uint256(3)));
         assertEq(abi.decode(entries[0].data, (string)), string(testData));
+        assertEq(entries[0].emitter, address(emitter));
     }
 
     // TODO
@@ -126,6 +131,7 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[0].topics[0], keccak256("LogTopic0(bytes)"));
         // While not a proper string, this conversion allows the comparison.
         assertEq(abi.decode(entries[0].data, (string)), string(testData));
+        assertEq(entries[0].emitter, address(emitter));
     }
 
     function testEmitRecordEmit() public {
@@ -142,6 +148,7 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[0].topics[0], keccak256("LogTopic1(uint256,bytes)"));
         assertEq(entries[0].topics[1], bytes32(uint256(3)));
         assertEq(abi.decode(entries[0].data, (string)), string(testData1));
+        assertEq(entries[0].emitter, address(emitter));
     }
 
     function testRecordOnEmitDifferentDepths() public {
@@ -165,12 +172,14 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[0].topics[0], keccak256("LogTopic(uint256,bytes)"));
         assertEq(entries[0].topics[1], bytes32(uint256(1)));
         assertEq(abi.decode(entries[0].data, (string)), string(testData0));
+        assertEq(entries[0].emitter, address(this));
 
         assertEq(entries[1].topics.length, 3);
         assertEq(entries[1].topics[0], keccak256("LogTopic12(uint256,uint256,bytes)"));
         assertEq(entries[1].topics[1], bytes32(uint256(2)));
         assertEq(entries[1].topics[2], bytes32(uint256(3)));
         assertEq(abi.decode(entries[1].data, (string)), string(testData1));
+        assertEq(entries[1].emitter, address(emitter));
 
         assertEq(entries[2].topics.length, 4);
         assertEq(entries[2].topics[0], keccak256("LogTopic123(uint256,uint256,uint256,bytes)"));
@@ -178,6 +187,7 @@ contract RecordLogsTest is DSTest {
         assertEq(entries[2].topics[2], bytes32(uint256(5)));
         assertEq(entries[2].topics[3], bytes32(uint256(6)));
         assertEq(abi.decode(entries[2].data, (string)), string(testData2));
+        assertEq(entries[2].emitter, emitter2.getEmitterAddr());
     }
 
     function testRecordsConsumednAsRead() public {
@@ -197,6 +207,7 @@ contract RecordLogsTest is DSTest {
         entries = cheats.getRecordedLogs();
         assertEq(entries.length, 1);
         assertEq(entries[0].topics.length, 3);
+        assertEq(entries[0].emitter, address(emitter));
 
         // let's emit two more!
         emitter.emitEvent(4, 5, 6, generateTestData(20));
@@ -206,6 +217,8 @@ contract RecordLogsTest is DSTest {
         assertEq(entries.length, 2);
         assertEq(entries[0].topics.length, 4);
         assertEq(entries[1].topics.length, 1);
+        assertEq(entries[0].emitter, address(emitter));
+        assertEq(entries[1].emitter, address(emitter));
 
         // the last one
         emitter.emitEvent(7, 8, 9, generateTestData(24));
@@ -213,5 +226,6 @@ contract RecordLogsTest is DSTest {
         entries = cheats.getRecordedLogs();
         assertEq(entries.length, 1);
         assertEq(entries[0].topics.length, 4);
+        assertEq(entries[0].emitter, address(emitter));
     }
 }


### PR DESCRIPTION
## Motivation
This change aims to fulfill [#2921](https://github.com/foundry-rs/foundry/issues/2921) in support of the ```getRecordedLogs``` cheatcode.  I'm new to the foundry codebase (& rust 🥂) so felt like this was a fitting task to get my feet wet in the dev environment

## Solution
Add additional ```Log``` struct which contains ```emitter``` field as outlined by @onbjerg.  Update unit tests to assert against proper emitter.

## Testing
```cargo build --bin forge``` to rebuild forge executable

modify ```./testdata/foundry.toml```: ```test = 'cheats/'```

```./target/debug/forge test -c ./testdata/cheats --config-path ./testdata/foundry.toml --match-contract RecordLogsTest```

```
Running 7 tests for cheats/RecordLogs.t.sol:RecordLogsTest
[PASS] testEmitRecordEmit() (gas: 53465)
[PASS] testRecordOffGetsNothing() (gas: 46202)
[PASS] testRecordOnEmitDifferentDepths() (gas: 489228)
[PASS] testRecordOnNoLogs() (gas: 3980)
[PASS] testRecordOnSingleLog() (gas: 17201)
[PASS] testRecordOnSingleLogTopic0() (gas: 49222)
[PASS] testRecordsConsumednAsRead() (gas: 113373)
Test result: ok. 7 passed; 0 failed; finished in 41.81ms
```