### PR TITLE
docs: consistent help headings

### DIFF
--- a/anvil/server/src/config.rs
+++ b/anvil/server/src/config.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 /// Additional server settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "clap", derive(clap::Parser), clap(next_help_heading = "Server options"))]
 pub struct ServerConfig {
     /// The cors `allow_origin` header
     #[cfg_attr(

--- a/anvil/server/src/config.rs
+++ b/anvil/server/src/config.rs
@@ -2,7 +2,7 @@ use crate::HeaderValue;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
 
-/// Additional server settings
+/// Additional server options.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::Parser), clap(next_help_heading = "Server options"))]
 pub struct ServerConfig {

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -28,7 +28,7 @@ use tracing::{error, trace};
 
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "EVM options")]
     pub evm_opts: AnvilEvmArgs,
 
     #[clap(
@@ -75,7 +75,7 @@ pub struct NodeArgs {
     )]
     pub derivation_path: Option<String>,
 
-    #[clap(flatten, next_help_heading = "SERVER OPTIONS")]
+    #[clap(flatten, next_help_heading = "Server options")]
     pub server_config: ServerConfig,
 
     #[clap(long, help = "Don't print anything on startup.")]
@@ -114,7 +114,7 @@ pub struct NodeArgs {
         help = "The host the server will listen on",
         value_name = "IP_ADDR",
         env = "ANVIL_IP_ADDR",
-        help_heading = "SERVER OPTIONS"
+        help_heading = "Server options"
     )]
     pub host: Option<IpAddr>,
 
@@ -327,7 +327,7 @@ pub struct AnvilEvmArgs {
         short,
         visible_alias = "rpc-url",
         value_name = "URL",
-        help_heading = "FORK CONFIG"
+        help_heading = "Fork config"
     )]
     pub fork_url: Option<ForkUrl>,
 
@@ -337,7 +337,7 @@ pub struct AnvilEvmArgs {
     #[clap(
         long = "timeout",
         name = "timeout",
-        help_heading = "FORK CONFIG",
+        help_heading = "Fork config",
         requires = "fork_url"
     )]
     pub fork_request_timeout: Option<u64>,
@@ -348,7 +348,7 @@ pub struct AnvilEvmArgs {
     #[clap(
         long = "retries",
         name = "retries",
-        help_heading = "FORK CONFIG",
+        help_heading = "Fork config",
         requires = "fork_url"
     )]
     pub fork_request_retries: Option<u32>,
@@ -356,13 +356,13 @@ pub struct AnvilEvmArgs {
     /// Fetch state from a specific block number over a remote endpoint.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BLOCK", help_heading = "FORK CONFIG")]
+    #[clap(long, requires = "fork_url", value_name = "BLOCK", help_heading = "Fork config")]
     pub fork_block_number: Option<u64>,
 
     /// Initial retry backoff on encountering errors.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "FORK CONFIG")]
+    #[clap(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "Fork config")]
     pub fork_retry_backoff: Option<u64>,
 
     /// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
@@ -372,7 +372,7 @@ pub struct AnvilEvmArgs {
     /// remote.
     #[clap(
         long,
-        help_heading = "FORK CONFIG",
+        help_heading = "Fork config",
         value_name = "CHAIN",
         requires = "fork_block_number"
     )]
@@ -389,7 +389,7 @@ pub struct AnvilEvmArgs {
         requires = "fork_url",
         alias = "cups",
         value_name = "CUPS",
-        help_heading = "FORK CONFIG"
+        help_heading = "Fork config"
     )]
     pub compute_units_per_second: Option<u64>,
 
@@ -404,7 +404,7 @@ pub struct AnvilEvmArgs {
         requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
         help = "Disables rate limiting for this node provider.",
-        help_heading = "FORK CONFIG"
+        help_heading = "Fork config"
     )]
     pub no_rate_limit: bool,
 
@@ -415,20 +415,20 @@ pub struct AnvilEvmArgs {
     /// This flag overrides the project's configuration file.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", help_heading = "FORK CONFIG")]
+    #[clap(long, requires = "fork_url", help_heading = "Fork config")]
     pub no_storage_caching: bool,
 
     /// The block gas limit.
-    #[clap(long, value_name = "GAS_LIMIT", help_heading = "ENVIRONMENT CONFIG")]
+    #[clap(long, value_name = "GAS_LIMIT", help_heading = "Environment config")]
     pub gas_limit: Option<u64>,
 
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
     /// default, it is 0x6000 (~25kb).
-    #[clap(long, value_name = "CODE_SIZE", help_heading = "ENVIRONMENT CONFIG")]
+    #[clap(long, value_name = "CODE_SIZE", help_heading = "Environment config")]
     pub code_size_limit: Option<usize>,
 
     /// The gas price.
-    #[clap(long, value_name = "GAS_PRICE", help_heading = "ENVIRONMENT CONFIG")]
+    #[clap(long, value_name = "GAS_PRICE", help_heading = "Environment config")]
     pub gas_price: Option<u64>,
 
     /// The base fee in a block.
@@ -436,12 +436,12 @@ pub struct AnvilEvmArgs {
         long,
         visible_alias = "base-fee",
         value_name = "FEE",
-        help_heading = "ENVIRONMENT CONFIG"
+        help_heading = "Environment config"
     )]
     pub block_base_fee_per_gas: Option<u64>,
 
     /// The chain ID.
-    #[clap(long, alias = "chain", value_name = "CHAIN_ID", help_heading = "ENVIRONMENT CONFIG")]
+    #[clap(long, alias = "chain", value_name = "CHAIN_ID", help_heading = "Environment config")]
     pub chain_id: Option<Chain>,
 
     #[clap(

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -316,7 +316,7 @@ impl NodeArgs {
     }
 }
 
