### PR TITLE
[RFC] feat: markdown compatible tables

### DIFF
--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -6,7 +6,7 @@ use crate::{
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
-use comfy_table::{Table, presets::ASCII_MARKDOWN};
+use comfy_table::{presets::ASCII_MARKDOWN, Table};
 use ethers::{
     prelude::{
         artifacts::output_selection::{
@@ -43,9 +43,6 @@ possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecod
     #[clap(long, help = "Pretty print the selected field, if supported.")]
     pub pretty: bool,
 
-    #[clap(long, help = "Print tables in a markdown compatible way.")]
-    pub markdown: bool,
-
     /// All build arguments are supported
     #[clap(flatten)]
     build: build::CoreBuildArgs,
@@ -54,7 +51,7 @@ possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecod
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { mut contract, field, build, pretty, markdown } = self;
+        let InspectArgs { mut contract, field, build, pretty } = self;
 
         // Map field to ContractOutputSelection
         let mut cos = build.compiler.extra_output;
@@ -137,9 +134,7 @@ impl Cmd for InspectArgs {
                 if pretty {
                     if let Some(storage_layout) = &artifact.storage_layout {
                         let mut table = Table::new();
-                        if markdown {
-                            table.load_preset(ASCII_MARKDOWN);
-                        }
+                        table.load_preset(ASCII_MARKDOWN);
                         table.set_header(vec![
                             "Name", "Type", "Slot", "Offset", "Bytes", "Contract",
                         ]);

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -6,7 +6,7 @@ use crate::{
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
-use comfy_table::Table;
+use comfy_table::{Table, presets::ASCII_MARKDOWN};
 use ethers::{
     prelude::{
         artifacts::output_selection::{
@@ -43,6 +43,9 @@ possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecod
     #[clap(long, help = "Pretty print the selected field, if supported.")]
     pub pretty: bool,
 
+    #[clap(long, help = "Print tables in a markdown compatible way.")]
+    pub markdown: bool,
+
     /// All build arguments are supported
     #[clap(flatten)]
     build: build::CoreBuildArgs,
@@ -51,7 +54,7 @@ possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecod
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { mut contract, field, build, pretty } = self;
+        let InspectArgs { mut contract, field, build, pretty, markdown } = self;
 
         // Map field to ContractOutputSelection
         let mut cos = build.compiler.extra_output;
@@ -134,6 +137,9 @@ impl Cmd for InspectArgs {
                 if pretty {
                     if let Some(storage_layout) = &artifact.storage_layout {
                         let mut table = Table::new();
+                        if markdown {
+                            table.load_preset(ASCII_MARKDOWN);
+                        }
                         table.set_header(vec![
                             "Name", "Type", "Slot", "Offset", "Bytes", "Contract",
                         ]);

--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -1,6 +1,6 @@
 //! Support for compiling [ethers::solc::Project]
 use crate::{term, TestFunctionExt};
-use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, *};
+use comfy_table::{presets::ASCII_MARKDOWN, *};
 use ethers_etherscan::contract::Metadata;
 use ethers_solc::{
     artifacts::{BytecodeObject, ContractBytecodeSome},
@@ -196,7 +196,7 @@ impl SizeReport {
 impl Display for SizeReport {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         let mut table = Table::new();
-        table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+        table.load_preset(ASCII_MARKDOWN);
         table.set_header(vec![
             Cell::new("Contract").add_attribute(Attribute::Bold).fg(Color::Blue),
             Cell::new("Size (kB)").add_attribute(Attribute::Bold).fg(Color::Blue),

--- a/forge/src/coverage.rs
+++ b/forge/src/coverage.rs
@@ -1,4 +1,4 @@
-use comfy_table::{Attribute, Cell, Color, Row, Table};
+use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Row, Table};
 pub use foundry_evm::coverage::*;
 use std::io::Write;
 
@@ -18,6 +18,7 @@ pub struct SummaryReporter {
 impl Default for SummaryReporter {
     fn default() -> Self {
         let mut table = Table::new();
+        table.load_preset(ASCII_MARKDOWN);
         table.set_header(["File", "% Lines", "% Statements", "% Branches", "% Funcs"]);
 
         Self { table, total: CoverageSummary::default() }

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -2,7 +2,7 @@ use crate::{
     executor::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS},
     trace::{CallTraceArena, RawOrDecodedCall, TraceKind},
 };
-use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, *};
+use comfy_table::{presets::ASCII_MARKDOWN, *};
 use ethers::types::U256;
 use foundry_common::{calc, TestFunctionExt};
 use serde::{Deserialize, Serialize};
@@ -124,7 +124,7 @@ impl Display for GasReport {
             }
 
             let mut table = Table::new();
-            table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+            table.load_preset(ASCII_MARKDOWN);
             table.set_header(vec![Cell::new(format!("{name} contract"))
                 .add_attribute(Attribute::Bold)
                 .fg(Color::Green)]);
@@ -158,7 +158,8 @@ impl Display for GasReport {
                     ]);
                 })
             });
-            writeln!(f, "{table}")?
+            writeln!(f, "{table}")?;
+            writeln!(f, "\n")?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

When using foundry features(inspect for storage layout, but potentially gas report etc), it often happens that in the end i want to put these results into a document. What i noticed ppl tend to do is: making screenshots of the terminal and embedding it into markdown. This imo is not so good as it makes this stuff hard to maintain and a bit cumbersome. Therefore i'd suggest to allow generating markdown compatible tables.

## Solution

The `comfy_table` crate used inside foundry provides a markdown preset that can be used.

I think is worth discussing:
Does this need a flag or should it just be the default?

I don't really see the value in "non markdown" tables (as markdown is perfectly readable in console as well).
If there's no opposition, would delete the flag and just use this preset in `all` tables.


Before:
+----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------+
| Name                             | Type                                                                                   | Slot | Offset | Bytes | Contract                                                                                                          |
+=======================================================================================================================================================================================================================================================================+
| _balances                        | mapping(address => uint256)                                                            | 0    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _allowances                      | mapping(address => mapping(address => uint256))                                        | 1    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _totalSupply                     | uint256                                                                                | 2    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _name                            | string                                                                                 | 3    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _symbol                          | string                                                                                 | 4    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _decimals                        | uint8                                                                                  | 5    | 0      | 1     | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _votingSnapshots                 | mapping(address => mapping(uint256 => struct GovernancePowerDelegationERC20.Snapshot)) | 6    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _votingSnapshotsCounts           | mapping(address => uint256)                                                            | 7    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _aaveGovernance                  | contract ITransferHook                                                                 | 8    | 0      | 20    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| lastInitializedRevision          | uint256                                                                                | 9    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| ______gap                        | uint256[50]                                                                            | 10   | 0      | 1600  | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| assets                           | mapping(address => struct AaveDistributionManager.AssetData)                           | 60   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| stakerRewardsToClaim             | mapping(address => uint256)                                                            | 61   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| stakersCooldowns                 | mapping(address => uint256)                                                            | 62   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _votingDelegates                 | mapping(address => address)                                                            | 63   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _propositionPowerSnapshots       | mapping(address => mapping(uint256 => struct GovernancePowerDelegationERC20.Snapshot)) | 64   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _propositionPowerSnapshotsCounts | mapping(address => uint256)                                                            | 65   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _propositionPowerDelegates       | mapping(address => address)                                                            | 66   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| DOMAIN_SEPARATOR                 | bytes32                                                                                | 67   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
|----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------|
| _nonces                          | mapping(address => uint256)                                                            | 68   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
+----------------------------------+----------------------------------------------------------------------------------------+------+--------+-------+-------------------------------------------------------------------------------------------------------------------+


After:
| Name                             | Type                                                                                   | Slot | Offset | Bytes | Contract                                                                                                          |
|----------------------------------|----------------------------------------------------------------------------------------|------|--------|-------|-------------------------------------------------------------------------------------------------------------------|
| _balances                        | mapping(address => uint256)                                                            | 0    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _allowances                      | mapping(address => mapping(address => uint256))                                        | 1    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _totalSupply                     | uint256                                                                                | 2    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _name                            | string                                                                                 | 3    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _symbol                          | string                                                                                 | 4    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _decimals                        | uint8                                                                                  | 5    | 0      | 1     | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _votingSnapshots                 | mapping(address => mapping(uint256 => struct GovernancePowerDelegationERC20.Snapshot)) | 6    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _votingSnapshotsCounts           | mapping(address => uint256)                                                            | 7    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _aaveGovernance                  | contract ITransferHook                                                                 | 8    | 0      | 20    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| lastInitializedRevision          | uint256                                                                                | 9    | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| ______gap                        | uint256[50]                                                                            | 10   | 0      | 1600  | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| assets                           | mapping(address => struct AaveDistributionManager.AssetData)                           | 60   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| stakerRewardsToClaim             | mapping(address => uint256)                                                            | 61   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| stakersCooldowns                 | mapping(address => uint256)                                                            | 62   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _votingDelegates                 | mapping(address => address)                                                            | 63   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _propositionPowerSnapshots       | mapping(address => mapping(uint256 => struct GovernancePowerDelegationERC20.Snapshot)) | 64   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _propositionPowerSnapshotsCounts | mapping(address => uint256)                                                            | 65   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _propositionPowerDelegates       | mapping(address => address)                                                            | 66   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| DOMAIN_SEPARATOR                 | bytes32                                                                                | 67   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
| _nonces                          | mapping(address => uint256)                                                            | 68   | 0      | 32    | src/etherscan/mainnet_0xe42f02713aec989132c1755117f768dbea523d2f/StakedTokenV2Rev3/Contract.sol:StakedTokenV2Rev3 |
