### PR TITLE
fix(anvil): Ensure the transaction's block number predates the fork before returning a receipt

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1606,7 +1606,14 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return Ok(fork.transaction_receipt(hash).await?)
+            let receipt = fork.transaction_receipt(hash).await?;
+            let number = self.convert_block_number(
+                receipt.clone().and_then(|r| r.block_number).map(|n| BlockNumber::from(n.as_u64())),
+            );
+
+            if fork.predates_fork_inclusive(number) {
+                return Ok(receipt)
+            }
         }
 
         Ok(None)

--- a/anvil/tests/it/fork.rs
+++ b/anvil/tests/it/fork.rs
@@ -805,6 +805,30 @@ async fn test_total_difficulty_fork() {
     assert_eq!(block.difficulty, U256::zero());
 }
 
+// <https://etherscan.io/block/14608400>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_receipt() {
+    let (api, _) = spawn(fork_config()).await;
+
+    // A transaction from the forked block (14608400)
+    let receipt = api
+        .transaction_receipt(
+            "0xce495d665e9091613fd962351a5cbca27a992b919d6a87d542af97e2723ec1e4".parse().unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(receipt.is_some());
+
+    // A transaction from a block in the future (14608401)
+    let receipt = api
+        .transaction_receipt(
+            "0x1a15472088a4a97f29f2f9159511dbf89954b58d9816e58a32b8dc17171dc0e8".parse().unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(receipt.is_none());
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn can_override_fork_chain_id() {
     let chain_id_override = 5u64;


### PR DESCRIPTION
## Motivation
There's a bug in Anvil where it returns a transaction receipt for transactions that occur after the forked block. 

Steps to reproduce:
1. Start a fork at a block number n in the past
2. Send an `eth_getTransactionReceipt` request for a mainnet transaction that occurred at n+1
3. Notice that the fork returns the transaction receipt for the mainnet transaction

## Solution
We should check that the transaction's block number predates the fork before returning it

## Testing
Added a test that uses the "Steps to reproduce" steps to verify that it's fixed. I also ran that test against the current master branch (without the fix), and verified that the test was failing