### PR TITLE
feat(anvil): disable eip3607 by default

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -740,6 +740,10 @@ impl NodeConfig {
                 spec_id: self.get_hardfork().into(),
                 chain_id: self.get_chain_id().into(),
                 limit_contract_code_size: self.code_size_limit,
+                // EIP-3607 rejects transactions from senders with deployed code.
+                // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
+                // caller is a contract. So we disable the check by default.
+                disable_eip3607: true,
                 ..Default::default()
             },
             block: BlockEnv {

--- a/anvil/src/eth/backend/cheats.rs
+++ b/anvil/src/eth/backend/cheats.rs
@@ -1,10 +1,10 @@
 //! Support for "cheat codes" / bypass functions
 
 use anvil_core::eth::transaction::TypedTransaction;
-use ethers::types::{Address, Signature, H256, U256};
-use forge::revm::Bytecode;
+use ethers::types::{Address, Signature, U256};
+use forge::hashbrown::HashSet;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 use tracing::trace;
 
 /// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
@@ -33,33 +33,25 @@ impl CheatsManager {
     /// This also accepts the actual code hash if the address is a contract to bypass EIP-3607
     ///
     /// Returns `true` if the account is already impersonated
-    pub fn impersonate(
-        &self,
-        addr: Address,
-        code_hash: Option<H256>,
-        code: Option<Bytecode>,
-    ) -> bool {
+    pub fn impersonate(&self, addr: Address) -> bool {
         trace!(target: "cheats", "Start impersonating {:?}", addr);
         let mut state = self.state.write();
-        if state.impersonated_accounts.contains_key(&addr) {
-            // need to check if already impersonated so we don't overwrite the code
+        if state.impersonated_accounts.contains(&addr) {
+            // need to check if already impersonated, so we don't overwrite the code
             return true
         }
-        state
-            .impersonated_accounts
-            .insert(addr, ImpersonatedAccount::new(code_hash, code))
-            .is_some()
+        state.impersonated_accounts.insert(addr)
     }
 
     /// Removes the account that from the impersonated set
-    pub fn stop_impersonating(&self, addr: &Address) -> Option<(Option<H256>, Option<Bytecode>)> {
+    pub fn stop_impersonating(&self, addr: &Address) {
         trace!(target: "cheats", "Stop impersonating {:?}", addr);
-        self.state.write().impersonated_accounts.remove(addr).map(|acc| (acc.code_hash, acc.code))
+        self.state.write().impersonated_accounts.remove(addr);
     }
 
     /// Returns true if the `addr` is currently impersonated
     pub fn is_impersonated(&self, addr: Address) -> bool {
-        self.state.read().impersonated_accounts.contains_key(&addr)
+        self.state.read().impersonated_accounts.contains(&addr)
     }
 
     /// Returns the signature to use to bypass transaction signing
@@ -72,11 +64,7 @@ impl CheatsManager {
 #[derive(Debug, Clone)]
 pub struct CheatsState {
     /// All accounts that are currently impersonated
-    ///
-    /// If the account is a contract it holds the hash of the contracts code that is temporarily
-    /// set to `KECCAK_EMPTY` to bypass EIP-3607 which rejects transactions from senders with
-    /// deployed code
-    pub impersonated_accounts: HashMap<Address, ImpersonatedAccount>,
+    pub impersonated_accounts: HashSet<Address>,
     /// The signature used for the `eth_sendUnsignedTransaction` cheat code
     pub bypass_signature: Signature,
 }
@@ -84,23 +72,5 @@ pub struct CheatsState {
 impl Default for CheatsState {
     fn default() -> Self {
         Self { impersonated_accounts: Default::default(), bypass_signature: BYPASS_SIGNATURE }
-    }
-}
-
-/// Tracks an impersonated account
-#[derive(Debug, Clone)]
-pub struct ImpersonatedAccount {
-    /// The account's code hash
-    pub code_hash: Option<H256>,
-    /// The account's code
-    pub code: Option<Bytecode>,
-}
-
-// === impl ImpersonatedAccount ===
-
-impl ImpersonatedAccount {
-    /// Create a new instance as `impersonated`
-    pub fn new(code_hash: Option<H256>, code: Option<Bytecode>) -> Self {
-        Self { code_hash, code }
     }
 }

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -152,8 +152,7 @@ async fn can_impersonate_gnosis_safe() {
     api.anvil_impersonate_account(safe).await.unwrap();
 
     let code = provider.get_code(safe, None).await.unwrap();
-    // impersonated contract code is temporarily removed
-    assert!(code.is_empty());
+    assert!(!code.is_empty());
 
     let balance = U256::from(1e18 as u64);
     // fund the impersonated account

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -43,6 +43,7 @@ revm = { version = "2.3", default-features = false, features = [
   "k256",
   "with-serde",
   "memory_limit",
+  "optional_eip3607"
 ] }
 
 # Fuzzer

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -53,6 +53,10 @@ where
             chain_id: override_chain_id.unwrap_or(rpc_chain_id.as_u64()).into(),
             memory_limit,
             limit_contract_code_size: Some(usize::MAX),
+            // EIP-3607 rejects transactions from senders with deployed code.
+            // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the caller
+            // is a contract. So we disable the check by default.
+            disable_eip3607: true,
             ..Default::default()
         },
         block: BlockEnv {

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -113,9 +113,12 @@ impl EvmOpts {
             cfg: CfgEnv {
                 chain_id: self.env.chain_id.unwrap_or(foundry_common::DEV_CHAIN_ID).into(),
                 spec_id: SpecId::MERGE,
-                perf_all_precompiles_have_balance: false,
                 limit_contract_code_size: self.env.code_size_limit.or(Some(usize::MAX)),
                 memory_limit: self.memory_limit,
+                // EIP-3607 rejects transactions from senders with deployed code.
+                // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
+                // caller is a contract. So we disable the check by default.
+                disable_eip3607: true,
                 ..Default::default()
             },
             tx: TxEnv {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3886
Blocked by https://github.com/foundry-rs/foundry/pull/4181

This disables the eip3607 check by default for anvil, allowing impersonation without manually removing the code
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
