### PR TITLE
test: add expectRevert test

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -474,7 +474,7 @@ where
                     retdata,
                 ) {
                     Err(retdata) => {
-                        trace!(expected=?expected_revert, actual=%hex::encode(&retdata), "Expected revert mismatch");
+                        trace!(expected=?expected_revert, actual=%hex::encode(&retdata), ?status, "Expected revert mismatch");
                         (Return::Revert, remaining_gas, retdata)
                     }
                     Ok((_, retdata)) => (Return::Return, remaining_gas, retdata),

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -221,3 +221,9 @@ fn test_issue_3674() {
 fn test_issue_3703() {
     test_repro!("Issue3703");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/3753>
+#[test]
+fn test_issue_3753() {
+    test_repro!("Issue3753");
+}

--- a/testdata/repros/Issue3753.t.sol
+++ b/testdata/repros/Issue3753.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3753
+contract Issue3753Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function test_repro() public {
+        bool res;
+        assembly {
+            res := staticcall(gas(), 4, 0, 0, 0, 0)
+        }
+        vm.expectRevert("require");
+        require(false, "require");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3753

expectRevert only checks the next call:

> If the next call does not revert with the expected message msg, then expectRevert will.

The exit condition looks like 

```
if evm.depth() <= expected_revert.depth {
 // check if reverted
}
```

The next call would be `expected_revert.depth + 1`, so after the call returns we check if it reverted. This is not the case in #3753

so in this case the expectRevert should be set directly before the require

@prestwich 

will add this example to the book.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
