### PR TITLE
fix(anvil): Use the block's base fee when calculating effective gas price for a tx receipt

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1643,8 +1643,10 @@ impl Backend {
         let effective_gas_price = match transaction {
             TypedTransaction::Legacy(t) => t.gas_price,
             TypedTransaction::EIP2930(t) => t.gas_price,
-            TypedTransaction::EIP1559(t) => self
-                .base_fee()
+            TypedTransaction::EIP1559(t) => block
+                .header
+                .base_fee_per_gas
+                .unwrap_or(self.base_fee())
                 .checked_add(t.max_priority_fee_per_gas)
                 .unwrap_or_else(U256::max_value),
         };


### PR DESCRIPTION
## Motivation
There's a small bug in Anvil where it uses the latest block's base fee to calculate the effective gas price of a transaction when constructing a transaction receipt. 

This becomes an issue for EIP-1559 transactions, if the original block's base fee was different than the current block's base fee (e.g. due to an `anvil_setNextBlockBaseFeePerGas` call).  

Steps to reproduce:
1. Set the block base fee using `anvil_setNextBlockBaseFeePerGas`
2. Send an EIP-1559 transaction
3. Mine blocks
4. Fetch the transaction receipt of the EIP-1559 transaction, and notice that the effective gas price is miscalculated

## Solution
We should use the original block's base fee when calculating the effective gas price for a transaction receipt

## Testing
Added a test that uses the "Steps to reproduce" steps to verify that it's fixed. I also ran that test against the current master branch (without the fix), and verified that the test was failing
