### PR TITLE
feat(forge) add non-aligned memory words in debugger

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -870,11 +870,11 @@ impl Tui {
                 let w = debug_steps[current_step].stack[stack_len - 1];
                 match op {
                     opcode::MLOAD => {
-                        word = Some(w.as_usize() / 32);
+                        word = Some(w.as_usize());
                         color = Some(Color::Cyan);
                     }
                     opcode::MSTORE => {
-                        word = Some(w.as_usize() / 32);
+                        word = Some(w.as_usize());
                         color = Some(Color::Red);
                     }
                     _ => {}
@@ -889,7 +889,7 @@ impl Tui {
             if let Instruction::OpCode(op) = debug_steps[prev_step].instruction {
                 if op == opcode::MSTORE {
                     let prev_top = debug_steps[prev_step].stack[stack_len - 1];
-                    word = Some(prev_top.as_usize() / 32);
+                    word = Some(prev_top.as_usize());
                     color = Some(Color::Green);
                 }
             }
@@ -906,11 +906,12 @@ impl Tui {
             .map(|(i, mem_word)| {
                 let words: Vec<Span> = mem_word
                     .iter()
-                    .map(|byte| {
+                    .enumerate()
+                    .map(|(j, byte)| {
                         Span::styled(
                             format!("{byte:02x} "),
                             if let (Some(w), Some(color)) = (word, color) {
-                                if i == w {
+                                if (i == w / 32 && j >= w % 32) || (i == w / 32 + 1 && j < w % 32) {
                                     Style::default().fg(color)
                                 } else if *byte == 0 {
                                     Style::default().add_modifier(Modifier::DIM)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

hotfix for https://github.com/foundry-rs/foundry/issues/4608

now everytime the memory is accessed in the debugger, words are not necessarly aligned anymore. e.g if I write `<value> 0x04 mstore`:

![image](https://user-images.githubusercontent.com/51274081/229309413-2a512606-c40c-41b8-8085-32548512c4af.png)

