### PR TITLE
Fix: env() need not require mutable reference to self.

### DIFF
--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -102,7 +102,7 @@ impl Executor {
     }
 
     /// Returns a reference to the Env
-    pub fn env(&mut self) -> &Env {
+    pub fn env(&self) -> &Env {
         &self.env
     }
 


### PR DESCRIPTION
## Motivation

getting an immutable reference to env should not require a mutable reference to self.

## Solution

change mutability requirement on self.
