### PR TITLE
fix(forge): ignore contracts defined in lib paths

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -1,7 +1,7 @@
 //! Coverage command
 use crate::{
     cmd::{
-        forge::{build::CoreBuildArgs, install, test::Filter},
+        forge::{build::CoreBuildArgs, install, test::FilterArgs},
         Cmd, LoadConfig,
     },
     utils::{self, p_println, STATIC_FUZZ_SEED},
@@ -49,7 +49,7 @@ pub struct CoverageArgs {
     report: Vec<CoverageReportKind>,
 
     #[clap(flatten)]
-    filter: Filter,
+    filter: FilterArgs,
 
     #[clap(flatten)]
     evm_opts: EvmArgs,

--- a/cli/src/cmd/forge/test/filter.rs
+++ b/cli/src/cmd/forge/test/filter.rs
@@ -1,6 +1,6 @@
 use crate::utils::FoundryPathExt;
 use clap::Parser;
-use ethers::solc::FileFilter;
+use ethers::solc::{FileFilter, ProjectPathsConfig};
 use forge::TestFilter;
 use foundry_config::Config;
 use std::{fmt, path::Path, str::FromStr};
@@ -10,7 +10,7 @@ use std::{fmt, path::Path, str::FromStr};
 /// See also `FileFilter`.
 #[derive(Clone, Parser)]
 #[clap(next_help_heading = "Test filtering")]
-pub struct Filter {
+pub struct FilterArgs {
     /// Only run test functions matching the specified regex pattern.
     ///
     /// Deprecated: See --match-test
@@ -73,9 +73,9 @@ pub struct Filter {
     pub path_pattern_inverse: Option<GlobMatcher>,
 }
 
-impl Filter {
+impl FilterArgs {
     /// Merges the set filter globs with the config's values
-    pub fn with_merged_config(&self, config: &Config) -> Self {
+    pub fn merge_with_config(&self, config: &Config) -> ProjectPathsAwareFilter {
         let mut filter = self.clone();
         if filter.test_pattern.is_none() {
             filter.test_pattern = config.test_pattern.clone().map(|p| p.into());
@@ -96,13 +96,13 @@ impl Filter {
         if filter.path_pattern_inverse.is_none() {
             filter.path_pattern_inverse = config.path_pattern_inverse.clone().map(Into::into);
         }
-        filter
+        ProjectPathsAwareFilter { args_filter: filter, paths: config.project_paths() }
     }
 }
 
-impl fmt::Debug for Filter {
+impl fmt::Debug for FilterArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Filter")
+        f.debug_struct("FilterArgs")
             .field("match", &self.pattern.as_ref().map(|r| r.as_str()))
             .field("match-test", &self.test_pattern.as_ref().map(|r| r.as_str()))
             .field("no-match-test", &self.test_pattern_inverse.as_ref().map(|r| r.as_str()))
@@ -114,7 +114,7 @@ impl fmt::Debug for Filter {
     }
 }
 
-impl FileFilter for Filter {
+impl FileFilter for FilterArgs {
     /// Returns true if the file regex pattern match the `file`
     ///
     /// If no file regex is set this returns true if the file ends with `.t.sol`, see
@@ -132,7 +132,7 @@ impl FileFilter for Filter {
     }
 }
 
-impl TestFilter for Filter {
+impl TestFilter for FilterArgs {
     fn matches_test(&self, test_name: impl AsRef<str>) -> bool {
         let mut ok = true;
         let test_name = test_name.as_ref();
@@ -174,7 +174,7 @@ impl TestFilter for Filter {
     }
 }
 
-impl fmt::Display for Filter {
+impl fmt::Display for FilterArgs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut patterns = Vec::new();
         if let Some(ref p) = self.pattern {
@@ -199,6 +199,59 @@ impl fmt::Display for Filter {
             patterns.push(format!("\tno-match-path: `{}`", p.as_str()));
         }
         write!(f, "{}", patterns.join("\n"))
+    }
+}
+
+/// A filter that combines all command line arguments and the paths of the current projects
+#[derive(Debug, Clone)]
+pub struct ProjectPathsAwareFilter {
+    args_filter: FilterArgs,
+    paths: ProjectPathsConfig,
+}
+
+// === impl ProjectPathsAwareFilter ===
+
+impl ProjectPathsAwareFilter {
+    /// Returns the CLI arguments
+    pub fn args(&self) -> &FilterArgs {
+        &self.args_filter
+    }
+
+    /// Returns the CLI arguments mutably
+    pub fn args_mut(&mut self) -> &mut FilterArgs {
+        &mut self.args_filter
+    }
+}
+
+impl FileFilter for ProjectPathsAwareFilter {
+    /// Returns true if the file regex pattern match the `file`
+    ///
+    /// If no file regex is set this returns true if the file ends with `.t.sol`, see
+    /// [FoundryPathExr::is_sol_test()]
+    fn is_match(&self, file: &Path) -> bool {
+        self.args_filter.is_match(file)
+    }
+}
+
+impl TestFilter for ProjectPathsAwareFilter {
+    fn matches_test(&self, test_name: impl AsRef<str>) -> bool {
+        self.args_filter.matches_test(test_name)
+    }
+
+    fn matches_contract(&self, contract_name: impl AsRef<str>) -> bool {
+        self.args_filter.matches_contract(contract_name)
+    }
+
+    fn matches_path(&self, path: impl AsRef<str>) -> bool {
+        let path = path.as_ref();
+        // we don't want to test files that belong to a library
+        self.args_filter.matches_path(path) && !self.paths.has_library_ancestor(Path::new(path))
+    }
+}
+
+impl fmt::Display for ProjectPathsAwareFilter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.args_filter.fmt(f)
     }
 }
 

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -136,10 +136,10 @@ pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
     let filter = args.filter(&config);
 
     // marker to check whether to override the command
-    let no_reconfigure = filter.pattern.is_some() ||
-        filter.test_pattern.is_some() ||
-        filter.path_pattern.is_some() ||
-        filter.contract_pattern.is_some() ||
+    let no_reconfigure = filter.args().pattern.is_some() ||
+        filter.args().test_pattern.is_some() ||
+        filter.args().path_pattern.is_some() ||
+        filter.args().contract_pattern.is_some() ||
         args.watch.run_all;
 
     let state = WatchTestState {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4008

adds a check in the `matches_path` that ensures that the path of the contract is not a child of a lib folder.
In other words: ignore all tests defined in lib folders.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a new filter type that wraps the existing filter but also has access to the project's paths.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
