### PR TITLE
chore: add update deps message in install command

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -127,6 +127,7 @@ pub(crate) fn install(
     let libs = root.join(&install_lib_dir);
 
     if dependencies.is_empty() && !opts.no_git {
+        p_println!(!opts.quiet => "Updating dependencies in {:?}", libs);
         let mut cmd = Command::new("git");
         cmd.current_dir(&root).args([
             "submodule",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4261
Add a message to `forge install` command if no dependency was provided, in which case all deps are updated.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
