### PR TITLE
Use XDG Base Directory specification in installation files

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$XDG_DATA_HOME/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$XDG_DATA_HOME/.foundry"}
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$BASE_DIR/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 

--- a/foundryup/install
+++ b/foundryup/install
@@ -3,12 +3,14 @@ set -e
 
 echo Installing foundryup...
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$XDG_DATA_HOME/.foundry"}
+BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$BASE_DIR/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
 BIN_URL="https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup"
 BIN_PATH="$FOUNDRY_BIN_DIR/foundryup"
+
 
 # Create the .foundry bin directory and foundryup binary if it doesn't exist.
 mkdir -p $FOUNDRY_BIN_DIR

--- a/foundryup/install
+++ b/foundryup/install
@@ -3,7 +3,7 @@ set -e
 
 echo Installing foundryup...
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$XDG_DATA_HOME/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 


### PR DESCRIPTION
## Motivation

The installation scripts assume `$HOME` as the default directory to store foundry files. This is not wrong, but we are defiling the `$HOME` directory. 
Some users might have proper configurations so that application-specific data is stored somewhere else logically.
We should follow [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) specification.


## Solution

Following XDG Base Directory specification, this kind of data should be in `$XDG_DATA_HOME`.
This PR updates the installation scripts to use this variable instead of `$HOME`,
