### PR TITLE
feat(evm): add "expectEmit" variants

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -74,6 +74,8 @@ ethers::contract::abigen!(
             accesses(address)(bytes32[],bytes32[])
             recordLogs()
             getRecordedLogs()(Log[])
+            expectEmit()
+            expectEmit(address)
             expectEmit(bool,bool,bool,bool)
             expectEmit(bool,bool,bool,bool,address)
             mockCall(address,bytes,bytes)

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -250,7 +250,24 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::ExpectRevert2(inner) => {
             expect_revert(state, Some(inner.0.to_vec().into()), data.journaled_state.depth())
         }
-        HEVMCalls::ExpectEmit0(inner) => {
+        HEVMCalls::ExpectEmit0(_) => {
+            state.expected_emits.push(ExpectedEmit {
+                depth: data.journaled_state.depth() - 1,
+                checks: [true, true, true, true],
+                ..Default::default()
+            });
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectEmit1(inner) => {
+            state.expected_emits.push(ExpectedEmit {
+                depth: data.journaled_state.depth() - 1,
+                checks: [true, true, true, true],
+                address: Some(inner.0),
+                ..Default::default()
+            });
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectEmit2(inner) => {
             state.expected_emits.push(ExpectedEmit {
                 depth: data.journaled_state.depth() - 1,
                 checks: [inner.0, inner.1, inner.2, inner.3],
@@ -258,7 +275,7 @@ pub fn apply<DB: DatabaseExt>(
             });
             Ok(Bytes::new())
         }
-        HEVMCalls::ExpectEmit1(inner) => {
+        HEVMCalls::ExpectEmit3(inner) => {
             state.expected_emits.push(ExpectedEmit {
                 depth: data.journaled_state.depth() - 1,
                 checks: [inner.0, inner.1, inner.2, inner.3],

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -168,6 +168,15 @@ interface Cheats {
     // Gets all the recorded logs
     function getRecordedLogs() external returns (Log[] memory);
 
+    // Prepare an expected log with all four checks enabled.
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emitted in the expected order with the expected topics and data.
+    // Second form also checks supplied address against emitting contract.
+    function expectEmit() external;
+
+    // Prepare an expected log with all four checks enabled, and check supplied address against emitting contract.
+    function expectEmit(address) external;
+
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans).

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -172,6 +172,17 @@ contract ExpectEmitTest is DSTest {
     }
 
     function testExpectEmitMultiple() public {
+        cheats.expectEmit();
+        emit Something(1, 2, 3, 4);
+        cheats.expectEmit();
+        emit Something(5, 6, 7, 8);
+
+        emitter.emitMultiple(
+            [uint256(1), uint256(5)], [uint256(2), uint256(6)], [uint256(3), uint256(7)], [uint256(4), uint256(8)]
+        );
+    }
+
+    function testExpectEmitMultipleWithArgs() public {
         cheats.expectEmit(true, true, true, true);
         emit Something(1, 2, 3, 4);
         cheats.expectEmit(true, true, true, true);
@@ -183,6 +194,14 @@ contract ExpectEmitTest is DSTest {
     }
 
     function testExpectEmitAddress() public {
+        cheats.expectEmit(address(emitter));
+        emit Something(1, 2, 3, 4);
+
+        emitter.emitEvent(1, 2, 3, 4);
+    }
+
+
+    function testExpectEmitAddressWithArgs() public {
         cheats.expectEmit(true, true, true, true, address(emitter));
         emit Something(1, 2, 3, 4);
 
@@ -190,6 +209,13 @@ contract ExpectEmitTest is DSTest {
     }
 
     function testFailExpectEmitAddress() public {
+        cheats.expectEmit(address(0));
+        emit Something(1, 2, 3, 4);
+
+        emitter.emitEvent(1, 2, 3, 4);
+    }
+
+    function testFailExpectEmitAddressWithArgs() public {
         cheats.expectEmit(true, true, true, true, address(0));
         emit Something(1, 2, 3, 4);
 

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -200,7 +200,6 @@ contract ExpectEmitTest is DSTest {
         emitter.emitEvent(1, 2, 3, 4);
     }
 
-
     function testExpectEmitAddressWithArgs() public {
         cheats.expectEmit(true, true, true, true, address(emitter));
         emit Something(1, 2, 3, 4);


### PR DESCRIPTION
## Motivation

From the Foundry Book on [best practices](https://book.getfoundry.sh/tutorials/best-practices):

> When testing events, prefer setting all `expectEmit` arguments to `true`, i.e. `vm.expectEmit(true, true, true, true)`.

This PR introduces two `expectEmit` cheatcode variants that have no boolean arguments. All of the topics (`checkTopic1`, `checkTopic2`, `checkTopic3`, and `checkData`) are set to `true` by default.

## Solution

I added the variants in the ABIGEN defined in `evm/src/executor/abi/mod.rs`, and then I implemented them in Rust in `evm/src/executor/inspector/cheatcodes/expect.rs`.

I'm not sure if any tests need to be written for this?