### PR TITLE
fix(evm): include missing CREATE and CREATE2 geth traces

### DIFF
--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -127,6 +127,8 @@ impl CallTraceArena {
                 Instruction::OpCode(opc) => {
                     match opc {
                         // If yes, descend into a child trace
+                        opcode::CREATE |
+                        opcode::CREATE2 |
                         opcode::DELEGATECALL |
                         opcode::CALL |
                         opcode::STATICCALL |


### PR DESCRIPTION
Hopefully fixes https://github.com/foundry-rs/foundry/issues/3819 - `CREATE` and `CREATE2` traces are missing in `debug_traceTransaction` output.