### PR TITLE
fix(forge): Fix cheatcodes not cooperating with `vm.transact`

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -122,15 +122,16 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         self.backend.to_mut().roll_fork_to_transaction(id, transaction, env, journaled_state)
     }
 
-    fn transact(
+    fn transact<INSP: Inspector<Backend>>(
         &mut self,
         id: Option<LocalForkId>,
         transaction: H256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
+        inspector: Option<&mut INSP>,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "fuzz: execute transaction");
-        self.backend.to_mut().transact(id, transaction, env, journaled_state)
+        self.backend.to_mut().transact(id, transaction, env, journaled_state, inspector)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -4,6 +4,7 @@ use crate::{
             diagnostic::RevertDiagnostic, error::DatabaseError, Backend, DatabaseExt, LocalForkId,
         },
         fork::{CreateFork, ForkId},
+        inspector::cheatcodes::Cheatcodes,
     },
     Address,
 };
@@ -122,16 +123,16 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         self.backend.to_mut().roll_fork_to_transaction(id, transaction, env, journaled_state)
     }
 
-    fn transact<INSP: Inspector<Backend>>(
+    fn transact(
         &mut self,
         id: Option<LocalForkId>,
         transaction: H256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
-        inspector: Option<&mut INSP>,
+        cheatcodes_inspector: Option<&mut Cheatcodes>,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "fuzz: execute transaction");
-        self.backend.to_mut().transact(id, transaction, env, journaled_state, inspector)
+        self.backend.to_mut().transact(id, transaction, env, journaled_state, cheatcodes_inspector)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -425,8 +425,8 @@ impl Backend {
         backend
     }
 
-    /// Creats a new instance of `Backend` with fork added to the fork database and sets the fork as
-    /// active
+    /// Creates a new instance of `Backend` with fork added to the fork database and sets the fork
+    /// as active
     pub(crate) fn new_with_fork(id: &ForkId, fork: Fork, journaled_state: JournaledState) -> Self {
         let mut backend = Self::spawn(None);
         let fork_ids = backend.inner.insert_new_fork(id.clone(), fork.db, journaled_state);

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -1083,16 +1083,13 @@ impl DatabaseExt for Backend {
         let id = self.ensure_fork(maybe_id)?;
         let fork_id = self.ensure_fork_id(id).cloned()?;
 
-        let mut env = if maybe_id.is_none() {
+        let env = if maybe_id.is_none() {
             self.forks
                 .get_env(fork_id.clone())?
                 .ok_or_else(|| eyre::eyre!("Requested fork `{}` does not exit", id))?
         } else {
             env.clone()
         };
-
-        let mut db = self.clone();
-        db.select_fork(id, &mut env, journaled_state)?;
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         let tx = fork.db.db.get_transaction(transaction)?;

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -18,8 +18,8 @@ pub use in_memory_db::MemDb;
 use revm::{
     db::{CacheDB, DatabaseRef},
     precompiles::Precompiles,
-    return_ok, Account, AccountInfo, Bytecode, CreateScheme, Database, DatabaseCommit, Env,
-    ExecutionResult, Inspector, JournaledState, Log, Return, SpecId, TransactTo, EVM, KECCAK_EMPTY,
+    Account, AccountInfo, Bytecode, CreateScheme, Database, DatabaseCommit, Env, ExecutionResult,
+    Inspector, JournaledState, Log, SpecId, TransactTo, EVM, KECCAK_EMPTY,
 };
 use std::collections::{HashMap, HashSet};
 use tracing::{trace, warn};
@@ -1691,7 +1691,7 @@ fn commit_transaction(
 ) {
     configure_tx_env(&mut env, &tx);
 
-    let (result, state) = {
+    let (_, state) = {
         let mut evm = EVM::new();
         evm.env = env;
 
@@ -1705,9 +1705,7 @@ fn commit_transaction(
         }
     };
 
-    if let return_ok!() = result.exit_reason {
-        apply_state_changeset(state, journaled_state, fork);
-    }
+    apply_state_changeset(state, journaled_state, fork);
 }
 
 /// Applies the changeset of a transaction to the active journaled state and also commits it in the

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -1,10 +1,7 @@
 use crate::{
     abi::HEVMCalls,
     error,
-    executor::inspector::{
-        cheatcodes::util::{self},
-        Cheatcodes,
-    },
+    executor::inspector::{cheatcodes::util, Cheatcodes},
 };
 use bytes::Bytes;
 use ethers::{

--- a/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -91,6 +91,16 @@ pub fn apply<DB: DatabaseExt>(
                 .map(|_| Default::default())
                 .map_err(error::encode_error)
         }
+        HEVMCalls::RollFork3(fork) => data
+            .db
+            .roll_fork_to_transaction(
+                Some(fork.0),
+                fork.1.into(),
+                data.env,
+                &mut data.journaled_state,
+            )
+            .map(|_| Default::default())
+            .map_err(error::encode_error),
         HEVMCalls::RpcUrl(rpc) => state.config.get_rpc_url(&rpc.0).map(|url| url.encode().into()),
         HEVMCalls::RpcUrls(_) => {
             let mut urls = Vec::with_capacity(state.config.rpc_endpoints.len());
@@ -122,12 +132,18 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::Transact0(inner) => data
             .db
-            .transact(None, inner.0.into(), data.env, &mut data.journaled_state)
+            .transact(None, inner.0.into(), data.env, &mut data.journaled_state, Some(state))
             .map(|_| Default::default())
             .map_err(error::encode_error),
         HEVMCalls::Transact1(inner) => data
             .db
-            .transact(Some(inner.0), inner.1.into(), data.env, &mut data.journaled_state)
+            .transact(
+                Some(inner.0),
+                inner.1.into(),
+                data.env,
+                &mut data.journaled_state,
+                Some(state),
+            )
             .map(|_| Default::default())
             .map_err(error::encode_error),
         _ => return None,

--- a/testdata/cheats/Fork2.t.sol
+++ b/testdata/cheats/Fork2.t.sol
@@ -94,6 +94,37 @@ contract ForkTest is DSTest {
         assertEq(block.number, mainBlock + 1);
     }
 
+    // test that we can "roll" blocks until a transaction
+    function testCanRollForkUntilTransaction() public {
+        // block to run transactions from
+        uint256 block = 16261704;
+
+        // fork until previous block
+        uint256 fork = cheats.createSelectFork("rpcAlias", block - 1);
+
+        // block transactions in order: https://beaconcha.in/block/16261704#transactions
+        // run transactions from current block until tx
+        bytes32 tx = 0x67cbad73764049e228495a3f90144aab4a37cb4b5fd697dffc234aa5ed811ace;
+
+        // account that sends ether in 2 transaction before tx
+        address account = 0xAe45a8240147E6179ec7c9f92c5A18F9a97B3fCA;
+
+        assertEq(account.balance, 275780074926400862972);
+
+        // transfer: 0.00275 ether (0.00095 + 0.0018)
+        // transaction 1: https://etherscan.io/tx/0xc51739580cf4cd2155cb171afa56ce314168eee3b5d59faefc3ceb9cacee46da
+        // transaction 2: https://etherscan.io/tx/0x3777bf87e91bcbb0f976f1df47a7678cea6d6e29996894293a6d1fad80233c28
+        uint256 transferAmount = 950391156965212 + 1822824618180000;
+        uint256 newBalance = account.balance - transferAmount;
+
+        // execute transactions in block until tx
+        cheats.rollFork(tx);
+
+        // balance must be less than newBalance due to gas spent
+        assert(account.balance < newBalance);
+    }
+
+
     /// checks that marking as persistent works
     function testMarkPersistent() public {
         assert(cheats.isPersistent(address(this)));

--- a/testdata/cheats/Fork2.t.sol
+++ b/testdata/cheats/Fork2.t.sol
@@ -124,7 +124,6 @@ contract ForkTest is DSTest {
         assert(account.balance < newBalance);
     }
 
-
     /// checks that marking as persistent works
     function testMarkPersistent() public {
         assert(cheats.isPersistent(address(this)));

--- a/testdata/fork/Transact.t.sol
+++ b/testdata/fork/Transact.t.sol
@@ -5,8 +5,17 @@ import "ds-test/test.sol";
 import "../cheats/Cheats.sol";
 import "../logs/console.sol";
 
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
 contract TransactOnForkTest is DSTest {
     Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    IERC20 constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
 
     function testTransact() public {
         // A random block https://etherscan.io/block/15596646
@@ -34,5 +43,56 @@ contract TransactOnForkTest is DSTest {
 
         // decreased by transferAmount and gas
         assert(sender.balance < expectedSenderBalance);
+    }
+
+    function testTransactCooperatesWithCheatcoes() public {
+        // A random block https://etherscan.io/block/16260609
+        uint256 fork = vm.createFork("rpcAlias", 16260609);
+        vm.selectFork(fork);
+
+        // a random ERC20 USDT transfer transaction in the next block: https://etherscan.io/tx/0x33350512fec589e635865cbdb38fa3a20a2aa160c52611f1783d0ba24ad13c8c
+        bytes32 tx = 0x33350512fec589e635865cbdb38fa3a20a2aa160c52611f1783d0ba24ad13c8c;
+
+        address sender = address(0x2e09BB78B3D64d98Da44D1C776fa77dcd133ED54);
+        address recipient = address(0x23a6B9711B711b1d404F2AA740bde350c67a6F06);
+
+        uint256 senderBalance = USDT.balanceOf(sender);
+        uint256 recipientBalance = USDT.balanceOf(recipient);
+
+        assertEq(senderBalance, 20041000000);
+        assertEq(recipientBalance, 66000000);
+
+        // transfer amount: 14000 USDT
+        uint256 transferAmount = 14000000000;
+        uint256 expectedRecipientBalance = recipientBalance + transferAmount;
+        uint256 expectedSenderBalance = senderBalance - transferAmount;
+
+        // expect a call to USDT's transfer
+        vm.expectCall(address(USDT), abi.encodeWithSelector(IERC20.transfer.selector, recipient, transferAmount));
+
+        // expect a Transfer event to be emitted
+        vm.expectEmit(true, true, false, true, address(USDT));
+        emit Transfer(address(sender), address(recipient), transferAmount);
+
+        // start recording logs
+        vm.recordLogs();
+
+        // execute the transaction
+        vm.transact(tx);
+
+        // extract recorded logs
+        Cheats.Log[] memory logs = vm.getRecordedLogs();
+
+        senderBalance = USDT.balanceOf(sender);
+        recipientBalance = USDT.balanceOf(recipient);
+
+        // recipient received transfer
+        assertEq(recipientBalance, expectedRecipientBalance);
+
+        // decreased by transferAmount
+        assertEq(senderBalance, expectedSenderBalance);
+
+        // recorded a `Transfer` log
+        assertEq(logs.length, 1);
     }
 }

--- a/testdata/fork/Transact.t.sol
+++ b/testdata/fork/Transact.t.sol
@@ -7,6 +7,7 @@ import "../logs/console.sol";
 
 interface IERC20 {
     function transfer(address to, uint256 amount) external returns (bool);
+
     function balanceOf(address account) external view returns (uint256);
 }
 
@@ -45,7 +46,7 @@ contract TransactOnForkTest is DSTest {
         assert(sender.balance < expectedSenderBalance);
     }
 
-    function testTransactCooperatesWithCheatcoes() public {
+    function testTransactCooperatesWithCheatcodes() public {
         // A random block https://etherscan.io/block/16260609
         uint256 fork = vm.createFork("rpcAlias", 16260609);
         vm.selectFork(fork);


### PR DESCRIPTION
## Motivation
Closes #3797 

## Solution
- Add optional inspector to `commit_transaction`
- Add implementation for `RollFork3`/`vm.rollFork(uint256 forkId, bytes32 transaction)` (which was not implemented until now for some particular reason?)
- Add tests for `transact` and `rollFork` cooperating with cheatcodes

It is evident that the `Cheatcodes` inspector doesn't inspect the transaction that is executed in `transact` since not only does `vm.recordLogs` not work as expected but even other cheatcodes like `vm.expectCall` doesn't work as expected.
I added an optional inspector to inspect the new `EVM` instance that the `transact` is run on. However, since the `Cheatcodes` inspector needs the `Database` to also implement the `DatabaseExt` trait, I create a new `Backend` database with the fork's database and pass it to the `EVM`.

Note that, this means that the `DatabaseExt` trait now depends on `Backend` which implements `DatabaseExt` itself. It is a circular dependency. Would this design be prefered or shall I move the responsibility of passing a `DatabaseExt` all the way up to the caller of `transact`?

Also, I've noticed that `vm.transact` doesn't revert when the transaction is supposed to revert, shall I create a separate issue for this?

