### PR TITLE
fix struct name output by only returning last name segment

### DIFF
--- a/utils/src/abi.rs
+++ b/utils/src/abi.rs
@@ -152,7 +152,7 @@ fn expand_input_param_type(
             let ty = if let Some(struct_name) =
                 structs.get_function_input_struct_solidity_id(&fun.name, param)
             {
-                struct_name.to_string()
+                struct_name.split('.').last().unwrap().to_string()
             } else {
                 kind.to_string()
             };
@@ -187,7 +187,7 @@ fn expand_output_param_type(
                     &fun.name,
                     param.internal_type.as_ref().unwrap(),
                 ) {
-                    struct_name.to_string()
+                    struct_name.split('.').last().unwrap().to_string()
                 } else {
                     kind.to_string()
                 };
@@ -260,7 +260,7 @@ fn expand_event_param_type(
             let ty = if let Some(struct_name) =
                 structs.get_event_input_struct_solidity_id(&event.name, idx)
             {
-                struct_name.to_string()
+                struct_name.split('.').last().unwrap().to_string()
             } else {
                 kind.to_string()
             };

--- a/utils/src/abi.rs
+++ b/utils/src/abi.rs
@@ -152,7 +152,7 @@ fn expand_input_param_type(
             let ty = if let Some(struct_name) =
                 structs.get_function_input_struct_solidity_id(&fun.name, param)
             {
-                struct_name.split('.').last().unwrap().to_string()
+                struct_name.rsplit('.').next().unwrap().to_string()
             } else {
                 kind.to_string()
             };
@@ -187,7 +187,7 @@ fn expand_output_param_type(
                     &fun.name,
                     param.internal_type.as_ref().unwrap(),
                 ) {
-                    struct_name.split('.').last().unwrap().to_string()
+                    struct_name.rsplit('.').next().unwrap().to_string()
                 } else {
                     kind.to_string()
                 };
@@ -260,7 +260,7 @@ fn expand_event_param_type(
             let ty = if let Some(struct_name) =
                 structs.get_event_input_struct_solidity_id(&event.name, idx)
             {
-                struct_name.split('.').last().unwrap().to_string()
+                struct_name.rsplit('.').next().unwrap().to_string()
             } else {
                 kind.to_string()
             };


### PR DESCRIPTION
## Motivation

Fixes #4624 

## Solution

I'm not sure if this is the right approach but it *should* be sufficient to just output the struct name without the parent scope as we are generated single, flat interfaces here. Or am I missing sth.?