### PR TITLE
feat(forge): install latest semver tag if it exists

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -524,7 +524,7 @@ impl ScriptArgs {
 
                 println!("\n==========================");
                 println!("\nChain {}", provider_info.chain);
-                println!("\nEstimated total gas used for script: {}", total_gas);
+                println!("\nEstimated total gas used for script: {total_gas}");
                 println!(
                     "\nEstimated amount required: {} ETH",
                     format_units(total_gas.saturating_mul(per_gas), 18)

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -219,7 +219,7 @@ impl ScriptArgs {
 
                 for (_kind, trace) in &mut traces {
                     decoder.decode(trace).await;
-                    println!("{}", trace);
+                    println!("{trace}");
                 }
             }
 

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -645,6 +645,7 @@ impl TestCommand {
     }
 
     /// Runs the command and asserts that it resulted in an error exit code.
+    #[track_caller]
     pub fn assert_err(&mut self) {
         let o = self.execute();
         if o.status.success() {
@@ -665,6 +666,7 @@ impl TestCommand {
     }
 
     /// Runs the command and asserts that something was printed to stderr.
+    #[track_caller]
     pub fn assert_non_empty_stderr(&mut self) {
         let o = self.execute();
         if o.status.success() || o.stderr.is_empty() {
@@ -685,6 +687,7 @@ impl TestCommand {
     }
 
     /// Runs the command and asserts that something was printed to stdout.
+    #[track_caller]
     pub fn assert_non_empty_stdout(&mut self) {
         let o = self.execute();
         if !o.status.success() || o.stdout.is_empty() {
@@ -705,6 +708,7 @@ impl TestCommand {
     }
 
     /// Runs the command and asserts that nothing was printed to stdout.
+    #[track_caller]
     pub fn assert_empty_stdout(&mut self) {
         let o = self.execute();
         if !o.status.success() || !o.stderr.is_empty() {
@@ -724,10 +728,12 @@ impl TestCommand {
         }
     }
 
+    #[track_caller]
     fn expect_success(&self, out: process::Output) -> process::Output {
         self.ensure_success(out).unwrap()
     }
 
+    #[track_caller]
     pub fn ensure_success(&self, out: process::Output) -> eyre::Result<process::Output> {
         if !out.status.success() {
             let suggest = if out.stderr.is_empty() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #401

cc @mds1 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
after submodule clone, scans all semver tags and install latest, if not tag was provided as argument.

eg:

```
forge install "openzeppelin/openzeppelin-contracts"
cat .gitmodules
```

```
[submodule "lib/forge-std"]
        path = lib/forge-std
        url = https://github.com/foundry-rs/forge-std
[submodule "lib/openzeppelin-contracts"]
        path = lib/openzeppelin-contracts
        url = https://github.com/openzeppelin/openzeppelin-contracts
        branch = v4.8.0
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
