### PR TITLE
fix(anvil): fix forked block edge case

### DIFF
--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -77,6 +77,50 @@ async fn test_fork_eth_get_balance() {
     }
 }
 
+// <https://github.com/foundry-rs/foundry/issues/4082>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_eth_get_balance_after_mine() {
+    let (api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+    let info = api.anvil_node_info().await.unwrap();
+    let number = info.fork_config.fork_block_number.unwrap();
+    assert_eq!(number, BLOCK_NUMBER);
+
+    let address = Address::random();
+
+    let _balance = provider
+        .get_balance(address, Some(BlockNumber::Number(number.into()).into()))
+        .await
+        .unwrap();
+
+    api.evm_mine(None).await.unwrap();
+
+    let _balance = provider
+        .get_balance(address, Some(BlockNumber::Number(number.into()).into()))
+        .await
+        .unwrap();
+}
+
+// <https://github.com/foundry-rs/foundry/issues/4082>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_eth_get_code_after_mine() {
+    let (api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+    let info = api.anvil_node_info().await.unwrap();
+    let number = info.fork_config.fork_block_number.unwrap();
+    assert_eq!(number, BLOCK_NUMBER);
+
+    let address = Address::random();
+
+    let _code =
+        provider.get_code(address, Some(BlockNumber::Number(number.into()).into())).await.unwrap();
+
+    api.evm_mine(None).await.unwrap();
+
+    let _code =
+        provider.get_code(address, Some(BlockNumber::Number(number.into()).into())).await.unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_code() {
     let (api, handle) = spawn(fork_config()).await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4082

This fixes an edge case where data from the forked block was requests (eth_getBalance) after the first block was mined.
Since we don't have a historic state for the forked block there was essentially an off-by-one error.

There's another edge case that prevents us from just requesting everything from remote under these circumstances, because relevant account could be provided via genesis which overrides remote accounts.

This introduces a new Database type that checks all genesis account infos first and fetch from remote otherwise.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
