### PR TITLE
feat(cast): Option to disassemble bytecode returned by cast code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
+ "evm-disassembler",
  "eyre",
  "foundry-common",
  "foundry-config",
@@ -2201,6 +2202,16 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "evm-disassembler"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b08282fd9e1790d311f83335549a07bed98b5e2df0414c4d3ff04b0058800c"
+dependencies = [
+ "eyre",
+ "hex",
+]
 
 [[package]]
 name = "eyre"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,9 +2207,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "evm-disassembler"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b08282fd9e1790d311f83335549a07bed98b5e2df0414c4d3ff04b0058800c"
+checksum = "584e7334177d2dc76c4d618967e5ef102be68c35f454ac363d88b72b854db4a9"
 dependencies = [
  "eyre",
  "hex",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -31,7 +31,7 @@ hex = "0.4.3"
 # aws
 rusoto_core = { version = "0.48.0", default-features = false, optional = true }
 rusoto_kms = { version = "0.48.0", default-features = false, optional = true }
-evm-disassembler = "0.1.0"
+evm-disassembler = "0.2.0"
 
 [dev-dependencies]
 async-trait = "0.1.53"

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -31,6 +31,7 @@ hex = "0.4.3"
 # aws
 rusoto_core = { version = "0.48.0", default-features = false, optional = true }
 rusoto_kms = { version = "0.48.0", default-features = false, optional = true }
+evm-disassembler = "0.1.0"
 
 [dev-dependencies]
 async-trait = "0.1.53"

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -607,7 +607,7 @@ where
     ) -> Result<String> {
         if disassemble {
             let code = self.provider.get_code(who, block).await?.to_vec();
-            Ok(format_operations(disassemble_bytes(code)?))
+            Ok(format_operations(disassemble_bytes(code)?)?)
         } else {
             Ok(format!("{}", self.provider.get_code(who, block).await?))
         }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1645,14 +1645,17 @@ impl SimpleCast {
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let bytecode = "0x608060405260043610603f57600035";
-    /// let opcodes = Cast::disassemble(bytecode);
+    /// let opcodes = Cast::disassemble(bytecode)?;
     /// println!("{}", opcodes);
     /// # Ok(())
     /// # }
     /// ```
-    pub fn disassemble(bytecode: &str) -> Result<String> {
-        return format_operations(disassemble_str(bytecode)?)
+    pub fn disassemble(
+        bytecode: &str,
+    ) -> Result<String> {
+        format_operations(disassemble_str(bytecode)?)
     }
+
 }
 
 fn strip_0x(s: &str) -> &str {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -18,7 +18,7 @@ use ethers_core::{
 };
 use ethers_etherscan::{errors::EtherscanError, Client};
 use ethers_providers::{Middleware, PendingTransaction};
-use evm_disassembler::{disassemble_bytes, format_operations};
+use evm_disassembler::{disassemble_bytes, disassemble_str, format_operations};
 use eyre::{Context, Result};
 use foundry_common::{abi::encode_args, fmt::*, TransactionReceiptWithRevertReason};
 pub use foundry_evm::*;
@@ -1634,6 +1634,24 @@ impl SimpleCast {
         let source_tree = meta.source_tree();
         source_tree.write_to(&output_directory)?;
         Ok(())
+    }
+
+    /// Disassembles hex encoded bytecode into individual / human readable opcodes
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let bytecode = "0x608060405260043610603f57600035";
+    /// let opcodes = Cast::disassemble(bytecode);
+    /// println!("{}", opcodes);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn disassemble(bytecode: &str) -> Result<String> {
+        return format_operations(disassemble_str(bytecode)?)
     }
 }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1650,12 +1650,9 @@ impl SimpleCast {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn disassemble(
-        bytecode: &str,
-    ) -> Result<String> {
+    pub fn disassemble(bytecode: &str) -> Result<String> {
         format_operations(disassemble_str(bytecode)?)
     }
-
 }
 
 fn strip_0x(s: &str) -> &str {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -264,6 +264,9 @@ async fn main() -> eyre::Result<()> {
             let computed = Cast::new(&provider).compute_address(address, nonce).await?;
             println!("Computed Address: {}", SimpleCast::to_checksum_address(&computed));
         }
+        Subcommands::Disassemble { bytecode } => {
+            println!("{}", SimpleCast::disassemble(&bytecode)?);
+        }
         Subcommands::FindBlock(cmd) => cmd.run().await?,
         Subcommands::GasPrice { rpc } => {
             let config = Config::from(&rpc);

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -258,10 +258,10 @@ async fn main() -> eyre::Result<()> {
             let provider = try_get_http_provider(rpc_url)?;
             println!("{}", provider.client_version().await?);
         }
-        Subcommands::Code { block, who, rpc_url } => {
+        Subcommands::Code { block, who, rpc_url, disassemble } => {
             let rpc_url = try_consume_config_rpc_url(rpc_url)?;
             let provider = try_get_http_provider(rpc_url)?;
-            println!("{}", Cast::new(provider).code(who, block).await?);
+            println!("{}", Cast::new(provider).code(who, block, disassemble).await?);
         }
         Subcommands::ComputeAddress { address, nonce, rpc_url } => {
             let rpc_url = try_consume_config_rpc_url(rpc_url)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -627,6 +627,12 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL", value_name = "URL")]
         rpc_url: Option<String>,
+        #[clap(
+            long = "disassemble",
+            short = 'd',
+            help_heading = "disassemble bytecodes into individual opcodes"
+        )]
+        disassemble: bool,
     },
     #[clap(name = "gas-price")]
     #[clap(visible_alias = "g")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -363,6 +363,13 @@ Examples:
         #[clap(flatten)]
         rpc: RpcOpts,
     },
+    #[clap(name = "disassemble")]
+    #[clap(visible_alias = "da")]
+    #[clap(about = "Disassembles hex encoded bytecode into individual / human readable opcodes")]
+    Disassemble {
+        #[clap(help = "The hex encoded bytecode", value_name = "BYTECODE")]
+        bytecode: String,
+    },
     #[clap(name = "namehash")]
     #[clap(visible_aliases = &["na", "nh"])]
     #[clap(about = "Calculate the ENS namehash of a name.")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Output of `cast code` is currently raw hex encoded bytes, which is hard to read and reason about.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a flag `--disassemble` that disassembles the bytecode into individual opcodes.
The format of the output is based on [pyevmasm](https://github.com/crytic/pyevmasm). (see screenshot).

The implementation of the disassembly is factored out into its own [little crate](https://crates.io/crates/evm-disassembler). Lmk if you'd like me to avoid that extra dependency and instead copy paste the implementation into a module here. 


EDIT: Additionally added a separate `disassemble` cast command

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
<img width="959" alt="image" src="https://user-images.githubusercontent.com/15629702/224284307-a544db7c-acc5-49ea-9698-dd6148a9c109.png">
