### PR TITLE
improving docs generation by adding homepage to config

### DIFF
--- a/config/src/doc.rs
+++ b/config/src/doc.rs
@@ -12,6 +12,8 @@ pub struct DocConfig {
     pub title: String,
     /// Path to user provided `book.toml`.
     pub book: PathBuf,
+    /// Path to user provided welcome markdown (default is Readme.md)
+    pub homepage: PathBuf,
     /// The repository url.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
@@ -24,6 +26,7 @@ impl Default for DocConfig {
         Self {
             out: PathBuf::from("docs"),
             book: PathBuf::from("book.toml"),
+            homepage: PathBuf::from("README.md"),
             title: String::default(),
             repository: None,
             ignore: Vec::default(),

--- a/config/src/doc.rs
+++ b/config/src/doc.rs
@@ -15,6 +15,7 @@ pub struct DocConfig {
     /// Path to user provided welcome markdown.
     ///
     /// If none is provided, it defaults to `README.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<PathBuf>,
     /// The repository url.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/config/src/doc.rs
+++ b/config/src/doc.rs
@@ -12,8 +12,10 @@ pub struct DocConfig {
     pub title: String,
     /// Path to user provided `book.toml`.
     pub book: PathBuf,
-    /// Path to user provided welcome markdown (default is Readme.md)
-    pub homepage: PathBuf,
+    /// Path to user provided welcome markdown.
+    ///
+    /// If none is provided, it defaults to `README.md`.
+    pub homepage: Option<PathBuf>,
     /// The repository url.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
@@ -26,7 +28,7 @@ impl Default for DocConfig {
         Self {
             out: PathBuf::from("docs"),
             book: PathBuf::from("book.toml"),
-            homepage: PathBuf::from("README.md"),
+            homepage: Some(PathBuf::from("README.md")),
             title: String::default(),
             repository: None,
             ignore: Vec::default(),

--- a/doc/src/builder.rs
+++ b/doc/src/builder.rs
@@ -230,12 +230,6 @@ impl DocBuilder {
         let out_dir_src = out_dir.join(Self::SRC);
         fs::create_dir_all(&out_dir_src)?;
 
-
-
-
-      
-
-
         // Write readme content if any
         let homepage_content = {
             
@@ -261,8 +255,6 @@ impl DocBuilder {
                 None => String::new(),
             }
            
-  
-        
         };
         let readme_path = out_dir_src.join(Self::README);
         fs::write(&readme_path, homepage_content)?;

--- a/doc/src/builder.rs
+++ b/doc/src/builder.rs
@@ -247,7 +247,7 @@ impl DocBuilder {
             //If not, fall back to src and root readme files, in that order.
             if homepage_or_src_readme.exists() {
                 fs::read_to_string(homepage_or_src_readme)?
-            } else if homepage_or_src_readme.exists() {
+            } else if root_readme.exists() {
                 fs::read_to_string(root_readme)?
             } else {
                 String::new()

--- a/doc/src/builder.rs
+++ b/doc/src/builder.rs
@@ -230,7 +230,11 @@ impl DocBuilder {
         let out_dir_src = out_dir.join(Self::SRC);
         fs::create_dir_all(&out_dir_src)?;
 
-        // Write readme content if any
+
+
+
+        /*
+     // Write readme content if any
         let readme_content = {
             let src_readme = self.sources.join(Self::README);
             let root_readme = self.root.join(Self::README);
@@ -242,8 +246,39 @@ impl DocBuilder {
                 String::new()
             }
         };
+      
+        */
+
+
+        // Write readme content if any
+        let homepage_content = {
+            
+            let src_readme = self.sources.join(Self::README);
+            let root_readme = self.root.join(Self::README);
+            
+
+            let homepage_path = {
+                if self.config.homepage.is_file() {
+                    Some(self.config.homepage.clone())
+                } else if src_readme.exists() {
+                    Some(src_readme)
+                }else if root_readme.exists() {
+                    Some(root_readme)
+                }else {
+                    None                
+                }
+            };
+            
+            match homepage_path {
+                Some(path) => fs::read_to_string(path)?,
+                None => String::new(),
+            }
+           
+  
+        
+        };
         let readme_path = out_dir_src.join(Self::README);
-        fs::write(&readme_path, readme_content)?;
+        fs::write(&readme_path, homepage_content)?;
 
         // Write summary and section readmes
         let mut summary = BufWriter::default();

--- a/doc/src/builder.rs
+++ b/doc/src/builder.rs
@@ -233,21 +233,7 @@ impl DocBuilder {
 
 
 
-        /*
-     // Write readme content if any
-        let readme_content = {
-            let src_readme = self.sources.join(Self::README);
-            let root_readme = self.root.join(Self::README);
-            if src_readme.exists() {
-                fs::read_to_string(src_readme)?
-            } else if root_readme.exists() {
-                fs::read_to_string(root_readme)?
-            } else {
-                String::new()
-            }
-        };
       
-        */
 
 
         // Write readme content if any
@@ -256,7 +242,8 @@ impl DocBuilder {
             let src_readme = self.sources.join(Self::README);
             let root_readme = self.root.join(Self::README);
             
-
+            //Check to see if there is a 'homepage' option specified in config.
+            //If not, fall back to src and root readme files.
             let homepage_path = {
                 if self.config.homepage.is_file() {
                     Some(self.config.homepage.clone())


### PR DESCRIPTION
 
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When using the docs command, I wanted to be able to use a different README file for the 'home page' of the docs other than README.md.    I want my README file to be used for developers to be able to boot up my smart contracts but i want the welcome page of our docs (teller finance) to be better for users.  However, there was no way to do this with 'forge doc' as it was hard coded to use README.md . It was also impossible to command 'forge doc' to copy files over and then separately build the book folder with a separate command  (that would be nice too but that would have to be a different PR).  


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->



Therefore, I added a config to my foundry.toml file llke so:


[doc]
homepage= "HOME.md"

and I created this PR which changes the builder so that it attempts to read that config value.  If it is present, it will use that specified file as the homepage for the docs (the content for README.md in /docs).  If not specified, it will fall back to the original code which checked for README in the root and source and then finally falls back upon new String().  

