### PR TITLE
feat(forge): add support for getting bytecode from Huff artifacts

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -72,6 +72,7 @@ enum ArtifactBytecode {
     Hardhat(HardhatArtifact),
     Solc(JsonAbi),
     Forge(CompactContractBytecode),
+    Huff(HuffArtifact),
 }
 
 impl ArtifactBytecode {
@@ -82,6 +83,7 @@ impl ArtifactBytecode {
                 inner.bytecode.and_then(|bytecode| bytecode.object.into_bytes())
             }
             ArtifactBytecode::Solc(inner) => inner.bytecode(),
+            ArtifactBytecode::Huff(inner) => Some(inner.bytecode),
         }
     }
 
@@ -92,6 +94,7 @@ impl ArtifactBytecode {
                 bytecode.bytecode.and_then(|bytecode| bytecode.object.into_bytes())
             }),
             ArtifactBytecode::Solc(inner) => inner.deployed_bytecode(),
+            ArtifactBytecode::Huff(inner) => Some(inner.runtime),
         }
     }
 }
@@ -104,6 +107,15 @@ struct HardhatArtifact {
     bytecode: ethers::types::Bytes,
     #[serde(deserialize_with = "ethers::solc::artifacts::deserialize_bytes")]
     deployed_bytecode: ethers::types::Bytes,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HuffArtifact {
+    #[serde(deserialize_with = "ethers::solc::artifacts::deserialize_bytes")]
+    bytecode: ethers::types::Bytes,
+    #[serde(deserialize_with = "ethers::solc::artifacts::deserialize_bytes")]
+    runtime: ethers::types::Bytes,
 }
 
 /// Returns the _deployed_ bytecode (`bytecode`) of the matching artifact

--- a/testdata/cheats/GetCode.t.sol
+++ b/testdata/cheats/GetCode.t.sol
@@ -43,6 +43,27 @@ contract GetCodeTest is DSTest {
         assertEq(string(fullPath), expected, "code for full path was incorrect");
     }
 
+    function testGetCodeHuffArtifact() public {
+        string memory path = "../testdata/fixtures/GetCode/HuffWorkingContract.json";
+        bytes memory bytecode = cheats.getCode(path);
+        string memory expected = string(
+            bytes(
+                hex"602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3"
+            )
+        );
+        assertEq(string(bytecode), expected, "code for path was incorrect");
+
+        // deploy the contract from the bytecode
+        address deployed;
+        assembly {
+            deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+        // get the deployed code using the cheatcode
+        bytes memory deployedCode = cheats.getDeployedCode(path);
+        // compare the loaded code to the actual deployed code
+        assertEq(string(deployedCode), string(deployed.code), "deployedCode for path was incorrect");
+    }
+
     function testFailGetUnlinked() public {
         cheats.getCode("UnlinkedContract.sol");
     }

--- a/testdata/fixtures/GetCode/HuffWorkingContract.json
+++ b/testdata/fixtures/GetCode/HuffWorkingContract.json
@@ -1,0 +1,32 @@
+{
+    "file": {
+      "path": "src/WorkingContract.huff"
+    },
+    "bytecode": "602d8060093d393df33d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3",
+    "runtime": "3d3560e01c63d1efd30d14610012573d3dfd5b6f656d6f2e6574682077757a206865726560801b3d523d6020f3",
+    "abi": {
+      "constructor": null,
+      "functions": {
+        "secret": {
+          "name": "secret",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "kind": {
+                "Uint": 256
+              },
+              "internal_type": null
+            }
+          ],
+          "constant": false,
+          "state_mutability": "View"
+        }
+      },
+      "events": {},
+      "errors": {},
+      "receive": false,
+      "fallback": false
+    }
+  }
+  


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

While not directly supported by Foundry, a good deal of [Huff EVM smart contract language](https://github.com/huff-language/huff-rs) tooling is based on Foundry, such as the [`foundry-huff` repo](https://github.com/huff-language/foundry-huff).

Since Foundry cannot load Huff artifacts, [standard procedure is to run tests and scripts using the potentially-unsafe `ffi` cheatcode](https://github.com/huff-language/foundry-huff/blob/main/src/HuffConfig.sol#L10) to compile and then load smart contract bytecode.




## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adding support for Huff artifacts to the `getCode` and `getDeployedCode` cheatcodes will make interacting with pre-compiled Huff smart contracts much easier and safer, as devs can compile Huff artifacts as part of a separate build step, and then use the `getCode` and `getDeployedCode` cheatcodes to interact with them. This pattern is already the norm when working with multiple versions of solc in the same Foundry project.

The `HuffArtifact` struct is mostly a copy of the `HardhatArtifact` struct, and minimally deserializes the `bytecode` and `runtime` properties from the Huff JSON artifacts.

Included is a Forge test that ensures both creation and runtime code can be retrieved with the cheatcodes.

