### PR TITLE
test: skip test if etherscan vars not set

### DIFF
--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -242,6 +242,12 @@ casttest!(cast_run_succeeds, |_: TestProject, mut cmd: TestCommand| {
 
 // tests that the `cast storage` command works correctly
 casttest!(test_live_cast_storage_succeeds, |_: TestProject, mut cmd: TestCommand| {
+    // ignore if ETHERSCAN_API_KEY not set
+    if std::env::var("ETHERSCAN_API_KEY").is_err() {
+        eprintln!("ETHERSCAN_API_KEY not set");
+        return
+    }
+
     let eth_rpc_url = next_http_rpc_endpoint();
 
     // WETH

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -330,7 +330,15 @@ forgetest!(
 forgetest_async!(
     test_live_can_deploy_and_verify,
     |prj: TestProject, mut cmd: TestCommand| async move {
-        let info = EnvExternalities::goerli().expect("Goerli secrets not set.");
+        let info = EnvExternalities::goerli();
+
+        // ignore if etherscan var not set
+        if std::env::var("ETHERSCAN_API_KEY").is_err() {
+            eprintln!("Goerli secrets not set.");
+            return
+        }
+
+        let info = info.unwrap();
 
         add_unique(&prj);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
etherscan vars are set as secrets in CI

this skips the test that would otherwise fail, so testing locally, without the env vars is more convenient.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
