### PR TITLE
feat(anvil): Add `--fork-chain-id` to enable offline-start mode

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -218,6 +218,7 @@ impl NodeArgs {
                     .fork_block_number
                     .or_else(|| self.evm_opts.fork_url.as_ref().and_then(|f| f.block)),
             )
+            .with_fork_chain_id(self.evm_opts.fork_chain_id)
             .fork_request_timeout(self.evm_opts.fork_request_timeout.map(Duration::from_millis))
             .fork_request_retries(self.evm_opts.fork_request_retries)
             .fork_retry_backoff(self.evm_opts.fork_retry_backoff.map(Duration::from_millis))
@@ -363,6 +364,18 @@ pub struct AnvilEvmArgs {
     /// See --fork-url.
     #[clap(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "FORK CONFIG")]
     pub fork_retry_backoff: Option<u64>,
+
+    /// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
+    ///
+    /// You still must pass both `--fork-url` and `--fork-block-number`, and already have your required
+    /// state cached on disk, anything missing locally would be fetched from the remote.
+    #[clap(
+        long,
+        help_heading = "FORK CONFIG",
+        value_name = "CHAIN",
+        requires = "fork_block_number"
+    )]
+    pub fork_chain_id: Option<Chain>,
 
     /// Sets the number of assumed available compute units per second for this provider
     ///

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -367,8 +367,9 @@ pub struct AnvilEvmArgs {
 
     /// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
     ///
-    /// You still must pass both `--fork-url` and `--fork-block-number`, and already have your required
-    /// state cached on disk, anything missing locally would be fetched from the remote.
+    /// You still must pass both `--fork-url` and `--fork-block-number`, and already have your
+    /// required state cached on disk, anything missing locally would be fetched from the
+    /// remote.
     #[clap(
         long,
         help_heading = "FORK CONFIG",

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -111,6 +111,8 @@ pub struct NodeConfig {
     pub eth_rpc_url: Option<String>,
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
+    /// specifies chain id for cache to skip fetching from remote in offline-start mode
+    pub fork_chain_id: Option<U256>,
     /// The generator used to generate the dev accounts
     pub account_generator: Option<AccountGenerator>,
     /// whether to enable tracing
@@ -358,6 +360,7 @@ impl Default for NodeConfig {
             fork_request_timeout: REQUEST_TIMEOUT,
             fork_request_retries: 5,
             fork_retry_backoff: Duration::from_millis(1_000),
+            fork_chain_id: None,
             // alchemy max cpus <https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups>
             compute_units_per_second: ALCHEMY_FREE_TIER_CUPS,
             ipc_path: None,
@@ -605,6 +608,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the `fork_chain_id` to use to fork off local cache from
+    #[must_use]
+    pub fn with_fork_chain_id<U: Into<U256>>(mut self, fork_chain_id: Option<U>) -> Self {
+        self.fork_chain_id = fork_chain_id.map(Into::into);
+        self
+    }
+
     /// Sets the `fork_request_timeout` to use for requests
     #[must_use]
     pub fn fork_request_timeout(mut self, fork_request_timeout: Option<Duration>) -> Self {
@@ -758,8 +768,10 @@ impl NodeConfig {
 
             let (fork_block_number, fork_chain_id) =
                 if let Some(fork_block_number) = self.fork_block_number {
-                    // auto adjust hardfork if not specified
-                    let chain_id = if self.hardfork.is_none() {
+                    let chain_id = if let Some(chain_id) = self.fork_chain_id {
+                        Some(chain_id)
+                    } else if self.hardfork.is_none() {
+                        // auto adjust hardfork if not specified
                         // but only if we're forking mainnet
                         let chain_id =
                             provider.get_chainid().await.expect("Failed to fetch network chain id");
@@ -784,10 +796,14 @@ impl NodeConfig {
                     )
                 };
 
-            let block = provider
+            let block = if self.fork_chain_id.is_some() {
+                Some(Default::default())
+            } else {
+                provider
                 .get_block(BlockNumber::Number(fork_block_number.into()))
                 .await
-                .expect("Failed to get fork block");
+                .expect("Failed to get fork block")
+            };
 
             let block = if let Some(block) = block {
                 block
@@ -841,7 +857,7 @@ impl NodeConfig {
                 }
             }
 
-            let block_hash = block.hash.unwrap();
+            let block_hash = block.hash.unwrap_or_default();
 
             let chain_id = if let Some(chain_id) = self.chain_id {
                 chain_id
@@ -862,8 +878,11 @@ impl NodeConfig {
             let override_chain_id = self.chain_id;
 
             let meta = BlockchainDbMeta::new(env.clone(), eth_rpc_url.clone());
-
-            let block_chain_db = BlockchainDb::new(meta, self.block_cache_path());
+            let block_chain_db = if self.fork_chain_id.is_some() {
+                BlockchainDb::new_skip_check(meta, self.block_cache_path())
+            } else {
+                BlockchainDb::new(meta, self.block_cache_path())
+            };
 
             // This will spawn the background thread that will use the provider to fetch
             // blockchain data from the other client

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -800,9 +800,9 @@ impl NodeConfig {
                 Some(Default::default())
             } else {
                 provider
-                .get_block(BlockNumber::Number(fork_block_number.into()))
-                .await
-                .expect("Failed to get fork block")
+                    .get_block(BlockNumber::Number(fork_block_number.into()))
+                    .await
+                    .expect("Failed to get fork block")
             };
 
             let block = if let Some(block) = block {

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -33,12 +33,34 @@ impl BlockchainDb {
     ///   - the file contains malformed data, or if it couldn't be read
     ///   - the provided `meta` differs from [BlockchainDbMeta] that's stored on disk
     pub fn new(meta: BlockchainDbMeta, cache_path: Option<PathBuf>) -> Self {
+        Self::new_db(meta, cache_path, false)
+    }
+
+    /// Creates a new instance of the [BlockchainDb] and skips check when comparing meta
+    /// This is useful for offline-start mode when we don't want to fetch metadata of `block`.
+    ///
+    /// if a `cache_path` is provided it attempts to load a previously stored [JsonBlockCacheData]
+    /// and will try to use the cached entries it holds.
+    ///
+    /// This will return a new and empty [MemDb] if
+    ///   - `cache_path` is `None`
+    ///   - the file the `cache_path` points to, does not exist
+    ///   - the file contains malformed data, or if it couldn't be read
+    ///   - the provided `meta` differs from [BlockchainDbMeta] that's stored on disk
+    pub fn new_skip_check(meta: BlockchainDbMeta, cache_path: Option<PathBuf>) -> Self {
+        Self::new_db(meta, cache_path, true)
+    }
+
+    fn new_db(meta: BlockchainDbMeta, cache_path: Option<PathBuf>, skip_check: bool) -> Self {
         trace!(target : "forge::cache", cache=?cache_path, "initialising blockchain db");
         // read cache and check if metadata matches
         let cache = cache_path
             .as_ref()
             .and_then(|p| {
                 JsonBlockCacheDB::load(p).ok().filter(|cache| {
+                    if skip_check {
+                        return true;
+                    }
                     let mut existing = cache.meta().write();
                     existing.hosts.extend(meta.hosts.clone());
                     if meta != *existing {

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -59,7 +59,7 @@ impl BlockchainDb {
             .and_then(|p| {
                 JsonBlockCacheDB::load(p).ok().filter(|cache| {
                     if skip_check {
-                        return true;
+                        return true
                     }
                     let mut existing = cache.meta().write();
                     existing.hosts.extend(meta.hosts.clone());


### PR DESCRIPTION
Signed-off-by: xphoniex <xphoniex@users.noreply.github.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/3837:  idea is being able to run `anvil` using a local cache file, without having to contact remote endpoint as long as the required state is in the local cache.



## Solution

When starting `anvil` from a fork, it first retrieves over rpc the `chain_id` of remote, and then creates the `block` and compares that with the one from local cache file, if they are the same, it'll populate in-memory db with local cache. 

Since we want to avoid unnecessary contact with remote, we'll have to pass `--fork-chain-id` so that we can know which local cache file to read, and since we don't know the state of `block`, we can either skip the check (as we're comparing `default` block vs. the one in the cache file) or we can load db twice, second load would be after we substitute the values for `block` with the ones we received from local cache file. I've opted for the former here.

Once `anvil` is up and running, rest of the operation would run just the same, and if any state data is missing it'll be retrieved from remote, and on shutdown, flushed to disk.