### PR TITLE
fix: use block.number when creating fork

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -733,12 +733,10 @@ impl NodeConfig {
     /// Returns the path where the cache file should be stored
     ///
     /// See also [ Config::foundry_block_cache_file()]
-    pub fn block_cache_path(&self) -> Option<PathBuf> {
+    pub fn block_cache_path(&self, block: u64) -> Option<PathBuf> {
         if self.no_storage_caching || self.eth_rpc_url.is_none() {
             return None
         }
-        // cache only if block explicitly set
-        let block = self.fork_block_number?;
         let chain_id = self.get_chain_id();
 
         Config::foundry_block_cache_file(chain_id, block)
@@ -902,9 +900,9 @@ impl NodeConfig {
 
             let meta = BlockchainDbMeta::new(env.clone(), eth_rpc_url.clone());
             let block_chain_db = if self.fork_chain_id.is_some() {
-                BlockchainDb::new_skip_check(meta, self.block_cache_path())
+                BlockchainDb::new_skip_check(meta, self.block_cache_path(fork_block_number))
             } else {
-                BlockchainDb::new(meta, self.block_cache_path())
+                BlockchainDb::new(meta, self.block_cache_path(fork_block_number))
             };
 
             // This will spawn the background thread that will use the provider to fetch

--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -740,7 +740,7 @@ mod tests {
         let mut evm_opts = config.extract::<EvmOpts>().unwrap();
         evm_opts.fork_block_number = Some(block_num);
 
-        let env = evm_opts.fork_evm_env(ENDPOINT).await.unwrap();
+        let (env, _block) = evm_opts.fork_evm_env(ENDPOINT).await.unwrap();
 
         let fork = CreateFork {
             enable_caching: true,

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -1,7 +1,7 @@
 use crate::utils::apply_chain_and_block_specific_env_changes;
 use ethers::{
     providers::Middleware,
-    types::{Address, U256},
+    types::{Address, Block, TxHash, U256},
 };
 use eyre::WrapErr;
 use futures::TryFutureExt;
@@ -16,7 +16,7 @@ pub async fn environment<M: Middleware>(
     override_chain_id: Option<u64>,
     pin_block: Option<u64>,
     origin: Address,
-) -> eyre::Result<Env>
+) -> eyre::Result<(Env, Block<TxHash>)>
 where
     M::Error: 'static,
 {
@@ -80,5 +80,5 @@ where
 
     apply_chain_and_block_specific_env_changes(&mut env, &block);
 
-    Ok(env)
+    Ok((env, block))
 }

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -2,7 +2,7 @@ use crate::executor::fork::CreateFork;
 use ethers::{
     providers::{Middleware, Provider},
     solc::utils::RuntimeOrHandle,
-    types::{Address, Chain, H256, U256},
+    types::{Address, Block, Chain, TxHash, H256, U256},
 };
 use eyre::WrapErr;
 use foundry_common::{self, ProviderBuilder, RpcUrl, ALCHEMY_FREE_TIER_CUPS};
@@ -59,7 +59,7 @@ impl EvmOpts {
     /// id, )
     pub async fn evm_env(&self) -> revm::Env {
         if let Some(ref fork_url) = self.fork_url {
-            self.fork_evm_env(fork_url).await.expect("Could not instantiate forked environment")
+            self.fork_evm_env(fork_url).await.expect("Could not instantiate forked environment").0
         } else {
             self.local_evm_env()
         }
@@ -72,14 +72,18 @@ impl EvmOpts {
     /// Returns an error if a RPC request failed, or the fork url is not a valid url
     pub fn evm_env_blocking(&self) -> eyre::Result<revm::Env> {
         if let Some(ref fork_url) = self.fork_url {
-            RuntimeOrHandle::new().block_on(self.fork_evm_env(fork_url))
+            RuntimeOrHandle::new().block_on(self.fork_evm_env(fork_url)).map(|res| res.0)
         } else {
             Ok(self.local_evm_env())
         }
     }
 
-    /// Returns the `revm::Env` configured with settings retrieved from the endpoints
-    pub async fn fork_evm_env(&self, fork_url: impl AsRef<str>) -> eyre::Result<revm::Env> {
+    /// Returns the `revm::Env` that is configured with settings retrieved from the endpoint.
+    /// And the block that was used to configure the environment.
+    pub async fn fork_evm_env(
+        &self,
+        fork_url: impl AsRef<str>,
+    ) -> eyre::Result<(revm::Env, Block<TxHash>)> {
         let fork_url = fork_url.as_ref();
         let provider = ProviderBuilder::new(fork_url)
             .compute_units_per_second(self.get_compute_units_per_second())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4683

In #4669 we're using the l1BlockNumber for `env.blockNumber` on arbitrum, but we still used `env.blocknumber` when configuring the fork and caching. Instead we need to use the number from the block `block.number`

cc @0xdapper
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
