### PR TITLE
chore: fix cargo default-features warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,17 +58,16 @@ strip = true
 panic = "abort"
 codegen-units = 1
 
-# Lock ethers-rs to a rev to allow this crate be safely used as a dependency
 [workspace.dependencies]
-ethers = { version = "2" }
-ethers-addressbook = { version = "2" }
-ethers-core = { version = "2" }
-ethers-contract = { version = "2" }
-ethers-providers = { version = "2" }
-ethers-signers = { version = "2" }
-ethers-middleware = { version = "2" }
-ethers-etherscan = { version = "2" }
-ethers-solc = { version = "2" }
+ethers = { version = "2", default-features = false }
+ethers-addressbook = { version = "2", default-features = false }
+ethers-core = { version = "2", default-features = false }
+ethers-contract = { version = "2", default-features = false }
+ethers-providers = { version = "2", default-features = false }
+ethers-signers = { version = "2", default-features = false }
+ethers-middleware = { version = "2", default-features = false }
+ethers-etherscan = { version = "2", default-features = false }
+ethers-solc = { version = "2", default-features = false }
 
 # # Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 # [patch."https://github.com/gakonst/ethers-rs"]

--- a/anvil/core/Cargo.toml
+++ b/anvil/core/Cargo.toml
@@ -14,7 +14,7 @@ revm = { version = "2.3", default-features = false, features = [
     "memory_limit",
 ] }
 
-ethers-core = { workspace = true, default-features = false }
+ethers-core = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0" }
 bytes = { version = "1.4" }

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -10,12 +10,8 @@ keywords = ["ethereum", "web3", "solidity"]
 
 [dependencies]
 foundry-config = { path = "../config" }
-ethers-solc = { workspace = true, default-features = false, features = [
-    "async",
-    "svm-solc",
-    "project-util",
-] }
-ethers-contract = { workspace = true, default-features = false, features = ["abigen"] }
+ethers-solc = { workspace = true, features = ["async", "svm-solc", "project-util"] }
+ethers-contract = { workspace = true, features = ["abigen"] }
 curl = { version = "0.4", default-features = false, features = ["http2"] }
 eyre = "0.6"
 git2 = { version = "0.16.1", default-features = false }

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -14,11 +14,11 @@ foundry-config = { path = "./../config" }
 foundry-common = { path = "./../common" }
 
 futures = "0.3.27"
-ethers-etherscan = { workspace = true, default-features = false }
-ethers-contract = { workspace = true, default-features = false, features = ["abigen"] }
-ethers-core = { workspace = true, default-features = false }
-ethers-providers = { workspace = true, default-features = false }
-ethers-signers = { workspace = true, default-features = false }
+ethers-etherscan = { workspace = true }
+ethers-contract = { workspace = true, features = ["abigen"] }
+ethers-core = { workspace = true }
+ethers-providers = { workspace = true }
+ethers-signers = { workspace = true }
 eyre = "0.6.8"
 rustc-hex = "2.1.0"
 serde = "1.0.159"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ cast = { path = "../cast" }
 ui = { path = "../ui" }
 
 # eth
-ethers = { workspace = true, default-features = false, features = ["rustls"] }
+ethers = { workspace = true, features = ["rustls"] }
 solang-parser = "=0.2.3"
 
 # cli

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -7,14 +7,15 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
-tempfile = "3.5"
-ethers-solc = { workspace = true, default-features = false, features = ["project-util"] }
-ethers = { workspace = true, default-features = false }
-
-walkdir = "2.3"
-once_cell = "1.17"
 foundry-config = { path = "../../config" }
 foundry-common = { path = "../../common" }
+
+ethers = { workspace = true }
+ethers-solc = { workspace = true, features = ["project-util"] }
+
+tempfile = "3.5"
+walkdir = "2.3"
+once_cell = "1.17"
 serde_json = "1.0.95"
 parking_lot = "0.12"
 eyre = "0.6"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-config = { path = "../config" }
 
 # eth
-ethers-core = { workspace = true, default-features = false }
-ethers-solc = { workspace = true, default-features = false }
-ethers-providers = { workspace = true, default-features = false }
-ethers-middleware = { workspace = true, default-features = false }
-ethers-etherscan = { workspace = true, default-features = false, features = ["ethers-solc"] }
+ethers-core = { workspace = true }
+ethers-solc = { workspace = true }
+ethers-providers = { workspace = true }
+ethers-middleware = { workspace = true }
+ethers-etherscan = { workspace = true, features = ["ethers-solc"] }
 
 # io
 reqwest = { version = "0.11", default-features = false }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 
 [dependencies]
 # eth
