### PR TITLE
fix(forge): set correct gas limit when exiting `CREATE` frames when gas metering is paused

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -321,12 +321,9 @@ where
                         }
                     }
                     _ => {
-                        match self.gas_metering_create {
-                            Some(None) => {
-                                // if just starting with CREATE opcodes, record its inner frame gas
-                                self.gas_metering_create = Some(Some(interpreter.gas))
-                            }
-                            _ => {}
+                        // if just starting with CREATE opcodes, record its inner frame gas
+                        if let Some(None) = self.gas_metering_create {
+                            self.gas_metering_create = Some(Some(interpreter.gas))
                         }
 
                         // dont monitor gas changes, keep it constant

--- a/testdata/cheats/GasMetering.t.sol
+++ b/testdata/cheats/GasMetering.t.sol
@@ -64,6 +64,18 @@ contract GasMeteringTest is DSTest {
         assertEq(gas_end_not_metered, 0);
     }
 
+    function testGasMeteringContractCreate() public {
+        cheats.pauseGasMetering();
+        uint256 gas_start_not_metered = gasleft();
+
+        B b = new B();
+
+        uint256 gas_end_not_metered = gas_start_not_metered - gasleft();
+        cheats.resumeGasMetering();
+
+        assertEq(gas_end_not_metered, 0);
+    }
+
     function addInLoop() internal returns (uint256) {
         uint256 b;
         for (uint256 i; i < 10000; i++) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Pausing gas metering before creating a new contract causes the test to revert. This PR builds on #3906 to correctly handle `CREATE`/`CREATE2` call frames.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`CREATE`/`CREATE2` opcodes deduct additional gas for code storage, and deducted amount is compared to gas limit. If we set this to 0, create opcodes would fail with out of gas.

If we however set gas limit to the limit of outer frame, it would cause a panic after erasing gas cost post-create. Reason for this is, pre-create REVM records `gas_limit - (gas_limit / 64)` as gas used, and erases costs by `remaining` gas post-create. 
`gas used ref`: https://github.com/bluealloy/revm/blob/2cb991091d32330cfe085320891737186947ce5a/crates/revm/src/instructions/host.rs#L254-L258
`post-create erase ref`: https://github.com/bluealloy/revm/blob/2cb991091d32330cfe085320891737186947ce5a/crates/revm/src/instructions/host.rs#L279

The solution is to record gas variable at first opcode inside `CREATE` frame, and use its limit when exiting it.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
