### PR TITLE
chore: use docker buildkit and cache mount for faster local incremental builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM alpine as build-environment
 ARG TARGETARCH
 WORKDIR /opt
@@ -10,7 +12,9 @@ RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >
 
 WORKDIR /opt/foundry
 COPY . .
-RUN source $HOME/.profile && cargo build --release \
+
+RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/root/.cargo/git \
+    source $HOME/.profile && cargo build --release \
     && strip /opt/foundry/target/release/forge \
     && strip /opt/foundry/target/release/cast \
     && strip /opt/foundry/target/release/anvil


### PR DESCRIPTION
This changes the `cargo build` step in the dockerfile so that it uses a cache mount between builds. This does not (yet) change the build performance of repeated builds in CI (tracked here: https://github.com/moby/buildkit/issues/1512) but significantly improves the performance of incremental rebuilds (locally).

## Motivation

I am currently working on a local dev environment and demo involving (amongst others) anvil in a containerized setup. As we are also working on some additions to anvil in the process (firehose instrumentalisation), re-building the docker images over-and-over was getting a bit annoying :-P. This reduces the build time (incremental builds) from 5+ minutes to ~20 seconds.

## Solution

This uses a "new" feature in docker buildkit (available via `docker buildx build`, `docker buildx bake`, etc.) that allows more fine grained cache control between builds complementary to the basic layer cache.

As your github workflows are already utilizing the buildkit action, no changes should be needed there.
