### PR TITLE
feat(cli): use Config for Etherscan and RPCs

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -53,7 +53,6 @@ where
     /// ```
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
-    /// use std::convert::TryFrom;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
@@ -306,7 +305,6 @@ where
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
-    /// use std::convert::TryFrom;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
@@ -613,7 +611,6 @@ where
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
-    /// use std::convert::TryFrom;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
@@ -653,7 +650,6 @@ where
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
-    /// use std::convert::TryFrom;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
@@ -716,7 +712,6 @@ where
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
-    /// use std::convert::TryFrom;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1150,11 +1150,10 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn from_rlp(value: impl AsRef<str>) -> Result<String> {
-        let value = value.as_ref();
-        let striped_value = strip_0x(value);
-        let bytes = hex::decode(striped_value).expect("Could not decode hex");
-        let item = rlp::decode::<Item>(&bytes).expect("Could not decode rlp");
-        Ok(format!("{item}"))
+        let data = strip_0x(value.as_ref());
+        let bytes = hex::decode(data).wrap_err("Could not decode hex")?;
+        let item = rlp::decode::<Item>(&bytes).wrap_err("Could not decode rlp")?;
+        Ok(item.to_string())
     }
 
     /// Encodes hex data or list of hex data to hexadecimal rlp
@@ -1173,7 +1172,8 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn to_rlp(value: &str) -> Result<String> {
-        let val = serde_json::from_str(value).unwrap_or(serde_json::Value::String(value.parse()?));
+        let val = serde_json::from_str(value)
+            .unwrap_or_else(|_| serde_json::Value::String(value.to_string()));
         let item = Item::value_to_item(&val)?;
         Ok(format!("0x{}", hex::encode(rlp::encode(&item))))
     }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -773,6 +773,7 @@ pub enum AbiPath {
 }
 
 pub struct SimpleCast;
+
 impl SimpleCast {
     /// Returns the maximum value of the given integer type
     ///

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     },
     try_get_http_provider,
 };
-use foundry_config::{Chain, Config};
+use foundry_config::Config;
 use rustc_hex::ToHex;
 
 #[tokio::main]
@@ -194,12 +194,7 @@ async fn main() -> eyre::Result<()> {
             let config = Config::from(&eth);
             let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
-            let chain: Chain = if let Some(chain) = eth.chain {
-                chain
-            } else {
-                provider.get_chainid().await?.into()
-            };
-
+            let chain = utils::get_chain(config.chain_id, &provider).await?;
             let mut builder =
                 TxBuilder::new(&provider, config.sender, Some(address), chain, false).await?;
             builder.set_args(&sig, args).await?;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -177,8 +177,8 @@ async fn main() -> eyre::Result<()> {
         Subcommands::CalldataEncode { sig, args } => {
             println!("{}", SimpleCast::calldata_encode(sig, &args)?);
         }
-        Subcommands::Interface(cmd) => cmd.run()?.await?,
-        Subcommands::Bind(cmd) => cmd.run()?.await?,
+        Subcommands::Interface(cmd) => cmd.run().await?,
+        Subcommands::Bind(cmd) => cmd.run().await?,
         Subcommands::PrettyCalldata { calldata, offline } => {
             let calldata = stdin::unwrap_line(calldata)?;
             println!("{}", pretty_calldata(&calldata, offline).await?);
@@ -271,7 +271,7 @@ async fn main() -> eyre::Result<()> {
             let computed = Cast::new(&provider).compute_address(address, nonce).await?;
             println!("Computed Address: {}", SimpleCast::to_checksum_address(&computed));
         }
-        Subcommands::FindBlock(cmd) => cmd.run()?.await?,
+        Subcommands::FindBlock(cmd) => cmd.run().await?,
         Subcommands::GasPrice { rpc_url } => {
             let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
@@ -302,7 +302,7 @@ async fn main() -> eyre::Result<()> {
             let value = provider.get_proof(address, slots, block).await?;
             println!("{}", serde_json::to_string(&value)?);
         }
-        Subcommands::Rpc(cmd) => cmd.run()?.await?,
+        Subcommands::Rpc(cmd) => cmd.run().await?,
         Subcommands::Storage(cmd) => cmd.run().await?,
 
         // Calls & transactions

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -13,7 +13,6 @@ use foundry_cli::{
     handler,
     opts::cast::{Opts, Subcommands, ToBaseArgs},
     prompt, stdin, utils,
-    utils::try_consume_config_rpc_url,
 };
 use foundry_common::{
     abi::{format_tokens, get_event},
@@ -22,7 +21,6 @@ use foundry_common::{
         decode_calldata, decode_event_topic, decode_function_selector, import_selectors,
         parse_signatures, pretty_calldata, ParsedSignatures, SelectorImportData,
     },
-    try_get_http_provider,
 };
 use foundry_config::Config;
 use rustc_hex::ToHex;
@@ -190,11 +188,11 @@ async fn main() -> eyre::Result<()> {
         }
 
         // Blockchain & RPC queries
-        Subcommands::AccessList { eth, address, sig, args, block, to_json } => {
-            let config = Config::from(&eth);
-            let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
-
+        Subcommands::AccessList { address, sig, args, block, to_json, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             let chain = utils::get_chain(config.chain_id, &provider).await?;
+
             let mut builder =
                 TxBuilder::new(&provider, config.sender, Some(address), chain, false).await?;
             builder.set_args(&sig, args).await?;
@@ -202,17 +200,17 @@ async fn main() -> eyre::Result<()> {
 
             println!("{}", Cast::new(&provider).access_list(builder_output, block, to_json).await?);
         }
-        Subcommands::Age { block, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Age { block, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!(
                 "{}",
                 Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
             );
         }
-        Subcommands::Balance { block, who, rpc_url, to_ether } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Balance { block, who, to_ether, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             let value = Cast::new(provider).balance(who, block).await?;
             if to_ether {
                 println!("{}", SimpleCast::from_wei(&value.to_string(), "eth")?);
@@ -220,80 +218,79 @@ async fn main() -> eyre::Result<()> {
                 println!("{value}");
             }
         }
-        Subcommands::BaseFee { block, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::BaseFee { block, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!(
                 "{}",
                 Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
             );
         }
-        Subcommands::Block { rpc_url, block, full, field, to_json } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Block { block, full, field, to_json, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);
         }
-        Subcommands::BlockNumber { rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::BlockNumber { rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).block_number().await?);
         }
-        Subcommands::Chain { rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Chain { rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).chain().await?);
         }
-        Subcommands::ChainId { rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::ChainId { rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).chain_id().await?);
         }
-        Subcommands::Client { rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Client { rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", provider.client_version().await?);
         }
-        Subcommands::Code { block, who, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Code { block, who, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).code(who, block).await?);
         }
-        Subcommands::ComputeAddress { address, nonce, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::ComputeAddress { address, nonce, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
 
             let address: Address = stdin::unwrap_line(address)?.parse()?;
             let computed = Cast::new(&provider).compute_address(address, nonce).await?;
             println!("Computed Address: {}", SimpleCast::to_checksum_address(&computed));
         }
         Subcommands::FindBlock(cmd) => cmd.run().await?,
-        Subcommands::GasPrice { rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::GasPrice { rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).gas_price().await?);
         }
         Subcommands::Index { key_type, key, slot_number } => {
-            let encoded = SimpleCast::index(&key_type, &key, &slot_number)?;
-            println!("{encoded}");
+            println!("{}", SimpleCast::index(&key_type, &key, &slot_number)?);
         }
-        Subcommands::Implementation { block, who, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Implementation { block, who, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).implementation(who, block).await?);
         }
-        Subcommands::Admin { block, who, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Admin { block, who, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).admin(who, block).await?);
         }
-        Subcommands::Nonce { block, who, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Nonce { block, who, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
-        Subcommands::Proof { address, slots, rpc_url, block } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Proof { address, slots, rpc, block } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             let value = provider.get_proof(address, slots, block).await?;
             println!("{}", serde_json::to_string(&value)?);
         }
@@ -303,9 +300,9 @@ async fn main() -> eyre::Result<()> {
         // Calls & transactions
         Subcommands::Call(cmd) => cmd.run().await?,
         Subcommands::Estimate(cmd) => cmd.run().await?,
-        Subcommands::PublishTx { eth, raw_tx, cast_async } => {
-            let config = Config::from(&eth);
-            let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
+        Subcommands::PublishTx { raw_tx, cast_async, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             let cast = Cast::new(&provider);
             let pending_tx = cast.publish(raw_tx).await?;
             let tx_hash = *pending_tx;
@@ -318,9 +315,9 @@ async fn main() -> eyre::Result<()> {
                 println!("{}", serde_json::json!(receipt));
             }
         }
-        Subcommands::Receipt { tx_hash, field, to_json, rpc_url, cast_async, confirmations } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Receipt { tx_hash, field, to_json, cast_async, confirmations, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!(
                 "{}",
                 Cast::new(provider)
@@ -330,9 +327,9 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Run(cmd) => cmd.run().await?,
         Subcommands::SendTx(cmd) => cmd.run().await?,
-        Subcommands::Tx { tx_hash, field, to_json, rpc_url } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::Tx { tx_hash, field, to_json, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(&provider).transaction(tx_hash, field, to_json).await?)
         }
 
@@ -392,9 +389,9 @@ async fn main() -> eyre::Result<()> {
             let name = stdin::unwrap_line(name)?;
             println!("{}", SimpleCast::namehash(&name)?);
         }
-        Subcommands::LookupAddress { who, rpc_url, verify } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::LookupAddress { who, rpc, verify } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
 
             let who = stdin::unwrap_line(who)?;
             let name = provider.lookup_address(who).await?;
@@ -407,9 +404,9 @@ async fn main() -> eyre::Result<()> {
             }
             println!("{name}");
         }
-        Subcommands::ResolveName { who, rpc_url, verify } => {
-            let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-            let provider = try_get_http_provider(rpc_url)?;
+        Subcommands::ResolveName { who, rpc, verify } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
 
             let who = stdin::unwrap_line(who)?;
             let address = provider.resolve_name(&who).await?;
@@ -452,32 +449,18 @@ async fn main() -> eyre::Result<()> {
         Subcommands::RightShift { value, bits, base_in, base_out } => {
             println!("{}", SimpleCast::right_shift(&value, &bits, base_in, &base_out)?);
         }
-        Subcommands::EtherscanSource { chain, address, directory, etherscan_api_key } => {
-            let api_key = match etherscan_api_key {
-                Some(inner) => inner,
-                _ => {
-                    if let Some(etherscan_api_key) = Config::load().etherscan_api_key {
-                        etherscan_api_key
-                    } else {
-                        eyre::bail!("No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY env var, or setting the -e CLI argument or etherscan-api-key in foundry.toml")
-                    }
-                }
-            };
+        Subcommands::EtherscanSource { address, directory, etherscan } => {
+            let config = Config::from(&etherscan);
+            let chain = config.chain_id.unwrap_or_default();
+            let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+            let chain = chain.named()?;
             match directory {
                 Some(dir) => {
-                    SimpleCast::expand_etherscan_source_to_directory(
-                        chain.inner,
-                        address,
-                        api_key,
-                        dir,
-                    )
-                    .await?
+                    SimpleCast::expand_etherscan_source_to_directory(chain, address, api_key, dir)
+                        .await?
                 }
                 None => {
-                    println!(
-                        "{}",
-                        SimpleCast::etherscan_source(chain.inner, address, api_key).await?
-                    );
+                    println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?);
                 }
             }
         }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -333,7 +333,7 @@ async fn main() -> eyre::Result<()> {
                     .await?
             );
         }
-        Subcommands::Run(cmd) => cmd.run()?,
+        Subcommands::Run(cmd) => cmd.run().await?,
         Subcommands::SendTx(cmd) => cmd.run().await?,
         Subcommands::Tx { tx_hash, field, to_json, rpc_url } => {
             let rpc_url = try_consume_config_rpc_url(rpc_url)?;

--- a/cli/src/cmd/cast/bind.rs
+++ b/cli/src/cmd/cast/bind.rs
@@ -1,9 +1,8 @@
-use crate::opts::ClapChain;
-use cast::AbiPath;
+use crate::opts::EtherscanOpts;
 use clap::{Parser, ValueHint};
 use ethers::prelude::{errors::EtherscanError, Abigen, Client, MultiAbigen};
-use forge::Address;
-use foundry_common::fs::json_files;
+use eyre::Result;
+use foundry_config::Config;
 use std::path::{Path, PathBuf};
 
 static DEFAULT_CRATE_NAME: &str = "foundry-contracts";
@@ -12,134 +11,97 @@ static DEFAULT_CRATE_VERSION: &str = "0.0.1";
 /// CLI arguments for `cast bind`.
 #[derive(Debug, Clone, Parser)]
 pub struct BindArgs {
-    #[clap(
-        help = "The contract address, or the path to an ABI Directory.",
-        long_help = r#"The contract address, or the path to an ABI Directory.
-
-If an address is specified, then the ABI is fetched from Etherscan."#,
-        value_name = "PATH_OR_ADDRESS"
-    )]
+    /// The contract address, or the path to an ABI Directory
+    ///
+    /// If an address is specified, then the ABI is fetched from Etherscan.
     path_or_address: String,
 
-    #[clap(long, short, env = "ETHERSCAN_API_KEY", help = "etherscan API key", value_name = "KEY")]
-    etherscan_api_key: Option<String>,
+    /// Path to where bindings will be stored
     #[clap(
-        help = "Path to where bindings will be stored",
-        long = "output-dir",
         short,
+        long,
         value_hint = ValueHint::DirPath,
         value_name = "PATH"
     )]
     pub output_dir: Option<PathBuf>,
 
+    /// The name of the Rust crate to generate.
+    ///
+    /// This should be a valid crates.io crate name. However, this is currently not validated by
+    /// this command.
     #[clap(
-        long = "crate-name",
-        help = "The name of the Rust crate to generate. This should be a valid crates.io crate name. However, it is not currently validated by this command.",
+        long,
         default_value = DEFAULT_CRATE_NAME,
+        value_name = "NAME"
     )]
     crate_name: String,
 
+    /// The version of the Rust crate to generate.
+    ///
+    /// This should be a standard semver version string. However, it is not currently validated by
+    /// this command.
     #[clap(
-        long = "crate-version",
-        help = "The version of the Rust crate to generate. This should be a standard semver version string. However, it is not currently validated by this command.",
+        long,
         default_value = DEFAULT_CRATE_VERSION,
-        value_name = "NAME"
+        value_name = "VERSION"
     )]
     crate_version: String,
 
-    #[clap(long = "seperate-files", help = "Generate bindings as seperate files.")]
+    /// Generate bindings as seperate files.
+    #[clap(long)]
     seperate_files: bool,
 
     #[clap(flatten)]
-    chain: ClapChain,
+    etherscan: EtherscanOpts,
 }
 
 impl BindArgs {
-    pub async fn run(self) -> eyre::Result<()> {
-        let bind_args = self.clone();
-        if Path::new(&self.path_or_address).exists() {
-            self.generate_bindings(AbiPath::Local { path: bind_args.path_or_address, name: None })
-                .await
+    pub async fn run(self) -> Result<()> {
+        let path = Path::new(&self.path_or_address);
+        let multi = if path.exists() {
+            MultiAbigen::from_json_files(path)
         } else {
-            self.generate_bindings(AbiPath::Etherscan {
-                address: bind_args.path_or_address.parse::<Address>().unwrap(),
-                chain: bind_args.chain.inner,
-                api_key: bind_args.etherscan_api_key.unwrap(),
-            })
-            .await
-        }
-    }
-}
+            self.abigen_etherscan().await
+        }?;
 
-impl BindArgs {
-    pub async fn generate_bindings(&self, address_or_path: AbiPath) -> eyre::Result<()> {
-        match address_or_path {
-            AbiPath::Etherscan { address, chain, api_key } => {
-                let client = Client::new(chain, api_key)?;
-                let metadata = &client.contract_source_code(address).await?.items[0];
-                let address = if metadata.implementation.is_some() {
-                    metadata.implementation.unwrap()
-                } else {
-                    address
-                };
-                let source = match client.contract_source_code(address).await {
-                    Ok(source) => source,
-                    Err(EtherscanError::InvalidApiKey) => {
-                        eyre::bail!("Invalid Etherscan API key. Did you set it correctly? You may be using an API key for another Etherscan API chain (e.g. Etherscan API key for Polygonscan).")
-                    }
-                    Err(EtherscanError::ContractCodeNotVerified(address)) => {
-                        eyre::bail!("Contract source code at {:?} on {} not verified. Maybe you have selected the wrong chain?", address, chain)
-                    }
-                    Err(err) => {
-                        eyre::bail!(err)
-                    }
-                };
-                let abigens = source
-                    .items
-                    .iter()
-                    .map(|item| Abigen::new(item.contract_name.clone(), item.abi.clone()).unwrap())
-                    .collect::<Vec<Abigen>>();
+        println!("Generating bindings for {} contracts", multi.len());
+        let bindings = multi.build()?;
 
-                let multi = MultiAbigen::from_abigens(abigens);
-
-                let bindings = multi.build().unwrap();
-                println!("Generating bindings for {} contracts", bindings.len());
-                bindings.write_to_crate(
-                    &self.crate_name,
-                    &self.crate_version,
-                    self.get_binding_root(),
-                    !self.seperate_files,
-                )?;
-            }
-            AbiPath::Local { path, name: _ } => {
-                let abis = json_files(Path::new(&path))
-                    .into_iter()
-                    .filter_map(|path| {
-                        let stem = path.file_stem()?;
-                        if stem.to_str()?.ends_with(".metadata") {
-                            None
-                        } else {
-                            Some(path)
-                        }
-                    })
-                    .map(Abigen::from_file)
-                    .collect::<Result<Vec<_>, _>>()?;
-                let multi = MultiAbigen::from_abigens(abis);
-
-                let bindings = multi.build().unwrap();
-                println!("Generating bindings for {} contracts", bindings.len());
-                bindings.write_to_crate(
-                    &self.crate_name,
-                    &self.crate_version,
-                    self.get_binding_root(),
-                    !self.seperate_files,
-                )?;
-            }
-        };
+        let out = self
+            .output_dir
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap().join("bindings"));
+        bindings.write_to_crate(self.crate_name, self.crate_version, out, !self.seperate_files)?;
         Ok(())
     }
 
-    fn get_binding_root(&self) -> PathBuf {
-        self.output_dir.clone().unwrap_or_else(|| std::env::current_dir().unwrap().join("bindings"))
+    async fn abigen_etherscan(&self) -> Result<MultiAbigen> {
+        let config = Config::from(&self.etherscan);
+
+        let chain = config.chain_id.unwrap_or_default();
+        let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+        let chain = chain.named()?;
+
+        let client = Client::new(chain, api_key)?;
+        let address = self.path_or_address.parse()?;
+        let source = match client.contract_source_code(address).await {
+            Ok(source) => source,
+            Err(EtherscanError::InvalidApiKey) => {
+                eyre::bail!("Invalid Etherscan API key. Did you set it correctly? You may be using an API key for another Etherscan API chain (e.g. Etherscan API key for Polygonscan).")
+            }
+            Err(EtherscanError::ContractCodeNotVerified(address)) => {
+                eyre::bail!("Contract source code at {:?} on {} not verified. Maybe you have selected the wrong chain?", address, chain)
+            }
+            Err(err) => {
+                eyre::bail!(err)
+            }
+        };
+        let abigens = source
+            .items
+            .into_iter()
+            .map(|item| Abigen::new(item.contract_name, item.abi).unwrap())
+            .collect::<Vec<Abigen>>();
+
+        Ok(MultiAbigen::from_abigens(abigens))
     }
 }

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -7,7 +7,6 @@ use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::types::{BlockId, NameOrAddress, U256};
 use eyre::WrapErr;
-use foundry_common::try_get_http_provider;
 use foundry_config::Config;
 use std::str::FromStr;
 
@@ -78,11 +77,12 @@ Examples: 1ether, 10gwei, 0.01ether"#,
 impl CallArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let CallArgs { to, sig, args, data, tx, eth, command, block } = self;
-        let config = Config::from(&eth);
-        let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
+        let config = Config::from(&eth);
+        let provider = utils::get_provider(&config)?;
         let chain = utils::get_chain(config.chain_id, &provider).await?;
         let sender = eth.wallet.sender().await;
+
         let mut builder = TxBuilder::new(&provider, sender, to, chain, tx.legacy).await?;
         builder
             .gas(tx.gas_limit)

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -1,17 +1,14 @@
 // cast estimate subcommands
 use crate::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::parse_ether_value,
+    utils::{self, parse_ether_value},
 };
 use cast::{Cast, TxBuilder};
 use clap::Parser;
