### PR TITLE
chore(script): improve path file name errors

### DIFF
--- a/cli/src/cmd/forge/script/multi.rs
+++ b/cli/src/cmd/forge/script/multi.rs
@@ -73,12 +73,20 @@ impl MultiChainSequence {
             out.push(DRY_RUN_DIR);
         }
 
-        let target_fname = target.source.file_name().wrap_err("No filename.")?.to_string_lossy();
+        let target_fname = target
+            .source
+            .file_name()
+            .wrap_err_with(|| format!("No filename for {:?}", target.source))?
+            .to_string_lossy();
         out.push(format!("{target_fname}-latest"));
 
         fs::create_dir_all(&out)?;
 
-        let filename = sig.split_once('(').wrap_err("Sig is invalid.")?.0.to_owned();
+        let filename = sig
+            .split_once('(')
+            .wrap_err_with(|| format!("Failed to compute file name: Signature {sig} is invalid."))?
+            .0
+            .to_string();
         out.push(format!("{filename}.json"));
 
         Ok(out)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4325
previous errors were unhelpful.

@joshieDo the `split_once('(')` or error seems weird tbh, but unclear what the assumptions regarding `sig` are here. seems weird that this is an error at all.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
