### PR TITLE
fix(evm): uninitialize fuzz backend on inspect

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -33,7 +33,7 @@ use tracing::trace;
 /// don't make use of them. Alternatively each test case would require its own `Backend` clone,
 /// which would add significant overhead for large fuzz sets even if the Database is not big after
 /// setup.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FuzzBackendWrapper<'a> {
     /// The underlying immutable `Backend`
     ///
@@ -236,5 +236,15 @@ impl<'a> Database for FuzzBackendWrapper<'a> {
 
     fn block_hash(&mut self, number: U256) -> Result<H256, Self::Error> {
         DatabaseRef::block_hash(self, number)
+    }
+}
+
+impl<'a> Clone for FuzzBackendWrapper<'a> {
+    fn clone(&self) -> Self {
+        Self {
+            backend: self.backend.clone(),
+            // we assume the clone is for a different fuzz run, so we set initialize back to false
+            is_initialized: false,
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Attempts to fix https://github.com/foundry-rs/foundry/issues/4586
the fuzzed backed is cloned across multiple fuzz runs, but each fuzz run can have different env settings (sender for example).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
when we call inspect, we unset the initialized state so if it is initialized again, this now behaves just as the regular backend.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
