### PR TITLE
--match-contract and --match-test changed to glob pattern

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -488,7 +488,7 @@ fn test(
                     if let Some(suggestion) =
                         suggestions::did_you_mean(test_name.as_str(), candidates.clone()).pop()
                     {
-                        println!("\nFor `{test_name}`, did you mean `*{suggestion}*`?");
+                        println!("\nFor `{test_name}`, did you mean `{suggestion}`?");
                     }
                 }
             }

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -486,7 +486,7 @@ fn test(
                 let candidates = runner.get_tests(&filter);
                 for test_name in test_pattern {
                     if let Some(suggestion) =
-                        suggestions::did_you_mean(&test_name.as_str(), candidates.clone()).pop()
+                        suggestions::did_you_mean(test_name.as_str(), candidates.clone()).pop()
                     {
                         println!("\nFor `{test_name}`, did you mean `*{suggestion}*`?");
                     }

--- a/cli/src/suggestions.rs
+++ b/cli/src/suggestions.rs
@@ -15,7 +15,7 @@ where
     let mut candidates: Vec<(f64, String)> = candidates
         .into_iter()
         .map(|pv| (strsim::jaro_winkler(v, pv.as_ref()), pv.as_ref().to_owned()))
-        .filter(|(similarity, _)| *similarity > 0.8)
+        .filter(|(similarity, _)| *similarity > 0.7)
         .collect();
     candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
     candidates.into_iter().map(|(_, pv)| pv).collect()

--- a/cli/src/suggestions.rs
+++ b/cli/src/suggestions.rs
@@ -15,7 +15,7 @@ where
     let mut candidates: Vec<(f64, String)> = candidates
         .into_iter()
         .map(|pv| (strsim::jaro_winkler(v, pv.as_ref()), pv.as_ref().to_owned()))
-        .filter(|(similarity, _)| *similarity > 0.7)
+        .filter(|(similarity, _)| *similarity > 0.8)
         .collect();
     candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
     candidates.into_iter().map(|(_, pv)| pv).collect()

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -791,7 +791,6 @@ impl OutputExt for process::Output {
         let expected = IGNORE_IN_FIXTURES.replace_all(&expected, "").replace('\\', "/");
         let stdout = String::from_utf8_lossy(&self.stdout);
         let out = IGNORE_IN_FIXTURES.replace_all(&stdout, "").replace('\\', "/");
-
         pretty_assertions::assert_eq!(expected, out);
 
         self

--- a/cli/tests/fixtures/suggest_when_no_tests_match.stdout
+++ b/cli/tests/fixtures/suggest_when_no_tests_match.stdout
@@ -3,11 +3,11 @@ Solc 0.8.10 finished in 185.25ms
 Compiler run successful
 
 No tests match the provided pattern:
-	match-test: `*testA*`
-	no-match-test: `*testB*`
-	match-contract: `*TestC*`
-	no-match-contract: `*TestD*`
+	match-test: `testA*`
+	no-match-test: `testB*`
+	match-contract: `TestC*`
+	no-match-contract: `TestD*`
 	match-path: `*TestE*`
 	no-match-path: `*TestF*`
 
-For `*testA*`, did you mean `*test1*`?
+For `testA*`, did you mean `test1`?

--- a/cli/tests/fixtures/suggest_when_no_tests_match.stdout
+++ b/cli/tests/fixtures/suggest_when_no_tests_match.stdout
@@ -3,11 +3,11 @@ Solc 0.8.10 finished in 185.25ms
 Compiler run successful
 
 No tests match the provided pattern:
-	match-test: `testA.*`
-	no-match-test: `testB.*`
-	match-contract: `TestC.*`
-	no-match-contract: `TestD.*`
+	match-test: `*testA*`
+	no-match-test: `*testB*`
+	match-contract: `*TestC*`
+	no-match-contract: `*TestD*`
 	match-path: `*TestE*`
 	no-match-path: `*TestF*`
 
-Did you mean `test1`?
+For `*testA*`, did you mean `*test1*`?

--- a/cli/tests/fixtures/warn_no_tests_match.stdout
+++ b/cli/tests/fixtures/warn_no_tests_match.stdout
@@ -3,9 +3,9 @@ Solc 0.8.13
 Compiler run successful
 
 No tests match the provided pattern:
-	match-test: `*testA*`
-	no-match-test: `*testB*`
-	match-contract: `*TestC*`
-	no-match-contract: `*TestD*`
+	match-test: `testA*`
+	no-match-test: `testB*`
+	match-contract: `TestC*`
+	no-match-contract: `TestD*`
 	match-path: `*TestE*`
 	no-match-path: `*TestF*`

--- a/cli/tests/fixtures/warn_no_tests_match.stdout
+++ b/cli/tests/fixtures/warn_no_tests_match.stdout
@@ -3,9 +3,9 @@ Solc 0.8.13
 Compiler run successful
 
 No tests match the provided pattern:
-	match-test: `testA.*`
-	no-match-test: `testB.*`
-	match-contract: `TestC.*`
-	no-match-contract: `TestD.*`
+	match-test: `*testA*`
+	no-match-test: `*testB*`
+	match-contract: `*TestC*`
+	no-match-contract: `*TestD*`
 	match-path: `*TestE*`
 	no-match-path: `*TestF*`

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -70,8 +70,8 @@ contract Dummy {}
         .unwrap();
 
     // set up command
-    cmd.args(["test", "--match-test", "*testA*", "--no-match-test", "*testB*"]);
-    cmd.args(["--match-contract", "*TestC*", "--no-match-contract", "*TestD*"]);
+    cmd.args(["test", "--match-test", "testA*", "--no-match-test", "testB*"]);
+    cmd.args(["--match-contract", "TestC*", "--no-match-contract", "TestD*"]);
     cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
     // run command and assert
@@ -99,8 +99,8 @@ contract TestC {
         .unwrap();
 
     // set up command
-    cmd.args(["test", "--match-test", "*testA*", "--no-match-test", "*testB*"]);
-    cmd.args(["--match-contract", "*TestC*", "--no-match-contract", "*TestD*"]);
+    cmd.args(["test", "--match-test", "testA*", "--no-match-test", "testB*"]);
+    cmd.args(["--match-contract", "TestC*", "--no-match-contract", "TestD*"]);
     cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
     // run command and assert
@@ -195,7 +195,7 @@ contract FailTest is DSTest {
         )
         .unwrap();
 
-    cmd.args(["test", "--match-test", "*testArray*"]);
+    cmd.args(["test", "--match-test", "testArray*"]);
     assert!(cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]"));
 });
 
@@ -235,7 +235,7 @@ contract FailTest is DSTest {
         )
         .unwrap();
 
-    cmd.args(["test", "--match-contract", "*ATest*"]);
+    cmd.args(["test", "--match-contract", "ATest*"]);
     assert!(cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]"));
 });
 
