### PR TITLE
fix: set block.number to l1BlockNumber on arbitrum

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -96,6 +96,12 @@ fn test_issue_2984() {
     test_repro!("Issue2984");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/4640>
+#[test]
+fn test_issue_4640() {
+    test_repro!("Issue4640");
+}
+
 // <https://github.com/foundry-rs/foundry/issues/3077>
 #[test]
 fn test_issue_3077() {

--- a/forge/tests/it/test_helpers.rs
+++ b/forge/tests/it/test_helpers.rs
@@ -63,7 +63,7 @@ pub static COMPILED_WITH_LIBS: Lazy<ProjectCompileOutput> = Lazy::new(|| {
 pub static EVM_OPTS: Lazy<EvmOpts> = Lazy::new(|| EvmOpts {
     env: Env {
         gas_limit: 18446744073709551615,
-        chain_id: Some(foundry_common::DEV_CHAIN_ID),
+        chain_id: None,
         tx_origin: Config::DEFAULT_SENDER,
         block_number: 1,
         block_timestamp: 1,

--- a/testdata/repros/Issue4640.t.sol
+++ b/testdata/repros/Issue4640.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+// https://github.com/foundry-rs/foundry/issues/4640
+contract Issue4640Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testArbitrumBlockNumber() public {
+        // <https://arbiscan.io/block/75219831>
+        vm.createSelectFork("https://rpc.ankr.com/arbitrum", 75219831);
+        // L1 block number
+        assertEq(block.number, 16939475);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4640

arbitrum `block.number` is l1BlockNumber
use the l1BlockNumber field to set env.blocknumber
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
