### PR TITLE
fix(cast): interface arg name lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "glob",
  "hex",
  "once_cell",
+ "pretty_assertions",
  "rand 0.8.5",
  "reqwest",
  "rlp",

--- a/testdata/fixtures/SolidityGeneration/WithStructs.json
+++ b/testdata/fixtures/SolidityGeneration/WithStructs.json
@@ -381,6 +381,30 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "implem",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct NFToken",
+        "name": "token",
+        "type": "tuple"
+      }
+    ],
+    "name": "NFTokenAdded",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "MAX_AUCTION_VALUE",
     "outputs": [
@@ -1213,6 +1237,56 @@
     ],
     "name": "withdrawStuckNativeToken",
     "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "implem",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct NFToken",
+        "name": "nft",
+        "type": "tuple"
+      }
+    ],
+    "name": "storeNFToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "viewNFToken",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "implem",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct NFToken",
+        "name": "nft",
+        "type": "tuple"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/testdata/fixtures/SolidityGeneration/WithStructs.sol
+++ b/testdata/fixtures/SolidityGeneration/WithStructs.sol
@@ -14,6 +14,7 @@ interface test {
     event FastLaneFeeSet(uint256 amount);
     event MinimumAutoshipThresholdSet(uint128 amount);
     event MinimumBidIncrementSet(uint256 amount);
+    event NFTokenAdded(NFToken token);
     event OpportunityAddressDisabled(address indexed opportunity, uint128 indexed auction_number);
     event OpportunityAddressEnabled(address indexed opportunity, uint128 indexed auction_number);
     event OpsSet(address ops);
@@ -41,6 +42,11 @@ interface test {
         address searcherContractAddress;
         address searcherPayableAddress;
         uint256 bidAmount;
+    }
+
+    struct NFToken {
+        address implem;
+        uint256 id;
     }
 
     struct Status {
@@ -123,8 +129,10 @@ interface test {
     function setStarter(address _starter) external;
     function setValidatorPreferences(uint128 _minAutoshipAmount, address _validatorPayableAddress) external;
     function startAuction() external;
+    function storeNFToken(NFToken memory nft) external;
     function submitBid(Bid memory bid) external;
     function transferOwnership(address newOwner) external;
+    function viewNFToken() external returns (NFToken memory nft);
     function withdrawStuckERC20(address _tokenAddress) external;
     function withdrawStuckNativeToken(uint256 amount) external;
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -41,6 +41,7 @@ foundry-common = { path = "./../common" }
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
     "solc-full",
 ] }
+pretty_assertions = "1.0.0"
 
 [features]
 test = ["tracing-subscriber"]

--- a/utils/src/abi.rs
+++ b/utils/src/abi.rs
@@ -150,7 +150,7 @@ fn expand_input_param_type(
         }
         ParamType::Tuple(_) => {
             let ty = if let Some(struct_name) =
-                structs.get_function_input_struct_type(&fun.name, param)
+                structs.get_function_input_struct_solidity_id(&fun.name, param)
             {
                 struct_name.to_string()
             } else {
@@ -183,7 +183,7 @@ fn expand_output_param_type(
                     kind.to_string().trim_start_matches('(').trim_end_matches(')').to_string();
                 Ok(result)
             } else {
-                let ty = if let Some(struct_name) = structs.get_function_output_struct_type(
+                let ty = if let Some(struct_name) = structs.get_function_output_struct_solidity_id(
                     &fun.name,
                     param.internal_type.as_ref().unwrap(),
                 ) {
@@ -257,12 +257,13 @@ fn expand_event_param_type(
             Ok(format!("{ty}[{}]", *size))
         }
         ParamType::Tuple(_) => {
-            let ty =
-                if let Some(struct_name) = structs.get_event_input_struct_type(&event.name, idx) {
-                    struct_name.to_string()
-                } else {
-                    kind.to_string()
-                };
+            let ty = if let Some(struct_name) =
+                structs.get_event_input_struct_solidity_id(&event.name, idx)
+            {
+                struct_name.to_string()
+            } else {
+                kind.to_string()
+            };
             Ok(ty)
         }
         _ => Ok(kind.to_string()),
@@ -342,11 +343,11 @@ mod tests {
             "../../testdata/fixtures/SolidityGeneration/InterfaceABI.json"
         ))
         .unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!("../../testdata/fixtures/SolidityGeneration/GeneratedNamedInterface.sol"),
             abi_to_solidity(&contract_abi, "test").unwrap()
         );
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!(
                 "../../testdata/fixtures/SolidityGeneration/GeneratedUnnamedInterface.sol"
             ),
@@ -360,7 +361,7 @@ mod tests {
             "../../testdata/fixtures/SolidityGeneration/GaugeController.json"
         ))
         .unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!("../../testdata/fixtures/SolidityGeneration/GeneratedGaugeController.sol"),
             abi_to_solidity(&contract_abi, "test").unwrap()
         );
@@ -372,7 +373,7 @@ mod tests {
             "../../testdata/fixtures/SolidityGeneration/LiquidityGaugeV4.json"
         ))
         .unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!(
                 "../../testdata/fixtures/SolidityGeneration/GeneratedLiquidityGaugeV4.sol"
             ),
@@ -386,7 +387,7 @@ mod tests {
             "../../testdata/fixtures/SolidityGeneration/Fastlane.json"
         ))
         .unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!("../../testdata/fixtures/SolidityGeneration/GeneratedFastLane.sol"),
             abi_to_solidity(&contract_abi, "test").unwrap()
         );
@@ -399,7 +400,7 @@ mod tests {
             "../../testdata/fixtures/SolidityGeneration/WithStructs.json"
         ))
         .unwrap();
-        assert_eq!(
+        pretty_assertions::assert_eq!(
             include_str!("../../testdata/fixtures/SolidityGeneration/WithStructs.sol").trim(),
             abi_to_solidity(&contract_abi, "test").unwrap().trim()
         );


### PR DESCRIPTION
Closes #3957 

`cast interface` incorrectly looked up the name of rust types for code generation instead of solidity type identifier