### PR TITLE
fix(ci): add `--slow` to goerli live test

### DIFF
--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -366,6 +366,7 @@ forgetest_async!(
             &info.pk,
             "--broadcast",
             "-vvvv",
+            "--slow",
             "--optimize",
             "--verify",
             "--optimizer-runs",


### PR DESCRIPTION
CI has been broken for a while since the goerli live test keeps failing with `Transaction dropped...`. However, I haven't been able to reproduce it locally even once. 

I feel like adding `--slow` might help out with the CI passing (adding around 5 block-time seconds to the job), while this is further investigated (#3969).