### PR TITLE
refactor(cli): add cli prompts

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -12,7 +12,7 @@ use foundry_cli::{
     cmd::Cmd,
     handler,
     opts::cast::{Opts, Subcommands, ToBaseArgs},
-    stdin, utils,
+    prompt, stdin, utils,
     utils::try_consume_config_rpc_url,
 };
 use foundry_common::{
@@ -26,7 +26,6 @@ use foundry_common::{
 };
 use foundry_config::{Chain, Config};
 use rustc_hex::ToHex;
-use std::io::{self, Write};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -346,9 +345,7 @@ async fn main() -> eyre::Result<()> {
                 0 => eyre::bail!("No signatures found"),
                 1 => sigs.get(0).unwrap(),
                 _ => {
-                    print!("Select a function signature by number: ");
-                    io::stdout().flush()?;
-                    let i: usize = stdin::unwrap_line(None)?;
+                    let i: usize = prompt!("Select a function signature by number: ")?;
                     sigs.get(i - 1).ok_or_else(|| eyre::eyre!("Invalid signature index"))?
                 }
             };

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -546,7 +546,7 @@ fn match_tag(tag: &String, libs: &Path, target_dir: &str) -> eyre::Result<String
             Ok(i) if i == 0 => return Ok(tag.into()),
             Ok(i) if (1..=n_candidates).contains(&i) => {
                 let c = &candidates[i];
-                println!("[{i}] {} selected", c);
+                println!("[{i}] {c} selected");
                 return Ok(c.clone())
             }
             _ => continue,

--- a/cli/src/stdin.rs
+++ b/cli/src/stdin.rs
@@ -14,11 +14,12 @@ use std::{
 /// # Examples
 ///
 /// ```no_run
+/// # use foundry_cli::prompt;
 /// let response: String = prompt!("Would you like to continue? [y/N] ")?;
 /// if !matches!(response.as_str(), "y" | "Y") {
 ///     return Ok(())
 /// }
-/// # Ok::<(), Box<dyn std::error::Error>>()
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[macro_export]
 macro_rules! prompt {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -251,7 +251,7 @@ impl CommandUtils for Command {
     #[track_caller]
     fn exec(&mut self) -> eyre::Result<Output> {
         let output = self.output()?;
-        if !&output.status.success() {
+        if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             eyre::bail!("{}", stderr.trim())
         }

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -317,7 +317,7 @@ forgetest!(can_init_in_empty_repo, |prj: TestProject, mut cmd: TestCommand| {
     // initialize new git repo
     let status = Command::new("git")
         .arg("init")
-        .current_dir(&root)
+        .current_dir(root)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -325,7 +325,7 @@ forgetest!(can_init_in_empty_repo, |prj: TestProject, mut cmd: TestCommand| {
     assert!(status.success());
     assert!(root.join(".git").exists());
 
-    cmd.arg("init").arg(&root);
+    cmd.arg("init").arg(root);
     cmd.assert_err();
 
     cmd.arg("--force");
@@ -340,7 +340,7 @@ forgetest!(can_init_in_non_empty_repo, |prj: TestProject, mut cmd: TestCommand| 
     // initialize new git repo
     let status = Command::new("git")
         .arg("init")
-        .current_dir(&root)
+        .current_dir(root)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -351,7 +351,7 @@ forgetest!(can_init_in_non_empty_repo, |prj: TestProject, mut cmd: TestCommand| 
     prj.create_file("README.md", "non-empty dir");
     prj.create_file(".gitignore", "not foundry .gitignore");
 
-    cmd.arg("init").arg(&root);
+    cmd.arg("init").arg(root);
     cmd.assert_err();
 
     cmd.arg("--force");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Remove boilerplate to prompt, wait stdin answer and parse:

```rust
print!("<prompt>");
io::stdout().flush()?;
let mut s = String::new();
io::stdin().read_line(&mut s)?;
let n: usize = s.parse()?;
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

add `prompt!` macro to `stdin` module
refactor where necessary to use `prompt!` instead of above

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
