### PR TITLE
Fix bind --overwrite failing on first run

### DIFF
--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -221,7 +221,7 @@ impl Cmd for BindArgs {
             return self.check_existing_bindings(&artifacts)
         }
 
-        if self.overwrite {
+        if self.overwrite && self.bindings_exist(&artifacts) {
             fs::remove_dir_all(self.bindings_root(&artifacts))?;
         }
 


### PR DESCRIPTION
If you run `forge bind --overwrite` without first running `forge bind`, the `--overwrite` tries to delete a nonexisting directory. This results in:
```
Error:
No such file or directory (os error 2)
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Want to avoid this error.

## Solution

Just a very quick and obvious fix.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
