### PR TITLE
fix(evm): Make sure new forks have  `state.depth = 0` before they're first selected

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -194,3 +194,12 @@ fn test_issue_3616() {
 fn test_issue_3653() {
     test_repro!("Issue3653");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3221>
+#[test]
+fn test_issue_3674() {
+    test_repro_with_sender!(
+        "Issue3674",
+        Address::from_str("0xF0959944122fb1ed4CfaBA645eA06EED30427BAA").unwrap()
+    );
+}

--- a/testdata/repros/Issue3674.t.sol
+++ b/testdata/repros/Issue3674.t.sol
@@ -9,10 +9,8 @@ contract Issue3674Test is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
 
     function testNonceCreateSelect() public {
-        vm.createSelectFork(
-            "https://goerli.infura.io/v3/f4a0bdad42674adab5fc0ac077ffab2b"
-        );
-        
+        vm.createSelectFork("https://goerli.infura.io/v3/f4a0bdad42674adab5fc0ac077ffab2b");
+
         vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc");
         assert(vm.getNonce(msg.sender) > 0x17);
     }

--- a/testdata/repros/Issue3674.t.sol
+++ b/testdata/repros/Issue3674.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3674
+contract Issue3674Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testNonceCreateSelect() public {
+        vm.createSelectFork(
+            "https://goerli.infura.io/v3/f4a0bdad42674adab5fc0ac077ffab2b"
+        );
+        
+        vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc");
+        assert(vm.getNonce(msg.sender) > 0x17);
+    }
+}


### PR DESCRIPTION

## Motivation

closes #3674 

Forks that were created after the first one was selected (on a `!launched_with_fork` scenario), were not  properly handling `msg.sender` account info. Reason being that `fork_init_state` was ending up with `state.depth = 1` .

## Solution

Make sure that that all created forks have a `state.depth = 0` before they're first selected.

