### PR TITLE
Revert "ci: run cross platform tests only on push"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,5 @@ jobs:
 
     cross-platform:
         name: Cross-platform tests
-        if: github.event_name != "pull_request"
         needs: [integration, lint, doc, unit]
         uses: ./.github/workflows/cross-platform.yml


### PR DESCRIPTION
Reverts foundry-rs/foundry#4028

`The workflow is not valid. .github/workflows/test.yml (Line: 224, Col: 13): Unexpected symbol: '"pull_request"'. Located at position 22 within expression: github.event_name != "pull_request"`

cc @DaniPopes 