### PR TITLE
chore: rm redundant Arc

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -32,10 +32,7 @@ use rustc_hex::{FromHexIter, ToHex};
 use std::{
     path::PathBuf,
     str::FromStr,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicBool, Ordering},
 };
 pub use tx::TxBuilder;
 use tx::{TxBuilderOutput, TxBuilderPeekOutput};
@@ -1693,14 +1690,10 @@ impl SimpleCast {
         };
 
         let num_threads = num_cpus::get();
-        let found = Arc::new(AtomicBool::new(false));
+        let found = AtomicBool::new(false);
 
-        let result: Option<(u32, String, String)> = std::iter::repeat(Arc::clone(&found))
-            .take(num_threads)
-            .enumerate()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .find_map_any(|(i, found)| {
+        let result: Option<(u32, String, String)> =
+            (0..num_threads).into_par_iter().find_map_any(|i| {
                 let nonce_start = i as u32;
                 let nonce_step = num_threads as u32;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I added this in https://github.com/foundry-rs/foundry/pull/4705
as @DaniPopes correctly pointed out, this is not needed because rayon's closures don't require 'static and AtomicBool isn't even Copy
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
