### PR TITLE
fix(fmt): --root shouldn't conflict with [PATH]

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -23,7 +23,6 @@ use tracing::log::warn;
 pub struct FmtArgs {
     #[clap(
         help = "path to the file, directory or '-' to read from stdin",
-        conflicts_with = "root",
         value_hint = ValueHint::FilePath,
         value_name = "PATH",
         num_args(1..)


### PR DESCRIPTION
This closes #4478 (cc @h0tw4t3r)
In `forge fmt` I think `--root` should work correctly with PATH(S).
The `conflicts_with = "root"` option was added by @mattsse in PR #2180 but after looking at the code and running some tests, I think both options can work together.
