### PR TITLE
chore: replace custom CLI parsers with ethers FromStr implementations

### DIFF
--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -1,9 +1,6 @@
 // cast estimate subcommands
 use crate::{
-    opts::{
-        cast::{parse_block_id, parse_name_or_address},
-        EthereumOpts, TransactionOpts,
-    },
+    opts::{EthereumOpts, TransactionOpts},
     utils::parse_ether_value,
 };
 use cast::{Cast, TxBuilder};
@@ -18,7 +15,7 @@ use foundry_config::{Chain, Config};
 
 #[derive(Debug, Parser)]
 pub struct CallArgs {
-    #[clap(help = "The destination of the transaction.", value_parser = parse_name_or_address, value_name = "TO")]
+    #[clap(help = "The destination of the transaction.", value_name = "TO")]
     to: Option<NameOrAddress>,
 
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]
@@ -42,7 +39,12 @@ pub struct CallArgs {
     #[clap(flatten)]
     eth: EthereumOpts,
 
-    #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", value_parser = parse_block_id, value_name = "BLOCK")]
+    #[clap(
+        long,
+        short,
+        help = "the block you want to query, can also be earliest/latest/pending",
+        value_name = "BLOCK"
+    )]
     block: Option<BlockId>,
 
     #[clap(subcommand)]

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -1,8 +1,5 @@
 // cast estimate subcommands
-use crate::{
-    opts::{cast::parse_name_or_address, EthereumOpts},
-    utils::parse_ether_value,
-};
+use crate::{opts::EthereumOpts, utils::parse_ether_value};
 use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{
@@ -15,7 +12,7 @@ use foundry_config::{Chain, Config};
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
-    #[clap(help = "The destination of the transaction.", value_parser = parse_name_or_address, value_name = "TO")]
+    #[clap(help = "The destination of the transaction.", value_name = "TO")]
     to: Option<NameOrAddress>,
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]
     sig: Option<String>,

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -1,5 +1,5 @@
 // cast send subcommands
-use crate::opts::{cast::parse_name_or_address, EthereumOpts, TransactionOpts, WalletType};
+use crate::opts::{EthereumOpts, TransactionOpts, WalletType};
 use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::{providers::Middleware, types::NameOrAddress};
@@ -11,10 +11,9 @@ use std::sync::Arc;
 #[derive(Debug, Parser)]
 pub struct SendTxArgs {
     #[clap(
-            help = "The destination of the transaction. If not provided, you must use cast send --create.",
-             value_parser = parse_name_or_address,
-            value_name = "TO"
-        )]
+        help = "The destination of the transaction. If not provided, you must use cast send --create.",
+        value_name = "TO"
+    )]
     to: Option<NameOrAddress>,
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]
     sig: Option<String>,

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -1,8 +1,4 @@
-use crate::{
-    cmd::forge::build,
-    opts::cast::{parse_block_id, parse_name_or_address, parse_slot},
-    utils::try_consume_config_rpc_url,
-};
+use crate::{cmd::forge::build, opts::cast::parse_slot, utils::try_consume_config_rpc_url};
 use cast::Cast;
 use clap::Parser;
 use comfy_table::{presets::ASCII_MARKDOWN, Table};
