### PR TITLE
feat: add user agent to etherscan API client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "path-slash",
  "pretty_assertions",
  "regex",
+ "reqwest",
  "semver",
  "serde",
  "serde_regex",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -40,6 +40,7 @@ semver = { version = "1.0.5", features = ["serde"] }
 tracing = "0.1"
 once_cell = "1.13"
 thiserror = "1.0"
+reqwest = { version = "0.11", default-features = false}
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.2.0"

--- a/config/src/etherscan.rs
+++ b/config/src/etherscan.rs
@@ -13,6 +13,9 @@ use std::{
 };
 use tracing::warn;
 
+/// The user agent to use when querying the etherscan API.
+pub const ETHERSCAN_USER_AGENT: &str = concat!("foundry/", env!("CARGO_PKG_VERSION"));
+
 /// Errors that can occur when creating an `EtherscanConfig`
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EtherscanConfigError {
@@ -256,6 +259,7 @@ impl ResolvedEtherscanConfig {
         }
 
         ethers_etherscan::Client::builder()
+            .with_client(reqwest::Client::builder().user_agent(ETHERSCAN_USER_AGENT).build()?)
             .with_api_key(api_key)
             .with_api_url(api_url.as_str())?
             .with_url(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
there are reports that etherscan responds with 403 if no user-agent is provided https://stackoverflow.com/questions/69312369/etherscan-api-request-403-forbidden-in-ropsten-network


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This sets `foundry/<version>` as user-agent

cc @hexonaut 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
