### PR TITLE
fix: encode env errors as errors

### DIFF
--- a/evm/src/error.rs
+++ b/evm/src/error.rs
@@ -4,11 +4,11 @@ use bytes::Bytes;
 use ethers::abi::AbiEncode;
 use std::fmt::Display;
 
-// keccak(Error(string))
+// keccak(Error(string)) "08c379a0"
 pub static REVERT_PREFIX: [u8; 4] = [8, 195, 121, 160];
 
 /// Custom error prefix
-/// keccak(CheatCodeError)
+/// keccak(CheatCodeError) "0bc44503"
 pub static ERROR_PREFIX: [u8; 4] = [11, 196, 69, 3];
 
 /// An extension trait for `std::error::Error` that can abi-encode itself

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -82,7 +82,7 @@ pub fn handle_expect_revert(
         return Err("Call reverted as expected, but without data".to_string().encode().into())
     }
 
-    let string_data = match retdata {
+    let maybe_prefixed_error_string = match retdata {
         _ if retdata.len() >= REVERT_PREFIX.len() &&
             retdata[..REVERT_PREFIX.len()] == REVERT_PREFIX =>
         {
@@ -103,8 +103,8 @@ pub fn handle_expect_revert(
             .unwrap_or_else(|| format!("0x{}", hex::encode(data)))
     };
 
-    let (err, actual_revert): (_, Bytes) = if let Some(data) = string_data {
-        // It's a revert string, so we do some conversion to perform the check
+    let (err_message, actual_revert): (_, Bytes) = if let Some(data) = maybe_prefixed_error_string {
+        // It's a prefixed revert string, so we do some conversion to perform the check
         let decoded_data = ethers::prelude::Bytes::decode(data)
             .expect("String error code, but data can't be decoded as bytes");
 
@@ -134,7 +134,7 @@ pub fn handle_expect_revert(
     if actual_revert == expected_revert {
         success_return!()
     } else {
-        Err(err)
+        Err(err_message)
     }
 }
 

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -166,4 +166,11 @@ contract ExpectRevertTest is DSTest {
     function testFailExpectRevertDangling() public {
         cheats.expectRevert("dangling");
     }
+
+    function testExpectRevertInvalidEnv() public {
+        cheats.expectRevert(
+            "Failed to get environment variable `_testExpectRevertInvalidEnv` as type `string`: environment variable not found"
+        );
+        string memory val = cheats.envString("_testExpectRevertInvalidEnv");
+    }
 }

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -133,17 +133,16 @@ contract ParseJson is DSTest {
     }
 
     function test_advancedJsonPath() public {
-         bytes memory data = cheats.parseJson(json, ".advancedJsonPath[*].id");
-         uint256[] memory numbers = abi.decode(data, (uint256[]));
-         assertEq(numbers[0], 1);
-         assertEq(numbers[1], 2);
+        bytes memory data = cheats.parseJson(json, ".advancedJsonPath[*].id");
+        uint256[] memory numbers = abi.decode(data, (uint256[]));
+        assertEq(numbers[0], 1);
+        assertEq(numbers[1], 2);
     }
 
     function test_canonicalizePath() public {
         bytes memory data = cheats.parseJson(json, "$.str");
         string memory decodedData = abi.decode(data, (string));
         assertEq("hai", decodedData);
-
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Unblocks https://github.com/foundry-rs/forge-std/pull/291

some cheatcode errors were not returned as errors but as abi strings, conflicting with the expect revert logic.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
return actual errors in env cheatcodes
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
