### PR TITLE
fix(fmt): extra line on multiline call args

### DIFF
--- a/fmt/src/formatter.rs
+++ b/fmt/src/formatter.rs
@@ -3003,15 +3003,16 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
         let multiline = self.are_chunks_separated_multiline("{}}", &chunks, ",")?;
         self.indented_if(multiline, 1, |fmt| fmt.write_chunks_separated(&chunks, ",", multiline))?;
 
-        let prefix = if multiline && !self.is_beginning_of_line() { "\n" } else { "" };
+        let prefix = if multiline && !self.is_beginning_of_line() {
+            "\n"
+        } else if self.config.bracket_spacing {
+            " "
+        } else {
+            ""
+        };
         let closing_bracket = format!("{prefix}{}", "}");
         let closing_bracket_loc = args.last().unwrap().loc.end();
-        write_chunk_spaced!(
-            self,
-            closing_bracket_loc,
-            Some(self.config.bracket_spacing),
-            "{closing_bracket}"
-        )?;
+        write_chunk!(self, closing_bracket_loc, "{closing_bracket}")?;
 
         Ok(())
     }

--- a/fmt/testdata/FunctionCallArgsStatement/bracket-spacing.fmt.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/bracket-spacing.fmt.sol
@@ -1,3 +1,4 @@
+// config: bracket_spacing = true
 interface ITarget {
     function run() external payable;
     function veryAndVeryLongNameOfSomeRunFunction() external payable;
@@ -22,20 +23,20 @@ contract FunctionCallArgsStatement {
     }
 
     function test() external {
-        target.run{gas: gasleft(), value: 1 wei};
+        target.run{ gas: gasleft(), value: 1 wei };
 
-        target.run{gas: 1, value: 0x00}();
+        target.run{ gas: 1, value: 0x00 }();
 
-        target.run{gas: 1000, value: 1 ether}();
+        target.run{ gas: 1000, value: 1 ether }();
 
-        target.run{gas: estimate(), value: value(1)}();
+        target.run{ gas: estimate(), value: value(1) }();
 
         target.run{
             value: value(1 ether),
             gas: veryAndVeryLongNameOfSomeGasEstimateFunction()
         }();
 
-        target.run{ /* comment 1 */ value: /* comment2 */ 1};
+        target.run{ /* comment 1 */ value: /* comment2 */ 1 };
 
         target.run{ /* comment3 */
             value: 1, // comment4
@@ -49,6 +50,6 @@ contract FunctionCallArgsStatement {
             gas: gasleft()
         };
 
-        vm.expectEmit({checkTopic1: false, checkTopic2: false});
+        vm.expectEmit({ checkTopic1: false, checkTopic2: false });
     }
 }

--- a/fmt/testdata/FunctionCallArgsStatement/original.sol
+++ b/fmt/testdata/FunctionCallArgsStatement/original.sol
@@ -44,5 +44,7 @@ contract FunctionCallArgsStatement {
             value: 1,
             // comment6
             gas: gasleft()};
+
+        vm.expectEmit({ checkTopic1: false, checkTopic2: false    });
     }
 }


### PR DESCRIPTION
Follow up to #4363. Extra line was added to multiline call args

