### PR TITLE
feat(forge): Add `compile` alias to `forge build`

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -54,7 +54,7 @@ pub enum Subcommands {
     #[clap(alias = "bi", about = "Generate Rust bindings for smart contracts.")]
     Bind(BindArgs),
 
-    #[clap(visible_alias = "b", about = "Build the project's smart contracts.")]
+    #[clap(visible_aliases = ["b", "compile"], about = "Build the project's smart contracts.")]
     Build(BuildArgs),
 
     #[clap(visible_alias = "d", about = "Debugs a single smart contract as a script.")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Adds the alias compile to forge build. Closes #3987 

I've done the initial work, but the issue never received "approval" from the maintainers so will close this PR or try to implement any further logic we want pending.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
