### PR TITLE
fix(script): Only deploy needed libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "indicatif 0.17.1",
  "itertools",
  "once_cell",
+ "ordered-float",
  "parking_lot 0.12.0",
  "path-slash",
  "pretty_assertions",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,6 +79,7 @@ thiserror = "1.0.30"
 indicatif = "0.17.1"
 which = "4.2.5"
 parking_lot = "0.12"
+ordered-float = "3.3.0"
 
 [dev-dependencies]
 anvil = { path = "../anvil" }

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -616,7 +616,7 @@ impl ScriptArgs {
 }
 
 /// How to send a single transaction
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum SendTransactionKind<'a> {
     Unlocked(Address),
     Raw(&'a WalletType),

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -78,6 +78,7 @@ impl ScriptArgs {
         let mut run_dependencies = vec![];
         let mut contract = CompactContractBytecode::default();
         let mut highlevel_known_contracts = BTreeMap::new();
+        #[allow(clippy::mutable_key_type)]
         let mut deploy_bytecode_to_dependencies = BTreeMap::new();
 
         let mut target_fname = dunce::canonicalize(&self.path)

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -374,6 +374,7 @@ impl ScriptArgs {
     }
 }
 
+#[allow(clippy::mutable_key_type)]
 fn get_relevant_predeploys(
     result: &ScriptResult,
     deploy_bytecode_to_dependencies: &BTreeMap<
@@ -391,6 +392,7 @@ fn get_relevant_predeploys(
     Ok(only_relevant_predeploys)
 }
 
+#[allow(clippy::mutable_key_type)]
 fn relevant_from_match(
     tx: &BroadcastableTransaction,
     deploy_bytecode_to_dependencies: &BTreeMap<
@@ -419,8 +421,6 @@ fn relevant_from_match(
                 {
                     Ok(found.1 .1.iter().map(|(_, bcode)| bcode.clone()).collect::<Vec<_>>())
                 } else {
-                    println!("{:#?}", deploy_bytecode_to_dependencies);
-                    println!("{:#?}", data);
                     Err(eyre::eyre!("Could not find matching known contract when determining dependencies that need to be deployed for a Create call"))
                 }
             }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -633,7 +633,7 @@ pub struct JsonResult {
     pub returns: HashMap<String, NestedValue>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NestedValue {
     pub internal_type: String,
     pub value: String,

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -29,7 +29,7 @@ pub const DRY_RUN_DIR: &str = "dry-run";
 
 /// Helper that saves the transactions sequence and its state on which transactions have been
 /// broadcasted
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone, Default, Debug)]
 pub struct ScriptSequence {
     pub transactions: VecDeque<TransactionWithMetadata>,
     #[serde(serialize_with = "wrapper::serialize_receipts")]


### PR DESCRIPTION
## Motivation
Fix #3924

## Solution
Look at the broadcast transactions, determine if its a "create" transaction, check the data against a mapping of creation bytecode to a vector of dependencies (libraries). Only predeploy those libraries.

WIP, need to handle a few cases like Create2 txs, and detect errors better.