### PR TITLE
feat(anvil): cache more fork responses

### DIFF
--- a/anvil/core/src/eth/transaction/mod.rs
+++ b/anvil/core/src/eth/transaction/mod.rs
@@ -40,7 +40,7 @@ pub enum TypedTransactionRequest {
 }
 
 /// Represents _all_ transaction requests received from RPC
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]

--- a/anvil/tests/it/transaction.rs
+++ b/anvil/tests/it/transaction.rs
@@ -104,7 +104,7 @@ async fn can_respect_nonces() {
 
     // ensure the listener for ready transactions times out
     let mut listener = api.new_ready_transactions();
-    let res = timeout(Duration::from_millis(1500), async move { listener.next().await }).await;
+    let res = timeout(Duration::from_millis(1500), listener.next()).await;
     res.unwrap_err();
 
     // send with the actual nonce which is mined immediately


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4564

cache responses when `eth_call`, `eth_estimate`, `logs` is delegated to the fork (if block number < forked block)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