-use ethers::{
-    providers::Middleware,
-    types::{BlockId, NameOrAddress, U256},
-};
+use ethers::types::{BlockId, NameOrAddress, U256};
 use eyre::WrapErr;
 use foundry_common::try_get_http_provider;
-use foundry_config::{Chain, Config};
+use foundry_config::Config;
 use std::str::FromStr;
 
 #[derive(Debug, Parser)]
@@ -84,10 +81,8 @@ impl CallArgs {
         let config = Config::from(&eth);
         let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
-        let chain: Chain =
-            if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
-
-        let sender = eth.sender().await;
+        let chain = utils::get_chain(config.chain_id, &provider).await?;
+        let sender = eth.wallet.sender().await;
         let mut builder = TxBuilder::new(&provider, sender, to, chain, tx.legacy).await?;
         builder
             .gas(tx.gas_limit)

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -1,13 +1,13 @@
 // cast estimate subcommands
-use crate::{opts::EthereumOpts, utils::parse_ether_value};
+use crate::{
+    opts::EthereumOpts,
+    utils::{self, parse_ether_value},
+};
 use cast::{Cast, TxBuilder};
 use clap::Parser;
-use ethers::{
-    providers::Middleware,
-    types::{NameOrAddress, U256},
-};
+use ethers::types::{NameOrAddress, U256};
 use foundry_common::try_get_http_provider;
-use foundry_config::{Chain, Config};
+use foundry_config::Config;
 use std::str::FromStr;
 
 /// CLI arguments for `cast estimate`.
@@ -68,10 +68,8 @@ impl EstimateArgs {
         let config = Config::from(&eth);
         let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
-        let chain: Chain =
-            if let Some(chain) = eth.chain { chain } else { provider.get_chainid().await?.into() };
-
-        let sender = eth.sender().await;
+        let chain = utils::get_chain(config.chain_id, &provider).await?;
+        let sender = eth.wallet.sender().await;
         let mut builder = TxBuilder::new(&provider, sender, to, chain, false).await?;
         builder.etherscan_api_key(config.get_etherscan_api_key(Some(chain)));
         match command {

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -1,77 +1,94 @@
 // cast estimate subcommands
 use crate::{
-    opts::EthereumOpts,
+    opts::{EtherscanOpts, RpcOpts},
     utils::{self, parse_ether_value},
 };
 use cast::{Cast, TxBuilder};
 use clap::Parser;
 use ethers::types::{NameOrAddress, U256};
-use foundry_common::try_get_http_provider;
-use foundry_config::Config;
+use eyre::Result;
+use foundry_config::{figment::Figment, Config};
 use std::str::FromStr;
 
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
-    #[clap(
-        help = "The destination of the transaction.",
-        value_parser = NameOrAddress::from_str,
-        value_name = "TO",
-    )]
+    /// The destination of the transaction
+    #[clap(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
-    #[clap(help = "The signature of the function to call.", value_name = "SIG")]
-    sig: Option<String>,
-    #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
-    args: Vec<String>,
-    #[clap(
-        long,
-        help = "Ether to send in the transaction.",
-        long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
 
-Examples: 1ether, 10gwei, 0.01ether"#,
-        value_parser = parse_ether_value,
-        value_name = "VALUE"
+    /// The signature of the function to call
+    sig: Option<String>,
+
+    /// The arguments of the function to call
+    args: Vec<String>,
+
+    /// The sender account
+    #[clap(
+        short,
+        long,
+        value_parser = NameOrAddress::from_str,
+        default_value = "0x0000000000000000000000000000000000000000",
+        env = "ETH_FROM",
     )]
+    from: NameOrAddress,
+
+    /// Ether to send in the transaction
+    ///
+    /// Either specified in wei, or as a string with a unit type:
+    ///
+    /// Examples: 1ether, 10gwei, 0.01ether
+    #[clap(long, value_parser = parse_ether_value)]
     value: Option<U256>,
+
     #[clap(flatten)]
-    // TODO: We only need RPC URL and Etherscan API key here.
-    eth: EthereumOpts,
+    rpc: RpcOpts,
+
+    #[clap(flatten)]
+    etherscan: EtherscanOpts,
+
     #[clap(subcommand)]
     command: Option<EstimateSubcommands>,
 }
 
 #[derive(Debug, Parser)]
 pub enum EstimateSubcommands {
-    #[clap(name = "--create", about = "Estimate gas cost to deploy a smart contract")]
+    /// Estimate gas cost to deploy a smart contract
+    #[clap(name = "--create")]
     Create {
-        #[clap(help = "Bytecode of contract.", value_name = "CODE")]
+        /// The bytecode of contract
         code: String,
-        #[clap(help = "The signature of the constructor.", value_name = "SIG")]
-        sig: Option<String>,
-        #[clap(help = "Constructor arguments", value_name = "ARGS")]
-        args: Vec<String>,
-        #[clap(
-            long,
-            help = "Ether to send in the transaction.",
-            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
 
-Examples: 1ether, 10gwei, 0.01ether"#,
-            value_parser = parse_ether_value,
-            value_name = "VALUE"
-        )]
+        /// The signature of the constructor
+        sig: Option<String>,
+
+        /// Constructor arguments
+        args: Vec<String>,
+
+        /// Ether to send in the transaction
+        ///
+        /// Either specified in wei, or as a string with a unit type:
+        ///
+        /// Examples: 1ether, 10gwei, 0.01ether
+        #[clap(long, value_parser = parse_ether_value)]
         value: Option<U256>,
     },
 }
-impl EstimateArgs {
-    pub async fn run(self) -> eyre::Result<()> {
-        let EstimateArgs { to, sig, args, value, eth, command } = self;
-        let config = Config::from(&eth);
-        let provider = try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?;
 
+impl EstimateArgs {
+    pub async fn run(self) -> Result<()> {
+        let EstimateArgs { from, to, sig, args, value, rpc, etherscan, command } = self;
+
+        let figment = Figment::from(Config::figment()).merge(etherscan).merge(rpc);
+        let config = Config::from_provider(figment);
+
+        let provider = utils::get_provider(&config)?;
         let chain = utils::get_chain(config.chain_id, &provider).await?;
-        let sender = eth.wallet.sender().await;
-        let mut builder = TxBuilder::new(&provider, sender, to, chain, false).await?;
-        builder.etherscan_api_key(config.get_etherscan_api_key(Some(chain)));
+        let api_key = config.get_etherscan_api_key(Some(chain));
+
+        let mut builder = TxBuilder::new(&provider, from, to, chain, false).await?;
+        builder.etherscan_api_key(api_key);
+
         match command {
             Some(EstimateSubcommands::Create { code, sig, args, value }) => {
                 builder.value(value);

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -1,12 +1,12 @@
 //! cast find-block subcommand
 
-use crate::{cmd::Cmd, utils::try_consume_config_rpc_url};
+use crate::utils::try_consume_config_rpc_url;
 use cast::Cast;
 use clap::Parser;
 use ethers::prelude::*;
 use eyre::Result;
 use foundry_common::try_get_http_provider;
-use futures::{future::BoxFuture, join};
+use futures::join;
 
 /// CLI arguments for `cast find-block`.
 #[derive(Debug, Clone, Parser)]
@@ -17,17 +17,10 @@ pub struct FindBlockArgs {
     rpc_url: Option<String>,
 }
 
-impl Cmd for FindBlockArgs {
-    type Output = BoxFuture<'static, Result<()>>;
-
-    fn run(self) -> Result<Self::Output> {
-        let FindBlockArgs { timestamp, rpc_url } = self;
-        Ok(Box::pin(Self::query_block(timestamp, rpc_url)))
-    }
-}
-
 impl FindBlockArgs {
-    async fn query_block(timestamp: u64, rpc_url: Option<String>) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
+        let FindBlockArgs { timestamp, rpc_url } = self;
+
         let ts_target = U256::from(timestamp);
         let rpc_url = try_consume_config_rpc_url(rpc_url)?;
 

--- a/cli/src/cmd/cast/interface.rs
+++ b/cli/src/cmd/cast/interface.rs
@@ -1,8 +1,6 @@
-use crate::opts::ClapChain;
+use crate::opts::EtherscanOpts;
 use cast::{AbiPath, SimpleCast};
 use clap::Parser;
-use ethers::types::Address;
-use eyre::WrapErr;
 use foundry_common::fs;
 use foundry_config::Config;
 use std::path::{Path, PathBuf};
@@ -18,8 +16,10 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         value_name = "PATH_OR_ADDRESS"
     )]
     path_or_address: String,
+
     #[clap(long, short, help = "The name to use for the generated interface", value_name = "NAME")]
     name: Option<String>,
+
     #[clap(
         long,
         short,
@@ -28,6 +28,7 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         value_name = "VERSION"
     )]
     pragma: String,
+
     #[clap(
         short,
         help = "The path to the output file.",
@@ -35,39 +36,24 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
         value_name = "PATH"
     )]
     output_location: Option<PathBuf>,
-    #[clap(long, short, env = "ETHERSCAN_API_KEY", help = "etherscan API key", value_name = "KEY")]
-    etherscan_api_key: Option<String>,
+
     #[clap(flatten)]
-    chain: ClapChain,
+    etherscan: EtherscanOpts,
 }
 
 impl InterfaceArgs {
     pub async fn run(self) -> eyre::Result<()> {
-        let InterfaceArgs {
-            path_or_address,
-            name,
-            pragma,
-            output_location,
-            etherscan_api_key,
-            chain,
-        } = self;
-        let interfaces = if Path::new(&path_or_address).exists() {
-            SimpleCast::generate_interface(AbiPath::Local { path: path_or_address, name }).await?
+        let InterfaceArgs { path_or_address, name, pragma, output_location, etherscan } = self;
+        let config = Config::from(&etherscan);
+        let chain = config.chain_id.unwrap_or_default();
+        let source = if Path::new(&path_or_address).exists() {
+            AbiPath::Local { path: path_or_address, name }
         } else {
-            let api_key = etherscan_api_key.or_else(|| {
-                    let config = Config::load();
-                    config.get_etherscan_api_key(Some(chain.inner))
-                }).ok_or_else(|| eyre::eyre!("No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY env var, or setting the -e CLI argument or etherscan-api-key in foundry.toml"))?;
-
-            SimpleCast::generate_interface(AbiPath::Etherscan {
-                chain: chain.inner,
-                api_key,
-                address: path_or_address
-                    .parse::<Address>()
-                    .wrap_err("Invalid address provided. Did you make a typo?")?,
-            })
-            .await?
+            let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+            let chain = chain.named()?;
+            AbiPath::Etherscan { chain, api_key, address: path_or_address.parse()? }
         };
+        let interfaces = SimpleCast::generate_interface(source).await?;
 
         // put it all together
         let pragma = format!("pragma solidity {pragma};");

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -8,27 +8,26 @@ use itertools::Itertools;
 /// CLI arguments for `cast rpc`.
 #[derive(Debug, Clone, Parser)]
 pub struct RpcArgs {
-    /// Send raw JSON parameters
-    #[clap(
-        short = 'w',
-        long,
-        long_help = r#"The first param will be interpreted as a raw JSON array of params.
-If no params are given, stdin will be used. For example:
-
-cast rpc eth_getBlockByNumber '["0x123", false]' --raw
-    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#
-    )]
-    raw: bool,
-
     /// RPC method name
     method: String,
 
     /// RPC parameters
-    #[clap(long_help = r#"RPC parameters interpreted as JSON:
-
-cast rpc eth_getBlockByNumber 0x123 false
-    => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }"#)]
+    ///
+    /// Interpreted as JSON:
+    ///
+    /// cast rpc eth_getBlockByNumber 0x123 false
+    /// => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }
     params: Vec<String>,
+
+    /// Send raw JSON parameters
+    ///
+    /// The first param will be interpreted as a raw JSON array of params.
+    /// If no params are given, stdin will be used. For example:
+    ///
+    /// cast rpc eth_getBlockByNumber '["0x123", false]' --raw
+    ///     => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }
+    #[clap(short = 'w', long)]
+    raw: bool,
 
     #[clap(flatten)]
     rpc: RpcOpts,

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -1,9 +1,8 @@
-use crate::{cmd::Cmd, utils::try_consume_config_rpc_url};
+use crate::utils::try_consume_config_rpc_url;
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
 use foundry_common::try_get_http_provider;
-use futures::future::BoxFuture;
 use itertools::Itertools;
 
 /// CLI arguments for `cast rpc`.
@@ -38,21 +37,10 @@ rpc eth_getBlockByNumber 0x123 false
     params: Vec<String>,
 }
 
