### PR TITLE
feat(anvil): assert that fee cap is higher than tip

### DIFF
--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -144,6 +144,11 @@ pub enum InvalidTransactionError {
     #[error("max fee per gas less than block base fee")]
     FeeTooLow,
 
+    /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
+    /// fee cap.
+    #[error("max priority fee per gas higher than max fee per gas")]
+    TipAboveFeeCap,
+
     /// Thrown when a tx was signed with a different chain_id
     #[error("invalid chain id for signer")]
     InvalidChainId,


### PR DESCRIPTION
## Motivation

At the moment, we allow transactions to execute if the tip is higher than the fee cap. Would be nice to reach parity with nodes such as [geth](https://github.com/ethereum/go-ethereum/blob/1db978ca6b28b28d5eda9cf04b519ee301b05345/core/error.go#L87) & [erigon](https://github.com/ledgerwatch/erigon/blob/devel/core/error.go#L37) who throw this error.

## Solution

Add a check to see if the tip is higher than the fee cap.
