### PR TITLE
feat(forge) add a prompt when verifying a contract with no key

### DIFF
--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -183,8 +183,8 @@ impl ScriptSequence {
 
         verify.set_chain(config, self.chain.into());
 
-        if verify.etherscan_key.is_some() ||
-            verify.verifier.verifier != VerificationProviderType::Etherscan
+        if verify.etherscan_key.is_some()
+            || verify.verifier.verifier != VerificationProviderType::Etherscan
         {
             let mut future_verifications = Vec::with_capacity(self.receipts.len());
             let mut unverifiable_contracts = vec![];
@@ -229,6 +229,8 @@ impl ScriptSequence {
             }
 
             println!("All ({num_verifications}) contracts were verified!");
+        } else {
+            eyre::bail!("No etherscan key provided")
         }
 
         Ok(())
@@ -287,12 +289,12 @@ impl Drop for ScriptSequence {
 fn sig_to_file_name(sig: &str) -> String {
     if let Some((name, _)) = sig.split_once('(') {
         // strip until call argument parenthesis
-        return name.to_string()
+        return name.to_string();
     }
     // assume calldata if `sig` is hex
     if let Ok(calldata) = hex::decode(sig) {
         // in which case we return the function signature
-        return hex::encode(&calldata[..SELECTOR_LEN])
+        return hex::encode(&calldata[..SELECTOR_LEN]);
     }
 
     // return sig as is


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This smol PR aims to implement https://github.com/foundry-rs/foundry/issues/3815
`forge script` used to fail silently when no etherscan API key was provided from the config.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Either adding a prompt to let the user enter his key and re-run all verifications, or return a more friendly error that says that no API key has been provided.

Any thoughts about this ?
