### PR TITLE
fix: recognize invariant tests as tests

### DIFF
--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -59,7 +59,7 @@ impl<'a> TestFunctionExt for &'a str {
     }
 
     fn is_test(&self) -> bool {
-        self.starts_with("test")
+        self.starts_with("test") || self.is_invariant_test()
     }
 
     fn is_test_fail(&self) -> bool {

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -283,7 +283,7 @@ impl MultiContractRunnerBuilder {
                 // if it's a test, add it to deployable contracts
                 if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                     abi.functions()
-                        .any(|func| func.name.is_test() || func.name.is_invariant_test())
+                        .any(|func| func.name.is_test())
                 {
                     deployable_contracts.insert(
                         id.clone(),

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -282,8 +282,7 @@ impl MultiContractRunnerBuilder {
                 let abi = contract.abi.expect("We should have an abi by now");
                 // if it's a test, add it to deployable contracts
                 if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
-                    abi.functions()
-                        .any(|func| func.name.is_test())
+                    abi.functions().any(|func| func.name.is_test())
                 {
                     deployable_contracts.insert(
                         id.clone(),


### PR DESCRIPTION
## Motivation

When running `forge build` warnings about test contracts being over the size limit are filtered out.
The problem is that contracts that only have invariant tests are not counted, because those tests start with `invariant` instead of `test`, and get flagged as being over the size limit.

## Solution

Update the `is_test` method to count invariant tests as tests also. I'm not certain if that method ever is used somewhere where the test must not be an invariant test. If so, we may need to update this solution. But from my look at `is_test()` usage, this seems ok, though there are instances where `.is_test()` is used to collect all tests, so now additional tests will be included there