### PR TITLE
[fix] GethTrace in ethers is using U256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "1.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#8a5b3cc6c95eb31fa7530117b9860e3fa52e5e0f"
+source = "git+https://github.com/gakonst/ethers-rs#799f752e55e80aa8d6357321d4f5f7ebf66daa8a"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -4512,9 +4512,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -161,7 +161,7 @@ impl CallTraceArena {
         let mut acc = GethTrace {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
-            gas: receipt_gas_used.as_u64(),
+            gas: receipt_gas_used,
             return_value: main_trace.output.to_bytes(),
             ..Default::default()
         };


### PR DESCRIPTION
Breaking change in ethers, GethTrace is using U256 instead of u64 as gas type.

https://github.com/gakonst/ethers-rs/commit/b27c7b0773d7ba329e0e1eebb37db652ac8fa601
