### PR TITLE
fix(anvil): make impersonated tx hashes sender unique

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -984,12 +984,20 @@ impl PendingTransaction {
     /// Creates a new pending transaction and tries to verify transaction and recover sender.
     pub fn new(transaction: TypedTransaction) -> Result<Self, SignatureError> {
         let sender = transaction.recover()?;
-        Ok(Self::with_sender(transaction, sender))
+        Ok(Self { hash: transaction.hash(), transaction, sender })
     }
 
-    /// Creates a new transaction with the given sender
-    pub fn with_sender(transaction: TypedTransaction, sender: Address) -> Self {
-        Self { hash: transaction.hash(), transaction, sender }
+    /// Creates a new transaction with the given sender.
+    ///
+    /// In order to prevent collisions from multiple different impersonated accounts, we update the
+    /// transaction's hash with the address to make it unique.
+    ///
+    /// See: <https://github.com/foundry-rs/foundry/issues/3759>
+    pub fn with_impersonated(transaction: TypedTransaction, sender: Address) -> Self {
+        let mut bytes = rlp::encode(&transaction);
+        bytes.extend_from_slice(sender.as_ref());
+        let hash = H256::from_slice(keccak256(&bytes).as_slice());
+        Self { hash, transaction, sender }
     }
 
     pub fn nonce(&self) -> &U256 {

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -751,7 +751,7 @@ impl EthApi {
             let bypass_signature = self.backend.cheats().bypass_signature();
             let transaction = sign::build_typed_transaction(request, bypass_signature)?;
             trace!(target : "node", ?from, "eth_sendTransaction: impersonating");
-            PendingTransaction::with_sender(transaction, from)
+            PendingTransaction::with_impersonated(transaction, from)
         } else {
             let transaction = self.sign_request(&from, request)?;
             PendingTransaction::new(transaction)?
@@ -1737,7 +1737,7 @@ impl EthApi {
         let bypass_signature = self.backend.cheats().bypass_signature();
         let transaction = sign::build_typed_transaction(request, bypass_signature)?;
 
-        let pending_transaction = PendingTransaction::with_sender(transaction, from);
+        let pending_transaction = PendingTransaction::with_impersonated(transaction, from);
 
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -212,6 +212,8 @@ async fn can_impersonate_multiple_account() {
 
     let receipt = provider.get_transaction_receipt(res1.transaction_hash).await.unwrap().unwrap();
     assert_eq!(res1, receipt);
+
+    assert_ne!(res0, res1);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/anvil/tests/it/anvil_api.rs
+++ b/anvil/tests/it/anvil_api.rs
@@ -170,8 +170,6 @@ async fn can_impersonate_gnosis_safe() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
-// <https://github.com/foundry-rs/foundry/issues/3759>
 async fn can_impersonate_multiple_account() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3759

~~blocked by https://github.com/foundry-rs/foundry/pull/4183~~

this reapplies changes made in https://github.com/foundry-rs/foundry/pull/3775 that were reverted

with #4183 we'll always use the hash we computed when the transaction was added, and are not using the calculated hash when the transaction is requested via RPC, this only affects impersonated transactions
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
