### PR TITLE
fix(forge): fix external call gas metering cheats

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -278,8 +278,20 @@ where
                 self.gas_metering = Some(Some(interpreter.gas));
             }
             Some(Some(gas)) => {
-                // dont monitor gas changes, keep it constant
-                interpreter.gas = gas;
+                match interpreter.contract.bytecode.bytecode()[interpreter.program_counter()] {
+                    opcode::STOP | opcode::RETURN | opcode::SELFDESTRUCT | opcode::REVERT => {
+                        // If we are ending current execution frame, we want to just fully reset gas
+                        // otherwise weird things with returning gas from a call happen
+                        // ref: https://github.com/bluealloy/revm/blob/2cb991091d32330cfe085320891737186947ce5a/crates/revm/src/evm_impl.rs#L190
+                        //
+                        // It would be nice if we had access to the interpreter in `call_end`, as we could just do this there instead.
+                        interpreter.gas = revm::Gas::new(0);
+                    }
+                    _ => {
+                        // dont monitor gas changes, keep it constant
+                        interpreter.gas = gas;
+                    }
+                }
             }
             _ => {}
         }

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -284,7 +284,8 @@ where
                         // otherwise weird things with returning gas from a call happen
                         // ref: https://github.com/bluealloy/revm/blob/2cb991091d32330cfe085320891737186947ce5a/crates/revm/src/evm_impl.rs#L190
                         //
-                        // It would be nice if we had access to the interpreter in `call_end`, as we could just do this there instead.
+                        // It would be nice if we had access to the interpreter in `call_end`, as we
+                        // could just do this there instead.
                         interpreter.gas = revm::Gas::new(0);
                     }
                     _ => {

--- a/testdata/cheats/GasMetering.t.sol
+++ b/testdata/cheats/GasMetering.t.sol
@@ -71,5 +71,4 @@ contract GasMeteringTest is DSTest {
         }
         return b;
     }
-
 }

--- a/testdata/cheats/GasMetering.t.sol
+++ b/testdata/cheats/GasMetering.t.sol
@@ -4,6 +4,12 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 import "./Cheats.sol";
 
+contract B {
+    function a() public returns (uint256) {
+        return 100;
+    }
+}
+
 contract GasMeteringTest is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
 
@@ -32,6 +38,32 @@ contract GasMeteringTest is DSTest {
         assertEq(gas_end_not_metered, 0);
     }
 
+    function testGasMeteringExternal() public {
+        B b = new B();
+        uint256 gas_start = gasleft();
+
+        b.a();
+
+        uint256 gas_end_normal = gas_start - gasleft();
+
+        cheats.pauseGasMetering();
+        uint256 gas_start_not_metered = gasleft();
+
+        b.a();
+
+        uint256 gas_end_not_metered = gas_start_not_metered - gasleft();
+        cheats.resumeGasMetering();
+
+        uint256 gas_start_metered = gasleft();
+
+        b.a();
+
+        uint256 gas_end_resume_metered = gas_start_metered - gasleft();
+
+        assertEq(gas_end_normal, gas_end_resume_metered);
+        assertEq(gas_end_not_metered, 0);
+    }
+
     function addInLoop() internal returns (uint256) {
         uint256 b;
         for (uint256 i; i < 10000; i++) {
@@ -39,4 +71,5 @@ contract GasMeteringTest is DSTest {
         }
         return b;
     }
+
 }


### PR DESCRIPTION


## Motivation
fix #3858
fix https://github.com/foundry-rs/forge-std/issues/257

## Solution
Due to this: https://github.com/bluealloy/revm/blob/2cb991091d32330cfe085320891737186947ce5a/crates/revm/src/evm_impl.rs#L190

when making external calls, there is a returned amount of gas that would cause an underflow when trying to return. This actually popped its head up as a `OutOfGas` overhead in some situations. So in the case that gas metering is off, and we are returning from an execution frame, we just set the gas to a `new` with 0 values for everything. This makes the above make no adjustments 
