### PR TITLE
fix(anvil): memory only state non-zero limit infinite loop

### DIFF
--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -142,7 +142,7 @@ impl InMemoryBlockStates {
         }
 
         // enforce on disk limit and purge the oldest state cached on disk
-        while self.oldest_on_disk.len() >= self.max_on_disk_limit {
+        while !self.is_memory_only() && self.oldest_on_disk.len() >= self.max_on_disk_limit {
             // evict the oldest block
             if let Some(hash) = self.oldest_on_disk.pop_front() {
                 self.on_disk_states.remove(&hash);


### PR DESCRIPTION
## Motivation
Follow-up of https://github.com/foundry-rs/foundry/pull/4263 which introduced a user-configurable maximum number of states to keep only in memory.

The issue is that with a non-zero limit (e.g. `--prune-history 50`) this causes an infinite loop in the following lines of code:

https://github.com/foundry-rs/foundry/blob/b45456717ffae1af65acdc71099f8cb95e6683a0/anvil/src/eth/backend/mem/storage.rs#L144-L151

`self.max_on_disk_limit` is zero in this case.

## Solution

Added an extra check `!self.is_memory_only()` that actually checks that `self.max_on_disk_limit != 0`.
