### PR TITLE
fix(anvil): make impersonated tx hashes sender unique

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -984,12 +984,21 @@ impl PendingTransaction {
     /// Creates a new pending transaction and tries to verify transaction and recover sender.
     pub fn new(transaction: TypedTransaction) -> Result<Self, SignatureError> {
         let sender = transaction.recover()?;
-        Ok(Self::with_sender(transaction, sender))
+        Ok( Self { hash: transaction.hash(), transaction, sender })
     }
 
-    /// Creates a new transaction with the given sender
-    pub fn with_sender(transaction: TypedTransaction, sender: Address) -> Self {
-        Self { hash: transaction.hash(), transaction, sender }
+    /// Creates a new transaction with the given sender.
+    ///
+    /// In order to prevent collisions from multiple different impersonated accounts, we update the transaction's hash with the address to make it unique.
+    ///
+    /// See: <https://github.com/foundry-rs/foundry/issues/3759>
+    pub fn with_impersonated(transaction: TypedTransaction, sender: Address) -> Self {
+        let mut bytes = rlp::encode(&transaction);
+        bytes.extend_from_slice(
+            sender.as_ref()
+        );
+        let hash = H256::from_slice(keccak256(&bytes).as_slice());
+        Self { hash, transaction, sender }
     }
 
     pub fn nonce(&self) -> &U256 {

--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -984,19 +984,18 @@ impl PendingTransaction {
     /// Creates a new pending transaction and tries to verify transaction and recover sender.
     pub fn new(transaction: TypedTransaction) -> Result<Self, SignatureError> {
         let sender = transaction.recover()?;
-        Ok( Self { hash: transaction.hash(), transaction, sender })
+        Ok(Self { hash: transaction.hash(), transaction, sender })
     }
 
     /// Creates a new transaction with the given sender.
     ///
-    /// In order to prevent collisions from multiple different impersonated accounts, we update the transaction's hash with the address to make it unique.
+    /// In order to prevent collisions from multiple different impersonated accounts, we update the
+    /// transaction's hash with the address to make it unique.
     ///
     /// See: <https://github.com/foundry-rs/foundry/issues/3759>
     pub fn with_impersonated(transaction: TypedTransaction, sender: Address) -> Self {
         let mut bytes = rlp::encode(&transaction);
-        bytes.extend_from_slice(
-            sender.as_ref()
-        );
+        bytes.extend_from_slice(sender.as_ref());
         let hash = H256::from_slice(keccak256(&bytes).as_slice());
         Self { hash, transaction, sender }
     }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -740,7 +740,7 @@ impl EthApi {
             let bypass_signature = self.backend.cheats().bypass_signature();
             let transaction = sign::build_typed_transaction(request, bypass_signature)?;
             trace!(target : "node", ?from, "eth_sendTransaction: impersonating");
-            PendingTransaction::with_sender(transaction, from)
+            PendingTransaction::with_impersonated(transaction, from)
         } else {
             let transaction = self.sign_request(&from, request)?;
             PendingTransaction::new(transaction)?
@@ -1630,7 +1630,7 @@ impl EthApi {
         let bypass_signature = self.backend.cheats().bypass_signature();
         let transaction = sign::build_typed_transaction(request, bypass_signature)?;
 
-        let pending_transaction = PendingTransaction::with_sender(transaction, from);
+        let pending_transaction = PendingTransaction::with_impersonated(transaction, from);
 
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -165,6 +165,51 @@ async fn can_impersonate_gnosis_safe() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_impersonate_multiple_account() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let impersonate0 = Address::random();
+    let impersonate1 = Address::random();
+    let to = Address::random();
+
+    let val = 1337u64;
+    let funding = U256::from(1e18 as u64);
+    // fund the impersonated accounts
+    api.anvil_set_balance(impersonate0, funding).await.unwrap();
+    api.anvil_set_balance(impersonate1, funding).await.unwrap();
+
+    let tx = TransactionRequest::new().from(impersonate0).to(to).value(val);
+
+    api.anvil_impersonate_account(impersonate0).await.unwrap();
+    api.anvil_impersonate_account(impersonate1).await.unwrap();
+
+    let res0 = provider.send_transaction(tx.clone(), None).await.unwrap().await.unwrap().unwrap();
+    assert_eq!(res0.from, impersonate0);
+
+    let nonce = provider.get_transaction_count(impersonate0, None).await.unwrap();
+    assert_eq!(nonce, 1u64.into());
+
+    let receipt = provider.get_transaction_receipt(res0.transaction_hash).await.unwrap().unwrap();
+    assert_eq!(res0, receipt);
+
+    let res1 = provider
+        .send_transaction(tx.from(impersonate1), None)
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(res1.from, impersonate1);
+
+    let nonce = provider.get_transaction_count(impersonate1, None).await.unwrap();
+    assert_eq!(nonce, 1u64.into());
+
+    let receipt = provider.get_transaction_receipt(res1.transaction_hash).await.unwrap().unwrap();
+    assert_eq!(res1, receipt);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_mine_manually() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3759

prevent collision by appending the impersonated sender to the transaction so impersonated tx hashes are unique.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
