### PR TITLE
fix(anvil): track impersonated sender for transaction

### DIFF
--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -18,7 +18,7 @@ vergen = { version = "7.0", default-features = false, features = ["build", "rust
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../evm" }
-anvil-core = { path = "core", features = ["fastrlp", "serde"] }
+anvil-core = { path = "core", features = ["fastrlp", "serde", "impersonated-tx"] }
 anvil-rpc = { path = "rpc" }
 anvil-server = { path = "server" }
 foundry-utils = { path = "../utils" }

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = []
+impersonated-tx = []
 fastrlp = ["dep:open-fastrlp"]
 serde = ["dep:serde"]
 

--- a/anvil/core/src/eth/transaction/ethers_compat.rs
+++ b/anvil/core/src/eth/transaction/ethers_compat.rs
@@ -1,8 +1,17 @@
 //! ethers compatibility, this is mainly necessary so we can use all of `ethers` signers
 
 use super::EthTransactionRequest;
-use crate::eth::transaction::{EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest, MaybeImpersonatedTransaction, TypedTransaction, TypedTransactionRequest};
-use ethers_core::types::{transaction::eip2718::TypedTransaction as EthersTypedTransactionRequest, Address, Eip1559TransactionRequest as EthersEip1559TransactionRequest, Eip2930TransactionRequest as EthersEip2930TransactionRequest, NameOrAddress, Transaction as EthersTransaction, TransactionRequest as EthersLegacyTransactionRequest, TransactionRequest, U256, U64, H256};
+use crate::eth::transaction::{
+    EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest,
+    MaybeImpersonatedTransaction, TypedTransaction, TypedTransactionRequest,
+};
+use ethers_core::types::{
+    transaction::eip2718::TypedTransaction as EthersTypedTransactionRequest, Address,
+    Eip1559TransactionRequest as EthersEip1559TransactionRequest,
+    Eip2930TransactionRequest as EthersEip2930TransactionRequest, NameOrAddress,
+    Transaction as EthersTransaction, TransactionRequest as EthersLegacyTransactionRequest,
+    TransactionRequest, H256, U256, U64,
+};
 
 impl From<TypedTransactionRequest> for EthersTypedTransactionRequest {
     fn from(tx: TypedTransactionRequest) -> Self {
@@ -82,8 +91,11 @@ impl From<TypedTransactionRequest> for EthersTypedTransactionRequest {
     }
 }
 
-
-fn to_ethers_transaction_with_hash_and_sender(transaction: TypedTransaction, hash: H256, from: Address) -> EthersTransaction {
+fn to_ethers_transaction_with_hash_and_sender(
+    transaction: TypedTransaction,
+    hash: H256,
+    from: Address,
+) -> EthersTransaction {
     match transaction {
         TypedTransaction::Legacy(t) => EthersTransaction {
             hash,

--- a/anvil/core/src/eth/transaction/ethers_compat.rs
+++ b/anvil/core/src/eth/transaction/ethers_compat.rs
@@ -1,17 +1,8 @@
 //! ethers compatibility, this is mainly necessary so we can use all of `ethers` signers
 
 use super::EthTransactionRequest;
-use crate::eth::transaction::{
-    EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest,
-    TypedTransaction, TypedTransactionRequest,
-};
-use ethers_core::types::{
-    transaction::eip2718::TypedTransaction as EthersTypedTransactionRequest, Address,
-    Eip1559TransactionRequest as EthersEip1559TransactionRequest,
-    Eip2930TransactionRequest as EthersEip2930TransactionRequest, NameOrAddress,
-    Transaction as EthersTransaction, TransactionRequest as EthersLegacyTransactionRequest,
-    TransactionRequest, U256, U64,
-};
+use crate::eth::transaction::{EIP1559TransactionRequest, EIP2930TransactionRequest, LegacyTransactionRequest, MaybeImpersonatedTransaction, TypedTransaction, TypedTransactionRequest};
+use ethers_core::types::{transaction::eip2718::TypedTransaction as EthersTypedTransactionRequest, Address, Eip1559TransactionRequest as EthersEip1559TransactionRequest, Eip2930TransactionRequest as EthersEip2930TransactionRequest, NameOrAddress, Transaction as EthersTransaction, TransactionRequest as EthersLegacyTransactionRequest, TransactionRequest, U256, U64, H256};
 
 impl From<TypedTransactionRequest> for EthersTypedTransactionRequest {
     fn from(tx: TypedTransactionRequest) -> Self {
@@ -91,77 +82,91 @@ impl From<TypedTransactionRequest> for EthersTypedTransactionRequest {
     }
 }
 
+
+fn to_ethers_transaction_with_hash_and_sender(transaction: TypedTransaction, hash: H256, from: Address) -> EthersTransaction {
+    match transaction {
+        TypedTransaction::Legacy(t) => EthersTransaction {
+            hash,
+            nonce: t.nonce,
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            from,
+            to: None,
+            value: t.value,
+            gas_price: Some(t.gas_price),
+            max_fee_per_gas: Some(t.gas_price),
+            max_priority_fee_per_gas: Some(t.gas_price),
+            gas: t.gas_limit,
+            input: t.input.clone(),
+            chain_id: t.chain_id().map(Into::into),
+            v: t.signature.v.into(),
+            r: t.signature.r,
+            s: t.signature.s,
+            access_list: None,
+            transaction_type: Some(0u64.into()),
+            other: Default::default(),
+        },
+        TypedTransaction::EIP2930(t) => EthersTransaction {
+            hash,
+            nonce: t.nonce,
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            from,
+            to: None,
+            value: t.value,
+            gas_price: Some(t.gas_price),
+            max_fee_per_gas: Some(t.gas_price),
+            max_priority_fee_per_gas: Some(t.gas_price),
+            gas: t.gas_limit,
+            input: t.input.clone(),
+            chain_id: Some(t.chain_id.into()),
+            v: U64::from(t.odd_y_parity as u8),
+            r: U256::from(t.r.as_bytes()),
+            s: U256::from(t.s.as_bytes()),
+            access_list: Some(t.access_list),
+            transaction_type: Some(1u64.into()),
+            other: Default::default(),
+        },
+        TypedTransaction::EIP1559(t) => EthersTransaction {
+            hash,
+            nonce: t.nonce,
+            block_hash: None,
+            block_number: None,
+            transaction_index: None,
+            from,
+            to: None,
+            value: t.value,
+            gas_price: None,
+            max_fee_per_gas: Some(t.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(t.max_priority_fee_per_gas),
+            gas: t.gas_limit,
+            input: t.input.clone(),
+            chain_id: Some(t.chain_id.into()),
+            v: U64::from(t.odd_y_parity as u8),
+            r: U256::from(t.r.as_bytes()),
+            s: U256::from(t.s.as_bytes()),
+            access_list: Some(t.access_list),
+            transaction_type: Some(2u64.into()),
+            other: Default::default(),
+        },
+    }
+}
+
 impl From<TypedTransaction> for EthersTransaction {
     fn from(transaction: TypedTransaction) -> Self {
         let hash = transaction.hash();
-        match transaction {
-            TypedTransaction::Legacy(t) => EthersTransaction {
-                hash,
-                nonce: t.nonce,
-                block_hash: None,
-                block_number: None,
-                transaction_index: None,
-                from: Address::default(),
-                to: None,
-                value: t.value,
-                gas_price: Some(t.gas_price),
-                max_fee_per_gas: Some(t.gas_price),
-                max_priority_fee_per_gas: Some(t.gas_price),
-                gas: t.gas_limit,
-                input: t.input.clone(),
-                chain_id: t.chain_id().map(Into::into),
-                v: t.signature.v.into(),
-                r: t.signature.r,
-                s: t.signature.s,
-                access_list: None,
-                transaction_type: Some(0u64.into()),
-                other: Default::default(),
-            },
-            TypedTransaction::EIP2930(t) => EthersTransaction {
-                hash,
-                nonce: t.nonce,
-                block_hash: None,
-                block_number: None,
-                transaction_index: None,
-                from: Address::default(),
-                to: None,
-                value: t.value,
-                gas_price: Some(t.gas_price),
-                max_fee_per_gas: Some(t.gas_price),
-                max_priority_fee_per_gas: Some(t.gas_price),
-                gas: t.gas_limit,
-                input: t.input.clone(),
-                chain_id: Some(t.chain_id.into()),
-                v: U64::from(t.odd_y_parity as u8),
-                r: U256::from(t.r.as_bytes()),
-                s: U256::from(t.s.as_bytes()),
-                access_list: Some(t.access_list),
-                transaction_type: Some(1u64.into()),
-                other: Default::default(),
-            },
-            TypedTransaction::EIP1559(t) => EthersTransaction {
-                hash,
-                nonce: t.nonce,
-                block_hash: None,
-                block_number: None,
-                transaction_index: None,
-                from: Address::default(),
-                to: None,
-                value: t.value,
-                gas_price: None,
-                max_fee_per_gas: Some(t.max_fee_per_gas),
-                max_priority_fee_per_gas: Some(t.max_priority_fee_per_gas),
-                gas: t.gas_limit,
-                input: t.input.clone(),
-                chain_id: Some(t.chain_id.into()),
-                v: U64::from(t.odd_y_parity as u8),
-                r: U256::from(t.r.as_bytes()),
-                s: U256::from(t.s.as_bytes()),
-                access_list: Some(t.access_list),
-                transaction_type: Some(2u64.into()),
-                other: Default::default(),
-            },
-        }
+        let sender = transaction.recover().unwrap_or_default();
+        to_ethers_transaction_with_hash_and_sender(transaction, hash, sender)
+    }
+}
+
+impl From<MaybeImpersonatedTransaction> for EthersTransaction {
+    fn from(transaction: MaybeImpersonatedTransaction) -> Self {
+        let hash = transaction.hash();
+        let sender = transaction.recover().unwrap_or_default();
+        to_ethers_transaction_with_hash_and_sender(transaction.into(), hash, sender)
     }
 }
 

--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -16,9 +16,15 @@ use ethers_core::{
 };
 use foundry_evm::trace::CallTraceArena;
 use revm::{CreateScheme, Return, TransactTo, TxEnv};
+use std::ops::Deref;
 
 /// compatibility with `ethers-rs` types
 mod ethers_compat;
+
+/// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
+#[cfg(feature = "impersonated-tx")]
+pub const IMPERSONATED_SIGNATURE: Signature =
+    Signature { r: U256([0, 0, 0, 0]), s: U256([0, 0, 0, 0]), v: 0 };
 
 /// Container type for various Ethereum transaction requests
 ///
@@ -387,6 +393,115 @@ impl Encodable for EIP1559TransactionRequest {
     }
 }
 
+/// A wrapper for `TypedTransaction` that allows impersonating accounts.
+///
+/// This is a helper that carries the `impersonated` sender so that the right hash
+/// [TypedTransaction::impersonated_hash] can be created.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MaybeImpersonatedTransaction {
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub transaction: TypedTransaction,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub impersonated_sender: Option<Address>,
+}
+
+// === impl MaybeImpersonatedTransaction ===
+
+impl MaybeImpersonatedTransaction {
+    /// Creates a new wrapper for the given transaction
+    pub fn new(transaction: TypedTransaction) -> Self {
+        Self { transaction, impersonated_sender: None }
+    }
+
+    /// Creates a new impersonated transaction wrapper using the given sender
+    pub fn impersonated(transaction: TypedTransaction, impersonated_sender: Address) -> Self {
+        Self { transaction, impersonated_sender: Some(impersonated_sender) }
+    }
+
+    /// Recovers the Ethereum address which was used to sign the transaction.
+    ///
+    /// Note: this is feature gated so it does not conflict with the `Deref`ed
+    /// [TypedTransaction::recover] function by default.
+    #[cfg(feature = "impersonated-tx")]
+    pub fn recover(&self) -> Result<Address, SignatureError> {
+        if let Some(sender) = self.impersonated_sender {
+            return Ok(sender)
+        }
+        self.transaction.recover()
+    }
+
+    /// Returns the hash of the transaction
+    ///
+    /// Note: this is feature gated so it does not conflict with the `Deref`ed
+    /// [TypedTransaction::hash] function by default.
+    #[cfg(feature = "impersonated-tx")]
+    pub fn hash(&self) -> H256 {
+        if self.transaction.is_impersonated() {
+            if let Some(sender) = self.impersonated_sender {
+                return self.transaction.impersonated_hash(sender)
+            }
+        }
+        self.transaction.hash()
+    }
+}
+
+impl Encodable for MaybeImpersonatedTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.transaction.rlp_append(s)
+    }
+}
+
+impl From<MaybeImpersonatedTransaction> for TypedTransaction {
+    fn from(value: MaybeImpersonatedTransaction) -> Self {
+        value.transaction
+    }
+}
+
+impl From<TypedTransaction> for MaybeImpersonatedTransaction {
+    fn from(value: TypedTransaction) -> Self {
+        MaybeImpersonatedTransaction::new(value)
+    }
+}
+
+impl Decodable for MaybeImpersonatedTransaction {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let transaction = TypedTransaction::decode(rlp)?;
+        Ok(Self { transaction, impersonated_sender: None })
+    }
+}
+
+#[cfg(feature = "fastrlp")]
+impl open_fastrlp::Encodable for MaybeImpersonatedTransaction {
+    fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
+        self.transaction.encode(out)
+    }
+    fn length(&self) -> usize {
+        self.transaction.length()
+    }
+}
+
+#[cfg(feature = "fastrlp")]
+impl open_fastrlp::Decodable for MaybeImpersonatedTransaction {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        Ok(Self { transaction: open_fastrlp::Decodable::decode(buf)?, impersonated_sender: None })
+    }
+}
+
+impl AsRef<TypedTransaction> for MaybeImpersonatedTransaction {
+    fn as_ref(&self) -> &TypedTransaction {
+        &self.transaction
+    }
+}
+
+impl Deref for MaybeImpersonatedTransaction {
+    type Target = TypedTransaction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.transaction
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TypedTransaction {
@@ -513,12 +628,32 @@ impl TypedTransaction {
         matches!(self, TypedTransaction::EIP1559(_))
     }
 
+    /// Returns the hash of the transaction.
+    ///
+    /// Note: If this transaction has the Impersonated signature then this returns a modified unique
+    /// hash. This allows us to treat impersonated transactions as unique.
     pub fn hash(&self) -> H256 {
         match self {
             TypedTransaction::Legacy(t) => t.hash(),
             TypedTransaction::EIP2930(t) => t.hash(),
             TypedTransaction::EIP1559(t) => t.hash(),
         }
+    }
+
+    /// Returns true if the transaction was impersonated (using the impersonate Signature)
+    #[cfg(feature = "impersonated-tx")]
+    pub fn is_impersonated(&self) -> bool {
+        self.signature() == IMPERSONATED_SIGNATURE
+    }
+
+    /// Returns the hash if the transaction is impersonated (using a fake signature)
+    ///
+    /// This appends the `address` before hashing it
+    #[cfg(feature = "impersonated-tx")]
+    pub fn impersonated_hash(&self, sender: Address) -> H256 {
+        let mut bytes = rlp::encode(self);
+        bytes.extend_from_slice(sender.as_ref());
+        H256::from_slice(keccak256(&bytes).as_slice())
     }
 
     /// Recovers the Ethereum address which was used to sign the transaction.
@@ -594,20 +729,6 @@ impl Decodable for TypedTransaction {
 
 #[cfg(feature = "fastrlp")]
 impl open_fastrlp::Encodable for TypedTransaction {
-    fn length(&self) -> usize {
-        match self {
-            TypedTransaction::Legacy(tx) => tx.length(),
-            tx => {
-                let payload_len = match tx {
-                    TypedTransaction::EIP2930(tx) => tx.length() + 1,
-                    TypedTransaction::EIP1559(tx) => tx.length() + 1,
-                    _ => unreachable!("legacy tx length already matched"),
-                };
-                // we include a string header for signed types txs, so include the length here
-                payload_len + open_fastrlp::length_of_length(payload_len)
-            }
-        }
-    }
     fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
         match self {
             TypedTransaction::Legacy(tx) => tx.encode(out),
@@ -637,6 +758,20 @@ impl open_fastrlp::Encodable for TypedTransaction {
                     }
                     _ => unreachable!("legacy tx encode already matched"),
                 }
+            }
+        }
+    }
+    fn length(&self) -> usize {
+        match self {
+            TypedTransaction::Legacy(tx) => tx.length(),
+            tx => {
+                let payload_len = match tx {
+                    TypedTransaction::EIP2930(tx) => tx.length() + 1,
+                    TypedTransaction::EIP1559(tx) => tx.length() + 1,
+                    _ => unreachable!("legacy tx length already matched"),
+                };
+                // we include a string header for signed types txs, so include the length here
+                payload_len + open_fastrlp::length_of_length(payload_len)
             }
         }
     }
@@ -971,7 +1106,7 @@ pub struct TransactionEssentials {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PendingTransaction {
     /// The actual transaction
-    pub transaction: TypedTransaction,
+    pub transaction: MaybeImpersonatedTransaction,
     /// the recovered sender of this transaction
     sender: Address,
     /// hash of `transaction`, so it can easily be reused with encoding and hashing agan
@@ -984,7 +1119,7 @@ impl PendingTransaction {
     /// Creates a new pending transaction and tries to verify transaction and recover sender.
     pub fn new(transaction: TypedTransaction) -> Result<Self, SignatureError> {
         let sender = transaction.recover()?;
-        Ok(Self { hash: transaction.hash(), transaction, sender })
+        Ok(Self { hash: transaction.hash(), transaction: transaction.into(), sender })
     }
 
     /// Creates a new transaction with the given sender.
@@ -993,10 +1128,10 @@ impl PendingTransaction {
     /// transaction's hash with the address to make it unique.
     ///
     /// See: <https://github.com/foundry-rs/foundry/issues/3759>
+    #[cfg(feature = "impersonated-tx")]
     pub fn with_impersonated(transaction: TypedTransaction, sender: Address) -> Self {
-        let mut bytes = rlp::encode(&transaction);
-        bytes.extend_from_slice(sender.as_ref());
-        let hash = H256::from_slice(keccak256(&bytes).as_slice());
+        let hash = transaction.impersonated_hash(sender);
+        let transaction = MaybeImpersonatedTransaction::impersonated(transaction, sender);
         Self { hash, transaction, sender }
     }
 
@@ -1023,7 +1158,7 @@ impl PendingTransaction {
         }
 
         let caller = *self.sender();
-        match &self.transaction {
+        match &self.transaction.transaction {
             TypedTransaction::Legacy(tx) => {
                 let chain_id = tx.chain_id();
                 let LegacyTransaction { nonce, gas_price, gas_limit, value, kind, input, .. } = tx;

--- a/anvil/src/eth/backend/cheats.rs
+++ b/anvil/src/eth/backend/cheats.rs
@@ -1,20 +1,11 @@
 //! Support for "cheat codes" / bypass functions
 
-use anvil_core::eth::transaction::TypedTransaction;
-use ethers::types::{Address, Signature, U256};
+use anvil_core::eth::transaction::IMPERSONATED_SIGNATURE;
+use ethers::types::{Address, Signature};
 use forge::hashbrown::HashSet;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use tracing::trace;
-
-/// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
-const BYPASS_SIGNATURE: Signature =
-    Signature { r: U256([0, 0, 0, 0]), s: U256([0, 0, 0, 0]), v: 0 };
-
-/// Returns `true` if the signature of the `transaction` is the `BYPASS_SIGNATURE`
-pub fn is_bypassed(transaction: &TypedTransaction) -> bool {
-    transaction.signature() == BYPASS_SIGNATURE
-}
 
 /// Manages user modifications that may affect the node's behavior
 ///
@@ -71,6 +62,6 @@ pub struct CheatsState {
 
 impl Default for CheatsState {
     fn default() -> Self {
-        Self { impersonated_accounts: Default::default(), bypass_signature: BYPASS_SIGNATURE }
+        Self { impersonated_accounts: Default::default(), bypass_signature: IMPERSONATED_SIGNATURE }
     }
 }

--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -49,7 +49,7 @@ impl ExecutedTransaction {
 
         // successful return see [Return]
         let status_code = u8::from(self.exit_reason as u8 <= Return::SelfDestruct as u8);
-        match &self.transaction.pending_transaction.transaction {
+        match &self.transaction.pending_transaction.transaction.transaction {
             TypedTransaction::Legacy(_) => TypedReceipt::Legacy(EIP658Receipt {
                 status_code,
                 gas_used: used_gas,

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -2,7 +2,6 @@
 use crate::{
     eth::{
         backend::{
-            cheats,
             cheats::CheatsManager,
             db::{AsHashDB, Db, MaybeHashDatabase, SerializableState},
             executor::{ExecutedTransactions, TransactionExecutor},
@@ -31,7 +30,8 @@ use anvil_core::{
         receipt::{EIP658Receipt, TypedReceipt},
         state::StateOverride,
         transaction::{
-            EthTransactionRequest, PendingTransaction, TransactionInfo, TypedTransaction,
+            EthTransactionRequest, MaybeImpersonatedTransaction, PendingTransaction,
+            TransactionInfo, TypedTransaction,
         },
         trie::RefTrieDB,
         utils::to_access_list,
@@ -1636,7 +1636,7 @@ impl Backend {
 
         let transaction = block.transactions[index].clone();
 
-        let effective_gas_price = match transaction {
+        let effective_gas_price = match transaction.transaction {
             TypedTransaction::Legacy(t) => t.gas_price,
             TypedTransaction::EIP2930(t) => t.gas_price,
             TypedTransaction::EIP1559(t) => block
@@ -1990,7 +1990,7 @@ impl TransactionValidator for Backend {
 #[allow(clippy::too_many_arguments)]
 pub fn transaction_build(
     tx_hash: Option<H256>,
-    eth_transaction: TypedTransaction,
+    eth_transaction: MaybeImpersonatedTransaction,
     block: Option<&Block>,
     info: Option<TransactionInfo>,
     is_eip1559: bool,
@@ -1998,14 +1998,7 @@ pub fn transaction_build(
 ) -> Transaction {
     let mut transaction: Transaction = eth_transaction.clone().into();
 
-    // if a specific hash was provided we update the transaction's hash
-    // This is important for impersonated transactions since they all use the `BYPASS_SIGNATURE`
-    // which would result in different hashes
-    if let Some(tx_hash) = tx_hash {
-        transaction.hash = tx_hash;
-    }
-
-    if let TypedTransaction::EIP1559(_) = eth_transaction {
+    if let TypedTransaction::EIP1559(_) = eth_transaction.as_ref() {
         if block.is_none() && info.is_none() {
             // transaction is not mined yet, gas price is considered just `max_fee_per_gas`
             transaction.gas_price = transaction.max_fee_per_gas;
@@ -2032,12 +2025,23 @@ pub fn transaction_build(
 
     transaction.transaction_index = info.as_ref().map(|status| status.transaction_index.into());
 
-    // need to check if the signature of the transaction is the `BYPASS_SIGNATURE`, if so then we
-    // can't recover the sender, instead we use the sender from the executed transaction
-    if cheats::is_bypassed(&eth_transaction) {
-        transaction.from = info.as_ref().map(|info| info.from).unwrap_or_default()
+    // need to check if the signature of the transaction is impersonated, if so then we
+    // can't recover the sender, instead we use the sender from the executed transaction and set the
+    // impersonated hash.
+    if eth_transaction.is_impersonated() {
+        transaction.from = info.as_ref().map(|info| info.from).unwrap_or_default();
+        transaction.hash = eth_transaction.impersonated_hash(transaction.from);
     } else {
         transaction.from = eth_transaction.recover().expect("can recover signed tx");
+    }
+
+    // if a specific hash was provided we update the transaction's hash
+    // This is important for impersonated transactions since they all use the `BYPASS_SIGNATURE`
+    // which would result in different hashes
+    // Note: for impersonated transactions this only concerns pending transactions because there's
+    // no `info` yet.
+    if let Some(tx_hash) = tx_hash {
+        transaction.hash = tx_hash;
     }
 
     transaction.to = info.as_ref().map_or(eth_transaction.to().cloned(), |status| status.to);

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -9,7 +9,7 @@ use crate::eth::{
 use anvil_core::eth::{
     block::{Block, PartialHeader},
     receipt::TypedReceipt,
-    transaction::TransactionInfo,
+    transaction::{MaybeImpersonatedTransaction, TransactionInfo},
 };
 use ethers::{
     prelude::{BlockId, BlockNumber, GethTrace, Trace, H256, H256 as TxHash, U64},
@@ -217,7 +217,7 @@ impl BlockchainStorage {
             difficulty: env.block.difficulty,
             ..Default::default()
         };
-        let block = Block::new(partial_header, vec![], vec![]);
+        let block = Block::new::<MaybeImpersonatedTransaction>(partial_header, vec![], vec![]);
         let genesis_hash = block.header.hash();
         let best_hash = genesis_hash;
         let best_number: U64 = 0u64.into();

--- a/anvil/src/eth/fees.rs
+++ b/anvil/src/eth/fees.rs
@@ -235,7 +235,8 @@ impl FeeHistoryService {
                 .enumerate()
                 .map(|(i, receipt)| {
                     let gas_used = receipt.gas_used().as_u64();
-                    let effective_reward = match block.transactions.get(i) {
+                    let effective_reward = match block.transactions.get(i).map(|tx| &tx.transaction)
+                    {
                         Some(TypedTransaction::Legacy(t)) => {
                             t.gas_price.saturating_sub(base_fee).as_u64()
                         }

--- a/anvil/tests/it/pubsub.rs
+++ b/anvil/tests/it/pubsub.rs
@@ -7,7 +7,7 @@ use ethers::{
     prelude::{Middleware, Ws},
     providers::{JsonRpcClient, PubsubClient},
     signers::Signer,
-    types::{Block, Filter, TxHash, ValueOrArray, U256},
+    types::{Address, Block, Filter, TransactionRequest, TxHash, ValueOrArray, U256},
 };
 use futures::StreamExt;
 use std::sync::Arc;
@@ -102,6 +102,47 @@ async fn test_sub_logs() {
     // get the emitted event
     let log = logs_sub.next().await.unwrap();
 
+    // ensure the log in the receipt is the same as received via subscription stream
+    assert_eq!(receipt.logs[0], log);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sub_logs_impersonated() {
+    abigen!(EmitLogs, "test-data/emit_logs.json");
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.ws_provider().await;
+
+    // impersonate account
+    let impersonate = Address::random();
+    let funding = U256::from(1e18 as u64);
+    api.anvil_set_balance(impersonate, funding).await.unwrap();
+    api.anvil_impersonate_account(impersonate).await.unwrap();
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    let msg = "First Message".to_string();
+    let contract =
+        EmitLogs::deploy(Arc::clone(&client), msg.clone()).unwrap().send().await.unwrap();
+
+    let _val = contract.get_value().call().await.unwrap();
+
+    // subscribe to events from the impersonated account
+    let filter = Filter::new().address(ValueOrArray::Value(contract.address()));
+    let mut logs_sub = client.subscribe_logs(&filter).await.unwrap();
+
+    // send a tx triggering an event
+    let data = contract.set_value("Next Message".to_string()).tx.data().cloned().unwrap();
+
+    let tx = TransactionRequest::new().from(impersonate).to(contract.address()).data(data);
+
+    let provider = handle.http_provider();
+
+    let receipt = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
+
+    // get the emitted event
+    let log = logs_sub.next().await.unwrap();
     // ensure the log in the receipt is the same as received via subscription stream
     assert_eq!(receipt.logs[0], log);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4205

after #4185 we're making impersonated transactions unique by appending the sender to the preimage. however we didn't use that everywhere, for example when retrieving the `TypedTransaction` of a block we'd still use the regular hash using the impersonated signature.

This PR includes following changes
* add wrapper type `MaybeImpersonatedTransaction(TypedTransaction,Option<Address>)` which keeps track of the sender so we can use in when computing the hash if the transaction is impersonated
* change `block.transactions` to `Vec<MaybeImpersonatedTransaction>`
* feature gate impersonated-tx in `anvil-core`

@jxom could you please give this a try?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
