### PR TITLE
fix: reuse in progress fork task

### DIFF
--- a/forge/tests/it/fork.rs
+++ b/forge/tests/it/fork.rs
@@ -56,3 +56,10 @@ fn test_transact_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}Transact"));
     TestConfig::filter(filter).run();
 }
+
+/// Tests that we can create the same fork (provider,block) concurretnly in different tests
+#[test]
+fn test_create_same_fork() {
+    let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}ForkSame"));
+    TestConfig::filter(filter).run();
+}

--- a/testdata/fork/ForkSame_1.t.sol
+++ b/testdata/fork/ForkSame_1.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+contract ForkTest is DSTest {
+    address constant WETH_TOKEN_ADDR = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    uint256 forkA;
+
+    // this will create two _different_ forks during setup
+    function setUp() public {
+        forkA = cheats.createFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 15_977_624);
+    }
+
+    function testDummy() public {
+        uint256 balance = WETH_TOKEN_ADDR.balance;
+    }
+}

--- a/testdata/fork/ForkSame_2.t.sol
+++ b/testdata/fork/ForkSame_2.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+contract ForkTest is DSTest {
+    address constant WETH_TOKEN_ADDR = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    uint256 forkA;
+
+    // this will create two _different_ forks during setup
+    function setUp() public {
+        forkA = cheats.createFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 15_977_624);
+    }
+
+    function testDummy() public {
+        uint256 balance = WETH_TOKEN_ADDR.balance;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Forks are identified via `provider+block`. 
This fixes a logic error where an additional task to create a fork while another task was active would overwrite the matching forkid's backend on completion.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Before starting a new task to create a fork, check if there's already an active for the same forkId, if so, simply push the `Sender` and don't start a new task.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
