### PR TITLE
change pretty-calldata labels from decimal ints to hex values

### DIFF
--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -332,8 +332,9 @@ impl fmt::Display for PossibleSigs {
 
         writeln!(f, " ------------")?;
         for (i, row) in self.data.iter().enumerate() {
-            let pad = if i < 10 { "  " } else { " " };
-            writeln!(f, " [{i}]:{pad}{row}")?;
+            let row_label_decimal = i * 32;
+            let row_label_hex = format!("{:03x}", row_label_decimal);
+            writeln!(f, " [{row_label_hex}]: {row}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR changes the labels on pretty-calldata from decimal integers to hex labels, like one finds in the debugger.

For example, 

```
 [0]:  0000000000000000000000000000000000000000000000000000000000000020
 [1]:  0000000000000000000000000000000000000000000000000000000000000002
 [2]:  0000000000000000000000000000000000000000000000000000000000000040
 [3]:  0000000000000000000000000000000000000000000000000000000000000140
 [4]:  000000000000000000000000da5a5adc64c8013d334a0da9e711b364af7a4c2d
 [5]:  0000000000000000000000000000000000000000000000000000000000000000
 [6]:  0000000000000000000000000000000000000000000000000000000000000000
 [7]:  0000000000000000000000000000000000000000000000000000000000000080
 [8]:  0000000000000000000000000000000000000000000000000000000000000044
 [9]:  40c10f19000000000000000000000000e05fcc23807536bee418f142d19fa0d2
 [10]: 1bb0cff700000000000000000000000000000000000000000000000000000000
 ...
```

becomes

```
 [000]: 0000000000000000000000000000000000000000000000000000000000000020
 [020]: 0000000000000000000000000000000000000000000000000000000000000002
 [040]: 0000000000000000000000000000000000000000000000000000000000000040
 [060]: 0000000000000000000000000000000000000000000000000000000000000140
 [080]: 000000000000000000000000da5a5adc64c8013d334a0da9e711b364af7a4c2d
 [0a0]: 0000000000000000000000000000000000000000000000000000000000000000
 [0c0]: 0000000000000000000000000000000000000000000000000000000000000000
 [0e0]: 0000000000000000000000000000000000000000000000000000000000000080
 [100]: 0000000000000000000000000000000000000000000000000000000000000044
 [120]: 40c10f19000000000000000000000000e05fcc23807536bee418f142d19fa0d2
 [140]: 1bb0cff700000000000000000000000000000000000000000000000000000000
 ...
```

## Motivation

The integer labels require mental energy to convert to hex, which is how my team typically thinks of these.  Converting to hex saves time and mental energy.

## Solution

I updated the display method for `PossibleSigs`.

NOTE: This is my first time writing rust and my first time making this type of contribution.  I read the contribution guidelines and attempted to follow their instructions, but I found some of the cargo checks hard to parse.  I skipped opening an issue since the change is tiny and cosmetic.  Please let me know what I need to do to properly comply with the letter and spirit of the contribution rules.

EDIT: This change also makes it easier to look up offsets.