-// Anvil's evm related arguments
+/// Anvil's EVM related arguments.
 #[derive(Debug, Clone, Parser)]
 #[clap(next_help_heading = "EVM options")]
 pub struct AnvilEvmArgs {

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -28,7 +28,7 @@ use tracing::{error, trace};
 
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {
-    #[clap(flatten, next_help_heading = "EVM options")]
+    #[clap(flatten)]
     pub evm_opts: AnvilEvmArgs,
 
     #[clap(
@@ -75,7 +75,7 @@ pub struct NodeArgs {
     )]
     pub derivation_path: Option<String>,
 
-    #[clap(flatten, next_help_heading = "Server options")]
+    #[clap(flatten)]
     pub server_config: ServerConfig,
 
     #[clap(long, help = "Don't print anything on startup.")]
@@ -318,6 +318,7 @@ impl NodeArgs {
 
 // Anvil's evm related arguments
 #[derive(Debug, Clone, Parser)]
+#[clap(next_help_heading = "EVM options")]
 pub struct AnvilEvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -34,10 +34,10 @@ pub(crate) const VERSION_MESSAGE: &str = concat!(
 #[derive(Debug, Parser)]
 #[clap(name = "chisel", version = VERSION_MESSAGE)]
 pub struct ChiselParser {
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     pub opts: BuildArgs,
 
-    #[clap(flatten, next_help_heading = "Evm options")]
+    #[clap(flatten)]
     pub evm_opts: EvmArgs,
 
     #[command(subcommand)]

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -34,10 +34,10 @@ pub(crate) const VERSION_MESSAGE: &str = concat!(
 #[derive(Debug, Parser)]
 #[clap(name = "chisel", version = VERSION_MESSAGE)]
 pub struct ChiselParser {
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     pub opts: BuildArgs,
 
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Evm options")]
     pub evm_opts: EvmArgs,
 
     #[command(subcommand)]

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -23,7 +23,7 @@ pub struct CallArgs {
     sig: Option<String>,
     #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
     args: Vec<String>,
-    #[clap(flatten, next_help_heading = "TRANSACTION OPTIONS")]
+    #[clap(flatten, next_help_heading = "Transaction options")]
     tx: TransactionOpts,
     #[clap(flatten)]
     // TODO: We only need RPC URL and Etherscan API key here.

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -23,11 +23,10 @@ pub struct CallArgs {
     sig: Option<String>,
     #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
     args: Vec<String>,
-    #[clap(flatten, next_help_heading = "Transaction options")]
+    #[clap(flatten)]
     tx: TransactionOpts,
     #[clap(flatten)]
-    // TODO: We only need RPC URL and Etherscan API key here.
-    eth: EthereumOpts,
+    eth: EthereumOpts, // TODO: We only need RPC URL and Etherscan API key from here.
     #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", value_parser = parse_block_id, value_name = "BLOCK")]
     block: Option<BlockId>,
     #[clap(subcommand)]

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -19,16 +19,23 @@ use foundry_config::{Chain, Config};
 pub struct CallArgs {
     #[clap(help = "The destination of the transaction.", value_parser = parse_name_or_address, value_name = "TO")]
     to: Option<NameOrAddress>,
+
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]
     sig: Option<String>,
+
     #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
     args: Vec<String>,
+
     #[clap(flatten)]
     tx: TransactionOpts,
+
+    // TODO: We only need RPC URL and Etherscan API key from here.
     #[clap(flatten)]
-    eth: EthereumOpts, // TODO: We only need RPC URL and Etherscan API key from here.
+    eth: EthereumOpts,
+
     #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", value_parser = parse_block_id, value_name = "BLOCK")]
     block: Option<BlockId>,
+
     #[clap(subcommand)]
     command: Option<CallSubcommands>,
 }

--- a/cli/src/cmd/cast/create2.rs
+++ b/cli/src/cmd/cast/create2.rs
@@ -13,6 +13,7 @@ use rayon::prelude::*;
 use regex::RegexSetBuilder;
 use std::{str::FromStr, time::Instant};
 
+/// CLI arguments for `cast create2`.
 #[derive(Debug, Clone, Parser)]
 pub struct Create2Args {
     #[clap(

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -12,6 +12,7 @@ use ethers::{
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
 
+/// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
     #[clap(help = "The destination of the transaction.", value_parser = parse_name_or_address, value_name = "TO")]

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -8,6 +8,7 @@ use eyre::Result;
 use foundry_common::try_get_http_provider;
 use futures::{future::BoxFuture, join};
 
+/// CLI arguments for `cast find-block`.
 #[derive(Debug, Clone, Parser)]
 pub struct FindBlockArgs {
     #[clap(help = "The UNIX timestamp to search for (in seconds)", value_name = "TIMESTAMP")]

--- a/cli/src/cmd/cast/interface.rs
+++ b/cli/src/cmd/cast/interface.rs
@@ -8,6 +8,7 @@ use foundry_config::Config;
 use futures::future::BoxFuture;
 use std::path::{Path, PathBuf};
 
+/// CLI arguments for `cast interface`.
 #[derive(Debug, Clone, Parser)]
 pub struct InterfaceArgs {
     #[clap(

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -6,6 +6,7 @@ use foundry_common::try_get_http_provider;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 
+/// CLI arguments for `cast rpc`.
 #[derive(Debug, Clone, Parser)]
 pub struct RpcArgs {
     #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -23,6 +23,7 @@ use tracing::trace;
 use ui::{TUIExitReason, Tui, Ui};
 use yansi::Paint;
 
+/// CLI arguments for `cast run`.
 #[derive(Debug, Clone, Parser)]
 pub struct RunArgs {
     #[clap(help = "The transaction hash.", value_name = "TXHASH")]

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -27,9 +27,9 @@ pub struct SendTxArgs {
         help = "Only print the transaction hash and exit immediately."
     )]
     cast_async: bool,
-    #[clap(flatten, next_help_heading = "Transaction options")]
+    #[clap(flatten)]
     tx: TransactionOpts,
-    #[clap(flatten, next_help_heading = "Ethereum options")]
+    #[clap(flatten)]
     eth: EthereumOpts,
     #[clap(
         short,

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -7,6 +7,7 @@ use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
 use std::sync::Arc;
 
+/// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub struct SendTxArgs {
     #[clap(

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -27,9 +27,9 @@ pub struct SendTxArgs {
         help = "Only print the transaction hash and exit immediately."
     )]
     cast_async: bool,
-    #[clap(flatten, next_help_heading = "TRANSACTION OPTIONS")]
+    #[clap(flatten, next_help_heading = "Transaction options")]
     tx: TransactionOpts,
-    #[clap(flatten, next_help_heading = "ETHEREUM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Ethereum options")]
     eth: EthereumOpts,
     #[clap(
         short,
@@ -39,7 +39,7 @@ pub struct SendTxArgs {
         value_name = "CONFIRMATIONS"
     )]
     confirmations: usize,
-    #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
+    #[clap(long = "json", short = 'j', help_heading = "Display options")]
     to_json: bool,
     #[clap(
         long = "resend",

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -25,6 +25,7 @@ use semver::Version;
 /// https://github.com/ethereum/solidity/blob/develop/Changelog.md#065-2020-04-06
 const MIN_SOLC: Version = Version::new(0, 6, 5);
 
+/// CLI arguments for `cast storage`.
 #[derive(Debug, Clone, Parser)]
 pub struct StorageArgs {
     // Storage

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -13,6 +13,7 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Chain, Signature},
 };
+use eyre::Context;
 
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
@@ -154,11 +155,11 @@ impl WalletSubcommands {
                 println!("Signature: 0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
-                let pubkey: Address = address.parse().expect("invalid pubkey provided");
-                let signature: Signature = signature.parse()?;
+                let pubkey: Address = address.parse().wrap_err("Invalid address")?;
+                let signature: Signature = signature.parse().wrap_err("Invalid signature")?;
                 match signature.verify(message, pubkey) {
                     Ok(_) => {
-                        println!("Validation success. Address {address} signed this message.")
+                        println!("Validation succeeded. Address {address} signed this message.")
                     }
                     Err(_) => {
                         println!("Validation failed. Address {address} did not sign this message.")

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -1,5 +1,7 @@
 //! cast wallet subcommand
 
+pub mod vanity;
+
 use crate::{
     cmd::{cast::wallet::vanity::VanityArgs, Cmd},
     opts::{EthereumOpts, Wallet, WalletType},
@@ -11,10 +13,8 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Chain, Signature},
 };
-use std::str::FromStr;
 
-pub mod vanity;
-
+/// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {
     #[clap(name = "new", visible_alias = "n", about = "Create a new random keypair.")]
@@ -154,8 +154,8 @@ impl WalletSubcommands {
                 println!("Signature: 0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
-                let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
-                let signature = Signature::from_str(&signature)?;
+                let pubkey: Address = address.parse().expect("invalid pubkey provided");
+                let signature: Signature = signature.parse()?;
                 match signature.verify(message, pubkey) {
                     Ok(_) => {
                         println!("Validation success. Address {address} signed this message.")

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 /// Type alias for the result of [generate_wallet].
 pub type GeneratedWallet = (SigningKey, H160);
 
+/// CLI arguments for `cast wallet vanity`.
 #[derive(Debug, Clone, Parser)]
 pub struct VanityArgs {
     #[clap(

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -24,6 +24,7 @@ impl_figment_convert!(BindArgs, build_args);
 static DEFAULT_CRATE_NAME: &str = "foundry-contracts";
 static DEFAULT_CRATE_VERSION: &str = "0.0.1";
 
+/// CLI arguments for `forge bind`.
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct BindArgs {
     #[clap(

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -18,7 +18,6 @@ use foundry_config::{
 use serde::Serialize;
 use std::path::PathBuf;
 
-/// Various arguments used by multiple subcommands
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 #[clap(next_help_heading = "Build options")]
 pub struct CoreBuildArgs {

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 pub struct CoreBuildArgs {
     #[clap(
-        help_heading = "CACHE OPTIONS",
+        help_heading = "Cache options",
         help = "Clear the cache and artifacts folder and recompile.",
         long
     )]
@@ -30,7 +30,7 @@ pub struct CoreBuildArgs {
     pub force: bool,
 
     #[clap(
-        help_heading = "LINKER OPTIONS",
+        help_heading = "Linker options",
         help = "Set pre-linked libraries.",
         long,
         env = "DAPP_LIBRARIES",
@@ -39,12 +39,12 @@ pub struct CoreBuildArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
-    #[clap(flatten, next_help_heading = "COMPILER OPTIONS")]
+    #[clap(flatten, next_help_heading = "Compiler options")]
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
     #[clap(
-        help_heading = "COMPILER OPTIONS",
+        help_heading = "Compiler options",
         help = "Ignore solc warnings by error code.",
         long,
         value_name = "ERROR_CODES"
@@ -53,26 +53,26 @@ pub struct CoreBuildArgs {
     pub ignored_error_codes: Vec<u64>,
 
     #[clap(
-        help_heading = "COMPILER OPTIONS",
+        help_heading = "Compiler options",
         help = "Warnings will trigger a compiler error",
         long
     )]
     #[serde(skip)]
     pub deny_warnings: bool,
 
-    #[clap(help_heading = "COMPILER OPTIONS", help = "Do not auto-detect solc.", long)]
+    #[clap(help_heading = "Compiler options", help = "Do not auto-detect solc.", long)]
     #[serde(skip)]
     pub no_auto_detect: bool,
 
     /// Specify the solc version, or a path to a local solc, to build with.
     ///
     /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
-    #[clap(help_heading = "COMPILER OPTIONS", value_name = "SOLC_VERSION", long = "use")]
+    #[clap(help_heading = "Compiler options", value_name = "SOLC_VERSION", long = "use")]
     #[serde(skip)]
     pub use_solc: Option<String>,
 
     #[clap(
-        help_heading = "COMPILER OPTIONS",
+        help_heading = "Compiler options",
         help = "Do not access the network.",
         long_help = "Do not access the network. Missing solc versions will not be installed.",
         long
@@ -81,19 +81,19 @@ pub struct CoreBuildArgs {
     pub offline: bool,
 
     #[clap(
-        help_heading = "COMPILER OPTIONS",
+        help_heading = "Compiler options",
         help = "Use the Yul intermediate representation compilation pipeline.",
         long
     )]
     #[serde(skip)]
     pub via_ir: bool,
 
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[clap(flatten, next_help_heading = "Project options")]
     #[serde(flatten)]
     pub project_paths: ProjectPathsArgs,
 
     #[clap(
-        help_heading = "PROJECT OPTIONS",
+        help_heading = "Project options",
         help = "The path to the contract artifacts folder.",
         long = "out",
         short,
@@ -104,7 +104,7 @@ pub struct CoreBuildArgs {
     pub out_path: Option<PathBuf>,
 
     #[clap(
-        help_heading = "PROJECT OPTIONS",
+        help_heading = "Project options",
         help = r#"Revert string configuration. Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert strings) and "verboseDebug""#,
         long = "revert-strings",
         value_name = "REVERT"
@@ -112,21 +112,21 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub revert_strings: Option<RevertStrings>,
 
-    #[clap(help_heading = "COMPILER OPTIONS", long, help = "Don't print anything on startup.")]
+    #[clap(help_heading = "Compiler options", long, help = "Don't print anything on startup.")]
     #[serde(skip)]
     pub silent: bool,
 
     #[clap(
         long,
         name = "build_info",
-        help_heading = "PROJECT OPTIONS",
+        help_heading = "Project options",
         help = "Generate build info files."
     )]
     #[serde(skip)]
     pub build_info: bool,
 
     #[clap(
-        help_heading = "PROJECT OPTIONS",
+        help_heading = "Project options",
         help = "Output path to directory that build info files will be written to.",
         long,
         value_hint = ValueHint::DirPath,

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 
 /// Various arguments used by multiple subcommands
 #[derive(Debug, Clone, Parser, Serialize, Default)]
+#[clap(next_help_heading = "Build options")]
 pub struct CoreBuildArgs {
     #[clap(
         help_heading = "Cache options",
@@ -39,7 +40,7 @@ pub struct CoreBuildArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
-    #[clap(flatten, next_help_heading = "Compiler options")]
+    #[clap(flatten)]
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
@@ -88,7 +89,7 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub via_ir: bool,
 
-    #[clap(flatten, next_help_heading = "Project options")]
+    #[clap(flatten)]
     #[serde(flatten)]
     pub project_paths: ProjectPathsArgs,
 

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -75,7 +75,7 @@ pub struct BuildArgs {
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 
-    #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
+    #[clap(flatten, next_help_heading = "Watch options")]
     #[serde(skip)]
     pub watch: WatchArgs,
 }

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -54,6 +54,7 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 /// Some arguments are marked as `#[serde(skip)]` and require manual processing in
 /// `figment::Provider` implementation
 #[derive(Debug, Clone, Parser, Serialize, Default)]
+#[clap(next_help_heading = "Build options")]
 pub struct BuildArgs {
     #[clap(flatten)]
     #[serde(flatten)]
@@ -75,7 +76,7 @@ pub struct BuildArgs {
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 
-    #[clap(flatten, next_help_heading = "Watch options")]
+    #[clap(flatten)]
     #[serde(skip)]
     pub watch: WatchArgs,
 }

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -32,7 +32,7 @@ pub use self::paths::ProjectPathsArgs;
 
 foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 
-/// All `forge build` related arguments
+/// CLI arguments for `forge build`.
 ///
 /// CLI arguments take the highest precedence in the Config/Figment hierarchy.
 /// In order to override them in the foundry `Config` they need to be merged into an existing
@@ -54,7 +54,7 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 /// Some arguments are marked as `#[serde(skip)]` and require manual processing in
 /// `figment::Provider` implementation
 #[derive(Debug, Clone, Parser, Serialize, Default)]
-#[clap(next_help_heading = "Build options")]
+#[clap(next_help_heading = "Build options", about = None)] // override doc
 pub struct BuildArgs {
     #[clap(flatten)]
     #[serde(flatten)]

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -12,7 +12,7 @@ use foundry_config::{
 use serde::Serialize;
 use std::path::PathBuf;
 
-/// Aggregates commonly used arguments related to paths
+/// Common arguments for a project's paths.
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 #[clap(next_help_heading = "Project options")]
 pub struct ProjectPathsArgs {

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 
 /// Aggregates commonly used arguments related to paths
 #[derive(Debug, Clone, Parser, Serialize, Default)]
+#[clap(next_help_heading = "Project options")]
 pub struct ProjectPathsArgs {
     #[clap(
         help = "The project's root path.",

--- a/cli/src/cmd/forge/cache.rs
+++ b/cli/src/cmd/forge/cache.rs
@@ -12,6 +12,7 @@ use foundry_config::{cache, Chain as FoundryConfigChain, Config};
 use std::{ffi::OsStr, str::FromStr};
 use strum::VariantNames;
 
+/// CLI arguments for `forge cache`.
 #[derive(Debug, Parser)]
 pub struct CacheArgs {
     #[clap(subcommand)]
@@ -22,10 +23,12 @@ pub struct CacheArgs {
 pub enum CacheSubcommands {
     #[clap(about = "Cleans cached data from ~/.foundry.")]
     Clean(CleanArgs),
+
     #[clap(about = "Shows cached data from ~/.foundry.")]
     Ls(LsArgs),
 }
 
+/// CLI arguments for `forge clean`.
 #[derive(Debug, Parser)]
 #[clap(group = clap::ArgGroup::new("etherscan-blocks").multiple(false))]
 pub struct CleanArgs {

--- a/cli/src/cmd/forge/config.rs
+++ b/cli/src/cmd/forge/config.rs
@@ -7,18 +7,22 @@ use foundry_config::fix::fix_tomls;
 
 foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
 
-/// Command to list currently set config values
+/// CLI arguments for `forge config`.
 #[derive(Debug, Clone, Parser)]
 pub struct ConfigArgs {
-    #[clap(help = "prints currently set config values as json", long)]
-    json: bool,
-    #[clap(help = "prints basic set of currently set config values", long)]
+    #[clap(help = "Print only a basic set of the currently set config values.", long)]
     basic: bool,
-    #[clap(help = "attempts to fix any configuration warnings", long)]
+
+    #[clap(help = "Print currently set config values as JSON.", long)]
+    json: bool,
+
+    #[clap(help = "Attempt to fix any configuration warnings.", long)]
     fix: bool,
+
     // support nested build arguments
     #[clap(flatten)]
     opts: BuildArgs,
+
     #[clap(flatten)]
     evm_opts: EvmArgs,
 }

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -48,13 +48,13 @@ pub struct CoverageArgs {
     )]
     report: Vec<CoverageReportKind>,
 
-    #[clap(flatten, next_help_heading = "TEST FILTERING")]
+    #[clap(flatten, next_help_heading = "Test filtering")]
     filter: Filter,
 
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Evm options")]
     evm_opts: EvmArgs,
 
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     opts: CoreBuildArgs,
 }
 

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -36,7 +36,7 @@ use tracing::trace;
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
 
-/// Generate coverage reports for your tests.
+/// CLI arguments for `forge coverage`.
 #[derive(Debug, Clone, Parser)]
 pub struct CoverageArgs {
     #[clap(

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -48,13 +48,13 @@ pub struct CoverageArgs {
     )]
     report: Vec<CoverageReportKind>,
 
-    #[clap(flatten, next_help_heading = "Test filtering")]
+    #[clap(flatten)]
     filter: Filter,
 
-    #[clap(flatten, next_help_heading = "Evm options")]
+    #[clap(flatten)]
     evm_opts: EvmArgs,
 
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     opts: CoreBuildArgs,
 }
 

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
 use tracing::log::trace;
 
+/// CLI arguments for `forge create`.
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
     #[clap(
@@ -79,7 +80,7 @@ pub struct CreateArgs {
     #[clap(flatten)]
     pub verifier: verify::VerifierArgs,
 
-    #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
+    #[clap(flatten)]
     retry: RetryArgs,
 }
 

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -50,18 +50,18 @@ pub struct CreateArgs {
     )]
     constructor_args_path: Option<PathBuf>,
 
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "TRANSACTION OPTIONS")]
+    #[clap(flatten, next_help_heading = "Transaction options")]
     tx: TransactionOpts,
 
-    #[clap(flatten, next_help_heading = "ETHEREUM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Ethereum options")]
     eth: EthereumOpts,
 
     #[clap(
         long = "json",
-        help_heading = "DISPLAY OPTIONS",
+        help_heading = "Display options",
         help = "Print the deployment information as JSON."
     )]
     json: bool,

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -50,13 +50,13 @@ pub struct CreateArgs {
     )]
     constructor_args_path: Option<PathBuf>,
 
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "Transaction options")]
+    #[clap(flatten)]
     tx: TransactionOpts,
 
-    #[clap(flatten, next_help_heading = "Ethereum options")]
+    #[clap(flatten)]
     eth: EthereumOpts,
 
     #[clap(

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -32,10 +32,10 @@ pub struct DebugArgs {
     #[clap(long)]
     pub debug: bool,
 
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     pub opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Evm options")]
     pub evm_opts: EvmArgs,
 }
 

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(DebugArgs, opts, evm_opts);
 
+/// CLI arguments for `forge debug`.
 #[derive(Debug, Clone, Parser)]
 pub struct DebugArgs {
     /// The contract you want to run. Either the file path or contract name.

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -32,10 +32,10 @@ pub struct DebugArgs {
     #[clap(long)]
     pub debug: bool,
 
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     pub opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "Evm options")]
+    #[clap(flatten)]
     pub evm_opts: EvmArgs,
 }
 

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -6,6 +6,7 @@ use clap::{Parser, ValueHint};
 use foundry_common::fs;
 use std::path::PathBuf;
 
+/// CLI arguments for `forge flatten`.
 #[derive(Debug, Clone, Parser)]
 pub struct FlattenArgs {
     #[clap(help = "The path to the contract to flatten.", value_hint = ValueHint::FilePath, value_name = "TARGET_PATH")]

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -21,7 +21,7 @@ pub struct FlattenArgs {
     )]
     pub output: Option<PathBuf>,
 
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[clap(flatten, next_help_heading = "Project options")]
     project_paths: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -21,7 +21,7 @@ pub struct FlattenArgs {
     )]
     pub output: Option<PathBuf>,
 
-    #[clap(flatten, next_help_heading = "Project options")]
+    #[clap(flatten)]
     project_paths: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use tracing::log::warn;
 
+/// CLI arguments for `forge fmt`.
 #[derive(Debug, Clone, Parser)]
 pub struct FmtArgs {
     #[clap(

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -25,7 +25,7 @@ pub struct UploadSelectorsArgs {
     )]
     pub all: bool,
 
-    #[clap(flatten, next_help_heading = "Project options")]
+    #[clap(flatten)]
     pub project_paths: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -10,6 +10,7 @@ use foundry_common::{
     selectors::{import_selectors, SelectorImportData},
 };
 
+/// CLI arguments for `forge upload-selectors`.
 #[derive(Debug, Clone, Parser)]
 pub struct UploadSelectorsArgs {
     #[clap(

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -25,7 +25,7 @@ pub struct UploadSelectorsArgs {
     )]
     pub all: bool,
 
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[clap(flatten, next_help_heading = "Project options")]
     pub project_paths: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/geiger/mod.rs
+++ b/cli/src/cmd/forge/geiger/mod.rs
@@ -14,6 +14,7 @@ mod error;
 mod find;
 mod visitor;
 
+/// CLI arguments for `forge geiger`.
 #[derive(Debug, Clone, Parser)]
 pub struct GeigerArgs {
     #[clap(

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use yansi::Paint;
 
-/// Command to initialize a new forge project
+/// CLI arguments for `forge init`.
 #[derive(Debug, Clone, Parser)]
 pub struct InitArgs {
     #[clap(

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -22,6 +22,7 @@ use serde_json::{to_value, Value};
 use std::{fmt, str::FromStr};
 use tracing::trace;
 
+/// CLI arguments for `forge inspect`.
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
     #[clap(

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -24,7 +24,7 @@ use yansi::Paint;
 static DEPENDENCY_VERSION_TAG_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^v?\d+(\.\d+)*$").unwrap());
 
-/// Command to install dependencies
+/// CLI arguments for `forge install`.
 #[derive(Debug, Clone, Parser)]
 #[clap(override_usage = "forge install [OPTIONS] [DEPENDENCIES]...
     forge install [OPTIONS] <github username>/<github project>@<tag>...
@@ -46,8 +46,10 @@ pub struct InstallArgs {
     /// The dependency will installed to `lib/<alias>`.
     #[clap(value_name = "DEPENDENCIES")]
     dependencies: Vec<Dependency>,
+
     #[clap(flatten)]
     opts: DependencyInstallOpts,
+
     #[clap(
         help = "The project's root path.",
         long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
@@ -74,8 +76,10 @@ impl Cmd for InstallArgs {
 pub struct DependencyInstallOpts {
     #[clap(help = "Install without adding the dependency as a submodule.", long)]
     pub no_git: bool,
+
     #[clap(help = "Do not create a commit.", long)]
     pub no_commit: bool,
+
     #[clap(help = "Do not print any messages.", short, long)]
     pub quiet: bool,
 }

--- a/cli/src/cmd/forge/remappings.rs
+++ b/cli/src/cmd/forge/remappings.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 use foundry_config::impl_figment_convert_basic;
 use std::path::PathBuf;
 
-/// Command to list remappings
+/// CLI arguments for `forge remappings`.
 #[derive(Debug, Clone, Parser)]
 pub struct RemappingArgs {
     #[clap(

--- a/cli/src/cmd/forge/remove.rs
+++ b/cli/src/cmd/forge/remove.rs
@@ -8,7 +8,7 @@ use eyre::WrapErr;
 use foundry_config::{find_git_root_path, impl_figment_convert_basic};
 use std::{path::PathBuf, process::Command};
 
-/// Command to remove dependencies
+/// CLI arguments for `forge remove`.
 #[derive(Debug, Clone, Parser)]
 pub struct RemoveArgs {
     #[clap(help = "The path to the dependency you want to remove.")]

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -124,13 +124,13 @@ pub struct ScriptArgs {
     )]
     pub gas_estimate_multiplier: u64,
 
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     pub opts: BuildArgs,
 
     #[clap(flatten)]
     pub wallets: MultiWallet,
 
-    #[clap(flatten, next_help_heading = "Evm options")]
+    #[clap(flatten)]
     pub evm_opts: EvmArgs,
 
     #[clap(

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -76,6 +76,7 @@ pub use transaction::TransactionWithMetadata;
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(ScriptArgs, opts, evm_opts);
 
+/// CLI arguments for `forge script`.
 #[derive(Debug, Clone, Parser, Default)]
 pub struct ScriptArgs {
     /// The contract you want to run. Either the file path or contract name.
@@ -189,7 +190,7 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
-    #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
+    #[clap(flatten)]
     pub retry: RetryArgs,
 }
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -124,13 +124,13 @@ pub struct ScriptArgs {
     )]
     pub gas_estimate_multiplier: u64,
 
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     pub opts: BuildArgs,
 
     #[clap(flatten)]
     pub wallets: MultiWallet,
 
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Evm options")]
     pub evm_opts: EvmArgs,
 
     #[clap(

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -37,7 +37,7 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
 #[derive(Debug, Clone, Parser)]
 pub struct SnapshotArgs {
     /// All test arguments are supported
-    #[clap(flatten, next_help_heading = "TEST OPTIONS")]
+    #[clap(flatten, next_help_heading = "Test options")]
     pub(crate) test: test::TestArgs,
 
     /// Additional configs for test results

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -34,6 +34,7 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?P<file>(.*?)):(?P<sig>(\w+)\s*\((.*?)\))\s*\(((gas:)?\s*(?P<gas>\d+)|(runs:\s*(?P<runs>\d+),\s*μ:\s*(?P<avg>\d+),\s*~:\s*(?P<med>\d+))|(runs:\s*(?P<invruns>\d+),\s*calls:\s*(?P<calls>\d+),\s*reverts:\s*(?P<reverts>\d+)))\)").unwrap()
 });
 
+/// CLI arguments for `forge snapshot`.
 #[derive(Debug, Clone, Parser)]
 pub struct SnapshotArgs {
     /// All test arguments are supported

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -37,7 +37,7 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
 #[derive(Debug, Clone, Parser)]
 pub struct SnapshotArgs {
     /// All test arguments are supported
-    #[clap(flatten, next_help_heading = "Test options")]
+    #[clap(flatten)]
     pub(crate) test: test::TestArgs,
 
     /// Additional configs for test results

--- a/cli/src/cmd/forge/test/filter.rs
+++ b/cli/src/cmd/forge/test/filter.rs
@@ -5,9 +5,9 @@ use forge::TestFilter;
 use foundry_config::Config;
 use std::{fmt, path::Path, str::FromStr};
 
-/// The filter to use during testing
+/// The filter to use during testing.
 ///
-/// See also `FileFilter`
+/// See also `FileFilter`.
 #[derive(Clone, Parser)]
 #[clap(next_help_heading = "Test filtering")]
 pub struct Filter {

--- a/cli/src/cmd/forge/test/filter.rs
+++ b/cli/src/cmd/forge/test/filter.rs
@@ -9,6 +9,7 @@ use std::{fmt, path::Path, str::FromStr};
 ///
 /// See also `FileFilter`
 #[derive(Clone, Parser)]
+#[clap(next_help_heading = "Test filtering")]
 pub struct Filter {
     /// Only run test functions matching the specified regex pattern.
     ///

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -74,10 +74,10 @@ pub struct TestArgs {
     allow_failure: bool,
 
     /// Output test results in JSON format.
-    #[clap(long, short, help_heading = "DISPLAY OPTIONS")]
+    #[clap(long, short, help_heading = "Display options")]
     json: bool,
 
-    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    #[clap(flatten, next_help_heading = "Evm options")]
     evm_opts: EvmArgs,
 
     #[clap(
@@ -88,14 +88,14 @@ pub struct TestArgs {
     )]
     etherscan_api_key: Option<String>,
 
-    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    #[clap(flatten, next_help_heading = "Build options")]
     opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
+    #[clap(flatten, next_help_heading = "Watch options")]
     pub watch: WatchArgs,
 
     /// List tests instead of running them
-    #[clap(long, short, help_heading = "DISPLAY OPTIONS")]
+    #[clap(long, short, help_heading = "Display options")]
     list: bool,
 
     #[clap(

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -43,6 +43,7 @@ use foundry_config::figment::{
 foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
 
 #[derive(Debug, Clone, Parser)]
+#[clap(next_help_heading = "Test options")]
 pub struct TestArgs {
     #[clap(flatten)]
     filter: Filter,
@@ -77,7 +78,7 @@ pub struct TestArgs {
     #[clap(long, short, help_heading = "Display options")]
     json: bool,
 
-    #[clap(flatten, next_help_heading = "Evm options")]
+    #[clap(flatten)]
     evm_opts: EvmArgs,
 
     #[clap(
@@ -88,10 +89,10 @@ pub struct TestArgs {
     )]
     etherscan_api_key: Option<String>,
 
-    #[clap(flatten, next_help_heading = "Build options")]
+    #[clap(flatten)]
     opts: CoreBuildArgs,
 
-    #[clap(flatten, next_help_heading = "Watch options")]
+    #[clap(flatten)]
     pub watch: WatchArgs,
 
     /// List tests instead of running them

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -42,6 +42,7 @@ use foundry_config::figment::{
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
 
+/// CLI arguments for `forge test`.
 #[derive(Debug, Clone, Parser)]
 #[clap(next_help_heading = "Test options")]
 pub struct TestArgs {

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -8,7 +8,7 @@ foundry_config::impl_figment_convert!(TreeArgs, opts);
 use crate::cmd::{forge::build::ProjectPathsArgs, LoadConfig};
 use ethers::solc::resolver::{Charset, TreeOptions};
 
-/// Command to display the project's dependency tree
+/// CLI arguments for `forge tree`.
 #[derive(Debug, Clone, Parser)]
 pub struct TreeArgs {
     #[clap(help = "Do not de-duplicate (repeats all shared dependencies)", long)]

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -20,7 +20,7 @@ pub struct TreeArgs {
         value_name = "CHARSET"
     )]
     charset: Charset,
-    #[clap(flatten, next_help_heading = "Project options")]
+    #[clap(flatten)]
     opts: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -20,7 +20,7 @@ pub struct TreeArgs {
         value_name = "CHARSET"
     )]
     charset: Charset,
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[clap(flatten, next_help_heading = "Project options")]
     opts: ProjectPathsArgs,
 }
 

--- a/cli/src/cmd/forge/update.rs
+++ b/cli/src/cmd/forge/update.rs
@@ -3,6 +3,7 @@ use crate::{cmd::Cmd, utils::CommandUtils};
 use clap::{Parser, ValueHint};
 use std::{path::PathBuf, process::Command};
 
+/// CLI arguments for `forge update`.
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
     #[clap(

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -41,7 +41,7 @@ impl Default for VerifierArgs {
     }
 }
 
-/// Verification arguments
+/// CLI arguments for `forge verify`.
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyArgs {
     #[clap(help = "The address of the contract to verify.", value_name = "ADDRESS")]
@@ -117,7 +117,7 @@ pub struct VerifyArgs {
     #[clap(long, help = "Wait for verification result after submission")]
     pub watch: bool,
 
-    #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
+    #[clap(flatten)]
     pub retry: RetryArgs,
 
     #[clap(

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -20,7 +20,7 @@ pub struct VerifierArgs {
     #[clap(
         value_enum,
         long = "verifier",
-        help_heading = "Verification Provider",
+        help_heading = "Verification provider",
         help = "Contract verification provider to use `etherscan`, `sourcify` or `blockscout`",
         default_value = "etherscan"
     )]
@@ -121,7 +121,7 @@ pub struct VerifyArgs {
     pub retry: RetryArgs,
 
     #[clap(
-        help_heading = "LINKER OPTIONS",
+        help_heading = "Linker options",
         help = "Set pre-linked libraries.",
         long,
         env = "DAPP_LIBRARIES",

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -20,6 +20,7 @@ use watchexec::{
 };
 
 #[derive(Debug, Clone, Parser, Default)]
+#[clap(next_help_heading = "Watch options")]
 pub struct WatchArgs {
     /// File update debounce delay
     ///

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -22,6 +22,28 @@ use watchexec::{
 #[derive(Debug, Clone, Parser, Default)]
 #[clap(next_help_heading = "Watch options")]
 pub struct WatchArgs {
+    /// Watch the given files or directories for changes.
+    ///
+    /// If no paths are provided, the source and test directories of the project are watched.
+    #[clap(
+        short,
+        long,
+        value_name = "PATH",
+        num_args(0..),
+        action = ArgAction::Append,
+    )]
+    pub watch: Option<Vec<PathBuf>>,
+
+    /// Do not restart the command while it's still running.
+    #[clap(long)]
+    pub no_restart: bool,
+
+    /// Explicitly re-run all tests when a change is made.
+    ///
+    /// By default, only the tests of the last modified test file are executed.
+    #[clap(long)]
+    pub run_all: bool,
+
     /// File update debounce delay
     ///
     /// During the delay, incoming change events are accumulated and
@@ -37,28 +59,6 @@ pub struct WatchArgs {
     /// overloading disk I/O.
     #[clap(long = "watch-delay", value_parser = clap::builder::NonEmptyStringValueParser::default(), value_name = "DELAY")]
     pub watch_delay: Option<String>,
-
-    #[clap(long = "no-restart", help = "Do not restart the command while it's still running.")]
-    pub no_restart: bool,
-
-    /// Explicitly re-run all tests when a change is made.
-    ///
-    /// By default, only the tests of the last modified test file are executed.
-    #[clap(long = "run-all")]
-    pub run_all: bool,
-
-    /// Watch specific file(s) or folder(s)
-    ///
-    /// By default, the project's source directory is watched.
-    #[clap(
-        short = 'w',
-        long = "watch",
-        value_name = "PATH",
-        num_args(0..),
-        action = ArgAction::Append,
-        help = "Watches the given files or directories for changes. If no paths are provided, the source and test directories of the project are watched."
-    )]
-    pub watch: Option<Vec<PathBuf>>,
 }
 
 impl WatchArgs {

--- a/cli/src/cmd/retry.rs
+++ b/cli/src/cmd/retry.rs
@@ -7,8 +7,9 @@ pub const RETRY_CHECK_ON_VERIFY: RetryArgs = RetryArgs { retries: 8, delay: 15 }
 /// Retry config used when waiting for a created contract
 pub const RETRY_VERIFY_ON_CREATE: RetryArgs = RetryArgs { retries: 15, delay: 5 };
 
-/// A type that keeps track of attempts
+/// Retry arguments for contract verification.
 #[derive(Debug, Clone, Copy, Parser)]
+#[clap(about = "Allows to use retry arguments for contract verification")] // override doc
 pub struct RetryArgs {
     #[clap(
         long,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -749,7 +749,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     },
 }
 
-/// Common args for ToHex, ToDec, ToBase
+/// CLI arguments for `cast --to-base`.
 #[derive(Debug, Parser)]
 pub struct ToBaseArgs {
     #[clap(allow_hyphen_values = true, value_name = "VALUE")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -247,7 +247,7 @@ Examples:
         #[clap(flatten)]
         // TODO: We only need RPC URL + etherscan stuff from this struct
         eth: EthereumOpts,
-        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
+        #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
     },
     #[clap(name = "block")]
@@ -268,7 +268,7 @@ Examples:
         field: Option<String>,
         #[clap(long, env = "CAST_FULL_BLOCK")]
         full: bool,
-        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
+        #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -343,7 +343,7 @@ Examples:
         tx_hash: String,
         #[clap(value_name = "FIELD")]
         field: Option<String>,
-        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
+        #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -372,7 +372,7 @@ Examples:
             help = "Exit immediately if the transaction was not found."
         )]
         cast_async: bool,
-        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
+        #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -37,7 +37,7 @@ pub struct EthereumOpts {
     #[serde(skip)]
     pub chain: Option<Chain>,
 
-    #[clap(flatten, next_help_heading = "WALLET OPTIONS")]
+    #[clap(flatten, next_help_heading = "Wallet options")]
     #[serde(skip)]
     pub wallet: Wallet,
 }

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
 impl_figment_convert_cast!(EthereumOpts);
+
 #[derive(Debug, Clone, Default, Parser, Serialize)]
+#[clap(next_help_heading = "Ethereum options")]
 pub struct EthereumOpts {
     #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The RPC endpoint.", value_name = "URL")]
     pub rpc_url: Option<String>,
@@ -37,7 +39,7 @@ pub struct EthereumOpts {
     #[serde(skip)]
     pub chain: Option<Chain>,
 
-    #[clap(flatten, next_help_heading = "Wallet options")]
+    #[clap(flatten)]
     #[serde(skip)]
     pub wallet: Wallet,
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -164,6 +164,7 @@ pub enum Subcommands {
 //
 // See also [`BuildArgs`]
 #[derive(Default, Debug, Clone, Parser, Serialize)]
+#[clap(next_help_heading = "Compiler options")]
 pub struct CompilerArgs {
     #[clap(help = "The target EVM version.", long, value_name = "VERSION")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -82,18 +82,10 @@ pub enum Subcommands {
     )]
     Remappings(RemappingArgs),
 
-    #[clap(
-        visible_alias = "v",
-        about = "Verify smart contracts on Etherscan.",
-        long_about = "Verify smart contracts on Etherscan."
-    )]
+    #[clap(visible_alias = "v", about = "Verify smart contracts on Etherscan.")]
     VerifyContract(VerifyArgs),
 
-    #[clap(
-        visible_alias = "vc",
-        about = "Check verification status on Etherscan.",
-        long_about = "Check verification status on Etherscan."
-    )]
+    #[clap(visible_alias = "vc", about = "Check verification status on Etherscan.")]
     VerifyCheck(VerifyCheckArgs),
 
     #[clap(visible_alias = "c", about = "Deploy a smart contract.")]

--- a/cli/src/opts/transaction.rs
+++ b/cli/src/opts/transaction.rs
@@ -4,6 +4,7 @@ use ethers::types::U256;
 use serde::Serialize;
 
 #[derive(Parser, Debug, Clone, Serialize)]
+#[clap(next_help_heading = "Transaction options")]
 pub struct TransactionOpts {
     #[clap(
     long = "gas-limit",

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -36,6 +36,7 @@ The wallet options can either be:
 6. Private Key (interactively via secure prompt)
 "#
 )]
+#[clap(next_help_heading = "Wallet options")]
 pub struct Wallet {
     #[clap(
         long,

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -40,14 +40,14 @@ pub struct Wallet {
     #[clap(
         long,
         short,
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Open an interactive prompt to enter your private key."
     )]
     pub interactive: bool,
 
     #[clap(
         long = "private-key",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the provided private key.",
         value_name = "RAW_PRIVATE_KEY",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix
@@ -57,7 +57,7 @@ pub struct Wallet {
     #[clap(
         long = "mnemonic",
         alias = "mnemonic-path",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the mnemonic phrase of mnemonic file at the specified path.",
         value_name = "PATH"
     )]
@@ -65,7 +65,7 @@ pub struct Wallet {
 
     #[clap(
         long = "mnemonic-passphrase",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use a BIP39 passphrase for the mnemonic.",
         value_name = "PASSPHRASE"
     )]
@@ -74,7 +74,7 @@ pub struct Wallet {
     #[clap(
         long = "mnemonic-derivation-path",
         alias = "hd-path",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "The wallet derivation path. Works with both --mnemonic-path and hardware wallets.",
         value_name = "PATH"
     )]
@@ -83,7 +83,7 @@ pub struct Wallet {
     #[clap(
         long = "mnemonic-index",
         conflicts_with = "hd_path",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the private key from the given mnemonic index. Used with --mnemonic-path.",
         default_value = "0",
         value_name = "INDEX"
@@ -93,7 +93,7 @@ pub struct Wallet {
     #[clap(
         env = "ETH_KEYSTORE",
         long = "keystore",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "Use the keystore in the given folder or file.",
         value_name = "PATH"
     )]
@@ -101,7 +101,7 @@ pub struct Wallet {
 
     #[clap(
         long = "password",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "The keystore password. Used with --keystore.",
         requires = "keystore_path",
         value_name = "PASSWORD"
@@ -111,7 +111,7 @@ pub struct Wallet {
     #[clap(
         env = "ETH_PASSWORD",
         long = "password-file",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "The keystore password file path. Used with --keystore.",
         requires = "keystore_path",
         value_name = "PASSWORD_FILE"
@@ -121,7 +121,7 @@ pub struct Wallet {
     #[clap(
         short,
         long = "ledger",
-        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help_heading = "Wallet options - hardware wallet",
         help = "Use a Ledger hardware wallet."
     )]
     pub ledger: bool,
@@ -129,7 +129,7 @@ pub struct Wallet {
     #[clap(
         short,
         long = "trezor",
-        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help_heading = "Wallet options - hardware wallet",
         help = "Use a Trezor hardware wallet."
     )]
     pub trezor: bool,
@@ -138,7 +138,7 @@ pub struct Wallet {
         env = "ETH_FROM",
         short,
         long = "from",
-        help_heading = "WALLET OPTIONS - REMOTE",
+        help_heading = "Wallet options - remote",
         help = "The sender account.",
         value_name = "ADDRESS"
     )]

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -93,7 +93,7 @@ pub struct MultiWallet {
     #[clap(
         long,
         short,
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Open an interactive prompt to enter your private key. Takes a value for the number of keys to enter",
         default_value = "0",
         value_name = "NUM"
@@ -102,7 +102,7 @@ pub struct MultiWallet {
 
     #[clap(
         long = "private-keys",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the provided private keys.",
         value_name = "RAW_PRIVATE_KEYS",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix,
@@ -112,7 +112,7 @@ pub struct MultiWallet {
 
     #[clap(
         long = "private-key",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the provided private key.",
         conflicts_with = "private_keys",
         value_name = "RAW_PRIVATE_KEY",
@@ -123,7 +123,7 @@ pub struct MultiWallet {
     #[clap(
         long = "mnemonics",
         alias = "mnemonic-paths",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the mnemonic phrases or mnemonic files at the specified paths.",
         value_name = "PATHS",
         action = ArgAction::Append,
@@ -132,7 +132,7 @@ pub struct MultiWallet {
 
     #[clap(
         long = "mnemonic-passphrases",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use a BIP39 passphrases for the mnemonic.",
         value_name = "PASSPHRASE",
         action = ArgAction::Append,
@@ -142,7 +142,7 @@ pub struct MultiWallet {
     #[clap(
         long = "mnemonic-derivation-paths",
         alias = "hd-paths",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "The wallet derivation path. Works with both --mnemonic-path and hardware wallets.",
         value_name = "PATHS",
         action = ArgAction::Append,
@@ -152,7 +152,7 @@ pub struct MultiWallet {
     #[clap(
         long = "mnemonic-indexes",
         conflicts_with = "hd_paths",
-        help_heading = "WALLET OPTIONS - RAW",
+        help_heading = "Wallet options - raw",
         help = "Use the private key from the given mnemonic index. Used with --mnemonic-paths.",
         default_value = "0",
         value_name = "INDEXES",
@@ -164,7 +164,7 @@ pub struct MultiWallet {
         env = "ETH_KEYSTORE",
         long = "keystore",
         visible_alias = "keystores",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "Use the keystore in the given folder or file.",
         action = ArgAction::Append,
         value_name = "PATHS",
@@ -173,7 +173,7 @@ pub struct MultiWallet {
 
     #[clap(
         long = "password",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "The keystore password. Used with --keystore.",
         requires = "keystore_paths",
         value_name = "PASSWORDS",
@@ -184,7 +184,7 @@ pub struct MultiWallet {
     #[clap(
         env = "ETH_PASSWORD",
         long = "password-file",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help_heading = "Wallet options - keystore",
         help = "The keystore password file path. Used with --keystore.",
         requires = "keystore_paths",
         value_name = "PASSWORD_FILE"
@@ -194,7 +194,7 @@ pub struct MultiWallet {
     #[clap(
         short,
         long = "ledger",
-        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help_heading = "Wallet options - hardware wallet",
         help = "Use a Ledger hardware wallet."
     )]
     pub ledger: bool,
@@ -202,7 +202,7 @@ pub struct MultiWallet {
     #[clap(
         short,
         long = "trezor",
-        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help_heading = "Wallet options - hardware wallet",
         help = "Use a Trezor hardware wallet."
     )]
     pub trezor: bool,
@@ -211,7 +211,7 @@ pub struct MultiWallet {
         env = "ETH_FROM",
         short = 'a',
         long = "froms",
-        help_heading = "WALLET OPTIONS - REMOTE",
+        help_heading = "Wallet options - remote",
         help = "The sender account.",
         value_name = "ADDRESSES",
         action = ArgAction::Append,

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 /// # }
 /// ```
 #[derive(Debug, Clone, Default, Parser, Serialize)]
-#[clap(next_help_heading = "EVM options")]
+#[clap(next_help_heading = "EVM options", about = None)] // override doc
 pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -35,6 +35,7 @@ use serde::Serialize;
 /// # }
 /// ```
 #[derive(Debug, Clone, Default, Parser, Serialize)]
+#[clap(next_help_heading = "EVM options")]
 pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -136,7 +136,7 @@ impl Provider for EvmArgs {
 
 /// Configures the executor environment during tests.
 #[derive(Debug, Clone, Default, Parser, Serialize)]
-#[clap(next_help_heading = "EXECUTOR ENVIRONMENT CONFIG")]
+#[clap(next_help_heading = "Executor environment config")]
 pub struct EnvArgs {
     /// The block gas limit.
     #[clap(long, value_name = "GAS_LIMIT")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Clap base command headings are `Usage`, `Commands`, `Options` while our custom headings are all in uppercase.

Rustdoc comments "leaking" into the clap help/about of commands (same as #720)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

sed \u help headings + move to struct definitions to avoid repetition when multiple commands depend on it

set `about = None` or an actual about to override the rustdoc, instead of making it a normal comment

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
