### PR TITLE
chore: migrate revm 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88bcb3a067a6555d577aba299e75eff9942da276e6506fc6274327daa026132"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3289,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hidapi-rusb"
@@ -5308,40 +5325,64 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d84c8f9836efb0f5f5f8de4700a953c4e1f3119e5cfcb0aad8e5be73daf991"
+checksum = "284747ad0324ed0e805dcf8f412e2beccb7a547fbd84f0607865001b8719c515"
 dependencies = [
- "arrayref",
  "auto_impl 1.0.1",
- "bytes",
- "hashbrown 0.13.2",
- "hex",
- "num_enum",
- "primitive-types",
- "revm_precompiles",
- "rlp",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1b86f1d21d1852b40ec8ac9b6d31ac8a7c000875155809d41ce68f6369dc56"
+dependencies = [
+ "derive_more",
+ "enumn",
+ "revm-primitives",
  "serde",
  "sha3",
 ]
 
 [[package]]
-name = "revm_precompiles"
-version = "1.1.2"
+name = "revm-precompile"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0353d456ef3e989dc9190f42c6020f09bc2025930c37895826029304413204b5"
+checksum = "66837781605c6dcb7f07ad87604eeab3119dae9149d69d8839073dd6f188673d"
 dependencies = [
- "bytes",
- "hashbrown 0.13.2",
  "k256",
  "num",
  "once_cell",
- "primitive-types",
+ "revm-primitives",
  "ripemd",
  "secp256k1",
  "sha2 0.10.6",
  "sha3",
  "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad165d3f69e4d14405d82c6625864ee48c162dcebdf170322e6dd80398226a9e"
+dependencies = [
+ "auto_impl 1.0.1",
+ "bytes",
+ "derive_more",
+ "enumn",
+ "fixed-hash",
+ "hashbrown 0.13.2",
+ "hex",
+ "hex-literal",
+ "rlp",
+ "ruint",
+ "serde",
+ "sha3",
 ]
 
 [[package]]
@@ -5420,6 +5461,27 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad3a104dc8c3867f653b0fec89c65e00b0ceb752718ad282177a7e0f33257ac"
+dependencies = [
+ "derive_more",
+ "primitive-types",
+ "rlp",
+ "ruint-macro",
+ "rustc_version",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62cc5760263ea229d367e7dff3c0cbf09e4797a125bd87059a6c095804f3b2d1"
 
 [[package]]
 name = "rusb"
@@ -5745,18 +5807,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
 dependencies = [
  "cc",
 ]

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -7,10 +7,9 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../../evm" }
-revm = { version = "2.3", default-features = false, features = [
+revm = { version = "3.0", default-features = false, features = [
     "std",
-    "k256",
-    "with-serde",
+    "serde",
     "memory_limit",
 ] }
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -2015,7 +2015,7 @@ impl EthApi {
             return_ok!() => {
                 // succeeded
             }
-            Return::OutOfGas | Return::LackOfFundForGasLimit | Return::OutOfFund => {
+            InstructionResult::OutOfGas | InstructionResult::LackOfFundForGasLimit | InstructionResult::OutOfFund => {
                 return Err(InvalidTransactionError::OutOfGas(gas_limit).into())
             }
             // need to check if the revert was due to lack of gas or unrelated reason
@@ -2084,10 +2084,10 @@ impl EthApi {
                     }
                     last_highest_gas_limit = highest_gas_limit;
                 }
-                Return::Revert |
-                Return::OutOfGas |
-                Return::LackOfFundForGasLimit |
-                Return::OutOfFund => {
+                InstructionResult::Revert |
+                InstructionResult::OutOfGas |
+                InstructionResult::LackOfFundForGasLimit |
+                InstructionResult::OutOfFund => {
                     lowest_gas_limit = mid_gas_limit;
                 }
                 reason => {

--- a/anvil/src/eth/backend/executor.rs
+++ b/anvil/src/eth/backend/executor.rs
@@ -48,7 +48,7 @@ impl ExecutedTransaction {
         let logs = self.logs.clone();
 
         // successful return see [Return]
-        let status_code = u8::from(self.exit_reason as u8 <= Return::SelfDestruct as u8);
+        let status_code = u8::from(self.exit_reason as u8 <= InstructionResult::SelfDestruct as u8);
         match &self.transaction.pending_transaction.transaction.transaction {
             TypedTransaction::Legacy(_) => TypedReceipt::Legacy(EIP658Receipt {
                 status_code,
@@ -262,7 +262,7 @@ impl<'a, 'b, DB: Db + ?Sized, Validator: TransactionValidator> Iterator
             evm.inspect_commit(&mut inspector);
         inspector.print_logs();
 
-        if exit_reason == Return::OutOfGas {
+        if exit_reason == InstructionResult::OutOfGas {
             // this currently useful for debugging estimations
             warn!(target: "backend", "[{:?}] executed with out of gas", transaction.hash())
         }

--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -66,7 +66,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],
             { inspector.initialize_interp(interp, data, is_static) }
         );
-        Return::Continue
+        InstructionResult::Continue
     }
 
     fn step(
@@ -82,7 +82,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
                 inspector.step(interp, data, is_static);
             }
         );
-        Return::Continue
+        InstructionResult::Continue
     }
 
     fn log(
@@ -140,7 +140,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             }
         );
 
-        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+        (InstructionResult::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
 
     fn call_end(
@@ -175,7 +175,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             }
         );
 
-        (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())
+        (InstructionResult::Continue, None, Gas::new(call.gas_limit), Bytes::new())
     }
 
     fn create_end(

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -772,13 +772,13 @@ impl Backend {
                     node_info!("    Gas used: {}", receipt.gas_used());
                     match info.exit {
                         return_ok!() => (),
-                        Return::OutOfFund => {
+                        InstructionResult::OutOfFund => {
                             node_info!("    Error: reverted due to running out of funds");
                         }
-                        Return::CallTooDeep => {
+                        InstructionResult::CallTooDeep => {
                             node_info!("    Error: reverted with call too deep");
                         }
-                        Return::Revert => {
+                        InstructionResult::Revert => {
                             if let Some(ref r) = info.out {
                                 if let Ok(reason) = decode_revert(r.as_ref(), None, None) {
                                     node_info!("    Error: reverted with '{}'", reason);
@@ -792,7 +792,7 @@ impl Backend {
                                 node_info!("    Error: reverted without a reason");
                             }
                         }
-                        Return::OutOfGas => {
+                        InstructionResult::OutOfGas => {
                             node_info!("    Error: ran out of gas");
                         }
                         reason => {

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -372,7 +372,7 @@ impl MinedTransaction {
             let action = node.parity_action();
             let result = node.parity_result();
 
-            let action_type = if node.status() == Return::SelfDestruct {
+            let action_type = if node.status() == InstructionResult::SelfDestruct {
                 ActionType::Suicide
             } else {
                 node.kind().into()

--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -47,7 +47,7 @@ serde = "1.0.145"
 serde_json = { version = "1.0.85", features = ["raw_value"] }
 semver = "1.0.14"
 bytes = "1.2.1"
-revm = "2.1.0"
+revm = "3.0"
 eyre = "0.6.8"
 dirs = "4.0.0"
 time = { version = "0.3.15", features = ["formatting"] }

--- a/chisel/src/runner.rs
+++ b/chisel/src/runner.rs
@@ -142,10 +142,10 @@ impl ChiselRunner {
                 self.executor.env_mut().tx.gas_limit = mid_gas_limit;
                 let res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
                 match res.exit_reason {
-                    Return::Revert |
-                    Return::OutOfGas |
-                    Return::LackOfFundForGasLimit |
-                    Return::OutOfFund => {
+                    InstructionResult::Revert |
+                    InstructionResult::OutOfGas |
+                    InstructionResult::LackOfFundForGasLimit |
+                    InstructionResult::OutOfFund => {
                         lowest_gas_limit = mid_gas_limit;
                     }
                     _ => {

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -339,10 +339,10 @@ impl ScriptRunner {
                 self.executor.env_mut().tx.gas_limit = mid_gas_limit;
                 let res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
                 match res.exit_reason {
-                    Return::Revert |
-                    Return::OutOfGas |
-                    Return::LackOfFundForGasLimit |
-                    Return::OutOfFund => {
+                    InstructionResult::Revert |
+                    InstructionResult::OutOfGas |
+                    InstructionResult::LackOfFundForGasLimit |
+                    InstructionResult::OutOfFund => {
                         lowest_gas_limit = mid_gas_limit;
                     }
                     _ => {

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -38,10 +38,9 @@ once_cell = "1.13"
 # EVM
 bytes = "1.1.0"
 hashbrown = { version = "0.13", features = ["serde"] }
-revm = { version = "2.3", default-features = false, features = [
+revm = { version = "3.0", default-features = false, features = [
   "std",
-  "k256",
-  "with-serde",
+  "serde",
   "memory_limit",
   "optional_eip3607",
   "optional_block_gas_limit"

--- a/evm/src/debug.rs
+++ b/evm/src/debug.rs
@@ -1,8 +1,8 @@
 use crate::{abi::HEVM_ABI, CallKind};
 use ethers::types::{Address, U256};
-use revm::{Memory, OpCode};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use revm::interpreter::{Memory, OpCode};
 
 /// An arena of [DebugNode]s
 #[derive(Default, Debug, Clone)]

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -1,3 +1,4 @@
+use ethers::types::U256;
 use super::{
     inspector::{Cheatcodes, Fuzzer, InspectorStackConfig},
     Executor,
@@ -6,8 +7,7 @@ use crate::{
     executor::{backend::Backend, inspector::CheatsConfig},
     fuzz::{invariant::RandomCallGenerator, strategies::EvmFuzzState},
 };
-use ethers::types::U256;
-use revm::{Env, SpecId};
+use revm::primitives::{Env, SpecId};
 
 /// The builder that allows to configure an evm [`Executor`] which a stack of optional
 /// [`revm::Inspector`]s, such as [`Cheatcodes`]
@@ -29,7 +29,7 @@ impl ExecutorBuilder {
     #[must_use]
     pub fn with_cheatcodes(mut self, config: CheatsConfig) -> Self {
         self.inspector_config.cheatcodes =
-            Some(Cheatcodes::new(self.env.block.clone(), self.env.tx.gas_price, config));
+            Some(Cheatcodes::new(self.env.block.clone(), self.env.tx.gas_price.into(), config));
         self
     }
 
@@ -92,7 +92,7 @@ impl ExecutorBuilder {
     #[must_use]
     pub fn with_config(mut self, env: Env) -> Self {
         self.inspector_config.block = env.block.clone();
-        self.inspector_config.gas_price = env.tx.gas_price;
+        self.inspector_config.gas_price = env.tx.gas_price.into();
         self.env = env;
         self
     }
@@ -106,7 +106,7 @@ impl ExecutorBuilder {
 
     /// Builds the executor as configured.
     pub fn build(self, db: Backend) -> Executor {
-        let gas_limit = self.gas_limit.unwrap_or(self.env.block.gas_limit);
+        let gas_limit = self.gas_limit.unwrap_or(self.env.block.gas_limit.into());
         Executor::new(db, self.env, self.inspector_config, gas_limit)
     }
 }

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -53,7 +53,7 @@ fn expect_revert(
 pub fn handle_expect_revert(
     is_create: bool,
     expected_revert: Option<&Bytes>,
-    status: Return,
+    status: InstructionResult,
     retdata: Bytes,
 ) -> Result<(Option<Address>, Bytes), Bytes> {
     trace!("handle expect revert");

--- a/evm/src/executor/inspector/chisel_state.rs
+++ b/evm/src/executor/inspector/chisel_state.rs
@@ -1,4 +1,5 @@
 use revm::{Database, Inspector};
+use revm::interpreter::{InstructionResult, Interpreter, Memory, Stack};
 
 /// An inspector for Chisel
 #[derive(Default)]
@@ -6,7 +7,7 @@ pub struct ChiselState {
     /// The PC of the final instruction
     pub final_pc: usize,
     /// The final state of the REPL contract call
-    pub state: Option<(revm::Stack, revm::Memory, revm::Return)>,
+    pub state: Option<(Stack, Memory, InstructionResult)>,
 }
 
 impl ChiselState {
@@ -21,16 +22,16 @@ where
 {
     fn step_end(
         &mut self,
-        interp: &mut revm::Interpreter,
+        interp: &mut Interpreter,
         _: &mut revm::EVMData<'_, DB>,
         _: bool,
-        eval: revm::Return,
-    ) -> revm::Return {
+        eval: InstructionResult,
+    ) -> InstructionResult {
         // If we are at the final pc of the REPL contract execution, set the state.
         if self.final_pc == interp.program_counter() - 1 {
             self.state = Some((interp.stack().clone(), interp.memory.clone(), eval))
         }
-        // Pass on [revm::Return] from arguments
+        // Pass on [InstructionResult] from arguments
         eval
     }
 }

--- a/evm/src/executor/inspector/coverage.rs
+++ b/evm/src/executor/inspector/coverage.rs
@@ -1,6 +1,7 @@
 use crate::coverage::{HitMap, HitMaps};
 use bytes::Bytes;
-use revm::{Database, EVMData, Inspector, Interpreter, Return};
+use revm::{Database, EVMData, Inspector};
+use revm::interpreter::{InstructionResult, Interpreter};
 
 #[derive(Default, Debug)]
 pub struct CoverageCollector {
@@ -17,14 +18,14 @@ where
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
         _: bool,
-    ) -> Return {
-        self.maps.entry(interpreter.contract.bytecode.hash()).or_insert_with(|| {
+    ) -> InstructionResult {
+        self.maps.entry(interpreter.contract.bytecode.hash().into()).or_insert_with(|| {
             HitMap::new(Bytes::copy_from_slice(
                 interpreter.contract.bytecode.original_bytecode_slice(),
             ))
         });
 
-        Return::Continue
+        InstructionResult::Continue
     }
 
     fn step(
@@ -32,11 +33,11 @@ where
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
         _is_static: bool,
-    ) -> Return {
+    ) -> InstructionResult {
         self.maps
-            .entry(interpreter.contract.bytecode.hash())
+            .entry(interpreter.contract.bytecode.hash().into())
             .and_modify(|map| map.hit(interpreter.program_counter()));
 
-        Return::Continue
+        InstructionResult::Continue
     }
 }

--- a/evm/src/executor/inspector/utils.rs
+++ b/evm/src/executor/inspector/utils.rs
@@ -2,9 +2,10 @@ use ethers::{
     types::Address,
     utils::{get_contract_address, get_create2_address},
 };
-use revm::{CreateInputs, CreateScheme, SpecId};
+use revm::interpreter::CreateInputs;
+use revm::primitives::{CreateScheme, SpecId};
 
-/// Returns [Return::Continue] on an error, discarding the error.
+/// Returns [InstructionResult::Continue] on an error, discarding the error.
 ///
 /// Useful for inspectors that read state that might be invalid, but do not want to emit
 /// appropriate errors themselves, instead opting to continue.
@@ -12,7 +13,7 @@ macro_rules! try_or_continue {
     ($e:expr) => {
         match $e {
             Ok(v) => v,
-            Err(_) => return Return::Continue,
+            Err(_) => return InstructionResult::Continue,
         }
     };
 }

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -5,9 +5,9 @@ use ethers::{
     types::{Address, Chain, H256, U256},
 };
 use eyre::WrapErr;
+use revm::primitives::{BlockEnv, CfgEnv, SpecId, TxEnv};
 use foundry_common::{self, ProviderBuilder, RpcUrl, ALCHEMY_FREE_TIER_CUPS};
 use foundry_config::Config;
-use revm::{BlockEnv, CfgEnv, SpecId, TxEnv};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::fork::environment;
@@ -99,16 +99,16 @@ impl EvmOpts {
     }
 
     /// Returns the `revm::Env` configured with only local settings
-    pub fn local_evm_env(&self) -> revm::Env {
+    pub fn local_evm_env(&self) -> Env {
         revm::Env {
             block: BlockEnv {
                 number: self.env.block_number.into(),
-                coinbase: self.env.block_coinbase,
+                coinbase: self.env.block_coinbase.into(),
                 timestamp: self.env.block_timestamp.into(),
                 difficulty: self.env.block_difficulty.into(),
-                prevrandao: Some(self.env.block_prevrandao),
+                prevrandao: Some(self.env.block_prevrandao.into()),
                 basefee: self.env.block_base_fee_per_gas.into(),
-                gas_limit: self.gas_limit(),
+                gas_limit: self.gas_limit().into(),
             },
             cfg: CfgEnv {
                 chain_id: self.env.chain_id.unwrap_or(foundry_common::DEV_CHAIN_ID).into(),
@@ -124,7 +124,7 @@ impl EvmOpts {
             tx: TxEnv {
                 gas_price: self.env.gas_price.unwrap_or_default().into(),
                 gas_limit: self.gas_limit().as_u64(),
-                caller: self.sender,
+                caller: self.sender.into(),
                 ..Default::default()
             },
         }

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -10,12 +10,12 @@ use ethers::{
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use hashbrown::HashMap;
 use node::CallTraceNode;
-use revm::{opcode, CallContext, Memory, Return, Stack};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
     fmt::{self, Write},
 };
+use revm::interpreter::{CallContext, InstructionResult, Memory, opcode, Stack};
 use yansi::{Color, Paint};
 
 /// Call trace address identifiers.
@@ -427,7 +427,7 @@ impl From<&CallTraceStep> for StructLog {
             } else {
                 None
             },
-            stack: Some(step.stack.data().clone()),
+            stack: Some(step.stack.data().iter().copied().map(|data|data.into()).collect()),
             // Filled in `CallTraceArena::geth_trace` as a result of compounding all slot changes
             storage: None,
         }
@@ -467,7 +467,7 @@ pub struct CallTrace {
     /// The gas cost of the call
     pub gas_cost: u64,
     /// The status of the trace's call
-    pub status: Return,
+    pub status: InstructionResult,
     /// call context of the runtime
     pub call_context: Option<CallContext>,
     /// Opcode-level execution steps
@@ -497,7 +497,7 @@ impl Default for CallTrace {
             data: Default::default(),
             output: Default::default(),
             gas_cost: Default::default(),
-            status: Return::Continue,
+            status: InstructionResult::Continue,
             call_context: Default::default(),
             steps: Default::default(),
         }

--- a/evm/src/trace/node.rs
+++ b/evm/src/trace/node.rs
@@ -12,7 +12,7 @@ use ethers::{
     types::{Action, Address, Call, CallResult, Create, CreateResult, Res, Suicide},
 };
 use foundry_common::SELECTOR_LEN;
-use revm::Return;
+use revm::interpreter::InstructionResult;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -41,7 +41,7 @@ impl CallTraceNode {
     }
 
     /// Returns the status of the call
-    pub fn status(&self) -> Return {
+    pub fn status(&self) -> InstructionResult {
         self.trace.status
     }
 
@@ -64,7 +64,7 @@ impl CallTraceNode {
 
     /// Returns the `Action` for a parity trace
     pub fn parity_action(&self) -> Action {
-        if self.status() == Return::SelfDestruct {
+        if self.status() == InstructionResult::SelfDestruct {
             return Action::Suicide(Suicide {
                 address: self.trace.address,
                 // TODO deserialize from calldata here?

--- a/evm/src/utils.rs
+++ b/evm/src/utils.rs
@@ -4,8 +4,9 @@ use ethers::{
     types::{BigEndianHash, Block, Chain},
 };
 use eyre::ContextCompat;
-use revm::{opcode, spec_opcode_gas, SpecId};
+use revm::interpreter::{opcode, spec_opcode_gas};
 use std::collections::BTreeMap;
+use revm::primitives::SpecId;
 
 /// Small helper function to convert [U256] into [H256].
 pub fn u256_to_h256_le(u: U256) -> H256 {

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -14,4 +14,4 @@ eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
 forge = { path = "../forge" }
-revm = { version = "2.3", features = ["std", "k256", "with-serde"] }
+revm = { version = "3.0", features = ["std", "serde"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
bump revm to 3.0

this is a bit horrible...

@DaniPopes would you be interested in taking on this task by any chance? 
I know it's pretty thankless work, but it's desperately needed.

There are a lot of breaking changes due to revm and the ruint/primtive-types situation.

I think the right approach would be to migrate `foundry-evm` first, step by step

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
