### PR TITLE
chore: Sort foundry workspace members alphabetically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ members = [
     "anvil/core",
     "anvil/rpc",
     "anvil/server",
-    "cast",
     "binder",
+    "cast",
+    "chisel",
     "cli",
     "cli/test-utils",
     "common",
@@ -14,11 +15,10 @@ members = [
     "evm",
     "fmt",
     "forge",
-    "ui",
-    "utils",
-    "chisel",
     "macros",
     "macros/impl",
+    "ui",
+    "utils",
 ]
 
 [profile.dev]


### PR DESCRIPTION
This simply sorts the workspace in foundry.toml

## Motivation

Simple change to make foundry code base a little bit better and make my first commit while learning the code base.
