### PR TITLE
fix(forge): exit in error if transaction is dropped when broadcasting a script

### DIFF
--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -84,6 +84,7 @@ pub async fn clear_pendings(
             Ok(TxStatus::Dropped) => {
                 // We want to remove it from pending so it will be re-broadcast.
                 deployment_sequence.remove_pending(tx_hash);
+                errors.push(format!("Transaction dropped from the mempool: {tx_hash:?}"));
             }
             Ok(TxStatus::Success(receipt)) => {
                 trace!(tx_hash = ?tx_hash, "received tx receipt");


### PR DESCRIPTION
## Motivation

If one transaction was dropped, we were not exiting in error. Furthermore, if all the transactions got dropped we would face a division by zero error here (last line):
https://github.com/foundry-rs/foundry/blob/9b1fe58a84b0c7103cba0e7d86f84bb4c479701f/cli/src/cmd/forge/script/broadcast.rs#L189-L200

Now, the only way to reach the above block is to have all successful transactions broadcasted.