### PR TITLE
fix: don't serialize rpc field so it's not in script broadcast logs

### DIFF
--- a/cli/src/cmd/forge/script/transaction.rs
+++ b/cli/src/cmd/forge/script/transaction.rs
@@ -37,7 +37,7 @@ pub struct TransactionWithMetadata {
     pub function: Option<String>,
     #[serde(default = "default_vec_of_strings")]
     pub arguments: Option<Vec<String>>,
-    #[serde(skip_serializing)]
+    #[serde(default, skip_serializing)]
     pub rpc: Option<RpcUrl>,
     pub transaction: TypedTransaction,
     pub additional_contracts: Vec<AdditionalContract>,

--- a/cli/src/cmd/forge/script/transaction.rs
+++ b/cli/src/cmd/forge/script/transaction.rs
@@ -37,6 +37,7 @@ pub struct TransactionWithMetadata {
     pub function: Option<String>,
     #[serde(default = "default_vec_of_strings")]
     pub arguments: Option<Vec<String>>,
+    #[serde(skip_serializing)]
     pub rpc: Option<RpcUrl>,
     pub transaction: TypedTransaction,
     pub additional_contracts: Vec<AdditionalContract>,


### PR DESCRIPTION
Closes #4614 by removing the `rpc` field. If this is too broad because we need to serialize with the `rpc` field in other parts of the code, perhaps we need to manually implement `Serialize`  for `ScriptSequence`?

Edit: Took a look at other places we serialize this struct, and they all involve file writing where we'd want to exclude RPC URLs, so this appears to be the cleanest solution