-impl Cmd for RpcArgs {
-    type Output = BoxFuture<'static, Result<()>>;
-    fn run(self) -> eyre::Result<Self::Output> {
-        let RpcArgs { rpc_url, raw, method, params } = self;
-        Ok(Box::pin(Self::do_rpc(rpc_url, raw, method, params)))
-    }
-}
-
 impl RpcArgs {
-    async fn do_rpc(
-        rpc_url: Option<String>,
-        raw: bool,
-        method: String,
-        params: Vec<String>,
-    ) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
+        let RpcArgs { rpc_url, raw, method, params } = self;
+
         let rpc_url = try_consume_config_rpc_url(rpc_url)?;
         let provider = try_get_http_provider(rpc_url)?;
         let params = if raw {

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,10 +1,9 @@
-use crate::{cmd::Cmd, init_progress, update_progress, utils::try_consume_config_rpc_url};
+use crate::{init_progress, update_progress, utils::try_consume_config_rpc_url};
 use cast::trace::{identifier::SignaturesIdentifier, CallTraceDecoder, Traces};
 use clap::Parser;
 use ethers::{
     abi::Address,
     prelude::{artifacts::ContractBytecodeSome, ArtifactId, Middleware},
-    solc::utils::RuntimeOrHandle,
     types::H256,
 };
 use eyre::WrapErr;
@@ -50,20 +49,13 @@ pub struct RunArgs {
     label: Vec<String>,
 }
 
-impl Cmd for RunArgs {
-    type Output = ();
+impl RunArgs {
     /// Executes the transaction by replaying it
     ///
     /// This replays the entire block the transaction was mined in unless `quick` is set to true
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
-    fn run(self) -> eyre::Result<Self::Output> {
-        RuntimeOrHandle::new().block_on(self.run_tx())
-    }
-}
-
-impl RunArgs {
-    async fn run_tx(self) -> eyre::Result<()> {
+    pub async fn run(self) -> eyre::Result<()> {
         let figment = Config::figment_with_root(find_project_root_path().unwrap());
         let mut evm_opts = figment.extract::<EvmOpts>()?;
         let config = Config::from_provider(figment).sanitized();

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,10 +1,9 @@
-use crate::{init_progress, update_progress, utils::try_consume_config_rpc_url};
+use crate::{init_progress, opts::RpcOpts, update_progress, utils};
 use cast::trace::{identifier::SignaturesIdentifier, CallTraceDecoder, Traces};
 use clap::Parser;
 use ethers::{
     abi::Address,
     prelude::{artifacts::ContractBytecodeSome, ArtifactId, Middleware},
-    types::H256,
 };
 use eyre::WrapErr;
 use forge::{
@@ -15,7 +14,6 @@ use forge::{
     },
     trace::{identifier::EtherscanIdentifier, CallTraceDecoderBuilder, TraceKind},
 };
-use foundry_common::try_get_http_provider;
 use foundry_config::{find_project_root_path, Config};
 use std::{collections::BTreeMap, str::FromStr};
 use tracing::trace;
@@ -27,26 +25,32 @@ use yansi::Paint;
 pub struct RunArgs {
     #[clap(help = "The transaction hash.", value_name = "TXHASH")]
     tx_hash: String,
-    #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-    rpc_url: Option<String>,
+
     #[clap(long, short = 'd', help = "Debugs the transaction.")]
     debug: bool,
+
     #[clap(long, short = 't', help = "Print out opcode traces.")]
     trace_printer: bool,
+
     #[clap(
         long,
         short = 'q',
         help = "Executes the transaction only with the state from the previous block. May result in different results than the live execution!"
     )]
     quick: bool,
+
     #[clap(long, short = 'v', help = "Prints full address")]
     verbose: bool,
+
     #[clap(
         long,
         help = "Labels address in the trace. 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth",
         value_name = "LABEL"
     )]
     label: Vec<String>,
+
+    #[clap(flatten)]
+    rpc: RpcOpts,
 }
 
 impl RunArgs {
@@ -56,14 +60,12 @@ impl RunArgs {
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
     pub async fn run(self) -> eyre::Result<()> {
-        let figment = Config::figment_with_root(find_project_root_path().unwrap());
+        let figment = Config::figment_with_root(find_project_root_path().unwrap()).merge(self.rpc);
         let mut evm_opts = figment.extract::<EvmOpts>()?;
         let config = Config::from_provider(figment).sanitized();
+        let provider = utils::get_provider(&config)?;
 
-        let rpc_url = try_consume_config_rpc_url(self.rpc_url)?;
-        let provider = try_get_http_provider(&rpc_url)?;
-
-        let tx_hash = H256::from_str(&self.tx_hash).wrap_err("invalid tx hash")?;
+        let tx_hash = self.tx_hash.parse().wrap_err("invalid tx hash")?;
         let tx = provider
             .get_transaction(tx_hash)
             .await?
@@ -73,7 +75,7 @@ impl RunArgs {
             .block_number
             .ok_or_else(|| eyre::eyre!("tx may still be pending: {:?}", tx_hash))?
             .as_u64();
-        evm_opts.fork_url = Some(rpc_url);
+        evm_opts.fork_url = Some(config.get_rpc_url_or_localhost_http()?.into_owned());
         // we need to set the fork block to the previous block, because that's the state at
         // which we access the data in order to execute the transaction(s)
         evm_opts.fork_block_number = Some(tx_block_number - 1);

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -37,7 +37,6 @@ pub struct SendTxArgs {
     #[clap(flatten)]
     eth: EthereumOpts,
     #[clap(
-        short,
         long,
         help = "The number of confirmations until the receipt is fetched.",
         default_value = "1",

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -87,6 +87,7 @@ impl SendTxArgs {
         let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
         let chain = utils::get_chain(config.chain_id, &provider).await?;
+        let api_key = config.get_etherscan_api_key(Some(chain));
         let mut sig = sig.unwrap_or_default();
 
         if let Ok(signer) = eth.wallet.signer(chain.id()).await {
@@ -133,7 +134,7 @@ impl SendTxArgs {
                 (sig, args),
                 tx,
                 chain,
-                config.etherscan_api_key,
+                api_key,
                 cast_async,
                 confirmations,
                 to_json,
@@ -167,7 +168,7 @@ impl SendTxArgs {
                 (sig, args),
                 tx,
                 chain,
-                config.etherscan_api_key,
+                api_key,
                 cast_async,
                 confirmations,
                 to_json,

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -1,4 +1,8 @@
-use crate::{cmd::forge::build, opts::cast::parse_slot, utils::try_consume_config_rpc_url};
+use crate::{
+    cmd::forge::build,
+    opts::{cast::parse_slot, EtherscanOpts, RpcOpts},
+    utils,
+};
 use cast::Cast;
 use clap::Parser;
 use comfy_table::{presets::ASCII_MARKDOWN, Table};
@@ -6,13 +10,13 @@ use ethers::{
     abi::ethabi::ethereum_types::BigEndianHash, etherscan::Client, prelude::*,
     solc::artifacts::StorageLayout,
 };
-use eyre::{ContextCompat, Result};
+use eyre::Result;
 use foundry_common::{
     abi::find_source,
     compile::{compile, etherscan_project, suppress_compile},
-    try_get_http_provider, RetryProvider,
+    RetryProvider,
 };
-use foundry_config::Config;
+use foundry_config::{figment::Figment, Config};
 use futures::future::join_all;
 use semver::Version;
 use std::str::FromStr;
@@ -25,55 +29,38 @@ const MIN_SOLC: Version = Version::new(0, 6, 5);
 /// CLI arguments for `cast storage`.
 #[derive(Debug, Clone, Parser)]
 pub struct StorageArgs {
-    // Storage
-    #[clap(
-        help = "The contract address.", 
-        value_name = "ADDRESS",
-        value_parser = NameOrAddress::from_str
-    )]
+    /// The contract address
+    #[clap(value_parser = NameOrAddress::from_str)]
     address: NameOrAddress,
-    #[clap(
-        help = "The storage slot number (hex or decimal)",
-        value_parser = parse_slot,
-        value_name = "SLOT"
-    )]
+
+    /// The storage slot number
+    #[clap(value_parser = parse_slot)]
     slot: Option<H256>,
-    #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-    rpc_url: Option<String>,
-    #[clap(
-        long,
-        short = 'B',
-        help = "The block height you want to query at.",
-        long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
-        value_name = "BLOCK"
-    )]
+
+    /// The block height you want to query at
+    ///
+    /// Can also be the tags earliest, latest, or pending
+    #[clap(long, short = 'B')]
     block: Option<BlockId>,
 
-    // Etherscan
-    #[clap(long, short, env = "ETHERSCAN_API_KEY", help = "etherscan API key", value_name = "KEY")]
-    etherscan_api_key: Option<String>,
-    #[clap(
-        long,
-        visible_alias = "chain-id",
-        env = "CHAIN",
-        help = "The chain ID the contract is deployed to.",
-        default_value = "mainnet",
-        value_name = "CHAIN"
-    )]
-    chain: Chain,
+    #[clap(flatten)]
+    rpc: RpcOpts,
 
-    // Forge
+    #[clap(flatten)]
+    etherscan: EtherscanOpts,
+
     #[clap(flatten)]
     build: build::CoreBuildArgs,
 }
 
 impl StorageArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { address, block, build, rpc_url, slot, chain, etherscan_api_key } = self;
+        let Self { address, slot, block, rpc, etherscan, build } = self;
 
-        let rpc_url = try_consume_config_rpc_url(rpc_url)?;
-        let provider = try_get_http_provider(rpc_url)?;
+        let figment = Figment::from(Config::figment()).merge(etherscan).merge(rpc);
+        let config = Config::from_provider(figment);
 
+        let provider = utils::get_provider(&config)?;
         let address = match address {
             NameOrAddress::Name(name) => provider.resolve_name(&name).await?,
             NameOrAddress::Address(address) => address,
@@ -114,11 +101,10 @@ impl StorageArgs {
         // Not a forge project or artifact not found
         // Get code from Etherscan
         eprintln!("No matching artifacts found, fetching source code from Etherscan...");
-        let api_key = etherscan_api_key.or_else(|| {
-            let config = Config::load();
-            config.get_etherscan_api_key(Some(chain))
-        }).wrap_err("No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY env var, or setting the -e CLI argument or etherscan-api-key in foundry.toml")?;
-        let client = Client::new(chain, api_key)?;
+
+        let chain = utils::get_chain(config.chain_id, &provider).await?;
+        let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+        let client = Client::new(chain.named()?, api_key)?;
         let source = find_source(client, address).await?;
         let metadata = source.items.first().unwrap();
         if metadata.is_vyper() {

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -4,14 +4,14 @@ pub mod vanity;
 
 use crate::{
     cmd::{cast::wallet::vanity::VanityArgs, Cmd},
-    opts::{EthereumOpts, Wallet, WalletType},
+    opts::Wallet,
 };
 use cast::SimpleCast;
 use clap::Parser;
 use ethers::{
     core::rand::thread_rng,
     signers::{LocalWallet, Signer},
-    types::{Address, Chain, Signature},
+    types::{Address, Signature},
 };
 use eyre::Context;
 
@@ -84,8 +84,7 @@ impl WalletSubcommands {
                     let path = dunce::canonicalize(path)?;
                     if !path.is_dir() {
                         // we require path to be an existing directory
-                        eprintln!("`{}` is not a directory.", path.display());
-                        std::process::exit(1)
+                        eyre::bail!("`{}` is not a directory.", path.display());
                     }
 
                     let password = if let Some(password) = unsafe_password {
@@ -95,65 +94,33 @@ impl WalletSubcommands {
                         rpassword::prompt_password("Enter secret: ")?
                     };
 
-                    let (key, uuid) = LocalWallet::new_keystore(&path, &mut rng, password, None)?;
-                    let address = SimpleCast::to_checksum_address(&key.address());
-                    let filepath = path.join(uuid);
+                    let (wallet, uuid) =
+                        LocalWallet::new_keystore(&path, &mut rng, password, None)?;
 
-                    println!(
-                        r#"Created new encrypted keystore file: `{}`\nPublic Address of the key: {}"#,
-                        filepath.display(),
-                        address
-                    );
+                    println!("Created new encrypted keystore file: {}", path.join(uuid).display());
+                    println!("Address: {}", SimpleCast::to_checksum_address(&wallet.address()));
                 } else {
                     let wallet = LocalWallet::new(&mut rng);
-                    println!(
-                        "Successfully created new keypair.\nAddress: {}\nPrivate Key: 0x{}",
-                        SimpleCast::to_checksum_address(&wallet.address()),
-                        hex::encode(wallet.signer().to_bytes()),
-                    );
+                    println!("Successfully created new keypair.");
+                    println!("Address:     {}", SimpleCast::to_checksum_address(&wallet.address()));
+                    println!("Private key: 0x{}", hex::encode(wallet.signer().to_bytes()));
                 }
             }
             WalletSubcommands::Vanity(cmd) => {
                 cmd.run()?;
             }
             WalletSubcommands::Address { wallet, private_key_override } => {
-                let wallet = EthereumOpts {
-                    wallet: private_key_override
-                        .map(|pk| Wallet { private_key: Some(pk), ..Default::default() })
-                        .unwrap_or(wallet),
-                    rpc_url: Some("http://localhost:8545".to_string()),
-                    chain: Some(Chain::Mainnet.into()),
-                    ..Default::default()
-                }
-                .signer(0u64.into())
-                .await?
-                .unwrap();
-
-                let addr = match wallet {
-                    WalletType::Ledger(signer) => signer.address(),
-                    WalletType::Local(signer) => signer.address(),
-                    WalletType::Trezor(signer) => signer.address(),
-                    WalletType::Aws(signer) => signer.address(),
-                };
+                let wallet = private_key_override
+                    .map(|pk| Wallet { private_key: Some(pk), ..Default::default() })
+                    .unwrap_or(wallet)
+                    .signer(0)
+                    .await?;
+                let addr = wallet.address();
                 println!("{}", SimpleCast::to_checksum_address(&addr));
             }
             WalletSubcommands::Sign { message, wallet } => {
-                let wallet = EthereumOpts {
-                    wallet,
-                    rpc_url: Some("http://localhost:8545".to_string()),
-                    chain: Some(Chain::Mainnet.into()),
-                    ..Default::default()
-                }
-                .signer(0u64.into())
-                .await?
-                .unwrap();
-
-                let sig = match wallet {
-                    WalletType::Ledger(wallet) => wallet.signer().sign_message(&message).await?,
-                    WalletType::Local(wallet) => wallet.signer().sign_message(&message).await?,
-                    WalletType::Trezor(wallet) => wallet.signer().sign_message(&message).await?,
-                    WalletType::Aws(wallet) => wallet.signer().sign_message(&message).await?,
-                };
+                let wallet = wallet.signer(0).await?;
+                let sig = wallet.sign_message(message).await?;
                 println!("Signature: 0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -83,6 +83,7 @@ pub struct BuildArgs {
 
 impl Cmd for BuildArgs {
     type Output = ProjectCompileOutput;
+
     fn run(self) -> eyre::Result<Self::Output> {
         let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -37,7 +37,7 @@ pub struct ProjectPathsArgs {
     #[serde(rename = "src", skip_serializing_if = "Option::is_none")]
     pub contracts: Option<PathBuf>,
 
-    #[clap(help = "The project's remappings.", long, short, value_name = "REMAPPINGS")]
+    #[clap(help = "The project's remappings.", long, short = 'R', value_name = "REMAPPINGS")]
     #[serde(skip)]
     pub remappings: Vec<Remapping>,
 

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -30,7 +30,7 @@ pub struct ProjectPathsArgs {
         env = "DAPP_SRC",
         help = "The contracts source directory.",
         long,
-        short,
+        short = 'C',
         value_hint = ValueHint::DirPath,
         value_name = "PATH"
     )]

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -5,7 +5,7 @@ use crate::{
         forge::build::CoreBuildArgs, read_constructor_args_file, remove_contract, retry::RetryArgs,
         LoadConfig,
     },
-    opts::{EthereumOpts, TransactionOpts},
+    opts::{EthereumOpts, EtherscanOpts, TransactionOpts},
     utils,
 };
 use cast::SimpleCast;
@@ -168,8 +168,10 @@ impl CreateArgs {
             constructor_args,
             constructor_args_path: None,
             num_of_optimizations: None,
-            chain: chain.into(),
-            etherscan_key: self.eth.etherscan.key.clone(),
+            etherscan: EtherscanOpts {
+                key: self.eth.etherscan.key.clone(),
+                chain: Some(chain.into()),
+            },
             flatten: false,
             force: false,
             watch: true,
@@ -313,8 +315,7 @@ impl CreateArgs {
             constructor_args,
             constructor_args_path: None,
             num_of_optimizations,
-            chain: chain.into(),
-            etherscan_key: self.eth.etherscan.key.clone(),
+            etherscan: EtherscanOpts { key: self.eth.etherscan.key, chain: Some(chain.into()) },
             flatten: false,
             force: false,
             watch: true,

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -5,22 +5,22 @@ use crate::{
         forge::build::CoreBuildArgs, read_constructor_args_file, remove_contract, retry::RetryArgs,
         LoadConfig,
     },
-    opts::{EthereumOpts, TransactionOpts, WalletType},
+    opts::{EthereumOpts, TransactionOpts},
+    utils,
 };
 use cast::SimpleCast;
 use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, Constructor, Token},
-    prelude::{artifacts::BytecodeObject, ContractFactory, Middleware},
+    prelude::{artifacts::BytecodeObject, ContractFactory, Middleware, MiddlewareBuilder},
     solc::{info::ContractInfo, utils::canonicalized},
     types::{transaction::eip2718::TypedTransaction, Chain},
 };
 use eyre::Context;
-use foundry_common::{abi::parse_tokens, compile, estimate_eip1559_fees, try_get_http_provider};
+use foundry_common::{abi::parse_tokens, compile, estimate_eip1559_fees};
 use rustc_hex::ToHex;
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
-use tracing::log::trace;
 
 /// CLI arguments for `forge create`.
 #[derive(Debug, Clone, Parser)]
@@ -120,7 +120,7 @@ impl CreateArgs {
 
         // Add arguments to constructor
         let config = self.eth.try_load_config_emit_warnings()?;
-        let provider = Arc::new(try_get_http_provider(config.get_rpc_url_or_localhost_http()?)?);
+        let provider = utils::get_provider(&config)?;
         let params = match abi.constructor {
             Some(ref v) => {
                 let constructor_args =
@@ -134,29 +134,18 @@ impl CreateArgs {
             None => vec![],
         };
 
+        let chain_id = provider.get_chainid().await?.as_u64();
         if self.unlocked {
-            let sender = self.eth.wallet.from.expect("is required");
-            trace!("creating with unlocked account={:?}", sender);
-            // use unlocked provider
-            let provider =
-                Arc::try_unwrap(provider).expect("Only one ref; qed.").with_sender(sender);
-            self.deploy(abi, bin, params, provider).await?;
-            return Ok(())
+            // Deploy with unlocked account
+            let sender = self.eth.wallet.from.expect("required");
+            let provider = provider.with_sender(sender);
+            self.deploy(abi, bin, params, provider, chain_id).await
+        } else {
+            // Deploy with signer
+            let signer = self.eth.wallet.signer(chain_id).await?;
+            let provider = provider.with_signer(signer);
+            self.deploy(abi, bin, params, provider, chain_id).await
         }
-
-        // Deploy with signer
-        let chain_id = provider.get_chainid().await?;
-        match self.eth.signer_with(chain_id, provider).await? {
-            Some(signer) => match signer {
-                WalletType::Ledger(signer) => self.deploy(abi, bin, params, signer).await?,
-                WalletType::Local(signer) => self.deploy(abi, bin, params, signer).await?,
-                WalletType::Trezor(signer) => self.deploy(abi, bin, params, signer).await?,
-                WalletType::Aws(signer) => self.deploy(abi, bin, params, signer).await?,
-            },
-            None => eyre::bail!("could not find artifact"),
-        };
-
-        Ok(())
     }
 
     /// Ensures the verify command can be executed.
@@ -180,7 +169,7 @@ impl CreateArgs {
             constructor_args_path: None,
             num_of_optimizations: None,
             chain: chain.into(),
-            etherscan_key: self.eth.etherscan_api_key.clone(),
+            etherscan_key: self.eth.etherscan.key.clone(),
             flatten: false,
             force: false,
             watch: true,
@@ -201,8 +190,8 @@ impl CreateArgs {
         bin: BytecodeObject,
         args: Vec<Token>,
         provider: M,
+        chain: u64,
     ) -> eyre::Result<()> {
-        let chain = provider.get_chainid().await?.as_u64();
         let deployer_address =
             provider.default_sender().expect("no sender address set for provider");
         let bin = bin.into_bytes().unwrap_or_else(|| {
@@ -325,7 +314,7 @@ impl CreateArgs {
             constructor_args_path: None,
             num_of_optimizations,
             chain: chain.into(),
-            etherscan_key: self.eth.etherscan_api_key,
+            etherscan_key: self.eth.etherscan.key.clone(),
             flatten: false,
             force: false,
             watch: true,

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -52,6 +52,7 @@ possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecod
 
 impl Cmd for InspectArgs {
     type Output = ();
+
     fn run(self) -> eyre::Result<Self::Output> {
         let InspectArgs { mut contract, field, build, pretty } = self;
 

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -7,15 +7,15 @@ use crate::{
         has_batch_support, has_different_gas_calc,
     },
     init_progress,
-    opts::WalletType,
+    opts::WalletSigner,
     update_progress,
 };
 use ethers::{
-    prelude::{Provider, Signer, SignerMiddleware, TxHash},
+    prelude::{Provider, Signer, TxHash},
     providers::{JsonRpcClient, Middleware},
     utils::format_units,
 };
-use eyre::{bail, ContextCompat, WrapErr};
+use eyre::{bail, ContextCompat, Result, WrapErr};
 use foundry_common::{estimate_eip1559_fees, shell, try_get_http_provider, RetryProvider};
 use futures::StreamExt;
 use std::{cmp::min, collections::HashSet, ops::Mul, sync::Arc};
@@ -28,7 +28,7 @@ impl ScriptArgs {
         deployment_sequence: &mut ScriptSequence,
         fork_url: &str,
         script_wallets: &[LocalWallet],
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         let provider = Arc::new(try_get_http_provider(fork_url)?);
         let already_broadcasted = deployment_sequence.receipts.len();
 
@@ -119,7 +119,7 @@ impl ScriptArgs {
 
                     Ok((tx, kind))
                 })
-                .collect::<eyre::Result<Vec<_>>>()?;
+                .collect::<Result<Vec<_>>>()?;
 
             let pb = init_progress!(deployment_sequence.transactions, "txes");
 
@@ -216,7 +216,7 @@ impl ScriptArgs {
         kind: SendTransactionKind<'_>,
         sequential_broadcast: bool,
         fork_url: &str,
-    ) -> eyre::Result<TxHash> {
+    ) -> Result<TxHash> {
         let from = tx.from().expect("no sender");
 
         if sequential_broadcast {
@@ -248,12 +248,7 @@ impl ScriptArgs {
 
                 Ok(pending.tx_hash())
             }
-            SendTransactionKind::Raw(ref signer) => match signer {
-                WalletType::Local(signer) => self.broadcast(signer, tx).await,
-                WalletType::Ledger(signer) => self.broadcast(signer, tx).await,
-                WalletType::Trezor(signer) => self.broadcast(signer, tx).await,
-                WalletType::Aws(signer) => self.broadcast(signer, tx).await,
-            },
+            SendTransactionKind::Raw(signer) => self.broadcast(provider, signer, tx).await,
         }
     }
 
@@ -266,7 +261,7 @@ impl ScriptArgs {
         decoder: &mut CallTraceDecoder,
         mut script_config: ScriptConfig,
         verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         if let Some(txs) = result.transactions.take() {
             script_config.collect_rpcs(&txs);
             script_config.check_multi_chain_constraints(&libraries)?;
@@ -334,7 +329,7 @@ impl ScriptArgs {
         libraries: Libraries,
         result: ScriptResult,
         verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         trace!(target: "script", "broadcasting single chain deployment");
 
         let rpc = script_config.total_rpcs.into_iter().next().expect("exists; qed");
@@ -361,7 +356,7 @@ impl ScriptArgs {
         script_config: &mut ScriptConfig,
         decoder: &mut CallTraceDecoder,
         known_contracts: &ContractsByArtifact,
-    ) -> eyre::Result<Vec<ScriptSequence>> {
+    ) -> Result<Vec<ScriptSequence>> {
         if !txs.is_empty() {
             let gas_filled_txs = self
                 .fills_transactions_with_gas(txs, script_config, decoder, known_contracts)
@@ -393,7 +388,7 @@ impl ScriptArgs {
         script_config: &mut ScriptConfig,
         decoder: &mut CallTraceDecoder,
         known_contracts: &ContractsByArtifact,
-    ) -> eyre::Result<VecDeque<TransactionWithMetadata>> {
+    ) -> Result<VecDeque<TransactionWithMetadata>> {
         let gas_filled_txs = if self.skip_simulation {
             shell::println("\nSKIPPING ON CHAIN SIMULATION.")?;
             txs.into_iter()
@@ -427,7 +422,7 @@ impl ScriptArgs {
         target: &ArtifactId,
         config: &mut Config,
         returns: HashMap<String, NestedValue>,
-    ) -> eyre::Result<Vec<ScriptSequence>> {
+    ) -> Result<Vec<ScriptSequence>> {
         // User might be using both "in-code" forks and `--fork-url`.
         let last_rpc = &transactions.back().expect("exists; qed").rpc;
         let is_multi_deployment = transactions.iter().any(|tx| &tx.rpc != last_rpc);
@@ -560,50 +555,39 @@ impl ScriptArgs {
 
     /// Uses the signer to submit a transaction to the network. If it fails, it tries to retrieve
     /// the transaction hash that can be used on a later run with `--resume`.
-    async fn broadcast<T, S>(
+    async fn broadcast(
         &self,
-        signer: &SignerMiddleware<T, S>,
+        provider: Arc<RetryProvider>,
+        signer: &WalletSigner,
         mut legacy_or_1559: TypedTransaction,
-    ) -> eyre::Result<TxHash>
-    where
-        T: Middleware + 'static,
-        S: Signer + 'static,
-    {
+    ) -> Result<TxHash> {
         tracing::debug!("sending transaction: {:?}", legacy_or_1559);
 
         // Chains which use `eth_estimateGas` are being sent sequentially and require their gas
         // to be re-estimated right before broadcasting.
-        if has_different_gas_calc(signer.signer().chain_id()) || self.skip_simulation {
+        if has_different_gas_calc(signer.chain_id()) || self.skip_simulation {
             // if already set, some RPC endpoints might simply return the gas value that is
             // already set in the request and omit the estimate altogether, so
             // we remove it here
             let _ = legacy_or_1559.gas_mut().take();
 
-            self.estimate_gas(&mut legacy_or_1559, signer.provider()).await?;
+            self.estimate_gas(&mut legacy_or_1559, &provider).await?;
         }
 
         // Signing manually so we skip `fill_transaction` and its `eth_createAccessList`
         // request.
         let signature = signer
-            .sign_transaction(
-                &legacy_or_1559,
-                *legacy_or_1559.from().expect("Tx should have a `from`."),
-            )
+            .sign_transaction(&legacy_or_1559)
             .await
-            .wrap_err_with(|| "Failed to sign transaction")?;
+            .wrap_err("Failed to sign transaction")?;
 
         // Submit the raw transaction
-        let pending =
-            signer.provider().send_raw_transaction(legacy_or_1559.rlp_signed(&signature)).await?;
+        let pending = provider.send_raw_transaction(legacy_or_1559.rlp_signed(&signature)).await?;
 
         Ok(pending.tx_hash())
     }
 
-    async fn estimate_gas<T>(
-        &self,
-        tx: &mut TypedTransaction,
-        provider: &Provider<T>,
-    ) -> eyre::Result<()>
+    async fn estimate_gas<T>(&self, tx: &mut TypedTransaction, provider: &Provider<T>) -> Result<()>
     where
         T: JsonRpcClient,
     {
@@ -627,7 +611,7 @@ impl ScriptArgs {
 #[derive(Clone)]
 enum SendTransactionKind<'a> {
     Unlocked(Address),
-    Raw(&'a WalletType),
+    Raw(&'a WalletSigner),
 }
 
 /// Represents how to send _all_ transactions
@@ -635,14 +619,14 @@ enum SendTransactionsKind {
     /// Send via `eth_sendTransaction` and rely on the  `from` address being unlocked.
     Unlocked(HashSet<Address>),
     /// Send a signed transaction via `eth_sendRawTransaction`
-    Raw(HashMap<Address, WalletType>),
+    Raw(HashMap<Address, WalletSigner>),
 }
 
 impl SendTransactionsKind {
     /// Returns the [`SendTransactionKind`] for the given address
     ///
     /// Returns an error if no matching signer is found or the address is not unlocked
-    fn for_sender(&self, addr: &Address) -> eyre::Result<SendTransactionKind<'_>> {
+    fn for_sender(&self, addr: &Address) -> Result<SendTransactionKind<'_>> {
         match self {
             SendTransactionsKind::Unlocked(unlocked) => {
                 if !unlocked.contains(addr) {

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -228,7 +228,11 @@ impl ScriptArgs {
     ) -> eyre::Result<()> {
         trace!(target: "script", "resuming single deployment");
 
-        let fork_url = self.evm_opts.ensure_fork_url()?;
+        let fork_url = script_config
+            .evm_opts
+            .fork_url
+            .as_deref()
+            .ok_or_else(|| eyre::eyre!("Missing `--fork-url` field."))?;
         let provider = Arc::new(try_get_http_provider(fork_url)?);
 
         let chain = provider.get_chainid().await?.as_u64();

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -167,6 +167,7 @@ pub struct ScriptArgs {
     )]
     pub slow: bool,
 
+    /// The Etherscan (or equivalent) API key
     #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,
 

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -646,7 +646,7 @@ pub struct NestedValue {
     pub value: String,
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct ScriptConfig {
     pub config: Config,
     pub evm_opts: EvmOpts,

--- a/cli/src/cmd/forge/script/sequence.rs
+++ b/cli/src/cmd/forge/script/sequence.rs
@@ -183,7 +183,7 @@ impl ScriptSequence {
 
         verify.set_chain(config, self.chain.into());
 
-        if verify.etherscan_key.is_some() ||
+        if verify.etherscan.key.is_some() ||
             verify.verifier.verifier != VerificationProviderType::Etherscan
         {
             trace!(target: "script", "prepare future verifications");

--- a/cli/src/cmd/forge/script/verify.rs
+++ b/cli/src/cmd/forge/script/verify.rs
@@ -1,11 +1,14 @@
 //! Verify support
 
-use crate::cmd::{
-    forge::{
-        build::ProjectPathsArgs,
-        verify::{VerifierArgs, VerifyArgs},
+use crate::{
+    cmd::{
+        forge::{
+            build::ProjectPathsArgs,
+            verify::{VerifierArgs, VerifyArgs},
+        },
+        retry::RetryArgs,
     },
-    retry::RetryArgs,
+    opts::EtherscanOpts,
 };
 use ethers::{
     abi::Address,
@@ -20,9 +23,8 @@ use semver::Version;
 pub struct VerifyBundle {
     pub num_of_optimizations: Option<usize>,
     pub known_contracts: ContractsByArtifact,
-    pub etherscan_key: Option<String>,
-    pub chain: Chain,
     pub project_paths: ProjectPathsArgs,
+    pub etherscan: EtherscanOpts,
     pub retry: RetryArgs,
     pub verifier: VerifierArgs,
 }
@@ -54,8 +56,7 @@ impl VerifyBundle {
         VerifyBundle {
             num_of_optimizations,
             known_contracts,
-            etherscan_key: None,
-            chain: Default::default(),
+            etherscan: Default::default(),
             project_paths,
             retry,
             verifier,
@@ -66,11 +67,8 @@ impl VerifyBundle {
     pub fn set_chain(&mut self, config: &Config, chain: Chain) {
         // If dealing with multiple chains, we need to be able to change inbetween the config
         // chain_id.
-        let mut config = config.clone();
-        config.chain_id = Some(chain);
-        self.etherscan_key =
-            config.get_etherscan_api_key(Some(chain)).or_else(|| config.etherscan_api_key.clone());
-        self.chain = chain;
+        self.etherscan.key = config.get_etherscan_api_key(Some(chain));
+        self.etherscan.chain = Some(chain);
     }
 
     /// Given a `VerifyBundle` and contract details, it tries to generate a valid `VerifyArgs` to
@@ -111,8 +109,7 @@ impl VerifyBundle {
                     constructor_args: Some(hex::encode(constructor_args)),
                     constructor_args_path: None,
                     num_of_optimizations: self.num_of_optimizations,
-                    chain: self.chain,
-                    etherscan_key: self.etherscan_key.clone(),
+                    etherscan: self.etherscan.clone(),
                     flatten: false,
                     force: false,
                     watch: true,

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -83,12 +83,8 @@ pub struct TestArgs {
     #[clap(flatten)]
     evm_opts: EvmArgs,
 
-    #[clap(
-        long,
-        env = "ETHERSCAN_API_KEY",
-        help = "Set etherscan api key to better decode traces",
-        value_name = "ETHERSCAN_KEY"
-    )]
+    /// The Etherscan (or equivalent) API key
+    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     etherscan_api_key: Option<String>,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/verify/etherscan/mod.rs
+++ b/cli/src/cmd/forge/verify/etherscan/mod.rs
@@ -117,9 +117,8 @@ impl VerificationProvider for EtherscanVerificationProvider {
             if args.watch {
                 let check_args = VerifyCheckArgs {
                     id: resp.result,
-                    chain: args.chain,
+                    etherscan: args.etherscan,
                     retry: RETRY_CHECK_ON_VERIFY,
-                    etherscan_key: args.etherscan_key,
                     verifier: args.verifier,
                 };
                 // return check_args.run().await
@@ -136,9 +135,9 @@ impl VerificationProvider for EtherscanVerificationProvider {
     async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()> {
         let config = args.try_load_config_emit_warnings()?;
         let etherscan = self.client(
-            args.chain,
+            args.etherscan.chain.unwrap_or_default(),
             args.verifier.verifier_url.as_deref(),
-            args.etherscan_key.as_deref(),
+            args.etherscan.key.as_deref(),
             &config,
         )?;
         let retry: Retry = args.retry.into();
@@ -222,9 +221,9 @@ impl EtherscanVerificationProvider {
     ) -> eyre::Result<(Client, VerifyContract)> {
         let config = args.try_load_config_emit_warnings()?;
         let etherscan = self.client(
-            args.chain,
+            args.etherscan.chain.unwrap_or_default(),
             args.verifier.verifier_url.as_deref(),
-            args.etherscan_key.as_deref(),
+            args.etherscan.key.as_deref(),
             &config,
         )?;
         let verify_args = self.create_verify_request(args, Some(config)).await?;
@@ -469,9 +468,9 @@ mod tests {
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan
             .client(
-                args.chain,
+                args.etherscan.chain.unwrap_or_default(),
                 args.verifier.verifier_url.as_deref(),
-                args.etherscan_key.as_deref(),
+                args.etherscan.key.as_deref(),
                 &config,
             )
             .unwrap();
@@ -496,9 +495,9 @@ mod tests {
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan
             .client(
-                args.chain,
+                args.etherscan.chain.unwrap_or_default(),
                 args.verifier.verifier_url.as_deref(),
-                args.etherscan_key.as_deref(),
+                args.etherscan.key.as_deref(),
                 &config,
             )
             .unwrap();

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -1,12 +1,15 @@
 //! Verify contract source
 
-use crate::cmd::{
-    forge::verify::{etherscan::EtherscanVerificationProvider, provider::VerificationProvider},
-    retry::RetryArgs,
+use crate::{
+    cmd::{
+        forge::verify::{etherscan::EtherscanVerificationProvider, provider::VerificationProvider},
+        retry::RetryArgs,
+    },
+    opts::EtherscanOpts,
 };
 use clap::{Parser, ValueHint};
 use ethers::{abi::Address, solc::info::ContractInfo};
-use foundry_config::{figment, impl_figment_convert, Chain, Config};
+use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config};
 use provider::VerificationProviderType;
 use reqwest::Url;
 use std::path::PathBuf;
@@ -88,22 +91,8 @@ pub struct VerifyArgs {
     )]
     pub num_of_optimizations: Option<usize>,
 
-    #[clap(
-        long,
-        visible_alias = "chain-id",
-        env = "CHAIN",
-        help = "The chain ID the contract is deployed to.",
-        default_value = "mainnet",
-        value_name = "CHAIN"
-    )]
-    pub chain: Chain,
-
-    #[clap(
-        help = "Your Etherscan API key.",
-        env = "ETHERSCAN_API_KEY",
-        value_name = "ETHERSCAN_KEY"
-    )]
-    pub etherscan_key: Option<String>,
+    #[clap(flatten)]
+    pub etherscan: EtherscanOpts,
 
     #[clap(help = "Flatten the source code before verifying.", long = "flatten")]
     pub flatten: bool,
@@ -177,7 +166,12 @@ impl figment::Provider for VerifyArgs {
 
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(mut self) -> eyre::Result<()> {
+        let config = Config::from(&self.etherscan);
+        let chain = config.chain_id.unwrap_or_default();
+        self.etherscan.chain = Some(chain);
+        self.etherscan.key = config.get_etherscan_api_key(Some(chain));
+
         if self.show_standard_json_input {
             let args =
                 EtherscanVerificationProvider::default().create_verify_request(&self, None).await?;
@@ -186,17 +180,21 @@ impl VerifyArgs {
         }
 
         let verifier_url = self.verifier.verifier_url.clone();
-        println!("Start verifying contract `{:?}` deployed on {}", self.address, self.chain);
-        self.verifier.verifier.client(&self.etherscan_key)?.verify(self).await.map_err(|err| {
+        println!("Start verifying contract `{:?}` deployed on {chain}", self.address);
+        self.verifier.verifier.client(&self.etherscan.key)?.verify(self).await.map_err(|err| {
             if let Some(verifier_url) = verifier_url {
                  match Url::parse(&verifier_url) {
                     Ok(url) => {
                         if is_host_only(&url) {
-                            return  err.wrap_err(format!("Provided URL `{verifier_url}` is host only.\n Did you mean to use the API endpoint`{verifier_url}/api` ?"))
+                            return err.wrap_err(format!(
+                                "Provided URL `{verifier_url}` is host only.\n Did you mean to use the API endpoint`{verifier_url}/api` ?"
+                            ))
                         }
                     }
                     Err(url_err) => {
-                       return  err.wrap_err(format!("Invalid URL {verifier_url} provided: {url_err}"))
+                        return err.wrap_err(format!(
+                            "Invalid URL {verifier_url} provided: {url_err}"
+                        ))
                     }
                 }
             }
@@ -207,7 +205,7 @@ impl VerifyArgs {
 
     /// Returns the configured verification provider
     pub fn verification_provider(&self) -> eyre::Result<Box<dyn VerificationProvider>> {
-        self.verifier.verifier.client(&self.etherscan_key)
+        self.verifier.verifier.client(&self.etherscan.key)
     }
 }
 
@@ -220,36 +218,23 @@ pub struct VerifyCheckArgs {
     )]
     id: String,
 
-    #[clap(
-        long,
-        visible_alias = "chain-id",
-        env = "CHAIN",
-        help = "The chain ID the contract is deployed to.",
-        default_value = "mainnet",
-        value_name = "CHAIN"
-    )]
-    chain: Chain,
-
     #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
     retry: RetryArgs,
 
-    #[clap(
-        long,
-        help = "Your Etherscan API key.",
-        env = "ETHERSCAN_API_KEY",
-        value_name = "ETHERSCAN_KEY"
-    )]
-    etherscan_key: Option<String>,
+    #[clap(flatten)]
+    etherscan: EtherscanOpts,
 
     #[clap(flatten)]
     verifier: VerifierArgs,
 }
 
+impl_figment_convert_cast!(VerifyCheckArgs);
+
 impl VerifyCheckArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> eyre::Result<()> {
-        println!("Checking verification status on {}", self.chain);
-        self.verifier.verifier.client(&self.etherscan_key)?.check(self).await
+        println!("Checking verification status on {}", self.etherscan.chain.unwrap_or_default());
+        self.verifier.verifier.client(&self.etherscan.key)?.check(self).await
     }
 }
 
@@ -257,22 +242,11 @@ impl figment::Provider for VerifyCheckArgs {
     fn metadata(&self) -> figment::Metadata {
         figment::Metadata::named("Verify Check Provider")
     }
+
     fn data(
         &self,
     ) -> Result<figment::value::Map<figment::Profile, figment::value::Dict>, figment::Error> {
-        Ok(figment::value::Map::from([(Config::selected_profile(), figment::value::Dict::new())]))
-    }
-}
-impl<'a> From<&'a VerifyCheckArgs> for figment::Figment {
-    fn from(args: &'a VerifyCheckArgs) -> Self {
-        Config::figment_with_root(foundry_config::find_project_root_path().unwrap()).merge(args)
-    }
-}
-
-impl<'a> From<&'a VerifyCheckArgs> for Config {
-    fn from(args: &'a VerifyCheckArgs) -> Self {
-        let figment: figment::Figment = args.into();
-        Config::from_provider(figment).sanitized()
+        self.etherscan.data()
     }
 }
 

--- a/cli/src/cmd/forge/verify/sourcify.rs
+++ b/cli/src/cmd/forge/verify/sourcify.rs
@@ -82,7 +82,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                         "{}check-by-addresses?addresses={}&chainIds={}",
                         args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL),
                         args.id,
-                        args.chain.id(),
+                        args.etherscan.chain.unwrap_or_default().id(),
                     );
 
                     let response = reqwest::get(url).await?;
@@ -161,7 +161,7 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
 
         let req = SourcifyVerifyRequest {
             address: format!("{:?}", args.address),
-            chain: args.chain.id().to_string(),
+            chain: args.etherscan.chain.unwrap_or_default().id().to_string(),
             files,
             chosen_contract: None,
         };

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,4 +1,4 @@
-use super::{ClapChain, EthereumOpts};
+use super::{EtherscanOpts, RpcOpts};
 use crate::{
     cmd::cast::{
         bind::BindArgs, call::CallArgs, create2::Create2Args, estimate::EstimateArgs,
@@ -110,6 +110,7 @@ The input can be:
     FromFixedPoint {
         #[clap(value_name = "DECIMALS")]
         decimals: Option<String>,
+
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
@@ -127,6 +128,7 @@ The input can be:
     ToFixedPoint {
         #[clap(value_name = "DECIMALS")]
         decimals: Option<String>,
+
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         value: Option<String>,
     },
@@ -149,10 +151,13 @@ The input can be:
     LeftShift {
         #[clap(value_name = "VALUE")]
         value: String,
+
         #[clap(value_name = "BITS")]
         bits: String,
+
         #[clap(long = "base-in", help = "The input base")]
         base_in: Option<String>,
+
         #[clap(long = "base-out", help = "The output base", default_value = "16")]
         base_out: String,
     },
@@ -161,10 +166,13 @@ The input can be:
     RightShift {
         #[clap(value_name = "VALUE")]
         value: String,
+
         #[clap(value_name = "BITS")]
         bits: String,
+
         #[clap(long = "base-in", help = "The input base")]
         base_in: Option<String>,
+
         #[clap(long = "base-out", help = "The output base", default_value = "16")]
         base_out: String,
     },
@@ -185,6 +193,7 @@ Examples:
         #[clap(value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
+
         #[clap(
             help = "The unit to convert to (ether, gwei, wei).",
             default_value = "wei",
@@ -199,6 +208,7 @@ Examples:
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
+
         #[clap(value_name = "UNIT", default_value = "eth")]
         unit: String,
     },
@@ -209,6 +219,7 @@ Examples:
         #[clap(allow_hyphen_values = true, value_name = "VALUE")]
         // negative values not yet supported internally
         value: Option<String>,
+
         #[clap(value_name = "UNIT", default_value = "eth")]
         unit: String,
     },
@@ -232,6 +243,7 @@ Examples:
     ToBase {
         #[clap(flatten)]
         base: ToBaseArgs,
+
         #[clap(value_name = "BASE", help = "The output base")]
         base_out: Option<String>,
     },
@@ -245,10 +257,13 @@ Examples:
             value_name = "ADDRESS"
         )]
         address: NameOrAddress,
+
         #[clap(help = "The signature of the function to call.", value_name = "SIG")]
         sig: String,
+
         #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
         args: Vec<String>,
+
         #[clap(
             long,
             short = 'B',
@@ -257,11 +272,12 @@ Examples:
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(flatten)]
-        // TODO: We only need RPC URL + etherscan stuff from this struct
-        eth: EthereumOpts,
+
         #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "block")]
     #[clap(visible_alias = "bl")]
@@ -273,24 +289,28 @@ Examples:
             value_name = "BLOCK"
         )]
         block: BlockId,
+
         #[clap(
             help = "If specified, only get the given field of the block.",
             value_name = "FIELD"
         )]
         field: Option<String>,
+
         #[clap(long, env = "CAST_FULL_BLOCK")]
         full: bool,
+
         #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "block-number")]
     #[clap(visible_alias = "bn")]
     #[clap(about = "Get the latest block number.")]
     BlockNumber {
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "call")]
     #[clap(visible_alias = "c")]
@@ -306,28 +326,29 @@ Examples:
             value_name = "SIG"
         )]
         sig: String,
+
         #[clap(allow_hyphen_values = true, value_name = "ARGS")]
         args: Vec<String>,
     },
     #[clap(name = "chain")]
     #[clap(about = "Get the symbolic name of the current chain.")]
     Chain {
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "chain-id")]
     #[clap(visible_aliases = &["ci", "cid"])]
     #[clap(about = "Get the Ethereum chain ID.")]
     ChainId {
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "client")]
     #[clap(visible_alias = "cl")]
     #[clap(about = "Get the current client version.")]
     Client {
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "compute-address")]
     #[clap(visible_alias = "ca")]
@@ -335,10 +356,12 @@ Examples:
     ComputeAddress {
         #[clap(help = "The deployer address.", value_name = "ADDRESS")]
         address: Option<String>,
+
         #[clap(long, help = "The nonce of the deployer address.", value_parser = parse_u256, value_name = "NONCE")]
         nonce: Option<U256>,
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "namehash")]
     #[clap(visible_aliases = &["na", "nh"])]
@@ -353,12 +376,15 @@ Examples:
     Tx {
         #[clap(value_name = "TX_HASH")]
         tx_hash: String,
+
         #[clap(value_name = "FIELD")]
         field: Option<String>,
+
         #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "receipt")]
     #[clap(visible_alias = "re")]
@@ -366,8 +392,10 @@ Examples:
     Receipt {
         #[clap(value_name = "TX_HASH")]
         tx_hash: String,
+
         #[clap(value_name = "FIELD")]
         field: Option<String>,
+
         #[clap(
             short,
             long,
@@ -376,6 +404,7 @@ Examples:
             value_name = "CONFIRMATIONS"
         )]
         confirmations: usize,
+
         #[clap(
             long = "async",
             env = "CAST_ASYNC",
@@ -384,10 +413,12 @@ Examples:
             help = "Exit immediately if the transaction was not found."
         )]
         cast_async: bool,
+
         #[clap(long = "json", short = 'j', help_heading = "Display options")]
         to_json: bool,
-        #[clap(long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "send")]
     #[clap(visible_alias = "s")]
@@ -399,6 +430,7 @@ Examples:
     PublishTx {
         #[clap(help = "The raw transaction", value_name = "RAW_TX")]
         raw_tx: String,
+
         #[clap(
             long = "async",
             env = "CAST_ASYNC",
@@ -407,9 +439,9 @@ Examples:
             help = "Only print the transaction hash and exit immediately."
         )]
         cast_async: bool,
-        // FIXME: We only need the RPC URL and `--flashbots` options from this.
+
         #[clap(flatten)]
-        eth: EthereumOpts,
+        rpc: RpcOpts,
     },
     #[clap(name = "estimate")]
     #[clap(visible_alias = "e")]
@@ -424,6 +456,7 @@ Examples:
             value_name = "SIG"
         )]
         sig: String,
+
         #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
         calldata: String,
     },
@@ -441,8 +474,10 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             value_name = "SIG"
         )]
         sig: String,
+
         #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
         calldata: String,
+
         #[clap(long, short, help = "Decode input data.")]
         input: bool,
     },
@@ -452,6 +487,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     AbiEncode {
         #[clap(help = "The function signature.", value_name = "SIG")]
         sig: String,
+
         #[clap(help = "The arguments of the function.", value_name = "ARGS")]
         #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
@@ -462,8 +498,10 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
     Index {
         #[clap(help = "The mapping key type.", value_name = "KEY_TYPE")]
         key_type: String,
+
         #[clap(help = "The mapping key.", value_name = "KEY")]
         key: String,
+
         #[clap(help = "The storage slot of the mapping.", value_name = "SLOT_NUMBER")]
         slot_number: String,
     },
@@ -479,10 +517,12 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
         #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "admin")]
     #[clap(visible_alias = "adm")]
@@ -496,10 +536,12 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
         #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "4byte")]
     #[clap(visible_aliases = &["4", "4b"])]
@@ -570,8 +612,9 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "balance")]
     #[clap(visible_alias = "b")]
@@ -585,16 +628,19 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
         #[clap(
             help = "The account you want to query",
             value_parser = NameOrAddress::from_str,
             value_name = "WHO"
         )]
         who: NameOrAddress,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
         #[clap(long = "ether", short = 'e', help_heading = "format to ether")]
         to_ether: bool,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "basefee")]
     #[clap(visible_aliases = &["ba", "fee"])]
@@ -608,8 +654,9 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "code")]
     #[clap(visible_alias = "co")]
@@ -623,17 +670,19 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
         #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "gas-price")]
     #[clap(visible_alias = "g")]
     #[clap(about = "Get the current gas price.")]
     GasPrice {
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "sig-event")]
     #[clap(visible_alias = "se")]
@@ -655,10 +704,12 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     ResolveName {
         #[clap(help = "The name to lookup.", value_name = "WHO")]
         who: Option<String>,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
         #[clap(long, short, help = "Perform a reverse lookup to verify that the name is correct.")]
         verify: bool,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "lookup-address")]
     #[clap(visible_alias = "l")]
@@ -666,14 +717,16 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     LookupAddress {
         #[clap(help = "The account to perform the lookup for.", value_name = "WHO")]
         who: Option<Address>,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
         #[clap(
             long,
             short,
             help = "Perform a normal lookup to verify that the address is correct."
         )]
         verify: bool,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(
         name = "storage",
@@ -689,10 +742,10 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     Proof {
         #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "ADDRESS")]
         address: NameOrAddress,
+
         #[clap(help = "The storage slot numbers (hex or decimal).",  value_parser = parse_slot, value_name = "SLOTS")]
         slots: Vec<H256>,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
         #[clap(
             long,
             short = 'B',
@@ -701,6 +754,9 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "nonce")]
     #[clap(visible_alias = "n")]
@@ -714,23 +770,25 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
+
         #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
         who: NameOrAddress,
-        #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
-        rpc_url: Option<String>,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
     },
     #[clap(name = "etherscan-source")]
     #[clap(visible_aliases = &["et", "src"])]
     #[clap(about = "Get the source code of a contract from Etherscan.")]
     EtherscanSource {
-        #[clap(flatten)]
-        chain: ClapChain,
         #[clap(help = "The contract's address.", value_name = "ADDRESS")]
         address: String,
+
         #[clap(short, help = "The output directory to expand source tree into.", value_hint = ValueHint::DirPath, value_name = "DIRECTORY")]
         directory: Option<PathBuf>,
-        #[clap(long, short, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
-        etherscan_api_key: Option<String>,
+
+        #[clap(flatten)]
+        etherscan: EtherscanOpts,
     },
     #[clap(name = "wallet", visible_alias = "w", about = "Wallet management utilities.")]
     Wallet {
@@ -808,6 +866,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
 pub struct ToBaseArgs {
     #[clap(allow_hyphen_values = true, value_name = "VALUE")]
     pub value: Option<String>,
+
     #[clap(long = "base-in", short = 'i', help = "The input base")]
     pub base_in: Option<String>,
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -397,7 +397,6 @@ Examples:
         field: Option<String>,
 
         #[clap(
-            short,
             long,
             help = "The number of confirmations until the receipt is fetched",
             default_value = "1",

--- a/cli/src/opts/chain.rs
+++ b/cli/src/opts/chain.rs
@@ -12,8 +12,8 @@ pub struct ChainValueParser {
     pub inner: PossibleValuesParser,
 }
 
-impl ChainValueParser {
-    pub fn new() -> Self {
+impl Default for ChainValueParser {
+    fn default() -> Self {
         Self { inner: PossibleValuesParser::from(NamedChain::VARIANTS) }
     }
 }

--- a/cli/src/opts/chain.rs
+++ b/cli/src/opts/chain.rs
@@ -27,12 +27,19 @@ impl TypedValueParser for ChainValueParser {
         arg: Option<&clap::Arg>,
         value: &OsStr,
     ) -> Result<Self::Value, clap::Error> {
-        if let Some(id) = value.to_str().and_then(|value| value.parse::<u64>().ok()) {
+        let s =
+            value.to_str().ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidUtf8))?;
+        if let Ok(id) = s.parse() {
             Ok(Chain::Id(id))
         } else {
-            let string = self.inner.parse_ref(cmd, arg, value)?;
-            let named = string.parse::<NamedChain>().expect("Already validated");
-            Ok(Chain::Named(named))
+            // NamedChain::VARIANTS is a subset of all possible variants, since there are aliases:
+            // mumbai instead of polygon-mumbai etc
+            //
+            // Parse first as NamedChain, if it fails parse with NamedChain::VARIANTS for displaying
+            // the error to the user
+            s.parse()
+                .map_err(|_| self.inner.parse_ref(cmd, arg, value).unwrap_err())
+                .map(Chain::Named)
         }
     }
 }

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -1,13 +1,10 @@
-use super::{Wallet, WalletType};
-use cast::{AwsChainProvider, AwsClient, AwsHttpClient, AwsRegion, KmsClient};
-use clap::Parser;
-use ethers::{
-    middleware::SignerMiddleware,
-    signers::{AwsSigner, HDPath as LedgerHDPath, Ledger, Signer, Trezor, TrezorHDPath},
-    types::{Address, U256},
+use super::{Wallet, WalletSigner};
+use clap::{
+    builder::{PossibleValuesParser, TypedValueParser},
+    Parser,
 };
+use ethers::types::Chain as NamedChain;
 use eyre::Result;
-use foundry_common::{ProviderBuilder, RetryProvider};
 use foundry_config::{
     figment::{
         self,
@@ -17,124 +14,123 @@ use foundry_config::{
     impl_figment_convert_cast, Chain, Config,
 };
 use serde::Serialize;
-use std::sync::Arc;
+use std::borrow::Cow;
+use strum::VariantNames;
 
 const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
-impl_figment_convert_cast!(EthereumOpts);
+#[allow(dead_code)]
+static E: &str = "\
+No Etherscan API Key is set. Consider using the ETHERSCAN_API_KEY environment variable,\n\
+setting the -e CLI argument or etherscan-api-key in foundry.toml\
+";
 
-#[derive(Debug, Clone, Default, Parser, Serialize)]
+#[derive(Clone, Debug, Default, Parser)]
+pub struct RpcOpts {
+    /// The RPC endpoint
+    #[clap(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
+    pub url: Option<String>,
+
+    /// Use the Flashbots RPC URL (https://rpc.flashbots.net)
+    #[clap(long, conflicts_with = "rpc_url")]
+    pub flashbots: bool,
+}
+
+impl_figment_convert_cast!(RpcOpts);
+
+impl figment::Provider for RpcOpts {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("RpcOpts")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        Ok(Map::from([(Config::selected_profile(), self.dict())]))
+    }
+}
+
+impl RpcOpts {
+    /// Returns the RPC endpoint.
+    pub fn url<'a>(&'a self, config: Option<&'a Config>) -> Result<Option<Cow<'a, str>>> {
+        let url = match (self.flashbots, self.url.as_deref(), config) {
+            (true, ..) => Some(Cow::Borrowed(FLASHBOTS_URL)),
+            (false, Some(url), _) => Some(Cow::Borrowed(url)),
+            (false, None, Some(config)) => config.get_rpc_url().transpose()?,
+            (false, None, None) => None,
+        };
+        Ok(url)
+    }
+
+    fn dict(&self) -> Dict {
+        let mut dict = Dict::new();
+        if let Ok(Some(url)) = self.url(None) {
+            dict.insert("eth_rpc_url".into(), url.into_owned().into());
+        }
+        dict
+    }
+}
+
+#[derive(Clone, Debug, Default, Parser, Serialize)]
+pub struct EtherscanOpts {
+    /// The Etherscan (or equivalent) API key
+    #[clap(short = 'e', long = "etherscan-api-key", env = "ETHERSCAN_API_KEY")]
+    #[serde(rename = "etherscan_api_key", skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+
+    /// The chain name or EIP-155 chain ID
+    #[clap(
+        short,
+        long,
+        env = "CHAIN",
+        value_parser = ChainValueParser::default(),
+    )]
+    #[serde(rename = "chain_id", skip_serializing_if = "Option::is_none")]
+    pub chain: Option<Chain>,
+}
+
+impl_figment_convert_cast!(EtherscanOpts);
+
+impl figment::Provider for EtherscanOpts {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("EtherscanOpts")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        Ok(Map::from([(Config::selected_profile(), self.dict())]))
+    }
+}
+
+impl EtherscanOpts {
+    pub fn key<'a>(&'a self, config: Option<&'a Config>) -> Option<Cow<'a, str>> {
+        match (self.key.as_deref(), config) {
+            (Some(key), _) => Some(Cow::Borrowed(key)),
+            (None, Some(config)) => config.get_etherscan_api_key(self.chain).map(Cow::Owned),
+            (None, None) => None,
+        }
+    }
+
+    fn dict(&self) -> Dict {
+        Value::serialize(self).unwrap().into_dict().unwrap()
+    }
+}
+
+#[derive(Clone, Debug, Default, Parser)]
 #[clap(next_help_heading = "Ethereum options")]
 pub struct EthereumOpts {
-    #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The RPC endpoint.", value_name = "URL")]
-    pub rpc_url: Option<String>,
-
-    #[clap(long, help = "Use the flashbots RPC URL (https://rpc.flashbots.net)")]
-    pub flashbots: bool,
-
-    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub etherscan_api_key: Option<String>,
-
-    #[clap(long, env = "CHAIN", value_name = "CHAIN_NAME")]
-    #[serde(skip)]
-    pub chain: Option<Chain>,
+    #[clap(flatten)]
+    pub rpc: RpcOpts,
 
     #[clap(flatten)]
-    #[serde(skip)]
+    pub etherscan: EtherscanOpts,
+
+    #[clap(flatten)]
     pub wallet: Wallet,
 }
 
+impl_figment_convert_cast!(EthereumOpts);
+
 impl EthereumOpts {
-    /// Returns the sender address of the signer or `from`
-    #[allow(unused)]
-    pub async fn sender(&self) -> Address {
-        if let Ok(Some(signer)) = self.signer(0.into()).await {
-            match signer {
-                WalletType::Ledger(signer) => signer.address(),
-                WalletType::Local(signer) => signer.address(),
-                WalletType::Trezor(signer) => signer.address(),
-                WalletType::Aws(signer) => signer.address(),
-            }
-        } else {
-            self.wallet.from.unwrap_or_else(Address::zero)
-        }
-    }
-
-    #[allow(unused)]
-    pub async fn signer(&self, chain_id: U256) -> eyre::Result<Option<WalletType>> {
-        self.signer_with(
-            chain_id,
-            Arc::new(
-                ProviderBuilder::new(self.rpc_url()?)
-                    .chain(chain_id)
-                    .initial_backoff(1000)
-                    .connect()
-                    .await?,
-            ),
-        )
-        .await
-    }
-
-    /// Returns a [`SignerMiddleware`] corresponding to the provided private key, mnemonic or hw
-    /// signer
-    pub async fn signer_with(
-        &self,
-        chain_id: U256,
-        provider: Arc<RetryProvider>,
-    ) -> eyre::Result<Option<WalletType>> {
-        if self.wallet.ledger {
-            let derivation = match &self.wallet.hd_path {
-                Some(hd_path) => LedgerHDPath::Other(hd_path.clone()),
-                None => LedgerHDPath::LedgerLive(self.wallet.mnemonic_index as usize),
-            };
-            let ledger = Ledger::new(derivation, chain_id.as_u64()).await?;
-
-            Ok(Some(WalletType::Ledger(SignerMiddleware::new(provider, ledger))))
-        } else if self.wallet.trezor {
-            let derivation = match &self.wallet.hd_path {
-                Some(hd_path) => TrezorHDPath::Other(hd_path.clone()),
-                None => TrezorHDPath::TrezorLive(self.wallet.mnemonic_index as usize),
-            };
-
-            // cached to ~/.ethers-rs/trezor/cache/trezor.session
-            let trezor = Trezor::new(derivation, chain_id.as_u64(), None).await?;
-
-            Ok(Some(WalletType::Trezor(SignerMiddleware::new(provider, trezor))))
-        } else if self.wallet.aws {
-            let client =
-                AwsClient::new_with(AwsChainProvider::default(), AwsHttpClient::new().unwrap());
-
-            let kms = KmsClient::new_with_client(client, AwsRegion::default());
-
-            let key_id = std::env::var("AWS_KMS_KEY_ID")?;
-
-            let aws_signer = AwsSigner::new(kms, key_id, chain_id.as_u64()).await?;
-
-            Ok(Some(WalletType::Aws(SignerMiddleware::new(provider, aws_signer))))
-        } else {
-            let local = self
-                .wallet
-                .private_key()
-                .transpose()
-                .or_else(|| self.wallet.interactive().transpose())
-                .or_else(|| self.wallet.mnemonic().transpose())
-                .or_else(|| self.wallet.keystore().transpose())
-                .transpose()?
-                .ok_or_else(|| eyre::eyre!("error accessing local wallet, did you set a private key, mnemonic or keystore? Run `cast send --help` or `forge create --help` and use the corresponding CLI flag to set your key via --private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger. Alternatively, if you're using a local node with unlocked accounts, use the --unlocked flag and set the `ETH_FROM` environment variable to the address of the unlocked account you want to use"))?;
-
-            let local = local.with_chain_id(chain_id.as_u64());
-
-            Ok(Some(WalletType::Local(SignerMiddleware::new(provider, local))))
-        }
-    }
-
-    pub fn rpc_url(&self) -> Result<&str> {
-        if self.flashbots {
-            Ok(FLASHBOTS_URL)
-        } else {
-            Ok(self.rpc_url.as_deref().unwrap_or("http://localhost:8545"))
-        }
+    pub async fn signer(&self) -> Result<WalletSigner> {
+        self.wallet.signer(self.etherscan.chain.unwrap_or_default().id()).await
     }
 }
 
@@ -145,22 +141,43 @@ impl figment::Provider for EthereumOpts {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
-        let value = Value::serialize(self)?;
-        let mut dict = value.into_dict().unwrap();
-
-        let rpc_url = self.rpc_url().map_err(|err| err.to_string())?;
-        if rpc_url != "http://localhost:8545" {
-            dict.insert("eth_rpc_url".to_string(), rpc_url.to_string().into());
-        }
+        let mut dict = self.etherscan.dict();
+        dict.extend(self.rpc.dict());
 
         if let Some(from) = self.wallet.from {
             dict.insert("sender".to_string(), format!("{from:?}").into());
         }
 
-        if let Some(etherscan_api_key) = &self.etherscan_api_key {
-            dict.insert("etherscan_api_key".to_string(), etherscan_api_key.to_string().into());
-        }
-
         Ok(Map::from([(Config::selected_profile(), dict)]))
+    }
+}
+
+/// The value parser for `Chain`s
+#[derive(Clone, Debug)]
+pub struct ChainValueParser {
+    pub inner: PossibleValuesParser,
+}
+
+impl Default for ChainValueParser {
+    fn default() -> Self {
+        ChainValueParser { inner: NamedChain::VARIANTS.into() }
+    }
+}
+
+impl TypedValueParser for ChainValueParser {
+    type Value = Chain;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        self.inner.parse_ref(cmd, arg, value)?.parse::<Chain>().map_err(|_| {
+            clap::Error::raw(
+                clap::error::ErrorKind::InvalidValue,
+                "chain argument did not match any possible chain variant",
+            )
+        })
     }
 }

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -49,7 +49,7 @@ impl RpcOpts {
         Ok(url)
     }
 
-    fn dict(&self) -> Dict {
+    pub fn dict(&self) -> Dict {
         let mut dict = Dict::new();
         if let Ok(Some(url)) = self.url(None) {
             dict.insert("eth_rpc_url".into(), url.into_owned().into());
@@ -98,7 +98,7 @@ impl EtherscanOpts {
         }
     }
 
-    fn dict(&self) -> Dict {
+    pub fn dict(&self) -> Dict {
         Value::serialize(self).unwrap().into_dict().unwrap()
     }
 }

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -71,7 +71,7 @@ pub struct EtherscanOpts {
         long,
         alias = "chain-id",
         env = "CHAIN",
-        value_parser = ChainValueParser::new(),
+        value_parser = ChainValueParser::default(),
     )]
     #[serde(rename = "chain_id", skip_serializing_if = "Option::is_none")]
     pub chain: Option<Chain>,

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -43,119 +43,99 @@ The wallet options can either be:
 )]
 #[clap(next_help_heading = "Wallet options")]
 pub struct Wallet {
+    /// The sender account
     #[clap(
-        long,
         short,
+        long,
         help_heading = "Wallet options - raw",
-        help = "Open an interactive prompt to enter your private key."
+        value_name = "ADDRESS",
+        env = "ETH_FROM"
     )]
+    pub from: Option<Address>,
+
+    /// Open an interactive prompt to enter your private key
+    #[clap(long, short, help_heading = "Wallet options - raw")]
     pub interactive: bool,
 
+    /// Use the provided private key
     #[clap(
-        long = "private-key",
+        long,
         help_heading = "Wallet options - raw",
-        help = "Use the provided private key.",
         value_name = "RAW_PRIVATE_KEY",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix
     )]
     pub private_key: Option<String>,
 
-    #[clap(
-        long = "mnemonic",
-        alias = "mnemonic-path",
-        help_heading = "Wallet options - raw",
-        help = "Use the mnemonic phrase of mnemonic file at the specified path.",
-        value_name = "PATH"
-    )]
+    /// Use the mnemonic phrase of mnemonic file at the specified path
+    #[clap(long, alias = "mnemonic-path", help_heading = "Wallet options - raw")]
     pub mnemonic: Option<String>,
 
+    /// Use a BIP39 passphrase for the mnemonic
     #[clap(
         long = "mnemonic-passphrase",
         help_heading = "Wallet options - raw",
-        help = "Use a BIP39 passphrase for the mnemonic.",
         value_name = "PASSPHRASE"
     )]
     pub mnemonic_passphrase: Option<String>,
 
+    /// The wallet derivation path. Works with both --mnemonic-path and hardware wallets
     #[clap(
         long = "mnemonic-derivation-path",
         alias = "hd-path",
         help_heading = "Wallet options - raw",
-        help = "The wallet derivation path. Works with both --mnemonic-path and hardware wallets.",
         value_name = "PATH"
     )]
     pub hd_path: Option<String>,
 
