### PR TITLE
Optimize nonce calculations

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1451,22 +1451,8 @@ impl Backend {
         block_request: Option<BlockRequest>,
     ) -> Result<U256, BlockchainError> {
         if let Some(BlockRequest::Pending(pool_transactions)) = block_request.as_ref() {
-            let highest_nonce_tx = pool_transactions
-                .iter()
-                .filter(|tx| *tx.pending_transaction.sender() == address)
-                .reduce(|accum, item| {
-                    let nonce = item.pending_transaction.nonce();
-                    if nonce.gt(accum.pending_transaction.nonce()) {
-                        item
-                    } else {
-                        accum
-                    }
-                });
-            if let Some(highest_nonce_tx) = highest_nonce_tx {
-                return Ok(highest_nonce_tx
-                    .pending_transaction
-                    .nonce()
-                    .saturating_add(U256::from(1)))
+            if let Some(value) = get_pool_transactions_nonce(pool_transactions, address) {
+                return Ok(value)
             }
         }
         let final_block_request = match block_request {
@@ -1824,6 +1810,28 @@ impl Backend {
             .lock()
             .retain(|tx| tx.unbounded_send(notification.clone()).is_ok());
     }
+}
+
+/// Get max nonce from transaction pool by address
+fn get_pool_transactions_nonce(
+    pool_transactions: &[Arc<PoolTransaction>],
+    address: ethers::types::H160,
+) -> Option<U256> {
+    let highest_nonce_tx = pool_transactions
+        .iter()
+        .filter(|tx| *tx.pending_transaction.sender() == address)
+        .reduce(|accum, item| {
+            let nonce = item.pending_transaction.nonce();
+            if nonce.gt(accum.pending_transaction.nonce()) {
+                item
+            } else {
+                accum
+            }
+        });
+    if let Some(highest_nonce_tx) = highest_nonce_tx {
+        return Some(highest_nonce_tx.pending_transaction.nonce().saturating_add(U256::one()))
+    }
+    None
 }
 
 #[async_trait::async_trait]

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1450,21 +1450,19 @@ impl Backend {
         address: Address,
         block_request: Option<BlockRequest>,
     ) -> Result<U256, BlockchainError> {
-        if let Some(ref block_request) = block_request {
-            if let BlockRequest::Pending(pool_transactions) = block_request {
-                let highest_nonce = pool_transactions
-                    .iter()
-                    .filter(|tx| *tx.pending_transaction.sender() == address)
-                    .fold(U256::zero(), |res, tx| {
-                        let nonce = tx.pending_transaction.nonce();
-                        if nonce.ge(&res) {
-                            return nonce.saturating_add(U256::from(1))
-                        }
-                        res
-                    });
-                if !highest_nonce.is_zero() {
-                    return Ok(highest_nonce)
-                }
+        if let Some(BlockRequest::Pending(pool_transactions)) = block_request.as_ref() {
+            let highest_nonce = pool_transactions
+                .iter()
+                .filter(|tx| *tx.pending_transaction.sender() == address)
+                .fold(U256::zero(), |res, tx| {
+                    let nonce = tx.pending_transaction.nonce();
+                    if nonce.ge(&res) {
+                        return nonce.saturating_add(U256::from(1))
+                    }
+                    res
+                });
+            if !highest_nonce.is_zero() {
+                return Ok(highest_nonce)
             }
         }
         let final_block_request = match block_request {

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -635,6 +635,58 @@ async fn can_get_pending_transaction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_first_noce_is_zero() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+    let from = handle.dev_wallets().next().unwrap().address();
+
+    let nonce = provider
+        .get_transaction_count(from, Some(BlockId::Number(BlockNumber::Pending)))
+        .await
+        .unwrap();
+
+    assert_eq!(nonce, U256::zero());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_handle_different_sender_nonce_calculation() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    let from_first = accounts[0].address();
+    let from_second = accounts[1].address();
+
+    let tx_count = 10u64;
+
+    // send a bunch of tx to the mempool and check nonce is returned correctly
+    for idx in 1..=tx_count {
+        let tx_from_first =
+            TransactionRequest::new().from(from_first).value(1337u64).to(Address::random());
+        let _ = provider.send_transaction(tx_from_first, None).await.unwrap();
+        let nonce_from_first = provider
+            .get_transaction_count(from_first, Some(BlockId::Number(BlockNumber::Pending)))
+            .await
+            .unwrap();
+        assert_eq!(nonce_from_first, idx.into());
+
+        let tx_from_second =
+            TransactionRequest::new().from(from_second).value(1337u64).to(Address::random());
+        let _ = provider.send_transaction(tx_from_second, None).await.unwrap();
+        let nonce_from_second = provider
+            .get_transaction_count(from_second, Some(BlockId::Number(BlockNumber::Pending)))
+            .await
+            .unwrap();
+        assert_eq!(nonce_from_second, idx.into());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn includes_pending_tx_for_transaction_count() {
     let (api, handle) = spawn(NodeConfig::test()).await;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
During eth_sendTransaction anvil is doing evm_mine operation with out writing it to storage in order to calculate nonce
This is look likes very expensive (also see this during profiling), especially when sending many transactions

## Solution
Simplify nonce calculation, but looking for max nonce value
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
