### PR TITLE
cast: eip1967 commands

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -503,6 +503,62 @@ where
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
     /// let cast = Cast::new(provider);
     /// let addr = Address::from_str("0x7eD52863829AB99354F3a0503A622e82AcD5F7d3")?;
+    /// let implementation = cast.implementation(addr, None).await?;
+    /// println!("{}", implementation);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn implementation<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>,
+    ) -> Result<String> {
+        let slot = H256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?;
+        let value = self.provider.get_storage_at(who, slot, block).await?;
+        let addr: H160 = value.into();
+        Ok(format!("{:?}", addr))
+    }
+
+    /// # Example
+    ///
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x7eD52863829AB99354F3a0503A622e82AcD5F7d3")?;
+    /// let admin = cast.admin(addr, None).await?;
+    /// println!("{}", admin);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn admin<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>,
+    ) -> Result<String> {
+        let slot = H256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")?;
+        let value = self.provider.get_storage_at(who, slot, block).await?;
+        let addr: H160 = value.into();
+        Ok(format!("{:?}", addr))
+    }
+
+    /// # Example
+    ///
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x7eD52863829AB99354F3a0503A622e82AcD5F7d3")?;
     /// let nonce = cast.nonce(addr, None).await? + 5;
     /// let computed_address = cast.compute_address(addr, Some(nonce)).await?;
     /// println!("Computed address for address {} with nonce {}: {}", addr, nonce, computed_address);

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -513,7 +513,8 @@ where
         who: T,
         block: Option<BlockId>,
     ) -> Result<String> {
-        let slot = H256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?;
+        let slot =
+            H256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?;
         let value = self.provider.get_storage_at(who, slot, block).await?;
         let addr: H160 = value.into();
         Ok(format!("{:?}", addr))
@@ -541,7 +542,8 @@ where
         who: T,
         block: Option<BlockId>,
     ) -> Result<String> {
-        let slot = H256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")?;
+        let slot =
+            H256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")?;
         let value = self.provider.get_storage_at(who, slot, block).await?;
         let addr: H160 = value.into();
         Ok(format!("{:?}", addr))

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -517,7 +517,7 @@ where
             H256::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?;
         let value = self.provider.get_storage_at(who, slot, block).await?;
         let addr: H160 = value.into();
-        Ok(format!("{:?}", addr))
+        Ok(format!("{addr:?}"))
     }
 
     /// # Example
@@ -546,7 +546,7 @@ where
             H256::from_str("0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103")?;
         let value = self.provider.get_storage_at(who, slot, block).await?;
         let addr: H160 = value.into();
-        Ok(format!("{:?}", addr))
+        Ok(format!("{addr:?}"))
     }
 
     /// # Example

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -276,6 +276,16 @@ async fn main() -> eyre::Result<()> {
             let encoded = SimpleCast::index(&key_type, &key, &slot_number)?;
             println!("{encoded}");
         }
+        Subcommands::Implementation { block, who, rpc_url } => {
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
+            let provider = try_get_http_provider(rpc_url)?;
+            println!("{}", Cast::new(provider).implementation(who, block).await?);
+        }
+        Subcommands::Admin { block, who, rpc_url } => {
+            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
+            let provider = try_get_http_provider(rpc_url)?;
+            println!("{}", Cast::new(provider).admin(who, block).await?);
+        }
         Subcommands::Nonce { block, who, rpc_url } => {
             let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -455,6 +455,42 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
         #[clap(help = "The storage slot of the mapping.", value_name = "SLOT_NUMBER")]
         slot_number: String,
     },
+    #[clap(name = "implementation")]
+    #[clap(visible_alias = "impl")]
+    #[clap(about = "Fetch the EIP-1967 implementation account")]
+    Implementation {
+        #[clap(
+            long,
+            short = 'B',
+            help = "The block height you want to query at.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+             value_parser = parse_block_id,
+            value_name = "BLOCK"
+        )]
+        block: Option<BlockId>,
+        #[clap(help = "The address you want to get the nonce for.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        who: NameOrAddress,
+        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
+        rpc_url: Option<String>,
+    },
+    #[clap(name = "admin")]
+    #[clap(visible_alias = "adm")]
+    #[clap(about = "Fetch the EIP-1967 admin account")]
+    Admin {
+        #[clap(
+            long,
+            short = 'B',
+            help = "The block height you want to query at.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+             value_parser = parse_block_id,
+            value_name = "BLOCK"
+        )]
+        block: Option<BlockId>,
+        #[clap(help = "The address you want to get the nonce for.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        who: NameOrAddress,
+        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
+        rpc_url: Option<String>,
+    },
     #[clap(name = "4byte")]
     #[clap(visible_aliases = &["4", "4b"])]
     #[clap(


### PR DESCRIPTION
## Motivation

I want an easy to to tell if a contract is a proxy and to be able to know the proxy admin and proxy impl using `cast`.

## Solution

Implements two new commands for `cast` that fetch common EIP-1967 storage slots and print the values as address strings.

```
$ cast admin
$ cast implementation
```

This makes it very easy to determine if a contract is proxied.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Closes https://github.com/foundry-rs/foundry/issues/4168