### PR TITLE
feat(anvil): shutdown on sigterm

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -289,7 +289,7 @@ impl NodeArgs {
         task_manager.spawn(async move {
 
             let mut stream =
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
             let sigterm = stream.recv();
             pin_mut!(sigterm);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Supports SIGTERM, allowing docker setups to do a graceful shutdown by default.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
