### PR TITLE
  Due our work with anvil we faced huge memory consumption for long t…

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -178,6 +178,9 @@ pub struct NodeArgs {
 
     #[clap(long, help = "Don't keep full chain history.")]
     pub prune_history: bool,
+
+    #[clap(long, help = "Number of blocks with transactions to keep in memory.")]
+    pub transaction_block_keeper: Option<usize>,
 }
 
 #[cfg(windows)]
@@ -235,6 +238,7 @@ impl NodeArgs {
             .set_pruned_history(self.prune_history)
             .with_init_state(self.load_state)
             .with_init_state(self.state.and_then(|s| s.state))
+            .with_transaction_block_keeper(self.transaction_block_keeper)
     }
 
     fn account_generator(&self) -> AccountGenerator {

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -145,6 +145,8 @@ pub struct NodeConfig {
     pub prune_history: bool,
     /// The file where to load the state from
     pub init_state: Option<SerializableState>,
+    /// max number of blocks with transactions in memory
+    pub transaction_block_keeper: Option<usize>,
 }
 
 impl NodeConfig {
@@ -362,6 +364,7 @@ impl Default for NodeConfig {
             code_size_limit: None,
             prune_history: false,
             init_state: None,
+            transaction_block_keeper: None,
         }
     }
 }
@@ -444,6 +447,16 @@ impl NodeConfig {
     #[must_use]
     pub fn set_pruned_history(mut self, prune_history: bool) -> Self {
         self.prune_history = prune_history;
+        self
+    }
+
+    /// Sets max number of blocks with transactions to keep in memory
+    #[must_use]
+    pub fn with_transaction_block_keeper<U: Into<usize>>(
+        mut self,
+        transaction_block_keeper: Option<U>,
+    ) -> Self {
+        self.transaction_block_keeper = transaction_block_keeper.map(Into::into);
         self
     }
 
@@ -908,6 +921,7 @@ impl NodeConfig {
             fork,
             self.enable_steps_tracing,
             self.prune_history,
+            self.transaction_block_keeper,
         )
         .await;
 

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -145,6 +145,8 @@ pub struct Backend {
     enable_steps_tracing: bool,
     /// Whether to keep history state
     prune_history: bool,
+    /// max number of blocks with transactions in memory
+    transaction_block_keeper: Option<usize>,
 }
 
 impl Backend {
@@ -157,6 +159,7 @@ impl Backend {
         fork: Option<ClientFork>,
         enable_steps_tracing: bool,
         prune_history: bool,
+        transaction_block_keeper: Option<usize>,
     ) -> Self {
         // if this is a fork then adjust the blockchain storage
         let blockchain = if let Some(ref fork) = fork {
@@ -186,6 +189,7 @@ impl Backend {
             active_snapshots: Arc::new(Mutex::new(Default::default())),
             enable_steps_tracing,
             prune_history,
+            transaction_block_keeper,
         };
 
         // Note: this can only fail in forking mode, in which case we can't recover
@@ -752,6 +756,22 @@ impl Backend {
                     block_number: block_number.as_u64(),
                 };
                 storage.transactions.insert(mined_tx.info.transaction_hash, mined_tx);
+            }
+
+            if let Some(transaction_block_keeper) = self.transaction_block_keeper {
+                if storage.blocks.len() > transaction_block_keeper {
+                    let n: U64 = block_number
+                        .as_u64()
+                        .saturating_sub(transaction_block_keeper.try_into().unwrap())
+                        .into();
+                    if let Some(hash) = storage.hashes.get(&n) {
+                        if let Some(block) = storage.blocks.get(hash) {
+                            for tx in block.clone().transactions {
+                                let _ = storage.transactions.remove(&tx.hash());
+                            }
+                        }
+                    }
+                }
             }
 
             // we intentionally set the difficulty to `0` for newer blocks

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -151,6 +151,7 @@ pub struct Backend {
 
 impl Backend {
     /// Initialises the balance of the given accounts
+    #[allow(clippy::too_many_arguments)]
     pub async fn with_genesis(
         db: Arc<AsyncRwLock<dyn Db>>,
         env: Arc<RwLock<Env>>,


### PR DESCRIPTION
## Motivation

 Due our work with anvil we faced huge memory consumption for long tests
 Anvil is keeping all mined transaction in memory

## Solution
 so proposal is to add config option that will limit number of block with transaction in memory


  This is workaround
  Related to https://github.com/foundry-rs/foundry/issues/3478
