### PR TITLE
fix: replace difficulty with prevrandao after merge

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -33,6 +33,7 @@ use foundry_evm::{
     executor::fork::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     revm,
     revm::{BlockEnv, CfgEnv, SpecId, TxEnv},
+    utils::apply_chain_and_block_specific_env_changes,
 };
 use parking_lot::RwLock;
 use serde_json::{json, to_writer, Value};
@@ -839,6 +840,9 @@ impl NodeConfig {
                 coinbase: env.block.coinbase,
                 basefee: env.block.basefee,
             };
+
+            // apply changes such as difficulty -> prevrandao
+            apply_chain_and_block_specific_env_changes(&mut env, &block);
 
             // if not set explicitly we use the base fee of the latest block
             if self.base_fee.is_none() {

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -1,3 +1,4 @@
+use crate::utils::apply_chain_and_block_specific_env_changes;
 use ethers::{
     providers::Middleware,
     types::{Address, U256},
@@ -48,7 +49,7 @@ where
         eyre::bail!("Failed to get block for block number: {}", block_number)
     };
 
-    Ok(Env {
+    let mut env = Env {
         cfg: CfgEnv {
             chain_id: override_chain_id.unwrap_or(rpc_chain_id.as_u64()).into(),
             memory_limit,
@@ -75,5 +76,9 @@ where
             gas_limit: block.gas_limit.as_u64(),
             ..Default::default()
         },
-    })
+    };
+
+    apply_chain_and_block_specific_env_changes(&mut env, &block);
+
+    Ok(env)
 }

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -39,7 +39,7 @@ pub fn apply_chain_and_block_specific_env_changes<T>(env: &mut revm::Env, block:
     if let Ok(chain) = Chain::try_from(env.cfg.chain_id) {
         let block_number = block.number.unwrap_or_default();
 
-        #[allow(clippy::single-match)]
+        #[allow(clippy::single_match)]
         match chain {
             Chain::Mainnet => {
                 // after merge difficulty is supplanted with prevrandao EIP-4399

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -1,6 +1,7 @@
 use ethers::{
     abi::{Abi, FixedBytes, Function},
     prelude::{H256, U256},
+    types::{BigEndianHash, Block, Chain},
 };
 use eyre::ContextCompat;
 use revm::{opcode, spec_opcode_gas, SpecId};
@@ -28,6 +29,33 @@ pub fn h256_to_u256_be(storage: H256) -> U256 {
 /// Small helper function to convert [H256] into [U256].
 pub fn h256_to_u256_le(storage: H256) -> U256 {
     U256::from_little_endian(storage.as_bytes())
+}
+
+/// Depending on the configured chain id and block number this should apply any specific changes
+///
+/// This checks for:
+///    - prevrandao mixhash after merge
+pub fn apply_chain_and_block_specific_env_changes<T>(env: &mut revm::Env, block: &Block<T>) {
+    if let Ok(chain) = Chain::try_from(env.cfg.chain_id) {
+        let block_number = block.number.unwrap_or_default();
+        #[allow(clippy::single-match)]
+        match chain {
+            Chain::Mainnet => {
+                // after merge difficulty is supplanted with prevrandao EIP-4399
+                if block_number.as_u64() >= 15_537_351u64 {
+                    env.block.difficulty = env.block.prevrandao.unwrap_or_default().into_uint();
+                }
+
+                return
+            }
+            _ => {}
+        }
+    }
+
+    // if difficulty is `0` we assume it's past merge
+    if block.difficulty.is_zero() {
+        env.block.difficulty = env.block.prevrandao.unwrap_or_default().into_uint();
+    }
 }
 
 /// A map of program counters to instruction counters.

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -38,6 +38,7 @@ pub fn h256_to_u256_le(storage: H256) -> U256 {
 pub fn apply_chain_and_block_specific_env_changes<T>(env: &mut revm::Env, block: &Block<T>) {
     if let Ok(chain) = Chain::try_from(env.cfg.chain_id) {
         let block_number = block.number.unwrap_or_default();
+
         #[allow(clippy::single-match)]
         match chain {
             Chain::Mainnet => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4086

adds check to enabled  EIP-4399 and replace difficulty with prevrandao after merge
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
configure difficulty with prevrandao if block difficulty is 0 or specific for mainnent
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
