### PR TITLE
fix(chisel): stop appending memory to event params

### DIFF
--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -524,7 +524,7 @@ impl ChiselDispatcher {
                                             .inputs
                                             .iter()
                                             .map(|input| {
-                                                let mut formatted = format_param!(input);
+                                                let mut formatted = format!("{}", input.kind);
                                                 if input.indexed {
                                                     formatted.push_str(" indexed");
                                                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I was trying out chisel and failed on
```
❯ chisel
Welcome to Chisel! Type `!help` to show available commands.
➜ !fetch 0x142FD5b9d67721EfDA3A5E2E9be47A96c9B724A4 IERC1155CreatorImplementation
Added 0x142FD5b9d67721EfDA3A5E2E9be47A96c9B724A4's interface to source as `IERC1155CreatorImplementation`
➜ !source
Failed to format session source
```

The cause seems to be that in dispatcher.rs::527 the event parameters are formatted and the keyword ` memory` is appended to dynamic parameters of FixedArrays or Tuples. However this should happen only for function parameters, not event parameters. Appending it causes the compiler/formatter to fail.

## Solution

Removing the macro `format_param` for event parameters does the trick.
