### PR TITLE
fix: properly detect deny_warnings CLI flag

### DIFF
--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -216,6 +216,10 @@ impl Provider for CoreBuildArgs {
             dict.insert("offline".to_string(), true.into());
         }
 
+        if self.deny_warnings {
+            dict.insert("deny_warnings".to_string(), true.into());
+        }
+
         if self.via_ir {
             dict.insert("via_ir".to_string(), true.into());
         }


### PR DESCRIPTION
`--deny-warnings` was introduced in https://github.com/foundry-rs/foundry/pull/3784, but it didn't properly pick up the config when it was passed from the CLI, i.e. `forge build --deny-warnings`

cc @jatokz