### PR TITLE
Chore: Quality of Life improvements for writeJson

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -17,7 +17,7 @@ use foundry_config::fs_permissions::FsAccessKind;
 use hex::FromHex;
 use jsonpath_lib;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::{
     collections::{BTreeMap, HashMap},
     env,
@@ -432,17 +432,16 @@ fn array_eval_to_str<T: UIfmt>(array: &Vec<T>) -> String {
 /// object.
 fn write_json(
     _state: &mut Cheatcodes,
-    object_key: &str,
+    object: &str,
     path: impl AsRef<Path>,
     json_path_or_none: Option<&str>,
 ) -> Result<Bytes, Bytes> {
-    let json: Value = json!(_state.serialized_jsons.get(object_key).unwrap_or(&HashMap::new()));
+    let json: Value = serde_json::from_str(object).unwrap_or(Value::String(object.to_owned()));
     let json_string = serde_json::to_string(&if let Some(json_path) = json_path_or_none {
         let path = _state
             .config
             .ensure_path_allowed(&path, FsAccessKind::Read)
             .map_err(error::encode_error)?;
-
         let data = serde_json::from_str(&fs::read_to_string(path).map_err(error::encode_error)?)
             .map_err(error::encode_error)?;
         let result =

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -329,7 +329,7 @@ fn value_to_token(value: &Value) -> eyre::Result<Token> {
         Ok(Token::Int(number.into()))
     } else if let Some(array) = value.as_array() {
         Ok(Token::Array(array.iter().map(value_to_token).collect::<eyre::Result<Vec<_>>>()?))
-    } else if let Some(_) = value.as_object() {
+    } else if value.as_object().is_some() {
         let ordered_object: BTreeMap<String, Value> =
             serde_json::from_value(value.clone()).unwrap();
         let values =

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -436,7 +436,7 @@ fn write_json(
     path: impl AsRef<Path>,
     json_path_or_none: Option<&str>,
 ) -> Result<Bytes, Bytes> {
-    let json = json!(_state.serialized_jsons.get(object_key).unwrap());
+    let json: Value = json!(_state.serialized_jsons.get(object_key).unwrap_or(&HashMap::new()));
     let json_string = serde_json::to_string(&if let Some(json_path) = json_path_or_none {
         let path = _state
             .config

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -19,7 +19,7 @@ use jsonpath_lib;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     env,
     io::{BufRead, BufReader, Write},
     path::Path,
@@ -329,8 +329,11 @@ fn value_to_token(value: &Value) -> eyre::Result<Token> {
         Ok(Token::Int(number.into()))
     } else if let Some(array) = value.as_array() {
         Ok(Token::Array(array.iter().map(value_to_token).collect::<eyre::Result<Vec<_>>>()?))
-    } else if let Some(object) = value.as_object() {
-        let values = object.values().map(value_to_token).collect::<eyre::Result<Vec<_>>>()?;
+    } else if let Some(_) = value.as_object() {
+        let ordered_object: BTreeMap<String, Value> =
+            serde_json::from_value(value.clone()).unwrap();
+        let values =
+            ordered_object.values().map(value_to_token).collect::<eyre::Result<Vec<_>>>()?;
         Ok(Token::Tuple(values))
     } else if value.is_null() {
         Ok(Token::FixedBytes(vec![0; 32]))

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -134,10 +134,10 @@ contract WriteJson is DSTest {
         bytes[] memory data3 = new bytes[](3);
         data3[0] = bytes("123");
         data3[2] = bytes("fpovhpgjaiosfjhapiufpsdf");
-        vm.serializeBytes(json1, "array3", data3);
+        string memory finalJson = vm.serializeBytes(json1, "array3", data3);
 
         string memory path = "../testdata/fixtures/Json/write_test_array.json";
-        vm.writeJson(json1, path);
+        vm.writeJson(finalJson, path);
 
         string memory json = vm.readFile(path);
         bytes memory rawData = vm.parseJson(json, ".array1");
@@ -172,8 +172,8 @@ contract WriteJson is DSTest {
         string memory json3 = "json3";
         string memory path = "../testdata/fixtures/Json/write_test.json";
         vm.serializeUint(json3, "a", uint256(123));
-        vm.serializeString(json3, "b", "test");
-        vm.writeJson(json3, path);
+        string memory finalJson = vm.serializeString(json3, "b", "test");
+        vm.writeJson(finalJson, path);
 
         string memory json = vm.readFile(path);
         bytes memory data = vm.parseJson(json);
@@ -182,12 +182,20 @@ contract WriteJson is DSTest {
         assertEq(decodedData.b, "test");
 
         // write json3 to key b
-        vm.writeJson(json3, path, ".b");
+        vm.writeJson(finalJson, path, ".b");
         // read again
         json = vm.readFile(path);
         data = vm.parseJson(json, ".b");
         decodedData = abi.decode(data, (simpleJson));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
+
+        // replace a single value to key b
+        address ex = address(0xBEEF);
+        vm.writeJson(vm.toString(ex), path, ".b");
+        json = vm.readFile(path);
+        data = vm.parseJson(json, ".b");
+        address decodedAddress = abi.decode(data, (address));
+        assertEq(decodedAddress, ex);
     }
 }


### PR DESCRIPTION
When I changed the JSON path library to one that supports "replace", I inadvertently broke existing functionality for parseJson, as the new library would not order the values of the objects by alphabetical order of the keys. 

Added a small intermediary step to force the order and forge-std tests again pass. 

**EDIT:** 

I also changed how `writeJson` works to support writing either a full Json or a single value. Now writeJson will get as input the stringified JSON (that we got from `serialize()`) instead of the key. From a UX perspective is also better cause it mimics how writeFile works. 