@@ -29,7 +25,7 @@ const MIN_SOLC: Version = Version::new(0, 6, 5);
 #[derive(Debug, Clone, Parser)]
 pub struct StorageArgs {
     // Storage
-    #[clap(help = "The contract address.", value_parser = parse_name_or_address, value_name = "ADDRESS")]
+    #[clap(help = "The contract address.", value_name = "ADDRESS")]
     address: NameOrAddress,
     #[clap(
         help = "The storage slot number (hex or decimal)",
@@ -44,7 +40,6 @@ pub struct StorageArgs {
         short = 'B',
         help = "The block height you want to query at.",
         long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-        value_parser = parse_block_id,
         value_name = "BLOCK"
     )]
     block: Option<BlockId>,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -10,7 +10,7 @@ use crate::{
 use clap::{Parser, Subcommand, ValueHint};
 use ethers::{
     abi::ethabi::ethereum_types::BigEndianHash,
-    types::{serde_helpers::Numeric, Address, BlockId, BlockNumber, NameOrAddress, H256, U256},
+    types::{serde_helpers::Numeric, Address, BlockId, NameOrAddress, H256, U256},
 };
 use std::{path::PathBuf, str::FromStr};
 
@@ -239,7 +239,7 @@ Examples:
     #[clap(visible_aliases = &["ac", "acl"])]
     #[clap(about = "Create an access list for a transaction.")]
     AccessList {
-        #[clap(help = "The destination of the transaction.",  value_parser = parse_name_or_address, value_name = "ADDRESS")]
+        #[clap(help = "The destination of the transaction.", value_name = "ADDRESS")]
         address: NameOrAddress,
         #[clap(help = "The signature of the function to call.", value_name = "SIG")]
         sig: String,
@@ -250,7 +250,6 @@ Examples:
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -267,7 +266,6 @@ Examples:
         #[clap(
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-            value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: BlockId,
@@ -474,11 +472,10 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -492,11 +489,10 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -567,7 +563,6 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -583,11 +578,10 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The account you want to query",  value_parser = parse_name_or_address, value_name = "WHO")]
+        #[clap(help = "The account you want to query", value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -603,7 +597,6 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -619,11 +612,10 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The contract address.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        #[clap(help = "The contract address.", value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -687,7 +679,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         about = "Generate a storage proof for a given storage slot."
     )]
     Proof {
-        #[clap(help = "The contract address.",  value_parser = parse_name_or_address, value_name = "ADDRESS")]
+        #[clap(help = "The contract address.", value_name = "ADDRESS")]
         address: NameOrAddress,
         #[clap(help = "The storage slot numbers (hex or decimal).",  value_parser = parse_slot, value_name = "SLOTS")]
         slots: Vec<H256>,
@@ -698,7 +690,6 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -712,11 +703,10 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             short = 'B',
             help = "The block height you want to query at.",
             long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-             value_parser = parse_block_id,
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.",  value_parser = parse_name_or_address, value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -812,24 +802,6 @@ pub struct ToBaseArgs {
     pub value: Option<String>,
     #[clap(long = "base-in", short = 'i', help = "The input base")]
     pub base_in: Option<String>,
-}
-
-pub fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {
-    Ok(if s.starts_with("0x") {
-        NameOrAddress::Address(s.parse()?)
-    } else {
-        NameOrAddress::Name(s.into())
-    })
-}
-
-pub fn parse_block_id(s: &str) -> eyre::Result<BlockId> {
-    Ok(match s {
-        "earliest" => BlockId::Number(BlockNumber::Earliest),
-        "latest" => BlockId::Number(BlockNumber::Latest),
-        "pending" => BlockId::Number(BlockNumber::Pending),
-        s if s.starts_with("0x") => BlockId::Hash(s.parse()?),
-        s => BlockId::Number(BlockNumber::Number(s.parse::<u64>()?.into())),
-    })
 }
 
 pub fn parse_slot(s: &str) -> eyre::Result<H256> {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -844,7 +844,7 @@ mod tests {
             expect: BlockId,
         }
 
-        let test_cases = vec![[
+        let test_cases = [
             TestCase {
                 input: "0".to_string(),
                 expect: BlockId::Number(BlockNumber::Number(0u64.into())),
@@ -872,11 +872,11 @@ mod tests {
                 input: "finalized".to_string(),
                 expect: BlockId::Number(BlockNumber::Finalized),
             },
-        ]];
+        ];
 
         for test in test_cases {
-            let result: BlockId = test[0].input.parse().unwrap();
-            assert_eq!(result, test[0].expect);
+            let result: BlockId = test.input.parse().unwrap();
+            assert_eq!(result, test.expect);
         }
     }
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -813,6 +813,7 @@ pub fn parse_slot(s: &str) -> eyre::Result<H256> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ethers::types::BlockNumber;
 
     #[test]
     fn parse_call_data() {
@@ -874,7 +875,7 @@ mod tests {
         ]];
 
         for test in test_cases {
-            let result = parse_block_id(&test[0].input).unwrap();
+            let result: BlockId = test[0].input.parse().unwrap();
             assert_eq!(result, test[0].expect);
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
tg discussions, ref gakonst/ethers-rs#2095

current implementation contains a bug, fixed by: gakonst/ethers-rs#2155

## Solution

remove `parse_name_or_address` and `parse_block_id`, which Clap defaults the parsing to use `FromStr::from_str`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
