### PR TITLE
fix(anvil): dont adjust from block

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1162,7 +1162,12 @@ impl Backend {
             let to_block =
                 self.convert_block_number(filter.block_option.get_to_block().copied()).min(best);
             let from_block =
-                self.convert_block_number(filter.block_option.get_from_block().copied()).min(best);
+                self.convert_block_number(filter.block_option.get_from_block().copied());
+            if from_block > best {
+                // requested log range does not exist yet
+                return Ok(vec![])
+            }
+
             self.logs_for_range(&filter, from_block, to_block).await
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/4729

removes a check that could lead to unrequested logs because we forcefully set the lower bound to the best block

eg:

`from_block: 5`
`best: 4`
would include logs of block 4
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
