### PR TITLE
fix: roll back deals on revert

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -194,3 +194,9 @@ fn test_issue_3616() {
 fn test_issue_3653() {
     test_repro!("Issue3653");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3596>
+#[test]
+fn test_issue_3596() {
+    test_repro!("Issue3596", true, None);
+}

--- a/testdata/repros/Issue3596.t.sol
+++ b/testdata/repros/Issue3596.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3596
+contract Issue3596Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testDealTransfer() public {
+        address addr = vm.addr(1337);
+        vm.startPrank(addr);
+        vm.deal(addr, 20000001 ether);
+        payable(address(this)).transfer(20000000 ether);
+
+        Nested nested = new Nested();
+        nested.doStuff();
+        vm.stopPrank();
+    }
+}
+
+contract Nested {
+    function doStuff() public {
+        doRevert();
+    }
+
+    function doRevert() public {
+        revert("This fails");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3596

This fixes an issue with `deal` cheat code on revert.

`Deal` sets the balance of an address. revm records balance transfers which are then rolled back on revert via unchecked math (reverse transfer).

If, after a transfer, a transaction occurs that sets the recipient's balance to a value lower than that previously transferred, this will result in an underflow when the transfer is reversed during revm's cleanup.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
record all `deal`s and roll them back manually on revert before revm applies the actual revert
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
