### PR TITLE
fix(evm): console_log_format

### DIFF
--- a/evm/src/executor/abi/fmt.rs
+++ b/evm/src/executor/abi/fmt.rs
@@ -160,7 +160,7 @@ fn console_log_format_inner<'a>(
             }
         } else {
             expect_fmt = ch == '%';
-            // push when not a % or there won't be an identifier
+            // push when not a `%` or it's the last char
             if !expect_fmt || i == s.len() - 1 {
                 result.push(ch);
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Lots of byte indexing with UTF-8 strings which may break the formatted output

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use char_indices and clean up reverse logic

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
