### PR TITLE
dep: upgrade git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
  "ethers-solc",
  "eyre",
  "foundry-config",
- "git2",
+ "git2 0.16.1",
  "tempfile",
  "tracing",
  "url",
@@ -3069,6 +3069,19 @@ name = "git2"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -3765,9 +3778,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
@@ -6960,7 +6973,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "enum-iterator",
  "getset",
- "git2",
+ "git2 0.15.0",
  "rustc_version",
  "rustversion",
  "thiserror",

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -20,7 +20,7 @@ ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-featur
 ] }
 curl = { version = "0.4", default-features = false, features = ["http2"] }
 eyre = "0.6"
-git2 = { version = "0.15.0", default-features = false }
+git2 = { version = "0.16.1", default-features = false }
 url = "2.2"
 tracing = "0.1"
 tempfile = "3.3.0"

--- a/binder/README.md
+++ b/binder/README.md
@@ -8,7 +8,7 @@ First add `foundry-binder` to your cargo build-dependencies.
 [build-dependencies]
 foundry-binder = { git = "https://github.com/foundry-rs/foundry" }
 # required in order to enable ssh support in [libgit2](https://github.com/rust-lang/git2-rs)
-git2 = "0.13"
+git2 = "0.16.1"
 ```
 
 ```rust


### PR DESCRIPTION
Upgrade git2 dep. Ref https://github.com/libgit2/libgit2/security/advisories/GHSA-8643-3wh5-rmjq