+    /// Use the private key from the given mnemonic index. Used with --mnemonic-path.
     #[clap(
         long = "mnemonic-index",
         conflicts_with = "hd_path",
         help_heading = "Wallet options - raw",
-        help = "Use the private key from the given mnemonic index. Used with --mnemonic-path.",
-        default_value = "0",
+        default_value_t = 0,
         value_name = "INDEX"
     )]
     pub mnemonic_index: u32,
 
+    /// Use the keystore in the given folder or file
     #[clap(
-        env = "ETH_KEYSTORE",
         long = "keystore",
         help_heading = "Wallet options - keystore",
-        help = "Use the keystore in the given folder or file.",
-        value_name = "PATH"
+        value_name = "PATH",
+        env = "ETH_KEYSTORE"
     )]
     pub keystore_path: Option<String>,
 
+    /// The keystore password. Used with --keystore
     #[clap(
         long = "password",
         help_heading = "Wallet options - keystore",
-        help = "The keystore password. Used with --keystore.",
         requires = "keystore_path",
         value_name = "PASSWORD"
     )]
     pub keystore_password: Option<String>,
 
+    /// The keystore password file path. Used with --keystore.
     #[clap(
-        env = "ETH_PASSWORD",
         long = "password-file",
         help_heading = "Wallet options - keystore",
