### PR TITLE
fix(forge): get etherscan api key from config when using anvil chain

### DIFF
--- a/cli/src/cmd/forge/script/verify.rs
+++ b/cli/src/cmd/forge/script/verify.rs
@@ -68,7 +68,8 @@ impl VerifyBundle {
         // chain_id.
         let mut config = config.clone();
         config.chain_id = Some(chain);
-        self.etherscan_key = config.get_etherscan_api_key(Some(chain));
+        self.etherscan_key =
+            config.get_etherscan_api_key(Some(chain)).or_else(|| config.etherscan_api_key.clone());
         self.chain = chain;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

fix #3872 

## Solution

https://github.com/foundry-rs/foundry/pull/4220#issuecomment-1408133145

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
