### PR TITLE
chore: improve error message if given verifier url is host only

### DIFF
--- a/cli/src/cmd/forge/verify/provider.rs
+++ b/cli/src/cmd/forge/verify/provider.rs
@@ -63,20 +63,19 @@ pub enum VerificationProviderType {
 
 impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
-    #[allow(clippy::box_default)]
     pub fn client(&self, key: &Option<String>) -> eyre::Result<Box<dyn VerificationProvider>> {
         match self {
             VerificationProviderType::Etherscan => {
                 if key.as_ref().map_or(true, |key| key.is_empty()) {
                     eyre::bail!("ETHERSCAN_API_KEY must be set")
                 }
-                Ok(Box::new(EtherscanVerificationProvider::default()))
+                Ok(Box::<EtherscanVerificationProvider>::default())
             }
             VerificationProviderType::Sourcify => {
-                Ok(Box::new(SourcifyVerificationProvider::default()))
+                Ok(Box::<SourcifyVerificationProvider>::default())
             }
             VerificationProviderType::Blockscout => {
-                Ok(Box::new(EtherscanVerificationProvider::default()))
+                Ok(Box::<EtherscanVerificationProvider>::default())
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4056

Adds a check on error if the provided verifier URL is either invalid or host only, indicating missing /api
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
