### PR TITLE
fix(cheats): delay on revert cleanup until expected revert handled

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -386,7 +386,7 @@ fn serialize_json(
         serialization.clone()
     };
     let stringified = serde_json::to_string(&json)
-        .map_err(|err| error::encode_error(format!("Failed to stringify hashmap: {}", err)))?;
+        .map_err(|err| error::encode_error(format!("Failed to stringify hashmap: {err}")))?;
     Ok(abi::encode(&[Token::String(stringified)]).into())
 }
 /// Converts an array to it's stringified version, adding the appropriate quotes around it's

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -189,6 +189,12 @@ fn test_issue_3616() {
     test_repro!("Issue3616");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/3685>
+#[test]
+fn test_issue_3685() {
+    test_repro!("Issue3685");
+}
+
 // <https://github.com/foundry-rs/foundry/issues/3653>
 #[test]
 fn test_issue_3653() {

--- a/testdata/repros/Issue3685.t.sol
+++ b/testdata/repros/Issue3685.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+import "../logs/console.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3685
+contract Issue3685Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+    Actor a;
+    Actor b;
+
+    function setUp() public {
+        a = new Actor();
+        b = new Actor();
+        vm.deal(address(a), 1 ether);
+    }
+
+    // should not end up with 0 balance
+    function test_wrong_balance() public {
+        console.log("should be 1 ether       ", address(a).balance);
+        vm.expectRevert(bytes("rev"));
+        a.spendFail(b);
+        console.log("should still be 1 ether ", address(a).balance);
+        a.spendSuccess(b); // panics here if back_and_forth() is called before
+    }
+    // panics
+
+    function test_panic() public {
+        back_and_forth();
+        test_wrong_balance();
+    }
+
+    function back_and_forth() internal {
+        a.spendSuccess(b);
+        b.spendSuccess(a);
+    }
+}
+
+contract Actor {
+    function spendSuccess(Actor a) public {
+        a.receiveSuccess{value: 1 ether}();
+    }
+
+    function spendFail(Actor a) public {
+        a.receiveFail{value: 1 ether}();
+    }
+
+    function receiveFail() public payable {
+        revert("rev");
+    }
+
+    function receiveSuccess() public payable {}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3685

This delays the on_revert cleanup until a potential expectRevert was handled.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
