### PR TITLE
fix(forge): set test contract address during constructor call

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -188,3 +188,9 @@ fn test_issue_3347() {
 fn test_issue_3616() {
     test_repro!("Issue3616");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3653>
+#[test]
+fn test_issue_3653() {
+    test_repro!("Issue3653");
+}

--- a/testdata/repros/Issue3653.t.sol
+++ b/testdata/repros/Issue3653.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3653
+contract Issue3653Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+    uint256 fork;
+    Token token;
+
+    constructor() {
+        fork = vm.createSelectFork("rpcAlias", 10);
+        token = new Token();
+        vm.makePersistent(address(token));
+    }
+
+    function testDummy() public {
+        assertEq(block.number, 10);
+    }
+}
+
+contract Token {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3653

previously we only set the test contract address when the `setUp` function was called, via the `to` field of the tx.

With this fork inits inside the constructor are also supported, by deriving the address of the test contract from the CREATE transaction.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
