### PR TITLE
fix(forge): do not reset tx.origin during broadcast in forge script

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -863,3 +863,71 @@ forgetest_async!(does_script_override_correctly, |prj: TestProject, cmd: TestCom
 
     tester.add_sig("CheckOverrides", "run()").simulate(ScriptOutcome::OkNoEndpoint);
 });
+
+forgetest_async!(
+    assert_tx_origin_is_not_overritten,
+    |prj: TestProject, mut cmd: TestCommand| async move {
+        cmd.args(["init", "--force"]).arg(prj.root());
+        cmd.assert_non_empty_stdout();
+        cmd.forge_fuse();
+
+        let script = prj
+            .inner()
+            .add_script(
+                "ScriptTxOrigin.s.sol",
+                r#"
+pragma solidity ^0.8.13;
+
+import { Script } from "forge-std/Script.sol";
+
+contract ScriptTxOrigin is Script {
+    function run() public {
+        uint256 pk = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+        vm.startBroadcast(pk); // 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+
+        ContractA contractA = new ContractA();
+        ContractB contractB = new ContractB();
+
+        contractA.test(address(contractB));
+        contractB.method(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+
+        require(tx.origin == 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+        vm.stopBroadcast();
+    }
+}
+
+contract ContractA {
+    function test(address _contractB) public {
+        require(msg.sender == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        require(tx.origin == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        ContractB contractB = ContractB(_contractB);
+        ContractC contractC = new ContractC();
+        require(msg.sender == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        require(tx.origin == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        contractB.method(address(this));
+        contractC.method(address(this));
+        require(msg.sender == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        require(tx.origin == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+    }
+}
+
+contract ContractB {
+    function method(address sender) public view {
+        require(msg.sender == sender);
+        require(tx.origin == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+    }
+}
+contract ContractC {
+    function method(address sender) public view {
+        require(msg.sender == sender);
+        require(tx.origin == 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+    }
+}
+   "#,
+            )
+            .unwrap();
+
+        cmd.arg("script").arg(script).args(["--tc", "ScriptTxOrigin"]);
+        assert!(cmd.stdout_lossy().contains("Script ran successfully."));
+    }
+);

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -534,7 +534,9 @@ where
 
         // Clean up broadcast
         if let Some(broadcast) = &self.broadcast {
-            data.env.tx.caller = broadcast.original_origin;
+            if data.journaled_state.depth() == broadcast.depth {
+                data.env.tx.caller = broadcast.original_origin;
+            }
 
             if broadcast.single_call {
                 std::mem::take(&mut self.broadcast);
@@ -727,7 +729,9 @@ where
 
         // Clean up broadcasts
         if let Some(broadcast) = &self.broadcast {
-            data.env.tx.caller = broadcast.original_origin;
+            if data.journaled_state.depth() == broadcast.depth {
+                data.env.tx.caller = broadcast.original_origin;
+            }
 
             if broadcast.single_call {
                 std::mem::take(&mut self.broadcast);


### PR DESCRIPTION
This PR fixes #4434 
In `forge script` during a broadcast, from within a call, if a call is made to another contract, or if a contract is created, the `new_origin` is reset to the original `original_origin` which basically means that the `tx.origin` is not the "broadcaster" anymore.
This is because before resetting, the depth of the call was not checked.
This should fix it.

I wrote a test to go with it. It's pretty simple. Let me know if I should write more tests.  
The test is entirely written in the test file `script.rs`. I saw that there is a `Broadcast.t.sol` which seems to be used for test. I can also move it there if it's better.