### PR TITLE
Fix: Properly encode json path that returns array 

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -411,7 +411,7 @@ fn parse_json(
     // an entire JSON object.
     dbg!(&values);
     if let Some(coercion_type) = coerce {
-        if !values.iter().filter(|value| value.is_object()).collect::<Vec<&&Value>>().is_empty() {
+        if values.iter().any(|value| value.is_object()) {
             return Err(error::encode_error(format!(
                 "You can only coerce values or arrays, not JSON objects. The key '{key}' returns an object",
             )))

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -15,53 +15,53 @@ contract ParseJson is DSTest {
     }
 
     function test_uintArray() public {
-        bytes memory data = cheats.parseJson(json, ".uintArray");
+        bytes memory data = cheats.parseJson(json, "uintArray");
         uint256[] memory decodedData = abi.decode(data, (uint256[]));
         assertEq(42, decodedData[0]);
         assertEq(43, decodedData[1]);
     }
 
     function test_str() public {
-        bytes memory data = cheats.parseJson(json, ".str");
+        bytes memory data = cheats.parseJson(json, "str");
         string memory decodedData = abi.decode(data, (string));
         assertEq("hai", decodedData);
     }
 
     function test_strArray() public {
-        bytes memory data = cheats.parseJson(json, ".strArray");
+        bytes memory data = cheats.parseJson(json, "strArray");
         string[] memory decodedData = abi.decode(data, (string[]));
         assertEq("hai", decodedData[0]);
         assertEq("there", decodedData[1]);
     }
 
     function test_bool() public {
-        bytes memory data = cheats.parseJson(json, ".bool");
+        bytes memory data = cheats.parseJson(json, "bool");
         bool decodedData = abi.decode(data, (bool));
         assertTrue(decodedData);
     }
 
     function test_boolArray() public {
-        bytes memory data = cheats.parseJson(json, ".boolArray");
+        bytes memory data = cheats.parseJson(json, "boolArray");
         bool[] memory decodedData = abi.decode(data, (bool[]));
         assertTrue(decodedData[0]);
         assertTrue(!decodedData[1]);
     }
 
     function test_address() public {
-        bytes memory data = cheats.parseJson(json, ".address");
+        bytes memory data = cheats.parseJson(json, "address");
         address decodedData = abi.decode(data, (address));
         assertEq(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, decodedData);
     }
 
     function test_addressArray() public {
-        bytes memory data = cheats.parseJson(json, ".addressArray");
+        bytes memory data = cheats.parseJson(json, "addressArray");
         address[] memory decodedData = abi.decode(data, (address[]));
         assertEq(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, decodedData[0]);
         assertEq(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, decodedData[1]);
     }
 
     function test_H160ButNotaddress() public {
-        string memory data = abi.decode(cheats.parseJson(json, ".H160NotAddress"), (string));
+        string memory data = abi.decode(cheats.parseJson(json, "H160NotAddress"), (string));
         assertEq("0000000000000000000000000000000000001337", data);
     }
 
@@ -111,25 +111,32 @@ contract ParseJson is DSTest {
         assertEq(number, 115792089237316195423570985008687907853269984665640564039457584007913129639935);
         number = cheats.parseJsonUint(json, "numberUint");
         assertEq(number, 115792089237316195423570985008687907853269984665640564039457584007913129639935);
-        uint256[] memory numbers = cheats.parseJsonUintArray(json, ".arrayUint");
+        uint256[] memory numbers = cheats.parseJsonUintArray(json, "arrayUint");
         assertEq(numbers[0], 1231232);
         assertEq(numbers[1], 1231232);
         assertEq(numbers[2], 1231232);
     }
 
     function test_coercionInt() public {
-        int256 number = cheats.parseJsonInt(json, ".hexInt");
+        int256 number = cheats.parseJsonInt(json, "hexInt");
         assertEq(number, -12);
         number = cheats.parseJsonInt(json, "stringInt");
         assertEq(number, -12);
     }
 
-    function test_coercion_bool() public {
-        bool boolean = cheats.parseJsonBool(json, ".booleanString");
+    function test_coercionBool() public {
+        bool boolean = cheats.parseJsonBool(json, "booleanString");
         assertEq(boolean, true);
-        bool[] memory booleans = cheats.parseJsonBoolArray(json, ".booleanArray");
+        bool[] memory booleans = cheats.parseJsonBoolArray(json, "booleanArray");
         assert(booleans[0]);
         assert(!booleans[1]);
+    }
+
+    function test_advancedJsonPath() public {
+         bytes memory data = cheats.parseJson(json, "advancedJsonPath[*].id");
+         uint256[] memory numbers = abi.decode(data, (uint256[]));
+         assertEq(numbers[0], 1);
+         assertEq(numbers[1], 2);
     }
 }
 
@@ -168,47 +175,32 @@ contract WriteJson is DSTest {
         bytes[] memory data3 = new bytes[](3);
         data3[0] = bytes("123");
         data3[2] = bytes("fpovhpgjaiosfjhapiufpsdf");
-        vm.serializeBytes(json1, "array3", data3);
-
-        uint256[] memory data4 = new uint256[](0);
-        vm.serializeUint(json1, "array4", data4);
-
-        address[] memory data5 = new address[](0);
-        string memory finalJson = vm.serializeAddress(json1, "array5", data5);
+        string memory finalJson = vm.serializeBytes(json1, "array3", data3);
 
         string memory path = "../testdata/fixtures/Json/write_test_array.json";
         vm.writeJson(finalJson, path);
 
         string memory json = vm.readFile(path);
-        bytes memory rawData = vm.parseJson(json, ".array1");
+        bytes memory rawData = vm.parseJson(json, "array1");
         bool[] memory parsedData1 = new bool[](3);
         parsedData1 = abi.decode(rawData, (bool[]));
         assertEq(parsedData1[0], data1[0]);
         assertEq(parsedData1[1], data1[1]);
         assertEq(parsedData1[2], data1[2]);
 
-        rawData = vm.parseJson(json, ".array2");
+        rawData = vm.parseJson(json, "array2");
         address[] memory parsedData2 = new address[](3);
         parsedData2 = abi.decode(rawData, (address[]));
         assertEq(parsedData2[0], data2[0]);
         assertEq(parsedData2[1], data2[1]);
         assertEq(parsedData2[2], data2[2]);
 
-        rawData = vm.parseJson(json, ".array3");
+        rawData = vm.parseJson(json, "array3");
         bytes[] memory parsedData3 = new bytes[](3);
         parsedData3 = abi.decode(rawData, (bytes[]));
         assertEq(parsedData3[0], data3[0]);
         assertEq(parsedData3[1], data3[1]);
         assertEq(parsedData3[2], data3[2]);
-
-        rawData = vm.parseJson(json, ".array4");
-        uint256[] memory parsedData4 = new uint256[](0);
-        parsedData4 = abi.decode(rawData, (uint256[]));
-
-        rawData = vm.parseJson(json, ".array5");
-        address[] memory parsedData5 = new address[](0);
-        parsedData5 = abi.decode(rawData, (address[]));
-
         vm.removeFile(path);
     }
 
@@ -250,19 +242,19 @@ contract WriteJson is DSTest {
         assertEq(decodedData.b, "test");
 
         // write json3 to key b
-        vm.writeJson(finalJson, path, ".b");
+        vm.writeJson(finalJson, path, "b");
         // read again
         json = vm.readFile(path);
-        data = vm.parseJson(json, ".b");
+        data = vm.parseJson(json, "b");
         decodedData = abi.decode(data, (simpleJson));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 
         // replace a single value to key b
         address ex = address(0xBEEF);
-        vm.writeJson(vm.toString(ex), path, ".b");
+        vm.writeJson(vm.toString(ex), path, "b");
         json = vm.readFile(path);
-        data = vm.parseJson(json, ".b");
+        data = vm.parseJson(json, "b");
         address decodedAddress = abi.decode(data, (address));
         assertEq(decodedAddress, ex);
     }

--- a/testdata/fixtures/Json/test.json
+++ b/testdata/fixtures/Json/test.json
@@ -23,5 +23,6 @@
   "numberInt": -12,
   "hexInt": "0x-C",
   "booleanString": "true",
-  "booleanArray": [true, "false"]
+  "booleanArray": [true, "false"],
+  "advancedJsonPath": [{ "id": 1 }, { "id": 2 }]
 }


### PR DESCRIPTION
## Motivation

fixes #4244 

## Solution 

The cheatcode incorrectly always assumed that the jsonPath would return a single value (an object, an array, etc.), but a jsonPath can return multiple values (as in the issue that this PR fixes). Now it will correctly encode the values as an Array if they are numerous.

## Breaking Change

Before, both notations ".key" and "key" would work because of the bug. The cheatcode adds internally `$.` in front of the passed key, so it's easier for users. That meant that `.key` would be translated to `$..key`, which returned **all values** in the JSON path, no matter their nested position. Due to the bug, it would take the first value of the array, so it worked virtually thew same.

Now that this is fixed, `.key` will not longer work properly, as it will be translated to `$..key` and `key` to `$.key`.  That means that apps that use `.key` need to migrate their keys to `key` notation.
