### PR TITLE
fix: exclude deployed contracts from sender strategy

### DIFF
--- a/evm/src/fuzz/invariant/contract.rs
+++ b/evm/src/fuzz/invariant/contract.rs
@@ -1,0 +1,13 @@
+use crate::Address;
+use ethers::abi::{Contract as Abi, Function};
+
+/// Test contract which is testing its invariants.
+#[derive(Debug, Clone)]
+pub struct InvariantContract<'a> {
+    /// Address of the test contract.
+    pub address: Address,
+    /// Invariant functions present in the test contract.
+    pub invariant_functions: Vec<&'a Function>,
+    /// Abi of the test contract.
+    pub abi: &'a Abi,
+}

--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -1,8 +1,11 @@
-use super::{BasicTxDetails, InvariantContract};
+use super::BasicTxDetails;
 use crate::{
     decode::decode_revert,
     executor::{Executor, RawCallResult},
-    fuzz::{invariant::set_up_inner_replay, *},
+    fuzz::{
+        invariant::{set_up_inner_replay, InvariantContract},
+        *,
+    },
     trace::{load_contracts, TraceKind, Traces},
     CALLER,
 };

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -220,7 +220,7 @@ pub fn collect_created_contracts(
     targeted_contracts: FuzzRunIdentifiedContracts,
     created_contracts: &mut Vec<Address>,
 ) -> eyre::Result<()> {
-    let mut writable_targeted = targeted_contracts.lock();
+    let mut writable_targeted = targeted_contracts.write();
 
     for (address, account) in state_changeset {
         if !setup_contracts.contains_key(address) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2963

This checks if the selected address is a deployed contract, in which case it should not be used as the sender.

I'm not entirely sure if this will fix all issues related to EIP-3607 (sender with code) @joshieDo 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
