### PR TITLE
perf(chisel): solidity_helper

### DIFF
--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -26,11 +26,11 @@ use strum::IntoEnumIterator;
 use yansi::Paint;
 
 /// Prompt arrow slice
-static PROMPT_ARROW: char = '➜';
+pub static PROMPT_ARROW: char = '➜';
 /// Command leader character
-static COMMAND_LEADER: char = '!';
+pub static COMMAND_LEADER: char = '!';
 /// Chisel character
-static CHISEL_CHAR: &str = "⚒️";
+pub static CHISEL_CHAR: &str = "⚒️";
 
 /// Matches Solidity comments
 static COMMENT_RE: Lazy<Regex> =
@@ -286,7 +286,7 @@ impl ChiselDispatcher {
                         session_source.config.foundry_config.fmt.clone(),
                     ) {
                         Ok(formatted_source) => DispatchResult::CommandSuccess(Some(
-                            SolidityHelper::highlight(&formatted_source),
+                            SolidityHelper::highlight(&formatted_source).into_owned(),
                         )),
                         Err(_) => DispatchResult::CommandFailed(String::from(
                             "Failed to format session source",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

highlighting is done on every input change so it's pretty important that they run fast

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- instatiate vecs with capacity
- run Paint::is_enabled (atomic load) only once per highlight call (at the start) instead of twice per token (in fmt::Display of Paint), which also allows to early return with no changes to input
- saturating add on usize counters to normal addassign since your computer's memory will overflow before those will
- more efficient command comparisons
- use COMMAND_LEADER constant instead of hardcoding the same character many times

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
