### PR TITLE
Feat: Add --parse-bytes32-address

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1274,6 +1274,24 @@ impl SimpleCast {
         Ok(parse_bytes32_string(&buffer)?.to_owned())
     }
 
+    /// Decodes checksummed address from bytes32 value
+    pub fn parse_bytes32_address(s: &str) -> Result<String> {
+        let s = strip_0x(s);
+        if s.len() != 64 {
+            eyre::bail!("string not 32 bytes");
+        }
+
+        let s = strip_12_zero_bytes(s);
+        if s.len() != 40 {
+            eyre::bail!("Not convertible to address, there are non-zero bytes");
+        }
+
+        let lowercase_address_string = format!("0x{s}");
+        let lowercase_address = Address::from_str(&lowercase_address_string)?;
+
+        Ok(utils::to_checksum(&lowercase_address, None))
+    }
+
     /// Decodes abi-encoded hex input or output
     ///
     /// # Example
@@ -1722,6 +1740,10 @@ impl SimpleCast {
 
 fn strip_0x(s: &str) -> &str {
     s.strip_prefix("0x").unwrap_or(s)
+}
+
+fn strip_12_zero_bytes(s: &str) -> &str {
+    s.strip_prefix("000000000000000000000000").unwrap_or(s)
 }
 
 #[cfg(test)]

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -157,6 +157,10 @@ async fn main() -> eyre::Result<()> {
             let value = stdin::unwrap_line(bytes)?;
             println!("{}", SimpleCast::parse_bytes32_string(&value)?);
         }
+        Subcommands::ParseBytes32Address { bytes } => {
+            let value = stdin::unwrap_line(bytes)?;
+            println!("{}", SimpleCast::parse_bytes32_address(&value)?);
+        }
 
         // ABI encoding & decoding
         Subcommands::AbiDecode { sig, calldata, input } => {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -876,6 +876,12 @@ Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
     },
+    #[clap(name = "--parse-bytes32-address")]
+    #[clap(about = "Parses a checksummed address from bytes32 encoding.")]
+    ParseBytes32Address {
+        #[clap(value_name = "BYTES")]
+        bytes: Option<String>,
+    },
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -355,3 +355,11 @@ casttest!(cast_receipt_revert_reason, |_: TestProject, mut cmd: TestCommand| {
     assert!(output.contains("revertReason"));
     assert!(output.contains("Transaction too old"));
 });
+
+// tests that `cast --parse-bytes32-address` command is working correctly.
+casttest!(parse_bytes32_address, |_: TestProject, mut cmd: TestCommand| {
+    // Call `cast find-block`
+    cmd.args(["--parse-bytes32-address", "0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Add the `--parse-bytes32-address` option to `cast`. Earlier today, I was reading storage values and couldn't find a way to parse them into a checksummed address, i.e. go from this : `0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045` to this : `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implemented it

## Other

I'm new to Rust and contributing (and quite proud of this PR actually), so feel free to provide any feedback.