-        help = "The keystore password file path. Used with --keystore.",
         requires = "keystore_path",
-        value_name = "PASSWORD_FILE"
+        value_name = "PASSWORD_FILE",
+        env = "ETH_PASSWORD"
     )]
     pub keystore_password_file: Option<String>,
 
-    #[clap(
-        short,
-        long = "ledger",
-        help_heading = "Wallet options - hardware wallet",
-        help = "Use a Ledger hardware wallet."
-    )]
+    /// Use a Ledger hardware wallet
+    #[clap(short, long, help_heading = "Wallet options - hardware wallet")]
     pub ledger: bool,
 
-    #[clap(
-        short,
-        long = "trezor",
-        help_heading = "Wallet options - hardware wallet",
-        help = "Use a Trezor hardware wallet."
-    )]
+    /// Use a Trezor hardware wallet
+    #[clap(short, long = "trezor", help_heading = "Wallet options - hardware wallet")]
     pub trezor: bool,
 
-    #[clap(
-        long = "aws",
-        help_heading = "WALLET OPTIONS - KEYSTORE",
-        help = "Use AWS Key Management Service"
-    )]
+    /// Use AWS Key Management Service
+    #[clap(long = "aws", help_heading = "Wallet options - remote")]
     pub aws: bool,
-
-    #[clap(
-        env = "ETH_FROM",
-        short,
-        long = "from",
-        help_heading = "Wallet options - remote",
-        help = "The sender account.",
-        value_name = "ADDRESS"
-    )]
-    pub from: Option<Address>,
 }
 
 impl Wallet {

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -1,17 +1,23 @@
+use async_trait::async_trait;
+use cast::{AwsChainProvider, AwsClient, AwsHttpClient, AwsRegion, KmsClient};
 use clap::Parser;
 use ethers::{
-    middleware::SignerMiddleware,
-    prelude::Signer,
-    signers::{coins_bip39::English, AwsSigner, Ledger, LocalWallet, MnemonicBuilder, Trezor},
-    types::Address,
+    signers::{
+        coins_bip39::English, AwsSigner, AwsSignerError, HDPath as LedgerHDPath, Ledger,
+        LedgerError, LocalWallet, MnemonicBuilder, Signer, Trezor, TrezorError, TrezorHDPath,
+        WalletError,
+    },
+    types::{
+        transaction::{eip2718::TypedTransaction, eip712::Eip712},
+        Address, Signature,
+    },
 };
 use eyre::{bail, eyre, Result, WrapErr};
-use foundry_common::{fs, RetryProvider};
+use foundry_common::fs;
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Arc,
 };
 
 pub mod multi_wallet;
