### PR TITLE
Support running forge as a rust lib

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -37,7 +37,7 @@ pub struct MultiContractRunner {
     /// All known errors, used for decoding reverts
     pub errors: Option<Abi>,
     /// The address which will be used as the `from` field in all EVM calls
-    sender: Option<Address>,
+    pub sender: Option<Address>,
     /// A map of contract names to absolute source file paths
     pub source_paths: BTreeMap<String, String>,
     /// The fork to use at launch


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
In order to use forge as a library, it's neccessary to expose the `sender` field in `MultiContractRunner`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This pr simply makes the `sender` field public.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

closes #4087