### PR TITLE
fix(cast): block opt

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -229,7 +229,12 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Block { block, full, field, to_json, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);
+            println!(
+                "{}",
+                Cast::new(provider)
+                    .block(block.unwrap_or(BlockId::Number(Latest)), full, field, to_json)
+                    .await?
+            );
         }
         Subcommands::BlockNumber { rpc } => {
             let config = Config::from(&rpc);

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -43,7 +43,8 @@ pub struct CallArgs {
     #[clap(
         long,
         short,
-        help = "the block you want to query, can also be earliest/latest/pending",
+        help = "The block height you want to query at.",
+        long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
         value_name = "BLOCK"
     )]
     block: Option<BlockId>,

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -42,7 +42,7 @@ pub struct StorageArgs {
 
     /// The block height you want to query at
     ///
-    /// Can also be the tags earliest, latest, or pending
+    /// Can also be the tags earliest, finalized, safe, latest, or pending
     #[clap(long, short = 'B')]
     block: Option<BlockId>,
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -291,6 +291,8 @@ Examples:
         block: Option<BlockId>,
 
         #[clap(
+            long,
+            short = 'f',
             help = "If specified, only get the given field of the block.",
             value_name = "FIELD"
         )]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -268,7 +268,7 @@ Examples:
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -285,10 +285,10 @@ Examples:
     Block {
         #[clap(
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
-        block: BlockId,
+        block: Option<BlockId>,
 
         #[clap(
             help = "If specified, only get the given field of the block.",
@@ -519,7 +519,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -538,7 +538,7 @@ Defaults to decoding output data. To decode input data pass --input or use cast 
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -611,10 +611,8 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     #[clap(about = "Get the timestamp of a block.")]
     Age {
         #[clap(
-            long,
-            short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -630,7 +628,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -653,10 +651,8 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
     #[clap(about = "Get the basefee of a block.")]
     BaseFee {
         #[clap(
-            long,
-            short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -672,7 +668,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -763,7 +759,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,
@@ -779,7 +775,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             long,
             short = 'B',
             help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
             value_name = "BLOCK"
         )]
         block: Option<BlockId>,

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -35,7 +35,7 @@ casttest!(latest_block, |_: TestProject, mut cmd: TestCommand| {
     assert!(output.contains("gasUsed"));
 
     // <https://etherscan.io/block/15007840>
-    cmd.cast_fuse().args(["block", "15007840", "hash", "--rpc-url", eth_rpc_url.as_str()]);
+    cmd.cast_fuse().args(["block", "15007840", "-f", "hash", "--rpc-url", eth_rpc_url.as_str()]);
     let output = cmd.stdout_lossy();
     assert_eq!(output.trim(), "0x950091817a57e22b6c1f3b951a15f52d41ac89b299cc8f9c89bb6d185f80c415")
 });

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -333,7 +333,7 @@ impl fmt::Display for PossibleSigs {
         writeln!(f, " ------------")?;
         for (i, row) in self.data.iter().enumerate() {
             let row_label_decimal = i * 32;
-            let row_label_hex = format!("{:03x}", row_label_decimal);
+            let row_label_hex = format!("{row_label_decimal:03x}");
             writeln!(f, " [{row_label_hex}]: {row}")?;
         }
         Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
1. Remove the requirement to specify `--block` for `cast basefee` and `case age`. (Both only depend on the block argument besides rpc opts). Closes #4584.
2. Unify and improve help text for the `block` argument. Add `finalized` and `safe` tag in help text.
3. Make `block` argument optional for `cast block` and default to `latest` following other commands.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
