### PR TITLE
fix: use FromStr for NameOrAddress parsing

### DIFF
--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -18,8 +18,8 @@ use std::str::FromStr;
 pub struct CallArgs {
     #[clap(
         help = "The destination of the transaction.", 
-        value_parser = NameOrAddress::from_str, 
         value_name = "TO",
+        value_parser = NameOrAddress::from_str
     )]
     to: Option<NameOrAddress>,
 

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -12,10 +12,15 @@ use ethers::{
 use eyre::WrapErr;
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
+use std::str::FromStr;
 
 #[derive(Debug, Parser)]
 pub struct CallArgs {
-    #[clap(help = "The destination of the transaction.", value_name = "TO")]
+    #[clap(
+        help = "The destination of the transaction.", 
+        value_parser = NameOrAddress::from_str, 
+        value_name = "TO",
+    )]
     to: Option<NameOrAddress>,
 
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -8,11 +8,16 @@ use ethers::{
 };
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
+use std::str::FromStr;
 
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
-    #[clap(help = "The destination of the transaction.", value_name = "TO")]
+    #[clap(
+        help = "The destination of the transaction.",
+        value_parser = NameOrAddress::from_str,
+        value_name = "TO",
+    )]
     to: Option<NameOrAddress>,
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]
     sig: Option<String>,

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -5,14 +5,15 @@ use clap::Parser;
 use ethers::{providers::Middleware, types::NameOrAddress};
 use foundry_common::try_get_http_provider;
 use foundry_config::{Chain, Config};
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub struct SendTxArgs {
     #[clap(
         help = "The destination of the transaction. If not provided, you must use cast send --create.",
-        value_name = "TO"
+        value_parser = NameOrAddress::from_str,
+        value_name = "TO",
     )]
     to: Option<NameOrAddress>,
     #[clap(help = "The signature of the function to call.", value_name = "SIG")]

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -15,6 +15,7 @@ use foundry_common::{
 use foundry_config::Config;
 use futures::future::join_all;
 use semver::Version;
+use std::str::FromStr;
 
 /// The minimum Solc version for outputting storage layouts.
 ///
@@ -25,7 +26,11 @@ const MIN_SOLC: Version = Version::new(0, 6, 5);
 #[derive(Debug, Clone, Parser)]
 pub struct StorageArgs {
     // Storage
-    #[clap(help = "The contract address.", value_name = "ADDRESS")]
+    #[clap(
+        help = "The contract address.", 
+        value_parser = NameOrAddress::from_str, 
+        value_name = "ADDRESS",
+    )]
     address: NameOrAddress,
     #[clap(
         help = "The storage slot number (hex or decimal)",

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -28,8 +28,8 @@ pub struct StorageArgs {
     // Storage
     #[clap(
         help = "The contract address.", 
-        value_parser = NameOrAddress::from_str, 
         value_name = "ADDRESS",
+        value_parser = NameOrAddress::from_str
     )]
     address: NameOrAddress,
     #[clap(

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -239,7 +239,11 @@ Examples:
     #[clap(visible_aliases = &["ac", "acl"])]
     #[clap(about = "Create an access list for a transaction.")]
     AccessList {
-        #[clap(help = "The destination of the transaction.", value_name = "ADDRESS")]
+        #[clap(
+            help = "The destination of the transaction.",
+            value_parser = NameOrAddress::from_str,
+            value_name = "ADDRESS"
+        )]
         address: NameOrAddress,
         #[clap(help = "The signature of the function to call.", value_name = "SIG")]
         sig: String,
@@ -475,7 +479,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -492,7 +496,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -581,7 +585,11 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The account you want to query", value_name = "WHO")]
+        #[clap(
+            help = "The account you want to query",
+            value_parser = NameOrAddress::from_str,
+            value_name = "WHO"
+        )]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -615,7 +623,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The contract address.", value_name = "WHO")]
+        #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
@@ -679,7 +687,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         about = "Generate a storage proof for a given storage slot."
     )]
     Proof {
-        #[clap(help = "The contract address.", value_name = "ADDRESS")]
+        #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "ADDRESS")]
         address: NameOrAddress,
         #[clap(help = "The storage slot numbers (hex or decimal).",  value_parser = parse_slot, value_name = "SLOTS")]
         slots: Vec<H256>,
@@ -706,7 +714,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(help = "The address you want to get the nonce for.", value_name = "WHO")]
+        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #4378

Clap prioritizes `From<&str>` over `FromStr` (with [`value_parser`](https://docs.rs/clap/latest/clap/macro.value_parser.html)'s automatic detection), thus we have to explicitly declare `value_parser` to use the `FromStr` implementation.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
