### PR TITLE
docs: correct example for disable-next-line

### DIFF
--- a/fmt/README.md
+++ b/fmt/README.md
@@ -121,14 +121,14 @@ TODO: update ^
 
 ### Disable Line
 
-The formatter can be disabled on specific lines by adding a comment `// forgefmt: disable-line`, like this:
+The formatter can be disabled on specific lines by adding a comment `// forgefmt: disable-next-line`, like this:
 
 ```solidity
-// forgefmt: disable-line
+// forgefmt: disable-next-line
 uint x = 100;
 ```
 
-The comment can also be placed at the end of the line:
+Alternatively, the comment can also be placed at the end of the line. In this case, you'd have to use `disable-line` instead:
 
 ```solidity
 uint x = 100; // forgefmt: disable-line


### PR DESCRIPTION
In #4372, I introduced an error when documenting the behavior of the comments that can disable `forge fmt`.

I should have referred to `disable-next-line` instead of `disable-line` in the first example I gave.

This PR fixes that.