### PR TITLE
feat: allow multiple coverage output formats

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     utils::{self, p_println, STATIC_FUZZ_SEED},
 };
-use clap::{Parser, ValueEnum};
+use clap::{ArgAction, Parser, ValueEnum};
 use ethers::{
     abi::Address,
     prelude::{
@@ -42,10 +42,11 @@ pub struct CoverageArgs {
     #[clap(
         long,
         value_enum,
+        action = ArgAction::Append,
         default_value = "summary",
-        help = "The report type to use for coverage."
+        help = "The report type to use for coverage. This flag can be used multiple times."
     )]
-    report: CoverageReportKind,
+    report: Vec<CoverageReportKind>,
 
     #[clap(flatten, next_help_heading = "TEST FILTERING")]
     filter: Filter,
@@ -317,14 +318,17 @@ impl CoverageArgs {
         let _ = handle.join();
 
         // Output final report
-        match self.report {
-            CoverageReportKind::Summary => SummaryReporter::default().report(report),
-            // TODO: Sensible place to put the LCOV file
-            CoverageReportKind::Lcov => {
-                LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(report)
-            }
-            CoverageReportKind::Debug => DebugReporter::default().report(report),
+        for report_kind in self.report {
+            match report_kind {
+                CoverageReportKind::Summary => SummaryReporter::default().report(&report),
+                // TODO: Sensible place to put the LCOV file
+                CoverageReportKind::Lcov => {
+                    LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
+                }
+                CoverageReportKind::Debug => DebugReporter::default().report(&report),
+            }?;
         }
+        Ok(())
     }
 }
 

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 
 /// A coverage reporter.
 pub trait CoverageReporter {
-    fn report(self, report: CoverageReport) -> eyre::Result<()>;
+    fn report(self, report: &CoverageReport) -> eyre::Result<()>;
 }
 
 /// A simple summary reporter that prints the coverage results in a table.
@@ -37,7 +37,7 @@ impl SummaryReporter {
 }
 
 impl CoverageReporter for SummaryReporter {
-    fn report(mut self, report: CoverageReport) -> eyre::Result<()> {
+    fn report(mut self, report: &CoverageReport) -> eyre::Result<()> {
         for (path, summary) in report.summary_by_file() {
             self.total += &summary;
             self.add_row(path, summary);
@@ -78,7 +78,7 @@ impl<'a> LcovReporter<'a> {
 }
 
 impl<'a> CoverageReporter for LcovReporter<'a> {
-    fn report(self, report: CoverageReport) -> eyre::Result<()> {
+    fn report(self, report: &CoverageReport) -> eyre::Result<()> {
         for (file, items) in report.items_by_source() {
             let summary = items.iter().fold(CoverageSummary::default(), |mut summary, item| {
                 summary += item;
@@ -138,7 +138,7 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
 pub struct DebugReporter;
 
 impl CoverageReporter for DebugReporter {
-    fn report(self, report: CoverageReport) -> eyre::Result<()> {
+    fn report(self, report: &CoverageReport) -> eyre::Result<()> {
         for (path, items) in report.items_by_source() {
             println!("Uncovered for {path}:");
             items.iter().for_each(|item| {
@@ -149,7 +149,7 @@ impl CoverageReporter for DebugReporter {
             println!();
         }
 
-        for (contract_id, anchors) in report.anchors {
+        for (contract_id, anchors) in &report.anchors {
             println!("Anchors for {contract_id}:");
             anchors.iter().for_each(|anchor| {
                 println!("- {anchor}");


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/3644

Now you can do get multiple output formats with a single `forge coverage` run, such as:

```
$ forge coverage --report summary --report lcov
[⠒] Compiling...
[⠆] Compiling 18 files with 0.8.16
[⠔] Solc 0.8.16 finished in 2.17s
Compiler run successful
Analysing contracts...
Running tests...
+---------------------+---------------+---------------+---------------+---------------+
| File                | % Lines       | % Statements  | % Branches    | % Funcs       |
+=====================================================================================+
| script/Deploy.s.sol | 0.00% (0/2)   | 0.00% (0/2)   | 100.00% (0/0) | 0.00% (0/1)   |
|---------------------+---------------+---------------+---------------+---------------|
| src/Counter.sol     | 100.00% (2/2) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
|---------------------+---------------+---------------+---------------+---------------|
| test/Counter.t.sol  | 0.00% (0/1)   | 0.00% (0/1)   | 100.00% (0/0) | 0.00% (0/1)   |
|---------------------+---------------+---------------+---------------+---------------|
| Total               | 40.00% (2/5)  | 40.00% (2/5)  | 100.00% (0/0) | 50.00% (2/4)  |
+---------------------+---------------+---------------+---------------+---------------+
Wrote LCOV report.
```

Used that syntax to keep consistent UX with e.g. `forge build --skip test --skip script`

cc @naszam