### PR TITLE
fix(bind): exclude forge-std contracts by default

### DIFF
--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -125,7 +125,18 @@ impl BindArgs {
         if !self.skip.is_empty() {
             return ExcludeContracts::default().extend_regex(self.skip.clone()).into()
         }
-        ExcludeContracts::default().add_pattern(".*Test").add_pattern(".*Script").into()
+        // This excludes all Test/Script and forge-std contracts
+        ExcludeContracts::default()
+            .extend_pattern([
+                ".*Test.*",
+                ".*Script",
+                "console[2]?",
+                "CommonBase",
+                "Components",
+                "[Ss]td(Math|Error|Json|Utils|Cheats|Assertions|Storage(Safe)?)",
+                "[Vv]m.*",
+            ])
+            .into()
     }
 
     /// Instantiate the multi-abigen


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
exclude `forge-std` contracts by default in `forge bind`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
