### PR TITLE
fix(chisel): Improve error verbosity when an expression inspection reverts

### DIFF
--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -3,7 +3,7 @@
 //! This module contains the core readline loop for the Chisel CLI as well as the
 //! executable's `main` function.
 
-use chisel::prelude::{ChiselCommand, ChiselDisptacher, DispatchResult, SolidityHelper};
+use chisel::prelude::{ChiselCommand, ChiselDispatcher, DispatchResult, SolidityHelper};
 use clap::Parser;
 use foundry_cli::cmd::{forge::build::BuildArgs, LoadConfig};
 use foundry_common::evm::EvmArgs;
@@ -73,7 +73,7 @@ async fn main() -> eyre::Result<()> {
     let (config, evm_opts) = args.load_config_and_evm_opts()?;
 
     // Create a new cli dispatcher
-    let mut dispatcher = ChiselDisptacher::new(&chisel::session_source::SessionSourceConfig {
+    let mut dispatcher = ChiselDispatcher::new(&chisel::session_source::SessionSourceConfig {
         // Enable traces if any level of verbosity was passed
         traces: config.verbosity > 0,
         foundry_config: config,

--- a/chisel/src/cmd.rs
+++ b/chisel/src/cmd.rs
@@ -3,7 +3,7 @@
 //! This module holds the [ChiselCommand] enum, which contains all builtin commands that
 //! can be executed within the REPL.
 
-use crate::prelude::ChiselDisptacher;
+use crate::prelude::ChiselDispatcher;
 use std::{error::Error, str::FromStr};
 use strum::EnumIter;
 
@@ -70,7 +70,7 @@ impl FromStr for ChiselCommand {
             "export" | "ex" => Ok(ChiselCommand::Export),
             "fetch" | "fe" => Ok(ChiselCommand::Fetch),
             "exec" | "e" => Ok(ChiselCommand::Exec),
-            _ => Err(ChiselDisptacher::make_error(format!(
+            _ => Err(ChiselDispatcher::make_error(format!(
                 "Unknown command \"{s}\"! See available commands with `!help`.",
             ))
             .into()),

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -33,7 +33,7 @@ static CHISEL_CHAR: &str = "⚒️";
 
 /// Chisel input dispatcher
 #[derive(Debug)]
-pub struct ChiselDisptacher {
+pub struct ChiselDispatcher {
     /// The status of the previous dispatch
     pub errored: bool,
     /// A Chisel Session
@@ -107,7 +107,7 @@ pub fn format_source(source: &str, config: FormatterConfig) -> eyre::Result<Stri
     }
 }
 
-impl ChiselDisptacher {
+impl ChiselDispatcher {
     /// Associated public function to create a new Dispatcher instance
     pub fn new(config: &SessionSourceConfig) -> eyre::Result<Self> {
         ChiselSession::new(config).map(|session| Self { errored: false, session })
@@ -682,8 +682,8 @@ impl ChiselDisptacher {
                     // If traces are enabled or there was an error in execution, show the execution
                     // traces.
                     if new_source.config.traces || failed {
-                        if let Ok(decoder) = self.decode_traces(&new_source.config, &mut res) {
-                            if self.show_traces(&decoder, &mut res).await.is_err() {
+                        if let Ok(decoder) = Self::decode_traces(&new_source.config, &mut res) {
+                            if Self::show_traces(&decoder, &mut res).await.is_err() {
                                 self.errored = true;
                                 return DispatchResult::CommandFailed(
                                     "Failed to display traces".to_owned(),
@@ -749,7 +749,6 @@ impl ChiselDisptacher {
     ///
     /// Optionally, a [CallTraceDecoder]
     pub fn decode_traces(
-        &self,
         session_config: &SessionSourceConfig,
         result: &mut ChiselResult,
         // known_contracts: &ContractsByArtifact,
@@ -785,7 +784,6 @@ impl ChiselDisptacher {
     ///
     /// Optionally, a unit type signifying a successful result.
     pub async fn show_traces(
-        &self,
         decoder: &CallTraceDecoder,
         result: &mut ChiselResult,
     ) -> eyre::Result<()> {

--- a/chisel/src/lib.rs
+++ b/chisel/src/lib.rs
@@ -28,6 +28,7 @@ pub mod solidity_helper;
 /// Prelude of all chisel modules
 pub mod prelude {
     pub use crate::{
-        cmd::*, dispatcher::*, runner::*, session::*, session_source::*, solidity_helper::*,
+        cmd::*, dispatcher::*, executor::*, runner::*, session::*, session_source::*,
+        solidity_helper::*,
     };
 }


### PR DESCRIPTION
# Overview

Improves error verbosity by showing traces when an expression inspection reverts.

(Also fixes a typo: `ChiselDisptacher` -> `ChiselDispatcher`)

## Motivation

@devtooligan pointed out that if an expression inspection reverts, chisel only showed a `No state present` error message, which didn't help explain why the inspection failed.
![image](https://user-images.githubusercontent.com/8406232/209867229-72c2cd5a-a30c-4c70-9379-ece39977b315.png)

## Solution

Always show traces when an expression inspection fails.
![Screenshot from 2022-12-28 15-14-02](https://user-images.githubusercontent.com/8406232/209867199-9f1ba088-aa41-4af8-ae07-4c5a34c2a65a.png)
