### PR TITLE
refactor: always use hash of MinedTransaction when building tx

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -939,6 +939,7 @@ impl EthApi {
         let mut tx = self.pool.get_transaction(hash).map(|pending| {
             let from = *pending.sender();
             let mut tx = transaction_build(
+                Some(*pending.hash()),
                 pending.transaction,
                 None,
                 None,
@@ -1808,6 +1809,7 @@ impl EthApi {
         fn convert(tx: Arc<PoolTransaction>) -> Transaction {
             let from = *tx.pending_transaction.sender();
             let mut tx = transaction_build(
+                Some(*tx.hash()),
                 tx.pending_transaction.transaction.clone(),
                 None,
                 None,
@@ -2095,7 +2097,14 @@ impl EthApi {
         for info in transactions {
             let tx = block.transactions.get(info.transaction_index as usize)?.clone();
 
-            let tx = transaction_build(tx, Some(&block), Some(info), true, Some(base_fee));
+            let tx = transaction_build(
+                Some(info.transaction_hash),
+                tx,
+                Some(&block),
+                Some(info),
+                true,
+                Some(base_fee),
+            );
             block_transactions.push(tx);
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/3759

This prepares a pending fix for #3759 by re-enabling this https://github.com/foundry-rs/foundry/pull/3809/files

This will always use the hash we already store for the transaction, this allows us to override modified hashes, for example for impersonated transactions
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
