### PR TITLE
chore: replace bad panic with error

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -447,8 +447,8 @@ impl ScriptArgs {
         let mut txes_iter = transactions.into_iter().peekable();
 
         while let Some(mut tx) = txes_iter.next() {
-            let tx_rpc = match &tx.rpc {
-                Some(rpc) => rpc.clone(),
+            let tx_rpc = match tx.rpc.clone() {
+                Some(rpc) => rpc,
                 None => {
                     let rpc = self.evm_opts.ensure_fork_url()?.clone();
                     // Fills the RPC inside the transaction, if missing one.
@@ -507,16 +507,14 @@ impl ScriptArgs {
         if !self.skip_simulation {
             // Present gas information on a per RPC basis.
             for (rpc, total_gas) in total_gas_per_rpc {
-                let provider_info = manager.inner.get(&rpc).expect("to be set.");
+                let provider_info = manager.get(&rpc).expect("provider is set.");
 
                 // We don't store it in the transactions, since we want the most updated value.
                 // Right before broadcasting.
                 let per_gas = if let Some(gas_price) = self.with_gas_price {
                     gas_price
-                } else if provider_info.is_legacy {
-                    provider_info.gas_price.expect("to be set.")
                 } else {
-                    provider_info.eip1559_fees.expect("to be set.").0
+                    provider_info.gas_price()?
                 };
 
                 println!("\n==========================");

--- a/cli/src/cmd/forge/script/providers.rs
+++ b/cli/src/cmd/forge/script/providers.rs
@@ -1,13 +1,15 @@
 use ethers::prelude::{Http, Middleware, Provider, RetryClient, U256};
+use eyre::WrapErr;
 use foundry_common::{get_http_provider, RpcUrl};
 use foundry_config::Chain;
 use std::{
     collections::{hash_map::Entry, HashMap},
+    ops::Deref,
     sync::Arc,
 };
 
-#[derive(Default)]
 /// Contains a map of RPC urls to single instances of [`ProviderInfo`].
+#[derive(Default)]
 pub struct ProvidersManager {
     pub inner: HashMap<RpcUrl, ProviderInfo>,
 }
@@ -29,14 +31,28 @@ impl ProvidersManager {
     }
 }
 
+impl Deref for ProvidersManager {
+    type Target = HashMap<RpcUrl, ProviderInfo>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 /// Holds related metadata to each provider RPC.
 #[derive(Debug)]
 pub struct ProviderInfo {
     pub provider: Arc<Provider<RetryClient<Http>>>,
     pub chain: u64,
-    pub gas_price: Option<U256>,
-    pub eip1559_fees: Option<(U256, U256)>,
+    pub gas_price: GasPrice,
     pub is_legacy: bool,
+}
+
+/// Represents the outcome of a gas price request
+#[derive(Debug)]
+pub enum GasPrice {
+    Legacy(eyre::Result<U256>),
+    EIP1559(eyre::Result<(U256, U256)>),
 }
 
 impl ProviderInfo {
@@ -48,12 +64,28 @@ impl ProviderInfo {
             is_legacy |= chain.is_legacy();
         };
 
-        let (gas_price, eip1559_fees) = if is_legacy {
-            (provider.get_gas_price().await.ok(), None)
+        let gas_price = if is_legacy {
+            GasPrice::Legacy(
+                provider.get_gas_price().await.wrap_err("Failed to get legacy gas price"),
+            )
         } else {
-            (None, provider.estimate_eip1559_fees(None).await.ok())
+            GasPrice::EIP1559(
+                provider.estimate_eip1559_fees(None).await.wrap_err("Failed to get EIP-1559 fees"),
+            )
         };
 
-        Ok(ProviderInfo { provider, chain, gas_price, eip1559_fees, is_legacy })
+        Ok(ProviderInfo { provider, chain, gas_price, is_legacy })
+    }
+
+    /// Returns the gas price to use
+    pub fn gas_price(&self) -> eyre::Result<U256> {
+        let res = match &self.gas_price {
+            GasPrice::Legacy(res) => res.as_ref(),
+            GasPrice::EIP1559(res) => res.as_ref().map(|res| &res.0),
+        };
+        match res {
+            Ok(val) => Ok(*val),
+            Err(err) => Err(eyre::eyre!("{}", err)),
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/3838

Replace bad panic with proper error.

The panic likely happened due to an erroneous `estimate_eip1559_fees` call which was converted to an `Option`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This keeps the `Result`s of the gas price requests so we can properly report failed rpc calls. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
