### PR TITLE
(Feat Anvil): add geth like debug_traceCall api

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -1109,6 +1109,29 @@ mod tests {
     }
 
     #[test]
+    fn test_serde_debug_trace_call() {
+        let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockNumber": "latest" }]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockNumber": "0x0" }]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" }]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockNumber": "0x0" }, {"disableStorage": true}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
     fn test_serde_eth_storage() {
         let s = r#"{"method": "eth_getStorageAt", "params": ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "0x0", "latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();

--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -263,6 +263,14 @@ pub enum EthRequest {
         #[cfg_attr(feature = "serde", serde(default))] GethDebugTracingOptions,
     ),
 
+    /// geth's `debug_traceCall`  endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "debug_traceCall"))]
+    DebugTraceCall(
+        EthTransactionRequest,
+        #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
+        #[cfg_attr(feature = "serde", serde(default))] GethDebugTracingOptions,
+    ),
+
     /// Trace transaction endpoint for parity's `trace_transaction`
     #[cfg_attr(feature = "serde", serde(rename = "trace_transaction", with = "sequence"))]
     TraceTransaction(H256),

--- a/anvil/tests/it/traces.rs
+++ b/anvil/tests/it/traces.rs
@@ -3,7 +3,7 @@ use anvil::{spawn, NodeConfig};
 use ethers::{
     contract::Contract,
     prelude::{Action, ContractFactory, Middleware, Signer, SignerMiddleware, TransactionRequest},
-    types::{ActionType, Address, Trace},
+    types::{ActionType, Address, GethDebugTracingCallOptions, Trace},
     utils::hex,
 };
 use ethers_solc::{project_util::TempProject, Artifact};
@@ -88,6 +88,55 @@ contract Contract {
     let traces = handle.http_provider().trace_transaction(tx.transaction_hash).await.unwrap();
     assert!(!traces.is_empty());
     assert_eq!(traces[0].action_type, ActionType::Suicide);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transfer_debug_trace_call() {
+    let prj = TempProject::dapptools().unwrap();
+    prj.add_source(
+        "Contract",
+        r#"
+pragma solidity 0.8.13;
+contract Contract {
+    address payable private owner;
+    constructor() public {
+        owner = payable(msg.sender);
+    }
+    function goodbye() public {
+        selfdestruct(owner);
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let mut compiled = prj.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+    let contract = compiled.remove_first("Contract").unwrap();
+    let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.ws_provider().await;
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
+
+    // deploy successfully
+    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let contract = factory.deploy(()).unwrap().send().await.unwrap();
+
+    let contract = Contract::new(
+        contract.address(),
+        abi.unwrap(),
+        SignerMiddleware::new(handle.http_provider(), wallets[1].clone()),
+    );
+    let call = contract.method::<_, ()>("goodbye", ()).unwrap();
+
+    let traces = handle
+        .http_provider()
+        .debug_trace_call(call.tx, None, GethDebugTracingCallOptions::default())
+        .await
+        .unwrap();
+    assert!(!traces.failed);
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2656>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
 trying to address this https://github.com/foundry-rs/foundry/issues/2782 issue. Related https://github.com/foundry-rs/foundry/issues/1737

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug_tracecall geth like api. Return same data like debug_traceTransaction