### PR TITLE
fix(anvil): ensure prevrandao is set in forking mode

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -830,7 +830,8 @@ impl NodeConfig {
                 number: fork_block_number.into(),
                 timestamp: block.timestamp,
                 difficulty: block.difficulty,
-                prevrandao: block.mix_hash,
+                // ensures prevrandao is set
+                prevrandao: Some(block.mix_hash.unwrap_or_default()),
                 gas_limit,
                 // Keep previous `coinbase` and `basefee` value
                 coinbase: env.block.coinbase,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4232

ensure prevrandao is set, even if no mixHash in response
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
