### PR TITLE
ci: switch ubuntu-20.04 to ubuntu latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
     container:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
         permissions:
             id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 jobs:
     prepare:
         name: Prepare release
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         outputs:
             tag_name: ${{ steps.release_info.outputs.tag_name }}
@@ -79,12 +79,12 @@ jobs:
                     # The target is used by Cargo
                     # The arch is either 386, arm64 or amd64
                     # The svm target platform to use for the binary https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-                    - os: ubuntu-20.04
+                    - os: ubuntu-latest
                       platform: linux
                       target: x86_64-unknown-linux-gnu
                       arch: amd64
                       svm_target_platform: linux-amd64
-                    - os: ubuntu-20.04
+                    - os: ubuntu-latest
                       platform: linux
                       target: aarch64-unknown-linux-gnu
                       arch: arm64
@@ -215,7 +215,7 @@ jobs:
 
     cleanup:
         name: Release cleanup
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         needs: release
 
         steps:


### PR DESCRIPTION
Hej there,

ubuntu-latest is at the time of this PR pinned to ubuntu-22.04 which is the current LTS release, hence it should be okay to switch CI to this target.
## Motivation
Using the latest LTS of Ubuntu for CI

## Solution

Replaced `ubuntu-20.04` with `ubuntu-22.04`
