### PR TITLE
fix(foundryup): strip grep line number

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -84,7 +84,7 @@ main() {
         | grep -Eo '"sha"[^,]*' \
         | grep -Eo '[^:]*$' \
         | tr -d '"' \
-        | tr -d ' '
+        | tr -d ' ' \
         | cut -d ':' -f2 )
       FOUNDRYUP_TAG="nightly-${SHA}"
     elif [[ "$FOUNDRYUP_VERSION" == nightly* ]]; then

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -84,7 +84,8 @@ main() {
         | grep -Eo '"sha"[^,]*' \
         | grep -Eo '[^:]*$' \
         | tr -d '"' \
-        | tr -d ' ')
+        | tr -d ' '
+        | cut -d ':' -f2 )
       FOUNDRYUP_TAG="nightly-${SHA}"
     elif [[ "$FOUNDRYUP_VERSION" == nightly* ]]; then
       FOUNDRYUP_VERSION="nightly"


### PR DESCRIPTION
## Motivation

Grep's `-n` option does not allow `foundryup` to download the correct archive.

## Solution

Strip the relative line number (if it exists) from grep's output, so the output is a valid SHA.

Fixes #4510 