### PR TITLE
feat(forge): add fsMetadata cheat

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -17,7 +17,7 @@ ethers::contract::abigen!(
     r#"[
             struct Log {bytes32[] topics; bytes data;}
             struct Rpc {string name; string url;}
-            struct FsMetadata {bool isDir; bool isSymlink; uint256 len; bool readOnly; uint256 modified; uint256 accessed; uint256 created;}
+            struct FsMetadata {bool isDir; bool isSymlink; uint256 length; bool readOnly; uint256 modified; uint256 accessed; uint256 created;}
             roll(uint256)
             warp(uint256)
             difficulty(uint256)

--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -17,6 +17,7 @@ ethers::contract::abigen!(
     r#"[
             struct Log {bytes32[] topics; bytes data;}
             struct Rpc {string name; string url;}
+            struct FsMetadata {bool isDir; bool isSymlink; uint256 len; bool readOnly; uint256 modified; uint256 accessed; uint256 created;}
             roll(uint256)
             warp(uint256)
             difficulty(uint256)
@@ -90,6 +91,7 @@ ethers::contract::abigen!(
             writeLine(string,string)
             closeFile(string)
             removeFile(string)
+            fsMetadata(string)(FsMetadata)
             toString(bytes)
             toString(address)
             toString(uint256)

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -25,7 +25,7 @@ use std::{
     path::Path,
     process::Command,
     str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
+    time::UNIX_EPOCH,
 };
 use tracing::{error, trace};
 /// Invokes a `Command` with the given args and returns the abi encoded response
@@ -297,6 +297,9 @@ fn remove_file(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, 
     Ok(Bytes::new())
 }
 
+/// Gets the metadata of a file/directory
+///
+/// This will return an error if no file/directory is found, or if the target path isn't allowed
 fn fs_metadata(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, Bytes> {
     let path =
         state.config.ensure_path_allowed(&path, FsAccessKind::Read).map_err(error::encode_error)?;
@@ -306,10 +309,7 @@ fn fs_metadata(state: &mut Cheatcodes, path: impl AsRef<Path>) -> Result<Bytes, 
     // These fields not available on all platforms; default to 0
     let [modified, accessed, created] =
         [metadata.modified(), metadata.accessed(), metadata.created()].map(|time| {
-            time.unwrap_or(SystemTime::from(UNIX_EPOCH))
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs()
+            time.unwrap_or(UNIX_EPOCH).duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
         });
 
     let metadata = (

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -19,7 +19,7 @@ interface Cheats {
     struct FsMetadata {
         bool isDir;
         bool isSymlink;
-        uint256 len;
+        uint256 length;
         bool readOnly;
         uint256 modified;
         uint256 accessed;

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -15,6 +15,17 @@ interface Cheats {
         string url;
     }
 
+    // Used in fsMetadata
+    struct FsMetadata {
+        bool isDir;
+        bool isSymlink;
+        uint256 len;
+        bool readOnly;
+        uint256 modified;
+        uint256 accessed;
+        uint256 created;
+    }
+
     // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
     // Set block.difficulty (newDifficulty)
@@ -140,6 +151,8 @@ interface Cheats {
     function readFileBinary(string calldata) external returns (bytes memory);
     // Get the path of the current project root
     function projectRoot() external returns (string memory);
+    // Get the metadata for a file/directory
+    function fsMetadata(string calldata) external returns (FsMetadata memory);
     // Reads next line of file to string, (path) => (line)
     function readLine(string calldata) external returns (string memory);
     // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -129,16 +129,28 @@ contract FileTest is DSTest {
     }
 
     function testFsMetadata() public {
-        // TODO: create folder/file/symlink just for this test
         string memory path = "../testdata/fixtures/File/";
         Cheats.FsMetadata memory metadata = cheats.fsMetadata(path);
         assertEq(metadata.isDir, true);
         assertEq(metadata.isSymlink, false);
-        // TODO: don't make assertions that break on other people's machines
-        assertEq(metadata.len, 96);
         assertEq(metadata.readOnly, false);
-        assertEq(metadata.modified, 1668898281);
-        assertEq(metadata.accessed, 1668898283);
-        assertEq(metadata.created, 1668808281);
+        assertGt(metadata.len, 0);
+        assertGt(metadata.modified, 0);
+        assertGt(metadata.accessed, 0);
+        assertGt(metadata.created, 0);
+
+        path = "../testdata/fixtures/File/read.txt";
+        metadata = cheats.fsMetadata(path);
+        assertEq(metadata.isDir, false);
+
+        path = "../testdata/fixtures/File/symlink";
+        metadata = cheats.fsMetadata(path);
+        assertEq(metadata.isSymlink, true);
+
+        cheats.expectRevert();
+        cheats.fsMetadata("../not-found");
+
+        cheats.expectRevert(FOUNDRY_READ_ERR);
+        cheats.fsMetadata("/etc/hosts");
     }
 }

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -129,15 +129,16 @@ contract FileTest is DSTest {
     }
 
     function testFsMetadata() public {
-        string memory path = "../testdata/fixtures/File/";
+        string memory path = "../testdata/fixtures/File";
         Cheats.FsMetadata memory metadata = cheats.fsMetadata(path);
         assertEq(metadata.isDir, true);
         assertEq(metadata.isSymlink, false);
         assertEq(metadata.readOnly, false);
         assertGt(metadata.len, 0);
-        assertGt(metadata.modified, 0);
-        assertGt(metadata.accessed, 0);
-        assertGt(metadata.created, 0);
+        // These fields aren't available on all platforms, default to zero
+        // assertGt(metadata.modified, 0);
+        // assertGt(metadata.accessed, 0);
+        // assertGt(metadata.created, 0);
 
         path = "../testdata/fixtures/File/read.txt";
         metadata = cheats.fsMetadata(path);

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -127,4 +127,18 @@ contract FileTest is DSTest {
         cheats.expectRevert(FOUNDRY_TOML_ACCESS_ERR);
         cheats.writeFile("./../foundry.toml", "\nffi = true\n");
     }
+
+    function testFsMetadata() public {
+        // TODO: create folder/file/symlink just for this test
+        string memory path = "../testdata/fixtures/File/";
+        Cheats.FsMetadata memory metadata = cheats.fsMetadata(path);
+        assertEq(metadata.isDir, true);
+        assertEq(metadata.isSymlink, false);
+        // TODO: don't make assertions that break on other people's machines
+        assertEq(metadata.len, 96);
+        assertEq(metadata.readOnly, false);
+        assertEq(metadata.modified, 1668898281);
+        assertEq(metadata.accessed, 1668898283);
+        assertEq(metadata.created, 1668808281);
+    }
 }

--- a/testdata/cheats/File.t.sol
+++ b/testdata/cheats/File.t.sol
@@ -134,7 +134,7 @@ contract FileTest is DSTest {
         assertEq(metadata.isDir, true);
         assertEq(metadata.isSymlink, false);
         assertEq(metadata.readOnly, false);
-        assertGt(metadata.len, 0);
+        assertGt(metadata.length, 0);
         // These fields aren't available on all platforms, default to zero
         // assertGt(metadata.modified, 0);
         // assertGt(metadata.accessed, 0);

--- a/testdata/fixtures/File/symlink
+++ b/testdata/fixtures/File/symlink
@@ -1,0 +1,2 @@
+hello readable world
+this is the second line!


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Resolves half of #3695 - Per @mattsse request, let's get some file/dir metadata going.

## Solution

Created `cheats.fsMetadata` which returns a struct roughly mirroring `std::fs::Metadata`.

A couple areas that may deserve review attention:
- is it appropriate to have the test in File.t.sol?
- is it appropriate to use dir+file from the File fixture in the test?
- for modified, created, accessed timestamps, is it appropriate to return 0 when not supported by platform?
- currently i called filesize `len` like std::fs::Metadata does, but I'm wondering if `size` is better!
- And probably tons of other stuff I'm unaware of...

I'll be really happy for your feedback, this is my first foundry PR!