### PR TITLE
fix: serialize empty array to JSON

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -454,13 +454,13 @@ fn serialize_json(
 /// ellements. This is to signify that the elements of the array are string themselves.
 fn array_str_to_str<T: UIfmt>(array: &Vec<T>) -> String {
     format!(
-        "[{}",
+        "[{}]",
         array
             .iter()
             .enumerate()
             .map(|(index, value)| {
                 if index == array.len() - 1 {
-                    format!("\"{}\"]", value.pretty())
+                    format!("\"{}\"", value.pretty())
                 } else {
                     format!("\"{}\",", value.pretty())
                 }
@@ -474,13 +474,13 @@ fn array_str_to_str<T: UIfmt>(array: &Vec<T>) -> String {
 /// etc.)
 fn array_eval_to_str<T: UIfmt>(array: &Vec<T>) -> String {
     format!(
-        "[{}",
+        "[{}]",
         array
             .iter()
             .enumerate()
             .map(|(index, value)| {
                 if index == array.len() - 1 {
-                    format!("{}]", value.pretty())
+                    value.pretty()
                 } else {
                     format!("{},", value.pretty())
                 }

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -168,7 +168,13 @@ contract WriteJson is DSTest {
         bytes[] memory data3 = new bytes[](3);
         data3[0] = bytes("123");
         data3[2] = bytes("fpovhpgjaiosfjhapiufpsdf");
-        string memory finalJson = vm.serializeBytes(json1, "array3", data3);
+        vm.serializeBytes(json1, "array3", data3);
+
+        uint256[] memory data4 = new uint256[](0);
+        vm.serializeUint(json1, "array4", data4);
+
+        address[] memory data5 = new address[](0);
+        string memory finalJson = vm.serializeAddress(json1, "array5", data5);
 
         string memory path = "../testdata/fixtures/Json/write_test_array.json";
         vm.writeJson(finalJson, path);
@@ -194,6 +200,15 @@ contract WriteJson is DSTest {
         assertEq(parsedData3[0], data3[0]);
         assertEq(parsedData3[1], data3[1]);
         assertEq(parsedData3[2], data3[2]);
+
+        rawData = vm.parseJson(json, ".array4");
+        uint256[] memory parsedData4 = new uint256[](0);
+        parsedData4 = abi.decode(rawData, (uint256[]));
+
+        rawData = vm.parseJson(json, ".array5");
+        address[] memory parsedData5 = new address[](0);
+        parsedData5 = abi.decode(rawData, (address[]));
+
         vm.removeFile(path);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Serializing an empty array resulted in an incomplete JSON `"["`. e.g.

```solidity
address[] memory arr = new address[](0);
console.log(stdJson.serialize("", "qwer", arr));
// Logs {"qwer":"["}
```

Experienced the bug in:
- MacOS 12.6, Apple M1 chip
- forge 0.2.0 (e1eb912 2023-01-17T00:11:52.918569Z)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Fix the array serializer functions `array_eval_to_str` and `array_str_to_str` to work when `array.len() == 0`
- Add a test in `testdata/cheats`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
