### PR TITLE
fix(anvil): disable interval mining when set to zero

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1359,9 +1359,12 @@ impl EthApi {
     /// Handler for ETH RPC call: `evm_setIntervalMining`
     pub fn anvil_set_interval_mining(&self, secs: u64) -> Result<()> {
         node_info!("evm_setIntervalMining");
-        self.miner.set_mining_mode(MiningMode::FixedBlockTime(FixedBlockTimeMiner::new(
-            Duration::from_secs(secs),
-        )));
+        let mining_mode = if secs == 0 {
+            MiningMode::None
+        } else {
+            MiningMode::FixedBlockTime(FixedBlockTimeMiner::new(Duration::from_secs(secs)))
+        };
+        self.miner.set_mining_mode(mining_mode);
         Ok(())
     }
 

--- a/anvil/tests/it/anvil.rs
+++ b/anvil/tests/it/anvil.rs
@@ -23,6 +23,13 @@ async fn test_can_change_mining_mode() {
     tokio::time::sleep(std::time::Duration::from_millis(700)).await;
     let num = provider.get_block_number().await.unwrap();
     assert_eq!(num.as_u64(), 1);
+
+    // assert that no block is mined when the interval is set to 0
+    api.anvil_set_interval_mining(0).unwrap();
+    assert!(!api.anvil_get_auto_mine().unwrap());
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    let num = provider.get_block_number().await.unwrap();
+    assert_eq!(num.as_u64(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

See #3913 + reaches [parity](https://github.com/NomicFoundation/hardhat/blob/f081b1cc5fd7bfe2bd20abfa18a5e1d6838067ad/packages/hardhat-core/src/internal/hardhat-network/provider/MiningTimer.ts#L43-L46) with Hardhat.

## Solution

Set the mining mode to `MiningMode::None` when the interval is zero.
