### PR TITLE
ci: pin ubunut-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ env:
 jobs:
     prepare:
         name: Prepare release
-        runs-on: ubuntu-latest
+        # Temporarily pin to `20.04` instead of `ubuntu-latest`, until ubuntu-latest migration is complete
+        # See also <https://github.com/foundry-rs/foundry/issues/3827>
+        runs-on: ubuntu-20.04
 
         outputs:
             tag_name: ${{ steps.release_info.outputs.tag_name }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
github is _gradually_ migrating `ubuntu-latest` to `ubuntu-22.04`: https://github.com/actions/runner-images/issues/6399

which caused some issues if the forge release CI is run on 22.04. which breaks on 20.04 https://github.com/foundry-rs/foundry/issues/3827

pin release runner 20.04 until stabilized.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
