### PR TITLE
perf(anvil): fetch all dev accounts concurrently in forking mode

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -227,17 +227,34 @@ impl Backend {
     /// This will fund, create the genesis accounts
     async fn apply_genesis(&self) -> DatabaseResult<()> {
         trace!(target: "backend", "setting genesis balances");
-        let mut db = self.db.write().await;
 
         if self.fork.is_some() {
+            // fetch all account first
+            let mut genesis_accounts_futures = Vec::with_capacity(self.genesis.accounts.len());
+            for address in self.genesis.accounts.iter().copied() {
+                let db = Arc::clone(&self.db);
+
+                // The forking Database backend can handle concurrent requests, we can fetch all dev
+                // accounts concurrently by spawning the job to a new task
+                genesis_accounts_futures.push(tokio::task::spawn(async move {
+                    let db = db.read().await;
+                    let info = db.basic(address)?.unwrap_or_default();
+                    Ok::<_, DatabaseError>((address, info))
+                }));
+            }
+
+            let genesis_accounts = futures::future::join_all(genesis_accounts_futures).await;
+
+            let mut db = self.db.write().await;
+
             // in fork mode we only set the balance, this way the accountinfo is fetched from the
             // remote client, preserving code and nonce. The reason for that is private keys for dev
             // accounts are commonly known and are used on testnets
             let mut fork_genesis_infos = self.genesis.fork_genesis_account_infos.lock();
             fork_genesis_infos.clear();
 
-            for address in self.genesis.accounts.iter().copied() {
-                let mut info = db.basic(address)?.unwrap_or_default();
+            for res in genesis_accounts {
+                let (address, mut info) = res??;
                 info.balance = self.genesis.balance;
                 db.insert_account(address, info.clone());
 
@@ -245,11 +262,13 @@ impl Backend {
                 fork_genesis_infos.push(info);
             }
         } else {
+            let mut db = self.db.write().await;
             for (account, info) in self.genesis.account_infos() {
                 db.insert_account(account, info);
             }
         }
 
+        let db = self.db.write().await;
         // apply the genesis.json alloc
         self.genesis.apply_genesis_json_alloc(db)?;
         Ok(())

--- a/evm/src/executor/backend/error.rs
+++ b/evm/src/executor/backend/error.rs
@@ -42,6 +42,8 @@ pub enum DatabaseError {
         "CREATE2 Deployer not present on this chain. [0x4e59b44847b379578588920ca78fbf26c0b4956c]"
     )]
     MissingCreate2Deployer,
+    #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
 }
 
 impl DatabaseError {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
previously all dev accounts were fetched sequentially, however since the forked backend can handle multiple requests, we can fetch all of them concurrently.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
