### PR TITLE
chore(forge): doc, context on custom tags

### DIFF
--- a/doc/src/parser/comment.rs
+++ b/doc/src/parser/comment.rs
@@ -46,7 +46,7 @@ impl FromStr for CommentTag {
                     _ => CommentTag::Custom(custom_tag.to_owned()),
                 }
             }
-            _ => eyre::bail!("unknown comment tag: {trimmed}"),
+            _ => eyre::bail!("unknown comment tag: {trimmed}, custom tags must be preceded by \"custom:\""),
         };
         Ok(tag)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We encountered an error on invalid natspec tags when using `forge doc`, we didn't know custom natspec tags had to be preceded by the string `"custom:"` and it appears this is a recent addition to natspec, much to our confusion. Another user encountered the same problem

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add some extra context on the "unknown comment tag" error, guiding the user towards learning about `"custom:"`

Otherwise, if this PR is not merged, they might then stumble upon the issue below when they encounter the error. I'm not sure it is appropriate to provide context on error messages.

related to #4118 