### PR TITLE
fix: serialize into BtreeMap

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -19,7 +19,7 @@ use jsonpath_lib;
 use serde::Deserialize;
 use serde_json::Value;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     env,
     io::{BufRead, BufReader, Write},
     path::Path,
@@ -463,7 +463,7 @@ fn serialize_json(
         serialization.insert(value_key.to_string(), parsed_value);
         serialization.clone()
     } else {
-        let mut serialization = HashMap::new();
+        let mut serialization = BTreeMap::new();
         serialization.insert(value_key.to_string(), parsed_value);
         state.serialized_jsons.insert(object_key.to_string(), serialization.clone());
         serialization.clone()

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -146,7 +146,7 @@ pub struct Cheatcodes {
     // Used to prevent duplicate changes file executing non-committing calls.
     pub fs_commit: bool,
 
-    pub serialized_jsons: HashMap<String, HashMap<String, Value>>,
+    pub serialized_jsons: BTreeMap<String, BTreeMap<String, Value>>,
 
     /// Records all eth deals
     pub eth_deals: Vec<DealRecord>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4592

serialize into BTreeMap instead of HashMap
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
