### PR TITLE
fix(macros): windows tests

### DIFF
--- a/macros/impl/src/utils.rs
+++ b/macros/impl/src/utils.rs
@@ -6,7 +6,7 @@ pub fn krate() -> syn::Path {
 #[inline]
 pub fn crate_str() -> &'static str {
     match std::env::var("CARGO_MANIFEST_DIR") {
-        Ok(var) if var.ends_with("/macros") => "crate",
+        Ok(var) if var.ends_with("macros") => "crate",
         _ => "::foundry_macros",
     }
 }

--- a/macros/src/console_fmt.rs
+++ b/macros/src/console_fmt.rs
@@ -189,6 +189,11 @@ mod tests {
     use crate::ConsoleFmt;
     use std::str::FromStr;
 
+    /// Workaround for the derive macro using `foundry_macros` when it's `crate`.
+    mod foundry_macros {
+        pub use crate::*;
+    }
+
     macro_rules! logf1 {
         ($a:ident) => {{
             let args: [&dyn ConsoleFmt; 1] = [&$a.p_1];

--- a/macros/src/console_fmt.rs
+++ b/macros/src/console_fmt.rs
@@ -189,11 +189,6 @@ mod tests {
     use crate::ConsoleFmt;
     use std::str::FromStr;
 
-    /// Workaround for the derive macro using `foundry_macros` when it's `crate`.
-    mod foundry_macros {
-        pub use crate::*;
-    }
-
     macro_rules! logf1 {
         ($a:ident) => {{
             let args: [&dyn ConsoleFmt; 1] = [&$a.p_1];

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,3 +1,7 @@
+//! Foundry's procedural macros.
+
+// TODO: Remove dependency on foundry-common (currently only used for the UIfmt trait).
+
 mod console_fmt;
 pub use console_fmt::{console_format, ConsoleFmt, FormatSpec};
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Derive macro was using `crate::` for when manifest dir ended with /macros so windows would not use this

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

```diff
- .ends_with("/macros")
+ .ends_with("macros")
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
