### PR TITLE
fix: don't prompt for password in cast call/estimate when ETH_FROM ad…

### DIFF
--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -10,7 +10,7 @@ use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{
     providers::Middleware,
-    types::{BlockId, NameOrAddress, U256},
+    types::{Address, BlockId, NameOrAddress, U256},
 };
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
@@ -71,7 +71,7 @@ impl CallArgs {
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
 
-        let from = eth.sender().await;
+        let from = eth.wallet.from.unwrap_or(Address::zero());
         let mut builder = TxBuilder::new(&provider, from, to, chain, tx.legacy).await?;
         builder
             .gas(tx.gas_limit)

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -7,7 +7,7 @@ use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{
     providers::Middleware,
-    types::{NameOrAddress, U256},
+    types::{Address, NameOrAddress, U256},
 };
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
@@ -69,7 +69,7 @@ impl EstimateArgs {
         let chain: Chain =
             if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
 
-        let from = eth.sender().await;
+        let from = eth.wallet.from.unwrap_or(Address::zero());
         let mut builder = TxBuilder::new(&provider, from, to, chain, false).await?;
         builder.etherscan_api_key(config.get_etherscan_api_key(Some(chain)));
         match command {


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/4035

If the `ETH_FROM` env var is set, `cast call` and `cast estimate` may try to unlock the keystore for that address by interactively requesting the keystore password.

This PR changes that, since these methods are not sending txs and therefore do not need the signer unlocked. It defaults to using the zero address as the from address, unless one is specified with the `--from` flag (@mattsse I assume `eth.wallet.from` would also hold the `ETH_FROM` address if that env var is defined? I never really use that env var so I'm not sure and haven't tested). This is consistent with [seth's](https://github.com/dapphub/dapptools/blob/1be7d796a468f52a5eb5b6830591d76a3b4b1c49/src/seth/libexec/seth/seth-call#L60) and [geth's](https://geth.ethereum.org/docs/rpc/ns-eth#eth_call) behavior

This is similar to https://github.com/foundry-rs/foundry/pull/716, which it seems got changed in a refactor at some point

