### PR TITLE
fix(chisel): panic on empty input

### DIFF
--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -759,7 +759,7 @@ impl ChiselDispatcher {
         // Check if the input is a builtin command.
         // Commands are denoted with a `!` leading character.
         if input.starts_with(COMMAND_LEADER) {
-            let split: Vec<&str> = input.split(' ').collect();
+            let split: Vec<&str> = input.split_whitespace().collect();
             let raw_cmd = &split[0][1..];
 
             return match raw_cmd.parse::<ChiselCommand>() {
@@ -773,8 +773,8 @@ impl ChiselDispatcher {
                     DispatchResult::UnrecognizedCommand(e)
                 }
             }
-        } else if input.is_empty() {
-            return DispatchResult::CommandFailed(Self::make_error("Input is empty."))
+        } else if input.trim().is_empty() {
+            return DispatchResult::CommandSuccess(None)
         }
 
         // Get a mutable reference to the session source


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Chisel currently returns an error when the input is completely empty, or panics with the following message when it is only whitespaces:

```text
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', chisel/src/executor.rs:215:55
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Return `CommandSuccess(None)` when the input is only whitespace or empty, as it shouldn't error

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
