### PR TITLE
chore: Bump revm to v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4693,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87344ffd3eec06b568e1fc69c225e4cbd8d68d8d9051b6d2652d596947efa1ce"
+checksum = "cf7259a494c33494fb23f087b36394acf4ac5e6d2dc30b2b8d6d98c314bc96c3"
 dependencies = [
  "arrayref",
  "auto_impl 1.0.1",

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../../evm" }
-revm = { version = "2.1", default-features = false, features = [
+revm = { version = "2.2", default-features = false, features = [
     "std",
     "k256",
     "with-serde",

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = "1.13"
 # EVM
 bytes = "1.1.0"
 hashbrown = { version = "0.12", features = ["serde"] }
-revm = { version = "2.1", default-features = false, features = [
+revm = { version = "2.2", default-features = false, features = [
   "std",
   "k256",
   "with-serde",

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -14,4 +14,4 @@ eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
 forge = { path = "../forge" }
-revm = { version = "2.1", features = ["std", "k256", "with-serde"] }
+revm = { version = "2.2", features = ["std", "k256", "with-serde"] }


### PR DESCRIPTION
bump revm to v2.2.0.

changelog: https://github.com/bluealloy/revm/blob/main/crates/revm/CHANGELOG.md