### PR TITLE
Make foundryup installation script more flexible for ZSH users

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -18,10 +18,10 @@ chmod +x $BIN_PATH
 # Create the man directory for future man files if it doesn't exist.
 mkdir -p $FOUNDRY_MAN_DIR
 
-# Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
+# Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE=${ZDOTDIR-"$HOME"}/.zshrc
+    PROFILE=${ZDOTDIR-"$HOME"}/.zshenv
     PREF_SHELL=zsh
     ;;
 */bash)

--- a/foundryup/install
+++ b/foundryup/install
@@ -21,7 +21,7 @@ mkdir -p $FOUNDRY_MAN_DIR
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE=$HOME/.zshrc
+    PROFILE=${ZDOTDIR-"$HOME"}/.zshrc
     PREF_SHELL=zsh
     ;;
 */bash)


### PR DESCRIPTION
## Motivation

So far, the `foundryup` installation script assumes that if the preferred shell is zsh, then the path to the foundry binary will be stored in the `$HOME/.zshrc`.
This could trap zsh users because they could have their zsh configuration elsewhere. This script will create a file on the $HOME directory, forcing zsh users to copy that line to the correct file and then remove the newly created file. 
We should use the `$ZDOTDIR` value instead; if this value is unset, it will default to `$HOME`.

Another thing is that following [zsh documentation](https://zsh.sourceforge.io/Intro/intro_3.html), `.zshrc` is not the correct file to store paths. Instead, we should use `.zshenv` because this file is executed for all zsh shells, whether they are interactive or not. 
The `.zshrc` file configures the user's interactive shell sessions. In contrast, the `.zshenv` file sets environment variables that should be available to all zsh sessions on the system.


## Solution

This PR makes the installation script more flexible for zsh users. 
Now, the default profile will have the correct path and will write the path in the right file.
