### PR TITLE
perf(anvil): get rid of redundant chain id call

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -785,8 +785,7 @@ impl NodeConfig {
                     .compute_units_per_second(self.compute_units_per_second)
                     .max_retry(10)
                     .initial_backoff(1000)
-                    .connect()
-                    .await
+                    .build()
                     .expect("Failed to establish provider to fork url"),
             );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
connect adjusts the provider interval based on the chain's avg blocktime, this is not used in forking mode, so can skip that.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
