### PR TITLE
feat: add rpcUrlStructs cheat

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -16,6 +16,7 @@ ethers::contract::abigen!(
     HEVM,
     r#"[
             struct Log {bytes32[] topics; bytes data;}
+            struct Rpc {string name; string url;}
             roll(uint256)
             warp(uint256)
             difficulty(uint256)
@@ -126,6 +127,7 @@ ethers::contract::abigen!(
             rollFork(uint256,bytes32)
             rpcUrl(string)(string)
             rpcUrls()(string[2][])
+            rpcUrlStructs()(Rpc[])
             parseJson(string, string)(bytes)
             parseJson(string)(bytes)
             allowCheatcodes(address)

--- a/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -103,6 +103,18 @@ pub fn apply<DB: DatabaseExt>(
             }
             Ok(urls.encode().into())
         }
+        HEVMCalls::RpcUrlStructs(_) => {
+            let mut urls = Vec::with_capacity(state.config.rpc_endpoints.len());
+            for alias in state.config.rpc_endpoints.keys().cloned() {
+                match state.config.get_rpc_url(&alias) {
+                    Ok(url) => {
+                        urls.push([alias, url]);
+                    }
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+            Ok(urls.encode().into())
+        }
         HEVMCalls::AllowCheatcodes(addr) => {
             data.db.allow_cheatcode_access(addr.0);
             Ok(Default::default())

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -8,8 +8,14 @@ interface Cheats {
         bytes data;
         address emitter;
     }
-    // Set block.timestamp (newTimestamp)
 
+    // Used in getRpcStructs
+    struct Rpc {
+        string name;
+        string url;
+    }
+
+    // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
     // Set block.difficulty (newDifficulty)
     function difficulty(uint256) external;
@@ -225,6 +231,8 @@ interface Cheats {
     function rpcUrl(string calldata) external returns (string memory);
     /// Returns all rpc urls and their aliases `[alias, url][]`
     function rpcUrls() external returns (string[2][] memory);
+    /// Returns all rpc urls and their aliases as an array of structs
+    function rpcUrlStructs() external returns (Rpc[] memory);
     function parseJson(string calldata, string calldata) external returns (bytes memory);
     function parseJson(string calldata) external returns (bytes memory);
 


### PR DESCRIPTION
This helps avoid stack to deep errors in older solidity versions when returning a nested array of strings with `vm.rpcUrl`

Ref https://github.com/foundry-rs/forge-std/pull/217, https://github.com/foundry-rs/forge-std/issues/215

Open to alternative function names