@@ -292,7 +292,7 @@ contract FailTest is DSTest {
         )
         .unwrap();
 
-    cmd.args(["test", "--match-contract", "*ATest*,*BTest*"]);
+    cmd.args(["test", "--match-contract", "ATest*,BTest*"]);
     assert!(cmd.stdout().matches("[PASS]").count() == 2 && !cmd.stdout().contains("[FAIL]"));
 });
 
@@ -348,8 +348,8 @@ contract FailTest is DSTest {
         )
         .unwrap();
 
-    cmd.args(["test", "--match-contract", "*ATest*,*BTest*"]);
-    cmd.args(["--no-match-contract", "*BTest*"]);
+    cmd.args(["test", "--match-contract", "ATest*,BTest*"]);
+    cmd.args(["--no-match-contract", "BTest*"]);
     assert!(cmd.stdout().matches("[PASS]").count() == 1 && !cmd.stdout().contains("[FAIL]"));
 });
 

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -9,14 +9,14 @@ use std::{path::PathBuf, str::FromStr};
 
 // tests that test filters are handled correctly
 forgetest!(can_set_filter_values, |prj: TestProject, mut cmd: TestCommand| {
-    let patt = regex::Regex::new("test*").unwrap();
+    let patt = vec![globset::Glob::from_str("test*").unwrap()];
     let glob = globset::Glob::from_str("foo/bar/baz*").unwrap();
 
     // explicitly set patterns
     let config = Config {
-        test_pattern: Some(patt.clone().into()),
+        test_pattern: Some(patt.clone()),
         test_pattern_inverse: None,
-        contract_pattern: Some(patt.clone().into()),
+        contract_pattern: Some(patt.clone()),
         contract_pattern_inverse: None,
         path_pattern: Some(glob.clone()),
         path_pattern_inverse: None,
@@ -25,10 +25,9 @@ forgetest!(can_set_filter_values, |prj: TestProject, mut cmd: TestCommand| {
     prj.write_config(config);
 
     let config = cmd.config();
-
-    assert_eq!(config.test_pattern.unwrap().as_str(), patt.as_str());
+    assert_eq!(config.test_pattern.unwrap(), patt);
     assert_eq!(config.test_pattern_inverse, None);
-    assert_eq!(config.contract_pattern.unwrap().as_str(), patt.as_str());
+    assert_eq!(config.contract_pattern.unwrap(), patt);
     assert_eq!(config.contract_pattern_inverse, None);
     assert_eq!(config.path_pattern.unwrap(), glob);
     assert_eq!(config.path_pattern_inverse, None);
@@ -71,8 +70,8 @@ contract Dummy {}
         .unwrap();
 
     // set up command
-    cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
-    cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
+    cmd.args(["test", "--match-test", "*testA*", "--no-match-test", "*testB*"]);
+    cmd.args(["--match-contract", "*TestC*", "--no-match-contract", "*TestD*"]);
     cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
     // run command and assert
@@ -100,8 +99,8 @@ contract TestC {
         .unwrap();
 
     // set up command
-    cmd.args(["test", "--match-test", "testA.*", "--no-match-test", "testB.*"]);
-    cmd.args(["--match-contract", "TestC.*", "--no-match-contract", "TestD.*"]);
+    cmd.args(["test", "--match-test", "*testA*", "--no-match-test", "*testB*"]);
+    cmd.args(["--match-contract", "*TestC*", "--no-match-contract", "*TestD*"]);
     cmd.args(["--match-path", "*TestE*", "--no-match-path", "*TestF*"]);
 
     // run command and assert
@@ -160,6 +159,200 @@ contract ATest is DSTest {
     cmd.stdout().contains("[PASS]")
 });
 
+// tests that using the --match-test option only runs files matching the test function
+forgetest!(can_test_with_match_test, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+
+    prj.inner()
+        .add_source(
+            "ATest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract ATest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "FailTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract FailTest is DSTest {
+    function testNothing() external {
+        assertTrue(false);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.args(["test", "--match-test", "*testArray*"]);
+    assert!(cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]"));
+});
+
+// tests that using the --match-contract option only runs files matching the test function
+forgetest!(can_test_with_match_contract, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+
+    prj.inner()
+        .add_source(
+            "ATest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract ATest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "FailTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract FailTest is DSTest {
+    function testNothing() external {
+        assertTrue(false);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.args(["test", "--match-contract", "*ATest*"]);
+    assert!(cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]"));
+});
+
+// tests that using the --match-contract option with multiple globs only runs files matching the
+// test function
+forgetest!(can_test_with_match_multiple_contracts, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+
+    prj.inner()
+        .add_source(
+            "ATest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract ATest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "BTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract BTest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "FailTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract FailTest is DSTest {
+    function testNothing() external {
+        assertTrue(false);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.args(["test", "--match-contract", "*ATest*,*BTest*"]);
+    assert!(cmd.stdout().matches("[PASS]").count() == 2 && !cmd.stdout().contains("[FAIL]"));
+});
+
+// tests that using the --match-contract with --no-match-contract cancels the one that matches
+forgetest!(can_test_with_match_inverse_contradicts, |prj: TestProject, mut cmd: TestCommand| {
+    prj.insert_ds_test();
+
+    prj.inner()
+        .add_source(
+            "ATest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract ATest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "BTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract BTest is DSTest {
+    function testArray(uint64[2] calldata values) external {
+        assertTrue(true);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    prj.inner()
+        .add_source(
+            "FailTest.t.sol",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+import "./test.sol";
+contract FailTest is DSTest {
+    function testNothing() external {
+        assertTrue(false);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.args(["test", "--match-contract", "*ATest*,*BTest*"]);
+    cmd.args(["--no-match-contract", "*BTest*"]);
+    assert!(cmd.stdout().matches("[PASS]").count() == 1 && !cmd.stdout().contains("[FAIL]"));
+});
+
 // tests that using the --match-path option only runs files matching the path
 forgetest!(can_test_with_match_path, |prj: TestProject, mut cmd: TestCommand| {
     prj.insert_ds_test();
@@ -197,7 +390,7 @@ contract FailTest is DSTest {
         .unwrap();
 
     cmd.args(["test", "--match-path", "*src/ATest.t.sol"]);
-    cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]")
+    assert!(cmd.stdout().contains("[PASS]") && !cmd.stdout().contains("[FAIL]"));
 });
 
 // tests that `forge test` will pick up tests that are stored in the `test = <path>` config value

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1618,12 +1618,12 @@ pub(crate) mod from_opt_vec_glob {
     {
         let s: Option<String> = Option::deserialize(deserializer)?;
         if let Some(s) = s {
-            let split = s.split(",");
+            let split = s.split(',');
             return Ok(Some(
                 split
                     .clone()
                     .into_iter()
-                    .map(|s| globset::Glob::new(&s).map_err(serde::de::Error::custom))
+                    .map(|s| globset::Glob::new(s).map_err(serde::de::Error::custom))
                     .collect::<Result<Vec<globset::Glob>, D::Error>>()?,
             ))
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -205,18 +205,18 @@ pub struct Config {
     pub ignored_error_codes: Vec<SolidityErrorCode>,
     /// When true, compiler warnings are treated as errors
     pub deny_warnings: bool,
-    /// Only run test functions matching the specified regex pattern.
-    #[serde(rename = "match_test")]
-    pub test_pattern: Option<RegexWrapper>,
-    /// Only run test functions that do not match the specified regex pattern.
-    #[serde(rename = "no_match_test")]
-    pub test_pattern_inverse: Option<RegexWrapper>,
-    /// Only run tests in contracts matching the specified regex pattern.
-    #[serde(rename = "match_contract")]
-    pub contract_pattern: Option<RegexWrapper>,
-    /// Only run tests in contracts that do not match the specified regex pattern.
-    #[serde(rename = "no_match_contract")]
-    pub contract_pattern_inverse: Option<RegexWrapper>,
+    /// Only run test functions matching the specified glob patterns.
+    #[serde(rename = "match_test", with = "from_opt_vec_glob")]
+    pub test_pattern: Option<Vec<globset::Glob>>,
+    /// Only run test functions that do not match the specified glob patterns.
+    #[serde(rename = "no_match_test", with = "from_opt_vec_glob")]
+    pub test_pattern_inverse: Option<Vec<globset::Glob>>,
+    /// Only run tests in contracts matching the specified glob patterns.
+    #[serde(rename = "match_contract", with = "from_opt_vec_glob")]
+    pub contract_pattern: Option<Vec<globset::Glob>>,
+    /// Only run tests in contracts that do not match the specified glob patterns.
+    #[serde(rename = "no_match_contract", with = "from_opt_vec_glob")]
+    pub contract_pattern_inverse: Option<Vec<globset::Glob>>,
     /// Only run tests in source files matching the specified glob pattern.
     #[serde(rename = "match_path", with = "from_opt_glob")]
     pub path_pattern: Option<globset::Glob>,
@@ -1589,6 +1589,43 @@ pub(crate) mod from_opt_glob {
         let s: Option<String> = Option::deserialize(deserializer)?;
         if let Some(s) = s {
             return Ok(Some(globset::Glob::new(&s).map_err(serde::de::Error::custom)?))
+        }
+        Ok(None)
+    }
+}
+
+pub(crate) mod from_opt_vec_glob {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(
+        value: &Option<Vec<globset::Glob>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(globs) => serializer.serialize_str(
+                &globs.iter().map(|glob| glob.to_string()).collect::<Vec<String>>().join(","),
+            ),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<globset::Glob>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            let split = s.split(",");
+            return Ok(Some(
+                split
+                    .clone()
+                    .into_iter()
+                    .map(|s| globset::Glob::new(&s).map_err(serde::de::Error::custom))
+                    .collect::<Result<Vec<globset::Glob>, D::Error>>()?,
+            ))
         }
         Ok(None)
     }


### PR DESCRIPTION
Motivation

Closes [#1230](https://github.com/foundry-rs/foundry/issues/1230)

Solution

Patterns take a comma separated string which converts to a vector of globs. Jaro Winkler got lowered a little because glob symbols mess with prefix.

edit: I rebased a few times so its cleaner when it gets reviewed the first time, i did some refactoring. 