### PR TITLE
chore(foundryup): print banner after parsing args

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -10,7 +10,6 @@ BINS=(forge cast anvil chisel)
 export RUSTFLAGS="-C target-cpu=native"
 
 main() {
-  banner
   need_cmd git
   need_cmd curl
 
@@ -29,9 +28,14 @@ main() {
         exit 0
         ;;
       *)
-        err "internal error: unknown option \"$1\"\n";;
+        warn "unknown option: $1"
+        usage
+        exit 1
     esac; shift
   done
+
+  # Print the banner after successfully parsing args
+  banner
 
   if [ -n "$FOUNDRYUP_PR" ]; then
     if [ -z "$FOUNDRYUP_BRANCH" ]; then


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

banner prints before any arg parsing or missing command error which may be confusing

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


also fix invalid arg message and print usage:
from: `foundryup: internal error: unknown option "-a"\n`
to: `foundryup: unknown option: -a`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
