### PR TITLE
fix: make coverage optimizer settings more consistent

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -105,6 +105,8 @@ impl CoverageArgs {
 
             // Disable the optimizer for more accurate source maps
             project.solc_config.settings.optimizer.disable();
+            project.solc_config.settings.optimizer.runs = Some(0);
+            project.solc_config.settings.optimizer.details = None;
             project.solc_config.settings.via_ir = Some(false);
 
             project

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -105,9 +105,9 @@ impl CoverageArgs {
 
             // Disable the optimizer for more accurate source maps
             project.solc_config.settings.optimizer.disable();
-            project.solc_config.settings.optimizer.runs = Some(0);
+            project.solc_config.settings.optimizer.runs = None;
             project.solc_config.settings.optimizer.details = None;
-            project.solc_config.settings.via_ir = Some(false);
+            project.solc_config.settings.via_ir = None;
 
             project
         };


### PR DESCRIPTION
## Motivation

I was struggling to stabilize the codehash of one of my contracts between unit tests & coverage. I was aware that `forge coverage` would disable the optimizer but found it tricky to determine the exact settings. It appeared that  the `optimizer_runs` parameter affected the codehash (despite the optimizer being disabled, which was bizarre).

In the end, I thought it best to be more explicit about disabling all optimizer related fields.

## Solution

This is a pretty simple change and may not be appropriate for merging. That said, my CI currently builds forge in 28 minutes which is making my eyes water, so keen to have this problem resolved in `master` one way or another.