### PR TITLE
Prevent stopping not existing broadcasts

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -461,6 +461,9 @@ pub fn apply<DB: DatabaseExt>(
             )?
         }
         HEVMCalls::StopBroadcast(_) => {
+            if state.broadcast.is_none() {
+                return Err("No broadcast in progress to stop".to_string().encode().into())
+            }
             state.broadcast = None;
             Bytes::new()
         }

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -155,6 +155,10 @@ contract BroadcastTest is DSTest {
         Test test2 = new Test();
         cheats.stopBroadcast();
     }
+
+    function testFailNoBroadcast() public {
+        cheats.stopBroadcast();
+    }
 }
 
 contract NoLink is DSTest {


### PR DESCRIPTION
## Motivation

The original motivation was stated in: https://github.com/foundry-rs/foundry/issues/2453. 

Running `vm.stopBroadcast();` without starting the broadcast first should result in error as it doesn't make sense. @onbjerg agreed that this could be improved.

## Solution
I tweaked implementation of `vm.stopBroadcast()` cheatcode.