### PR TITLE
Add complete type annotations for into I256

### DIFF
--- a/evm/src/fuzz/strategies/int.rs
+++ b/evm/src/fuzz/strategies/int.rs
@@ -25,12 +25,12 @@ impl IntValueTree {
     /// * `start` - Starting value for the tree
     /// * `fixed` - If `true` the tree would only contain one element and won't be simplified.
     fn new(start: I256, fixed: bool) -> Self {
-        Self { lo: 0.into(), curr: start, hi: start, fixed }
+        Self { lo: I256::zero(), curr: start, hi: start, fixed }
     }
 
     fn reposition(&mut self) -> bool {
         let interval = self.hi - self.lo;
-        let new_mid = self.lo + interval / 2.into();
+        let new_mid = self.lo + interval / I256::from(2);
 
         if new_mid == self.curr {
             false
@@ -69,7 +69,7 @@ impl ValueTree for IntValueTree {
             return false
         }
 
-        self.lo = self.curr + if self.hi < 0.into() { (-1).into() } else { 1.into() };
+        self.lo = self.curr + if self.hi.is_negative() { I256::minus_one() } else { I256::one() };
 
         self.reposition()
     }
@@ -119,7 +119,7 @@ impl IntStrategy {
         let kind = rng.gen_range(0..4);
         let start = match kind {
             0 => I256::overflowing_from_sign_and_abs(Sign::Negative, umax + 1).0 + offset,
-            1 => -offset - 1.into(),
+            1 => -offset - I256::one(),
             2 => offset,
             3 => I256::overflowing_from_sign_and_abs(Sign::Positive, umax).0 - offset,
             _ => unreachable!(),
@@ -143,7 +143,7 @@ impl IntStrategy {
         let bits = rng.gen_range(0..=self.bits);
 
         if bits == 0 {
-            return Ok(IntValueTree::new(0.into(), false))
+            return Ok(IntValueTree::new(I256::zero(), false))
         }
 
         // init 2 128-bit randoms


### PR DESCRIPTION
## Motivation
Per issue #4462, when using `foundry-evm` as a cargo dependency, we receive compilation errors that do not occur when building the project standalone. This error is not entirely obvious as to why it occurs only when used as a dependency, but the error itself simply asks for more type annotations to be available for the compiler, which are easily enough added here (since we know we want every conversation to be a u32 to I256). As such, adding these annotations fixes that error and makes the code slightly more explicit, which seems on the whole, a positive change.

## Solution
Adds type annotations to `evm/src/fuzz/strategies/int.rs` to assist compiler, esp. when used as a dependency. There should be zero net effect on the code aside of (possibly) marginally faster build times (as more type information is supplied by the code).
