### PR TITLE
fix(chisel): support library imports

### DIFF
--- a/chisel/src/dispatcher.rs
+++ b/chisel/src/dispatcher.rs
@@ -7,7 +7,7 @@ use crate::prelude::{
     ChiselCommand, ChiselResult, ChiselSession, CmdCategory, CmdDescriptor, SessionSourceConfig,
     SolidityHelper,
 };
-use ethers::{abi::ParamType, contract::Lazy, types::H160, utils::hex};
+use ethers::{abi::ParamType, contract::Lazy, types::Address, utils::hex};
 use forge::{
     decode::decode_console_logs,
     trace::{
@@ -21,7 +21,7 @@ use regex::Regex;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use solang_parser::diagnostics::Diagnostic;
-use std::{borrow::Cow, error::Error, io::Write, path::PathBuf, process::Command, str::FromStr};
+use std::{borrow::Cow, error::Error, io::Write, path::PathBuf, process::Command};
 use strum::IntoEnumIterator;
 use yansi::Paint;
 
@@ -808,7 +808,7 @@ impl ChiselDispatcher {
             // Convert the match to a string slice
             let match_str = m.as_str();
             // We can always safely unwrap here due to the regex matching.
-            let addr = H160::from_str(match_str).unwrap();
+            let addr: Address = match_str.parse().expect("Valid address regex");
             // Replace all occurrences of the address with a checksummed version
             heap_input = heap_input.replace(match_str, &ethers::utils::to_checksum(&addr, None));
         });

--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -34,7 +34,7 @@ impl SessionSource {
         // Recompile the project and ensure no errors occurred.
         let compiled = self.build()?;
         if let Some((_, contract)) =
-            compiled.compiler_output.contracts_into_iter().find(|(name, _)| name == "REPL")
+            compiled.clone().compiler_output.contracts_into_iter().find(|(name, _)| name == "REPL")
         {
             // These *should* never panic after a successful compilation.
             let bytecode = contract


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4467

chisel uses solc directly and remappings were not configured in the compiler input.
This sets the remappings retrieved from the config, so if invoked in a project this will also set all remappings but not forge-std because we set the VM directly (we can not rely on forge-std being present).

cc @mlgarchery @exp-table @clabby 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
