### PR TITLE
Feat: add log hints to add `[x ether]` to Uints parsed in verbose output

### DIFF
--- a/common/src/abi.rs
+++ b/common/src/abi.rs
@@ -157,8 +157,8 @@ pub fn format_uint_with_ether_conversion(num: &U256) -> String {
 
     // skip printing the ether conversion if:
     // - it is zero
-    // - it is too small (less than 0.0001 ether)
-    // - it is too big (more than 1 million ether)
+    // - it is less than 0.0001 ether
+    // - it is more than 1 million ether
     if eth == 0f32 || eth.abs().lt(&0.000_1f32) || eth.abs().gt(&1_000_000f32) {
         return num.to_string()
     } else {


### PR DESCRIPTION
## Motivation

Added log hints on Uint values printed by the logger converted in Ether.

Closes #4743 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I added a simple helper: `format_uint_with_ether_conversion` which appends a dimmed `[x ether]` text at the end of the parsed Uint.

I added some heuristics to try and make the hints more useful for debugging: the conversion is skipped if the amount is `0`, if it's less than `0.0001 ether` or more than `1 million` ether. 


## Notes

- I think log hints could make the debugging experience nicer, and this is just a small step in that direction
- Should there be the possibility to show these hints only on a specific verbosity level or to turn them off completely?

## Preview

Here is a preview of what it looks like:

<img width="458" alt="example_eth_1" src="https://user-images.githubusercontent.com/48695862/232226969-74ca3a71-8ec8-44f9-b530-7388a17ae391.png">

I've also tested it on `uniswap/permit2` to see how it would look like on a larger codebase. Here's a test taken from that repo:

<img width="1703" alt="example_permit2" src="https://user-images.githubusercontent.com/48695862/232227106-d738ade3-9822-4f2a-b595-6378d0e8b295.png">


