### PR TITLE
fix(evm): update env properly when fork to tx

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -1054,9 +1054,6 @@ impl DatabaseExt for Backend {
         // roll the fork to the transaction's block or latest if it's pending
         self.roll_fork(Some(id), fork_block.as_u64().into(), env, journaled_state)?;
 
-        // replay all transactions that came before
-        let mut env = env.clone();
-
         // update the block's env accordingly
         env.block.timestamp = block.timestamp;
         env.block.coinbase = block.author.unwrap_or_default();
@@ -1065,6 +1062,9 @@ impl DatabaseExt for Backend {
         env.block.basefee = block.base_fee_per_gas.unwrap_or_default();
         env.block.gas_limit = block.gas_limit;
         env.block.number = block.number.unwrap_or(fork_block).as_u64().into();
+
+        // replay all transactions that came before
+        let env = env.clone();
 
         self.replay_until(id, env, transaction, journaled_state)?;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
when we fork to tx we need to fork the state at (tx.block - 1) but use the `tx.block` env (block number, timestamp etc.)

ref https://t.me/foundry_rs/27136
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