@@ -19,8 +25,6 @@ use crate::opts::error::PrivateKeyError;
 pub use multi_wallet::*;
 
 pub mod error;
-
-type SignerClient<T> = SignerMiddleware<Arc<RetryProvider>, T>;
 
 #[derive(Parser, Debug, Default, Clone, Serialize)]
 #[cfg_attr(not(doc), allow(missing_docs))]
@@ -187,6 +191,68 @@ impl Wallet {
             None
         })
     }
+
+    /// Returns the sender address of the signer or `from`.
+    pub async fn sender(&self) -> Address {
+        if let Ok(signer) = self.signer(0).await {
+            signer.address()
+        } else {
+            self.from.unwrap_or_else(Address::zero)
+        }
+    }
+
+    /// Returns a [Signer] corresponding to the provided private key, mnemonic or hardware signer.
+    pub async fn signer(&self, chain_id: u64) -> eyre::Result<WalletSigner> {
+        if self.ledger {
+            let derivation = match self.hd_path.as_ref() {
+                Some(hd_path) => LedgerHDPath::Other(hd_path.clone()),
+                None => LedgerHDPath::LedgerLive(self.mnemonic_index as usize),
+            };
+            let ledger = Ledger::new(derivation, chain_id).await?;
+
+            Ok(WalletSigner::Ledger(ledger))
+        } else if self.trezor {
+            let derivation = match self.hd_path.as_ref() {
+                Some(hd_path) => TrezorHDPath::Other(hd_path.clone()),
+                None => TrezorHDPath::TrezorLive(self.mnemonic_index as usize),
+            };
+
+            // cached to ~/.ethers-rs/trezor/cache/trezor.session
+            let trezor = Trezor::new(derivation, chain_id, None).await?;
+
+            Ok(WalletSigner::Trezor(trezor))
+        } else if self.aws {
+            let client =
+                AwsClient::new_with(AwsChainProvider::default(), AwsHttpClient::new().unwrap());
+
+            let kms = KmsClient::new_with_client(client, AwsRegion::default());
+
+            let key_id = std::env::var("AWS_KMS_KEY_ID")?;
+
+            let aws_signer = AwsSigner::new(kms, key_id, chain_id).await?;
+
+            Ok(WalletSigner::Aws(aws_signer))
+        } else {
+            let maybe_local = self
+                .private_key()
+                .or_else(|_| self.interactive())
+                .or_else(|_| self.mnemonic())
+                .or_else(|_| self.keystore())?;
+            let local = maybe_local
+                .ok_or_else(|| eyre::eyre!("\
+                    Error accessing local wallet. Did you set a private key, mnemonic or keystore?\n\
+                    Run `cast send --help` or `forge create --help` and use the corresponding CLI\n\
+                    flag to set your key via:\n\
+                    --private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.\n\
+                    \n\
+                    Alternatively, if you're using a local node with unlocked accounts,\n\
+                    use the --unlocked flag and set the `ETH_FROM` environment variable to the address\n\
+                    of the unlocked account you want to use.\
+                "))?;
+
+            Ok(WalletSigner::Local(local.with_chain_id(chain_id)))
+        }
+    }
 }
 
 pub trait WalletTrait {
@@ -200,7 +266,6 @@ pub trait WalletTrait {
     }
 
     fn get_from_private_key(&self, private_key: &str) -> Result<LocalWallet> {
-        use ethers::signers::WalletError;
         let privk = private_key.trim().strip_prefix("0x").unwrap_or(private_key);
         LocalWallet::from_str(privk).map_err(|err| {
             // helper macro to check if pk was meant to be an env var, this usually happens if `$`
@@ -337,46 +402,134 @@ impl WalletTrait for Wallet {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum WalletSignerError {
+    #[error(transparent)]
+    Local(#[from] WalletError),
+    #[error(transparent)]
+    Ledger(#[from] LedgerError),
+    #[error(transparent)]
+    Trezor(#[from] TrezorError),
+    #[error(transparent)]
+    Aws(#[from] AwsSignerError),
+}
+
 #[derive(Debug)]
-pub enum WalletType {
-    Local(SignerClient<LocalWallet>),
-    Ledger(SignerClient<Ledger>),
-    Trezor(SignerClient<Trezor>),
-    Aws(SignerClient<AwsSigner>),
+pub enum WalletSigner {
+    Local(LocalWallet),
+    Ledger(Ledger),
+    Trezor(Trezor),
+    Aws(AwsSigner),
 }
 
-impl From<SignerClient<Ledger>> for WalletType {
-    fn from(hw: SignerClient<Ledger>) -> WalletType {
-        WalletType::Ledger(hw)
+impl From<LocalWallet> for WalletSigner {
+    fn from(wallet: LocalWallet) -> Self {
+        Self::Local(wallet)
     }
 }
 
-impl From<SignerClient<Trezor>> for WalletType {
-    fn from(hw: SignerClient<Trezor>) -> WalletType {
-        WalletType::Trezor(hw)
+impl From<Ledger> for WalletSigner {
+    fn from(hw: Ledger) -> Self {
+        Self::Ledger(hw)
     }
 }
 
-impl From<SignerClient<LocalWallet>> for WalletType {
-    fn from(wallet: SignerClient<LocalWallet>) -> WalletType {
-        WalletType::Local(wallet)
+impl From<Trezor> for WalletSigner {
+    fn from(hw: Trezor) -> Self {
+        Self::Trezor(hw)
     }
 }
 
-impl From<SignerClient<AwsSigner>> for WalletType {
-    fn from(wallet: SignerClient<AwsSigner>) -> WalletType {
-        WalletType::Aws(wallet)
+impl From<AwsSigner> for WalletSigner {
+    fn from(wallet: AwsSigner) -> Self {
+        Self::Aws(wallet)
     }
 }
 
-impl WalletType {
-    pub fn chain_id(&self) -> u64 {
-        match self {
-            WalletType::Local(inner) => inner.signer().chain_id(),
-            WalletType::Ledger(inner) => inner.signer().chain_id(),
-            WalletType::Trezor(inner) => inner.signer().chain_id(),
-            WalletType::Aws(inner) => inner.signer().chain_id(),
+macro_rules! delegate {
+    ($s:ident, $inner:ident => $e:expr) => {
+        match $s {
+            Self::Local($inner) => $e,
+            Self::Ledger($inner) => $e,
+            Self::Trezor($inner) => $e,
+            Self::Aws($inner) => $e,
         }
+    };
+}
+
+#[async_trait]
+impl Signer for WalletSigner {
+    type Error = WalletSignerError;
+
+    async fn sign_message<S: Send + Sync + AsRef<[u8]>>(
+        &self,
+        message: S,
+    ) -> Result<Signature, Self::Error> {
+        delegate!(self, inner => inner.sign_message(message).await.map_err(Into::into))
+    }
+
+    async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
+        delegate!(self, inner => inner.sign_transaction(message).await.map_err(Into::into))
+    }
+
+    async fn sign_typed_data<T: Eip712 + Send + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<Signature, Self::Error> {
+        delegate!(self, inner => inner.sign_typed_data(payload).await.map_err(Into::into))
+    }
+
+    fn address(&self) -> Address {
+        delegate!(self, inner => inner.address())
+    }
+
+    fn chain_id(&self) -> u64 {
+        delegate!(self, inner => inner.chain_id())
+    }
+
+    fn with_chain_id<T: Into<u64>>(self, chain_id: T) -> Self {
+        match self {
+            Self::Local(inner) => Self::Local(inner.with_chain_id(chain_id)),
+            Self::Ledger(inner) => Self::Ledger(inner.with_chain_id(chain_id)),
+            Self::Trezor(inner) => Self::Trezor(inner.with_chain_id(chain_id)),
+            Self::Aws(inner) => Self::Aws(inner.with_chain_id(chain_id)),
+        }
+    }
+}
+
+#[async_trait]
+impl Signer for &WalletSigner {
+    type Error = WalletSignerError;
+
+    async fn sign_message<S: Send + Sync + AsRef<[u8]>>(
+        &self,
+        message: S,
+    ) -> Result<Signature, Self::Error> {
+        (*self).sign_message(message).await
+    }
+
+    async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
+        (*self).sign_transaction(message).await
+    }
+
+    async fn sign_typed_data<T: Eip712 + Send + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<Signature, Self::Error> {
+        (*self).sign_typed_data(payload).await
+    }
+
+    fn address(&self) -> Address {
+        (*self).address()
+    }
+
+    fn chain_id(&self) -> u64 {
+        (*self).chain_id()
+    }
+
+    fn with_chain_id<T: Into<u64>>(self, chain_id: T) -> Self {
+        let _ = chain_id;
+        self
     }
 }
 

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -1,8 +1,7 @@
-use super::{WalletTrait, WalletType};
+use super::{WalletSigner, WalletTrait};
 use cast::{AwsChainProvider, AwsClient, AwsHttpClient, AwsRegion, KmsClient};
 use clap::{ArgAction, Parser};
 use ethers::{
-    middleware::SignerMiddleware,
     prelude::{Middleware, Signer},
     signers::{AwsSigner, HDPath as LedgerHDPath, Ledger, LocalWallet, Trezor, TrezorHDPath},
     types::Address,
@@ -26,23 +25,6 @@ macro_rules! get_wallets {
                 $call;
             }
         )+
-    };
-}
-
-macro_rules! collect_addresses {
-    ($local:expr, $unused:expr, $addresses:expr, $addr:expr, $wallet:expr) => {
-        if $addresses.contains(&$addr) {
-            $addresses.remove(&$addr);
-
-            $local.insert($addr, $wallet);
-
-            if $addresses.is_empty() {
-                return Ok($local)
-            }
-        } else {
-            // Just to show on error.
-            $unused.push($addr);
-        }
     };
 }
 
@@ -242,19 +224,12 @@ impl MultiWallet {
         provider: Arc<RetryProvider>,
         mut addresses: HashSet<Address>,
         script_wallets: &[LocalWallet],
-    ) -> Result<HashMap<Address, WalletType>> {
+    ) -> Result<HashMap<Address, WalletSigner>> {
         println!("\n###\nFinding wallets for all the necessary addresses...");
         let chain = provider.get_chainid().await?.as_u64();
 
         let mut local_wallets = HashMap::new();
         let mut unused_wallets = vec![];
-
-        let script_wallets_fn = || -> Result<Option<Vec<LocalWallet>>> {
-            if !script_wallets.is_empty() {
-                return Ok(Some(script_wallets.to_vec()))
-            }
-            Ok(None)
-        };
 
         get_wallets!(
             wallets,
@@ -266,14 +241,23 @@ impl MultiWallet {
                 self.mnemonics()?,
                 self.keystores()?,
                 self.aws_signers(chain).await?,
-                script_wallets_fn()?
+                (!script_wallets.is_empty()).then(|| script_wallets.to_vec())
             ],
             for wallet in wallets.into_iter() {
                 let address = wallet.address();
-                let wallet = wallet.with_chain_id(chain);
-                let wallet: WalletType = SignerMiddleware::new(provider.clone(), wallet).into();
+                if addresses.contains(&address) {
+                    addresses.remove(&address);
 
-                collect_addresses!(local_wallets, unused_wallets, addresses, address, wallet);
+                    let signer = WalletSigner::from(wallet.with_chain_id(chain));
+                    local_wallets.insert(address, signer);
+
+                    if addresses.is_empty() {
+                        return Ok(local_wallets)
+                    }
+                } else {
+                    // Just to show on error.
+                    unused_wallets.push(address);
+                }
             }
         );
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -99,17 +99,10 @@ pub fn parse_u256(s: &str) -> Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
 }
 
-/// Returns `rpc-url` cli argument if given, or consume `eth-rpc-url` from foundry.toml. Default to
-/// `localhost:8545`
+/// Returns a [RetryProvider](foundry_common::RetryProvider) instantiated using [Config]'s RPC URL
+/// and chain.
 ///
-/// This also supports rpc aliases and try to load the current foundry.toml file if it exists
-pub fn try_consume_config_rpc_url(rpc_url: Option<String>) -> Result<String> {
-    let mut config = Config::load();
-    config.eth_rpc_url = rpc_url;
-    let url = config.get_rpc_url_or_localhost_http()?;
-    Ok(url.into_owned())
-}
-
+/// Defaults to `http://localhost:8545` and `Mainnet`.
 pub fn get_provider(config: &Config) -> Result<foundry_common::RetryProvider> {
     let url = config.get_rpc_url_or_localhost_http()?;
     let chain = config.chain_id.unwrap_or_default();

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -2,10 +2,12 @@ use console::Emoji;
 use ethers::{
     abi::token::{LenientTokenizer, Tokenizer},
     prelude::TransactionReceipt,
+    providers::Middleware,
     solc::EvmVersion,
     types::U256,
     utils::format_units,
 };
+use eyre::Result;
 use forge::executor::SpecId;
 use foundry_config::{Chain, Config};
 use std::{
@@ -93,7 +95,7 @@ pub fn evm_spec(evm: &EvmVersion) -> SpecId {
 }
 
 /// parse a hex str or decimal str as U256
-pub fn parse_u256(s: &str) -> eyre::Result<U256> {
+pub fn parse_u256(s: &str) -> Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
 }
 
@@ -101,11 +103,28 @@ pub fn parse_u256(s: &str) -> eyre::Result<U256> {
 /// `localhost:8545`
 ///
 /// This also supports rpc aliases and try to load the current foundry.toml file if it exists
-pub fn try_consume_config_rpc_url(rpc_url: Option<String>) -> eyre::Result<String> {
+pub fn try_consume_config_rpc_url(rpc_url: Option<String>) -> Result<String> {
     let mut config = Config::load();
     config.eth_rpc_url = rpc_url;
     let url = config.get_rpc_url_or_localhost_http()?;
     Ok(url.into_owned())
+}
+
+pub fn get_provider(config: &Config) -> Result<foundry_common::RetryProvider> {
+    let url = config.get_rpc_url_or_localhost_http()?;
+    let chain = config.chain_id.unwrap_or_default();
+    foundry_common::ProviderBuilder::new(url.as_ref()).chain(chain).build()
+}
+
+pub async fn get_chain<M>(chain: Option<Chain>, provider: M) -> Result<Chain>
+where
+    M: Middleware,
+    M::Error: 'static,
+{
+    match chain {
+        Some(chain) => Ok(chain),
+        None => Ok(Chain::Id(provider.get_chainid().await?.as_u64())),
+    }
 }
 
 /// Parses an ether value from a string.
@@ -114,7 +133,7 @@ pub fn try_consume_config_rpc_url(rpc_url: Option<String>) -> eyre::Result<Strin
 ///
 /// If the string represents an untagged amount (e.g. "100") then
 /// it is interpreted as wei.
-pub fn parse_ether_value(value: &str) -> eyre::Result<U256> {
+pub fn parse_ether_value(value: &str) -> Result<U256> {
     Ok(if value.starts_with("0x") {
         U256::from_str(value)?
     } else {
@@ -123,7 +142,7 @@ pub fn parse_ether_value(value: &str) -> eyre::Result<U256> {
 }
 
 /// Parses a `Duration` from a &str
-pub fn parse_delay(delay: &str) -> eyre::Result<Duration> {
+pub fn parse_delay(delay: &str) -> Result<Duration> {
     let delay = if delay.ends_with("ms") {
         let d: u64 = delay.trim_end_matches("ms").parse()?;
         Duration::from_millis(d)
@@ -241,15 +260,15 @@ pub fn print_receipt(chain: Chain, receipt: &TransactionReceipt) {
 /// Useful extensions to [`std::process::Command`].
 pub trait CommandUtils {
     /// Returns the command's output if execution is successful, otherwise, throws an error.
-    fn exec(&mut self) -> eyre::Result<Output>;
+    fn exec(&mut self) -> Result<Output>;
 
     /// Returns the command's stdout if execution is successful, otherwise, throws an error.
-    fn get_stdout_lossy(&mut self) -> eyre::Result<String>;
+    fn get_stdout_lossy(&mut self) -> Result<String>;
 }
 
 impl CommandUtils for Command {
     #[track_caller]
-    fn exec(&mut self) -> eyre::Result<Output> {
+    fn exec(&mut self) -> Result<Output> {
         let output = self.output()?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -259,7 +278,7 @@ impl CommandUtils for Command {
     }
 
     #[track_caller]
-    fn get_stdout_lossy(&mut self) -> eyre::Result<String> {
+    fn get_stdout_lossy(&mut self) -> Result<String> {
         let output = self.exec()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(stdout.trim().into())

--- a/cli/test-utils/src/script.rs
+++ b/cli/test-utils/src/script.rs
@@ -32,7 +32,7 @@ impl ScriptTester {
 
         cmd.args([
             "script",
-            "-r",
+            "-R",
             "ds-test/=lib/",
             target_contract,
             "--root",

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -63,7 +63,7 @@ casttest!(new_wallet_keystore_with_password, |_: TestProject, mut cmd: TestComma
     cmd.args(["wallet", "new", ".", "--unsafe-password", "test"]);
     let out = cmd.stdout_lossy();
     assert!(out.contains("Created new encrypted keystore file"));
-    assert!(out.contains("Public Address of the key"));
+    assert!(out.contains("Address"));
 });
 
 // tests that `cast estimate` is working correctly.

--- a/config/src/chain.rs
+++ b/config/src/chain.rs
@@ -1,5 +1,6 @@
 use crate::U256;
-use ethers_core::types::U64;
+use ethers_core::types::{Chain as NamedChain, U64};
+use eyre::Result;
 use open_fastrlp::{Decodable, Encodable};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt, str::FromStr};
@@ -10,17 +11,27 @@ use std::{fmt, str::FromStr};
 pub enum Chain {
     /// Contains a known chain
     #[serde(serialize_with = "super::from_str_lowercase::serialize")]
-    Named(ethers_core::types::Chain),
+    Named(NamedChain),
     /// Contains the id of a chain
     Id(u64),
 }
 
 impl Chain {
-    /// The id of the chain
-    pub fn id(&self) -> u64 {
+    /// The id of the chain.
+    pub const fn id(&self) -> u64 {
         match self {
             Chain::Named(chain) => *chain as u64,
             Chain::Id(id) => *id,
+        }
+    }
+
+    /// Returns the wrapped named chain or tries converting the ID into one.
+    pub fn named(&self) -> Result<NamedChain> {
+        match self {
+            Self::Named(chain) => Ok(*chain),
+            Self::Id(id) => {
+                NamedChain::try_from(*id).map_err(|_| eyre::eyre!("Unsupported chain: {id}"))
+            }
         }
     }
 
@@ -47,7 +58,7 @@ impl fmt::Display for Chain {
         match self {
             Chain::Named(chain) => chain.fmt(f),
             Chain::Id(id) => {
-                if let Ok(chain) = ethers_core::types::Chain::try_from(*id) {
+                if let Ok(chain) = NamedChain::try_from(*id) {
                     chain.fmt(f)
                 } else {
                     id.fmt(f)
@@ -57,15 +68,15 @@ impl fmt::Display for Chain {
     }
 }
 
-impl From<ethers_core::types::Chain> for Chain {
-    fn from(id: ethers_core::types::Chain) -> Self {
+impl From<NamedChain> for Chain {
+    fn from(id: NamedChain) -> Self {
         Chain::Named(id)
     }
 }
 
 impl From<u64> for Chain {
     fn from(id: u64) -> Self {
-        ethers_core::types::Chain::try_from(id).map(Chain::Named).unwrap_or_else(|_| Chain::Id(id))
+        NamedChain::try_from(id).map(Chain::Named).unwrap_or_else(|_| Chain::Id(id))
     }
 }
 
@@ -96,8 +107,8 @@ impl From<Chain> for U256 {
     }
 }
 
-impl TryFrom<Chain> for ethers_core::types::Chain {
-    type Error = <ethers_core::types::Chain as TryFrom<u64>>::Error;
+impl TryFrom<Chain> for NamedChain {
+    type Error = <NamedChain as TryFrom<u64>>::Error;
 
     fn try_from(chain: Chain) -> Result<Self, Self::Error> {
         match chain {
@@ -111,7 +122,7 @@ impl FromStr for Chain {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(chain) = ethers_core::types::Chain::from_str(s) {
+        if let Ok(chain) = NamedChain::from_str(s) {
             Ok(Chain::Named(chain))
         } else {
             s.parse::<u64>()
@@ -137,9 +148,9 @@ impl<'de> Deserialize<'de> for Chain {
             ChainId::Named(s) => {
                 s.to_lowercase().parse().map(Chain::Named).map_err(serde::de::Error::custom)
             }
-            ChainId::Id(id) => Ok(ethers_core::types::Chain::try_from(id)
-                .map(Chain::Named)
-                .unwrap_or_else(|_| Chain::Id(id))),
+            ChainId::Id(id) => {
+                Ok(NamedChain::try_from(id).map(Chain::Named).unwrap_or_else(|_| Chain::Id(id)))
+            }
         }
     }
 }
@@ -167,6 +178,6 @@ impl Decodable for Chain {
 
 impl Default for Chain {
     fn default() -> Self {
-        ethers_core::types::Chain::Mainnet.into()
+        NamedChain::Mainnet.into()
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #4484
Closes #4474
Closes #4401
Closes #4057
Closes #3824

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Refactor `EthereumOpts` into `EtherscanOpts` and `RpcOpts`, which implement figment traits, for usage in Cast and Forge subcommands since `rpc_url` and the rest were always separate and had inconsistent flags/envs etc...

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## BREAKING

`--remappings` and `--contracts`'s short flags are now `-R` and `-C` (uppercase instead of lowercase) due to conflicts with `--rpc-url` and `--chain` respectively, while `--confirmations`'s short flag in Forge script has been removed

This is done to have consistent flags throughout all CLIs since for most of cast  `-r` is `rpc-url` while some of forge has `-r` as `--remappings`