### PR TITLE
feat(anvil): add evm_setTime

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -441,6 +441,19 @@ pub enum EthRequest {
     )]
     SetNextBlockBaseFeePerGas(U256),
 
+    /// Sets the specific timestamp
+    /// Accepts timestamp (Unix epoch) with millisecond precision and returns the number of seconds
+    /// between the given timestamp and the current time.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            rename = "anvil_setTime",
+            alias = "evm_setTime",
+            deserialize_with = "deserialize_number_seq"
+        )
+    )]
+    EvmSetTime(U256),
+
     /// Serializes the current state (including contracts code, contract's storage, accounts
     /// properties, etc.) into a savable data blob
     #[cfg_attr(
@@ -925,6 +938,17 @@ mod tests {
     #[test]
     fn test_serde_custom_next_block_base_fee() {
         let s = r#"{"method": "anvil_setNextBlockBaseFeePerGas", "params": ["0x0"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_set_time() {
+        let s = r#"{"method": "anvil_setTime", "params": ["0x0"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "anvil_increaseTime", "params": 1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4144

adds `evm_setTime` which allows setting the timestamp directly
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
