### PR TITLE
feat(doc): add out path option in config

### DIFF
--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -34,7 +34,7 @@ impl Cmd for DocArgs {
         DocBuilder::from_config(DocConfig {
             root: self.root.as_ref().unwrap_or(&find_project_root_path()?).to_path_buf(),
             sources: config.project_paths().sources,
-            out: self.out.as_ref().unwrap().to_path_buf(),
+            out: self.out.as_ref().unwrap_or(&PathBuf::from("docs")).to_path_buf(),
             ..Default::default()
         })
         .build()

--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -34,7 +34,7 @@ impl Cmd for DocArgs {
         DocBuilder::from_config(DocConfig {
             root: self.root.as_ref().unwrap_or(&find_project_root_path()?).to_path_buf(),
             sources: config.project_paths().sources,
-            out: self.out.as_ref().unwrap_or(&PathBuf::from("docs")).to_path_buf(),
+            out: self.out.clone().unwrap_or_else(|| PathBuf::from("docs")),
             ..Default::default()
         })
         .build()

--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -14,6 +14,16 @@ pub struct DocArgs {
         value_name = "PATH"
     )]
     root: Option<PathBuf>,
+
+    #[clap(
+        help = "The doc's output path.",
+        long_help = "The path where the docs are gonna get generated. By default, this is gonna be the docs directory at the root of the project.",
+        long = "out",
+        short,
+        value_hint = ValueHint::DirPath,
+        value_name = "PATH"
+    )]
+    out: Option<PathBuf>,
 }
 
 impl Cmd for DocArgs {
@@ -24,6 +34,7 @@ impl Cmd for DocArgs {
         DocBuilder::from_config(DocConfig {
             root: self.root.as_ref().unwrap_or(&find_project_root_path()?).to_path_buf(),
             sources: config.project_paths().sources,
+            out: self.out.as_ref().unwrap().to_path_buf(),
             ..Default::default()
         })
         .build()

--- a/doc/src/builder.rs
+++ b/doc/src/builder.rs
@@ -405,7 +405,7 @@ impl DocBuilder {
             writeln!(out)?;
         }
 
-        return Ok(out);
+        return Ok(out)
     }
 
     fn write_book_config(&self, filenames: Vec<(Identifier, PathBuf)>) -> eyre::Result<()> {
@@ -549,7 +549,7 @@ impl DocBuilder {
                         );
                         return Ok(Some(
                             DocOutput::Link(&base.doc(), &path.display().to_string()).doc(),
-                        ));
+                        ))
                     }
                 }
             }


### PR DESCRIPTION
A config option for `forge doc` that let's you specify an output path for the doc generation. Continuation work for #2701 