### PR TITLE
fix(anvil): `anvil_setNextBlockBaseFeePerGas` return error old hardfork

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1504,6 +1504,12 @@ impl EthApi {
     /// Handler for RPC call: `anvil_setNextBlockBaseFeePerGas`
     pub async fn anvil_set_next_block_base_fee_per_gas(&self, basefee: U256) -> Result<()> {
         node_info!("anvil_setNextBlockBaseFeePerGas");
+        if !self.backend.is_eip1559() {
+            return Err(RpcError::invalid_params(
+                "anvil_setNextBlockBaseFeePerGas is only supported when EIP-1559 is active",
+            )
+            .into())
+        }
         self.backend.set_base_fee(basefee);
         Ok(())
     }


### PR DESCRIPTION
## Motivation

It only makes sense to the next block base fee per gas when EIP-1559 (hardfork `london` or newer) is enabled. Hardhat returns an error in this case with a slightly different error message (`hardhat_setNextBlockBaseFeePerGas is disabled because EIP-1559 is not active`).