### PR TITLE
cast: parse additional blocktags

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -873,36 +873,35 @@ mod tests {
             expect: BlockId,
         }
 
-        let test_cases = vec!([
-            TestCase{
+        let test_cases = vec![[
+            TestCase {
                 input: "0".to_string(),
                 expect: BlockId::Number(BlockNumber::Number(0u64.into())),
             },
-            TestCase{
-                input: "0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a".to_string(),
-                expect: BlockId::Hash("0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a".parse().unwrap()),
+            TestCase {
+                input: "0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a"
+                    .to_string(),
+                expect: BlockId::Hash(
+                    "0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a"
+                        .parse()
+                        .unwrap(),
+                ),
             },
-            TestCase{
-                input: "latest".to_string(),
-                expect: BlockId::Number(BlockNumber::Latest),
-            },
-            TestCase{
+            TestCase { input: "latest".to_string(), expect: BlockId::Number(BlockNumber::Latest) },
+            TestCase {
                 input: "earliest".to_string(),
                 expect: BlockId::Number(BlockNumber::Earliest),
             },
-            TestCase{
+            TestCase {
                 input: "pending".to_string(),
                 expect: BlockId::Number(BlockNumber::Pending),
             },
-            TestCase{
-                input: "safe".to_string(),
-                expect: BlockId::Number(BlockNumber::Safe),
-            },
-            TestCase{
+            TestCase { input: "safe".to_string(), expect: BlockId::Number(BlockNumber::Safe) },
+            TestCase {
                 input: "finalized".to_string(),
                 expect: BlockId::Number(BlockNumber::Finalized),
             },
-        ]);
+        ]];
 
         for test in test_cases {
             let result = parse_block_id(&test[0].input).unwrap();

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -827,6 +827,8 @@ pub fn parse_block_id(s: &str) -> eyre::Result<BlockId> {
         "earliest" => BlockId::Number(BlockNumber::Earliest),
         "latest" => BlockId::Number(BlockNumber::Latest),
         "pending" => BlockId::Number(BlockNumber::Pending),
+        "safe" => BlockId::Number(BlockNumber::Safe),
+        "finalized" => BlockId::Number(BlockNumber::Finalized),
         s if s.starts_with("0x") => BlockId::Hash(s.parse()?),
         s => BlockId::Number(BlockNumber::Number(s.parse::<u64>()?.into())),
     })
@@ -862,5 +864,49 @@ mod tests {
                 unreachable!()
             }
         };
+    }
+
+    #[test]
+    fn parse_block_ids() {
+        struct TestCase {
+            input: String,
+            expect: BlockId,
+        }
+
+        let test_cases = vec!([
+            TestCase{
+                input: "0".to_string(),
+                expect: BlockId::Number(BlockNumber::Number(0u64.into())),
+            },
+            TestCase{
+                input: "0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a".to_string(),
+                expect: BlockId::Hash("0x56462c47c03df160f66819f0a79ea07def1569f8aac0fe91bb3a081159b61b4a".parse().unwrap()),
+            },
+            TestCase{
+                input: "latest".to_string(),
+                expect: BlockId::Number(BlockNumber::Latest),
+            },
+            TestCase{
+                input: "earliest".to_string(),
+                expect: BlockId::Number(BlockNumber::Earliest),
+            },
+            TestCase{
+                input: "pending".to_string(),
+                expect: BlockId::Number(BlockNumber::Pending),
+            },
+            TestCase{
+                input: "safe".to_string(),
+                expect: BlockId::Number(BlockNumber::Safe),
+            },
+            TestCase{
+                input: "finalized".to_string(),
+                expect: BlockId::Number(BlockNumber::Finalized),
+            },
+        ]);
+
+        for test in test_cases {
+            let result = parse_block_id(&test[0].input).unwrap();
+            assert_eq!(result, test[0].expect);
+        }
     }
 }


### PR DESCRIPTION
## Motivation

I'd like to use the `finalized` and `safe` blocktags with `cast`

## Solution

The `parse_block_id` function is used to parse `cast` cli commands.

Adds support for the following blocktags:
- `safe`
- `finalized`

These changes will apply to all commands that accept a blocktag.

Also includes unit tests for the different cases.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->




