### PR TITLE
Fix `--sizes` for contracts without ABI

### DIFF
--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -147,11 +147,17 @@ impl ProjectCompiler {
             for (name, artifact) in artifacts {
                 let size = deployed_contract_size(artifact).unwrap_or_default();
 
-                let dev_functions = artifact.abi.as_ref().unwrap().abi.functions().filter(|func| {
-                    func.name.is_test() || func.name.eq("IS_TEST") || func.name.eq("IS_SCRIPT")
-                });
+                let dev_functions = artifact
+                    .abi
+                    .as_ref()
+                    .map(|abi| abi.abi.functions())
+                    .into_iter()
+                    .flatten()
+                    .filter(|func| {
+                        func.name.is_test() || func.name.eq("IS_TEST") || func.name.eq("IS_SCRIPT")
+                    });
 
-                let is_dev_contract = dev_functions.into_iter().count() > 0;
+                let is_dev_contract = dev_functions.count() > 0;
                 size_report.contracts.insert(name, ContractInfo { size, is_dev_contract });
             }
 


### PR DESCRIPTION
When running `forge build --sizes` in a project with contracts without ABI, it fails with:
```
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: common/src/compile.rs:151
```

This PR fixes this
