### PR TITLE
fix(cast): `etherscan-source` api key short arg

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -729,7 +729,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         address: String,
         #[clap(short, help = "The output directory to expand source tree into.", value_hint = ValueHint::DirPath, value_name = "DIRECTORY")]
         directory: Option<PathBuf>,
-        #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+        #[clap(long, short, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
         etherscan_api_key: Option<String>,
     },
     #[clap(name = "wallet", visible_alias = "w", about = "Wallet management utilities.")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Running `cast etherscan-source ADDRESS` without setting Etherscan API key will show the following error message, telling user to specify it with `-e` option.

```
No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY env var, or **setting the -e CLI argument** or etherscan-api-key in foundry.toml
```

But `-e` option is not available,
```
❯ cast src --help
Get the source code of a contract from Etherscan.

Usage: cast etherscan-source [OPTIONS] <ADDRESS>

Arguments:
  <ADDRESS>  The contract's address.

Options:
  -c, --chain <CHAIN>            [env: CHAIN=] [default: mainnet]
  -d <DIRECTORY>                 The output directory to expand source tree into.
      --etherscan-api-key <KEY>  [env: ETHERSCAN_API_KEY=]
  -h, --help                     Print help
```
 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add missing short arg of `etherscan-source` for the `ehterscan_api_key` option.

(I've checked for other `cast` commands that involves Etherscan API key, e.g. `interface` and `storage`, they all have `-e` option available already.)