### PR TITLE
feat: pretty print json test results

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -496,7 +496,7 @@ fn test(
 
     if json {
         let results = runner.test(&filter, None, test_options)?;
-        println!("{}", serde_json::to_string(&results)?);
+        println!("{}", serde_json::to_string_pretty(&results)?);
         Ok(TestOutcome::new(results, allow_failure))
     } else {
         // Set up identifiers


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
issue #4725

## Motivation
The default print test results in `json` result is unreadable. It would be nice if the options provided a readable json out. 

![Screenshot from 2023-04-12 17-44-08](https://user-images.githubusercontent.com/30603522/231497033-1534faf3-c183-4c8f-834b-5d422537a376.png)


## Solution
Add the `pretty print` option provided by serde_json

_after the code change_
![image](https://user-images.githubusercontent.com/30603522/231497283-4b6f0a35-c4f6-4d70-9d34-a854aa1f33cb.png)





