### PR TITLE
fix(cast): only set function args if signature provided

### DIFF
--- a/cast/src/errors.rs
+++ b/cast/src/errors.rs
@@ -6,6 +6,7 @@ use std::fmt;
 /// An error thrown when resolving a function via signature failed
 #[derive(Debug, Clone)]
 pub enum FunctionSignatureError {
+    MissingSignature,
     MissingEtherscan { sig: String },
     UnknownChain(Chain),
     MissingToAddress,
@@ -14,6 +15,9 @@ pub enum FunctionSignatureError {
 impl fmt::Display for FunctionSignatureError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            FunctionSignatureError::MissingSignature => {
+                writeln!(f, "Function signature must be set")
+            }
             FunctionSignatureError::MissingEtherscan { sig } => {
                 writeln!(f, "Failed to determine function signature for `{sig}`")?;
                 writeln!(f, "To lookup a function signature of a deployed contract by name, a valid ETHERSCAN_API_KEY must be set.")?;

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -98,26 +98,29 @@ where
         let (tx, func) = builder_output;
         let res = self.provider.call(&tx, block).await?;
 
-        // decode args into tokens
-        let func = func.expect("no valid function signature was provided.");
-        let decoded = match func.decode_output(res.as_ref()) {
-            Ok(decoded) => decoded,
-            Err(err) => {
-                // ensure the address is a contract
-                if res.is_empty() {
-                    // check that the recipient is a contract that can be called
-                    if let Some(NameOrAddress::Address(addr)) = tx.to() {
-                        let code = self.provider.get_code(*addr, block).await?;
-                        if code.is_empty() {
-                            eyre::bail!("Contract {:?} does not exist", addr)
+        let mut decoded = vec![];
+
+        if let Some(func) = func {
+            // decode args into tokens
+            decoded = match func.decode_output(res.as_ref()) {
+                Ok(decoded) => decoded,
+                Err(err) => {
+                    // ensure the address is a contract
+                    if res.is_empty() {
+                        // check that the recipient is a contract that can be called
+                        if let Some(NameOrAddress::Address(addr)) = tx.to() {
+                            let code = self.provider.get_code(*addr, block).await?;
+                            if code.is_empty() {
+                                eyre::bail!("Contract {:?} does not exist", addr)
+                            }
                         }
                     }
+                    return Err(err).wrap_err(
+                        "could not decode output. did you specify the wrong function return data type perhaps?"
+                    );
                 }
-                return Err(err).wrap_err(
-                    "could not decode output. did you specify the wrong function return data type perhaps?"
-                );
-            }
-        };
+            };
+        }
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {
             format!("{res}\n")

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -170,6 +170,10 @@ impl<'a, M: Middleware> TxBuilder<'a, M> {
         sig: &str,
         args: Vec<String>,
     ) -> Result<(Vec<u8>, Function)> {
+        if sig.trim().is_empty() {
+            return Err(FunctionSignatureError::MissingSignature.into())
+        }
+
         let args = resolve_name_args(&args, self.provider).await;
 
         let func = if sig.contains('(') {

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -93,7 +93,10 @@ impl CallArgs {
                 builder.set_data(data);
             }
             _ => {
-                builder.value(tx.value).set_args(sig.unwrap().as_str(), args).await?;
+                builder.value(tx.value);
+                if let Some(sig) = sig {
+                    builder.set_args(sig.as_str(), args).await?;
+                }
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4016

only set args if `sig` argument provided.

```
cast call
0x
```

```
cast call 0x<address>
0x
```

should cast call without an address arg fail @prestwich ?

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
