### PR TITLE
perf: restrict state dictionary size

### DIFF
--- a/config/src/fuzz.rs
+++ b/config/src/fuzz.rs
@@ -26,6 +26,14 @@ pub struct FuzzConfig {
     pub include_storage: bool,
     /// The flag indicating whether to include push bytes values
     pub include_push_bytes: bool,
+    /// How many addresses to record at most.
+    /// Once the fuzzer exceeds this limit, it will start evicting random entries
+    ///
+    /// This limit is put in place to prevent memory blowup.
+    pub max_fuzz_dictionary_addresses: usize,
+    /// How many values to record at most.
+    /// Once the fuzzer exceeds this limit, it will start evicting random entries
+    pub max_fuzz_dictionary_values: usize,
 }
 
 impl Default for FuzzConfig {
@@ -37,6 +45,10 @@ impl Default for FuzzConfig {
             dictionary_weight: 40,
             include_storage: true,
             include_push_bytes: true,
+            // limit this to 200MB
+            max_fuzz_dictionary_addresses: (200 * 1024 * 1024) / 20,
+            // limit this to 200MB
+            max_fuzz_dictionary_values: (200 * 1024 * 1024) / 32,
         }
     }
 }

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -109,6 +109,15 @@ impl<'a> FuzzedExecutor<'a> {
                 .as_ref()
                 .ok_or_else(|| TestCaseError::fail(FuzzError::EmptyChangeset))?;
 
+            // keep memory in check
+            {
+                let mut state = state.write();
+                state.enforce_limit(
+                    self.config.max_fuzz_dictionary_addresses,
+                    self.config.max_fuzz_dictionary_values,
+                );
+            }
+
             // Build fuzzer state
             collect_state_from_call(
                 &call.logs,

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -40,11 +40,14 @@ pub struct FuzzDictionary {
 impl FuzzDictionary {
     /// If the dictionary exceeds these limits it randomly evicts
     pub fn enforce_limit(&mut self, max_addresses: usize, max_values: usize) {
-        assert_ne!(max_addresses, 0);
-        assert_ne!(max_values, 0);
-
         if self.inner.len() < max_values && self.cache.len() < max_addresses {
             return
+        }
+        if max_addresses == 0 {
+            self.cache.clear();
+        }
+        if max_values == 0 {
+            self.inner.clear();
         }
         let mut rng = thread_rng();
         while self.inner.len() > max_values {

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -262,3 +262,29 @@ pub fn collect_created_contracts(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::prelude::rand::RngCore;
+
+    #[test]
+    fn can_enforce_entries() {
+        let mut dictionary = FuzzDictionary::default();
+        let max_values = 10;
+        let max_address = 10;
+
+        for _ in 0..(max_values + 1) {
+            dictionary.cache.insert(Address::random());
+        }
+        for _ in 0..(max_address + 1) {
+            let mut val = [0u8; 32];
+            thread_rng().fill_bytes(&mut val[..]);
+            dictionary.inner.insert(val);
+        }
+
+        dictionary.enforce_limit(max_address, max_values);
+        assert_eq!(dictionary.cache.len(), max_address);
+        assert_eq!(dictionary.inner.len(), max_values);
+    }
+}

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -100,7 +100,9 @@ pub static TEST_OPTS: TestOptions = TestOptions {
         seed: None,
         include_storage: true,
         include_push_bytes: true,
+        max_fuzz_dictionary_addresses: 10_000,
         dictionary_weight: 40,
+        max_fuzz_dictionary_values: 10_000,
     },
     invariant: InvariantConfig {
         runs: 256,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4618

Identified the root cause for unbounded mem growth and it was the state dictionary which records all state changes over all fuzz runs.

This adds size restrictions to the state dictionary. if it exceeds the limit random entries are removed.

perhaps the current limits (200MB addresses, 200MB values) are still a bit excessive but with some napkin math this should now be limited by the number of parallel fuzz tests.

for example on a machine with 16 cores (max 16 parallel tests)
16 * (200MB+200MB) so around 6.4 GB for the fuzz state alone at most

I ran seaport and stayed under 4GB, but now we can easily tune this

cc @sambarnes

these settings are now configurable via 
`max_fuzz_dictionary_addresses` and `max_fuzz_dictionary_values` config values, address is 20byte, value 32, perhaps these should be in bytes and not max entries?
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
