### PR TITLE
feat(chisel): `rawstack` / `rs` command

### DIFF
--- a/chisel/src/cmd.rs
+++ b/chisel/src/cmd.rs
@@ -73,7 +73,7 @@ impl FromStr for ChiselCommand {
             "fetch" | "fe" => Ok(ChiselCommand::Fetch),
             "exec" | "e" => Ok(ChiselCommand::Exec),
             "rawstack" | "rs" => Ok(ChiselCommand::RawStack),
-            _ => Err(ChiselDisptacher::make_error(format!(
+            _ => Err(ChiselDispatcher::make_error(format!(
                 "Unknown command \"{s}\"! See available commands with `!help`.",
             ))
             .into()),

--- a/chisel/src/cmd.rs
+++ b/chisel/src/cmd.rs
@@ -47,6 +47,8 @@ pub enum ChiselCommand {
     Fetch,
     /// Executes a shell command
     Exec,
+    /// Display the raw value of a variable's stack allocation.
+    RawStack,
 }
 
 /// Attempt to convert a string slice to a `ChiselCommand`
@@ -70,6 +72,7 @@ impl FromStr for ChiselCommand {
             "export" | "ex" => Ok(ChiselCommand::Export),
             "fetch" | "fe" => Ok(ChiselCommand::Fetch),
             "exec" | "e" => Ok(ChiselCommand::Exec),
+            "rawstack" | "rs" => Ok(ChiselCommand::RawStack),
             _ => Err(ChiselDisptacher::make_error(format!(
                 "Unknown command \"{s}\"! See available commands with `!help`.",
             ))
@@ -129,6 +132,7 @@ impl From<ChiselCommand> for CmdDescriptor {
             // Debug
             ChiselCommand::MemDump => (&["memdump", "md"], "Dump the raw memory of the current state", CmdCategory::Debug),
             ChiselCommand::StackDump => (&["stackdump", "sd"], "Dump the raw stack of the current state", CmdCategory::Debug),
+            ChiselCommand::RawStack => (&["rawstack <var>", "rs <var>"], "Display the raw value of a variable's stack allocation. For variables that are > 32 bytes in length, this will display their memory pointer.", CmdCategory::Debug),
         }
     }
 }

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -623,15 +623,12 @@ impl ChiselDisptacher {
                 let to_inspect = args[0];
 
                 // Get a mutable reference to the session source
-                let source =
-                    match self.session.session_source.as_mut().ok_or(DispatchResult::Failure(None))
-                    {
-                        Ok(project) => project,
-                        Err(e) => {
-                            self.errored = true;
-                            return e
-                        }
-                    };
+                let source = match self.session.session_source.as_mut().ok_or(
+                    DispatchResult::CommandFailed(String::from("Session source not present")),
+                ) {
+                    Ok(session_source) => session_source,
+                    Err(e) => return e,
+                };
 
                 // Copy the variable's stack contents into a bytes32 variable without updating
                 // the current session source.

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -610,6 +610,53 @@ impl ChiselDisptacher {
                     Err(e) => DispatchResult::CommandFailed(e.to_string()),
                 }
             }
+            ChiselCommand::RawStack => {
+                if args.is_empty() {
+                    return DispatchResult::CommandFailed(Self::make_error("No variable supplied!"))
+                } else if args.len() > 1 {
+                    return DispatchResult::CommandFailed(Self::make_error(
+                        "!rawstack only takes one argument.",
+                    ))
+                }
+
+                // Store the variable that we want to inspect
+                let to_inspect = args[0];
+
+                // Get a mutable reference to the session source
+                let source =
+                    match self.session.session_source.as_mut().ok_or(DispatchResult::Failure(None))
+                    {
+                        Ok(project) => project,
+                        Err(e) => {
+                            self.errored = true;
+                            return e
+                        }
+                    };
+
+                // Copy the variable's stack contents into a bytes32 variable without updating
+                // the current session source.
+                if let Ok((mut new_source, _)) = source.clone_with_new_line(format!(
+                    "bytes32 __raw__; assembly {{ __raw__ := {to_inspect} }}"
+                )) {
+                    match new_source.inspect("__raw__").await {
+                        Ok(res) => {
+                            // If the input was inspected, hault here and display the contents
+                            // of the `__raw__` variable's stack allocation.
+                            if let Some(res) = res {
+                                return DispatchResult::CommandSuccess(Some(res))
+                            }
+                        }
+                        Err(e) => {
+                            // If there was an explicit error thrown, hault here.
+                            return DispatchResult::CommandFailed(Self::make_error(e))
+                        }
+                    }
+                }
+
+                DispatchResult::CommandFailed(String::from(
+                    "Variable must exist within `run()` function.",
+                ))
+            }
         }
     }
 

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -623,12 +623,13 @@ impl ChiselDisptacher {
                 let to_inspect = args[0];
 
                 // Get a mutable reference to the session source
-                let source = match self.session.session_source.as_mut().ok_or(
-                    DispatchResult::CommandFailed(String::from("Session source not present")),
-                ) {
-                    Ok(session_source) => session_source,
-                    Err(e) => return e,
-                };
+                let source =
+                    match self.session.session_source.as_mut().ok_or(DispatchResult::CommandFailed(
+                        "Session source not present".to_string(),
+                    )) {
+                        Ok(session_source) => session_source,
+                        Err(e) => return e,
+                    };
 
                 // Copy the variable's stack contents into a bytes32 variable without updating
                 // the current session source.
@@ -650,9 +651,9 @@ impl ChiselDisptacher {
                     }
                 }
 
-                DispatchResult::CommandFailed(String::from(
-                    "Variable must exist within `run()` function.",
-                ))
+                DispatchResult::CommandFailed(
+                    "Variable must exist within `run()` function.".to_string(),
+                )
             }
         }
     }


### PR DESCRIPTION
# Overview

Adds a new `!rawstack` / `!rs` command to chisel that displays the raw value of a variable's stack allocation.

## Motivation

Feature requested by @transmissions11 

## Solution

1. Clone the current session source.
2. Append the following code to the cloned source's `run()` function, where `to_inspect` is the argument supplied to `!rawstack`
```solidity
bytes32 __raw__;
assembly {
    __raw__ := to_inspect
}
```
3. Inspect the `__raw__` variable.

## Usage
![Screenshot from 2022-12-28 14-31-32](https://user-images.githubusercontent.com/8406232/209863157-45aa0f54-5987-4cc0-b2e1-9de445766cc5.png)