-ethers-core = { workspace = true, default-features = false }
-ethers-solc = { workspace = true, default-features = false, features = ["async", "svm-solc"] }
-ethers-etherscan = { workspace = true, default-features = false }
+ethers-core = { workspace = true }
+ethers-solc = { workspace = true, features = ["async", "svm-solc"] }
+ethers-etherscan = { workspace = true }
 
 # formats
 Inflector = "0.11.4"

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -16,8 +16,8 @@ foundry-config = { path = "../config" }
 foundry-utils = { path = "../utils" }
 
 # ethers
-ethers-solc = { workspace = true, default-features = false, features = ["async"] }
-ethers-core = { workspace = true, default-features = false }
+ethers-solc = { workspace = true, features = ["async"] }
+ethers-core = { workspace = true }
 
 # cli
 clap = { version = "4.2", features = ["derive", "env", "unicode", "wrap_help"] }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -16,7 +16,7 @@ foundry-macros = { path = "../macros" }
 serde_json = "1.0.95"
 serde = "1.0.159"
 hex = "0.4.3"
-ethers = { workspace = true, default-features = false, features = ["solc-full", "abigen"] }
+ethers = { workspace = true, features = ["solc-full", "abigen"] }
 jsonpath_lib = "0.3.0"
 
 # Error handling

--- a/fmt/Cargo.toml
+++ b/fmt/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ethereum", "web3", "solidity", "linter"]
 foundry-config = { path = "../config" }
 
 # ethers
-ethers-core = { workspace = true, default-features = false }
+ethers-core = { workspace = true }
 
 # parser
 solang-parser = "=0.2.3"

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -10,7 +10,7 @@ foundry-common = { path = "./../common" }
 foundry-config = { path = "./../config" }
 foundry-evm = { path = "./../evm" }
 
-ethers = { workspace = true, default-features = false, features = ["solc-full"] }
+ethers = { workspace = true, features = ["solc-full"] }
 eyre = "0.6.8"
 semver = "1.0.17"
 serde_json = "1.0.95"
@@ -31,5 +31,5 @@ comfy-table = "6.1.4"
 parking_lot = "0.12"
 
 [dev-dependencies]
-ethers = { workspace = true, default-features = false, features = ["solc-full", "solc-tests"] }
+ethers = { workspace = true, features = ["solc-full", "solc-tests"] }
 foundry-utils = { path = "./../utils", features = ["test"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/foundry-rs/foundry"
 foundry-macros-impl = { path = "./impl" }
 foundry-common = { path = "../common" }
 
-ethers-core = { workspace = true, default-features = false }
+ethers-core = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,21 +7,19 @@ readme = "README.md"
 repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
-ethers-core = { workspace = true, default-features = false }
-ethers-contract = { workspace = true, default-features = false, features = [
-    "abigen",
-] }
-ethers-etherscan = { workspace = true, default-features = false }
-ethers-addressbook = { workspace = true, default-features = false }
-ethers-providers = { workspace = true, default-features = false }
-ethers-solc = { workspace = true, default-features = false }
+forge-fmt = { path = "../fmt" }
+
+ethers-core = { workspace = true }
+ethers-contract = { workspace = true, features = ["abigen"] }
+ethers-etherscan = { workspace = true }
+ethers-addressbook = { workspace = true }
+ethers-providers = { workspace = true }
+ethers-solc = { workspace = true }
+
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
 ], optional = true }
-
-forge-fmt = { path = "../fmt" }
-
 eyre = { version = "0.6.8", default-features = false }
 hex = "0.4.3"
 reqwest = { version = "0.11.16", default-features = false, features = ["json", "rustls"] }
@@ -38,9 +36,7 @@ glob = "0.3.1"
 
 [dev-dependencies]
 foundry-common = { path = "./../common" }
-ethers = { workspace = true, default-features = false, features = [
-    "solc-full",
-] }
+ethers = { workspace = true, features = ["solc-full"] }
 pretty_assertions = "1.3.0"
 
 [features]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

```log
warning: /path/to/Cargo.toml: `default-features` is ignored for ethers, since `default-features` was not specified for `workspace.dependencies.ethers`, this could become a hard error in the future
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `default-features = false` for `workspace.dependencies.ethers[-*]`, and remove it from all the workspace crates

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
