### PR TITLE
feat(anvil): `anvil_nodeInfo` RPC call

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -441,6 +441,10 @@ pub enum EthRequest {
     )]
     LoadState(Bytes),
 
+    /// Retrieves the Anvil node configuration params
+    #[cfg_attr(feature = "serde", serde(rename = "anvil_nodeInfo", with = "empty_params"))]
+    NodeInfo(()),
+
     // Ganache compatible calls
     /// Snapshot the state of the blockchain at the current block.
     #[cfg_attr(

--- a/anvil/core/src/types.rs
+++ b/anvil/core/src/types.rs
@@ -156,7 +156,7 @@ impl<'a> serde::Deserialize<'a> for Index {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     pub current_block_number: U64,

--- a/anvil/core/src/types.rs
+++ b/anvil/core/src/types.rs
@@ -168,7 +168,7 @@ pub struct NodeInfo {
     pub fork_config: NodeForkConfig,
 }
 
-#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeEnvironment {
     pub base_fee: U256,
@@ -177,7 +177,7 @@ pub struct NodeEnvironment {
     pub gas_price: U256,
 }
 
-#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeForkConfig {
     pub fork_url: Option<String>,

--- a/anvil/core/src/types.rs
+++ b/anvil/core/src/types.rs
@@ -1,4 +1,5 @@
-use ethers_core::types::H256;
+use ethers_core::types::{H256, U256, U64};
+use revm::SpecId;
 
 #[cfg(feature = "serde")]
 use serde::{de::Error, Deserializer, Serializer};
@@ -85,8 +86,6 @@ impl serde::Serialize for Work {
     where
         S: Serializer,
     {
-        use ethers_core::types::U256;
-
         if let Some(num) = self.number {
             (&self.pow_hash, &self.seed_hash, &self.target, U256::from(num)).serialize(s)
         } else {
@@ -155,4 +154,33 @@ impl<'a> serde::Deserialize<'a> for Index {
 
         deserializer.deserialize_any(IndexVisitor)
     }
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    pub current_block_number: U64,
+    pub current_block_timestamp: u64,
+    pub current_block_hash: H256,
+    pub hard_fork: SpecId,
+    pub transaction_order: String,
+    pub environment: NodeEnvironment,
+    pub fork_config: NodeForkConfig,
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeEnvironment {
+    pub base_fee: U256,
+    pub chain_id: U256,
+    pub gas_limit: U256,
+    pub gas_price: U256,
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeForkConfig {
+    pub fork_url: Option<String>,
+    pub fork_block_number: Option<u64>,
+    pub fork_retry_backoff: Option<u128>,
 }

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -54,7 +54,10 @@ use ethers::{
     },
     utils::rlp,
 };
-use forge::{executor::DatabaseRef, revm::BlockEnv};
+use forge::{
+    executor::DatabaseRef,
+    revm::{BlockEnv, SpecId},
+};
 use foundry_common::ProviderBuilder;
 use foundry_evm::{
     executor::backend::DatabaseError,
@@ -62,7 +65,6 @@ use foundry_evm::{
 };
 use futures::channel::mpsc::Receiver;
 use parking_lot::RwLock;
-use serde_json::{json, Value};
 use std::{sync::Arc, time::Duration};
 use tracing::{trace, warn};
 
@@ -70,6 +72,62 @@ use super::backend::mem::BlockRequest;
 
 /// The client version: `anvil/v{major}.{minor}.{patch}`
 pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    current_block_number: U64,
+    current_block_timestamp: u64,
+    current_block_hash: H256,
+    hard_fork: SpecId,
+    transaction_order: String,
+    environment: NodeEnvironment,
+    fork_config: NodeForkConfig,
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeEnvironment {
+    base_fee: U256,
+    chain_id: U256,
+    gas_limit: U256,
+    gas_price: U256,
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeForkConfig {
+    fork_url: Option<String>,
+    fork_block_number: Option<u64>,
+    fork_retry_backoff: Option<u128>,
+}
+
+impl NodeInfo {
+    pub fn new(
+        current_block_number: U64,
+        current_block_timestamp: u64,
+        current_block_hash: H256,
+        hard_fork: SpecId,
+        transaction_order: String,
+        base_fee: U256,
+        chain_id: U256,
+        gas_limit: U256,
+        gas_price: U256,
+        fork_url: Option<String>,
+        fork_block_number: Option<u64>,
+        fork_retry_backoff: Option<u128>,
+    ) -> NodeInfo {
+        NodeInfo {
+            current_block_number,
+            current_block_timestamp,
+            current_block_hash,
+            hard_fork,
+            transaction_order,
+            environment: NodeEnvironment { base_fee, chain_id, gas_limit, gas_price },
+            fork_config: NodeForkConfig { fork_url, fork_block_number, fork_retry_backoff },
+        }
+    }
+}
 
 /// The entry point for executing eth api RPC call - The Eth RPC interface.
 ///
@@ -1481,45 +1539,43 @@ impl EthApi {
     /// Retrieves the Anvil node configuration params.
     ///
     /// Handler for RPC call: `anvil_nodeInfo`
-    pub async fn anvil_node_info(&self) -> Result<Value> {
+    pub async fn anvil_node_info(&self) -> Result<NodeInfo> {
         node_info!("anvil_nodeInfo");
 
         let env = self.backend.env().read();
         let fork_config = self.backend.get_fork();
         let tx_order = self.transaction_order.read();
+        let fork_config = match fork_config {
+            Some(fork) => {
+                let config = fork.config.read();
+                NodeForkConfig {
+                    fork_url: Some(config.eth_rpc_url.clone()),
+                    fork_block_number: Some(config.block_number),
+                    fork_retry_backoff: Some(config.backoff.as_millis()),
+                }
+            }
+            None => {
+                NodeForkConfig { fork_url: None, fork_block_number: None, fork_retry_backoff: None }
+            }
+        };
 
-        Ok(json!({
-            // accounts,
-            "current_block_number": self.backend.best_number(),
-            "current_block_timestamp": env.block.timestamp.try_into().unwrap_or(u64::MAX),
-            "current_block_hash": self.backend.best_hash(),
-            "hard_fork": env.cfg.spec_id,
-            "transaction_order": match *tx_order {
-                TransactionOrder::Fifo => "fifo",
-                TransactionOrder::Fees => "fees",
+        Ok(NodeInfo::new(
+            self.backend.best_number(),
+            env.block.timestamp.try_into().unwrap_or(u64::MAX),
+            self.backend.best_hash(),
+            env.cfg.spec_id,
+            match *tx_order {
+                TransactionOrder::Fifo => "fifo".to_owned(),
+                TransactionOrder::Fees => "fees".to_owned(),
             },
-            "environment": {
-                "base_fee": self.backend.base_fee(),
-                "chain_id": self.backend.chain_id(),
-                "gas_limit": self.backend.gas_limit(),
-                "gas_price": self.backend.gas_price(),
-            },
-            "fork_config": match fork_config {
-                Some(fork) => {
-                    let config = fork.config.read();
-                    json!({
-                        "fork_url": config.eth_rpc_url,
-                        "fork_block_number": config.block_number,
-                        "fork_retry_backoff": config.backoff.as_millis(),
-                    })
-                },
-                None => json!({
-                        "fork_url": Value::Null,
-                        "fork_block_number": Value::Null,
-                        "fork_retry_backoff": Value::Null,
-                }),
-        }
-        }))
+            self.backend.base_fee(),
+            self.backend.chain_id(),
+            self.backend.gas_limit(),
+            self.backend.gas_price(),
+            fork_config.fork_url,
+            fork_config.fork_block_number,
+            fork_config.fork_retry_backoff,
+        ))
     }
 
     /// Snapshot the state of the blockchain at the current block.

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1493,8 +1493,8 @@ impl EthApi {
             current_block_hash: self.backend.best_hash(),
             hard_fork: env.cfg.spec_id,
             transaction_order: match *tx_order {
-                TransactionOrder::Fifo => "fifo".to_owned(),
-                TransactionOrder::Fees => "fees".to_owned(),
+                TransactionOrder::Fifo => "fifo".to_string(),
+                TransactionOrder::Fees => "fees".to_string(),
             },
             environment: NodeEnvironment {
                 base_fee: self.backend.base_fee(),

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1502,21 +1502,17 @@ impl EthApi {
                 gas_limit: self.backend.gas_limit(),
                 gas_price: self.backend.gas_price(),
             },
-            fork_config: match fork_config {
-                Some(fork) => {
+            fork_config: fork_config
+                .map(|fork| {
                     let config = fork.config.read();
+
                     NodeForkConfig {
                         fork_url: Some(config.eth_rpc_url.clone()),
                         fork_block_number: Some(config.block_number),
                         fork_retry_backoff: Some(config.backoff.as_millis()),
                     }
-                }
-                None => NodeForkConfig {
-                    fork_url: None,
-                    fork_block_number: None,
-                    fork_retry_backoff: None,
-                },
-            },
+                })
+                .unwrap_or_default(),
         })
     }
 

--- a/anvil/src/eth/pool/transactions.rs
+++ b/anvil/src/eth/pool/transactions.rs
@@ -26,7 +26,7 @@ pub fn to_marker(nonce: u64, from: Address) -> TxMarker {
 /// Modes that determine the transaction ordering of the mempool
 ///
 /// This type controls the transaction order via the priority metric of a transaction
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+#[derive(Debug, Clone, Eq, PartialEq, Copy, serde::Serialize, serde::Deserialize)]
 pub enum TransactionOrder {
     /// Keep the pool transaction transactions sorted in the order they arrive.
     ///

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -1,6 +1,9 @@
 //! tests for custom anvil endpoints
 use crate::{abi::*, fork::fork_config};
-use anvil::{eth::api::NodeInfo, spawn, Hardfork, NodeConfig};
+use anvil::{
+    eth::api::{NodeEnvironment, NodeForkConfig, NodeInfo},
+    spawn, Hardfork, NodeConfig,
+};
 use anvil_core::eth::EthRequest;
 use ethers::{
     abi::{ethereum_types::BigEndianHash, AbiDecode},
@@ -301,13 +304,13 @@ async fn can_get_node_info() {
         block.hash.unwrap(),
         SpecId::LATEST,
         "fees".to_owned(),
-        U256::from_str("0x3b9aca00").unwrap(),
-        U256::from_str("0x7a69").unwrap(),
-        U256::from_str("0x1c9c380").unwrap(),
-        U256::from_str("0x77359400").unwrap(),
-        None,
-        None,
-        None,
+        NodeEnvironment::new(
+            U256::from_str("0x3b9aca00").unwrap(),
+            U256::from_str("0x7a69").unwrap(),
+            U256::from_str("0x1c9c380").unwrap(),
+            U256::from_str("0x77359400").unwrap(),
+        ),
+        NodeForkConfig::new(None, None, None),
     );
 
     assert_eq!(node_info, expected_node_info);

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -281,3 +281,24 @@ async fn test_can_set_storage_bsc_fork() {
     let balance = busd.balance_of(call.0).call().await.unwrap();
     assert_eq!(balance, U256::from(12345u64));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_node_info() {
+    let (api, _) = spawn(NodeConfig::test()).await;
+
+    let node_info = api.anvil_node_info().await.unwrap();
+    assert!(node_info.is_object());
+    assert_eq!(node_info["current_block_number"], "0x0");
+    assert_eq!(node_info["current_block_timestamp"], 1);
+    assert_eq!(node_info["hard_fork"], "LATEST");
+    assert_eq!(node_info["transaction_order"], "fees");
+    assert_eq!(node_info["environment"]["chain_id"], "0x7a69");
+    assert_eq!(node_info["environment"]["base_fee"], "0x3b9aca00");
+    assert_eq!(node_info["environment"]["gas_limit"], "0x1c9c380");
+    assert_eq!(node_info["environment"]["gas_price"], "0x77359400");
+
+    // Assert fork config as null as the node spawned is not from a fork
+    assert_eq!(node_info["fork_config"]["fork_url"], serde_json::value::Value::Null);
+    assert_eq!(node_info["fork_config"]["fork_block_number"], serde_json::value::Value::Null);
+    assert_eq!(node_info["fork_config"]["fork_retry_backoff"], serde_json::value::Value::Null);
+}

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -1,10 +1,10 @@
 //! tests for custom anvil endpoints
 use crate::{abi::*, fork::fork_config};
-use anvil::{
-    eth::api::{NodeEnvironment, NodeForkConfig, NodeInfo},
-    spawn, Hardfork, NodeConfig,
+use anvil::{spawn, Hardfork, NodeConfig};
+use anvil_core::{
+    eth::EthRequest,
+    types::{NodeEnvironment, NodeForkConfig, NodeInfo},
 };
-use anvil_core::eth::EthRequest;
 use ethers::{
     abi::{ethereum_types::BigEndianHash, AbiDecode},
     prelude::{Middleware, SignerMiddleware},
@@ -298,20 +298,24 @@ async fn can_get_node_info() {
     let block_number = provider.get_block_number().await.unwrap();
     let block = provider.get_block(block_number).await.unwrap().unwrap();
 
-    let expected_node_info = NodeInfo::new(
-        U64([0]),
-        1,
-        block.hash.unwrap(),
-        SpecId::LATEST,
-        "fees".to_owned(),
-        NodeEnvironment::new(
-            U256::from_str("0x3b9aca00").unwrap(),
-            U256::from_str("0x7a69").unwrap(),
-            U256::from_str("0x1c9c380").unwrap(),
-            U256::from_str("0x77359400").unwrap(),
-        ),
-        NodeForkConfig::new(None, None, None),
-    );
+    let expected_node_info = NodeInfo {
+        current_block_number: U64([0]),
+        current_block_timestamp: 1,
+        current_block_hash: block.hash.unwrap(),
+        hard_fork: SpecId::LATEST,
+        transaction_order: "fees".to_owned(),
+        environment: NodeEnvironment {
+            base_fee: U256::from_str("0x3b9aca00").unwrap(),
+            chain_id: U256::from_str("0x7a69").unwrap(),
+            gas_limit: U256::from_str("0x1c9c380").unwrap(),
+            gas_price: U256::from_str("0x77359400").unwrap(),
+        },
+        fork_config: NodeForkConfig {
+            fork_url: None,
+            fork_block_number: None,
+            fork_retry_backoff: None,
+        },
+    };
 
     assert_eq!(node_info, expected_node_info);
 }


### PR DESCRIPTION
## Motivation
Feature inspired in #2424, which asks for an `anvil_nodeInfo` rpc method with helpful info about the current anvil node.


## Solution
adds an `anvil_nodeInfo` RPC method to fetch info about the queried anvil node. Opening a draft to see what's the best way to proceed and finish shaping the PR as it's my first non-docs contrib :).

A few doubts/qs:
- What other info should we include?
- How should we order the fields? I went with somewhat mimicking the configuration params, but happy to change.
- Happy to discuss how the `json` is being constructed/return type. Right now i'm just building the json through the `json!` macro as I didn't wanna introduce an intermediate struct for this, but also happy to change it.

Sample response with current draft:
```json
{
	"jsonrpc": "2.0",
	"id": 1,
	"result": {
		"current_block_number": "0x0",
		"current_block_timestamp": 1,
		"current_block_hash": "0xda4ee66ac06b3ca79f380c686095953b5835b94cea744800baf8ee6faa05908f",
		"hard_fork": "LATEST",
		"transaction_order": "fees",
		"environment": {
			"base_fee": "0x3b9aca00",
			"chain_id": "0x7a69",
			"gas_limit": "0x1c9c380",
			"gas_price": "0x77359400"
		},
		"fork_config": {
			"fork_url": null,
			"fork_block_number": null,
			"fork_retry_backoff": null
		}
	}
}
```