### PR TITLE
use workspace dependency for ethers-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2128,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.0"
-source = "git+https://github.com/gakonst/ethers-rs#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
+source = "git+https://github.com/gakonst/ethers-rs?rev=279280c6fdae215a9411cdcf5270f34b7cf3fb70#279280c6fdae215a9411cdcf5270f34b7cf3fb70"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,18 @@ strip = true
 panic = "abort"
 codegen-units = 1
 
+# Lock ethers-rs to a rev to allow this crate be safely used as a dependency
+[workspace.dependencies]
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "279280c6fdae215a9411cdcf5270f34b7cf3fb70" }
+
 # # Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 # [patch."https://github.com/gakonst/ethers-rs"]
 # ethers = { path = "../ethers-rs" }

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -28,7 +28,7 @@ foundry-config = { path = "../config" }
 
 # evm support
 bytes = "1.1.0"
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["ws"] }
+ethers = { workspace = true, features = ["ws"] }
 trie-db = { version = "0.23" }
 hash-db = { version = "0.15" }
 memory-db = { version = "0.29" }
@@ -68,13 +68,13 @@ ethereum-forkid = "0.11"
 
 # ethers
 [target.'cfg(not(windows))'.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["rustls", "ws", "ipc"] }
+ethers = { workspace = true, features = ["rustls", "ws", "ipc"] }
 [target.'cfg(windows)'.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["rustls", "ws"] }
+ethers = { workspace = true, features = ["rustls", "ws"] }
 
 [dev-dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", features = ["project-util", "full"] }
+ethers = { workspace = true, features = ["abigen"] }
+ethers-solc = { workspace = true, features = ["project-util", "full"] }
 pretty_assertions = "1.2.1"
 tokio = { version = "1", features = ["full"] }
 crc = "3.0.0"

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -14,7 +14,7 @@ revm = { version = "2.3", default-features = false, features = [
     "memory_limit",
 ] }
 
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { workspace = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0" }
 bytes = { version = "1.1" }

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -10,12 +10,12 @@ keywords = ["ethereum", "web3", "solidity"]
 
 [dependencies]
 foundry-config = { path = "../config" }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-solc = { workspace = true, default-features = false, features = [
     "async",
     "svm-solc",
     "project-util",
 ] }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-contract = { workspace = true, default-features = false, features = [
     "abigen",
 ] }
 curl = { version = "0.4", default-features = false, features = ["http2"] }

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -14,13 +14,13 @@ foundry-config = { path = "./../config" }
 foundry-common = { path = "./../common" }
 
 futures = "0.3.17"
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-etherscan = { workspace = true, default-features = false }
+ethers-contract = { workspace = true, default-features = false, features = [
     "abigen",
 ] }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { workspace = true, default-features = false }
+ethers-providers = { workspace = true, default-features = false }
+ethers-signers = { workspace = true, default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde = "1.0.136"

--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -27,8 +27,8 @@ foundry-common = { path = "../common" }
 forge-fmt = { path = "../fmt" }
 
 # ethers
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", features = ["project-util", "full"] }
+ethers = { workspace = true }
+ethers-solc = { workspace = true, features = ["project-util", "full"] }
 
 # async
 tokio = { version = "1.21.2", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ cast = { path = "../cast" }
 ui = { path = "../ui" }
 
 # eth
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["rustls"] }
+ethers = { workspace = true, default-features = false, features = ["rustls"] }
 solang-parser = "=0.2.3"
 
 # cli

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
 tempfile = "3.3.0"
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-solc = { workspace = true, default-features = false, features = [
     "project-util",
 ] }
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers = { workspace = true, default-features = false }
 
 walkdir = "2.3.2"
 once_cell = "1.13"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-config = { path = "../config" }
 
 # eth
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["ethers-solc"] }
+ethers-core = { workspace = true, default-features = false }
+ethers-solc = { workspace = true, default-features = false }
+ethers-providers = { workspace = true, default-features = false }
+ethers-middleware = { workspace = true, default-features = false }
+ethers-etherscan = { workspace = true, default-features = false, features = ["ethers-solc"] }
 
 # io
 reqwest = { version = "0.11", default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,12 +9,12 @@ readme = "README.md"
 
 [dependencies]
 # eth
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-core = { workspace = true, default-features = false }
+ethers-solc = { workspace = true, default-features = false, features = [
     "async",
     "svm-solc",
 ] }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { workspace = true, default-features = false }
 
 # formats
 Inflector = "0.11.4"

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -16,8 +16,8 @@ foundry-config = { path = "../config" }
 foundry-utils = { path = "../utils" }
 
 # ethers
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["async"] }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-solc = { workspace = true, default-features = false, features = ["async"] }
+ethers-core = { workspace = true, default-features = false }
 
 # cli
 clap = { version = "3.0.10", features = [

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -16,7 +16,7 @@ foundry-macros = { path = "../macros" }
 serde_json = "1.0.67"
 serde = "1.0.130"
 hex = "0.4.3"
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { workspace = true, default-features = false, features = [
   "solc-full",
   "abigen",
 ] }

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ethereum", "web3", "solidity", "linter"]
 foundry-config = { path = "../config" }
 
 # ethers
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { workspace = true, default-features = false }
 
 # parser
 solang-parser = "=0.2.3"

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -10,9 +10,7 @@ foundry-common = { path = "./../common" }
 foundry-config = { path = "./../config" }
 foundry-evm = { path = "./../evm" }
 
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
-    "solc-full",
-] }
+ethers = { workspace = true, default-features = false, features = ["solc-full"] }
 eyre = "0.6.5"
 semver = "1.0.5"
 serde_json = "1.0.67"
@@ -33,7 +31,7 @@ comfy-table = "6.0.0"
 parking_lot = "0.12"
 
 [dev-dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { workspace = true, default-features = false, features = [
     "solc-full",
     "solc-tests",
 ] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-macros-impl = { path = "./impl" }
 foundry-common = { path = "../common" }
 
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { workspace = true, default-features = false }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,6 +12,6 @@ crossterm = "0.22.1"
 tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 eyre = "0.6.5"
 hex = "0.4.3"
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
+ethers = { workspace = true }
 forge = { path = "../forge" }
 revm = { version = "2.3", features = ["std", "k256", "with-serde"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,14 +7,14 @@ readme = "README.md"
 repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers-core = { workspace = true, default-features = false }
+ethers-contract = { workspace = true, default-features = false, features = [
     "abigen",
 ] }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { workspace = true, default-features = false }
+ethers-addressbook = { workspace = true, default-features = false }
+ethers-providers = { workspace = true, default-features = false }
+ethers-solc = { workspace = true, default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
@@ -38,7 +38,7 @@ glob = "0.3.0"
 
 [dev-dependencies]
 foundry-common = { path = "./../common" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = [
+ethers = { workspace = true, default-features = false, features = [
     "solc-full",
 ] }
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Not pinning the ethers-rs dependency to a specific `rev` causes cargo to fetch literally any commit when forge is used as a library

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Pin the etherers-rs to a specific `rev` using workspace dependencies, also makes it easier to update

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
