### PR TITLE
fix(forge): remove early mempool check when broadcasting

### DIFF
--- a/cli/src/cmd/forge/script/receipts.rs
+++ b/cli/src/cmd/forge/script/receipts.rs
@@ -142,12 +142,6 @@ async fn check_tx_status(
             return Ok(receipt.into())
         }
 
-        // Next check if the tx is in the mempool
-        let tx_opt = provider.get_transaction(hash).await?;
-        if tx_opt.is_none() {
-            return Ok(TxStatus::Dropped)
-        }
-
         // If the tx is present in the mempool, run the pending tx future, and
         // assume the next drop is really really real
         let pending_res = PendingTransaction::new(hash, provider).await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We are getting a lot of reports with errors such `Transaction dropped...` , while the transaction has actually been confirmed.

Was able to reproduce it consistently with fuji (#3880). Also saw reports that it happens fairly frequently on avalanche mainnet.

## Solution

Remove an early mempool check. That might be checking it too fast? I'm assuming that a similar thing happens on `goerli` #3969 (can't confirm, since I cannot reproduce it locally for `goerli`).

If it's really dropped, we should know on the return of the following `PendingTransaction.await` anyway. I'd rather wait more on a transaction dropped event, than the current state.

wdyt @prestwich 

Also, leaning towards adding a second `PendingTransaction` attempt, but I want to see if the `CI` performs better with just this fix.
