### PR TITLE
fix(anvil): always fetch forked block

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -804,14 +804,10 @@ impl NodeConfig {
                     )
                 };
 
-            let block = if self.fork_chain_id.is_some() {
-                Some(Default::default())
-            } else {
-                provider
-                    .get_block(BlockNumber::Number(fork_block_number.into()))
-                    .await
-                    .expect("Failed to get fork block")
-            };
+            let block = provider
+                .get_block(BlockNumber::Number(fork_block_number.into()))
+                .await
+                .expect("Failed to get fork block");
 
             let block = if let Some(block) = block {
                 block

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -804,3 +804,37 @@ async fn test_total_difficulty_fork() {
     assert_eq!(block.total_difficulty, Some(next_total_difficulty));
     assert_eq!(block.difficulty, U256::zero());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_override_fork_chain_id() {
+    let chain_id_override = 5u64;
+    let (_api, handle) = spawn(
+        fork_config()
+            .with_fork_block_number(Some(16506610u64))
+            .with_chain_id(Some(chain_id_override)),
+    )
+    .await;
+    let provider = handle.http_provider();
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    let greeter_contract = Greeter::deploy(Arc::clone(&client), "Hello World!".to_string())
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    let greeting = greeter_contract.greet().call().await.unwrap();
+    assert_eq!("Hello World!", greeting);
+
+    let greeter_contract =
+        Greeter::deploy(client, "Hello World!".to_string()).unwrap().send().await.unwrap();
+
+    let greeting = greeter_contract.greet().call().await.unwrap();
+    assert_eq!("Hello World!", greeting);
+
+    let provider = handle.http_provider();
+    let chain_id = provider.get_chainid().await.unwrap();
+    assert_eq!(chain_id.as_u64(), chain_id_override);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
fixes a bug that occurred when the `--fork-chain-id` argument was provided, in which case the block wasn't fetched.
this resulted in failing transactions due to wrong config, for example `prevrandio None` after merge.

I don't really know why in this case the block was initialized with `Default`, but this is def wrong, because we need the block.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
always fetch the requested block
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
