### PR TITLE
chore(forge): add hint to error message if chain does not support EIP1559

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -241,7 +241,7 @@ impl CreateArgs {
             // estimate EIP1559 fees
             let (max_fee, max_priority_fee) = estimate_eip1559_fees(&provider, Some(chain))
                 .await
-                .wrap_err("Failed to estimate EIP1559 fees")?;
+                .wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;
             deployer.tx.set_gas_price(max_fee);
             if priority_fee.is_none() {
                 priority_fee = Some(max_priority_fee);

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -78,7 +78,7 @@ impl ScriptArgs {
                     TypedTransaction::Eip1559(_) => {
                         let fees = estimate_eip1559_fees(&provider, Some(chain))
                             .await
-                            .wrap_err("Failed to estimate EIP1559 fees")?;
+                            .wrap_err("Failed to estimate EIP1559 fees. This chain might not support EIP1559, try adding --legacy to your command.")?;
 
                         (None, Some(fees))
                     }


### PR DESCRIPTION
## Motivation

For future cases.

ref [#3846](https://github.com/foundry-rs/foundry/issues/3846)
