### PR TITLE
fix(evm): initialize fuzzed backend

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -39,13 +39,15 @@ pub struct FuzzBackendWrapper<'a> {
     ///
     /// No calls on the `FuzzBackendWrapper` will ever persistently modify the `backend`'s state.
     pub backend: Cow<'a, Backend>,
+    /// Keeps track of whether the backed is already intialized
+    is_initialized: bool,
 }
 
 // === impl FuzzBackendWrapper ===
 
 impl<'a> FuzzBackendWrapper<'a> {
     pub fn new(backend: &'a Backend) -> Self {
-        Self { backend: Cow::Borrowed(backend) }
+        Self { backend: Cow::Borrowed(backend), is_initialized: false }
     }
 
     /// Executes the configured transaction of the `env` without committing state changes
@@ -59,12 +61,25 @@ impl<'a> FuzzBackendWrapper<'a> {
     {
         revm::evm_inner::<Self, true>(env, self, &mut inspector).transact()
     }
+
+    /// Returns a mutable instance of the Backend.
+    ///
+    /// If this is the first time this is called, the backed is cloned and initialized.
+    fn backend_mut(&mut self, env: &Env) -> &mut Backend {
+        if self.is_initialized {
+            let backend = self.backend.to_mut();
+            backend.initialize(env);
+            self.is_initialized = true;
+            return backend
+        }
+        self.backend.to_mut()
+    }
 }
 
 impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn snapshot(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {
         trace!("fuzz: create snapshot");
-        self.backend.to_mut().snapshot(journaled_state, env)
+        self.backend_mut(env).snapshot(journaled_state, env)
     }
 
     fn revert(
@@ -74,7 +89,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         current: &mut Env,
     ) -> Option<JournaledState> {
         trace!(?id, "fuzz: revert snapshot");
-        self.backend.to_mut().revert(id, journaled_state, current)
+        self.backend_mut(current).revert(id, journaled_state, current)
     }
 
     fn create_fork(&mut self, fork: CreateFork) -> eyre::Result<LocalForkId> {
@@ -98,7 +113,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, "fuzz: select fork");
-        self.backend.to_mut().select_fork(id, env, journaled_state)
+        self.backend_mut(env).select_fork(id, env, journaled_state)
     }
 
     fn roll_fork(
@@ -109,7 +124,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?block_number, "fuzz: roll fork");
-        self.backend.to_mut().roll_fork(id, block_number, env, journaled_state)
+        self.backend_mut(env).roll_fork(id, block_number, env, journaled_state)
     }
 
     fn roll_fork_to_transaction(
@@ -120,7 +135,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "fuzz: roll fork to transaction");
-        self.backend.to_mut().roll_fork_to_transaction(id, transaction, env, journaled_state)
+        self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
     }
 
     fn transact(
@@ -132,7 +147,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         cheatcodes_inspector: Option<&mut Cheatcodes>,
     ) -> eyre::Result<()> {
         trace!(?id, ?transaction, "fuzz: execute transaction");
-        self.backend.to_mut().transact(id, transaction, env, journaled_state, cheatcodes_inspector)
+        self.backend_mut(env).transact(id, transaction, env, journaled_state, cheatcodes_inspector)
     }
 
     fn active_fork_id(&self) -> Option<LocalForkId> {

--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -66,7 +66,7 @@ impl<'a> FuzzBackendWrapper<'a> {
     ///
     /// If this is the first time this is called, the backed is cloned and initialized.
     fn backend_mut(&mut self, env: &Env) -> &mut Backend {
-        if self.is_initialized {
+        if !self.is_initialized {
             let backend = self.backend.to_mut();
             backend.initialize(env);
             self.is_initialized = true;

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -669,15 +669,10 @@ impl Backend {
         logs
     }
 
-    /// Executes the configured test call of the `env` without commiting state changes
-    pub fn inspect_ref<INSP>(
-        &mut self,
-        env: &mut Env,
-        mut inspector: INSP,
-    ) -> (ExecutionResult, Map<Address, Account>)
-    where
-        INSP: Inspector<Self>,
-    {
+    /// Initializes settings we need to keep track of.
+    ///
+    /// We need to track these mainly to prevent issues when switching between different evms
+    pub(crate) fn initialize(&mut self, env: &Env) {
         self.set_caller(env.tx.caller);
         self.set_spec_id(env.cfg.spec_id);
 
@@ -692,6 +687,18 @@ impl Backend {
             }
         };
         self.set_test_contract(test_contract);
+    }
+
+    /// Executes the configured test call of the `env` without commiting state changes
+    pub fn inspect_ref<INSP>(
+        &mut self,
+        env: &mut Env,
+        mut inspector: INSP,
+    ) -> (ExecutionResult, Map<Address, Account>)
+    where
+        INSP: Inspector<Self>,
+    {
+        self.initialize(env);
 
         revm::evm_inner::<Self, true>(env, self, &mut inspector).transact()
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
should close https://github.com/foundry-rs/foundry/issues/4572
when we're fuzzing we only take reference of the backend until we need to modify it (cheatcodes). however then the backend wasn't initialized properly and resulted in panics in the evm.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
initialize fuzzed backend when cloned.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
