### PR TITLE
Fix misspellings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
                       ${{ steps.man.outputs.foundry_man }}
 
             # If this is a nightly release, it also updates the release
-            # tagged `nightly` for compatability with `foundryup`
+            # tagged `nightly` for compatibility with `foundryup`
             - name: Update nightly release
               if: ${{ env.IS_NIGHTLY }}
               uses: softprops/action-gh-release@v1

--- a/anvil/src/genesis.rs
+++ b/anvil/src/genesis.rs
@@ -85,8 +85,8 @@ impl Genesis {
         if let Some(chain_id) = self.chain_id() {
             env.cfg.chain_id = chain_id.into();
         }
-        if let Some(timestmap) = self.timestamp {
-            env.block.timestamp = timestmap.into();
+        if let Some(timestamp) = self.timestamp {
+            env.block.timestamp = timestamp.into();
         }
         if let Some(base_fee) = self.base_fee_per_gas {
             env.block.basefee = base_fee;

--- a/cast/src/rlp_converter.rs
+++ b/cast/src/rlp_converter.rs
@@ -2,7 +2,7 @@ use ethers_core::utils::rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream
 use serde_json::Value;
 use std::fmt::{Debug, Display, Formatter, Write};
 
-/// Arbitrarly nested data
+/// Arbitrary nested data
 /// Item::Array(vec![]); is equivalent to []
 /// Item::Array(vec![Item::Data(vec![])]); is equivalent to [""] or [null]
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -809,7 +809,7 @@ impl ChiselDispatcher {
             let match_str = m.as_str();
             // We can always safely unwrap here due to the regex matching.
             let addr = H160::from_str(match_str).unwrap();
-            // Replace all occurances of the address with a checksummed version
+            // Replace all occurrences of the address with a checksummed version
             heap_input = heap_input.replace(match_str, &ethers::utils::to_checksum(&addr, None));
         });
         // Replace the old input with the formatted input.

--- a/cli/src/cmd/cast/bind.rs
+++ b/cli/src/cmd/cast/bind.rs
@@ -47,9 +47,9 @@ pub struct BindArgs {
     )]
     crate_version: String,
 
-    /// Generate bindings as seperate files.
+    /// Generate bindings as separate files.
     #[clap(long)]
-    seperate_files: bool,
+    separate_files: bool,
 
     #[clap(flatten)]
     etherscan: EtherscanOpts,
@@ -71,7 +71,7 @@ impl BindArgs {
             .output_dir
             .clone()
             .unwrap_or_else(|| std::env::current_dir().unwrap().join("bindings"));
-        bindings.write_to_crate(self.crate_name, self.crate_version, out, !self.seperate_files)?;
+        bindings.write_to_crate(self.crate_name, self.crate_version, out, !self.separate_files)?;
         Ok(())
     }
 

--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -189,7 +189,7 @@ pub fn has_batch_support(chain: u64) -> bool {
 
 /// Helpers for loading configuration.
 ///
-/// This is usually implicity implemented on a "&CmdArgs" struct via impl macros defined in
+/// This is usually implicitly implemented on a "&CmdArgs" struct via impl macros defined in
 /// `forge_config` (See [`forge_config::impl_figment_convert`] for more details) and the impl
 /// definition on `T: Into<Config> + Into<Figment>` below.
 ///

--- a/config/src/fix.rs
+++ b/config/src/fix.rs
@@ -300,7 +300,7 @@ mod tests {
     // mocking the `$HOME` has no effect on windows, see [`dirs_next::home_dir()`]
     fix_test!(
         #[cfg(not(windows))]
-        test_gloabl_toml_is_edited,
+        test_global_toml_is_edited,
         |jail| {
             jail.create_file(
                 "foundry.toml",

--- a/config/src/warning.rs
+++ b/config/src/warning.rs
@@ -19,14 +19,14 @@ pub enum Warning {
     CouldNotReadToml {
         /// The path of the TOML file
         path: PathBuf,
-        /// The error message that occured
+        /// The error message that occurred
         err: String,
     },
     /// Could not write TOML
     CouldNotWriteToml {
         /// The path of the TOML file
         path: PathBuf,
-        /// The error message that occured
+        /// The error message that occurred
         err: String,
     },
     /// Invalid profile. Profile should be a table
@@ -35,7 +35,7 @@ pub enum Warning {
         path: PathBuf,
         /// The profile to be fixed
         profile: String,
-        /// The error message that occured
+        /// The error message that occurred
         err: String,
     },
     /// Deprecated key.

--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ skip-tree = []
 
 [licenses]
 unlicensed = "deny"
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [

--- a/evm/src/decode.rs
+++ b/evm/src/decode.rs
@@ -179,7 +179,7 @@ pub fn decode_revert(
                 }
             }
 
-            // optimistically try to decode as string, unkown selector or `CheatcodeError`
+            // optimistically try to decode as string, unknown selector or `CheatcodeError`
             String::decode(err)
                 .ok()
                 .or_else(|| {

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -689,7 +689,7 @@ impl Backend {
         self.set_test_contract(test_contract);
     }
 
-    /// Executes the configured test call of the `env` without commiting state changes
+    /// Executes the configured test call of the `env` without committing state changes
     pub fn inspect_ref<INSP>(
         &mut self,
         env: &mut Env,

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -335,7 +335,7 @@ pub fn check_if_fixed_gas_limit<DB: DatabaseExt>(
 ) -> bool {
     // If the gas limit was not set in the source code it is set to the estimated gas left at the
     // time of the call, which should be rather close to configured gas limit.
-    // TODO: Find a way to reliably make this determenation. (for example by
+    // TODO: Find a way to reliably make this determination. (for example by
     // generating it in the compilation or evm simulation process)
     U256::from(data.env.tx.gas_limit) > data.env.block.gas_limit &&
         U256::from(call_gas_limit) <= data.env.block.gas_limit

--- a/evm/src/fuzz/invariant/call_override.rs
+++ b/evm/src/fuzz/invariant/call_override.rs
@@ -21,7 +21,7 @@ pub struct RandomCallGenerator {
     pub strategy: SBoxedStrategy<Option<(Address, Bytes)>>,
     /// Reference to which contract we want a fuzzed calldata from.
     pub target_reference: Arc<RwLock<Address>>,
-    /// Flag to know if a call has been overriden. Don't allow nesting for now.
+    /// Flag to know if a call has been overridden. Don't allow nesting for now.
     pub used: bool,
     /// If set to `true`, consumes the next call from `last_sequence`, otherwise queries it from
     /// the strategy.

--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -201,7 +201,7 @@ impl InvariantFuzzError {
     ) -> Vec<&'a BasicTxDetails> {
         let mut anchor = 0;
         let mut removed_calls = vec![];
-        let mut shrinked = calls.iter().collect::<Vec<_>>();
+        let mut shrunk = calls.iter().collect::<Vec<_>>();
         trace!(target: "forge::test", "Shrinking.");
 
         while anchor != calls.len() {
@@ -209,8 +209,8 @@ impl InvariantFuzzError {
             let removed =
                 match self.fails_successfully(executor.clone(), calls, anchor, &removed_calls) {
                     Ok(new_sequence) => {
-                        if shrinked.len() > new_sequence.len() {
-                            shrinked = new_sequence;
+                        if shrunk.len() > new_sequence.len() {
+                            shrunk = new_sequence;
                         }
                         removed_calls.last().cloned()
                     }
@@ -236,6 +236,6 @@ impl InvariantFuzzError {
             }
         }
 
-        shrinked
+        shrunk
     }
 }

--- a/fmt/src/buffer.rs
+++ b/fmt/src/buffer.rs
@@ -130,7 +130,7 @@ impl<W: Sized> FormatBuffer<W> {
         self.current_line_len
     }
 
-    /// Check if the buffer is at the beggining of a new line
+    /// Check if the buffer is at the beginning of a new line
     pub fn is_beginning_of_line(&self) -> bool {
         matches!(self.state, WriteState::LineStart(_))
     }

--- a/fmt/testdata/Yul/fmt.sol
+++ b/fmt/testdata/Yul/fmt.sol
@@ -32,14 +32,14 @@ contract Yul {
         bytes4 PAIR_SWAP_ID;
         address memUser;
         assembly {
-            // You can only access teh fallback function if you're authorized
+            // You can only access the fallback function if you're authorized
             if iszero(eq(caller(), memUser)) {
                 // Ohm (3, 3) makes your code more efficient
                 // WGMI
                 revert(3, 3)
             }
 
-            // Extract out teh variables
+            // Extract out the variables
             // We don't have function signatures sweet saving EVEN MORE GAS
 
             // bytes20

--- a/fmt/testdata/Yul/original.sol
+++ b/fmt/testdata/Yul/original.sol
@@ -30,14 +30,14 @@ contract Yul {
         bytes4 PAIR_SWAP_ID;
         address memUser;
         assembly {
-            // You can only access teh fallback function if you're authorized
+            // You can only access the fallback function if you're authorized
             if iszero(eq(caller(), memUser)) {
                 // Ohm (3, 3) makes your code more efficient
                 // WGMI
                 revert(3, 3)
             }
 
-            // Extract out teh variables
+            // Extract out the variables
             // We don't have function signatures sweet saving EVEN MORE GAS
 
             // bytes20

--- a/testdata/fuzz/invariant/common/InvariantReentrancy.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantReentrancy.t.sol
@@ -5,7 +5,7 @@ import "ds-test/test.sol";
 
 contract Malicious {
     function world() public {
-        // Does not matter, since it will get overriden.
+        // Does not matter, since it will get overridden.
     }
 }
 


### PR DESCRIPTION
This PR fixes misspellings in the codes.

## Motivation
For maintenance and clarity.
I found some misspellings when I was reading the codes.

## Solution

Ran the following command using https://github.com/client9/misspell
(Ignored some words that might be false-positive)

```shell
misspell -i inbetween,strat -w .
```