### PR TITLE
bump ethereum-forkid to be compatible with ethers 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
@@ -1770,14 +1770,14 @@ dependencies = [
 
 [[package]]
 name = "ethereum-forkid"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b823f6b913b97e58a2bd67a7beeb48b0338d4aa8e3cc21d9cdab457716e4d4"
+checksum = "291ca23d87abc5fc3ef05273451b822579cf5e933fd2a6d2cc3bc620fee7cbea"
 dependencies = [
  "crc 1.8.1",
  "fastrlp",
  "maplit",
- "primitive-types 0.11.1",
+ "primitive-types",
  "thiserror",
 ]
 
@@ -1788,11 +1788,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.12.1",
+ "primitive-types",
  "scale-info",
  "uint",
 ]
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "fastrlp"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
+checksum = "d0953dca2de7dff20aedc20fa4fcac1d2ae54f9da021d9a044e23a2a84c7eca7"
 dependencies = [
  "arrayvec 0.7.2",
  "auto_impl 1.0.1",
@@ -2160,15 +2160,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -4450,21 +4441,11 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
@@ -4851,7 +4832,7 @@ dependencies = [
  "hashbrown 0.13.1",
  "hex",
  "num_enum",
- "primitive-types 0.12.1",
+ "primitive-types",
  "revm_precompiles",
  "rlp",
  "serde",
@@ -4869,7 +4850,7 @@ dependencies = [
  "k256",
  "num",
  "once_cell",
- "primitive-types 0.12.1",
+ "primitive-types",
  "ripemd",
  "secp256k1",
  "sha2 0.10.6",
@@ -6091,7 +6072,7 @@ dependencies = [
  "hex",
  "hidapi-rusb",
  "log",
- "primitive-types 0.12.1",
+ "primitive-types",
  "protobuf",
  "rusb",
 ]

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -64,7 +64,7 @@ auto_impl = "0.5.0"
 ctrlc = { version = "3", optional = true }
 fdlimit = { version = "0.2.1", optional = true }
 clap_complete_fig = "4.0"
-ethereum-forkid = "0.10.0"
+ethereum-forkid = "0.11"
 
 # ethers
 [target.'cfg(not(windows))'.dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Anvil and ethers-rs 1.0.2 use two different versions of `primitive-types` crate. This fixes it.

We should also remove all of the git dependencies on the ethers-rs repo and just shift to the crates.io version. This will break anyone still pointing to the repo so maybe we want to schedule that or something. It's not in this PR.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
