### PR TITLE
refactor(fmt): change default for `override_spacing` to `false`

### DIFF
--- a/config/src/fmt.rs
+++ b/config/src/fmt.rs
@@ -113,7 +113,7 @@ impl Default for FormatterConfig {
             quote_style: QuoteStyle::Double,
             number_underscore: NumberUnderscore::Preserve,
             single_line_statement_blocks: SingleLineBlockStyle::Preserve,
-            override_spacing: true,
+            override_spacing: false,
             wrap_comments: false,
             ignore: vec![],
         }

--- a/fmt/testdata/FunctionDefinition/all.fmt.sol
+++ b/fmt/testdata/FunctionDefinition/all.fmt.sol
@@ -718,7 +718,7 @@ contract FunctionOverrides is
     }
 
     function oneParam(uint256 x)
-        override (
+        override(
             FunctionInterfaces,
             FunctionDefinitions,
             SomeOtherFunctionContract,

--- a/fmt/testdata/FunctionDefinition/fmt.sol
+++ b/fmt/testdata/FunctionDefinition/fmt.sol
@@ -697,7 +697,7 @@ contract FunctionOverrides is
     }
 
     function oneParam(uint256 x)
-        override (
+        override(
             FunctionInterfaces,
             FunctionDefinitions,
             SomeOtherFunctionContract,

--- a/fmt/testdata/FunctionDefinition/override-spacing.fmt.sol
+++ b/fmt/testdata/FunctionDefinition/override-spacing.fmt.sol
@@ -1,5 +1,5 @@
 // config: line_length = 60
-// config: override_spacing = false
+// config: override_spacing = true
 interface FunctionInterfaces {
     function noParamsNoModifiersNoReturns();
 
@@ -698,7 +698,7 @@ contract FunctionOverrides is
     }
 
     function oneParam(uint256 x)
-        override(
+        override (
             FunctionInterfaces,
             FunctionDefinitions,
             SomeOtherFunctionContract,

--- a/fmt/testdata/FunctionDefinition/params-first.fmt.sol
+++ b/fmt/testdata/FunctionDefinition/params-first.fmt.sol
@@ -698,7 +698,7 @@ contract FunctionOverrides is
     }
 
     function oneParam(uint256 x)
-        override (
+        override(
             FunctionInterfaces,
             FunctionDefinitions,
             SomeOtherFunctionContract,

--- a/fmt/testdata/ModifierDefinition/fmt.sol
+++ b/fmt/testdata/ModifierDefinition/fmt.sol
@@ -10,5 +10,5 @@ contract ModifierDefinitions {
         uint256 c,
         uint256 d
     ) {}
-    modifier overridden() override (Base1, Base2) {}
+    modifier overridden() override(Base1, Base2) {}
 }

--- a/fmt/testdata/ModifierDefinition/override-spacing.fmt.sol
+++ b/fmt/testdata/ModifierDefinition/override-spacing.fmt.sol
@@ -1,5 +1,5 @@
 // config: line_length = 60
-// config: override_spacing = false
+// config: override_spacing = true
 contract ModifierDefinitions {
     modifier noParams() {}
     modifier oneParam(uint256 a) {}
@@ -11,5 +11,5 @@ contract ModifierDefinitions {
         uint256 c,
         uint256 d
     ) {}
-    modifier overridden() override(Base1, Base2) {}
+    modifier overridden() override (Base1, Base2) {}
 }

--- a/fmt/testdata/VariableDefinition/fmt.sol
+++ b/fmt/testdata/VariableDefinition/fmt.sol
@@ -4,11 +4,11 @@ contract Contract {
     bytes32
         private
         constant
-        override (Base1) BYTES;
+        override(Base1) BYTES;
     bytes32
         private
         constant
-        override (Base1, Base2) BYTES;
+        override(Base1, Base2) BYTES;
     bytes32
         private
         constant
@@ -23,7 +23,7 @@ contract Contract {
     bytes32
         private
         constant
-        override (
+        override(
             Base1,
             Base2,
             SomeLongBaseContract,

--- a/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
+++ b/fmt/testdata/VariableDefinition/override-spacing.fmt.sol
@@ -1,15 +1,15 @@
 // config: line_length = 40
-// config: override_spacing = false
+// config: override_spacing = true
 contract Contract {
     bytes32 private constant BYTES;
     bytes32
         private
         constant
-        override(Base1) BYTES;
+        override (Base1) BYTES;
     bytes32
         private
         constant
-        override(Base1, Base2) BYTES;
+        override (Base1, Base2) BYTES;
     bytes32
         private
         constant
@@ -24,7 +24,7 @@ contract Contract {
     bytes32
         private
         constant
-        override(
+        override (
             Base1,
             Base2,
             SomeLongBaseContract,


### PR DESCRIPTION
## Motivation

[The Solidity documentation](https://docs.soliditylang.org/en/v0.8.17/contracts.html#function-overriding) uses no spacing between the `override` keyword and the overridden contract names:

```solidity
contract Inherited is Base1, Base2
{
    // Derives from multiple bases defining foo(), so we must explicitly
    // override it
    function foo() public override(Base1, Base2) {}
}
```

Anecdotally, most Solidity code bases I've seen adhere to the same pattern where there is no spacing. This is perhaps the same reason why @benesjan opened issue #3522 in the first place.

## Solution

Set the default value of `variable_override_spacing` to `false`.

Though, before this is merged in, we should fix #4025 first.