### PR TITLE
docs: document "cbor_metadata" in README

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -146,7 +146,7 @@ no_storage_caching = false
 # To not include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, use "none"
 bytecode_hash = "ipfs"
 # Whether to append the metadata hash to the bytecode
-cbor_metadata = false
+cbor_metadata = true
 # How to treat revert (and require) reason strings.
 # Possible values are: "default", "strip", "debug" and "verboseDebug".
 #  "default" does not inject compiler-generated revert strings and keeps user-supplied ones.

--- a/config/README.md
+++ b/config/README.md
@@ -145,6 +145,8 @@ no_storage_caching = false
 # use ipfs method to generate the metadata hash, solc's default.
 # To not include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, use "none"
 bytecode_hash = "ipfs"
+# Whether to append the metadata hash to the bytecode
+cbor_metadata = false
 # How to treat revert (and require) reason strings.
 # Possible values are: "default", "strip", "debug" and "verboseDebug".
 #  "default" does not inject compiler-generated revert strings and keeps user-supplied ones.


### PR DESCRIPTION
## Motivation

#3481 added support for `cbor_metadata` internally, but it did not document it in the README. Users currently have to look up Foundry's source code to find the name of this new compiler setting.

## Solution

Mention the newly introduced `cbor_metadata` setting in the config README.