### PR TITLE
fix(forge): init errors

### DIFF
--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -104,7 +104,7 @@ impl Cmd for InitArgs {
             std::env::set_current_dir(initial_dir)?;
         } else {
             // check if target is empty
-            if !force && root.read_dir().map(|mut i| i.next().is_none()).unwrap_or(true) {
+            if !force && root.read_dir().map(|mut i| i.next().is_some()).unwrap_or(false) {
                 eyre::bail!(
                     "Cannot run `init` on a non-empty directory.\n\
                     Run with the `--force` flag to initialize regardless."
@@ -194,14 +194,12 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
             .current_dir(root)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .spawn()
-            .ok()?
-            .wait_with_output()
+            .get_stdout_lossy()
             .ok()?;
-
-        return Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        Some(output)
+    } else {
+        None
     }
-    None
 }
 
 /// Initialises `root` as a git repository.

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -204,28 +204,30 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
     None
 }
 
-/// Initialises the `root` as git repository if it's not a git repository yet
+/// Initialises `root` as a git repository.
+///
+/// Creates `.gitignore` and `.github/workflows/test.yml`, and commits everything in `root` if
+/// `no_commit` is false.
 fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
+    // git init
     if !is_git(root)? {
-        let gitignore_path = root.join(".gitignore");
-        fs::write(gitignore_path, include_str!("../../../assets/.gitignoreTemplate"))?;
-
-        // git init
         Command::new("git").arg("init").current_dir(root).exec()?;
+    }
 
-        // create github workflow
-        let gh = root.join(".github").join("workflows");
-        fs::create_dir_all(&gh)?;
-        let workflow_path = gh.join("test.yml");
-        fs::write(workflow_path, include_str!("../../../assets/workflowTemplate.yml"))?;
+    // .gitignore
+    let gitignore = root.join(".gitignore");
+    fs::write(gitignore, include_str!("../../../assets/.gitignoreTemplate"))?;
 
-        if !no_commit {
-            Command::new("git").args(["add", "."]).current_dir(root).exec()?;
-            Command::new("git")
-                .args(["commit", "-m", "chore: forge init"])
-                .current_dir(root)
-                .exec()?;
-        }
+    // github workflow
+    let gh = root.join(".github").join("workflows");
+    fs::create_dir_all(&gh)?;
+    let workflow_path = gh.join("test.yml");
+    fs::write(workflow_path, include_str!("../../../assets/workflowTemplate.yml"))?;
+
+    // commit everything
+    if !no_commit {
+        Command::new("git").args(["add", "."]).current_dir(root).exec()?;
+        Command::new("git").args(["commit", "-m", "chore: forge init"]).current_dir(root).exec()?;
     }
 
     Ok(())

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -138,7 +138,7 @@ impl Cmd for InitArgs {
             let contract_path = script.join("Counter.s.sol");
             fs::write(contract_path, include_str!("../../../assets/CounterTemplate.s.sol"))?;
 
-            // write foundry.toml
+            // write foundry.toml, if it doesn't exist already
             let dest = root.join(Config::FILE_NAME);
             let mut config = Config::load_with_root(&root);
             if !dest.exists() {
@@ -202,10 +202,11 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
     }
 }
 
-/// Initialises `root` as a git repository.
+/// Initialises `root` as a git repository, if it isn't one already.
 ///
-/// Creates `.gitignore` and `.github/workflows/test.yml`, and commits everything in `root` if
-/// `no_commit` is false.
+/// Creates `.gitignore` and `.github/workflows/test.yml`, if they don't exist already.
+///
+/// Commits everything in `root` if `no_commit` is false.
 fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
     // git init
     if !is_git(root)? {
@@ -214,13 +215,17 @@ fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
 
     // .gitignore
     let gitignore = root.join(".gitignore");
-    fs::write(gitignore, include_str!("../../../assets/.gitignoreTemplate"))?;
+    if !gitignore.exists() {
+        fs::write(gitignore, include_str!("../../../assets/.gitignoreTemplate"))?;
+    }
 
     // github workflow
     let gh = root.join(".github").join("workflows");
-    fs::create_dir_all(&gh)?;
-    let workflow_path = gh.join("test.yml");
-    fs::write(workflow_path, include_str!("../../../assets/workflowTemplate.yml"))?;
+    if !gh.exists() {
+        fs::create_dir_all(&gh)?;
+        let workflow_path = gh.join("test.yml");
+        fs::write(workflow_path, include_str!("../../../assets/workflowTemplate.yml"))?;
+    }
 
     // commit everything
     if !no_commit {

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -116,7 +116,7 @@ impl Cmd for InitArgs {
             }
 
             // ensure git status is clean before generating anything
-            if !no_git && !no_commit && is_git(&root)? {
+            if !no_git && !no_commit && !force && is_git(&root)? {
                 ensure_git_status_clean(&root)?;
             }
 

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -103,12 +103,16 @@ impl Cmd for InitArgs {
             // Navigate back.
             std::env::set_current_dir(initial_dir)?;
         } else {
-            // check if target is empty
-            if !force && root.read_dir().map(|mut i| i.next().is_some()).unwrap_or(false) {
-                eyre::bail!(
-                    "Cannot run `init` on a non-empty directory.\n\
-                    Run with the `--force` flag to initialize regardless."
-                );
+            // if target is not empty
+            if root.read_dir().map(|mut i| i.next().is_some()).unwrap_or(false) {
+                if !force {
+                    eyre::bail!(
+                        "Cannot run `init` on a non-empty directory.\n\
+                        Run with the `--force` flag to initialize regardless."
+                    );
+                }
+
+                p_println!(!quiet => "Target directory is not empty, but `--force` was specified");
             }
 
             // ensure git status is clean before generating anything

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -306,16 +306,8 @@ fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyr
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
         eyre::bail!(
-            "\
-This command's target directory is, or is in an already initialized git repository,
-and it requires clean working and staging areas, including no untracked files.
-
-Check the current git repository's status with `git status`.
-Then, you can track files with `git add ...` and then commit them with `git commit`,
-ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
-
-If none of the previous steps worked, please open an issue at:
-https://github.com/foundry-rs/foundry/issues/new/choose"
+            "This command requires clean working and staging areas, including no untracked files.\n\
+            Modify .gitignore and/or add/commit first, or add the --no-commit option."
         )
     }
     Ok(())

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -305,10 +305,7 @@ fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyr
 
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
-        eyre::bail!(
-            "This command requires clean working and staging areas, including no untracked files.\n\
-            Modify .gitignore and/or add/commit first, or add the --no-commit option."
-        )
+        eyre::bail!("This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.")
     }
     Ok(())
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -305,7 +305,10 @@ fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyr
 
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
-        eyre::bail!("This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.")
+        eyre::bail!(
+            "This command requires clean working and staging areas, including no untracked files.\n\
+            Modify .gitignore and/or add/commit first, or add the --no-commit option."
+        )
     }
     Ok(())
 }
@@ -314,7 +317,7 @@ pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
 fn git_status_clean(root: impl AsRef<Path>) -> eyre::Result<bool> {
     let stdout =
         Command::new("git").args(["status", "--short"]).current_dir(root).get_stdout_lossy()?;
-    Ok(stdout.is_empty())
+    Ok(stdout.trim().is_empty())
 }
 
 /// Executes a git clone

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -305,10 +305,17 @@ fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyr
 
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
-        eyre::bail!(
-            "This command requires clean working and staging areas, including no untracked files.\n\
-            Modify .gitignore and/or add/commit first, or add the --no-commit option."
-        )
+        let msg = "\
+This command's target directory is, or is in an already initialized git repository,
+and it requires clean working and staging areas, including no untracked files.
+
+Check the current git repository's status with `git status`.
+Then, you can track files with `git add ...` and then commit them with `git commit`,
+ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
+
+If none of the previous steps worked, please open an issue at:
+https://github.com/foundry-rs/foundry/issues/new/choose";
+        eyre::bail!(msg)
     }
     Ok(())
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -305,7 +305,8 @@ fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyr
 
 pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
     if !git_status_clean(root)? {
-        let msg = "\
+        eyre::bail!(
+            "\
 This command's target directory is, or is in an already initialized git repository,
 and it requires clean working and staging areas, including no untracked files.
 
@@ -314,8 +315,8 @@ Then, you can track files with `git add ...` and then commit them with `git comm
 ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
 
 If none of the previous steps worked, please open an issue at:
-https://github.com/foundry-rs/foundry/issues/new/choose";
-        eyre::bail!(msg)
+https://github.com/foundry-rs/foundry/issues/new/choose"
+        )
     }
     Ok(())
 }

--- a/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
+++ b/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
@@ -1,10 +1,2 @@
 Error: 
-This command's target directory is, or is in an already initialized git repository,
-and it requires clean working and staging areas, including no untracked files.
-
-Check the current git repository's status with `git status`.
-Then, you can track files with `git add ...` and then commit them with `git commit`,
-ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
-
-If none of the previous steps worked, please open an issue at:
-https://github.com/foundry-rs/foundry/issues/new/choose
+This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.

--- a/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
+++ b/cli/tests/fixtures/can_detect_dirty_git_status_on_init.stderr
@@ -1,2 +1,10 @@
 Error: 
-This command requires clean working and staging areas, including no untracked files. Modify .gitignore and/or add/commit first, or add the --no-commit option.
+This command's target directory is, or is in an already initialized git repository,
+and it requires clean working and staging areas, including no untracked files.
+
+Check the current git repository's status with `git status`.
+Then, you can track files with `git add ...` and then commit them with `git commit`,
+ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
+
+If none of the previous steps worked, please open an issue at:
+https://github.com/foundry-rs/foundry/issues/new/choose

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -244,7 +244,7 @@ forgetest!(can_detect_dirty_git_status_on_init, |prj: TestProject, mut cmd: Test
     // initialize new git repo
     let status = Command::new("git")
         .arg("init")
-        .current_dir(&root)
+        .current_dir(prj.root())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -17,7 +17,12 @@ use foundry_cli_test_utils::{
 };
 use foundry_config::{parse_with_profile, BasicConfig, Chain, Config, SolidityErrorCode};
 use semver::Version;
-use std::{env, fs, path::PathBuf, process::Command, str::FromStr};
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+    str::FromStr,
+};
 
 // tests `--help` is printed to std out
 forgetest!(print_help, |_: TestProject, mut cmd: TestCommand| {
@@ -234,11 +239,17 @@ forgetest!(can_init_repo_with_config, |prj: TestProject, mut cmd: TestCommand| {
 
 // Checks that a forge project fails to initialise if dir is already git repo and dirty
 forgetest!(can_detect_dirty_git_status_on_init, |prj: TestProject, mut cmd: TestCommand| {
-    use std::process::Command;
     prj.wipe();
 
-    // initialise new git
-    Command::new("git").arg("init").current_dir(prj.root()).output().unwrap();
+    // initialize new git repo
+    let status = Command::new("git")
+        .arg("init")
+        .current_dir(&root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("could not run git init");
+    assert!(status.success());
 
     std::fs::write(prj.root().join("untracked.text"), "untracked").unwrap();
 
@@ -287,7 +298,7 @@ forgetest!(can_init_with_dir, |prj: TestProject, mut cmd: TestCommand| {
     assert!(prj.root().join("foobar").exists());
 });
 
-// `forge init` does only work on non-empty dirs
+// `forge init --force` works on non-empty dirs
 forgetest!(can_init_non_empty, |prj: TestProject, mut cmd: TestCommand| {
     prj.create_file("README.md", "non-empty dir");
     cmd.arg("init").arg(prj.root());
@@ -297,6 +308,29 @@ forgetest!(can_init_non_empty, |prj: TestProject, mut cmd: TestCommand| {
     cmd.assert_non_empty_stdout();
     assert!(prj.root().join(".git").exists());
     assert!(prj.root().join("lib/forge-std").exists());
+});
+
+// `forge init --force` works on already initialized git repository
+forgetest!(can_init_with_repo, |prj: TestProject, mut cmd: TestCommand| {
+    let root = prj.root();
+
+    // initialize new git repo
+    let status = Command::new("git")
+        .arg("init")
+        .current_dir(&root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("could not run git init");
+    assert!(status.success());
+    assert!(root.join(".git").exists());
+
+    cmd.arg("init").arg(&root);
+    cmd.assert_err();
+
+    cmd.arg("--force");
+    cmd.assert_non_empty_stdout();
+    assert!(root.join("lib/forge-std").exists());
 });
 
 // Checks that remappings.txt and .vscode/settings.json is generated


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #4214

If the folder is already initialized to a git repo (and using `--force`), we're creating all the necessary files, except for workflow, .gitignore and the initial commit (`init_git_repo` doesn't run), so when git status is checked later during forge-std installation, it fails with that message because the initialized files didnt get committed

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

make `if !is_git` block only apply to `git init` itself
do not overwrite `.gitignore` and `.github/workflows`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
