### PR TITLE
feat: disable eip3607 by default in forge test

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -43,6 +43,7 @@ revm = { version = "2.3", default-features = false, features = [
   "k256",
   "with-serde",
   "memory_limit",
+  "optional_eip3607"
 ] }
 
 # Fuzzer

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -53,6 +53,10 @@ where
             chain_id: override_chain_id.unwrap_or(rpc_chain_id.as_u64()).into(),
             memory_limit,
             limit_contract_code_size: Some(usize::MAX),
+            // EIP-3607 rejects transactions from senders with deployed code.
+            // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the caller
+            // is a contract. So we disable the check by default.
+            disable_eip3607: true,
             ..Default::default()
         },
         block: BlockEnv {

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -113,9 +113,12 @@ impl EvmOpts {
             cfg: CfgEnv {
                 chain_id: self.env.chain_id.unwrap_or(foundry_common::DEV_CHAIN_ID).into(),
                 spec_id: SpecId::MERGE,
-                perf_all_precompiles_have_balance: false,
                 limit_contract_code_size: self.env.code_size_limit.or(Some(usize::MAX)),
                 memory_limit: self.memory_limit,
+                // EIP-3607 rejects transactions from senders with deployed code.
+                // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
+                // caller is a contract. So we disable the check by default.
+                disable_eip3607: true,
                 ..Default::default()
             },
             tx: TxEnv {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2963

This disables the EIP3607 check by default.

This will allow senders with code, which has been an issue during fuzzing etc...
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
