### PR TITLE
Fix bugs when gas is disabled

### DIFF
--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -86,7 +86,7 @@ where
 
         let total_gas_used = gas_used(
             data.env.cfg.spec_id,
-            interpreter.gas.limit() - self.gas_inspector.borrow().gas_remaining(),
+            interpreter.gas.limit().saturating_sub(self.gas_inspector.borrow().gas_remaining()),
             interpreter.gas.refunded() as u64,
         );
 

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -380,7 +380,10 @@ impl FuzzedCases {
     }
 
     fn gas_values(&self, with_stipend: bool) -> Vec<u64> {
-        self.cases.iter().map(|c| if with_stipend { c.gas } else { c.gas - c.stipend }).collect()
+        self.cases
+            .iter()
+            .map(|c| if with_stipend { c.gas } else { c.gas.saturating_sub(c.stipend) })
+            .collect()
     }
 
     /// Returns the case with the highest gas usage


### PR DESCRIPTION
This just uses `saturating_sub` on some gas subtractions to ensure no underflows.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I'm doing some funky stuff with forge and currently disabling gas costs, which caused me to notice these bugs. While they are unlikely to occur for others, might as well fix them.

## Solution

This just changes two subtractions to use `saturating_sub`. So instead of underflowing an unsigned integer, the remaining gas will be left at zero.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
