### PR TITLE
fix(verify): improve etherscan section parsing

### DIFF
--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -171,7 +171,7 @@ impl VerifyArgs {
         let config = self.load_config_emit_warnings();
         let chain = config.chain_id.unwrap_or_default();
         self.etherscan.chain = Some(chain);
-        self.etherscan.key = config.get_etherscan_api_key(Some(chain));
+        self.etherscan.key = config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
 
         if self.show_standard_json_input {
             let args =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes https://github.com/foundry-rs/foundry/issues/3861
Closes https://github.com/foundry-rs/foundry/issues/4571
closes #4563

This includes a fix that gives the `etherscan_api_key` of the config precedence over the chain. This is sound because, if --etherscan-api-key is provided via CLI it should be prefered over the etherscan table.

This also improves the error message instead of `ETHERSCAN_API_KEY` not found.

```
Failed to resolve env var `BSC_ETHERSCAN_API_KEY` in `${BSC_ETHERSCAN_API_KEY}`: environment variable not found

Context:
- environment variable not found
```

ptal @DaniPopes 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
