### PR TITLE
fix(anvil): stricter memory limits in interval mining mode

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -945,6 +945,7 @@ impl NodeConfig {
             self.enable_steps_tracing,
             self.prune_history,
             self.transaction_block_keeper,
+            self.block_time,
         )
         .await;
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1397,7 +1397,12 @@ impl EthApi {
         let mining_mode = if secs == 0 {
             MiningMode::None
         } else {
-            MiningMode::FixedBlockTime(FixedBlockTimeMiner::new(Duration::from_secs(secs)))
+            let block_time = Duration::from_secs(secs);
+
+            // This ensures that memory limits are stricter in interval-mine mode
+            self.backend.update_interval_mine_block_time(block_time);
+
+            MiningMode::FixedBlockTime(FixedBlockTimeMiner::new(block_time))
         };
         self.miner.set_mining_mode(mining_mode);
         Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The previous max memory setting was pretty high resulting in bloated memory.

This decreases the max in memory limit and also adapts it if in interval mining, in which case it should be drastically decreased. so that only a couple blocks should be stored in mem, since unlikely older state will be requested at all.

this needs a followup to fix https://github.com/foundry-rs/foundry/issues/3623 which concerns disk space.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
