### PR TITLE
fix(chisel): invalid input panic

### DIFF
--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -25,11 +25,11 @@ use strum::IntoEnumIterator;
 use yansi::Paint;
 
 /// Prompt arrow slice
-pub static PROMPT_ARROW: char = '➜';
+static PROMPT_ARROW: char = '➜';
 /// Command leader character
-pub static COMMAND_LEADER: char = '!';
+static COMMAND_LEADER: char = '!';
 /// Chisel character
-pub static CHISEL_CHAR: &str = "⚒️";
+static CHISEL_CHAR: &str = "⚒️";
 
 /// Chisel input dispatcher
 #[derive(Debug)]
@@ -281,7 +281,7 @@ impl ChiselDispatcher {
                         session_source.config.foundry_config.fmt.clone(),
                     ) {
                         Ok(formatted_source) => DispatchResult::CommandSuccess(Some(
-                            SolidityHelper::highlight(&formatted_source).into_owned(),
+                            SolidityHelper::highlight(&formatted_source),
                         )),
                         Err(_) => DispatchResult::CommandFailed(String::from(
                             "Failed to format session source",

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -25,11 +25,11 @@ use strum::IntoEnumIterator;
 use yansi::Paint;
 
 /// Prompt arrow slice
-static PROMPT_ARROW: char = '➜';
+pub static PROMPT_ARROW: char = '➜';
 /// Command leader character
-static COMMAND_LEADER: char = '!';
+pub static COMMAND_LEADER: char = '!';
 /// Chisel character
-static CHISEL_CHAR: &str = "⚒️";
+pub static CHISEL_CHAR: &str = "⚒️";
 
 /// Chisel input dispatcher
 #[derive(Debug)]
@@ -281,7 +281,7 @@ impl ChiselDispatcher {
                         session_source.config.foundry_config.fmt.clone(),
                     ) {
                         Ok(formatted_source) => DispatchResult::CommandSuccess(Some(
-                            SolidityHelper::highlight(&formatted_source),
+                            SolidityHelper::highlight(&formatted_source).into_owned(),
                         )),
                         Err(_) => DispatchResult::CommandFailed(String::from(
                             "Failed to format session source",

--- a/chisel/src/solidity_helper.rs
+++ b/chisel/src/solidity_helper.rs
@@ -21,7 +21,7 @@ use yansi::{Color, Paint, Style};
 /// The default pre-allocation for solang parsed comments
 const DEFAULT_COMMENTS: usize = 5;
 
-/// The maximum length of an ANSI prefix + suffix characters using [SolidityHelper].
+/// The maximum length of the ANSI prefix + suffix characters when using [SolidityHelper].
 ///
 /// * 5 - prefix:
 ///   * 2 - start: `\x1B[`
@@ -85,7 +85,7 @@ impl SolidityHelper {
 
     /// Highlights a solidity source string
     pub fn highlight(input: &str) -> Cow<str> {
-        if !Paint::is_enabled() {
+        if !Paint::is_enabled() || Self::skip_input(input) {
             return Cow::Borrowed(input)
         }
 
@@ -132,6 +132,11 @@ impl SolidityHelper {
 
     /// Validate that a source snippet is closed (i.e., all braces and parenthesis are matched).
     fn validate_closed(input: &str) -> ValidationResult {
+        if Self::skip_input(input) {
+            let msg = Paint::red("\nInput must not start with `.<number>`");
+            return ValidationResult::Invalid(Some(msg.to_string()))
+        }
+
         let mut bracket_depth = 0usize;
         let mut paren_depth = 0usize;
         let mut brace_depth = 0usize;
@@ -183,6 +188,14 @@ impl SolidityHelper {
         let _ = style.fmt_prefix(out);
         out.push_str(string);
         let _ = style.fmt_suffix(out);
+    }
+
+    /// Whether to skip parsing this input due to known errors or panics
+    #[inline]
+    fn skip_input(input: &str) -> bool {
+        // input.startsWith(/\.[0-9]/)
+        let mut chars = input.chars();
+        chars.next() == Some('.') && chars.next().map(|c| c.is_ascii_digit()).unwrap_or_default()
     }
 }
 

--- a/chisel/src/solidity_helper.rs
+++ b/chisel/src/solidity_helper.rs
@@ -3,7 +3,7 @@
 //! This module contains the `SolidityHelper`, a [rustyline::Helper] implementation for
 //! usage in Chisel. It is ported from [soli](https://github.com/jpopesculian/soli/blob/master/src/main.rs).
 
-use crate::prelude::{ChiselCommand, COMMAND_LEADER};
+use crate::prelude::ChiselCommand;
 use rustyline::{
     completion::Completer,
     highlight::Highlighter,
@@ -18,57 +18,45 @@ use solang_parser::{
 use std::{borrow::Cow, str::FromStr};
 use yansi::{Color, Paint, Style};
 
-/// The default pre-allocation for solang parsed comments
-const DEFAULT_COMMENTS: usize = 5;
-
-/// The maximum length of the ANSI prefix + suffix characters when using [SolidityHelper].
-///
-/// * 5 - prefix:
-///   * 2 - start: `\x1B[`
-///   * 2 - fg: `3<fg_code>`
-///   * 1 - end: `m`
-/// * 4 - suffix: `\x1B[0m`
-const MAX_ANSI_LEN: usize = 9;
-
-/// `(start, style, end)`
-pub type SpannedStyle = (usize, Style, usize);
-
 /// A rustyline helper for Solidity code
 pub struct SolidityHelper;
 
+/// Highlighter implementation for `SolHighlighter`
+impl Highlighter for SolidityHelper {
+    fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
+        Cow::Owned(SolidityHelper::highlight(line))
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        pos == line.len()
+    }
+}
+
 impl SolidityHelper {
     /// Get styles for a solidity source string
-    pub fn get_styles(input: &str) -> Vec<SpannedStyle> {
-        let mut comments = Vec::with_capacity(DEFAULT_COMMENTS);
-        let mut errors = Vec::with_capacity(5);
-        let mut out = Lexer::new(input, 0, &mut comments, &mut errors)
+    pub fn get_styles(input: &str) -> Vec<(usize, Style, usize)> {
+        let mut comments = Vec::new();
+        let mut out = Lexer::new(input, 0, &mut comments, &mut vec![])
             .flatten()
             .map(|(start, token, end)| (start, token.style(), end))
             .collect::<Vec<_>>();
-
-        // highlight comments too
-        let comments_iter = comments.into_iter().map(|comment| {
+        for comment in comments {
             let loc = match comment {
                 pt::Comment::Line(loc, _) |
                 pt::Comment::Block(loc, _) |
                 pt::Comment::DocLine(loc, _) |
                 pt::Comment::DocBlock(loc, _) => loc,
             };
-            (loc.start(), Style::default().dimmed(), loc.end())
-        });
-        out.extend(comments_iter);
-
+            out.push((loc.start(), Style::default().dimmed(), loc.end()))
+        }
         out
     }
 
     /// Get contiguous styles for a solidity source string
-    pub fn get_contiguous_styles(input: &str) -> Vec<SpannedStyle> {
+    pub fn get_contiguous_styles(input: &str) -> Vec<(usize, Style, usize)> {
         let mut styles = Self::get_styles(input);
-        styles.sort_unstable_by_key(|(start, _, _)| *start);
-
-        let len = input.len();
-        // len / 4 is just a random average of whitespaces in the input
-        let mut out = Vec::with_capacity(styles.len() + len / 4 + 1);
+        styles.sort_by_key(|(start, _, _)| *start);
+        let mut out = vec![];
         let mut index = 0;
         for (start, style, end) in styles {
             if index < start {
@@ -77,57 +65,34 @@ impl SolidityHelper {
             out.push((start, style, end));
             index = end;
         }
-        if index < len {
-            out.push((index, Style::default(), len));
+        if index < input.len() {
+            out.push((index, Style::default(), input.len()));
         }
         out
     }
 
     /// Highlights a solidity source string
-    pub fn highlight(input: &str) -> Cow<str> {
-        if !Paint::is_enabled() || Self::skip_input(input) {
-            return Cow::Borrowed(input)
+    pub fn highlight(input: &str) -> String {
+        if Self::skip_input(input) {
+            return input.to_string()
         }
 
+        let mut out = String::new();
         // Highlight commands separately
-        if input.starts_with(COMMAND_LEADER) {
-            let (cmd, rest) = match input.split_once(' ') {
-                Some((cmd, rest)) => (cmd, Some(rest)),
-                None => (input, None),
-            };
-            let cmd = cmd.strip_prefix(COMMAND_LEADER).unwrap_or(cmd);
-
-            let mut out = String::with_capacity(input.len() + MAX_ANSI_LEN);
-
-            // cmd
-            out.push(COMMAND_LEADER);
-            let cmd_res = ChiselCommand::from_str(cmd);
-            let style = Style::new(if cmd_res.is_ok() { Color::Green } else { Color::Red });
-            Self::paint_unchecked(cmd, style, &mut out);
-
-            // rest
-            match rest {
-                Some(rest) if !rest.is_empty() => {
-                    out.push(' ');
-                    out.push_str(rest);
-                }
-                _ => {}
-            }
-
-            Cow::Owned(out)
+        if input.starts_with('!') {
+            let split: Vec<&str> = input.split(' ').collect();
+            let cmd = ChiselCommand::from_str(&split[0][1..]);
+            out = format!(
+                "!{} {}",
+                if cmd.is_ok() { Paint::green(&split[0][1..]) } else { Paint::red(&split[0][1..]) },
+                split[1..].join(" ")
+            );
         } else {
-            let styles = Self::get_contiguous_styles(input);
-            let len = styles.len();
-            if len == 0 {
-                Cow::Borrowed(input)
-            } else {
-                let mut out = String::with_capacity(input.len() + MAX_ANSI_LEN * len);
-                for (start, style, end) in styles {
-                    Self::paint_unchecked(&input[start..end], style, &mut out);
-                }
-                Cow::Owned(out)
+            for (start, style, end) in Self::get_contiguous_styles(input) {
+                out.push_str(&format!("{}", style.paint(&input[start..end])))
             }
         }
+        out
     }
 
     /// Validate that a source snippet is closed (i.e., all braces and parenthesis are matched).
@@ -140,9 +105,8 @@ impl SolidityHelper {
         let mut bracket_depth = 0usize;
         let mut paren_depth = 0usize;
         let mut brace_depth = 0usize;
-        let mut comments = Vec::with_capacity(DEFAULT_COMMENTS);
-        // returns on any encountered error, so allocate for just one
-        let mut errors = Vec::with_capacity(1);
+        let mut comments = Vec::new();
+        let mut errors = Vec::new();
         for res in Lexer::new(input, 0, &mut comments, &mut errors) {
             match res {
                 Err(err) => match err {
@@ -153,13 +117,13 @@ impl SolidityHelper {
                 },
                 Ok((_, token, _)) => match token {
                     Token::OpenBracket => {
-                        bracket_depth += 1;
+                        bracket_depth = bracket_depth.saturating_add(1);
                     }
                     Token::OpenCurlyBrace => {
-                        brace_depth += 1;
+                        brace_depth = brace_depth.saturating_add(1);
                     }
                     Token::OpenParenthesis => {
-                        paren_depth += 1;
+                        paren_depth = paren_depth.saturating_add(1);
                     }
                     Token::CloseBracket => {
                         bracket_depth = bracket_depth.saturating_sub(1);
@@ -181,31 +145,12 @@ impl SolidityHelper {
         }
     }
 
-    /// Formats `input` with `style` into `out`, without checking `style.wrapping` or
-    /// `Paint::is_enabled`
-    #[inline]
-    fn paint_unchecked(string: &str, style: Style, out: &mut String) {
-        let _ = style.fmt_prefix(out);
-        out.push_str(string);
-        let _ = style.fmt_suffix(out);
-    }
-
     /// Whether to skip parsing this input due to known errors or panics
     #[inline]
     fn skip_input(input: &str) -> bool {
         // input.startsWith(/\.[0-9]/)
         let mut chars = input.chars();
         chars.next() == Some('.') && chars.next().map(|c| c.is_ascii_digit()).unwrap_or_default()
-    }
-}
-
-impl Highlighter for SolidityHelper {
-    fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
-        Self::highlight(line)
-    }
-
-    fn highlight_char(&self, line: &str, pos: usize) -> bool {
-        pos == line.len()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

any input that starts with a dot `.` followed by a number will make the solang Lexer panic:

```log
Welcome to Chisel! Type `!help` to show available commands.
➜ .thread 'main' panicked at 'attempted to index str up to maximum usize', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/solang-parser-0.2.1/src/lexer.rs:699:28
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

add a skip input method that will check for the panic condition

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
