### PR TITLE
fix(chisel): properly load and save history

### DIFF
--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -17,7 +17,7 @@ use foundry_config::{
     },
     Config,
 };
-use rustyline::{error::ReadlineError, Editor};
+use rustyline::{config::Configurer, error::ReadlineError, Editor};
 use yansi::Paint;
 
 // Loads project's figment and merges the build cli arguments into it
@@ -135,6 +135,9 @@ async fn main() -> eyre::Result<()> {
     let mut rl = Editor::<SolidityHelper, _>::new()?;
     rl.set_helper(Some(SolidityHelper::default()));
 
+    // automatically add lines to history
+    rl.set_auto_add_history(true);
+
     // load history
     if let Some(chisel_history) = chisel_history_file() {
         let _ = rl.load_history(&chisel_history);
@@ -158,9 +161,6 @@ async fn main() -> eyre::Result<()> {
             Ok(line) => {
                 // Clear interrupt flag
                 interrupt = false;
-
-                // Add line to history
-                rl.add_history_entry(&line)?;
 
                 // Dispatch and match results
                 match dispatcher.dispatch(&line).await {

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -3,7 +3,10 @@
 //! This module contains the core readline loop for the Chisel CLI as well as the
 //! executable's `main` function.
 
-use chisel::prelude::{ChiselCommand, ChiselDispatcher, DispatchResult, SolidityHelper};
+use chisel::{
+    history::chisel_history_file,
+    prelude::{ChiselCommand, ChiselDispatcher, DispatchResult, SolidityHelper},
+};
 use clap::Parser;
 use foundry_cli::cmd::{forge::build::BuildArgs, LoadConfig};
 use foundry_common::evm::EvmArgs;
@@ -132,6 +135,11 @@ async fn main() -> eyre::Result<()> {
     let mut rl = Editor::<SolidityHelper, _>::new()?;
     rl.set_helper(Some(SolidityHelper::default()));
 
+    // load history
+    if let Some(chisel_history) = chisel_history_file() {
+        let _ = rl.load_history(&chisel_history);
+    }
+
     // Print welcome header
     println!("Welcome to Chisel! Type `{}` to show available commands.", Paint::green("!help"));
 
@@ -183,6 +191,10 @@ async fn main() -> eyre::Result<()> {
                 break
             }
         }
+    }
+
+    if let Some(chisel_history) = chisel_history_file() {
+        let _ = rl.save_history(&chisel_history);
     }
 
     Ok(())

--- a/chisel/src/history.rs
+++ b/chisel/src/history.rs
@@ -1,0 +1,11 @@
+//! chisel history file
+
+use std::path::PathBuf;
+
+/// The name of the chisel history file
+pub const CHISEL_HISTORY_FILE_NAME: &'static str = ".chisel_history";
+
+/// Returns the path to foundry's global toml file that's stored at `~/.foundry/.chisel_history`
+pub fn chisel_history_file() -> Option<PathBuf> {
+    foundry_config::Config::foundry_dir().map(|p| p.join(CHISEL_HISTORY_FILE_NAME))
+}

--- a/chisel/src/history.rs
+++ b/chisel/src/history.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 /// The name of the chisel history file
-pub const CHISEL_HISTORY_FILE_NAME: &'static str = ".chisel_history";
+pub const CHISEL_HISTORY_FILE_NAME: &str = ".chisel_history";
 
 /// Returns the path to foundry's global toml file that's stored at `~/.foundry/.chisel_history`
 pub fn chisel_history_file() -> Option<PathBuf> {

--- a/chisel/src/lib.rs
+++ b/chisel/src/lib.rs
@@ -10,6 +10,8 @@ pub mod dispatcher;
 /// Builtin Chisel commands
 pub mod cmd;
 
+pub mod history;
+
 /// Chisel Environment Module
 pub mod session;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
load and save chisel history

default location is `~/.foundry/.chisel_history`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
