### PR TITLE
chore: rm forge-std submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testdata/lib/forge-std"]
-	path = testdata/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -29,7 +29,7 @@ offline = false
 optimizer = true
 optimizer_runs = 200
 out = 'out'
-remappings = ['ds-test/=lib/ds-test/src/', 'forge-std/=lib/forge-std/src/']
+remappings = ['ds-test/=lib/ds-test/src/']
 sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
 sizes = false
 sparse_mode = false


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
forge-std submodule was accidentally merged here https://github.com/foundry-rs/foundry/pull/2854

The reason why we don't use forge-std as test standard is, because we'd otherwise have a circular dependency `forge <-> forge-std`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
