### PR TITLE
fix(chisel): comment errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "foundry-common",
  "foundry-config",
  "foundry-evm",
+ "regex",
  "reqwest",
  "revm",
  "rustyline",

--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -51,6 +51,7 @@ revm = "2.1.0"
 eyre = "0.6.8"
 dirs = "4.0.0"
 time = { version = "0.3.15", features = ["formatting"] }
+regex = "1"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -667,11 +667,9 @@ impl ChiselDispatcher {
                                 if let Ok(decoder) =
                                     Self::decode_traces(&new_session_source.config, &mut res)
                                 {
-                                    if Self::show_traces(&decoder, &mut res).await.is_err() {
+                                    if let Err(e) = Self::show_traces(&decoder, &mut res).await {
                                         self.errored = true;
-                                        return DispatchResult::CommandFailed(
-                                            "Failed to display traces".to_owned(),
-                                        )
+                                        return DispatchResult::CommandFailed(e.to_string())
                                     };
 
                                     // Show console logs, if there are any
@@ -824,11 +822,9 @@ impl ChiselDispatcher {
                     // traces.
                     if new_source.config.traces || failed {
                         if let Ok(decoder) = Self::decode_traces(&new_source.config, &mut res) {
-                            if Self::show_traces(&decoder, &mut res).await.is_err() {
+                            if let Err(e) = Self::show_traces(&decoder, &mut res).await {
                                 self.errored = true;
-                                return DispatchResult::CommandFailed(
-                                    "Failed to display traces".to_owned(),
-                                )
+                                return DispatchResult::CommandFailed(e.to_string())
                             };
 
                             // Show console logs, if there are any

--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -174,9 +174,7 @@ impl SessionSource {
             })
         } else {
             if let Ok(decoder) = ChiselDispatcher::decode_traces(&source.config, &mut res) {
-                if ChiselDispatcher::show_traces(&decoder, &mut res).await.is_err() {
-                    eyre::bail!("Failed to display traces");
-                };
+                ChiselDispatcher::show_traces(&decoder, &mut res).await?;
 
                 // Show console logs, if there are any
                 let decoded_logs = decode_console_logs(&res.logs);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Various errors or panics when using comments with or without traces:
- panic on inspect with a block comment, same as #4131
- "no traces" error when the first input is a line comment

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

If the input is a comment, add it to the run code so we avoid running with empty input

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
