### PR TITLE
fix(forge): set tx.origin correctly when passing a key to `broadcast(address)`

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -857,3 +857,9 @@ forgetest_async!(
         tester.add_sig("BroadcastEmptySetUp", "run()").simulate(ScriptOutcome::OkNoEndpoint);
     }
 );
+
+forgetest_async!(does_script_override_correctly, |prj: TestProject, cmd: TestCommand| async move {
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+
+    tester.add_sig("CheckOverrides", "run()").simulate(ScriptOutcome::OkNoEndpoint);
+});

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -419,26 +419,28 @@ where
                     // At the target depth we set `msg.sender` & tx.origin.
                     // We are simulating the caller as being an EOA, so *both* must be set to the
                     // broadcast.origin.
-                    call.context.caller = broadcast.origin;
-                    call.transfer.source = broadcast.origin;
+                    data.env.tx.caller = broadcast.new_origin;
+
+                    call.context.caller = broadcast.new_origin;
+                    call.transfer.source = broadcast.new_origin;
                     // Add a `legacy` transaction to the VecDeque. We use a legacy transaction here
                     // because we only need the from, to, value, and data. We can later change this
                     // into 1559, in the cli package, relatively easily once we
                     // know the target chain supports EIP-1559.
                     if !is_static {
                         if let Err(err) =
-                            data.journaled_state.load_account(broadcast.origin, data.db)
+                            data.journaled_state.load_account(broadcast.new_origin, data.db)
                         {
                             return (Return::Revert, Gas::new(call.gas_limit), err.encode_string())
                         }
 
                         let account =
-                            data.journaled_state.state().get_mut(&broadcast.origin).unwrap();
+                            data.journaled_state.state().get_mut(&broadcast.new_origin).unwrap();
 
                         self.broadcastable_transactions.push_back(BroadcastableTransaction {
                             rpc: data.db.active_fork_url(),
                             transaction: TypedTransaction::Legacy(TransactionRequest {
-                                from: Some(broadcast.origin),
+                                from: Some(broadcast.new_origin),
                                 to: Some(NameOrAddress::Address(call.contract)),
                                 value: Some(call.transfer.value),
                                 data: Some(call.input.clone().into()),
@@ -493,6 +495,8 @@ where
 
         // Clean up broadcast
         if let Some(broadcast) = &self.broadcast {
+            data.env.tx.caller = broadcast.original_origin;
+
             if broadcast.single_call {
                 std::mem::take(&mut self.broadcast);
             }
@@ -622,27 +626,28 @@ where
             if data.journaled_state.depth() == broadcast.depth &&
                 call.caller == broadcast.original_caller
             {
-                if let Err(err) = data.journaled_state.load_account(broadcast.origin, data.db) {
+                if let Err(err) = data.journaled_state.load_account(broadcast.new_origin, data.db) {
                     return (Return::Revert, None, Gas::new(call.gas_limit), err.encode_string())
                 }
 
-                let (bytecode, to, nonce) =
-                    match process_create(broadcast.origin, call.init_code.clone(), data, call) {
-                        Ok(val) => val,
-                        Err(err) => {
-                            return (
-                                Return::Revert,
-                                None,
-                                Gas::new(call.gas_limit),
-                                err.encode_string(),
-                            )
-                        }
-                    };
+                data.env.tx.caller = broadcast.new_origin;
+
+                let (bytecode, to, nonce) = match process_create(
+                    broadcast.new_origin,
+                    call.init_code.clone(),
+                    data,
+                    call,
+                ) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        return (Return::Revert, None, Gas::new(call.gas_limit), err.encode_string())
+                    }
+                };
 
                 self.broadcastable_transactions.push_back(BroadcastableTransaction {
                     rpc: data.db.active_fork_url(),
                     transaction: TypedTransaction::Legacy(TransactionRequest {
-                        from: Some(broadcast.origin),
+                        from: Some(broadcast.new_origin),
                         to,
                         value: Some(call.value),
                         data: Some(bytecode.into()),
@@ -677,6 +682,8 @@ where
 
         // Clean up broadcasts
         if let Some(broadcast) = &self.broadcast {
+            data.env.tx.caller = broadcast.original_origin;
+
             if broadcast.single_call {
                 std::mem::take(&mut self.broadcast);
             }

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -435,3 +435,74 @@ contract BroadcastEmptySetUp is DSTest {
         new Test();
     }
 }
+
+contract ContractA {
+    uint256 var1;
+
+    constructor(address script_caller) {
+        require(msg.sender == script_caller);
+        require(tx.origin == script_caller);
+    }
+
+    function method(address script_caller) public {
+        require(msg.sender == script_caller);
+        require(tx.origin == script_caller);
+    }
+}
+
+contract ContractB {
+    uint256 var2;
+
+    constructor(address script_caller) {
+        require(msg.sender == address(0x1337));
+        require(tx.origin == address(0x1337));
+    }
+
+    function method(address script_caller) public {
+        require(msg.sender == address(0x1337));
+        require(tx.origin == address(0x1337));
+    }
+}
+
+contract CheckOverrides is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function run() external {
+        // `script_caller` can be set by `--private-key ...` or `--sender ...`
+        // Otherwise it will take the default value of 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38
+        address script_caller = msg.sender;
+        require(script_caller == 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+        require(tx.origin == script_caller);
+
+        // startBroadcast(script_caller)
+        cheats.startBroadcast();
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+
+        ContractA a = new ContractA(script_caller);
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+
+        a.method(script_caller);
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+
+        cheats.stopBroadcast();
+
+        // startBroadcast(msg.sender)
+        cheats.startBroadcast(address(0x1337));
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+        require(msg.sender != address(0x1337));
+
+        ContractB b = new ContractB(script_caller);
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+
+        b.method(script_caller);
+        require(tx.origin == script_caller);
+        require(msg.sender == script_caller);
+
+        cheats.stopBroadcast();
+    }
+}

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -454,11 +454,13 @@ contract ContractB {
     uint256 var2;
 
     constructor(address script_caller) {
+        require(address(0x1337) != script_caller);
         require(msg.sender == address(0x1337));
         require(tx.origin == address(0x1337));
     }
 
     function method(address script_caller) public {
+        require(address(0x1337) != script_caller);
         require(msg.sender == address(0x1337));
         require(tx.origin == address(0x1337));
     }


### PR DESCRIPTION
We were not correctly setting `tx.origin` when calling `startBroadcast(address)` or `broadcast(address)`. 

Added an exhaustive test that we can also probably link in the book, that exemplifies what `msg.sender` is in different broadcasting contexts.
