### PR TITLE
feat(anvil): support max mem history value for --prune-history

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -176,8 +176,11 @@ pub struct NodeArgs {
     )]
     pub ipc: Option<Option<String>>,
 
-    #[clap(long, help = "Don't keep full chain history.")]
-    pub prune_history: bool,
+    #[clap(
+        long,
+        help = "Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory."
+    )]
+    pub prune_history: Option<Option<usize>>,
 
     #[clap(long, help = "Number of blocks with transactions to keep in memory.")]
     pub transaction_block_keeper: Option<usize>,
@@ -641,5 +644,14 @@ mod tests {
     fn can_parse_hardfork() {
         let args: NodeArgs = NodeArgs::parse_from(["anvil", "--hardfork", "berlin"]);
         assert_eq!(args.hardfork, Some(Hardfork::Berlin));
+    }
+
+    #[test]
+    fn can_parse_prune_config() {
+        let args: NodeArgs = NodeArgs::parse_from(["anvil", "--prune-history"]);
+        assert!(args.prune_history.is_some());
+
+        let args: NodeArgs = NodeArgs::parse_from(["anvil", "--prune-history", "100"]);
+        assert_eq!(args.prune_history, Some(Some(100)));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4252

add --prune-history <max-memory> argument

only keep the latest `max-memory` states in memory, no disk caching.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
