### PR TITLE
fix(forge): ignore external gas estimation error when estimating total gas

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -468,7 +468,25 @@ impl ScriptArgs {
 
                 if has_different_gas_calc(provider_info.chain) {
                     trace!("estimating with different gas calculation");
-                    self.estimate_gas(typed_tx, &provider_info.provider).await?;
+                    let gas = typed_tx.gas().expect("gas is set by simulation.").clone();
+
+                    // We are trying to show the user an estimation of the total gas usage.
+                    //
+                    // However, some transactions might depend on previous ones. For
+                    // example, tx1 might deploy a contract that tx2 uses. That
+                    // will result in the following `estimate_gas` call to fail,
+                    // since tx1 hasn't been broadcasted yet.
+                    //
+                    // Not exiting here will not be a problem when actually broadcasting, because
+                    // for chains where `has_different_gas_calc` returns true,
+                    // we await each transaction before broadcasting the next
+                    // one.
+                    if let Err(err) = self.estimate_gas(typed_tx, &provider_info.provider).await {
+                        trace!("gas estimation failed: {err}");
+
+                        // Restore gas value, since `estimate_gas` will remove it.
+                        typed_tx.set_gas(gas);
+                    }
                 }
 
                 let total_gas = total_gas_per_rpc.entry(tx_rpc.clone()).or_insert(U256::zero());

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -468,7 +468,7 @@ impl ScriptArgs {
 
                 if has_different_gas_calc(provider_info.chain) {
                     trace!("estimating with different gas calculation");
-                    let gas = typed_tx.gas().expect("gas is set by simulation.").clone();
+                    let gas = *typed_tx.gas().expect("gas is set by simulation.");
 
                     // We are trying to show the user an estimation of the total gas usage.
                     //


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

closes [#3897](https://github.com/foundry-rs/foundry/issues/3897)

>There's a stage where we estimate the gas usage to show the user (even without the --broadcast). For arbitrum and other similar chains, we rely on the external RPC to give us the gas usage estimation (and disregard the locally calculated one). However, in situations like this (tx2 depends on tx1), we obviously hit these kind of errors.
>It doesn't happen on eth_mainnet and eth_goerli, because we don't disregard the locally calculated one.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Just ignore the error. (reminder that this is only an issue for chains which rely on external RPC gas estimation).

```Rust
// We are trying to show the user an estimation of the total gas usage.
//
// However, some transactions might depend on previous ones. For
// example, tx1 might deploy a contract that tx2 uses. That
// will result in the following `estimate_gas` call to fail,
// since tx1 hasn't been broadcasted yet.
//
// Not exiting here will not be a problem when actually broadcasting, because
// for chains where `has_different_gas_calc` returns true,
// we await each transaction before broadcasting the next
// one.
```

However, this will result in incorrect costs shown to the user...

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
