### PR TITLE
feat(verify): add preflight check

### DIFF
--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -1,6 +1,9 @@
 //! Verify contract source
 
-use crate::cmd::{forge::verify::etherscan::EtherscanVerificationProvider, retry::RetryArgs};
+use crate::cmd::{
+    forge::verify::{etherscan::EtherscanVerificationProvider, provider::VerificationProvider},
+    retry::RetryArgs,
+};
 use clap::{Parser, ValueHint};
 use ethers::{abi::Address, solc::info::ContractInfo};
 use foundry_config::{figment, impl_figment_convert, Chain, Config};
@@ -183,6 +186,11 @@ impl VerifyArgs {
 
         println!("Start verifying contract `{:?}` deployed on {}", self.address, self.chain);
         self.verifier.verifier.client(&self.etherscan_key)?.verify(self).await
+    }
+
+    /// Returns the configured verification provider
+    pub fn verification_provider(&self) -> eyre::Result<Box<dyn VerificationProvider>> {
+        self.verifier.verifier.client(&self.etherscan_key)
     }
 }
 

--- a/cli/src/cmd/forge/verify/provider.rs
+++ b/cli/src/cmd/forge/verify/provider.rs
@@ -8,7 +8,19 @@ use std::{fmt, str::FromStr};
 /// An abstraction for various verification providers such as etherscan, sourcify, blockscout
 #[async_trait]
 pub trait VerificationProvider {
+    /// This should ensure the verify request can be prepared successfully.
+    ///
+    /// Caution: Implementers must ensure that this _never_ sends the actual verify request
+    /// `[VerificationProvider::verify]`, instead this is supposed to evaluate whether the given
+    /// [`VerifyArgs`] are valid to begin with. This should prevent situations where there's a
+    /// contract deployment that's executed before the verify request and the subsequent verify task
+    /// fails due to misconfiguration.
+    async fn preflight_check(&self, args: VerifyArgs) -> eyre::Result<()>;
+
+    /// Sends the actual verify request for the targeted contract.
     async fn verify(&self, args: VerifyArgs) -> eyre::Result<()>;
+
+    /// Checks whether the contract is verified.
     async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()>;
 }
 

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -21,64 +21,13 @@ pub struct SourcifyVerificationProvider;
 
 #[async_trait]
 impl VerificationProvider for SourcifyVerificationProvider {
+    async fn preflight_check(&self, args: VerifyArgs) -> eyre::Result<()> {
+        let _ = self.prepare_request(&args)?;
+        Ok(())
+    }
+
     async fn verify(&self, args: VerifyArgs) -> eyre::Result<()> {
-        let mut config = args.try_load_config_emit_warnings()?;
-        config.libraries.extend(args.libraries.clone());
-
-        let project = config.project()?;
-
-        if !config.cache {
-            eyre::bail!("Cache is required for sourcify verification.")
-        }
-
-        let cache = project.read_cache_file()?;
-        let (path, entry) = crate::cmd::get_cached_entry_by_name(&cache, &args.contract.name)?;
-
-        if entry.solc_config.settings.metadata.is_none() {
-            eyre::bail!(
-                r#"Contract {} was compiled without the solc `metadata` setting.
-Sourcify requires contract metadata for verification.
-metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
-                args.contract.name
-            )
-        }
-
-        let mut files = HashMap::with_capacity(2 + entry.imports.len());
-
-        // the metadata is included in the contract's artifact file
-        let artifact_path = entry
-            .find_artifact_path(&args.contract.name)
-            .ok_or_else(|| eyre::eyre!("No artifact found for contract {}", args.contract.name))?;
-
-        let artifact: ConfigurableContractArtifact = fs::read_json_file(artifact_path)?;
-        if let Some(metadata) = artifact.metadata {
-            let metadata = serde_json::to_string_pretty(&metadata)?;
-            files.insert("metadata.json".to_string(), metadata);
-        } else {
-            eyre::bail!(
-                r#"No metadata found in artifact `{}` for contract {}.
-Sourcify requires contract metadata for verification.
-metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
-                artifact_path.display(),
-                args.contract.name
-            )
-        }
-
-        let contract_path = args.contract.path.map_or(path, PathBuf::from);
-        let filename = contract_path.file_name().unwrap().to_string_lossy().to_string();
-        files.insert(filename, fs::read_to_string(&contract_path)?);
-
-        for import in entry.imports {
-            let import_entry = format!("{}", import.display());
-            files.insert(import_entry, fs::read_to_string(&import)?);
-        }
-
-        let body = SourcifyVerifyRequest {
-            address: format!("{:?}", args.address),
-            chain: args.chain.id().to_string(),
-            files,
-            chosen_contract: None,
-        };
+        let body = self.prepare_request(&args)?;
 
         trace!("submitting verification request {:?}", body);
 
@@ -157,6 +106,69 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
 }
 
 impl SourcifyVerificationProvider {
+    /// Configures the API request to the sourcify API using the given [`VerifyArgs`].
+    fn prepare_request(&self, args: &VerifyArgs) -> eyre::Result<SourcifyVerifyRequest> {
+        let mut config = args.try_load_config_emit_warnings()?;
+        config.libraries.extend(args.libraries.clone());
+
+        let project = config.project()?;
+
+        if !config.cache {
+            eyre::bail!("Cache is required for sourcify verification.")
+        }
+
+        let cache = project.read_cache_file()?;
+        let (path, entry) = crate::cmd::get_cached_entry_by_name(&cache, &args.contract.name)?;
+
+        if entry.solc_config.settings.metadata.is_none() {
+            eyre::bail!(
+                r#"Contract {} was compiled without the solc `metadata` setting.
+Sourcify requires contract metadata for verification.
+metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
+                args.contract.name
+            )
+        }
+
+        let mut files = HashMap::with_capacity(2 + entry.imports.len());
+
+        // the metadata is included in the contract's artifact file
+        let artifact_path = entry
+            .find_artifact_path(&args.contract.name)
+            .ok_or_else(|| eyre::eyre!("No artifact found for contract {}", args.contract.name))?;
+
+        let artifact: ConfigurableContractArtifact = fs::read_json_file(artifact_path)?;
+        if let Some(metadata) = artifact.metadata {
+            let metadata = serde_json::to_string_pretty(&metadata)?;
+            files.insert("metadata.json".to_string(), metadata);
+        } else {
+            eyre::bail!(
+                r#"No metadata found in artifact `{}` for contract {}.
+Sourcify requires contract metadata for verification.
+metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.toml`"#,
+                artifact_path.display(),
+                args.contract.name
+            )
+        }
+
+        let contract_path = args.contract.path.clone().map_or(path, PathBuf::from);
+        let filename = contract_path.file_name().unwrap().to_string_lossy().to_string();
+        files.insert(filename, fs::read_to_string(&contract_path)?);
+
+        for import in entry.imports {
+            let import_entry = format!("{}", import.display());
+            files.insert(import_entry, fs::read_to_string(&import)?);
+        }
+
+        let req = SourcifyVerifyRequest {
+            address: format!("{:?}", args.address),
+            chain: args.chain.id().to_string(),
+            files,
+            chosen_contract: None,
+        };
+
+        Ok(req)
+    }
+
     fn process_sourcify_response(&self, response: Option<Vec<SourcifyResponseElement>>) {
         let response = response.unwrap().remove(0);
         if response.status == "perfect" {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref #3691

Adds a `preflight_check` routine for `create + verify` combo.

This should prevent contract deployments when the subsequent verify will fail due to config issues.

This adds a new `VerificationProvider::preflight_check` function that prepares the verify request but does not send it, the same way the actual `VerificationProvider::verify` would do.

@rkrasiuk mind giving this a spin?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
