### PR TITLE
perf: dont keep all fuzzed cases around

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -185,11 +185,11 @@ impl TestArgs {
 
                     // Build debugger args if this is a fuzz test
                     let sig = match test_kind {
-                        TestKind::Fuzz(cases) => {
+                        TestKind::Fuzz { first_case, .. } => {
                             if let Some(CounterExample::Single(counterexample)) = counterexample {
                                 counterexample.calldata.to_string()
                             } else {
-                                cases.cases().first().expect("no fuzz cases run").calldata.to_string()
+                                first_case.calldata.to_string()
                             }
                         },
                         _ => sig,

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -64,8 +64,11 @@ impl<'a> FuzzedExecutor<'a> {
         should_fail: bool,
         errors: Option<&Abi>,
     ) -> Result<FuzzTestResult> {
-        // Stores the consumed gas and calldata of every successful fuzz call
-        let cases: RefCell<Vec<FuzzCase>> = RefCell::default();
+        // Stores the first Fuzzcase
+        let first_case: RefCell<Option<FuzzCase>> = RefCell::default();
+
+        // gas usage per case
+        let gas_by_case: RefCell<Vec<(u64, u64)>> = RefCell::default();
 
         // Stores the result and calldata of the last failed call, if any.
         let counterexample: RefCell<(Bytes, RawCallResult)> = RefCell::default();
@@ -128,11 +131,15 @@ impl<'a> FuzzedExecutor<'a> {
             );
 
             if success {
-                cases.borrow_mut().push(FuzzCase {
-                    calldata,
-                    gas: call.gas_used,
-                    stipend: call.stipend,
-                });
+                let mut first_case = first_case.borrow_mut();
+                if first_case.is_none() {
+                    first_case.replace(FuzzCase {
+                        calldata,
+                        gas: call.gas_used,
+                        stipend: call.stipend,
+                    });
+                }
+                gas_by_case.borrow_mut().push((call.gas_used, call.stipend));
 
                 traces.replace(call.traces);
 
@@ -165,11 +172,10 @@ impl<'a> FuzzedExecutor<'a> {
             }
         });
 
-        tracing::trace!(target: "forge::test::fuzz::dictionary", "{:?}", state.read().iter().map(hex::encode).collect::<Vec<_>>());
-
         let (calldata, call) = counterexample.into_inner();
         let mut result = FuzzTestResult {
-            cases: FuzzedCases::new(cases.into_inner()),
+            first_case: first_case.take().unwrap_or_default(),
+            gas_by_case: gas_by_case.take(),
             success: run_result.is_ok(),
             reason: None,
             counterexample: None,
@@ -304,9 +310,10 @@ impl fmt::Display for BaseCounterExample {
 /// The outcome of a fuzz test
 #[derive(Debug)]
 pub struct FuzzTestResult {
-    /// Every successful fuzz test case
-    pub cases: FuzzedCases,
-
+    /// we keep this for the debugger
+    pub first_case: FuzzCase,
+    /// Gas usage (gas_used, call_stipend) per cases
+    pub gas_by_case: Vec<(u64, u64)>,
     /// Whether the test case was successful. This means that the transaction executed
     /// properly, or that there was a revert and that the test was expected to fail
     /// (prefixed with `testFail`)
@@ -337,6 +344,29 @@ pub struct FuzzTestResult {
 
     /// Raw coverage info
     pub coverage: Option<HitMaps>,
+}
+
+impl FuzzTestResult {
+    /// Returns the median gas of all test cases
+    pub fn median_gas(&self, with_stipend: bool) -> u64 {
+        let mut values = self.gas_values(with_stipend);
+        values.sort_unstable();
+        calc::median_sorted(&values)
+    }
+
+    /// Returns the average gas use of all test cases
+    pub fn mean_gas(&self, with_stipend: bool) -> u64 {
+        let mut values = self.gas_values(with_stipend);
+        values.sort_unstable();
+        calc::mean(&values).as_u64()
+    }
+
+    fn gas_values(&self, with_stipend: bool) -> Vec<u64> {
+        self.gas_by_case
+            .iter()
+            .map(|gas| if with_stipend { gas.0 } else { gas.0.saturating_sub(gas.1) })
+            .collect()
+    }
 }
 
 /// Container type for all successful test cases
@@ -410,7 +440,7 @@ impl FuzzedCases {
 }
 
 /// Data of a single fuzz test case
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct FuzzCase {
     /// The calldata used for this fuzz test
     pub calldata: Bytes,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -317,7 +317,7 @@ impl<'a> ContractRunner<'a> {
 
             results.into_iter().zip(functions.iter()).for_each(|(result, function)| {
                 match result.kind {
-                    TestKind::Invariant(ref _cases, _) => {
+                    TestKind::Invariant { .. } => {
                         test_results.insert(function.signature(), result);
                     }
                     _ => unreachable!(),
@@ -494,6 +494,12 @@ impl<'a> ContractRunner<'a> {
                         }
                     }
 
+                    let kind = TestKind::Invariant {
+                        runs: cases.len(),
+                        calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
+                        reverts,
+                    };
+
                     Ok(TestResult {
                         success: test_error.is_none(),
                         reason: test_error.as_ref().and_then(|err| {
@@ -502,7 +508,7 @@ impl<'a> ContractRunner<'a> {
                         counterexample,
                         decoded_logs: decode_console_logs(&logs),
                         logs,
-                        kind: TestKind::Invariant(cases.clone(), reverts),
+                        kind,
                         coverage: None, // todo?
                         traces,
                         labeled_addresses: labeled_addresses.clone(),
@@ -534,6 +540,13 @@ impl<'a> ContractRunner<'a> {
                 .fuzz(func, address, should_fail, self.errors)
                 .wrap_err("Failed to run fuzz test")?;
 
+        let kind = TestKind::Fuzz {
+            median_gas: result.median_gas(false),
+            mean_gas: result.mean_gas(false),
+            first_case: result.first_case,
+            runs: result.gas_by_case.len(),
+        };
+
         // Record logs, labels and traces
         logs.append(&mut result.logs);
         labeled_addresses.append(&mut result.labeled_addresses);
@@ -551,7 +564,7 @@ impl<'a> ContractRunner<'a> {
             counterexample: result.counterexample,
             decoded_logs: decode_console_logs(&logs),
             logs,
-            kind: TestKind::Fuzz(result.cases),
+            kind,
             traces,
             coverage: result.coverage,
             labeled_addresses,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/4618

this reduces fuzz mem footprint drastically, for some reason we kept all cases in memory but we don't need them

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
calculate report info (gas usage) ad-hoc so cases are longer required to be in memory.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
