### PR TITLE
chore: use compat wording in out of gas error

### DIFF
--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -137,7 +137,7 @@ pub enum InvalidTransactionError {
     /// But transaction is still valid.
     #[error("Insufficient funds for gas * price + value")]
     ExhaustsGasResources,
-    #[error("Out of gas: required gas exceeds allowance: {0:?}")]
+    #[error("Out of gas: gas required exceeds allowance: {0:?}")]
     OutOfGas(U256),
 
     /// Thrown post London if the transaction's fee is less than the base fee of the block


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4388

cc @PhilippLgh

use same wording as hardhat.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
