### PR TITLE
feat(cast): add optimize selector command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "futures",
  "hex",
  "num_cpus",
+ "rayon",
  "rusoto_core",
  "rusoto_kms",
  "rustc-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "foundry-utils",
  "futures",
  "hex",
+ "num_cpus",
  "rusoto_core",
  "rusoto_kms",
  "rustc-hex",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -25,6 +25,7 @@ serde = "1.0.159"
 serde_json = "1.0.95"
 chrono = "0.4.24"
 hex = "0.4.3"
+num_cpus = "1.13.0"
 
 # aws
 rusoto_core = { version = "0.48.0", default-features = false, optional = true }

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.95"
 chrono = "0.4.24"
 hex = "0.4.3"
 num_cpus = "1.13.0"
+rayon = "1.5.1"
 
 # aws
 rusoto_core = { version = "0.48.0", default-features = false, optional = true }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1689,7 +1689,7 @@ impl SimpleCast {
         }
         let mut name: &str = "";
         let mut params: &str = "";
-        if let Some(index) = signature.find("(") {
+        if let Some(index) = signature.find('(') {
             name = &signature[..index];
             params = &signature[index..];
         }
@@ -1721,7 +1721,7 @@ impl SimpleCast {
             })
             .collect();
 
-        let result = results.into_iter().filter_map(|r| r).min_by_key(|r| r.0);
+        let result = results.into_iter().flatten().min_by_key(|r| r.0);
 
         match result {
             Some((_nonce, selector, signature)) => {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -28,7 +28,12 @@ pub use rusoto_core::{
 };
 pub use rusoto_kms::KmsClient;
 use rustc_hex::{FromHexIter, ToHex};
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    path::PathBuf,
+    str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
+};
 pub use tx::TxBuilder;
 use tx::{TxBuilderOutput, TxBuilderPeekOutput};
 
@@ -1655,6 +1660,75 @@ impl SimpleCast {
     /// ```
     pub fn disassemble(bytecode: &str) -> Result<String> {
         format_operations(disassemble_str(bytecode)?)
+    }
+
+    /// Gets the selector for a given function signature
+    /// Optimizes if the `optimize` parameter is set to a number of leading zeroes
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::get_selector("foo(address,uint256)")?.0, String::from("0xbd0d639f");
+    ///     assert_eq!(Cast::get_selector("foo(address,uint256)", 2)?.0, String::from("0x0000bf3e");
+    ///     assert_eq!(Cast::get_selector("foo(address,uint256)", 2)?.1, String::from("foo71661(address,uint256)");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```    
+    pub fn get_selector(
+        signature: String,
+        optimize: Option<usize>,
+    ) -> Result<(String, Option<String>, Option<Duration>)> {
+        if optimize.is_none() || optimize.unwrap() > 4 {
+            let selector = HumanReadableParser::parse_function(&signature)?.short_signature();
+            return Ok((hex::encode(selector), None, None))
+        }
+        let mut name: &str = "";
+        let mut params: &str = "";
+        if let Some(index) = signature.find("(") {
+            name = &signature[..index];
+            params = &signature[index..];
+        }
+
+        let num_threads = num_cpus::get();
+        let start_time = Instant::now();
+        let found = AtomicBool::new(false);
+
+        let results: Vec<Option<(u32, String, String)>> = (0..num_threads)
+            .into_iter()
+            .map(|i| {
+                let nonce_start = i as u32;
+                let nonce_step = num_threads as u32;
+
+                let mut nonce = nonce_start;
+                while nonce < std::u32::MAX && !found.load(Ordering::Relaxed) {
+                    let input = format!("{}{}{}", name, nonce, params);
+                    let hash = keccak256(input.as_bytes());
+                    let selector = &hash[..4];
+
+                    if selector.iter().take(optimize.unwrap()).all(|&byte| byte == 0) {
+                        found.store(true, Ordering::Relaxed);
+                        return Some((nonce, hex::encode(selector), input))
+                    }
+
+                    nonce += nonce_step;
+                }
+                None
+            })
+            .collect();
+
+        let result = results.into_iter().filter_map(|r| r).min_by_key(|r| r.0);
+
+        match result {
+            Some((_nonce, selector, signature)) => {
+                let elapsed_time = start_time.elapsed();
+                Ok((selector, Some(signature), Some(elapsed_time)))
+            }
+            None => Ok((String::from(""), None, None)),
+        }
     }
 }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1703,7 +1703,7 @@ impl SimpleCast {
                     let hash = keccak256(input.as_bytes());
                     let selector = &hash[..4];
 
-                    if selector.iter().take(optimize).all(|&byte| byte == 0) {
+                    if selector.iter().take_while(|&&byte| byte == 0).count() == optimize {
                         found.store(true, Ordering::Relaxed);
                         return Some((nonce, format!("0x{}", hex::encode(selector)), input))
                     }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1672,9 +1672,9 @@ impl SimpleCast {
     /// use cast::SimpleCast as Cast;
     ///
     /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::get_selector("foo(address,uint256)")?.0, String::from("0xbd0d639f");
-    ///     assert_eq!(Cast::get_selector("foo(address,uint256)", 2)?.0, String::from("0x0000bf3e");
-    ///     assert_eq!(Cast::get_selector("foo(address,uint256)", 2)?.1, String::from("foo71661(address,uint256)");
+    ///     assert_eq!(Cast::get_selector(String::from("foo(address,uint256)"), None)?.0, String::from("0xbd0d639f"));
+    ///     assert_eq!(Cast::get_selector(String::from("foo(address,uint256)"), Some(2))?.0, String::from("0x0000bf3e"));
+    ///     assert_eq!(Cast::get_selector(String::from("foo(address,uint256)"), Some(2))?.1, Some(String::from("foo71661(address,uint256)")));
     ///
     ///     Ok(())
     /// }
@@ -1685,7 +1685,7 @@ impl SimpleCast {
     ) -> Result<(String, Option<String>, Option<Duration>)> {
         if optimize.is_none() || optimize.unwrap() > 4 {
             let selector = HumanReadableParser::parse_function(&signature)?.short_signature();
-            return Ok((hex::encode(selector), None, None))
+            return Ok((format!("0x{}", hex::encode(selector)), None, None))
         }
         let mut name: &str = "";
         let mut params: &str = "";
@@ -1712,7 +1712,7 @@ impl SimpleCast {
 
                     if selector.iter().take(optimize.unwrap()).all(|&byte| byte == 0) {
                         found.store(true, Ordering::Relaxed);
-                        return Some((nonce, hex::encode(selector), input))
+                        return Some((nonce, format!("0x{}", hex::encode(selector)), input))
                     }
 
                     nonce += nonce_step;

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -22,6 +22,7 @@ use evm_disassembler::{disassemble_bytes, disassemble_str, format_operations};
 use eyre::{Context, Result};
 use foundry_common::{abi::encode_args, fmt::*, TransactionReceiptWithRevertReason};
 pub use foundry_evm::*;
+use rayon::prelude::*;
 pub use rusoto_core::{
     credential::ChainProvider as AwsChainProvider, region::Region as AwsRegion,
     request::HttpClient as AwsHttpClient, Client as AwsClient,
@@ -1698,7 +1699,7 @@ impl SimpleCast {
         let found = AtomicBool::new(false);
 
         let results: Vec<Option<(u32, String, String)>> = (0..num_threads)
-            .into_iter()
+            .into_par_iter()
             .map(|i| {
                 let nonce_start = i as u32;
                 let nonce_step = num_threads as u32;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -183,8 +183,15 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::Sig { sig, optimize } => {
             let sig = stdin::unwrap_line(sig)?;
-            let selector = HumanReadableParser::parse_function(&sig)?.short_signature();
-            println!("0x{}", hex::encode(selector));
+            if optimize.is_none() {
+                println!("{}", SimpleCast::get_selector(sig, None)?.0);
+            } else {
+                println!("Starting to optimize signature...");
+                let result = SimpleCast::get_selector(sig, optimize)?;
+                println!("Successfully generated in {} seconds", result.2.unwrap().as_secs());
+                println!("Selector: {}", result.0);
+                println!("Optimized signature: {}", result.1.unwrap());
+            }
         }
 
         // Blockchain & RPC queries

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -2,7 +2,6 @@ use cast::{Cast, SimpleCast, TxBuilder};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use ethers::{
-    abi::HumanReadableParser,
     core::types::{BlockId, BlockNumber::Latest, H256},
     providers::Middleware,
     types::Address,

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -181,7 +181,7 @@ async fn main() -> eyre::Result<()> {
             let calldata = stdin::unwrap_line(calldata)?;
             println!("{}", pretty_calldata(&calldata, offline).await?);
         }
-        Subcommands::Sig { sig } => {
+        Subcommands::Sig { sig, optimize } => {
             let sig = stdin::unwrap_line(sig)?;
             let selector = HumanReadableParser::parse_function(&sig)?.short_signature();
             println!("0x{}", hex::encode(selector));

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -23,6 +23,7 @@ use foundry_common::{
 };
 use foundry_config::Config;
 use rustc_hex::ToHex;
+use std::time::Instant;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -183,13 +184,15 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Sig { sig, optimize } => {
             let sig = stdin::unwrap_line(sig)?;
             if optimize.is_none() {
-                println!("{}", SimpleCast::get_selector(sig, None)?.0);
+                println!("{}", SimpleCast::get_selector(&sig, None)?.0);
             } else {
                 println!("Starting to optimize signature...");
-                let result = SimpleCast::get_selector(sig, optimize)?;
-                println!("Successfully generated in {} seconds", result.2.unwrap().as_secs());
-                println!("Selector: {}", result.0);
-                println!("Optimized signature: {}", result.1.unwrap());
+                let start_time = Instant::now();
+                let (selector, signature) = SimpleCast::get_selector(&sig, optimize)?;
+                let elapsed_time = start_time.elapsed();
+                println!("Successfully generated in {} seconds", elapsed_time.as_secs());
+                println!("Selector: {}", selector);
+                println!("Optimized signature: {}", signature);
             }
         }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -833,7 +833,7 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             help = "Optimize signature to contain provided amount of leading zeroes in selector.",
             value_name = "OPTIMIZE"
         )]
-        optimize: u8,
+        optimize: Option<usize>,
     },
     #[clap(
         name = "create2",

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -828,6 +828,12 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
             value_name = "SIG"
         )]
         sig: Option<String>,
+
+        #[clap(
+            help = "Optimize signature to contain provided amount of leading zeroes in selector.",
+            value_name = "OPTIMIZE"
+        )]
+        optimize: u8,
     },
     #[clap(
         name = "create2",


### PR DESCRIPTION
Adds `--optimize` option to cast sig to optimize the signature to have a defined number of leading zeroes, similar to description in: https://github.com/foundry-rs/foundry/issues/2175.

## Motivation

As described in: https://github.com/foundry-rs/foundry/issues/2175, this feature provides users the ability to easily optimize function signatures.

## Solution

Allows user to provide `--optimize` option along with `cast sig`, defining a number of leading zeroes to mine by adding a nonce to the function signature.