### PR TITLE
feat(anvil): resolve rpc aliases if foundry.toml is present

### DIFF
--- a/anvil/src/anvil.rs
+++ b/anvil/src/anvil.rs
@@ -26,7 +26,8 @@ pub enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let app = App::parse();
+    let mut app = App::parse();
+    app.node.evm_opts.resolve_rpc_alias();
 
     if let Some(ref cmd) = app.cmd {
         match cmd {

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -468,14 +468,14 @@ pub struct AnvilEvmArgs {
     pub steps_tracing: bool,
 }
 
+/// Resolves an alias passed as fork-url to the matching url defined in the rpc_endpoints section
+/// of the project configuration file.
+/// Does nothing if the fork-url is not a configured alias.
 impl AnvilEvmArgs {
     pub fn resolve_rpc_alias(&mut self) {
         if let Some(fork_url) = &self.fork_url {
-            if fork_url.url.starts_with("http://") || fork_url.url.starts_with("https://") {
-                return
-            }
             let config = Config::load();
-            if let Some(Ok(url)) = config.rpc_endpoints.resolved().get(&fork_url.url) {
+            if let Some(Ok(url)) = config.get_rpc_url_with_alias(&fork_url.url) {
                 self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
             }
         }

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -475,10 +475,8 @@ impl AnvilEvmArgs {
                 return
             }
             let config = Config::load();
-            if let Some(rpc_endpoint) = config.rpc_endpoints.get(&fork_url.url) {
-                if let Some(url) = rpc_endpoint.as_url() {
-                    self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
-                }
+            if let Some(Ok(url)) = config.rpc_endpoints.resolved().get(&fork_url.url) {
+                self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
             }
         }
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -766,12 +766,35 @@ impl Config {
     /// ```
     pub fn get_rpc_url(&self) -> Option<Result<Cow<str>, UnresolvedEnvVarError>> {
         let maybe_alias = self.eth_rpc_url.as_ref().or(self.etherscan_api_key.as_ref())?;
-        let mut endpoints = self.rpc_endpoints.clone().resolved();
-        if let Some(alias) = endpoints.remove(maybe_alias) {
-            Some(alias.map(Cow::Owned))
+        if let Some(alias) = self.get_rpc_url_with_alias(maybe_alias) {
+            Some(alias)
         } else {
             Some(Ok(Cow::Borrowed(self.eth_rpc_url.as_deref()?)))
         }
+    }
+
+    /// Resolves the given alias to a matching rpc url
+    ///
+    /// Returns:
+    ///    - the matching, resolved url of  `rpc_endpoints` if `maybe_alias` is an alias
+    ///    - None otherwise
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// 
+    /// use foundry_config::Config;
+    /// # fn t() {
+    ///     let config = Config::with_root("./");
+    ///     let rpc_url = config.get_rpc_url_with_alias("mainnet").unwrap().unwrap();
+    /// # }
+    /// ```
+    pub fn get_rpc_url_with_alias(
+        &self,
+        maybe_alias: &str,
+    ) -> Option<Result<Cow<str>, UnresolvedEnvVarError>> {
+        let mut endpoints = self.rpc_endpoints.clone().resolved();
+        Some(endpoints.remove(maybe_alias)?.map(Cow::Owned))
     }
 
     /// Returns the configured rpc, or the fallback url


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently it is not possible to use the alias defined in foundry.toml when passing the `--fork-url` parameter to anvil.
closes: https://github.com/foundry-rs/foundry/issues/3379

## Solution
Add logic that loads the config file and attempts to resolve the alias using the `rpc_endpoints` field.
