### PR TITLE
fix(forge) fix a typo in logging output

### DIFF
--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -110,7 +110,7 @@ impl ScriptSequence {
                 )?),
                 &self,
             )?;
-            shell::println(format!("\nTransactionsdffs saved to: {path}\n"))?;
+            shell::println(format!("\nTransactions saved to: {path}\n"))?;
         }
 
         Ok(())


### PR DESCRIPTION
Fix for a typo introduced in yesterday's commit: https://github.com/foundry-rs/foundry/commit/5c2db0babf02e1f1016b1471de3b21593cb06b56#r98769848

We relied on the logging output format to grab the path of the transaction log.