### PR TITLE
fix(anvil): disable block gas limit in eth_call

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -859,6 +859,9 @@ impl Backend {
         let gas_limit = gas.unwrap_or(block_env.gas_limit);
         let mut env = self.env.read().clone();
         env.block = block_env;
+        // we want to disable this in eth_call, since this is common practice used by other node
+        // impls and providers <https://github.com/foundry-rs/foundry/issues/4388>
+        env.cfg.disable_block_gas_limit = true;
 
         if let Some(base) = max_fee_per_gas {
             env.block.basefee = base;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4388

> sending gasLimit on a read (especially larger than block limit) is ignored by hardhat but failing in anvil:

> error: { code: -32603, message: 'EVM error CallerGasLimitMoreThenBlock' }
(Just noticed it seems there is also a typo: "CallerGasLimitMoreThanBlock")

> I know that Infura supports up to 10x block gas on reads so maybe the default setting should not be capped like this?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
disable block gas limit setting for eth_call
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
