### PR TITLE
chore: add more info to nonce error when broadcasting sequentially

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -227,7 +227,7 @@ impl ScriptArgs {
             let tx_nonce = tx.nonce().expect("no nonce");
 
             if nonce != *tx_nonce {
-                bail!("EOA nonce changed unexpectedly while sending transactions.")
+                bail!("EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider.")
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/foundry-rs/foundry/actions/runs/4024562774/jobs/6916738254
Got a possible [flake/error](https://github.com/foundry-rs/foundry/actions/runs/4024562774/jobs/6916738254) on CI during the goerli live tests. Only happened in that commit afaik. This would help gather more information if it happens again.

## Solution

Specify what nonce was expected, and what was given by the RPC provider

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
