### PR TITLE
feat(fmt): wrap collect comments

### DIFF
--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -292,18 +292,18 @@ impl<'a, I: Iterator<Item = &'a String>> Iterator for CommentContents<'a, I> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.peeked.take().flatten().or_else(|| self.contents.next()).and_then(|content| {
+        self.peeked.take().flatten().or_else(|| self.contents.next()).map(|content| {
             let mut comment = content.as_str();
-            comment = comment.strip_prefix(self.start_token).unwrap_or(&comment);
+            comment = comment.strip_prefix(self.start_token).unwrap_or(comment);
             if let Some(end_token) = self.end_token {
-                comment = comment.strip_suffix(end_token).unwrap_or(&comment);
+                comment = comment.strip_suffix(end_token).unwrap_or(comment);
             }
             if !self.is_first {
                 comment = comment.trim_start();
             } else {
                 self.is_first = false;
             }
-            Some(comment)
+            comment
         })
     }
 }

--- a/fmt/testdata/DocComments/fmt.sol
+++ b/fmt/testdata/DocComments/fmt.sol
@@ -130,3 +130,11 @@ contract FractionalPool {
 // - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
 //   rolled up into a single delegated vote made by the pool before the proposal is completed
 contract FractionalPool2 {}
+
+/// Some contract specification that:
+/// * satisfies the first long constraint
+/// * must uphold to the second constraint under every condition
+/// * correctly implements
+///  the interface required for
+///interacting with other contracts
+contract ContractWithBulletItems {}

--- a/fmt/testdata/DocComments/fmt.sol
+++ b/fmt/testdata/DocComments/fmt.sol
@@ -98,3 +98,35 @@ contract HelloWorld {
  * }
  */
 function freeFloatingMultilineIndent() {}
+
+/// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+/// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+/// lending protocol, such as Compound Finance or Aave, in that:
+///
+/// - Tokens can be deposited into the Pool by suppliers
+/// - Tokens can be withdrawn from the Pool by borrowers
+/// - Depositors are able to express their vote preferences on individual governance proposals
+/// - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
+///   rolled up into a single delegated vote made by the pool before the proposal is completed
+contract FractionalPool {
+    /// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+    /// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+    /// lending protocol, such as Compound Finance or Aave, in that:
+    function testDocWrap() external {}
+
+    // @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+    // governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+    // lending protocol, such as Compound Finance or Aave, in that:
+    function testLineWrap() external {}
+}
+
+// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+// lending protocol, such as Compound Finance or Aave, in that:
+//
+// - Tokens can be deposited into the Pool by suppliers
+// - Tokens can be withdrawn from the Pool by borrowers
+// - Depositors are able to express their vote preferences on individual governance proposals
+// - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
+//   rolled up into a single delegated vote made by the pool before the proposal is completed
+contract FractionalPool2 {}

--- a/fmt/testdata/DocComments/original.sol
+++ b/fmt/testdata/DocComments/original.sol
@@ -93,3 +93,36 @@ contract A {
 }
 */
 function freeFloatingMultilineIndent() {}
+
+/// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+/// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+/// lending protocol, such as Compound Finance or Aave, in that:
+///
+/// - Tokens can be deposited into the Pool by suppliers
+/// - Tokens can be withdrawn from the Pool by borrowers
+/// - Depositors are able to express their vote preferences on individual governance proposals
+/// - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
+///   rolled up into a single delegated vote made by the pool before the proposal is completed
+contract FractionalPool {
+    /// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+    /// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+    /// lending protocol, such as Compound Finance or Aave, in that:
+    function testDocWrap() external {}
+
+    // @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+    // governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+    // lending protocol, such as Compound Finance or Aave, in that:
+    function testLineWrap() external {}
+}
+
+
+// @notice A proof-of-concept implementation demonstrating how Flexible Voting can be used to allow holders of
+// governance tokens to use them in DeFi but still participate in governance. The FractionalPool simulates a
+// lending protocol, such as Compound Finance or Aave, in that:
+//
+// - Tokens can be deposited into the Pool by suppliers
+// - Tokens can be withdrawn from the Pool by borrowers
+// - Depositors are able to express their vote preferences on individual governance proposals
+// - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
+//   rolled up into a single delegated vote made by the pool before the proposal is completed
+contract FractionalPool2 {}

--- a/fmt/testdata/DocComments/original.sol
+++ b/fmt/testdata/DocComments/original.sol
@@ -126,3 +126,11 @@ contract FractionalPool {
 // - The vote preferences of all Depositors are expressed proportionally across any tokens held by the pool, and
 //   rolled up into a single delegated vote made by the pool before the proposal is completed
 contract FractionalPool2 {}
+
+/// Some contract specification that:
+/// * satisfies the first long constraint
+/// * must uphold to the second constraint under every condition
+/// * correctly implements
+///  the interface required for
+///interacting with other contracts
+contract ContractWithBulletItems {}

--- a/fmt/testdata/DocComments/wrap-comments.fmt.sol
+++ b/fmt/testdata/DocComments/wrap-comments.fmt.sol
@@ -181,10 +181,10 @@ contract FractionalPool {
 // implementation demonstrating how
 // Flexible Voting can be used to allow
 // holders of governance tokens to use
-// them in DeFi but still participate
-// in governance. The FractionalPool
-// simulates a lending protocol, such
-// as Compound Finance or Aave, in that:
+// them in DeFi but still participate in
+// governance. The FractionalPool
+// simulates a lending protocol, such as
+// Compound Finance or Aave, in that:
 //
 // - Tokens can be deposited into the
 //   Pool by suppliers

--- a/fmt/testdata/DocComments/wrap-comments.fmt.sol
+++ b/fmt/testdata/DocComments/wrap-comments.fmt.sol
@@ -126,3 +126,78 @@ contract HelloWorld {
  * }
  */
 function freeFloatingMultilineIndent() {}
+
+/// @notice A proof-of-concept
+/// implementation demonstrating how
+/// Flexible Voting can be used to allow
+/// holders of governance tokens to use
+/// them in DeFi but still participate
+/// in governance. The FractionalPool
+/// simulates a lending protocol, such
+/// as Compound Finance or Aave, in
+/// that:
+///
+/// - Tokens can be deposited into the
+///   Pool by suppliers
+/// - Tokens can be withdrawn from the
+///   Pool by borrowers
+/// - Depositors are able to express
+///   their vote preferences on
+///   individual governance proposals
+/// - The vote preferences of all
+///   Depositors are expressed
+///   proportionally across any tokens
+///   held by the pool, and rolled up
+///   into a single delegated vote made
+///   by the pool before the proposal is
+///   completed
+contract FractionalPool {
+    /// @notice A proof-of-concept
+    /// implementation demonstrating
+    /// how Flexible Voting can be used
+    /// to allow holders of governance
+    /// tokens to use them in DeFi but
+    /// still participate in governance.
+    /// The FractionalPool simulates a
+    /// lending protocol, such as
+    /// Compound Finance or Aave, in
+    /// that:
+    function testDocWrap() external {}
+
+    // @notice A proof-of-concept
+    // implementation demonstrating how
+    // Flexible Voting can be used to
+    // allow holders of governance
+    // tokens to use them in DeFi but
+    // still participate in governance.
+    // The FractionalPool simulates a
+    // lending protocol, such as
+    // Compound Finance or Aave, in
+    // that:
+    function testLineWrap() external {}
+}
+
+// @notice A proof-of-concept
+// implementation demonstrating how
+// Flexible Voting can be used to allow
+// holders of governance tokens to use
+// them in DeFi but still participate
+// in governance. The FractionalPool
+// simulates a lending protocol, such
+// as Compound Finance or Aave, in that:
+//
+// - Tokens can be deposited into the
+//   Pool by suppliers
+// - Tokens can be withdrawn from the
+//   Pool by borrowers
+// - Depositors are able to express
+//   their vote preferences on
+//   individual governance proposals
+// - The vote preferences of all
+//   Depositors are expressed
+//   proportionally across any tokens
+//   held by the pool, and rolled up
+//   into a single delegated vote made
+//   by the pool before the proposal is
+//   completed
+contract FractionalPool2 {}

--- a/fmt/testdata/DocComments/wrap-comments.fmt.sol
+++ b/fmt/testdata/DocComments/wrap-comments.fmt.sol
@@ -153,9 +153,9 @@ function freeFloatingMultilineIndent() {}
 ///   completed
 contract FractionalPool {
     /// @notice A proof-of-concept
-    /// implementation demonstrating
-    /// how Flexible Voting can be used
-    /// to allow holders of governance
+    /// implementation demonstrating how
+    /// Flexible Voting can be used to
+    /// allow holders of governance
     /// tokens to use them in DeFi but
     /// still participate in governance.
     /// The FractionalPool simulates a
@@ -201,3 +201,13 @@ contract FractionalPool {
 //   by the pool before the proposal is
 //   completed
 contract FractionalPool2 {}
+
+/// Some contract specification that:
+/// * satisfies the first long
+///   constraint
+/// * must uphold to the second
+///   constraint under every condition
+/// * correctly implements
+///   the interface required for
+///   interacting with other contracts
+contract ContractWithBulletItems {}


### PR DESCRIPTION
## Motivation

close #3604 

## Solution

If the `wrap_comments` option is enabled, collect all adjacent comments before writing them.

The line comment and any subsequent line comment that starts with an alphanumeric character are now collected into a single comment. If the first line starts with `-` or `*` characters, any subsequent line comment will be padded with whitespace to align with the first alphanumeric character from the first line.
