### PR TITLE
feat(anvil): enable dumping state while forked

### DIFF
--- a/anvil/src/eth/backend/mem/fork_db.rs
+++ b/anvil/src/eth/backend/mem/fork_db.rs
@@ -1,10 +1,12 @@
 use crate::{
-    eth::backend::db::{Db, MaybeHashDatabase, SerializableState, StateDb},
+    eth::backend::db::{
+        Db, MaybeHashDatabase, SerializableAccountRecord, SerializableState, StateDb,
+    },
     revm::AccountInfo,
     Address, U256,
 };
 use ethers::prelude::H256;
-use forge::revm::Database;
+use forge::revm::{Bytecode, Database, KECCAK_EMPTY};
 pub use foundry_evm::executor::fork::database::ForkedDatabase;
 use foundry_evm::executor::{
     backend::{snapshot::StateSnapshot, DatabaseResult},
@@ -28,11 +30,60 @@ impl Db for ForkedDatabase {
     }
 
     fn dump_state(&self) -> DatabaseResult<Option<SerializableState>> {
-        Ok(None)
+        let db = self.database();
+        let accounts = db
+            .accounts
+            .clone()
+            .into_iter()
+            .map(|(k, v)| -> DatabaseResult<_> {
+                let code = if let Some(code) = v.info.code {
+                    code
+                } else {
+                    db.clone().code_by_hash(v.info.code_hash)?
+                }
+                .to_checked();
+                Ok((
+                    k,
+                    SerializableAccountRecord {
+                        nonce: v.info.nonce,
+                        balance: v.info.balance,
+                        code: code.bytes()[..code.len()].to_vec().into(),
+                        storage: v.storage.into_iter().collect(),
+                    },
+                ))
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(Some(SerializableState { accounts }))
     }
 
-    fn load_state(&mut self, _buf: SerializableState) -> DatabaseResult<bool> {
-        Ok(false)
+    fn load_state(&mut self, state: SerializableState) -> DatabaseResult<bool> {
+        for (addr, account) in state.accounts.into_iter() {
+            let old_account_nonce =
+                self.database_mut().accounts.get(&addr).map(|a| a.info.nonce).unwrap_or_default();
+            // use max nonce in case account is imported multiple times with difference
+            // nonces to prevent collisions
+            let nonce = std::cmp::max(old_account_nonce, account.nonce);
+
+            self.insert_account(
+                addr,
+                AccountInfo {
+                    balance: account.balance,
+                    code_hash: KECCAK_EMPTY, // will be set automatically
+                    code: if account.code.0.is_empty() {
+                        None
+                    } else {
+                        Some(Bytecode::new_raw(account.code.0).to_checked())
+                    },
+                    nonce,
+                },
+            );
+
+            for (k, v) in account.storage.into_iter() {
+                self.set_storage_at(addr, k, v)?;
+            }
+        }
+
+        Ok(true)
     }
 
     fn snapshot(&mut self) -> U256 {

--- a/anvil/src/eth/backend/mem/fork_db.rs
+++ b/anvil/src/eth/backend/mem/fork_db.rs
@@ -30,8 +30,9 @@ impl Db for ForkedDatabase {
     }
 
     fn dump_state(&self) -> DatabaseResult<Option<SerializableState>> {
-        let db = self.database();
-        let accounts = db
+        let mut db = self.database().clone();
+        let accounts = self
+            .database()
             .accounts
             .clone()
             .into_iter()
@@ -39,7 +40,7 @@ impl Db for ForkedDatabase {
                 let code = if let Some(code) = v.info.code {
                     code
                 } else {
-                    db.clone().code_by_hash(v.info.code_hash)?
+                    db.code_by_hash(v.info.code_hash)?
                 }
                 .to_checked();
                 Ok((


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Addresses: https://github.com/foundry-rs/foundry/issues/4026

Anvil currently does not have state dump / loading enabled when using a fork. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Implement, code is modified from non fork methods.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
