### PR TITLE
chore: check for libusb in alternative homebrew location

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -48,7 +48,7 @@ if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
 fi
 
 # Warn MacOS users that they may need to manually install libusb via Homebrew:
-if [[ "$OSTYPE" =~ ^darwin && ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
+if [[ "$OSTYPE" =~ ^darwin && ! [ -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib || -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
     echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
 fi
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
on apple silicon homebrew might be installed under /opt/homebrew
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
