### PR TITLE
fix: only merge account if it was loaded

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -1632,7 +1632,14 @@ fn merge_db_account_data<ExtDB: DatabaseRef>(
     fork_db: &mut ForkDB,
 ) {
     trace!(?addr, "merging database data");
-    let mut acc = active.accounts.get(&addr).cloned().unwrap_or_default();
+
+    let mut acc = if let Some(acc) = active.accounts.get(&addr).cloned() {
+        acc
+    } else {
+        // Account does not exist
+        return
+    };
+
     if let Some(code) = active.contracts.get(&acc.info.code_hash).cloned() {
         fork_db.contracts.insert(acc.info.code_hash, code);
     }

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -20,6 +20,7 @@ use foundry_common::{fmt::*, RpcUrl};
 use hex::FromHex;
 use revm::{Account, CreateInputs, Database, EVMData, JournaledState, TransactTo};
 use std::{collections::VecDeque, str::FromStr};
+use tracing::trace;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
@@ -201,11 +202,13 @@ where
             match &info.code {
                 Some(code) => {
                     if code.is_empty() {
+                        trace!(create2=?DEFAULT_CREATE2_DEPLOYER, "Empty Create 2 deployer code");
                         return Err(DatabaseError::MissingCreate2Deployer)
                     }
                 }
                 None => {
                     // forked db
+                    trace!(create2=?DEFAULT_CREATE2_DEPLOYER, "Missing Create 2 deployer code");
                     if data.db.code_by_hash(info.code_hash)?.is_empty() {
                         return Err(DatabaseError::MissingCreate2Deployer)
                     }

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -132,7 +132,7 @@ impl Executor {
 
     /// Creates the default CREATE2 Contract Deployer for local tests and scripts.
     pub fn deploy_create2_deployer(&mut self) -> eyre::Result<()> {
-        trace!("deploying create2 deployer");
+        trace!("deploying local create2 deployer");
         let create2_deployer_account = self
             .backend_mut()
             .basic(DEFAULT_CREATE2_DEPLOYER)?
@@ -153,7 +153,7 @@ impl Executor {
                 U256::zero(),
                 None
             )?;
-            trace!(create2=?res.address, "deployed create2 deployer");
+            trace!(create2=?res.address, "deployed local create2 deployer");
 
             self.set_balance(creator, initial_balance)?;
         }

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -139,6 +139,12 @@ fn test_issue_3221() {
     test_repro!("Issue3221");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/3708>
+#[test]
+fn test_issue_3708() {
+    test_repro!("Issue3708");
+}
+
 // <https://github.com/foundry-rs/foundry/issues/3221>
 #[test]
 fn test_issue_3223() {

--- a/testdata/repros/Issue3708.sol
+++ b/testdata/repros/Issue3708.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/3708
+contract Issue3708Test is DSTest {
+    // https://optimistic.etherscan.io/address/0x4e59b44847b379578588920ca78fbf26c0b4956c#code
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function setUp() public {
+        string memory RPC_URL = "https://mainnet.optimism.io";
+        uint256 forkId = vm.createSelectFork(RPC_URL);
+
+        bytes memory code =
+            hex"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3";
+        assertEq(CREATE2_DEPLOYER.code, code);
+    }
+
+    function test_deployer() public {
+        bytes memory code =
+            hex"7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3";
+        assertEq(CREATE2_DEPLOYER.code, code);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3708

CREATE2 deployer address is persistent by default, however when merging the underlying dbs on select, we did `unwrap_or_default` so if the CREATE2 deployer hasn't been loaded yet an empty account was created.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Skip non-existing, persistent accounts
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
