### PR TITLE
refactor/docs: rewrite clap attributes to use doc comments

### DIFF
--- a/anvil/src/anvil.rs
+++ b/anvil/src/anvil.rs
@@ -15,12 +15,15 @@ pub struct App {
 
 #[derive(Clone, Debug, Subcommand, Eq, PartialEq)]
 pub enum Commands {
-    #[clap(visible_alias = "com", about = "Generate shell completions script.")]
+    /// Generate shell completions script.
+    #[clap(visible_alias = "com")]
     Completions {
         #[clap(value_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
+
+    /// Generate Fig autocompletion spec.
+    #[clap(visible_alias = "fig")]
     GenerateFigSpec,
 }
 

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -31,158 +31,114 @@ pub struct NodeArgs {
     #[clap(flatten)]
     pub evm_opts: AnvilEvmArgs,
 
-    #[clap(
-        long,
-        short,
-        help = "Port number to listen on.",
-        default_value = "8545",
-        value_name = "NUM"
-    )]
+    /// Port number to listen on.
+    #[clap(long, short, default_value = "8545", value_name = "NUM")]
     pub port: u16,
 
-    #[clap(
-        long,
-        short,
-        help = "Number of dev accounts to generate and configure.",
-        default_value = "10",
-        value_name = "NUM"
-    )]
+    /// Number of dev accounts to generate and configure.
+    #[clap(long, short, default_value = "10", value_name = "NUM")]
     pub accounts: u64,
 
-    #[clap(
-        long,
-        help = "The balance of every dev account in Ether.",
-        default_value = "10000",
-        value_name = "NUM"
-    )]
+    /// The balance of every dev account in Ether.
+    #[clap(long, default_value = "10000", value_name = "NUM")]
     pub balance: u64,
 
-    #[clap(long, help = "The timestamp of the genesis block", value_name = "NUM")]
+    /// The timestamp of the genesis block.
+    #[clap(long, value_name = "NUM")]
     pub timestamp: Option<u64>,
 
-    #[clap(
-        long,
-        short,
-        help = "BIP39 mnemonic phrase used for generating accounts",
-        value_name = "MNEMONIC"
-    )]
+    /// BIP39 mnemonic phrase used for generating accounts.
+    #[clap(long, short)]
     pub mnemonic: Option<String>,
 
-    #[clap(
-        long,
-        help = "Sets the derivation path of the child key to be derived. [default: m/44'/60'/0'/0/]",
-        value_name = "DERIVATION_PATH"
-    )]
+    /// Sets the derivation path of the child key to be derived.
+    ///
+    /// [default: m/44'/60'/0'/0/]
+    #[clap(long)]
     pub derivation_path: Option<String>,
 
     #[clap(flatten)]
     pub server_config: ServerConfig,
 
-    #[clap(long, help = "Don't print anything on startup and don't print logs")]
+    /// Don't print anything on startup and don't print logs
+    #[clap(long)]
     pub silent: bool,
 
-    #[clap(long, help = "The EVM hardfork to use.", value_name = "HARDFORK", value_parser = Hardfork::from_str)]
+    /// The EVM hardfork to use.
+    #[clap(long, value_parser = Hardfork::from_str)]
     pub hardfork: Option<Hardfork>,
 
-    #[clap(
-        short,
-        long,
-        visible_alias = "blockTime",
-        help = "Block time in seconds for interval mining.",
-        name = "block-time",
-        value_name = "SECONDS"
-    )]
+    /// Block time in seconds for interval mining.
+    #[clap(short, long, visible_alias = "blockTime", name = "block-time", value_name = "SECONDS")]
     pub block_time: Option<u64>,
 
-    #[clap(
-        long,
-        help = "Writes output of `anvil` as json to user-specified file",
-        value_name = "OUT_FILE"
-    )]
+    /// Writes output of `anvil` as json to user-specified file.
+    #[clap(long, value_name = "OUT_FILE")]
     pub config_out: Option<String>,
 
-    #[clap(
-        long,
-        visible_alias = "no-mine",
-        help = "Disable auto and interval mining, and mine on demand instead.",
-        conflicts_with = "block-time"
-    )]
+    /// Disable auto and interval mining, and mine on demand instead.
+    #[clap(long, visible_alias = "no-mine", conflicts_with = "block-time")]
     pub no_mining: bool,
 
-    #[clap(
-        long,
-        help = "The host the server will listen on",
-        value_name = "IP_ADDR",
-        env = "ANVIL_IP_ADDR",
-        help_heading = "Server options"
-    )]
+    /// The host the server will listen on.
+    #[clap(long, value_name = "IP_ADDR", env = "ANVIL_IP_ADDR", help_heading = "Server options")]
     pub host: Option<IpAddr>,
 
-    #[clap(
-        long,
-        help = "How transactions are sorted in the mempool",
-        default_value = "fees",
-        value_name = "ORDER"
-    )]
+    /// How transactions are sorted in the mempool.
+    #[clap(long, default_value = "fees")]
     pub order: TransactionOrder,
 
-    #[clap(
-        long,
-        help = "Initialize the genesis block with the given `genesis.json` file.",
-        value_name = "PATH",
-        value_parser = Genesis::parse
-    )]
+    /// Initialize the genesis block with the given `genesis.json` file.
+    #[clap(long, value_name = "PATH", value_parser = Genesis::parse)]
     pub init: Option<Genesis>,
 
+    /// This is an alias for bot --load-state and --dump-state.
+    ///
+    /// It initializes the chain with the state stored at the file, if it exists, and dumps the
+    /// chain's state on exit.
     #[clap(
         long,
-        help = "This is an alias for bot --load-state and --dump-state. It initializes the chain with the state stored at the file, if it exists, and dumps the chain's state on exit",
         value_name = "PATH",
         value_parser = StateFile::parse,
-        conflicts_with_all = &["init", "dump_state", "load_state"]
+        conflicts_with_all = &[
+            "init",
+            "dump_state",
+            "load_state"
+        ]
     )]
     pub state: Option<StateFile>,
 
-    #[clap(
-        short,
-        long,
-        help = "Interval in seconds at which the status is to be dumped to disk. See --state and --dump-state",
-        value_name = "SECONDS"
-    )]
+    /// Interval in seconds at which the status is to be dumped to disk.
+    ///
+    /// See --state and --dump-state
+    #[clap(short, long, value_name = "SECONDS")]
     pub state_interval: Option<u64>,
 
-    #[clap(
-        long,
-        help = "Dump the state of chain on exit to the given file. If the value is a directory, the state will be written to `<VALUE>/state.json`.",
-        value_name = "PATH",
-        conflicts_with = "init"
-    )]
+    /// Dump the state of chain on exit to the given file.
+    ///
+    /// If the value is a directory, the state will be written to `<VALUE>/state.json`.
+    #[clap(long, value_name = "PATH", conflicts_with = "init")]
     pub dump_state: Option<PathBuf>,
 
+    /// Initialize the chain from a previously saved state snapshot.
     #[clap(
         long,
-        help = "Initialize the chain from a previously saved state snapshot.",
         value_name = "PATH",
         value_parser = SerializableState::parse,
         conflicts_with = "init"
     )]
     pub load_state: Option<SerializableState>,
 
-    #[clap(
-        long,
-        help = IPC_HELP,
-        value_name = "PATH",
-        visible_alias = "ipcpath"
-    )]
+    #[clap(long, value_name = "PATH", visible_alias = "ipcpath")]
     pub ipc: Option<Option<String>>,
 
-    #[clap(
-        long,
-        help = "Don't keep full chain history. If a number argument is specified, at most this number of states is kept in memory."
-    )]
+    /// Don't keep full chain history.
+    /// If a number argument is specified, at most this number of states is kept in memory.
+    #[clap(long)]
     pub prune_history: Option<Option<usize>>,
 
-    #[clap(long, help = "Number of blocks with transactions to keep in memory.")]
+    /// Number of blocks with transactions to keep in memory.
+    #[clap(long)]
     pub transaction_block_keeper: Option<usize>,
 }
 
@@ -429,7 +385,6 @@ pub struct AnvilEvmArgs {
         long,
         requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
-        help = "Disables rate limiting for this node provider.",
         help_heading = "Fork config",
         visible_alias = "no-rpc-rate-limit"
     )]
@@ -446,12 +401,7 @@ pub struct AnvilEvmArgs {
     pub no_storage_caching: bool,
 
     /// The block gas limit.
-    #[clap(
-        long,
-        value_name = "GAS_LIMIT",
-        alias = "block-gas-limit",
-        help_heading = "Environment config"
-    )]
+    #[clap(long, alias = "block-gas-limit", help_heading = "Environment config")]
     pub gas_limit: Option<u64>,
 
     /// Disable the `call.gas_limit <= block.gas_limit` constraint.
@@ -470,7 +420,7 @@ pub struct AnvilEvmArgs {
     pub code_size_limit: Option<usize>,
 
     /// The gas price.
-    #[clap(long, value_name = "GAS_PRICE", help_heading = "Environment config")]
+    #[clap(long, help_heading = "Environment config")]
     pub gas_price: Option<u64>,
 
     /// The base fee in a block.
@@ -483,14 +433,11 @@ pub struct AnvilEvmArgs {
     pub block_base_fee_per_gas: Option<u64>,
 
     /// The chain ID.
-    #[clap(long, alias = "chain", value_name = "CHAIN_ID", help_heading = "Environment config")]
+    #[clap(long, alias = "chain", help_heading = "Environment config")]
     pub chain_id: Option<Chain>,
 
-    #[clap(
-        long,
-        help = "Enable steps tracing used for debug calls returning geth-style traces",
-        visible_alias = "tracing"
-    )]
+    /// Enable steps tracing used for debug calls returning geth-style traces
+    #[clap(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
 }
 

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -129,7 +129,7 @@ pub struct NodeArgs {
     )]
     pub load_state: Option<SerializableState>,
 
-    #[clap(long, value_name = "PATH", visible_alias = "ipcpath")]
+    #[clap(long, help = IPC_HELP, value_name = "PATH", visible_alias = "ipcpath")]
     pub ipc: Option<Option<String>>,
 
     /// Don't keep full chain history.

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -52,10 +52,19 @@ pub struct ChiselParser {
 pub enum ChiselParserSub {
     /// List all cached sessions
     List,
+
     /// Load a cached session
-    Load { id: String },
+    Load {
+        /// The ID of the session to load.
+        id: String,
+    },
+
     /// View the source of a cached session
-    View { id: String },
+    View {
+        /// The ID of the session to load.
+        id: String,
+    },
+
     /// Clear all cached chisel sessions from the cache directory
     ClearCache,
 }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -197,7 +197,7 @@ async fn main() -> eyre::Result<()> {
         }
 
         // Blockchain & RPC queries
-        Subcommands::AccessList { address, sig, args, block, to_json, rpc } => {
+        Subcommands::AccessList { address, sig, args, block, json, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let chain = utils::get_chain(config.chain_id, &provider).await?;
@@ -207,7 +207,7 @@ async fn main() -> eyre::Result<()> {
             builder.set_args(&sig, args).await?;
             let builder_output = builder.peek();
 
-            println!("{}", Cast::new(&provider).access_list(builder_output, block, to_json).await?);
+            println!("{}", Cast::new(&provider).access_list(builder_output, block, json).await?);
         }
         Subcommands::Age { block, rpc } => {
             let config = Config::from(&rpc);
@@ -217,11 +217,11 @@ async fn main() -> eyre::Result<()> {
                 Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
             );
         }
-        Subcommands::Balance { block, who, to_ether, rpc } => {
+        Subcommands::Balance { block, who, ether, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let value = Cast::new(provider).balance(who, block).await?;
-            if to_ether {
+            if ether {
                 println!("{}", SimpleCast::from_wei(&value.to_string(), "eth")?);
             } else {
                 println!("{value}");
@@ -235,13 +235,13 @@ async fn main() -> eyre::Result<()> {
                 Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
             );
         }
-        Subcommands::Block { block, full, field, to_json, rpc } => {
+        Subcommands::Block { block, full, field, json, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             println!(
                 "{}",
                 Cast::new(provider)
-                    .block(block.unwrap_or(BlockId::Number(Latest)), full, field, to_json)
+                    .block(block.unwrap_or(BlockId::Number(Latest)), full, field, json)
                     .await?
             );
         }
@@ -332,22 +332,22 @@ async fn main() -> eyre::Result<()> {
                 println!("{}", serde_json::json!(receipt));
             }
         }
-        Subcommands::Receipt { tx_hash, field, to_json, cast_async, confirmations, rpc } => {
+        Subcommands::Receipt { tx_hash, field, json, cast_async, confirmations, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             println!(
                 "{}",
                 Cast::new(provider)
-                    .receipt(tx_hash, field, confirmations, cast_async, to_json)
+                    .receipt(tx_hash, field, confirmations, cast_async, json)
                     .await?
             );
         }
         Subcommands::Run(cmd) => cmd.run().await?,
         Subcommands::SendTx(cmd) => cmd.run().await?,
-        Subcommands::Tx { tx_hash, field, to_json, rpc } => {
+        Subcommands::Tx { tx_hash, field, json, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", Cast::new(&provider).transaction(tx_hash, field, to_json).await?)
+            println!("{}", Cast::new(&provider).transaction(tx_hash, field, json).await?)
         }
 
         // 4Byte

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -12,23 +12,19 @@ use std::str::FromStr;
 
 #[derive(Debug, Parser)]
 pub struct CallArgs {
-    #[clap(
-        help = "The destination of the transaction.", 
-        value_name = "TO",
-        value_parser = NameOrAddress::from_str
-    )]
+    /// The destination of the transaction.
+    #[clap(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
-    #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+    /// The signature of the function to call.
     sig: Option<String>,
 
-    #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+    /// The arguments of the function to call.
     args: Vec<String>,
 
+    /// Data for the transaction.
     #[clap(
         long,
-        help = "Data for the transaction.",
-        value_name = "DATA",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix,
         conflicts_with_all = &["sig", "args"]
     )]
@@ -40,41 +36,40 @@ pub struct CallArgs {
     #[clap(flatten)]
     eth: EthereumOpts,
 
-    #[clap(
-        long,
-        short,
-        help = "The block height you want to query at.",
-        long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-        value_name = "BLOCK"
-    )]
+    /// The block height to to query at.
+    ///
+    /// Can also be the tags earliest, finalized, safe, latest, or pending.
+    #[clap(long, short)]
     block: Option<BlockId>,
 
+    /// Simulate a contract deployment.
     #[clap(subcommand)]
     command: Option<CallSubcommands>,
 }
 
 #[derive(Debug, Parser)]
 pub enum CallSubcommands {
-    #[clap(name = "--create", about = "Simulate a contract deployment.")]
+    #[clap(name = "--create")]
     Create {
-        #[clap(help = "Bytecode of contract.", value_name = "CODE")]
+        /// Bytecode of contract.
         code: String,
-        #[clap(help = "The signature of the constructor.", value_name = "SIG")]
-        sig: Option<String>,
-        #[clap(help = "Constructor arguments", value_name = "ARGS")]
-        args: Vec<String>,
-        #[clap(
-            long,
-            help = "Ether to send in the transaction.",
-            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
 
-Examples: 1ether, 10gwei, 0.01ether"#,
-            value_parser = parse_ether_value,
-            value_name = "VALUE"
-        )]
+        /// The signature of the constructor.
+        sig: Option<String>,
+
+        /// The arguments of the constructor.
+        args: Vec<String>,
+
+        /// Ether to send in the transaction.
+        ///
+        /// Either specified in wei, or as a string with a unit type.
+        ///
+        /// Examples: 1ether, 10gwei, 0.01ether
+        #[clap(long, value_parser = parse_ether_value)]
         value: Option<U256>,
     },
 }
+
 impl CallArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let CallArgs { to, sig, args, data, tx, eth, command, block } = self;

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -36,7 +36,7 @@ pub struct CallArgs {
     #[clap(flatten)]
     eth: EthereumOpts,
 
-    /// The block height to to query at.
+    /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
     #[clap(long, short)]

--- a/cli/src/cmd/cast/create2.rs
+++ b/cli/src/cmd/cast/create2.rs
@@ -16,55 +16,49 @@ use std::{str::FromStr, time::Instant};
 /// CLI arguments for `cast create2`.
 #[derive(Debug, Clone, Parser)]
 pub struct Create2Args {
+    /// Prefix for the contract address.
     #[clap(
         long,
         short,
-        help = "Prefix for the contract address.",
         required_unless_present_any = &["ends-with", "matching"],
         value_name = "HEX"
     )]
     starts_with: Option<String>,
-    #[clap(
-        long,
-        short,
-        help = "Suffix for the contract address.",
-        value_name = "HEX",
-        name = "ends-with"
-    )]
+
+    /// Suffix for the contract address.
+    #[clap(long, short, value_name = "HEX")]
     ends_with: Option<String>,
-    #[clap(long, short, help = "Sequence that the address has to match", value_name = "HEX")]
+
+    /// Sequence that the address has to match.
+    #[clap(long, short, value_name = "HEX")]
     matching: Option<String>,
+
+    /// Case sensitive matching.
     #[clap(short, long)]
     case_sensitive: bool,
+
+    /// Address of the contract deployer.
     #[clap(
         short,
         long,
-        help = "Address of the contract deployer.",
         default_value = "0x4e59b44847b379578588920ca78fbf26c0b4956c",
         value_name = "ADDRESS"
     )]
     deployer: Address,
-    #[clap(
-        short,
-        long,
-        help = "Init code of the contract to be deployed.",
-        value_name = "HEX",
-        default_value = ""
-    )]
+
+    /// Init code of the contract to be deployed.
+    #[clap(short, long, value_name = "HEX", default_value = "")]
     init_code: String,
-    #[clap(
-        alias = "ch",
-        long,
-        help = "Init code hash the contract to be deployed.",
-        value_name = "HEX"
-    )]
+
+    /// Init code hash of the contract to be deployed.
+    #[clap(alias = "ch", long, value_name = "HASH")]
     init_code_hash: Option<String>,
 }
 
 #[allow(dead_code)]
 pub struct Create2Output {
-    address: Address,
-    salt: U256,
+    pub address: Address,
+    pub salt: U256,
 }
 
 impl Cmd for Create2Args {

--- a/cli/src/cmd/cast/create2.rs
+++ b/cli/src/cmd/cast/create2.rs
@@ -20,7 +20,7 @@ pub struct Create2Args {
     #[clap(
         long,
         short,
-        required_unless_present_any = &["ends-with", "matching"],
+        required_unless_present_any = &["ends_with", "matching"],
         value_name = "HEX"
     )]
     starts_with: Option<String>,

--- a/cli/src/cmd/cast/estimate.rs
+++ b/cli/src/cmd/cast/estimate.rs
@@ -13,17 +13,17 @@ use std::str::FromStr;
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
-    /// The destination of the transaction
+    /// The destination of the transaction.
     #[clap(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
-    /// The signature of the function to call
+    /// The signature of the function to call.
     sig: Option<String>,
 
-    /// The arguments of the function to call
+    /// The arguments of the function to call.
     args: Vec<String>,
 
-    /// The sender account
+    /// The sender account.
     #[clap(
         short,
         long,
@@ -33,7 +33,7 @@ pub struct EstimateArgs {
     )]
     from: NameOrAddress,
 
-    /// Ether to send in the transaction
+    /// Ether to send in the transaction.
     ///
     /// Either specified in wei, or as a string with a unit type:
     ///

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -11,7 +11,7 @@ use futures::join;
 /// CLI arguments for `cast find-block`.
 #[derive(Debug, Clone, Parser)]
 pub struct FindBlockArgs {
-    #[clap(help = "The UNIX timestamp to search for (in seconds)", value_name = "TIMESTAMP")]
+    /// The UNIX timestamp to search for, in seconds.
     timestamp: u64,
 
     #[clap(flatten)]
@@ -33,10 +33,10 @@ impl FindBlockArgs {
         let ts_block_latest = res.0?;
         let ts_block_1 = res.1?;
 
-        let block_num = if ts_block_latest.lt(&ts_target) {
+        let block_num = if ts_block_latest < ts_target {
             // If the most recent block's timestamp is below the target, return it
             last_block_num
-        } else if ts_block_1.gt(&ts_target) {
+        } else if ts_block_1 > ts_target {
             // If the target timestamp is below block 1's timestamp, return that
             U64::from(1_u64)
         } else {
@@ -44,7 +44,7 @@ impl FindBlockArgs {
             let mut low_block = U64::from(1_u64); // block 0 has a timestamp of 0: https://github.com/ethereum/go-ethereum/issues/17042#issuecomment-559414137
             let mut high_block = last_block_num;
             let mut matching_block: Option<U64> = None;
-            while high_block.gt(&low_block) && matching_block.is_none() {
+            while high_block > low_block && matching_block.is_none() {
                 // Get timestamp of middle block (this approach approach to avoids overflow)
                 let high_minus_low_over_2 = high_block
                     .checked_sub(low_block)
@@ -56,9 +56,9 @@ impl FindBlockArgs {
                 let ts_mid_block = cast_provider.timestamp(mid_block).await?;
 
                 // Check if we've found a match or should keep searching
-                if ts_mid_block.eq(&ts_target) {
+                if ts_mid_block == ts_target {
                     matching_block = Some(mid_block)
-                } else if high_block.checked_sub(low_block).unwrap().eq(&U64::from(1_u64)) {
+                } else if high_block.checked_sub(low_block).unwrap() == U64::from(1_u64) {
                     // The target timestamp is in between these blocks. This rounds to the
                     // highest block if timestamp is equidistant between blocks
                     let res = join!(
@@ -69,9 +69,9 @@ impl FindBlockArgs {
                     let ts_low = res.1.unwrap();
                     let high_diff = ts_high.checked_sub(ts_target).unwrap();
                     let low_diff = ts_target.checked_sub(ts_low).unwrap();
-                    let is_low = low_diff.lt(&high_diff);
+                    let is_low = low_diff < high_diff;
                     matching_block = if is_low { Some(low_block) } else { Some(high_block) }
-                } else if ts_mid_block.lt(&ts_target) {
+                } else if ts_mid_block < ts_target {
                     low_block = mid_block;
                 } else {
                     high_block = mid_block;

--- a/cli/src/cmd/cast/interface.rs
+++ b/cli/src/cmd/cast/interface.rs
@@ -8,34 +8,29 @@ use std::path::{Path, PathBuf};
 /// CLI arguments for `cast interface`.
 #[derive(Debug, Clone, Parser)]
 pub struct InterfaceArgs {
-    #[clap(
-        help = "The contract address, or the path to an ABI file.",
-        long_help = r#"The contract address, or the path to an ABI file.
-
-If an address is specified, then the ABI is fetched from Etherscan."#,
-        value_name = "PATH_OR_ADDRESS"
-    )]
+    /// The contract address, or the path to an ABI file.
+    ///
+    /// If an address is specified, then the ABI is fetched from Etherscan.
     path_or_address: String,
 
-    #[clap(long, short, help = "The name to use for the generated interface", value_name = "NAME")]
+    /// The name to use for the generated interface.
+    #[clap(long, short)]
     name: Option<String>,
 
-    #[clap(
-        long,
-        short,
-        default_value = "^0.8.10",
-        help = "Solidity pragma version.",
-        value_name = "VERSION"
-    )]
+    /// Solidity pragma version.
+    #[clap(long, short, default_value = "^0.8.10", value_name = "VERSION")]
     pragma: String,
 
+    /// The path to the output file.
+    ///
+    /// If not specified, the interface will be output to stdout.
     #[clap(
         short,
-        help = "The path to the output file.",
-        long_help = "The path to the output file. If not specified, the interface will be output to stdout.",
-        value_name = "PATH"
+        long,
+        value_hint = clap::ValueHint::FilePath,
+        value_name = "PATH",
     )]
-    output_location: Option<PathBuf>,
+    output: Option<PathBuf>,
 
     #[clap(flatten)]
     etherscan: EtherscanOpts,
@@ -43,7 +38,8 @@ If an address is specified, then the ABI is fetched from Etherscan."#,
 
 impl InterfaceArgs {
     pub async fn run(self) -> eyre::Result<()> {
-        let InterfaceArgs { path_or_address, name, pragma, output_location, etherscan } = self;
+        let InterfaceArgs { path_or_address, name, pragma, output: output_location, etherscan } =
+            self;
         let config = Config::from(&etherscan);
         let chain = config.chain_id.unwrap_or_default();
         let source = if Path::new(&path_or_address).exists() {

--- a/cli/src/cmd/cast/rpc.rs
+++ b/cli/src/cmd/cast/rpc.rs
@@ -26,7 +26,7 @@ pub struct RpcArgs {
     ///
     /// cast rpc eth_getBlockByNumber '["0x123", false]' --raw
     ///     => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }
-    #[clap(short = 'w', long)]
+    #[clap(long, short = 'w')]
     raw: bool,
 
     #[clap(flatten)]

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -27,7 +27,7 @@ pub struct RunArgs {
     tx_hash: String,
 
     /// Opens the transaction in the debugger.
-    #[clap(long, short = 'd')]
+    #[clap(long, short)]
     debug: bool,
 
     /// Print out opcode traces.

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -23,30 +23,31 @@ use yansi::Paint;
 /// CLI arguments for `cast run`.
 #[derive(Debug, Clone, Parser)]
 pub struct RunArgs {
-    #[clap(help = "The transaction hash.", value_name = "TXHASH")]
+    /// The transaction hash.
     tx_hash: String,
 
-    #[clap(long, short = 'd', help = "Debugs the transaction.")]
+    /// Opens the transaction in the debugger.
+    #[clap(long, short = 'd')]
     debug: bool,
 
-    #[clap(long, short = 't', help = "Print out opcode traces.")]
+    /// Print out opcode traces.
+    #[clap(long, short)]
     trace_printer: bool,
 
-    #[clap(
-        long,
-        short = 'q',
-        help = "Executes the transaction only with the state from the previous block. May result in different results than the live execution!"
-    )]
+    /// Executes the transaction only with the state from the previous block.
+    ///
+    /// May result in different results than the live execution!
+    #[clap(long, short)]
     quick: bool,
 
-    #[clap(long, short = 'v', help = "Prints full address")]
+    /// Prints the full address of the contract.
+    #[clap(long, short)]
     verbose: bool,
 
-    #[clap(
-        long,
-        help = "Labels address in the trace. 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth",
-        value_name = "LABEL"
-    )]
+    /// Label addresses in the trace.
+    ///
+    /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
+    #[clap(long, short)]
     label: Vec<String>,
 
     #[clap(flatten)]

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -17,10 +17,7 @@ pub struct SendTxArgs {
     /// The destination of the transaction.
     ///
     /// If not provided, you must use cast send --create.
-    #[clap(
-        value_parser = NameOrAddress::from_str,
-        value_name = "TO",
-    )]
+    #[clap(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
     /// The signature of the function to call.
@@ -40,7 +37,7 @@ pub struct SendTxArgs {
     eth: EthereumOpts,
 
     /// The number of confirmations until the receipt is fetched.
-    #[clap(long, default_value = "1", value_name = "CONFIRMATIONS")]
+    #[clap(long, default_value = "1")]
     confirmations: usize,
 
     /// Print the transaction receipt as JSON.

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -14,42 +14,41 @@ use std::str::FromStr;
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub struct SendTxArgs {
+    /// The destination of the transaction.
+    ///
+    /// If not provided, you must use cast send --create.
     #[clap(
-        help = "The destination of the transaction. If not provided, you must use cast send --create.",
         value_parser = NameOrAddress::from_str,
         value_name = "TO",
     )]
     to: Option<NameOrAddress>,
-    #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+
+    /// The signature of the function to call.
     sig: Option<String>,
-    #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+
+    /// The arguments of the function to call.
     args: Vec<String>,
-    #[clap(
-        long = "async",
-        env = "CAST_ASYNC",
-        name = "async",
-        alias = "cast-async",
-        help = "Only print the transaction hash and exit immediately."
-    )]
+
+    /// Only print the transaction hash and exit immediately.
+    #[clap(name = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
     cast_async: bool,
+
     #[clap(flatten)]
     tx: TransactionOpts,
+
     #[clap(flatten)]
     eth: EthereumOpts,
-    #[clap(
-        long,
-        help = "The number of confirmations until the receipt is fetched.",
-        default_value = "1",
-        value_name = "CONFIRMATIONS"
-    )]
+
+    /// The number of confirmations until the receipt is fetched.
+    #[clap(long, default_value = "1", value_name = "CONFIRMATIONS")]
     confirmations: usize,
-    #[clap(long = "json", short = 'j', help_heading = "Display options")]
-    to_json: bool,
-    #[clap(
-        long = "resend",
-        help = "Reuse the latest nonce for the sender account.",
-        conflicts_with = "nonce"
-    )]
+
+    /// Print the transaction receipt as JSON.
+    #[clap(long, short, help_heading = "Display options")]
+    json: bool,
+
+    /// Reuse the latest nonce for the sender account.
+    #[clap(long, conflicts_with = "nonce")]
     resend: bool,
 
     #[clap(subcommand)]
@@ -58,13 +57,16 @@ pub struct SendTxArgs {
 
 #[derive(Debug, Parser)]
 pub enum SendTxSubcommands {
-    #[clap(name = "--create", about = "Use to deploy raw contract bytecode")]
+    /// Use to deploy raw contract bytecode.
+    #[clap(name = "--create")]
     Create {
-        #[clap(help = "Bytecode of contract.", value_name = "CODE")]
+        /// The bytecode of the contract to deploy.
         code: String,
-        #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+
+        /// The signature of the function to call.
         sig: Option<String>,
-        #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+
+        /// The arguments of the function to call.
         args: Vec<String>,
     },
 }
@@ -79,7 +81,7 @@ impl SendTxArgs {
             mut args,
             mut tx,
             confirmations,
-            to_json,
+            json: to_json,
             resend,
             command,
         } = self;

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -32,18 +32,18 @@ const MIN_SOLC: Version = Version::new(0, 6, 5);
 /// CLI arguments for `cast storage`.
 #[derive(Debug, Clone, Parser)]
 pub struct StorageArgs {
-    /// The contract address
+    /// The contract address.
     #[clap(value_parser = NameOrAddress::from_str)]
     address: NameOrAddress,
 
-    /// The storage slot number
+    /// The storage slot number.
     #[clap(value_parser = parse_slot)]
     slot: Option<H256>,
 
-    /// The block height you want to query at
+    /// The block height to to query at.
     ///
-    /// Can also be the tags earliest, finalized, safe, latest, or pending
-    #[clap(long, short = 'B')]
+    /// Can also be the tags earliest, finalized, safe, latest, or pending.
+    #[clap(long, short)]
     block: Option<BlockId>,
 
     #[clap(flatten)]

--- a/cli/src/cmd/cast/storage.rs
+++ b/cli/src/cmd/cast/storage.rs
@@ -40,7 +40,7 @@ pub struct StorageArgs {
     #[clap(value_parser = parse_slot)]
     slot: Option<H256>,
 
-    /// The block height to to query at.
+    /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
     #[clap(long, short)]

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -13,64 +13,69 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Signature},
 };
-use eyre::Context;
 
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {
-    #[clap(name = "new", visible_alias = "n", about = "Create a new random keypair.")]
+    /// Create a new random keypair.
+    #[clap(visible_alias = "n")]
     New {
-        #[clap(
-            help = "If provided, then keypair will be written to an encrypted JSON keystore.",
-            value_name = "PATH"
-        )]
+        /// If provided, then keypair will be written to an encrypted JSON keystore.
         path: Option<String>,
-        #[clap(
-            long,
-            short,
-            help = r#"Deprecated: prompting for a hidden password is now the default.
-            Triggers a hidden password prompt for the JSON keystore."#,
-            conflicts_with = "unsafe_password",
-            requires = "path"
-        )]
+
+        /// Triggers a hidden password prompt for the JSON keystore.
+        ///
+        /// Deprecated: prompting for a hidden password is now the default.
+        #[clap(long, short, requires = "path", conflicts_with = "unsafe_password")]
         password: bool,
-        #[clap(
-            long,
-            help = "Password for the JSON keystore in cleartext. This is UNSAFE to use and we recommend using the --password.",
-            requires = "path",
-            env = "CAST_PASSWORD",
-            value_name = "PASSWORD"
-        )]
+
+        /// Password for the JSON keystore in cleartext.
+        ///
+        /// This is UNSAFE to use and we recommend using the --password.
+        #[clap(long, requires = "path", env = "CAST_PASSWORD", value_name = "PASSWORD")]
         unsafe_password: Option<String>,
     },
-    #[clap(name = "vanity", visible_alias = "va", about = "Generate a vanity address.")]
+
+    /// Generate a vanity address.
+    #[clap(visible_alias = "va")]
     Vanity(VanityArgs),
-    #[clap(name = "address", visible_aliases = &["a", "addr"], about = "Convert a private key to an address.")]
+
+    /// Convert a private key to an address.
+    #[clap(visible_aliases = &["a", "addr"])]
     Address {
+        /// If provided, the address will be derived from the specified private key.
         #[clap(
-            help = "If provided, the address will be derived from the specified private key.",
             value_name = "PRIVATE_KEY",
-            value_parser = foundry_common::clap_helpers::strip_0x_prefix
+            value_parser = foundry_common::clap_helpers::strip_0x_prefix,
         )]
         private_key_override: Option<String>,
+
         #[clap(flatten)]
         wallet: Wallet,
     },
-    #[clap(name = "sign", visible_alias = "s", about = "Sign a message.")]
+
+    /// Sign a message.
+    #[clap(visible_alias = "s")]
     Sign {
-        #[clap(help = "message to sign", value_name = "MESSAGE")]
+        /// The message to sign.
         message: String,
+
         #[clap(flatten)]
         wallet: Wallet,
     },
-    #[clap(name = "verify", visible_alias = "v", about = "Verify the signature of a message.")]
+
+    /// Verify the signature of a message.
+    #[clap(visible_alias = "v")]
     Verify {
-        #[clap(help = "The original message.", value_name = "MESSAGE")]
+        /// The original message.
         message: String,
-        #[clap(help = "The signature to verify.", value_name = "SIGNATURE")]
-        signature: String,
-        #[clap(long, short, help = "The address of the message signer.", value_name = "ADDRESS")]
-        address: String,
+
+        /// The signature to verify.
+        signature: Signature,
+
+        /// The address of the message signer.
+        #[clap(long, short)]
+        address: Address,
     },
 }
 
@@ -84,7 +89,7 @@ impl WalletSubcommands {
                     let path = dunce::canonicalize(path)?;
                     if !path.is_dir() {
                         // we require path to be an existing directory
-                        eyre::bail!("`{}` is not a directory.", path.display());
+                        eyre::bail!("`{}` is not a directory", path.display());
                     }
 
                     let password = if let Some(password) = unsafe_password {
@@ -124,9 +129,7 @@ impl WalletSubcommands {
                 println!("Signature: 0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
-                let pubkey: Address = address.parse().wrap_err("Invalid address")?;
-                let signature: Signature = signature.parse().wrap_err("Invalid signature")?;
-                match signature.verify(message, pubkey) {
+                match signature.verify(message, address) {
                     Ok(_) => {
                         println!("Validation succeeded. Address {address} signed this message.")
                     }

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -13,6 +13,7 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Signature},
 };
+use eyre::Context;
 
 /// CLI arguments for `cast send`.
 #[derive(Debug, Parser)]

--- a/cli/src/cmd/cast/wallet/vanity.rs
+++ b/cli/src/cmd/cast/wallet/vanity.rs
@@ -19,22 +19,24 @@ pub type GeneratedWallet = (SigningKey, H160);
 /// CLI arguments for `cast wallet vanity`.
 #[derive(Debug, Clone, Parser)]
 pub struct VanityArgs {
+    /// Prefix for the vanity address.
     #[clap(
         long,
-        help = "Prefix for the vanity address.",
         required_unless_present = "ends_with",
-        value_parser = HexAddressValidator::default(),
+        value_parser = HexAddressValidator,
         value_name = "HEX"
     )]
     pub starts_with: Option<String>,
-    #[clap(long, help = "Suffix for the vanity address.", value_parser = HexAddressValidator::default(), value_name = "HEX")]
+
+    /// Suffix for the vanity address.
+    #[clap(long, value_parser = HexAddressValidator, value_name = "HEX")]
     pub ends_with: Option<String>,
-    #[clap(
-        long,
-        help = "Generate a vanity contract address created by the generated keypair with the specified nonce.",
-        value_name = "NONCE"
-    )]
-    pub nonce: Option<u64>, /* 2^64-1 is max possible nonce per https://eips.ethereum.org/EIPS/eip-2681 */
+
+    // 2^64-1 is max possible nonce per [eip-2681](https://eips.ethereum.org/EIPS/eip-2681).
+    /// Generate a vanity contract address created by the generated keypair with the specified
+    /// nonce.
+    #[clap(long)]
+    pub nonce: Option<u64>,
 }
 
 impl Cmd for VanityArgs {
@@ -283,7 +285,6 @@ impl VanityMatcher for RegexMatcher {
 
 /// Parse 40 byte addresses
 #[derive(Copy, Clone, Debug, Default)]
-#[non_exhaustive]
 pub struct HexAddressValidator;
 
 impl TypedValueParser for HexAddressValidator {

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -21,21 +21,13 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 #[clap(next_help_heading = "Build options")]
 pub struct CoreBuildArgs {
-    #[clap(
-        help_heading = "Cache options",
-        help = "Clear the cache and artifacts folder and recompile.",
-        long
-    )]
+    /// Clear the cache and artifacts folder and recompile.
+    #[clap(long, help_heading = "Cache options")]
     #[serde(skip)]
     pub force: bool,
 
-    #[clap(
-        help_heading = "Linker options",
-        help = "Set pre-linked libraries.",
-        long,
-        env = "DAPP_LIBRARIES",
-        value_name = "LIBRARIES"
-    )]
+    /// Set pre-linked libraries.
+    #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
@@ -43,48 +35,37 @@ pub struct CoreBuildArgs {
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
-    #[clap(
-        help_heading = "Compiler options",
-        help = "Ignore solc warnings by error code.",
-        long,
-        value_name = "ERROR_CODES"
-    )]
+    /// Ignore solc warnings by error code.
+    #[clap(long, help_heading = "Compiler options", value_name = "ERROR_CODES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignored_error_codes: Vec<u64>,
 
-    #[clap(
-        help_heading = "Compiler options",
-        help = "Warnings will trigger a compiler error",
-        long
-    )]
+    /// Warnings will trigger a compiler error
+    #[clap(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub deny_warnings: bool,
 
-    #[clap(help_heading = "Compiler options", help = "Do not auto-detect solc.", long)]
+    /// Do not auto-detect the `solc` version.
+    #[clap(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub no_auto_detect: bool,
 
     /// Specify the solc version, or a path to a local solc, to build with.
     ///
     /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
-    #[clap(help_heading = "Compiler options", value_name = "SOLC_VERSION", long = "use")]
+    #[clap(long = "use", help_heading = "Compiler options", value_name = "SOLC_VERSION")]
     #[serde(skip)]
     pub use_solc: Option<String>,
 
-    #[clap(
-        help_heading = "Compiler options",
-        help = "Do not access the network.",
-        long_help = "Do not access the network. Missing solc versions will not be installed.",
-        long
-    )]
+    /// Do not access the network.
+    ///
+    /// Missing solc versions will not be installed.
+    #[clap(help_heading = "Compiler options", long)]
     #[serde(skip)]
     pub offline: bool,
 
-    #[clap(
-        help_heading = "Compiler options",
-        help = "Use the Yul intermediate representation compilation pipeline.",
-        long
-    )]
+    /// Use the Yul intermediate representation compilation pipeline.
+    #[clap(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub via_ir: bool,
 
@@ -92,46 +73,42 @@ pub struct CoreBuildArgs {
     #[serde(flatten)]
     pub project_paths: ProjectPathsArgs,
 
+    /// The path to the contract artifacts folder.
     #[clap(
-        help_heading = "Project options",
-        help = "The path to the contract artifacts folder.",
         long = "out",
         short,
+        help_heading = "Project options",
         value_hint = ValueHint::DirPath,
-        value_name = "PATH"
+        value_name = "PATH",
     )]
     #[serde(rename = "out", skip_serializing_if = "Option::is_none")]
     pub out_path: Option<PathBuf>,
 
-    #[clap(
-        help_heading = "Project options",
-        help = r#"Revert string configuration. Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert strings) and "verboseDebug""#,
-        long = "revert-strings",
-        value_name = "REVERT"
-    )]
+    /// Revert string configuration.
+    ///
+    /// Possible values are "default", "strip" (remove),
+    /// "debug" (Solidity-generated revert strings) and "verboseDebug"
+    #[clap(long, help_heading = "Project options", value_name = "REVERT")]
     #[serde(skip)]
     pub revert_strings: Option<RevertStrings>,
 
-    #[clap(help_heading = "Compiler options", long, help = "Don't print anything on startup.")]
+    /// Don't print anything on startup.
+    #[clap(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub silent: bool,
 
-    #[clap(
-        long,
-        name = "build_info",
-        help_heading = "Project options",
-        help = "Generate build info files."
-    )]
+    /// Generate build info files.
+    #[clap(long, help_heading = "Project options")]
     #[serde(skip)]
     pub build_info: bool,
 
+    /// Output path to directory that build info files will be written to.
     #[clap(
-        help_heading = "Project options",
-        help = "Output path to directory that build info files will be written to.",
         long,
+        help_heading = "Project options",
         value_hint = ValueHint::DirPath,
         value_name = "PATH",
-        requires = "build_info"
+        requires = "build_info",
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_info_path: Option<PathBuf>,

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -61,12 +61,12 @@ pub struct BuildArgs {
     pub args: CoreBuildArgs,
 
     /// Print compiled contract names.
-    #[clap(long = "names")]
+    #[clap(long)]
     #[serde(skip)]
     pub names: bool,
 
     /// Print compiled contract sizes.
-    #[clap(long = "sizes")]
+    #[clap(long)]
     #[serde(skip)]
     pub sizes: bool,
 

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -73,7 +73,7 @@ pub struct BuildArgs {
     /// Skip building files whose names contain the given filter.
     ///
     /// `test` and `script` are aliases for `.t.sol` and `.s.sol`.
-    #[clap(long)]
+    #[clap(long, num_args(1..))]
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -6,7 +6,7 @@ use crate::cmd::{
     },
     Cmd, LoadConfig,
 };
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use ethers::solc::{Project, ProjectCompileOutput};
 use foundry_common::{
     compile,
@@ -60,19 +60,20 @@ pub struct BuildArgs {
     #[serde(flatten)]
     pub args: CoreBuildArgs,
 
-    #[clap(help = "Print compiled contract names.", long = "names")]
+    /// Print compiled contract names.
+    #[clap(long = "names")]
     #[serde(skip)]
     pub names: bool,
 
-    #[clap(help = "Print compiled contract sizes.", long = "sizes")]
+    /// Print compiled contract sizes.
+    #[clap(long = "sizes")]
     #[serde(skip)]
     pub sizes: bool,
 
-    #[clap(
-        long,
-        num_args(1..),
-        action = ArgAction::Append,
-        help = "Skip building whose names contain SKIP. `test` and `script` are aliases for `.t.sol` and `.s.sol`. (this flag can be used multiple times)")]
+    /// Skip building files whose names contain the given filter.
+    ///
+    /// `test` and `script` are aliases for `.t.sol` and `.s.sol`.
+    #[clap(long)]
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -16,73 +16,48 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 #[clap(next_help_heading = "Project options")]
 pub struct ProjectPathsArgs {
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(skip)]
     pub root: Option<PathBuf>,
 
-    #[clap(
-        env = "DAPP_SRC",
-        help = "The contracts source directory.",
-        long,
-        short = 'C',
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The contracts source directory.
+    #[clap(long, short, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(rename = "src", skip_serializing_if = "Option::is_none")]
     pub contracts: Option<PathBuf>,
 
-    #[clap(help = "The project's remappings.", long, short = 'R', value_name = "REMAPPINGS")]
+    /// The project's remappings.
+    #[clap(long, short)]
     #[serde(skip)]
     pub remappings: Vec<Remapping>,
 
-    #[clap(
-        help = "The project's remappings from the environment.",
-        long = "remappings-env",
-        value_name = "ENV"
-    )]
+    /// The project's remappings from the environment.
+    #[clap(long, value_name = "ENV")]
     #[serde(skip)]
     pub remappings_env: Option<String>,
 
-    #[clap(
-        help = "The path to the compiler cache.",
-        long = "cache-path",
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The path to the compiler cache.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_path: Option<PathBuf>,
 
-    #[clap(
-        help = "The path to the library folder.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The path to the library folder.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(rename = "libs", skip_serializing_if = "Vec::is_empty")]
     pub lib_paths: Vec<PathBuf>,
 
-    #[clap(
-        help = "Use the Hardhat-style project layout.",
-        long_help = "This a convenience flag and is the same as passing `--contracts contracts --lib-paths node_modules`.",
-        long,
-        conflicts_with = "contracts",
-        visible_alias = "hh"
-    )]
+    /// Use the Hardhat-style project layout.
+    ///
+    /// This is the same as using: `--contracts contracts --lib-paths node_modules`.
+    #[clap(long, conflicts_with = "contracts", visible_alias = "hh")]
     #[serde(skip)]
     pub hardhat: bool,
 
-    #[clap(
-        help = "Path to the config file.",
-        long = "config-path",
-        value_hint = ValueHint::FilePath,
-        value_name = "FILE"
-    )]
+    /// Path to the config file.
+    #[clap(long, value_hint = ValueHint::FilePath, value_name = "FILE")]
     #[serde(skip)]
     pub config_path: Option<PathBuf>,
 }

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -25,12 +25,12 @@ pub struct ProjectPathsArgs {
     pub root: Option<PathBuf>,
 
     /// The contracts source directory.
-    #[clap(long, short, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[clap(long, short = 'C', value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(rename = "src", skip_serializing_if = "Option::is_none")]
     pub contracts: Option<PathBuf>,
 
     /// The project's remappings.
-    #[clap(long, short)]
+    #[clap(long, short = 'R')]
     #[serde(skip)]
     pub remappings: Vec<Remapping>,
 

--- a/cli/src/cmd/forge/cache.rs
+++ b/cli/src/cmd/forge/cache.rs
@@ -21,10 +21,10 @@ pub struct CacheArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum CacheSubcommands {
-    #[clap(about = "Cleans cached data from ~/.foundry.")]
+    /// Cleans cached data from the global foundry directory.
     Clean(CleanArgs),
 
-    #[clap(about = "Shows cached data from ~/.foundry.")]
+    /// Shows cached data from the global foundry directory.
     Ls(LsArgs),
 }
 
@@ -32,25 +32,28 @@ pub enum CacheSubcommands {
 #[derive(Debug, Parser)]
 #[clap(group = clap::ArgGroup::new("etherscan-blocks").multiple(false))]
 pub struct CleanArgs {
+    /// The chains to clean the cache for.
+    ///
+    /// Can also be "all" to clean all chains.
     #[clap(
         env = "CHAIN",
         default_value = "all",
         value_parser = ChainOrAllValueParser::default(),
-        value_name = "CHAINS"
     )]
     chains: Vec<ChainOrAll>,
 
+    /// The blocks to clean the cache for.
     #[clap(
         short,
         long,
         num_args(1..),
         use_value_delimiter(true),
         value_delimiter(','),
-        value_name = "BLOCKS",
         group = "etherscan-blocks"
     )]
     blocks: Vec<u64>,
 
+    /// Whether to clean the Etherscan cache.
     #[clap(long, group = "etherscan-blocks")]
     etherscan: bool,
 }
@@ -80,11 +83,13 @@ impl Cmd for CleanArgs {
 
 #[derive(Debug, Parser)]
 pub struct LsArgs {
+    /// The chains to list the cache for.
+    ///
+    /// Can also be "all" to list all chains.
     #[clap(
         env = "CHAIN",
         default_value = "all",
         value_parser = ChainOrAllValueParser::default(),
-        value_name = "CHAINS"
     )]
     chains: Vec<ChainOrAll>,
 }

--- a/cli/src/cmd/forge/config.rs
+++ b/cli/src/cmd/forge/config.rs
@@ -10,13 +10,16 @@ foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
 /// CLI arguments for `forge config`.
 #[derive(Debug, Clone, Parser)]
 pub struct ConfigArgs {
-    #[clap(help = "Print only a basic set of the currently set config values.", long)]
+    /// Print only a basic set of the currently set config values.
+    #[clap(long)]
     basic: bool,
 
-    #[clap(help = "Print currently set config values as JSON.", long)]
+    /// Print currently set config values as JSON.
+    #[clap(long)]
     json: bool,
 
-    #[clap(help = "Attempt to fix any configuration warnings.", long)]
+    /// Attempt to fix any configuration warnings.
+    #[clap(long)]
     fix: bool,
 
     // support nested build arguments

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     utils::{self, p_println, STATIC_FUZZ_SEED},
 };
-use clap::{ArgAction, Parser, ValueEnum};
+use clap::{Parser, ValueEnum};
 use ethers::{
     abi::Address,
     prelude::{
@@ -39,13 +39,10 @@ foundry_config::impl_figment_convert!(CoverageArgs, opts, evm_opts);
 /// CLI arguments for `forge coverage`.
 #[derive(Debug, Clone, Parser)]
 pub struct CoverageArgs {
-    #[clap(
-        long,
-        value_enum,
-        action = ArgAction::Append,
-        default_value = "summary",
-        help = "The report type to use for coverage. This flag can be used multiple times."
-    )]
+    /// The report type to use for coverage.
+    ///
+    /// This flag can be used multiple times.
+    #[clap(long, value_enum, default_value = "summary")]
     report: Vec<CoverageReportKind>,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -22,21 +22,6 @@ use rustc_hex::ToHex;
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
 
-/*
-For each field's `clap(help)` attribute:
-```rust
-#[clap(help = "<DOC>")]
-field: ...,
-```
-
-Create a new Rust struct with the same exact fields as the input, but with the
-`help` attribute removed, and replace with a doc comment, only if the
-`help` attribute exists, like so:
-```rust
-/// <doc>
-/// field: ...,
-*/
-
 /// CLI arguments for `forge create`.
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
@@ -70,7 +55,7 @@ pub struct CreateArgs {
     eth: EthereumOpts,
 
     /// Print the deployment information as JSON.
-    #[clap(long = "json", help_heading = "Display options")]
+    #[clap(long, help_heading = "Display options")]
     json: bool,
 
     /// Verify contract after creation.

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -22,32 +22,41 @@ use rustc_hex::ToHex;
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
 
+/*
+For each field's `clap(help)` attribute:
+```rust
+#[clap(help = "<DOC>")]
+field: ...,
+```
+
+Create a new Rust struct with the same exact fields as the input, but with the
+`help` attribute removed, and replace with a doc comment, only if the
+`help` attribute exists, like so:
+```rust
+/// <doc>
+/// field: ...,
+*/
+
 /// CLI arguments for `forge create`.
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
-    #[clap(
-        help = "The contract identifier in the form `<path>:<contractname>`.",
-        value_name = "CONTRACT"
-    )]
+    /// The contract identifier in the form `<path>:<contractname>`.
     contract: ContractInfo,
 
+    /// The constructor arguments.
     #[clap(
         long,
         num_args(1..),
-        help = "The constructor arguments.",
-        name = "constructor_args",
         conflicts_with = "constructor_args_path",
-        value_name = "ARGS"
+        value_name = "ARGS",
     )]
     constructor_args: Vec<String>,
 
+    /// The path to a file containing the constructor arguments.
     #[clap(
         long,
-        help = "The path to a file containing the constructor arguments.",
         value_hint = ValueHint::FilePath,
-        name = "constructor_args_path",
-        conflicts_with = "constructor_args",
-        value_name = "FILE"
+        value_name = "PATH",
     )]
     constructor_args_path: Option<PathBuf>,
 
@@ -60,21 +69,16 @@ pub struct CreateArgs {
     #[clap(flatten)]
     eth: EthereumOpts,
 
-    #[clap(
-        long = "json",
-        help_heading = "Display options",
-        help = "Print the deployment information as JSON."
-    )]
+    /// Print the deployment information as JSON.
+    #[clap(long = "json", help_heading = "Display options")]
     json: bool,
 
-    #[clap(long, help = "Verify contract after creation.")]
+    /// Verify contract after creation.
+    #[clap(long)]
     verify: bool,
 
-    #[clap(
-        long,
-        help = "Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender",
-        requires = "from"
-    )]
+    /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
+    #[clap(long, requires = "from")]
     unlocked: bool,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -14,11 +14,10 @@ pub struct DebugArgs {
     ///
     /// If multiple contracts exist in the same file you must specify the target contract with
     /// --target-contract.
-    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
+    #[clap(value_hint = ValueHint::FilePath)]
     pub path: PathBuf,
 
     /// Arguments to pass to the script function.
-    #[clap(value_name = "ARGS")]
     pub args: Vec<String>,
 
     /// The name of the contract you want to run.

--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -6,35 +6,38 @@ use std::{path::PathBuf, process::Command};
 
 #[derive(Debug, Clone, Parser)]
 pub struct DocArgs {
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
-    root: Option<PathBuf>,
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    pub root: Option<PathBuf>,
 
+    /// The doc's output path.
+    ///
+    /// By default, it is the `docs/` in project root.
     #[clap(
-        help = "The doc's output path.",
-        long_help = "The output path for the generated mdbook. By default, it is the `docs/` in project root.",
-        long = "out",
+        long,
         short,
         value_hint = ValueHint::DirPath,
-        value_name = "PATH"
+        value_name = "PATH",
     )]
     out: Option<PathBuf>,
 
-    #[clap(help = "Build the `mdbook` from generated files.", long, short)]
+    /// Build the `mdbook` from generated files.
+    #[clap(long, short)]
     build: bool,
 
-    #[clap(help = "Serve the documentation.", long, short)]
+    /// Serve the documentation.
+    #[clap(long, short)]
     serve: bool,
 
-    #[clap(help = "Hostname for serving documentation.", long, requires = "serve")]
+    /// Hostname for serving documentation.
+    #[clap(long, requires = "serve")]
     hostname: Option<String>,
 
-    #[clap(help = "Port for serving documentation.", long, short, requires = "serve")]
+    /// Port for serving documentation.
+    #[clap(long, short, requires = "serve")]
     port: Option<usize>,
 }
 

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -9,16 +9,18 @@ use std::path::PathBuf;
 /// CLI arguments for `forge flatten`.
 #[derive(Debug, Clone, Parser)]
 pub struct FlattenArgs {
-    #[clap(help = "The path to the contract to flatten.", value_hint = ValueHint::FilePath, value_name = "TARGET_PATH")]
+    /// The path to the contract to flatten.
+    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub target_path: PathBuf,
 
+    /// The path to output the flattened contract.
+    ///
+    /// If not specified, the flattened contract will be output to stdout.
     #[clap(
         long,
         short,
-        help = "The path to output the flattened contract.",
-        long_help = "The path to output the flattened contract. If not specified, the flattened contract will be output to stdout.",
         value_hint = ValueHint::FilePath,
-        value_name = "FILE"
+        value_name = "PATH",
     )]
     pub output: Option<PathBuf>,
 

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -28,13 +28,11 @@ pub struct FmtArgs {
         num_args(1..)
     )]
     paths: Vec<PathBuf>,
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
     #[clap(
         help = "run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required.",

--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -21,29 +21,26 @@ use tracing::log::warn;
 /// CLI arguments for `forge fmt`.
 #[derive(Debug, Clone, Parser)]
 pub struct FmtArgs {
-    #[clap(
-        help = "path to the file, directory or '-' to read from stdin",
-        value_hint = ValueHint::FilePath,
-        value_name = "PATH",
-        num_args(1..)
-    )]
+    /// Path to the file, directory or '-' to read from stdin.
+    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH", num_args(1..))]
     paths: Vec<PathBuf>,
+
     /// The project's root path.
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
-    #[clap(
-        help = "run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required.",
-        long
-    )]
+
+    /// Run in 'check' mode.
+    ///
+    /// Exits with 0 if input is formatted correctly.
+    /// Exits with 1 if formatting is required.
+    #[clap(long)]
     check: bool,
-    #[clap(
-        help = "in 'check' and stdin modes, outputs raw formatted code instead of diff",
-        long = "raw",
-        short
-    )]
+
+    /// In 'check' and stdin modes, outputs raw formatted code instead of the diff.
+    #[clap(long, short)]
     raw: bool,
 }
 

--- a/cli/src/cmd/forge/fourbyte.rs
+++ b/cli/src/cmd/forge/fourbyte.rs
@@ -13,17 +13,12 @@ use foundry_common::{
 /// CLI arguments for `forge upload-selectors`.
 #[derive(Debug, Clone, Parser)]
 pub struct UploadSelectorsArgs {
-    #[clap(
-        help = "The name of the contract to upload selectors for.",
-        required_unless_present = "all"
-    )]
+    /// The name of the contract to upload selectors for.
+    #[clap(required_unless_present = "all")]
     pub contract: Option<String>,
 
-    #[clap(
-        long,
-        help = "Upload selectors for all contracts in the project.",
-        required_unless_present = "contract"
-    )]
+    /// Upload selectors for all contracts in the project.
+    #[clap(long, required_unless_present = "contract")]
     pub all: bool,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -27,12 +27,13 @@ pub struct InitArgs {
     root: PathBuf,
 
     /// The template to start from.
-    #[clap(long, short, value_name = "TEMPLATE")]
+    #[clap(long, short)]
     template: Option<String>,
 
     /// Do not create a git repository.
     #[clap(long, conflicts_with = "template")]
     no_git: bool,
+
     /// Do not create an initial commit.
     #[clap(long, conflicts_with = "template")]
     no_commit: bool,

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -22,12 +22,9 @@ use yansi::Paint;
 /// CLI arguments for `forge init`.
 #[derive(Debug, Clone, Parser)]
 pub struct InitArgs {
-    /// The project's root path.
-    ///
-    /// By default root of the Git repository, if in one,
-    /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
-    root: Option<PathBuf>,
+    /// The root directory of the new project.
+    #[clap(value_hint = ValueHint::DirPath, default_value = ".", value_name = "PATH")]
+    root: PathBuf,
 
     /// The template to start from.
     #[clap(long, short, value_name = "TEMPLATE")]
@@ -64,7 +61,6 @@ impl Cmd for InitArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let InitArgs { root, template, no_git, no_commit, quiet, offline, force, vscode } = self;
 
-        let root = root.unwrap_or_else(|| std::env::current_dir().unwrap());
         // create the root dir if it does not exist
         if !root.exists() {
             fs::create_dir_all(&root)?;

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -22,38 +22,39 @@ use yansi::Paint;
 /// CLI arguments for `forge init`.
 #[derive(Debug, Clone, Parser)]
 pub struct InitArgs {
-    #[clap(
-        help = "The root directory of the new project. Defaults to the current working directory.",
-        value_hint = ValueHint::DirPath,
-        value_name = "ROOT"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
-    #[clap(help = "The template to start from.", long, short, value_name = "TEMPLATE")]
+
+    /// The template to start from.
+    #[clap(long, short, value_name = "TEMPLATE")]
     template: Option<String>,
-    #[clap(help = "Do not create a git repository.", conflicts_with = "template", long)]
+
+    /// Do not create a git repository.
+    #[clap(long, conflicts_with = "template")]
     no_git: bool,
-    #[clap(help = "Do not create an initial commit.", conflicts_with = "template", long)]
+    /// Do not create an initial commit.
+    #[clap(long, conflicts_with = "template")]
     no_commit: bool,
-    #[clap(help = "Do not print any messages.", short, long)]
+
+    /// Do not print any messages.
+    #[clap(long, short)]
     quiet: bool,
-    #[clap(
-        help = "Do not install dependencies from the network.",
-        conflicts_with = "template",
-        long,
-        visible_alias = "no-deps"
-    )]
+
+    /// Do not install dependencies from the network.
+    #[clap(long, conflicts_with = "template", visible_alias = "no-deps")]
     offline: bool,
-    #[clap(
-        help = "Create the project even if the specified root directory is not empty.",
-        conflicts_with = "template",
-        long
-    )]
+
+    /// Create the project even if the specified root directory is not empty.
+    #[clap(long, conflicts_with = "template")]
     force: bool,
-    #[clap(
-        help = "Create a .vscode/settings.json file with Solidity settings, and generate a remappings.txt file.",
-        conflicts_with = "template",
-        long
-    )]
+
+    /// Create a .vscode/settings.json file with Solidity settings, and generate a remappings.txt
+    /// file.
+    #[clap(long, conflicts_with = "template")]
     vscode: bool,
 }
 

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -19,30 +19,22 @@ use ethers::{
 };
 use foundry_common::compile;
 use serde_json::{to_value, Value};
-use std::{fmt, str::FromStr};
+use std::fmt;
 use tracing::trace;
 
 /// CLI arguments for `forge inspect`.
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
-    #[clap(
-        help = "The identifier of the contract to inspect in the form `(<path>:)?<contractname>`.",
-        value_name = "CONTRACT"
-    )]
+    /// The identifier of the contract to inspect in the form `(<path>:)?<contractname>`.
+    #[clap(value_name = "CONTRACT")]
     pub contract: ContractInfo,
 
-    #[clap(
-        value_name = "FIELD",
-        help = r#"The contract artifact field to inspect.
+    /// The contract artifact field to inspect.
+    #[clap(value_enum)]
+    pub field: ContractArtifactField,
 
-possible_values = ["abi", "b/bytes/bytecode", "deployedBytecode/deployed_bytecode/deployed-bytecode/deployedbytecode/deployed", "assembly/asm", "asmOptimized/assemblyOptimized/assemblyoptimized/assembly_optimized/asmopt/assembly-optimized/asmo/asm-optimized/asmoptimized/asm_optimized",
-"methods/methodidentifiers/methodIdentifiers/method_identifiers/method-identifiers/mi", "gasEstimates/gas/gas_estimates/gas-estimates/gasestimates",
-"storageLayout/storage_layout/storage-layout/storagelayout/storage", "devdoc/dev-doc/devDoc",
-"ir", "ir-optimized/irOptimized/iroptimized/iro/iropt", "metadata/meta", "userdoc/userDoc/user-doc", "ewasm/e-wasm", "events/ev"]"#
-    )]
-    pub field: ContractArtifactFields,
-
-    #[clap(long, help = "Pretty print the selected field, if supported.")]
+    /// Pretty print the selected field, if supported.
+    #[clap(long)]
     pub pretty: bool,
 
     /// All build arguments are supported
@@ -56,7 +48,7 @@ impl Cmd for InspectArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let InspectArgs { mut contract, field, build, pretty } = self;
 
-        trace!(target : "forge", ?field, ?contract, "running forge inspect");
+        trace!(target: "forge", ?field, ?contract, "running forge inspect");
 
         // Map field to ContractOutputSelection
         let mut cos = build.compiler.extra_output;
@@ -65,7 +57,7 @@ impl Cmd for InspectArgs {
         }
 
         // Run Optimized?
-        let optimized = if let ContractArtifactFields::AssemblyOptimized = field {
+        let optimized = if let ContractArtifactField::AssemblyOptimized = field {
             true
         } else {
             build.compiler.optimize
@@ -90,7 +82,7 @@ impl Cmd for InspectArgs {
         // Find the artifact
         let found_artifact = outcome.find_contract(&contract);
 
-        trace!(target : "forge", artifact=?found_artifact, input=?contract, "Found contract");
+        trace!(target: "forge", artifact=?found_artifact, input=?contract, "Found contract");
 
         // Unwrap the inner artifact
         let artifact = found_artifact.ok_or_else(|| {
@@ -99,28 +91,28 @@ impl Cmd for InspectArgs {
 
         // Match on ContractArtifactFields and Pretty Print
         match field {
-            ContractArtifactFields::Abi => {
+            ContractArtifactField::Abi => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.abi)?)?);
             }
-            ContractArtifactFields::Bytecode => {
+            ContractArtifactField::Bytecode => {
                 let tval: Value = to_value(&artifact.bytecode)?;
                 println!(
                     "{}",
-                    tval.get("object").unwrap_or(&tval).clone().as_str().ok_or_else(
-                        || eyre::eyre!("Failed to extract artifact bytecode as a string")
-                    )?
+                    tval.get("object").unwrap_or(&tval).as_str().ok_or_else(|| eyre::eyre!(
+                        "Failed to extract artifact bytecode as a string"
+                    ))?
                 );
             }
-            ContractArtifactFields::DeployedBytecode => {
+            ContractArtifactField::DeployedBytecode => {
                 let tval: Value = to_value(&artifact.deployed_bytecode)?;
                 println!(
                     "{}",
-                    tval.get("object").unwrap_or(&tval).clone().as_str().ok_or_else(
-                        || eyre::eyre!("Failed to extract artifact deployed bytecode as a string")
-                    )?
+                    tval.get("object").unwrap_or(&tval).as_str().ok_or_else(|| eyre::eyre!(
+                        "Failed to extract artifact deployed bytecode as a string"
+                    ))?
                 );
             }
-            ContractArtifactFields::Assembly | ContractArtifactFields::AssemblyOptimized => {
+            ContractArtifactField::Assembly | ContractArtifactField::AssemblyOptimized => {
                 println!(
                     "{}",
                     to_value(&artifact.assembly)?.as_str().ok_or_else(|| eyre::eyre!(
@@ -128,22 +120,22 @@ impl Cmd for InspectArgs {
                     ))?
                 );
             }
-            ContractArtifactFields::MethodIdentifiers => {
+            ContractArtifactField::MethodIdentifiers => {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&to_value(&artifact.method_identifiers)?)?
                 );
             }
-            ContractArtifactFields::GasEstimates => {
+            ContractArtifactField::GasEstimates => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.gas_estimates)?)?);
             }
-            ContractArtifactFields::StorageLayout => {
+            ContractArtifactField::StorageLayout => {
                 print_storage_layout(&artifact.storage_layout, pretty)?;
             }
-            ContractArtifactFields::DevDoc => {
+            ContractArtifactField::DevDoc => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.devdoc)?)?);
             }
-            ContractArtifactFields::Ir => {
+            ContractArtifactField::Ir => {
                 println!(
                     "{}",
                     to_value(&artifact.ir)?
@@ -151,7 +143,7 @@ impl Cmd for InspectArgs {
                         .ok_or_else(|| eyre::eyre!("Failed to extract artifact ir as a string"))?
                 );
             }
-            ContractArtifactFields::IrOptimized => {
+            ContractArtifactField::IrOptimized => {
                 println!(
                     "{}",
                     to_value(&artifact.ir_optimized)?.as_str().ok_or_else(|| eyre::eyre!(
@@ -159,13 +151,13 @@ impl Cmd for InspectArgs {
                     ))?
                 );
             }
-            ContractArtifactFields::Metadata => {
+            ContractArtifactField::Metadata => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.metadata)?)?);
             }
-            ContractArtifactFields::UserDoc => {
+            ContractArtifactField::UserDoc => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.userdoc)?)?);
             }
-            ContractArtifactFields::Ewasm => {
+            ContractArtifactField::Ewasm => {
                 println!(
                     "{}",
                     to_value(&artifact.ewasm)?.as_str().ok_or_else(|| eyre::eyre!(
@@ -173,12 +165,11 @@ impl Cmd for InspectArgs {
                     ))?
                 );
             }
-            ContractArtifactFields::Events => {
+            ContractArtifactField::Events => {
                 let mut out = serde_json::Map::new();
-                if let Some(LosslessAbi { abi, .. }) = artifact.abi.as_ref() {
-                    let events: Vec<_> = abi.events.iter().flat_map(|(_, events)| events).collect();
+                if let Some(LosslessAbi { abi, .. }) = &artifact.abi {
                     // print the signature of all events including anonymous
-                    for ev in events.iter() {
+                    for ev in abi.events.iter().flat_map(|(_, events)| events) {
                         let types =
                             ev.inputs.iter().map(|p| p.kind.to_string()).collect::<Vec<_>>();
                         out.insert(
@@ -232,8 +223,8 @@ pub fn print_storage_layout(
 }
 
 /// Contract level output selection
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ContractArtifactFields {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ContractArtifactField {
     Abi,
     Bytecode,
     DeployedBytecode,
@@ -251,107 +242,168 @@ pub enum ContractArtifactFields {
     Events,
 }
 
-// === impl ContractArtifactFields ===
+macro_rules! impl_value_enum {
+    (enum $name:ident { $($field:ident => $main:literal $(| $alias:literal)*),+ $(,)? }) => {
+        impl $name {
+            /// All the variants of this enum.
+            pub const ALL: &[Self] = &[$(Self::$field),+];
 
-impl ContractArtifactFields {
-    /// Returns true if this field is generated by default
-    pub fn is_default(&self) -> bool {
-        matches!(self, ContractArtifactFields::Bytecode | ContractArtifactFields::DeployedBytecode)
+            /// Returns the string representation of `self`.
+            #[inline]
+            pub const fn as_str(&self) -> &'static str {
+                match self {
+                    $(
+                        Self::$field => $main,
+                    )+
+                }
+            }
+
+            /// Returns all the aliases of `self`.
+            #[inline]
+            pub const fn aliases(&self) -> &'static [&'static str] {
+                match self {
+                    $(
+                        Self::$field => &[$($alias),*],
+                    )+
+                }
+            }
+        }
+
+        impl ::clap::ValueEnum for $name {
+            #[inline]
+            fn value_variants<'a>() -> &'a [Self] {
+                Self::ALL
+            }
+
+            #[inline]
+            fn to_possible_value(&self) -> Option<::clap::builder::PossibleValue> {
+                Some(::clap::builder::PossibleValue::new(Self::as_str(self)).aliases(Self::aliases(self)))
+            }
+
+            #[inline]
+            fn from_str(input: &str, ignore_case: bool) -> Result<Self, String> {
+                let _ = ignore_case;
+                <Self as ::std::str::FromStr>::from_str(input)
+            }
+        }
+
+        impl ::std::str::FromStr for $name {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(
+                        $main $(| $alias)* => Ok(Self::$field),
+                    )+
+                    _ => Err(format!(concat!("Invalid ", stringify!($name), " value: {}"), s)),
+                }
+            }
+        }
+    };
+}
+
+impl_value_enum! {
+    enum ContractArtifactField {
+        Abi               => "abi",
+        Bytecode          => "bytecode" | "bytes" | "b",
+        DeployedBytecode  => "deployedBytecode" | "deployed_bytecode" | "deployed-bytecode"
+                             | "deployed" | "deployedbytecode",
+        Assembly          => "assembly" | "asm",
+        AssemblyOptimized => "assemblyOptimized" | "asmOptimized" | "assemblyoptimized"
+                             | "assembly_optimized" | "asmopt" | "assembly-optimized"
+                             | "asmo" | "asm-optimized" | "asmoptimized" | "asm_optimized",
+        MethodIdentifiers => "methodIdentifiers" | "methodidentifiers" | "methods"
+                             | "method_identifiers" | "method-identifiers" | "mi",
+        GasEstimates      => "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates"
+                             | "gasestimates",
+        StorageLayout     => "storageLayout" | "storage_layout" | "storage-layout"
+                             | "storagelayout" | "storage",
+        DevDoc            => "devdoc" | "dev-doc" | "devDoc",
+        Ir                => "ir" | "iR" | "IR",
+        IrOptimized       => "irOptimized" | "ir-optimized" | "iroptimized" | "iro" | "iropt",
+        Metadata          => "metadata" | "meta",
+        UserDoc           => "userdoc" | "userDoc" | "user-doc",
+        Ewasm             => "ewasm" | "e-wasm",
+        Events            => "events" | "ev",
     }
 }
 
-impl From<ContractArtifactFields> for ContractOutputSelection {
-    fn from(field: ContractArtifactFields) -> Self {
+impl From<ContractArtifactField> for ContractOutputSelection {
+    fn from(field: ContractArtifactField) -> Self {
+        type CAF = ContractArtifactField;
         match field {
-            ContractArtifactFields::Abi => ContractOutputSelection::Abi,
-            ContractArtifactFields::Bytecode => ContractOutputSelection::Evm(
-                EvmOutputSelection::ByteCode(BytecodeOutputSelection::All),
-            ),
-            ContractArtifactFields::DeployedBytecode => ContractOutputSelection::Evm(
-                EvmOutputSelection::DeployedByteCode(DeployedBytecodeOutputSelection::All),
-            ),
-            ContractArtifactFields::Assembly | ContractArtifactFields::AssemblyOptimized => {
-                ContractOutputSelection::Evm(EvmOutputSelection::Assembly)
-            }
-            ContractArtifactFields::MethodIdentifiers => {
-                ContractOutputSelection::Evm(EvmOutputSelection::MethodIdentifiers)
-            }
-            ContractArtifactFields::GasEstimates => {
-                ContractOutputSelection::Evm(EvmOutputSelection::GasEstimates)
-            }
-            ContractArtifactFields::StorageLayout => ContractOutputSelection::StorageLayout,
-            ContractArtifactFields::DevDoc => ContractOutputSelection::DevDoc,
-            ContractArtifactFields::Ir => ContractOutputSelection::Ir,
-            ContractArtifactFields::IrOptimized => ContractOutputSelection::IrOptimized,
-            ContractArtifactFields::Metadata => ContractOutputSelection::Metadata,
-            ContractArtifactFields::UserDoc => ContractOutputSelection::UserDoc,
-            ContractArtifactFields::Ewasm => {
-                ContractOutputSelection::Ewasm(EwasmOutputSelection::All)
-            }
-            ContractArtifactFields::Events => ContractOutputSelection::Abi,
+            CAF::Abi => Self::Abi,
+            CAF::Bytecode => Self::Evm(EvmOutputSelection::ByteCode(BytecodeOutputSelection::All)),
+            CAF::DeployedBytecode => Self::Evm(EvmOutputSelection::DeployedByteCode(
+                DeployedBytecodeOutputSelection::All,
+            )),
+            CAF::Assembly | CAF::AssemblyOptimized => Self::Evm(EvmOutputSelection::Assembly),
+            CAF::MethodIdentifiers => Self::Evm(EvmOutputSelection::MethodIdentifiers),
+            CAF::GasEstimates => Self::Evm(EvmOutputSelection::GasEstimates),
+            CAF::StorageLayout => Self::StorageLayout,
+            CAF::DevDoc => Self::DevDoc,
+            CAF::Ir => Self::Ir,
+            CAF::IrOptimized => Self::IrOptimized,
+            CAF::Metadata => Self::Metadata,
+            CAF::UserDoc => Self::UserDoc,
+            CAF::Ewasm => Self::Ewasm(EwasmOutputSelection::All),
+            CAF::Events => Self::Abi,
         }
     }
 }
 
-impl PartialEq<ContractOutputSelection> for ContractArtifactFields {
+impl PartialEq<ContractOutputSelection> for ContractArtifactField {
     fn eq(&self, other: &ContractOutputSelection) -> bool {
-        self.to_string() == other.to_string()
+        type COS = ContractOutputSelection;
+        type EOS = EvmOutputSelection;
+        matches!(
+            (self, other),
+            (Self::Abi | Self::Events, COS::Abi) |
+                (Self::Bytecode, COS::Evm(EOS::ByteCode(_))) |
+                (Self::DeployedBytecode, COS::Evm(EOS::DeployedByteCode(_))) |
+                (Self::Assembly | Self::AssemblyOptimized, COS::Evm(EOS::Assembly)) |
+                (Self::MethodIdentifiers, COS::Evm(EOS::MethodIdentifiers)) |
+                (Self::GasEstimates, COS::Evm(EOS::GasEstimates)) |
+                (Self::StorageLayout, COS::StorageLayout) |
+                (Self::DevDoc, COS::DevDoc) |
+                (Self::Ir, COS::Ir) |
+                (Self::IrOptimized, COS::IrOptimized) |
+                (Self::Metadata, COS::Metadata) |
+                (Self::UserDoc, COS::UserDoc) |
+                (Self::Ewasm, COS::Ewasm(_))
+        )
     }
 }
 
-impl fmt::Display for ContractArtifactFields {
+impl fmt::Display for ContractArtifactField {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ContractArtifactFields::Abi => f.write_str("abi"),
-            ContractArtifactFields::Bytecode => f.write_str("bytecode"),
-            ContractArtifactFields::DeployedBytecode => f.write_str("deployedBytecode"),
-            ContractArtifactFields::Assembly => f.write_str("assembly"),
-            ContractArtifactFields::AssemblyOptimized => f.write_str("assemblyOptimized"),
-            ContractArtifactFields::MethodIdentifiers => f.write_str("methodIdentifiers"),
-            ContractArtifactFields::GasEstimates => f.write_str("gasEstimates"),
-            ContractArtifactFields::StorageLayout => f.write_str("storageLayout"),
-            ContractArtifactFields::DevDoc => f.write_str("devdoc"),
-            ContractArtifactFields::Ir => f.write_str("ir"),
-            ContractArtifactFields::IrOptimized => f.write_str("irOptimized"),
-            ContractArtifactFields::Metadata => f.write_str("metadata"),
-            ContractArtifactFields::UserDoc => f.write_str("userdoc"),
-            ContractArtifactFields::Ewasm => f.write_str("ewasm"),
-            ContractArtifactFields::Events => f.write_str("events"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
-impl FromStr for ContractArtifactFields {
-    type Err = String;
+impl ContractArtifactField {
+    /// Returns true if this field is generated by default.
+    pub const fn is_default(&self) -> bool {
+        matches!(self, Self::Bytecode | Self::DeployedBytecode)
+    }
+}
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "abi" => Ok(ContractArtifactFields::Abi),
-            "b" | "bytes" | "bytecode" => Ok(ContractArtifactFields::Bytecode),
-            "deployedBytecode" | "deployed_bytecode" | "deployed-bytecode" | "deployed" |
-            "deployedbytecode" => Ok(ContractArtifactFields::DeployedBytecode),
-            "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
-            "asmOptimized" | "assemblyOptimized" | "assemblyoptimized" | "assembly_optimized" |
-            "asmopt" | "assembly-optimized" | "asmo" | "asm-optimized" | "asmoptimized" |
-            "asm_optimized" => Ok(ContractArtifactFields::AssemblyOptimized),
-            "methods" | "methodidentifiers" | "methodIdentifiers" | "method_identifiers" |
-            "method-identifiers" | "mi" => Ok(ContractArtifactFields::MethodIdentifiers),
-            "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates" | "gasestimates" => {
-                Ok(ContractArtifactFields::GasEstimates)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_output_selection() {
+        for &field in ContractArtifactField::ALL {
+            let selection: ContractOutputSelection = field.into();
+            assert_eq!(field, selection);
+
+            let s = field.as_str();
+            assert_eq!(s, field.to_string());
+            assert_eq!(s.parse::<ContractArtifactField>().unwrap(), field);
+            for alias in field.aliases() {
+                assert_eq!(alias.parse::<ContractArtifactField>().unwrap(), field);
             }
-            "storageLayout" | "storage_layout" | "storage-layout" | "storagelayout" | "storage" => {
-                Ok(ContractArtifactFields::StorageLayout)
-            }
-            "devdoc" | "dev-doc" | "devDoc" => Ok(ContractArtifactFields::DevDoc),
-            "ir" | "iR" | "IR" => Ok(ContractArtifactFields::Ir),
-            "ir-optimized" | "irOptimized" | "iroptimized" | "iro" | "iropt" => {
-                Ok(ContractArtifactFields::IrOptimized)
-            }
-            "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
-            "userdoc" | "userDoc" | "user-doc" => Ok(ContractArtifactFields::UserDoc),
-            "ewasm" | "e-wasm" => Ok(ContractArtifactFields::Ewasm),
-            "events" | "ev" => Ok(ContractArtifactFields::Events),
-            _ => Err(format!("Unknown field: {s}")),
         }
     }
 }

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -26,7 +26,6 @@ use tracing::trace;
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
     /// The identifier of the contract to inspect in the form `(<path>:)?<contractname>`.
-    #[clap(value_name = "CONTRACT")]
     pub contract: ContractInfo,
 
     /// The contract artifact field to inspect.

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -330,47 +330,47 @@ impl_value_enum! {
 
 impl From<ContractArtifactField> for ContractOutputSelection {
     fn from(field: ContractArtifactField) -> Self {
-        type CAF = ContractArtifactField;
+        type Caf = ContractArtifactField;
         match field {
-            CAF::Abi => Self::Abi,
-            CAF::Bytecode => Self::Evm(EvmOutputSelection::ByteCode(BytecodeOutputSelection::All)),
-            CAF::DeployedBytecode => Self::Evm(EvmOutputSelection::DeployedByteCode(
+            Caf::Abi => Self::Abi,
+            Caf::Bytecode => Self::Evm(EvmOutputSelection::ByteCode(BytecodeOutputSelection::All)),
+            Caf::DeployedBytecode => Self::Evm(EvmOutputSelection::DeployedByteCode(
                 DeployedBytecodeOutputSelection::All,
             )),
-            CAF::Assembly | CAF::AssemblyOptimized => Self::Evm(EvmOutputSelection::Assembly),
-            CAF::MethodIdentifiers => Self::Evm(EvmOutputSelection::MethodIdentifiers),
-            CAF::GasEstimates => Self::Evm(EvmOutputSelection::GasEstimates),
-            CAF::StorageLayout => Self::StorageLayout,
-            CAF::DevDoc => Self::DevDoc,
-            CAF::Ir => Self::Ir,
-            CAF::IrOptimized => Self::IrOptimized,
-            CAF::Metadata => Self::Metadata,
-            CAF::UserDoc => Self::UserDoc,
-            CAF::Ewasm => Self::Ewasm(EwasmOutputSelection::All),
-            CAF::Events => Self::Abi,
+            Caf::Assembly | Caf::AssemblyOptimized => Self::Evm(EvmOutputSelection::Assembly),
+            Caf::MethodIdentifiers => Self::Evm(EvmOutputSelection::MethodIdentifiers),
+            Caf::GasEstimates => Self::Evm(EvmOutputSelection::GasEstimates),
+            Caf::StorageLayout => Self::StorageLayout,
+            Caf::DevDoc => Self::DevDoc,
+            Caf::Ir => Self::Ir,
+            Caf::IrOptimized => Self::IrOptimized,
+            Caf::Metadata => Self::Metadata,
+            Caf::UserDoc => Self::UserDoc,
+            Caf::Ewasm => Self::Ewasm(EwasmOutputSelection::All),
+            Caf::Events => Self::Abi,
         }
     }
 }
 
 impl PartialEq<ContractOutputSelection> for ContractArtifactField {
     fn eq(&self, other: &ContractOutputSelection) -> bool {
-        type COS = ContractOutputSelection;
-        type EOS = EvmOutputSelection;
+        type Cos = ContractOutputSelection;
+        type Eos = EvmOutputSelection;
         matches!(
             (self, other),
-            (Self::Abi | Self::Events, COS::Abi) |
-                (Self::Bytecode, COS::Evm(EOS::ByteCode(_))) |
-                (Self::DeployedBytecode, COS::Evm(EOS::DeployedByteCode(_))) |
-                (Self::Assembly | Self::AssemblyOptimized, COS::Evm(EOS::Assembly)) |
-                (Self::MethodIdentifiers, COS::Evm(EOS::MethodIdentifiers)) |
-                (Self::GasEstimates, COS::Evm(EOS::GasEstimates)) |
-                (Self::StorageLayout, COS::StorageLayout) |
-                (Self::DevDoc, COS::DevDoc) |
-                (Self::Ir, COS::Ir) |
-                (Self::IrOptimized, COS::IrOptimized) |
-                (Self::Metadata, COS::Metadata) |
-                (Self::UserDoc, COS::UserDoc) |
-                (Self::Ewasm, COS::Ewasm(_))
+            (Self::Abi | Self::Events, Cos::Abi) |
+                (Self::Bytecode, Cos::Evm(Eos::ByteCode(_))) |
+                (Self::DeployedBytecode, Cos::Evm(Eos::DeployedByteCode(_))) |
+                (Self::Assembly | Self::AssemblyOptimized, Cos::Evm(Eos::Assembly)) |
+                (Self::MethodIdentifiers, Cos::Evm(Eos::MethodIdentifiers)) |
+                (Self::GasEstimates, Cos::Evm(Eos::GasEstimates)) |
+                (Self::StorageLayout, Cos::StorageLayout) |
+                (Self::DevDoc, Cos::DevDoc) |
+                (Self::Ir, Cos::Ir) |
+                (Self::IrOptimized, Cos::IrOptimized) |
+                (Self::Metadata, Cos::Metadata) |
+                (Self::UserDoc, Cos::UserDoc) |
+                (Self::Ewasm, Cos::Ewasm(_))
         )
     }
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -70,13 +70,16 @@ impl Cmd for InstallArgs {
 
 #[derive(Debug, Clone, Copy, Default, Parser)]
 pub struct DependencyInstallOpts {
-    #[clap(help = "Install without adding the dependency as a submodule.", long)]
+    /// Install without adding the dependency as a submodule.
+    #[clap(long)]
     pub no_git: bool,
 
-    #[clap(help = "Do not create a commit.", long)]
+    /// Do not create a commit.
+    #[clap(long)]
     pub no_commit: bool,
 
-    #[clap(help = "Do not print any messages.", short, long)]
+    /// Do not print any messages.
+    #[clap(short, long)]
     pub quiet: bool,
 }
 

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -43,7 +43,6 @@ pub struct InstallArgs {
     ///
     /// Target installation directory can be added via `<alias>=` suffix.
     /// The dependency will installed to `lib/<alias>`.
-    #[clap(value_name = "DEPENDENCIES")]
     dependencies: Vec<Dependency>,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -49,13 +49,11 @@ pub struct InstallArgs {
     #[clap(flatten)]
     opts: DependencyInstallOpts,
 
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 }
 

--- a/cli/src/cmd/forge/remappings.rs
+++ b/cli/src/cmd/forge/remappings.rs
@@ -8,12 +8,11 @@ use std::path::PathBuf;
 /// CLI arguments for `forge remappings`.
 #[derive(Debug, Clone, Parser)]
 pub struct RemappingArgs {
-    #[clap(
-        help = "The project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 }
 impl_figment_convert_basic!(RemappingArgs);

--- a/cli/src/cmd/forge/remove.rs
+++ b/cli/src/cmd/forge/remove.rs
@@ -11,14 +11,14 @@ use std::{path::PathBuf, process::Command};
 /// CLI arguments for `forge remove`.
 #[derive(Debug, Clone, Parser)]
 pub struct RemoveArgs {
-    #[clap(help = "The path to the dependency you want to remove.")]
+    /// The dependencies you want to remove.
     dependencies: Vec<Dependency>,
-    #[clap(
-        help = "The project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 }
 impl_figment_convert_basic!(RemoveArgs);

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -85,11 +85,10 @@ pub struct ScriptArgs {
     ///
     /// If multiple contracts exist in the same file you must specify the target contract with
     /// --target-contract.
-    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
+    #[clap(value_hint = ValueHint::FilePath)]
     pub path: String,
 
     /// Arguments to pass to the script function.
-    #[clap(value_name = "ARGS")]
     pub args: Vec<String>,
 
     /// The name of the contract you want to run.
@@ -101,7 +100,6 @@ pub struct ScriptArgs {
         long,
         short,
         default_value = "run()",
-        value_name = "SIGNATURE",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix
     )]
     pub sig: String,
@@ -136,7 +134,7 @@ pub struct ScriptArgs {
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
     #[clap(
         long,
-        requires = "from",
+        requires = "sender",
         conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"],
     )]
     pub unlocked: bool,
@@ -854,14 +852,14 @@ mod tests {
         let root = temp.path();
 
         let config = r#"
-                [profile.default]
+            [profile.default]
 
-               [rpc_endpoints]
-                mumbai = "https://polygon-mumbai.g.alchemy.com/v2/${_EXTRACT_RPC_ALIAS}"
+            [rpc_endpoints]
+            mumbai = "https://polygon-mumbai.g.alchemy.com/v2/${_EXTRACT_RPC_ALIAS}"
 
-                [etherscan]
-                mumbai = { key = "${_POLYSCAN_API_KEY}", chain = 80001, url = "https://api-testnet.polygonscan.com/" }
-            "#;
+            [etherscan]
+            mumbai = { key = "${_POLYSCAN_API_KEY}", chain = 80001, url = "https://api-testnet.polygonscan.com/" }
+        "#;
 
         let toml_file = root.join(Config::FILE_NAME);
         fs::write(toml_file, config).unwrap();

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -105,25 +105,22 @@ pub struct ScriptArgs {
     )]
     pub sig: String,
 
-    #[clap(
-        long,
-        help = "Use legacy transactions instead of EIP1559 ones. this is auto-enabled for common networks without EIP1559."
-    )]
+    /// Use legacy transactions instead of EIP1559 ones.
+    ///
+    /// This is auto-enabled for common networks without EIP1559.
+    #[clap(long)]
     pub legacy: bool,
 
-    #[clap(long, help = "Broadcasts the transactions.")]
+    /// Broadcasts the transactions.
+    #[clap(long)]
     pub broadcast: bool,
 
-    #[clap(long, help = "Skips on-chain simulation")]
+    /// Skips on-chain simulation.
+    #[clap(long)]
     pub skip_simulation: bool,
 
-    #[clap(
-        long,
-        short,
-        default_value = "130",
-        value_name = "GAS_ESTIMATE_MULTIPLIER",
-        help = "Relative percentage to multiply gas estimates by"
-    )]
+    /// Relative percentage to multiply gas estimates by.
+    #[clap(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
 
     #[clap(flatten)]
@@ -135,11 +132,11 @@ pub struct ScriptArgs {
     #[clap(flatten)]
     pub evm_opts: EvmArgs,
 
+    /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
     #[clap(
         long,
-        help = "Send via `eth_sendTransaction` using the `--sender` argument or `$ETH_FROM` as sender",
-        requires = "sender",
-        conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"]
+        requires = "from",
+        conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"],
     )]
     pub unlocked: bool,
 
@@ -152,43 +149,42 @@ pub struct ScriptArgs {
     #[clap(long)]
     pub resume: bool,
 
-    #[clap(
-        long,
-        help = "If present, --resume or --verify will be assumed to be a multi chain deployment."
-    )]
+    /// If present, --resume or --verify will be assumed to be a multi chain deployment.
+    #[clap(long)]
     pub multi: bool,
 
-    #[clap(long, help = "Open the script in the debugger. Takes precedence over broadcast.")]
+    /// Open the script in the debugger.
+    ///
+    /// Takes precedence over broadcast.
+    #[clap(long)]
     pub debug: bool,
 
-    #[clap(
-        long,
-        help = "Makes sure a transaction is sent, only after its previous one has been confirmed and succeeded."
-    )]
+    /// Makes sure a transaction is sent,
+    /// only after its previous one has been confirmed and succeeded.
+    #[clap(long)]
     pub slow: bool,
 
     /// The Etherscan (or equivalent) API key
     #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,
 
-    #[clap(
-        long,
-        help = "If it finds a matching broadcast log, it tries to verify every contract found in the receipts."
-    )]
+    /// Verifies all the contracts found in the receipts of a script, if any.
+    #[clap(long)]
     pub verify: bool,
 
     #[clap(flatten)]
     pub verifier: super::verify::VerifierArgs,
 
-    #[clap(long, help = "Output results in JSON format.")]
+    /// Output results in JSON format.
+    #[clap(long)]
     pub json: bool,
 
+    /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.
     #[clap(
         long,
-        help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
         env = "ETH_GAS_PRICE",
         value_parser = parse_ether_value,
-        value_name = "PRICE"
+        value_name = "PRICE",
     )]
     pub with_gas_price: Option<U256>,
 

--- a/cli/src/cmd/forge/script/transaction.rs
+++ b/cli/src/cmd/forge/script/transaction.rs
@@ -406,10 +406,10 @@ pub mod wrapper {
         /// Number of the block this transaction was included within.
         #[serde(rename = "blockNumber")]
         pub block_number: Option<U64>,
-        /// address of the sender.
+        /// The address of the sender.
         #[serde(serialize_with = "serialize_addr")]
         pub from: Address,
-        // address of the receiver. null when its a contract creation transaction.
+        // The address of the receiver. `None` when its a contract creation transaction.
         #[serde(serialize_with = "serialize_opt_addr")]
         pub to: Option<Address>,
         /// Cumulative gas used within the block after this was executed.

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -69,19 +69,21 @@ pub struct SnapshotArgs {
     check: Option<Option<PathBuf>>,
 
     // Hidden because there is only one option
-    #[clap(help = "How to format the output.", long, hide(true))]
+    /// How to format the output.
+    #[clap(long, hide(true))]
     format: Option<Format>,
 
+    /// Output file for the snapshot.
     #[clap(
-        help = "Output file for the snapshot.",
-        default_value = ".gas-snapshot",
         long,
-        value_name = "SNAPSHOT_FILE"
+        default_value = ".gas-snapshot",
+        value_hint = ValueHint::FilePath,
+        value_name = "FILE",
     )]
     snap: PathBuf,
 
+    /// Tolerates gas deviations up to the specified percentage.
     #[clap(
-        help = "Tolerates gas deviations up to the specified percentage.",
         long,
         value_parser = RangedU64ValueParser::<u32>::new().range(0..100),
         value_name = "SNAPSHOT_THRESHOLD"

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -159,21 +159,20 @@ impl FromStr for Format {
 /// Additional filters that can be applied on the test results
 #[derive(Debug, Clone, Parser, Default)]
 struct SnapshotConfig {
-    #[clap(help = "Sort results by gas used (ascending).", long)]
+    /// Sort results by gas used (ascending).
+    #[clap(long)]
     asc: bool,
-    #[clap(help = "Sort results by gas used (descending).", conflicts_with = "asc", long)]
+
+    /// Sort results by gas used (descending).
+    #[clap(conflicts_with = "asc", long)]
     desc: bool,
-    #[clap(
-        help = "Only include tests that used more gas that the given amount.",
-        long,
-        value_name = "MIN_GAS"
-    )]
+
+    /// Only include tests that used more gas that the given amount.
+    #[clap(long, value_name = "MIN_GAS")]
     min: Option<u64>,
-    #[clap(
-        help = "Only include tests that used less gas that the given amount.",
-        long,
-        value_name = "MAX_GAS"
-    )]
+
+    /// Only include tests that used less gas that the given amount.
+    #[clap(long, value_name = "MAX_GAS")]
     max: Option<u64>,
 }
 

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -97,21 +97,18 @@ pub struct TestArgs {
     #[clap(long, short, help_heading = "Display options")]
     list: bool,
 
-    #[clap(
-        long,
-        help = "Set seed used to generate randomness during your fuzz runs",
-        value_parser =  utils::parse_u256
-    )]
+    /// Set seed used to generate randomness during your fuzz runs.
+    #[clap(long, value_parser = utils::parse_u256)]
     pub fuzz_seed: Option<U256>,
 }
 
 impl TestArgs {
-    /// Returns the flattened [`CoreBuildArgs`]
+    /// Returns the flattened [`CoreBuildArgs`].
     pub fn build_args(&self) -> &CoreBuildArgs {
         &self.opts
     }
 
-    /// Executes all the tests in the project
+    /// Executes all the tests in the project.
     ///
     /// This will trigger the build process first. On success all test contracts that match the
     /// configured filter will be executed
@@ -233,7 +230,7 @@ impl TestArgs {
         }
     }
 
-    /// Returns the flattened [`FilterArgs`] arguments merged with [`Config`]
+    /// Returns the flattened [`FilterArgs`] arguments merged with [`Config`].
     pub fn filter(&self, config: &Config) -> ProjectPathsAwareFilter {
         self.filter.merge_with_config(config)
     }

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -11,15 +11,16 @@ use ethers::solc::resolver::{Charset, TreeOptions};
 /// CLI arguments for `forge tree`.
 #[derive(Debug, Clone, Parser)]
 pub struct TreeArgs {
-    #[clap(help = "Do not de-duplicate (repeats all shared dependencies)", long)]
+    /// Do not de-duplicate (repeats all shared dependencies)
+    #[clap(long)]
     no_dedupe: bool,
-    #[clap(
-        help = "Character set to use in output: utf8, ascii",
-        default_value = "utf8",
-        long,
-        value_name = "CHARSET"
-    )]
+
+    /// Character set to use in output.
+    ///
+    /// [possible values: utf8, ascii]
+    #[clap(long, default_value = "utf8")]
     charset: Charset,
+
     #[clap(flatten)]
     opts: ProjectPathsArgs,
 }

--- a/cli/src/cmd/forge/update.rs
+++ b/cli/src/cmd/forge/update.rs
@@ -6,10 +6,8 @@ use std::{path::PathBuf, process::Command};
 /// CLI arguments for `forge update`.
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
-    #[clap(
-        help = "The path to the dependency you want to update.",
-        value_hint = ValueHint::DirPath
-    )]
+    /// The path to the dependency you want to update.
+    #[clap(value_hint = ValueHint::DirPath, value_name = "PATH")]
     lib: Option<PathBuf>,
 }
 
@@ -23,8 +21,6 @@ impl Cmd for UpdateArgs {
         if let Some(lib) = self.lib {
             cmd.args(["--", lib.display().to_string().as_str()]);
         }
-        cmd.exec()?;
-
-        Ok(())
+        cmd.exec().map(|_| ())
     }
 }

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -22,21 +22,16 @@ mod sourcify;
 /// Verification provider arguments
 #[derive(Debug, Clone, Parser)]
 pub struct VerifierArgs {
+    /// The contract verification provider to use.
     #[clap(
         value_enum,
         long = "verifier",
         help_heading = "Verification provider",
-        help = "Contract verification provider to use `etherscan`, `sourcify` or `blockscout`",
         default_value = "etherscan"
     )]
     pub verifier: VerificationProviderType,
 
-    #[clap(
-        long,
-        env = "VERIFIER_URL",
-        help = "The verifier URL, if using a custom provider",
-        value_name = "VERIFIER_URL"
-    )]
+    #[clap(long, env = "VERIFIER_URL", help = "The verifier URL, if using a custom provider")]
     pub verifier_url: Option<String>,
 }
 
@@ -49,95 +44,74 @@ impl Default for VerifierArgs {
 /// CLI arguments for `forge verify`.
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyArgs {
-    #[clap(help = "The address of the contract to verify.", value_name = "ADDRESS")]
+    /// The address of the contract to verify.
     pub address: Address,
 
-    #[clap(
-        help = "The contract identifier in the form `<path>:<contractname>`.",
-        value_name = "CONTRACT"
-    )]
+    /// The contract identifier in the form `<path>:<contractname>`.
     pub contract: ContractInfo,
 
+    /// The ABI-encoded constructor arguments.
     #[clap(
         long,
-        help = "The ABI-encoded constructor arguments.",
-        name = "constructor_args",
+        num_args(1..),
         conflicts_with = "constructor_args_path",
-        value_name = "ARGS"
+        value_name = "ARGS",
     )]
     pub constructor_args: Option<String>,
 
+    /// The path to a file containing the constructor arguments.
     #[clap(
         long,
-        help = "The path to a file containing the constructor arguments.",
         value_hint = ValueHint::FilePath,
-        name = "constructor_args_path",
-        conflicts_with = "constructor_args",
-        value_name = "FILE"
+        value_name = "PATH",
     )]
     pub constructor_args_path: Option<PathBuf>,
 
-    #[clap(
-        long,
-        help = "The compiler version used to build the smart contract.",
-        value_name = "VERSION"
-    )]
+    /// The `solc` version to use to build the smart contract.
+    #[clap(long, value_name = "VERSION")]
     pub compiler_version: Option<String>,
 
-    #[clap(
-        visible_alias = "optimizer-runs",
-        long,
-        help = "The number of optimization runs used to build the smart contract.",
-        value_name = "NUM"
-    )]
+    /// The number of optimization runs used to build the smart contract.
+    #[clap(long, visible_alias = "optimizer-runs", value_name = "NUM")]
     pub num_of_optimizations: Option<usize>,
 
     #[clap(flatten)]
     pub etherscan: EtherscanOpts,
 
-    #[clap(help = "Flatten the source code before verifying.", long = "flatten")]
+    /// Flatten the source code before verifying.
+    #[clap(long)]
     pub flatten: bool,
 
-    #[clap(
-        short,
-        long,
-        help = "Do not compile the flattened smart contract before verifying (if --flatten is passed)."
-    )]
+    /// Do not compile the flattened smart contract before verifying (if --flatten is passed).
+    #[clap(short, long)]
     pub force: bool,
 
-    #[clap(long, help = "Wait for verification result after submission")]
+    /// Wait for verification result after submission.
+    #[clap(long)]
     pub watch: bool,
 
     #[clap(flatten)]
     pub retry: RetryArgs,
 
-    #[clap(
-        help_heading = "Linker options",
-        help = "Set pre-linked libraries.",
-        long,
-        env = "DAPP_LIBRARIES",
-        value_name = "LIBRARIES"
-    )]
+    /// Set pre-linked libraries.
+    #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     pub libraries: Vec<String>,
 
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath,
-        value_name = "PATH"
-    )]
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
     #[clap(flatten)]
     pub verifier: VerifierArgs,
 
-    #[clap(
-        help = "Prints the standard json compiler input.",
-        long,
-        long_help = "The standard json compiler input can be used to manually submit contract verification in the browser.",
-        conflicts_with = "flatten"
-    )]
+    /// Prints the standard json compiler input.
+    ///
+    /// The standard json compiler input can be used to manually submit contract verification in
+    /// the browser.
+    #[clap(long, conflicts_with = "flatten")]
     pub show_standard_json_input: bool,
 }
 

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -23,15 +23,11 @@ mod sourcify;
 #[derive(Debug, Clone, Parser)]
 pub struct VerifierArgs {
     /// The contract verification provider to use.
-    #[clap(
-        value_enum,
-        long = "verifier",
-        help_heading = "Verification provider",
-        default_value = "etherscan"
-    )]
+    #[clap(long, help_heading = "Verifier options", default_value = "etherscan", value_enum)]
     pub verifier: VerificationProviderType,
 
-    #[clap(long, env = "VERIFIER_URL", help = "The verifier URL, if using a custom provider")]
+    /// The verifier URL, if using a custom provider
+    #[clap(long, help_heading = "Verifier options", env = "VERIFIER_URL")]
     pub verifier_url: Option<String>,
 }
 
@@ -51,20 +47,11 @@ pub struct VerifyArgs {
     pub contract: ContractInfo,
 
     /// The ABI-encoded constructor arguments.
-    #[clap(
-        long,
-        num_args(1..),
-        conflicts_with = "constructor_args_path",
-        value_name = "ARGS",
-    )]
+    #[clap(long, conflicts_with = "constructor_args_path", value_name = "ARGS")]
     pub constructor_args: Option<String>,
 
     /// The path to a file containing the constructor arguments.
-    #[clap(
-        long,
-        value_hint = ValueHint::FilePath,
-        value_name = "PATH",
-    )]
+    #[clap(long, value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub constructor_args_path: Option<PathBuf>,
 
     /// The `solc` version to use to build the smart contract.
@@ -187,13 +174,14 @@ impl VerifyArgs {
 /// Check verification status arguments
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyCheckArgs {
-    #[clap(
-        help = "The verification ID. For Etherscan - Submission GUID. For Sourcify - Contract Address",
-        value_name = "ID"
-    )]
+    /// The verification ID.
+    ///
+    /// For Etherscan - Submission GUID.
+    ///
+    /// For Sourcify - Contract Address.
     id: String,
 
-    #[clap(flatten, help = "Allows to use retry arguments for contract verification")]
+    #[clap(flatten)]
     retry: RetryArgs,
 
     #[clap(flatten)]

--- a/cli/src/cmd/forge/verify/provider.rs
+++ b/cli/src/cmd/forge/verify/provider.rs
@@ -54,8 +54,9 @@ impl fmt::Display for VerificationProviderType {
     }
 }
 
-#[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Debug, Default, Clone, PartialEq, Eq)]
 pub enum VerificationProviderType {
+    #[default]
     Etherscan,
     Sourcify,
     Blockscout,

--- a/cli/src/cmd/forge/watch.rs
+++ b/cli/src/cmd/forge/watch.rs
@@ -4,7 +4,7 @@ use crate::{
     cmd::forge::{build::BuildArgs, snapshot::SnapshotArgs, test::TestArgs},
     utils::{self, FoundryPathExt},
 };
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use foundry_config::Config;
 use std::{collections::HashSet, convert::Infallible, path::PathBuf, sync::Arc};
 use tracing::trace;
@@ -26,11 +26,10 @@ pub struct WatchArgs {
     ///
     /// If no paths are provided, the source and test directories of the project are watched.
     #[clap(
-        short,
         long,
-        value_name = "PATH",
+        short,
         num_args(0..),
-        action = ArgAction::Append,
+        value_name = "PATH",
     )]
     pub watch: Option<Vec<PathBuf>>,
 
@@ -44,7 +43,7 @@ pub struct WatchArgs {
     #[clap(long)]
     pub run_all: bool,
 
-    /// File update debounce delay
+    /// File update debounce delay.
     ///
     /// During the delay, incoming change events are accumulated and
     /// only once the delay has passed, is an action taken. Note that
@@ -57,7 +56,7 @@ pub struct WatchArgs {
     ///
     /// When using --poll mode, you'll want a larger duration, or risk
     /// overloading disk I/O.
-    #[clap(long = "watch-delay", value_parser = clap::builder::NonEmptyStringValueParser::default(), value_name = "DELAY")]
+    #[clap(long, value_name = "DELAY")]
     pub watch_delay: Option<String>,
 }
 

--- a/cli/src/cmd/retry.rs
+++ b/cli/src/cmd/retry.rs
@@ -11,21 +11,19 @@ pub const RETRY_VERIFY_ON_CREATE: RetryArgs = RetryArgs { retries: 15, delay: 5 
 #[derive(Debug, Clone, Copy, Parser)]
 #[clap(about = "Allows to use retry arguments for contract verification")] // override doc
 pub struct RetryArgs {
+    /// Number of attempts for retrying verification.
     #[clap(
         long,
-        help = "Number of attempts for retrying verification",
-        default_value = "5",
         value_parser = RangedU64ValueParser::<u32>::new().range(1..=10),
-        value_name = "RETRIES"
+        default_value = "5",
     )]
     pub retries: u32,
 
+    /// Optional delay to apply inbetween verification attempts, in seconds.
     #[clap(
         long,
-        help = "Optional delay to apply inbetween verification attempts in seconds.",
-        default_value = "5",
         value_parser = RangedU64ValueParser::<u32>::new().range(0..=30),
-        value_name = "DELAY"
+        default_value = "5",
     )]
     pub delay: u32,
 }

--- a/cli/src/cmd/retry.rs
+++ b/cli/src/cmd/retry.rs
@@ -39,3 +39,23 @@ impl From<RetryArgs> for Retry {
         Retry::new(r.retries, Some(r.delay))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli() {
+        let args = RetryArgs::parse_from(&["foundry-cli", "--retries", "10"]);
+        assert_eq!(args.retries, 10);
+        assert_eq!(args.delay, 5);
+
+        let args = RetryArgs::parse_from(&["foundry-cli", "--delay", "10"]);
+        assert_eq!(args.retries, 5);
+        assert_eq!(args.delay, 10);
+
+        let args = RetryArgs::parse_from(&["foundry-cli", "--retries", "10", "--delay", "10"]);
+        assert_eq!(args.retries, 10);
+        assert_eq!(args.delay, 10);
+    }
+}

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -57,14 +57,18 @@ fn main() -> eyre::Result<()> {
         Subcommands::Remappings(cmd) => cmd.run(),
         Subcommands::Init(cmd) => cmd.run(),
         Subcommands::Completions { shell } => {
-            Ok(generate(shell, &mut Opts::command(), "forge", &mut std::io::stdout()))
+            generate(shell, &mut Opts::command(), "forge", &mut std::io::stdout());
+            Ok(())
         }
-        Subcommands::GenerateFigSpec => Ok(clap_complete::generate(
-            clap_complete_fig::Fig,
-            &mut Opts::command(),
-            "forge",
-            &mut std::io::stdout(),
-        )),
+        Subcommands::GenerateFigSpec => {
+            clap_complete::generate(
+                clap_complete_fig::Fig,
+                &mut Opts::command(),
+                "forge",
+                &mut std::io::stdout(),
+            );
+            Ok(())
+        }
         Subcommands::Clean { root } => {
             let config = utils::load_config_with_root(root);
             config.project()?.cleanup()?;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -83,14 +83,7 @@ fn main() -> eyre::Result<()> {
         Subcommands::Inspect(cmd) => cmd.run(),
         Subcommands::UploadSelectors(args) => utils::block_on(args.run()),
         Subcommands::Tree(cmd) => cmd.run(),
-        Subcommands::Geiger(cmd) => {
-            let check = cmd.check;
-            let n = cmd.run()?;
-            if check && n > 0 {
-                std::process::exit(n as i32);
-            }
-            Ok(())
-        }
+        Subcommands::Geiger(cmd) => cmd.run(),
         Subcommands::Doc(cmd) => cmd.run(),
     }
 }

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -20,10 +20,10 @@ fn main() -> eyre::Result<()> {
     match opts.sub {
         Subcommands::Test(cmd) => {
             if cmd.is_watch() {
-                utils::block_on(watch::watch_test(cmd))?;
+                utils::block_on(watch::watch_test(cmd))
             } else {
                 let outcome = cmd.run()?;
-                outcome.ensure_ok()?;
+                outcome.ensure_ok()
             }
         }
         Subcommands::Script(cmd) => {
@@ -32,99 +32,65 @@ fn main() -> eyre::Result<()> {
                 cmd.opts.args.silent,
                 cmd.json,
             ))?;
-            utils::block_on(cmd.run_script())?;
+            utils::block_on(cmd.run_script())
         }
-        Subcommands::Coverage(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Bind(cmd) => {
-            cmd.run()?;
-        }
+        Subcommands::Coverage(cmd) => cmd.run(),
+        Subcommands::Bind(cmd) => cmd.run(),
         Subcommands::Build(cmd) => {
             if cmd.is_watch() {
-                utils::block_on(watch::watch_build(cmd))?;
+                utils::block_on(watch::watch_build(cmd))
             } else {
-                cmd.run()?;
+                cmd.run().map(|_| ())
             }
         }
-        Subcommands::Debug(cmd) => {
-            utils::block_on(cmd.debug())?;
-        }
-        Subcommands::VerifyContract(args) => {
-            utils::block_on(args.run())?;
-        }
-        Subcommands::VerifyCheck(args) => {
-            utils::block_on(args.run())?;
-        }
+        Subcommands::Debug(cmd) => utils::block_on(cmd.debug()),
+        Subcommands::VerifyContract(args) => utils::block_on(args.run()),
+        Subcommands::VerifyCheck(args) => utils::block_on(args.run()),
         Subcommands::Cache(cmd) => match cmd.sub {
-            CacheSubcommands::Clean(cmd) => {
-                cmd.run()?;
-            }
-            CacheSubcommands::Ls(cmd) => {
-                cmd.run()?;
-            }
+            CacheSubcommands::Clean(cmd) => cmd.run(),
+            CacheSubcommands::Ls(cmd) => cmd.run(),
         },
-        Subcommands::Create(cmd) => {
-            utils::block_on(cmd.run())?;
-        }
-        Subcommands::Update(cmd) => cmd.run()?,
-        Subcommands::Install(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Remove(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Remappings(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Init(cmd) => {
-            cmd.run()?;
-        }
+        Subcommands::Create(cmd) => utils::block_on(cmd.run()),
+        Subcommands::Update(cmd) => cmd.run(),
+        Subcommands::Install(cmd) => cmd.run(),
+        Subcommands::Remove(cmd) => cmd.run(),
+        Subcommands::Remappings(cmd) => cmd.run(),
+        Subcommands::Init(cmd) => cmd.run(),
         Subcommands::Completions { shell } => {
-            generate(shell, &mut Opts::command(), "forge", &mut std::io::stdout())
+            Ok(generate(shell, &mut Opts::command(), "forge", &mut std::io::stdout()))
         }
-        Subcommands::GenerateFigSpec => clap_complete::generate(
+        Subcommands::GenerateFigSpec => Ok(clap_complete::generate(
             clap_complete_fig::Fig,
             &mut Opts::command(),
             "forge",
             &mut std::io::stdout(),
-        ),
+        )),
         Subcommands::Clean { root } => {
             let config = utils::load_config_with_root(root);
             config.project()?.cleanup()?;
+            Ok(())
         }
         Subcommands::Snapshot(cmd) => {
             if cmd.is_watch() {
-                utils::block_on(watch::watch_snapshot(cmd))?;
+                utils::block_on(watch::watch_snapshot(cmd))
             } else {
-                cmd.run()?;
+                cmd.run()
             }
         }
-        Subcommands::Fmt(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Config(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Flatten(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::Inspect(cmd) => {
-            cmd.run()?;
-        }
-        Subcommands::UploadSelectors(args) => {
-            utils::block_on(args.run())?;
-        }
-        Subcommands::Tree(cmd) => {
-            cmd.run()?;
-        }
+        Subcommands::Fmt(cmd) => cmd.run(),
+        Subcommands::Config(cmd) => cmd.run(),
+        Subcommands::Flatten(cmd) => cmd.run(),
+        Subcommands::Inspect(cmd) => cmd.run(),
+        Subcommands::UploadSelectors(args) => utils::block_on(args.run()),
+        Subcommands::Tree(cmd) => cmd.run(),
         Subcommands::Geiger(cmd) => {
-            cmd.run()?;
+            let check = cmd.check;
+            let n = cmd.run()?;
+            if check && n > 0 {
+                std::process::exit(n as i32);
+            }
+            Ok(())
         }
-        Subcommands::Doc(cmd) => {
-            cmd.run()?;
-        }
+        Subcommands::Doc(cmd) => cmd.run(),
     }
-
-    Ok(())
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -314,7 +314,7 @@ pub enum Subcommands {
     },
 
     /// Get information about a block.
-    #[clap(name = "block", visible_alias = "bl")]
+    #[clap(visible_alias = "bl")]
     Block {
         /// The block height to query at.
         ///
@@ -344,7 +344,7 @@ pub enum Subcommands {
     },
 
     /// Perform a call on an account without publishing a transaction.
-    #[clap(name = "call", visible_alias = "c")]
+    #[clap(visible_alias = "c")]
     Call(CallArgs),
 
     /// ABI-encode a function with arguments.
@@ -359,7 +359,6 @@ pub enum Subcommands {
     },
 
     /// Get the symbolic name of the current chain.
-    #[clap(name = "chain")]
     Chain {
         #[clap(flatten)]
         rpc: RpcOpts,
@@ -373,7 +372,7 @@ pub enum Subcommands {
     },
 
     /// Get the current client version.
-    #[clap(name = "client", visible_alias = "cl")]
+    #[clap(visible_alias = "cl")]
     Client {
         #[clap(flatten)]
         rpc: RpcOpts,
@@ -394,18 +393,18 @@ pub enum Subcommands {
     },
 
     /// Disassembles hex encoded bytecode into individual / human readable opcodes
-    #[clap(name = "disassemble", visible_alias = "da")]
+    #[clap(visible_alias = "da")]
     Disassemble {
         /// The hex encoded bytecode.
         bytecode: String,
     },
 
     /// Calculate the ENS namehash of a name.
-    #[clap(name = "namehash", visible_aliases = &["na", "nh"])]
+    #[clap(visible_aliases = &["na", "nh"])]
     Namehash { name: Option<String> },
 
     /// Get information about a transaction.
-    #[clap(name = "tx", visible_alias = "t")]
+    #[clap(visible_alias = "t")]
     Tx {
         /// The transaction hash.
         tx_hash: String,
@@ -422,7 +421,7 @@ pub enum Subcommands {
     },
 
     /// Get the transaction receipt for a transaction.
-    #[clap(name = "receipt", visible_alias = "re")]
+    #[clap(visible_alias = "re")]
     Receipt {
         /// The transaction hash.
         tx_hash: String,
@@ -465,7 +464,7 @@ pub enum Subcommands {
     },
 
     /// Estimate the gas cost of a transaction.
-    #[clap(name = "estimate", visible_alias = "e")]
+    #[clap(visible_alias = "e")]
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
@@ -507,7 +506,7 @@ pub enum Subcommands {
     },
 
     /// Compute the storage slot for an entry in a mapping.
-    #[clap(name = "index", visible_alias = "in")]
+    #[clap(visible_alias = "in")]
     Index {
         /// The mapping key type.
         key_type: String,
@@ -520,7 +519,7 @@ pub enum Subcommands {
     },
 
     /// Fetch the EIP-1967 implementation account
-    #[clap(name = "implementation", visible_alias = "impl")]
+    #[clap(visible_alias = "impl")]
     Implementation {
         /// The block height to query at.
         ///
@@ -537,7 +536,7 @@ pub enum Subcommands {
     },
 
     /// Fetch the EIP-1967 admin account
-    #[clap(name = "admin", visible_alias = "adm")]
+    #[clap(visible_alias = "adm")]
     Admin {
         /// The block height to query at.
         ///
@@ -607,7 +606,7 @@ pub enum Subcommands {
     },
 
     /// Get the timestamp of a block.
-    #[clap(name = "age", visible_alias = "a")]
+    #[clap(visible_alias = "a")]
     Age {
         /// The block height to query at.
         ///
@@ -619,7 +618,7 @@ pub enum Subcommands {
     },
 
     /// Get the balance of an account in wei.
-    #[clap(name = "balance", visible_alias = "b")]
+    #[clap(visible_alias = "b")]
     Balance {
         /// The block height to query at.
         ///
@@ -640,7 +639,7 @@ pub enum Subcommands {
     },
 
     /// Get the basefee of a block.
-    #[clap(name = "basefee", visible_aliases = &["ba", "fee"])]
+    #[clap(visible_aliases = &["ba", "fee"])]
     BaseFee {
         /// The block height to query at.
         ///
@@ -652,7 +651,7 @@ pub enum Subcommands {
     },
 
     /// Get the bytecode of a contract.
-    #[clap(name = "code", visible_alias = "co")]
+    #[clap(visible_alias = "co")]
     Code {
         /// The block height to query at.
         ///
@@ -687,7 +686,7 @@ pub enum Subcommands {
     },
 
     /// Hash arbitrary data using Keccak-256.
-    #[clap(name = "keccak", visible_alias = "k")]
+    #[clap(visible_alias = "k")]
     Keccak {
         /// The data to hash.
         data: Option<String>,
@@ -722,11 +721,11 @@ pub enum Subcommands {
     },
 
     /// Get the raw value of a contract's storage slot.
-    #[clap(name = "storage", visible_alias = "st")]
+    #[clap(visible_alias = "st")]
     Storage(StorageArgs),
 
     /// Generate a storage proof for a given storage slot.
-    #[clap(name = "proof", visible_alias = "pr")]
+    #[clap(visible_alias = "pr")]
     Proof {
         /// The contract address.
         #[clap(value_parser = NameOrAddress::from_str)]
@@ -747,7 +746,7 @@ pub enum Subcommands {
     },
 
     /// Get the nonce for an account.
-    #[clap(name = "nonce", visible_alias = "n")]
+    #[clap(visible_alias = "n")]
     Nonce {
         /// The block height to query at.
         ///
@@ -778,7 +777,7 @@ pub enum Subcommands {
     },
 
     /// Wallet management utilities.
-    #[clap(name = "wallet", visible_alias = "w")]
+    #[clap(visible_alias = "w")]
     Wallet {
         #[clap(subcommand)]
         command: WalletSubcommands,
@@ -787,15 +786,15 @@ pub enum Subcommands {
     /// Generate a Solidity interface from a given ABI.
     ///
     /// Currently does not support ABI encoder v2.
-    #[clap(name = "interface", visible_alias = "i")]
+    #[clap(visible_alias = "i")]
     Interface(InterfaceArgs),
 
     /// Generate a rust binding from a given ABI.
-    #[clap(name = "bind", visible_alias = "bi")]
+    #[clap(visible_alias = "bi")]
     Bind(BindArgs),
 
     /// Get the selector for a function.
-    #[clap(name = "sig", visible_alias = "si")]
+    #[clap(visible_alias = "si")]
     Sig {
         /// The function signature, e.g. transfer(address,uint256).
         sig: Option<String>,
@@ -805,7 +804,7 @@ pub enum Subcommands {
     },
 
     /// Generate a deterministic contract address using CREATE2.
-    #[clap(name = "create2", visible_alias = "c2")]
+    #[clap(visible_alias = "c2")]
     Create2(Create2Args),
 
     /// Get the block number closest to the provided timestamp.
@@ -824,11 +823,11 @@ pub enum Subcommands {
     GenerateFigSpec,
 
     /// Runs a published transaction in a local environment and prints the trace.
-    #[clap(name = "run", visible_alias = "r")]
+    #[clap(visible_alias = "r")]
     Run(RunArgs),
 
     /// Perform a raw JSON-RPC request.
-    #[clap(name = "rpc", visible_alias = "rp")]
+    #[clap(visible_alias = "rp")]
     Rpc(RpcArgs),
 
     /// Formats a string into bytes32 encoding.
@@ -845,6 +844,7 @@ pub enum Subcommands {
         bytes: Option<String>,
     },
 }
+
 /// CLI arguments for `cast --to-base`.
 #[derive(Debug, Parser)]
 pub struct ToBaseArgs {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -21,870 +21,839 @@ pub struct Opts {
     pub sub: Subcommands,
 }
 
+/// Perform Ethereum RPC calls from the comfort of your command line.
 #[derive(Debug, Subcommand)]
 #[clap(
-    about = "Perform Ethereum RPC calls from the comfort of your command line.",
     after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html",
     next_display_order = None
 )]
 pub enum Subcommands {
-    #[clap(name = "--max-int")]
-    #[clap(visible_aliases = &["max-int", "maxi"])]
-    #[clap(about = "Get the maximum value of the given integer type.")]
+    /// Prints the maximum value of the given integer type.
+    #[clap(name = "--max-int", visible_aliases = &["max-int", "maxi"])]
     MaxInt {
+        /// The integer type to get the maximum value of.
         #[clap(default_value = "int256")]
         r#type: String,
     },
-    #[clap(name = "--min-int")]
-    #[clap(visible_aliases = &["min-int", "mini"])]
-    #[clap(about = "Get the minimum value of the given integer type.")]
+
+    /// Prints the minimum value of the given integer type.
+    #[clap(name = "--min-int", visible_aliases = &["min-int", "mini"])]
     MinInt {
+        /// The integer type to get the minimum value of.
         #[clap(default_value = "int256")]
         r#type: String,
     },
-    #[clap(name = "--max-uint")]
-    #[clap(visible_aliases = &["max-uint", "maxu"])]
-    #[clap(about = "Get the maximum value of the given integer type.")]
+
+    /// Prints the maximum value of the given integer type.
+    #[clap(name = "--max-uint", visible_aliases = &["max-uint", "maxu"])]
     MaxUint {
+        /// The unsigned integer type to get the maximum value of.
         #[clap(default_value = "uint256")]
         r#type: String,
     },
-    #[clap(name = "--address-zero", about = "Get zero address")]
-    #[clap(visible_aliases = &["address-zero", "az"])]
+
+    /// Prints the zero address.
+    #[clap(name = "--address-zero", visible_aliases = &["address-zero", "az"])]
     AddressZero,
-    #[clap(name = "--hash-zero", about = "Get zero hash")]
-    #[clap(visible_aliases = &["hash-zero", "hz"])]
+
+    /// Prints the zero hash.
+    #[clap(name = "--hash-zero", visible_aliases = &["hash-zero", "hz"])]
     HashZero,
 
-    #[clap(name = "--from-utf8")]
-    #[clap(visible_aliases = &["from-utf8", "--from-ascii", "from-ascii", "fu", "fa"])]
-    #[clap(about = "Convert UTF8 text to hex.")]
+    /// Convert UTF8 text to hex.
+    #[clap(
+        name = "--from-utf8",
+        visible_aliases = &["from-utf8",
+        "--from-ascii",
+        "from-ascii",
+        "fu",
+        "fa"]
+    )]
     FromUtf8 {
-        #[clap(value_name = "TEXT")]
+        /// The text to convert.
         text: Option<String>,
     },
-    #[clap(name = "--concat-hex")]
-    #[clap(visible_aliases = &["concat-hex", "ch"])]
-    #[clap(about = "Concatenate hex strings.")]
+
+    /// Concatenate hex strings.
+    #[clap(name = "--concat-hex", visible_aliases = &["concat-hex", "ch"])]
     ConcatHex {
-        #[clap(value_name = "DATA")]
+        /// The data to concatenate.
         data: Vec<String>,
     },
-    #[clap(name = "--from-bin")]
-    #[clap(visible_aliases = &["from-bin", "fb"])]
-    #[clap(about = "Convert binary data into hex data.")]
-    FromBin,
-    #[clap(name = "--to-hexdata")]
-    #[clap(visible_aliases = &["to-hexdata", "thd", "2hd"])]
-    #[clap(
-        about = "Normalize the input to lowercase, 0x-prefixed hex. See --help for more info.",
-        long_about = r#"Normalize the input to lowercase, 0x-prefixed hex.
 
-The input can be:
-- mixed case hex with or without 0x prefix
-- 0x prefixed hex, concatenated with a ':'
-- an absolute path to file
-- @tag, where the tag is defined in an environment variable"#
-    )]
+    /// "Convert binary data into hex data."
+    #[clap(name = "--from-bin", visible_aliases = &["from-binx", "fb"])]
+    FromBin,
+
+    /// Normalize the input to lowercase, 0x-prefixed hex.
+    ///
+    /// The input can be:
+    /// - mixed case hex with or without 0x prefix
+    /// - 0x prefixed hex, concatenated with a ':'
+    /// - an absolute path to file
+    /// - @tag, where the tag is defined in an environment variable
+    #[clap(name = "--to-hexdata", visible_aliases = &["to-hexdata", "thd", "2hd"])]
     ToHexdata {
-        #[clap(value_name = "INPUT")]
+        /// The input to normalize.
         input: Option<String>,
     },
-    #[clap(name = "--to-checksum-address")]
-    #[clap(visible_aliases = &["to-checksum-address", "--to-checksum", "to-checksum", "ta", "2a"])] // Compatibility with dapptools' cast
-    #[clap(about = "Convert an address to a checksummed format (EIP-55).")]
+
+    /// Convert an address to a checksummed format (EIP-55).
+    #[clap(
+        name = "--to-checksum-address",
+        visible_aliases = &["to-checksum-address",
+        "--to-checksum",
+        "to-checksum",
+        "ta",
+        "2a"]
+    )]
     ToCheckSumAddress {
-        #[clap(value_name = "ADDRESS")]
+        /// The address to convert.
         address: Option<Address>,
     },
-    #[clap(name = "--to-ascii")]
-    #[clap(visible_aliases = &["to-ascii", "tas", "2as"])]
-    #[clap(about = "Convert hex data to an ASCII string.")]
+
+    /// Convert hex data to an ASCII string.
+    #[clap(name = "--to-ascii", visible_aliases = &["to-ascii", "tas", "2as"])]
     ToAscii {
-        #[clap(value_name = "HEXDATA")]
+        /// The hex data to convert.
         hexdata: Option<String>,
     },
-    #[clap(name = "--from-fix")]
-    #[clap(visible_aliases = &["from-fix", "ff"])]
-    #[clap(about = "Convert a fixed point number into an integer.")]
+
+    /// Convert a fixed point number into an integer.
+    #[clap(name = "--from-fix", visible_aliases = &["from-fix", "ff"])]
     FromFixedPoint {
-        #[clap(value_name = "DECIMALS")]
+        /// The number of decimals to use.
         decimals: Option<String>,
 
-        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
-        // negative values not yet supported internally
+        /// The value to convert.
+        #[clap(allow_hyphen_values = true)]
         value: Option<String>,
     },
-    #[clap(name = "--to-bytes32")]
-    #[clap(visible_aliases = &["to-bytes32", "tb", "2b"])]
-    #[clap(about = "Right-pads hex data to 32 bytes.")]
+
+    /// Right-pads hex data to 32 bytes.
+    #[clap(name = "--to-bytes32", visible_aliases = &["to-bytes32", "tb", "2b"])]
     ToBytes32 {
-        #[clap(value_name = "BYTES")]
+        /// The hex data to convert.
         bytes: Option<String>,
     },
-    #[clap(name = "--to-fix")]
-    #[clap(visible_aliases = &["to-fix", "tf", "2f"])]
-    #[clap(about = "Convert an integer into a fixed point number.")]
+
+    /// Convert an integer into a fixed point number.
+    #[clap(name = "--to-fix", visible_aliases = &["to-fix", "tf", "2f"])]
     ToFixedPoint {
-        #[clap(value_name = "DECIMALS")]
+        /// The number of decimals to use.
         decimals: Option<String>,
 
-        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
+        /// The value to convert.
+        #[clap(allow_hyphen_values = true)]
         value: Option<String>,
     },
-    #[clap(name = "--to-uint256")]
-    #[clap(visible_aliases = &["to-uint256", "tu", "2u"])]
-    #[clap(about = "Convert a number to a hex-encoded uint256.")]
+
+    /// Convert a number to a hex-encoded uint256.
+    #[clap(name = "--to-uint256", visible_aliases = &["to-uint256", "tu", "2u"])]
     ToUint256 {
-        #[clap(value_name = "VALUE")]
+        /// The value to convert.
         value: Option<String>,
     },
-    #[clap(name = "--to-int256")]
-    #[clap(visible_aliases = &["to-int256", "ti", "2i"])]
-    #[clap(about = "Convert a number to a hex-encoded int256.")]
+
+    /// Convert a number to a hex-encoded int256.
+    #[clap(name = "--to-int256", visible_aliases = &["to-int256", "ti", "2i"])]
     ToInt256 {
-        #[clap(value_name = "VALUE")]
+        /// The value to convert.
         value: Option<String>,
     },
+
+    /// Perform a left shifting operation
     #[clap(name = "shl")]
-    #[clap(about = "Perform a left shifting operation")]
     LeftShift {
-        #[clap(value_name = "VALUE")]
+        /// The value to shift.
         value: String,
 
-        #[clap(value_name = "BITS")]
+        /// The number of bits to shift.
         bits: String,
 
-        #[clap(long = "base-in", help = "The input base")]
+        /// The input base.
+        #[clap(long)]
         base_in: Option<String>,
 
-        #[clap(long = "base-out", help = "The output base", default_value = "16")]
+        /// The output base.
+        #[clap(long, default_value = "16")]
         base_out: String,
     },
+
+    /// Perform a right shifting operation
     #[clap(name = "shr")]
-    #[clap(about = "Perform a right shifting operation")]
     RightShift {
-        #[clap(value_name = "VALUE")]
+        /// The value to shift.
         value: String,
 
-        #[clap(value_name = "BITS")]
+        /// The number of bits to shift.
         bits: String,
 
-        #[clap(long = "base-in", help = "The input base")]
+        /// The input base,
+        #[clap(long)]
         base_in: Option<String>,
 
-        #[clap(long = "base-out", help = "The output base", default_value = "16")]
+        /// The output base,
+        #[clap(long, default_value = "16")]
         base_out: String,
     },
-    #[clap(name = "--to-unit")]
-    #[clap(visible_aliases = &["to-unit", "tun", "2un"])]
-    #[clap(
-        about = "Convert an ETH amount into another unit (ether, gwei or wei).",
-        long_about = r#"Convert an ETH amount into another unit (ether, gwei or wei).\
 
-Examples:
-- 1ether wei
-- "1 ether" wei
-- 1ether
-- 1 gwei
-- 1gwei ether"#
-    )]
+    /// Convert an ETH amount into another unit (ether, gwei or wei).
+    ///
+    /// Examples:
+    /// - 1ether wei
+    /// - "1 ether" wei
+    /// - 1ether
+    /// - 1 gwei
+    /// - 1gwei ether
+    #[clap(name = "--to-unit", visible_aliases = &["to-unit", "tun", "2un"])]
     ToUnit {
-        #[clap(value_name = "VALUE")]
-        // negative values not yet supported internally
+        /// The value to convert.
         value: Option<String>,
 
-        #[clap(
-            help = "The unit to convert to (ether, gwei, wei).",
-            default_value = "wei",
-            value_name = "UNIT"
-        )]
+        /// The unit to convert to (ether, gwei, wei).
+        #[clap(default_value = "wei")]
         unit: String,
     },
-    #[clap(name = "--to-wei")]
-    #[clap(visible_aliases = &["to-wei", "tw", "2w"])]
-    #[clap(about = "Convert an ETH amount to wei. Consider using --to-unit.")]
+
+    /// Convert an ETH amount to wei.
+    ///
+    /// Consider using --to-unit.
+    #[clap(name = "--to-wei", visible_aliases = &["to-wei", "tw", "2w"])]
     ToWei {
-        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
-        // negative values not yet supported internally
+        /// The value to convert.
+        #[clap(allow_hyphen_values = true)]
         value: Option<String>,
 
-        #[clap(value_name = "UNIT", default_value = "eth")]
+        /// The unit to convert from (ether, gwei, wei).
+        #[clap(default_value = "eth")]
         unit: String,
     },
-    #[clap(name = "--from-wei")]
-    #[clap(visible_aliases = &["from-wei", "fw"])]
-    #[clap(about = "Convert wei into an ETH amount. Consider using --to-unit.")]
+
+    /// Convert wei into an ETH amount.
+    ///
+    /// Consider using --to-unit.
+    #[clap(name = "--from-wei", visible_aliases = &["from-wei", "fw"])]
     FromWei {
-        #[clap(allow_hyphen_values = true, value_name = "VALUE")]
-        // negative values not yet supported internally
+        /// The value to convert.
+        #[clap(allow_hyphen_values = true)]
         value: Option<String>,
 
-        #[clap(value_name = "UNIT", default_value = "eth")]
+        /// The unit to convert from (ether, gwei, wei).
+        #[clap(default_value = "eth")]
         unit: String,
     },
+
+    /// RLP encodes hex data, or an array of hex data
     #[clap(name = "--to-rlp")]
-    #[clap(about = "RLP encodes hex data, or an array of hex data")]
-    ToRlp { value: Option<String> },
+    ToRlp {
+        /// The value to convert.
+        value: Option<String>,
+    },
+
+    /// Decodes RLP encoded data.
+    ///
+    /// Input must be hexadecimal.
     #[clap(name = "--from-rlp")]
-    #[clap(about = "Decodes RLP encoded data. Input must be hexadecimal.")]
-    FromRlp { value: Option<String> },
-    #[clap(name = "--to-hex")]
-    #[clap(visible_aliases = &["to-hex", "th", "2h"])]
-    #[clap(about = "Converts a number of one base to another")]
+    FromRlp {
+        /// The value to convert.
+        value: Option<String>,
+    },
+
+    /// Converts a number of one base to another
+    #[clap(name = "--to-hex", visible_aliases = &["to-hex", "th", "2h"])]
     ToHex(ToBaseArgs),
-    #[clap(name = "--to-dec")]
-    #[clap(visible_aliases = &["to-dec", "td", "2d"])]
-    #[clap(about = "Converts a number of one base to decimal")]
+
+    /// Converts a number of one base to decimal
+    #[clap(name = "--to-dec", visible_aliases = &["to-dec", "td", "2d"])]
     ToDec(ToBaseArgs),
-    #[clap(name = "--to-base")]
-    #[clap(visible_aliases = &["to-base", "--to-radix", "to-radix", "tr", "2r"])]
-    #[clap(about = "Converts a number of one base to another")]
+
+    /// Converts a number of one base to another
+    #[clap(
+        name = "--to-base",
+        visible_aliases = &["to-base",
+        "--to-radix",
+        "to-radix",
+        "tr",
+        "2r"]
+    )]
     ToBase {
         #[clap(flatten)]
         base: ToBaseArgs,
 
-        #[clap(value_name = "BASE", help = "The output base")]
+        /// The output base.
+        #[clap(value_name = "BASE")]
         base_out: Option<String>,
     },
-    #[clap(name = "access-list")]
-    #[clap(visible_aliases = &["ac", "acl"])]
-    #[clap(about = "Create an access list for a transaction.")]
+
+    /// Create an access list for a transaction.
+    #[clap(name = "access-list", visible_aliases = &["ac", "acl"])]
     AccessList {
-        #[clap(
-            help = "The destination of the transaction.",
-            value_parser = NameOrAddress::from_str,
-            value_name = "ADDRESS"
-        )]
+        /// The destination of the transaction.
+        #[clap(value_parser = NameOrAddress::from_str)]
         address: NameOrAddress,
 
-        #[clap(help = "The signature of the function to call.", value_name = "SIG")]
+        /// The signature of the function to call.
         sig: String,
 
-        #[clap(help = "The arguments of the function to call.", value_name = "ARGS")]
+        /// The arguments of the function to call.
         args: Vec<String>,
 
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(long = "json", short = 'j', help_heading = "Display options")]
-        to_json: bool,
+        /// Print the access list as JSON.
+        #[clap(long, short, help_heading = "Display options")]
+        json: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "block")]
-    #[clap(visible_alias = "bl")]
-    #[clap(about = "Get information about a block.")]
+
+    /// Get information about a block.
+    #[clap(name = "block", visible_alias = "bl")]
     Block {
-        #[clap(
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
         block: Option<BlockId>,
 
-        #[clap(
-            long,
-            short = 'f',
-            help = "If specified, only get the given field of the block.",
-            value_name = "FIELD"
-        )]
+        /// If specified, only get the given field of the block.
+        #[clap(long, short)]
         field: Option<String>,
 
         #[clap(long, env = "CAST_FULL_BLOCK")]
         full: bool,
 
-        #[clap(long = "json", short = 'j', help_heading = "Display options")]
-        to_json: bool,
+        /// Print the block as JSON.
+        #[clap(long, short, help_heading = "Display options")]
+        json: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "block-number")]
-    #[clap(visible_alias = "bn")]
-    #[clap(about = "Get the latest block number.")]
+
+    /// Get the latest block number.
+    #[clap(name = "block-number", visible_alias = "bn")]
     BlockNumber {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "call")]
-    #[clap(visible_alias = "c")]
-    #[clap(about = "Perform a call on an account without publishing a transaction.")]
+
+    /// Perform a call on an account without publishing a transaction.
+    #[clap(name = "call", visible_alias = "c")]
     Call(CallArgs),
-    #[clap(name = "calldata")]
-    #[clap(visible_alias = "cd")]
-    #[clap(about = "ABI-encode a function with arguments.")]
+
+    /// ABI-encode a function with arguments.
+    #[clap(name = "calldata", visible_alias = "cd")]
     CalldataEncode {
-        #[clap(
-            help = "The function signature.",
-            long_help = "The function signature in the form <name>(<types...>)",
-            value_name = "SIG"
-        )]
+        /// The function signature in the form <name>(<types...>)
         sig: String,
 
-        #[clap(allow_hyphen_values = true, value_name = "ARGS")]
+        /// The arguments to encode.
+        #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
     },
+
+    /// Get the symbolic name of the current chain.
     #[clap(name = "chain")]
-    #[clap(about = "Get the symbolic name of the current chain.")]
     Chain {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "chain-id")]
-    #[clap(visible_aliases = &["ci", "cid"])]
-    #[clap(about = "Get the Ethereum chain ID.")]
+
+    /// Get the Ethereum chain ID.
+    #[clap(name = "chain-id", visible_aliases = &["ci", "cid"])]
     ChainId {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "client")]
-    #[clap(visible_alias = "cl")]
-    #[clap(about = "Get the current client version.")]
+
+    /// Get the current client version.
+    #[clap(name = "client", visible_alias = "cl")]
     Client {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "compute-address")]
-    #[clap(visible_alias = "ca")]
-    #[clap(about = "Compute the contract address from a given nonce and deployer address.")]
+
+    /// Compute the contract address from a given nonce and deployer address.
+    #[clap(name = "compute-address", visible_alias = "ca")]
     ComputeAddress {
-        #[clap(help = "The deployer address.", value_name = "ADDRESS")]
+        /// The deployer address.
         address: Option<String>,
 
-        #[clap(long, help = "The nonce of the deployer address.", value_parser = parse_u256, value_name = "NONCE")]
+        /// The nonce of the deployer address.
+        #[clap(long, value_parser = parse_u256)]
         nonce: Option<U256>,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "disassemble")]
-    #[clap(visible_alias = "da")]
-    #[clap(about = "Disassembles hex encoded bytecode into individual / human readable opcodes")]
+
+    /// Disassembles hex encoded bytecode into individual / human readable opcodes
+    #[clap(name = "disassemble", visible_alias = "da")]
     Disassemble {
-        #[clap(help = "The hex encoded bytecode", value_name = "BYTECODE")]
+        /// The hex encoded bytecode.
         bytecode: String,
     },
-    #[clap(name = "namehash")]
-    #[clap(visible_aliases = &["na", "nh"])]
-    #[clap(about = "Calculate the ENS namehash of a name.")]
-    Namehash {
-        #[clap(value_name = "NAME")]
-        name: Option<String>,
-    },
-    #[clap(name = "tx")]
-    #[clap(visible_alias = "t")]
-    #[clap(about = "Get information about a transaction.")]
+
+    /// Calculate the ENS namehash of a name.
+    #[clap(name = "namehash", visible_aliases = &["na", "nh"])]
+    Namehash { name: Option<String> },
+
+    /// Get information about a transaction.
+    #[clap(name = "tx", visible_alias = "t")]
     Tx {
-        #[clap(value_name = "TX_HASH")]
+        /// The transaction hash.
         tx_hash: String,
 
-        #[clap(value_name = "FIELD")]
+        /// If specified, only get the given field of the transaction.
         field: Option<String>,
 
-        #[clap(long = "json", short = 'j', help_heading = "Display options")]
-        to_json: bool,
+        /// Print as JSON.
+        #[clap(long, short, help_heading = "Display options")]
+        json: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "receipt")]
-    #[clap(visible_alias = "re")]
-    #[clap(about = "Get the transaction receipt for a transaction.")]
+
+    /// Get the transaction receipt for a transaction.
+    #[clap(name = "receipt", visible_alias = "re")]
     Receipt {
-        #[clap(value_name = "TX_HASH")]
+        /// The transaction hash.
         tx_hash: String,
 
-        #[clap(value_name = "FIELD")]
+        /// If specified, only get the given field of the transaction.
         field: Option<String>,
 
-        #[clap(
-            long,
-            help = "The number of confirmations until the receipt is fetched",
-            default_value = "1",
-            value_name = "CONFIRMATIONS"
-        )]
+        /// The number of confirmations until the receipt is fetched
+        #[clap(long, default_value = "1")]
         confirmations: usize,
 
-        #[clap(
-            long = "async",
-            env = "CAST_ASYNC",
-            name = "async",
-            alias = "cast-async",
-            help = "Exit immediately if the transaction was not found."
-        )]
+        /// Exit immediately if the transaction was not found.
+        #[clap(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
         cast_async: bool,
 
-        #[clap(long = "json", short = 'j', help_heading = "Display options")]
-        to_json: bool,
+        /// Print as JSON.
+        #[clap(long, short, help_heading = "Display options")]
+        json: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "send")]
-    #[clap(visible_alias = "s")]
-    #[clap(about = "Sign and publish a transaction.")]
+
+    /// Sign and publish a transaction.
+    #[clap(name = "send", visible_alias = "s")]
     SendTx(SendTxArgs),
-    #[clap(name = "publish")]
-    #[clap(visible_alias = "p")]
-    #[clap(about = "Publish a raw transaction to the network.")]
+
+    /// Publish a raw transaction to the network.
+    #[clap(name = "publish", visible_alias = "p")]
     PublishTx {
-        #[clap(help = "The raw transaction", value_name = "RAW_TX")]
+        /// The raw transaction
         raw_tx: String,
 
-        #[clap(
-            long = "async",
-            env = "CAST_ASYNC",
-            name = "async",
-            alias = "cast-async",
-            help = "Only print the transaction hash and exit immediately."
-        )]
+        /// Only print the transaction hash and exit immediately.
+        #[clap(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
         cast_async: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "estimate")]
-    #[clap(visible_alias = "e")]
-    #[clap(about = "Estimate the gas cost of a transaction.")]
+
+    /// Estimate the gas cost of a transaction.
+    #[clap(name = "estimate", visible_alias = "e")]
     Estimate(EstimateArgs),
-    #[clap(name = "--calldata-decode")]
-    #[clap(visible_alias = "cdd")]
-    #[clap(about = "Decode ABI-encoded input data.")]
+
+    /// Decode ABI-encoded input data.
+    #[clap(name = "--calldata-decode", visible_alias = "cdd")]
     CalldataDecode {
-        #[clap(
-            help = "The function signature in the format `<name>(<in-types>)(<out-types>)`.",
-            value_name = "SIG"
-        )]
+        /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
 
-        #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
+        /// The ABI-encoded calldata.
         calldata: String,
     },
-    #[clap(name = "--abi-decode")]
-    #[clap(visible_alias = "ad")]
-    #[clap(
-        about = "Decode ABI-encoded input or output data",
-        long_about = r#"Decode ABI-encoded input or output data.
 
-Defaults to decoding output data. To decode input data pass --input or use cast --calldata-decode."#
-    )]
+    /// Decode ABI-encoded input or output data.
+    ///
+    /// Defaults to decoding output data. To decode input data pass --input or use cast
+    /// --calldata-decode.
+    #[clap(name = "--abi-decode", visible_alias = "ad")]
     AbiDecode {
-        #[clap(
-            help = "The function signature in the format `<name>(<in-types>)(<out-types>)`.",
-            value_name = "SIG"
-        )]
+        /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
 
-        #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
+        /// The ABI-encoded calldata.
         calldata: String,
 
-        #[clap(long, short, help = "Decode input data.")]
+        /// Decode input data.
+        #[clap(long, short)]
         input: bool,
     },
-    #[clap(name = "abi-encode")]
-    #[clap(visible_alias = "ae")]
-    #[clap(about = "ABI encode the given function argument, excluding the selector.")]
+
+    /// ABI encode the given function argument, excluding the selector.
+    #[clap(name = "abi-encode", visible_alias = "ae")]
     AbiEncode {
-        #[clap(help = "The function signature.", value_name = "SIG")]
+        /// The function signature.
         sig: String,
 
-        #[clap(help = "The arguments of the function.", value_name = "ARGS")]
+        /// The arguments of the function.
         #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    #[clap(name = "index")]
-    #[clap(visible_alias = "in")]
-    #[clap(about = "Compute the storage slot for an entry in a mapping.")]
+
+    /// Compute the storage slot for an entry in a mapping.
+    #[clap(name = "index", visible_alias = "in")]
     Index {
-        #[clap(help = "The mapping key type.", value_name = "KEY_TYPE")]
+        /// The mapping key type.
         key_type: String,
 
-        #[clap(help = "The mapping key.", value_name = "KEY")]
+        /// The mapping key.
         key: String,
 
-        #[clap(help = "The storage slot of the mapping.", value_name = "SLOT_NUMBER")]
+        /// The storage slot of the mapping.
         slot_number: String,
     },
-    #[clap(name = "implementation")]
-    #[clap(visible_alias = "impl")]
-    #[clap(about = "Fetch the EIP-1967 implementation account")]
+
+    /// Fetch the EIP-1967 implementation account
+    #[clap(name = "implementation", visible_alias = "impl")]
     Implementation {
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
+        /// The address to get the nonce for.
+        #[clap(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "admin")]
-    #[clap(visible_alias = "adm")]
-    #[clap(about = "Fetch the EIP-1967 admin account")]
+
+    /// Fetch the EIP-1967 admin account
+    #[clap(name = "admin", visible_alias = "adm")]
     Admin {
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
+        /// The address to get the nonce for.
+        #[clap(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "4byte")]
-    #[clap(visible_aliases = &["4", "4b"])]
-    #[clap(
-        about = "Get the function signatures for the given selector from https://sig.eth.samczsun.com."
-    )]
+
+    /// Get the function signatures for the given selector from https://sig.eth.samczsun.com.
+    #[clap(name = "4byte", visible_aliases = &["4", "4b"])]
     FourByte {
-        #[clap(help = "The function selector.", value_name = "SELECTOR")]
+        /// The function selector.
         selector: Option<String>,
     },
-    #[clap(name = "4byte-decode")]
-    #[clap(visible_aliases = &["4d", "4bd"])]
-    #[clap(about = "Decode ABI-encoded calldata using https://sig.eth.samczsun.com.")]
+
+    /// Decode ABI-encoded calldata using https://sig.eth.samczsun.com.
+    #[clap(name = "4byte-decode", visible_aliases = &["4d", "4bd"])]
     FourByteDecode {
-        #[clap(help = "The ABI-encoded calldata.", value_name = "CALLDATA")]
+        /// The ABI-encoded calldata.
         calldata: Option<String>,
     },
-    #[clap(name = "4byte-event")]
-    #[clap(visible_aliases = &["4e", "4be"])]
-    #[clap(
-        about = "Get the event signature for a given topic 0 from https://sig.eth.samczsun.com."
-    )]
+
+    /// Get the event signature for a given topic 0 from https://sig.
+    ///
+    /// eth.samczsun.com.
+    #[clap(name = "4byte-event", visible_aliases = &["4e", "4be"])]
     FourByteEvent {
-        #[clap(help = "Topic 0", value_name = "TOPIC_0")]
+        /// Topic 0
+        #[clap(value_name = "TOPIC_0")]
         topic: Option<String>,
     },
-    #[clap(name = "upload-signature")]
-    #[clap(visible_aliases = &["ups"])]
-    #[clap(
-        about = "Upload the given signatures to https://sig.eth.samczsun.com.",
-        long_about = r#"Upload the given signatures to https://sig.eth.samczsun.com.
 
-Examples:
-- cast upload-signature "transfer(address,uint256)"
-- cast upload-signature "function transfer(address,uint256)"
-- cast upload-signature "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
-- cast upload-signature ./out/Contract.sol/Contract.json""#
-    )]
+    /// Upload the given signatures to https://sig.eth.samczsun.com.
+    ///
+    /// Example inputs:
+    /// - "transfer(address,uint256)"
+    /// - "function transfer(address,uint256)"
+    /// - "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
+    /// - "./out/Contract.sol/Contract.json"
+    #[clap(name = "upload-signature", visible_aliases = &["ups"])]
     UploadSignature {
-        #[clap(
-            help = "The signatures to upload. Prefix with 'function', 'event', or 'error'. Defaults to function if no prefix given. Can also take paths to contract artifact JSON."
-        )]
+        /// The signatures to upload.
+        ///
+        /// Prefix with 'function', 'event', or 'error'. Defaults to function if no prefix given.
+        /// Can also take paths to contract artifact JSON.
         signatures: Vec<String>,
     },
-    #[clap(name = "pretty-calldata")]
-    #[clap(visible_alias = "pc")]
-    #[clap(
-        about = "Pretty print calldata.",
-        long_about = r#"Pretty print calldata.
 
-Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline is passed."#
-    )]
+    /// Pretty print calldata.
+    ///
+    /// Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline is passed.
+    #[clap(name = "pretty-calldata", visible_alias = "pc")]
     PrettyCalldata {
-        #[clap(help = "The calldata.", value_name = "CALLDATA")]
+        /// The calldata.
         calldata: Option<String>,
-        #[clap(long, short, help = "Skip the https://sig.eth.samczsun.com lookup.")]
+
+        /// Skip the https://sig.eth.samczsun.com lookup.
+        #[clap(long, short)]
         offline: bool,
     },
-    #[clap(name = "age")]
-    #[clap(visible_alias = "a")]
-    #[clap(about = "Get the timestamp of a block.")]
+
+    /// Get the timestamp of a block.
+    #[clap(name = "age", visible_alias = "a")]
     Age {
-        #[clap(
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
         block: Option<BlockId>,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "balance")]
-    #[clap(visible_alias = "b")]
-    #[clap(about = "Get the balance of an account in wei.")]
+
+    /// Get the balance of an account in wei.
+    #[clap(name = "balance", visible_alias = "b")]
     Balance {
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(
-            help = "The account you want to query",
-            value_parser = NameOrAddress::from_str,
-            value_name = "WHO"
-        )]
+        /// The account to query.
+        #[clap(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(long = "ether", short = 'e', help_heading = "format to ether")]
-        to_ether: bool,
+        /// Format the balance in ether.
+        #[clap(long, short)]
+        ether: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "basefee")]
-    #[clap(visible_aliases = &["ba", "fee"])]
-    #[clap(about = "Get the basefee of a block.")]
+
+    /// Get the basefee of a block.
+    #[clap(name = "basefee", visible_aliases = &["ba", "fee"])]
     BaseFee {
-        #[clap(
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
         block: Option<BlockId>,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "code")]
-    #[clap(visible_alias = "co")]
-    #[clap(about = "Get the bytecode of a contract.")]
+
+    /// Get the bytecode of a contract.
+    #[clap(name = "code", visible_alias = "co")]
     Code {
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
+        /// The contract address.
+        #[clap(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(
-            long = "disassemble",
-            short = 'd',
-            help_heading = "disassemble bytecodes into individual opcodes"
-        )]
+        /// Disassemble bytecodes into individual opcodes.
+        #[clap(long, short)]
         disassemble: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "gas-price")]
-    #[clap(visible_alias = "g")]
-    #[clap(about = "Get the current gas price.")]
+
+    /// Get the current gas price.
+    #[clap(name = "gas-price", visible_alias = "g")]
     GasPrice {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "sig-event")]
-    #[clap(visible_alias = "se")]
-    #[clap(about = "Generate event signatures from event string.")]
+
+    /// Generate event signatures from event string.
+    #[clap(name = "sig-event", visible_alias = "se")]
     SigEvent {
-        #[clap(value_name = "EVENT_STRING")]
+        /// The event string.
         event_string: Option<String>,
     },
-    #[clap(name = "keccak")]
-    #[clap(visible_alias = "k")]
-    #[clap(about = "Hash arbitrary data using Keccak-256.")]
+
+    /// Hash arbitrary data using Keccak-256.
+    #[clap(name = "keccak", visible_alias = "k")]
     Keccak {
-        #[clap(value_name = "DATA")]
+        /// The data to hash.
         data: Option<String>,
     },
-    #[clap(name = "resolve-name")]
-    #[clap(visible_alias = "rn")]
-    #[clap(about = "Perform an ENS lookup.")]
+
+    /// Perform an ENS lookup.
+    #[clap(name = "resolve-name", visible_alias = "rn")]
     ResolveName {
-        #[clap(help = "The name to lookup.", value_name = "WHO")]
+        /// The name to lookup.
         who: Option<String>,
 
-        #[clap(long, short, help = "Perform a reverse lookup to verify that the name is correct.")]
+        /// Perform a reverse lookup to verify that the name is correct.
+        #[clap(long, short)]
         verify: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "lookup-address")]
-    #[clap(visible_alias = "l")]
-    #[clap(about = "Perform an ENS reverse lookup.")]
+
+    /// Perform an ENS reverse lookup.
+    #[clap(name = "lookup-address", visible_alias = "l")]
     LookupAddress {
-        #[clap(help = "The account to perform the lookup for.", value_name = "WHO")]
+        /// The account to perform the lookup for.
         who: Option<Address>,
 
-        #[clap(
-            long,
-            short,
-            help = "Perform a normal lookup to verify that the address is correct."
-        )]
+        /// Perform a normal lookup to verify that the address is correct.
+        #[clap(long, short)]
         verify: bool,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(
-        name = "storage",
-        visible_alias = "st",
-        about = "Get the raw value of a contract's storage slot."
-    )]
+
+    /// Get the raw value of a contract's storage slot.
+    #[clap(name = "storage", visible_alias = "st")]
     Storage(StorageArgs),
-    #[clap(
-        name = "proof",
-        visible_alias = "pr",
-        about = "Generate a storage proof for a given storage slot."
-    )]
+
+    /// Generate a storage proof for a given storage slot.
+    #[clap(name = "proof", visible_alias = "pr")]
     Proof {
-        #[clap(help = "The contract address.", value_parser = NameOrAddress::from_str, value_name = "ADDRESS")]
+        /// The contract address.
+        #[clap(value_parser = NameOrAddress::from_str)]
         address: NameOrAddress,
 
-        #[clap(help = "The storage slot numbers (hex or decimal).",  value_parser = parse_slot, value_name = "SLOTS")]
+        /// The storage slot numbers (hex or decimal).
+        #[clap(value_parser = parse_slot)]
         slots: Vec<H256>,
 
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "nonce")]
-    #[clap(visible_alias = "n")]
-    #[clap(about = "Get the nonce for an account.")]
+
+    /// Get the nonce for an account.
+    #[clap(name = "nonce", visible_alias = "n")]
     Nonce {
-        #[clap(
-            long,
-            short = 'B',
-            help = "The block height you want to query at.",
-            long_help = "The block height you want to query at. Can also be the tags earliest, finalized, safe, latest, or pending.",
-            value_name = "BLOCK"
-        )]
+        /// The block height to query at.
+        ///
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(help = "The address you want to get the nonce for.", value_parser = NameOrAddress::from_str, value_name = "WHO")]
+        /// The address to get the nonce for.
+        #[clap(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
         #[clap(flatten)]
         rpc: RpcOpts,
     },
-    #[clap(name = "etherscan-source")]
-    #[clap(visible_aliases = &["et", "src"])]
-    #[clap(about = "Get the source code of a contract from Etherscan.")]
+
+    /// Get the source code of a contract from Etherscan.
+    #[clap(name = "etherscan-source", visible_aliases = &["et", "src"])]
     EtherscanSource {
-        #[clap(help = "The contract's address.", value_name = "ADDRESS")]
+        /// The contract's address.
         address: String,
 
-        #[clap(short, help = "The output directory to expand source tree into.", value_hint = ValueHint::DirPath, value_name = "DIRECTORY")]
+        /// The output directory to expand source tree into.
+        #[clap(short, value_hint = ValueHint::DirPath)]
         directory: Option<PathBuf>,
 
         #[clap(flatten)]
         etherscan: EtherscanOpts,
     },
-    #[clap(name = "wallet", visible_alias = "w", about = "Wallet management utilities.")]
+
+    /// Wallet management utilities.
+    #[clap(name = "wallet", visible_alias = "w")]
     Wallet {
         #[clap(subcommand)]
         command: WalletSubcommands,
     },
-    #[clap(
-        name = "interface",
-        visible_alias = "i",
-        about = "Generate a Solidity interface from a given ABI.",
-        long_about = "Generate a Solidity interface from a given ABI. Currently does not support ABI encoder v2."
-    )]
+
+    /// Generate a Solidity interface from a given ABI.
+    ///
+    /// Currently does not support ABI encoder v2.
+    #[clap(name = "interface", visible_alias = "i")]
     Interface(InterfaceArgs),
-    #[clap(
-        name = "bind",
-        visible_alias = "bi",
-        about = "Generate a rust binding from a given ABI.",
-        long_about = "Generate a rust binding from a given ABI. Currently does not support ABI encoder v2."
-    )]
+
+    /// Generate a rust binding from a given ABI.
+    #[clap(name = "bind", visible_alias = "bi")]
     Bind(BindArgs),
 
-    #[clap(name = "sig", visible_alias = "si", about = "Get the selector for a function.")]
+    /// Get the selector for a function.
+    #[clap(name = "sig", visible_alias = "si")]
     Sig {
-        #[clap(
-            help = "The function signature, e.g. transfer(address,uint256).",
-            value_name = "SIG"
-        )]
+        /// The function signature, e.g. transfer(address,uint256).
         sig: Option<String>,
 
-        #[clap(
-            help = "Optimize signature to contain provided amount of leading zeroes in selector.",
-            value_name = "OPTIMIZE"
-        )]
+        /// Optimize signature to contain provided amount of leading zeroes in selector.
         optimize: Option<usize>,
     },
-    #[clap(
-        name = "create2",
-        visible_alias = "c2",
-        about = "Generate a deterministic contract address using CREATE2"
-    )]
+
+    /// Generate a deterministic contract address using CREATE2.
+    #[clap(name = "create2", visible_alias = "c2")]
     Create2(Create2Args),
-    #[clap(
-        name = "find-block",
-        visible_alias = "f",
-        about = "Get the block number closest to the provided timestamp."
-    )]
+
+    /// Get the block number closest to the provided timestamp.
+    #[clap(name = "find-block", visible_alias = "f")]
     FindBlock(FindBlockArgs),
-    #[clap(visible_alias = "com", about = "Generate shell completions script")]
+
+    /// Generate shell completions script.
+    #[clap(visible_alias = "com")]
     Completions {
         #[clap(value_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
+
+    /// Generate Fig autocompletion spec.
+    #[clap(visible_alias = "fig")]
     GenerateFigSpec,
-    #[clap(
-        name = "run",
-        visible_alias = "r",
-        about = "Runs a published transaction in a local environment and prints the trace."
-    )]
+
+    /// Runs a published transaction in a local environment and prints the trace.
+    #[clap(name = "run", visible_alias = "r")]
     Run(RunArgs),
-    #[clap(name = "rpc")]
-    #[clap(visible_alias = "rp")]
-    #[clap(about = "Perform a raw JSON-RPC request")]
+
+    /// Perform a raw JSON-RPC request.
+    #[clap(name = "rpc", visible_alias = "rp")]
     Rpc(RpcArgs),
+
+    /// Formats a string into bytes32 encoding.
     #[clap(name = "--format-bytes32-string")]
-    #[clap(about = "Formats a string into bytes32 encoding.")]
     FormatBytes32String {
-        #[clap(value_name = "STRING")]
+        /// The string to format.
         string: Option<String>,
     },
+
+    /// Parses a string from bytes32 encoding.
     #[clap(name = "--parse-bytes32-string")]
-    #[clap(about = "Parses a string from bytes32 encoding.")]
     ParseBytes32String {
-        #[clap(value_name = "BYTES")]
+        /// The string to parse.
         bytes: Option<String>,
     },
 }
-
 /// CLI arguments for `cast --to-base`.
 #[derive(Debug, Parser)]
 pub struct ToBaseArgs {
-    #[clap(allow_hyphen_values = true, value_name = "VALUE")]
+    /// The value to convert.
+    #[clap(allow_hyphen_values = true)]
     pub value: Option<String>,
 
-    #[clap(long = "base-in", short = 'i', help = "The input base")]
+    /// The input base.
+    #[clap(long, short = 'i')]
     pub base_in: Option<String>,
 }
 
@@ -915,9 +884,7 @@ mod tests {
                     vec!["5c9d55b78febcc2061715ba4f57ecf8ea2711f2c".to_string(), "2".to_string()]
                 )
             }
-            _ => {
-                unreachable!()
-            }
+            _ => unreachable!(),
         };
     }
 

--- a/cli/src/opts/dependency.rs
+++ b/cli/src/opts/dependency.rs
@@ -123,6 +123,13 @@ impl FromStr for Dependency {
     }
 }
 
+impl Dependency {
+    /// Returns the name of the dependency, prioritizing the alias if it exists.
+    pub fn name(&self) -> &String {
+        self.alias.as_ref().unwrap_or(&self.name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/opts/ethereum.rs
+++ b/cli/src/opts/ethereum.rs
@@ -16,11 +16,11 @@ const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct RpcOpts {
-    /// The RPC endpoint
+    /// The RPC endpoint.
     #[clap(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
     pub url: Option<String>,
 
-    /// Use the Flashbots RPC URL (https://rpc.flashbots.net)
+    /// Use the Flashbots RPC URL (https://rpc.flashbots.net).
     #[clap(long)]
     pub flashbots: bool,
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -104,12 +104,11 @@ pub enum Subcommands {
     GenerateFigSpec,
     #[clap(visible_alias = "cl", about = "Remove the build artifacts and cache directories.")]
     Clean {
-        #[clap(
-            help = "The project's root path. Defaults to the current working directory.",
-            long,
-            value_hint = ValueHint::DirPath,
-            value_name = "PATH"
-        )]
+        /// The project's root path.
+        ///
+        /// By default root of the Git repository, if in one,
+        /// or the current working directory.
+        #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
         root: Option<PathBuf>,
     },
 

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -40,69 +40,76 @@ pub struct Opts {
 )]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
-    #[clap(visible_alias = "t", about = "Run the project's tests.")]
+    /// Run the project's tests.
+    #[clap(visible_alias = "t")]
     Test(test::TestArgs),
 
-    #[clap(
-        about = "Run a smart contract as a script, building transactions that can be sent onchain."
-    )]
+    /// Run a smart contract as a script, building transactions that can be sent onchain.
     Script(ScriptArgs),
 
-    #[clap(about = "Generate coverage reports.")]
+    /// Generate coverage reports.
     Coverage(coverage::CoverageArgs),
 
-    #[clap(alias = "bi", about = "Generate Rust bindings for smart contracts.")]
+    /// Generate Rust bindings for smart contracts.
+    #[clap(alias = "bi")]
     Bind(BindArgs),
 
-    #[clap(visible_aliases = ["b", "compile"], about = "Build the project's smart contracts.")]
+    /// Build the project's smart contracts.
+    #[clap(visible_aliases = ["b", "compile"])]
     Build(BuildArgs),
 
-    #[clap(visible_alias = "d", about = "Debugs a single smart contract as a script.")]
+    /// Debugs a single smart contract as a script.
+    #[clap(visible_alias = "d")]
     Debug(DebugArgs),
 
-    #[clap(
-        visible_alias = "u",
-        about = "Update one or multiple dependencies.",
-        long_about = "Update one or multiple dependencies. If no arguments are provided, then all dependencies are updated."
-    )]
+    /// Update one or multiple dependencies.
+    ///
+    /// If no arguments are provided, then all dependencies are updated.
+    #[clap(visible_alias = "u")]
     Update(update::UpdateArgs),
 
-    #[clap(
-        visible_alias = "i",
-        about = "Install one or multiple dependencies.",
-        long_about = "Install one or multiple dependencies. If no arguments are provided, then existing dependencies will be installed."
-    )]
+    /// Install one or multiple dependencies.
+    ///
+    /// If no arguments are provided, then existing dependencies will be installed.
+    #[clap(visible_alias = "i")]
     Install(InstallArgs),
 
-    #[clap(visible_alias = "rm", about = "Remove one or multiple dependencies.")]
+    /// Remove one or multiple dependencies.
+    #[clap(visible_alias = "rm")]
     Remove(RemoveArgs),
 
-    #[clap(
-        visible_alias = "re",
-        about = "Get the automatically inferred remappings for the project."
-    )]
+    /// Get the automatically inferred remappings for the project.
+    #[clap(visible_alias = "re")]
     Remappings(RemappingArgs),
 
-    #[clap(visible_alias = "v", about = "Verify smart contracts on Etherscan.")]
+    /// Verify smart contracts on Etherscan.
+    #[clap(visible_alias = "v")]
     VerifyContract(VerifyArgs),
 
-    #[clap(visible_alias = "vc", about = "Check verification status on Etherscan.")]
+    /// Check verification status on Etherscan.
+    #[clap(visible_alias = "vc")]
     VerifyCheck(VerifyCheckArgs),
 
-    #[clap(visible_alias = "c", about = "Deploy a smart contract.")]
+    /// Deploy a smart contract.
+    #[clap(visible_alias = "c")]
     Create(CreateArgs),
 
-    #[clap(about = "Create a new Forge project.")]
+    /// Create a new Forge project.
     Init(InitArgs),
 
-    #[clap(visible_alias = "com", about = "Generate shell completions script.")]
+    /// Generate shell completions script.
+    #[clap(visible_alias = "com")]
     Completions {
         #[clap(value_enum)]
         shell: clap_complete::Shell,
     },
-    #[clap(visible_alias = "fig", about = "Generate Fig autocompletion spec.")]
+
+    /// Generate Fig autocompletion spec.
+    #[clap(visible_alias = "fig")]
     GenerateFigSpec,
-    #[clap(visible_alias = "cl", about = "Remove the build artifacts and cache directories.")]
+
+    /// Remove the build artifacts and cache directories.
+    #[clap(visible_alias = "cl")]
     Clean {
         /// The project's root path.
         ///
@@ -112,45 +119,41 @@ pub enum Subcommands {
         root: Option<PathBuf>,
     },
 
-    #[clap(about = "Manage the Foundry cache.")]
+    /// Manage the Foundry cache.
     Cache(CacheArgs),
 
-    #[clap(visible_alias = "s", about = "Create a snapshot of each test's gas usage.")]
+    /// Create a snapshot of each test's gas usage.
+    #[clap(visible_alias = "s")]
     Snapshot(snapshot::SnapshotArgs),
 
-    #[clap(visible_alias = "co", about = "Display the current config.")]
+    /// Display the current config.
+    #[clap(visible_alias = "co")]
     Config(config::ConfigArgs),
 
-    #[clap(
-        visible_alias = "f",
-        about = "Flatten a source file and all of its imports into one file."
-    )]
+    /// Flatten a source file and all of its imports into one file.
+    #[clap(visible_alias = "f")]
     Flatten(flatten::FlattenArgs),
 
-    #[clap(about = "Formats Solidity source files.")]
+    /// Format Solidity source files.
     Fmt(FmtArgs),
 
-    #[clap(visible_alias = "in", about = "Get specialized information about a smart contract.")]
+    /// Get specialized information about a smart contract.
+    #[clap(visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 
-    #[clap(
-        visible_alias = "up",
-        about = "Uploads abi of given contract to https://sig.eth.samczsun.com function selector database."
-    )]
+    /// Uploads abi of given contract to the https://sig.eth.samczsun.com
+    /// function selector database.
+    #[clap(visible_alias = "up")]
     UploadSelectors(UploadSelectorsArgs),
 
-    #[clap(
-        visible_alias = "tr",
-        about = "Display a tree visualization of the project's dependency graph."
-    )]
+    /// Display a tree visualization of the project's dependency graph.
+    #[clap(visible_alias = "tr")]
     Tree(tree::TreeArgs),
 
-    #[clap(
-        about = "Detects usage of unsafe cheat codes in a foundry project and its dependencies."
-    )]
+    /// Detects usage of unsafe cheat codes in a project and its dependencies.
     Geiger(geiger::GeigerArgs),
 
-    #[clap(about = "Generate documentation for the project.")]
+    /// Generate documentation for the project.
     Doc(DocArgs),
 }
 
@@ -161,15 +164,18 @@ pub enum Subcommands {
 #[derive(Default, Debug, Clone, Parser, Serialize)]
 #[clap(next_help_heading = "Compiler options")]
 pub struct CompilerArgs {
-    #[clap(help = "The target EVM version.", long, value_name = "VERSION")]
+    /// The target EVM version.
+    #[clap(long, value_name = "VERSION")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evm_version: Option<EvmVersion>,
 
-    #[clap(help = "Activate the Solidity optimizer.", long)]
+    /// Activate the Solidity optimizer.
+    #[clap(long)]
     #[serde(skip)]
     pub optimize: bool,
 
-    #[clap(help = "The number of optimizer runs.", long, value_name = "RUNS")]
+    /// The number of optimizer runs.
+    #[clap(long, value_name = "RUNS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimizer_runs: Option<usize>,
 

--- a/cli/src/opts/transaction.rs
+++ b/cli/src/opts/transaction.rs
@@ -2,62 +2,46 @@ use crate::utils::{parse_ether_value, parse_u256};
 use clap::Parser;
 use ethers::types::U256;
 use serde::Serialize;
-
 #[derive(Parser, Debug, Clone, Serialize)]
 #[clap(next_help_heading = "Transaction options")]
 pub struct TransactionOpts {
-    #[clap(
-    long = "gas-limit",
-        help = "Gas limit for the transaction.",
-        env = "ETH_GAS_LIMIT",
-        value_parser = parse_u256,
-        value_name = "GAS_LIMIT"
-    )]
+    /// Gas limit for the transaction.
+    #[clap(long, env = "ETH_GAS_LIMIT", value_parser = parse_u256)]
     pub gas_limit: Option<U256>,
 
+    /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.
     #[clap(
-        long = "gas-price",
-        help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
+        long,
         env = "ETH_GAS_PRICE",
         value_parser = parse_ether_value,
         value_name = "PRICE"
     )]
     pub gas_price: Option<U256>,
 
+    /// Max priority fee per gas for EIP1559 transactions.
     #[clap(
-        long = "priority-gas-price",
-        help = "Max priority fee per gas for EIP1559 transactions.",
+        long,
         env = "ETH_PRIORITY_GAS_PRICE",
         value_parser = parse_ether_value,
         value_name = "PRICE"
     )]
     pub priority_gas_price: Option<U256>,
 
-    #[clap(
-        long,
-        help = "Ether to send in the transaction.",
-        long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
-
-Examples: 1ether, 10gwei, 0.01ether"#,
-        value_parser = parse_ether_value,
-        value_name = "VALUE"
-    )]
+    /// Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+    ///
+    ///
+    ///
+    /// Examples: 1ether, 10gwei, 0.01ether
+    #[clap(long, value_parser = parse_ether_value)]
     pub value: Option<U256>,
 
-    #[clap(
-        long,
-        help = "Nonce for the transaction.",
-        value_parser = parse_u256,
-        value_name = "NONCE"
-    )]
+    /// Nonce for the transaction.
+    #[clap(long, value_parser = parse_u256)]
     pub nonce: Option<U256>,
 
-    #[clap(
-        long,
-        help = "Send a legacy transaction instead of an EIP1559 transaction.",
-        long_help = r#"Send a legacy transaction instead of an EIP1559 transaction.
-
-This is automatically enabled for common networks without EIP1559."#
-    )]
+    /// Send a legacy transaction instead of an EIP1559 transaction.
+    ///
+    /// This is automatically enabled for common networks without EIP1559.
+    #[clap(long)]
     pub legacy: bool,
 }

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -66,11 +66,7 @@ pub struct Wallet {
     pub mnemonic: Option<String>,
 
     /// Use a BIP39 passphrase for the mnemonic.
-    #[clap(
-        long = "mnemonic-passphrase",
-        help_heading = "Wallet options - raw",
-        value_name = "PASSPHRASE"
-    )]
+    #[clap(long, help_heading = "Wallet options - raw", value_name = "PASSPHRASE")]
     pub mnemonic_passphrase: Option<String>,
 
     /// The wallet derivation path.
@@ -88,7 +84,7 @@ pub struct Wallet {
     ///
     /// Used with --mnemonic-path.
     #[clap(
-        long = "mnemonic-index",
+        long,
         conflicts_with = "hd_path",
         help_heading = "Wallet options - raw",
         default_value_t = 0,

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -38,21 +38,21 @@ pub mod error;
 #[derive(Parser, Debug, Default, Clone, Serialize)]
 #[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct Wallet {
-    /// The sender account
+    /// The sender account.
     #[clap(
-        short,
         long,
+        short,
         help_heading = "Wallet options - raw",
         value_name = "ADDRESS",
         env = "ETH_FROM"
     )]
     pub from: Option<Address>,
 
-    /// Open an interactive prompt to enter your private key
+    /// Open an interactive prompt to enter your private key.
     #[clap(long, short, help_heading = "Wallet options - raw")]
     pub interactive: bool,
 
-    /// Use the provided private key
+    /// Use the provided private key.
     #[clap(
         long,
         help_heading = "Wallet options - raw",
@@ -61,11 +61,11 @@ pub struct Wallet {
     )]
     pub private_key: Option<String>,
 
-    /// Use the mnemonic phrase of mnemonic file at the specified path
+    /// Use the mnemonic phrase of mnemonic file at the specified path.
     #[clap(long, alias = "mnemonic-path", help_heading = "Wallet options - raw")]
     pub mnemonic: Option<String>,
 
-    /// Use a BIP39 passphrase for the mnemonic
+    /// Use a BIP39 passphrase for the mnemonic.
     #[clap(
         long = "mnemonic-passphrase",
         help_heading = "Wallet options - raw",
@@ -73,7 +73,9 @@ pub struct Wallet {
     )]
     pub mnemonic_passphrase: Option<String>,
 
-    /// The wallet derivation path. Works with both --mnemonic-path and hardware wallets
+    /// The wallet derivation path.
+    ///
+    /// Works with both --mnemonic-path and hardware wallets.
     #[clap(
         long = "mnemonic-derivation-path",
         alias = "hd-path",
@@ -82,7 +84,9 @@ pub struct Wallet {
     )]
     pub hd_path: Option<String>,
 
-    /// Use the private key from the given mnemonic index. Used with --mnemonic-path.
+    /// Use the private key from the given mnemonic index.
+    ///
+    /// Used with --mnemonic-path.
     #[clap(
         long = "mnemonic-index",
         conflicts_with = "hd_path",
@@ -92,7 +96,7 @@ pub struct Wallet {
     )]
     pub mnemonic_index: u32,
 
-    /// Use the keystore in the given folder or file
+    /// Use the keystore in the given folder or file.
     #[clap(
         long = "keystore",
         help_heading = "Wallet options - keystore",
@@ -101,7 +105,9 @@ pub struct Wallet {
     )]
     pub keystore_path: Option<String>,
 
-    /// The keystore password. Used with --keystore
+    /// The keystore password.
+    ///
+    /// Used with --keystore.
     #[clap(
         long = "password",
         help_heading = "Wallet options - keystore",
@@ -110,7 +116,9 @@ pub struct Wallet {
     )]
     pub keystore_password: Option<String>,
 
-    /// The keystore password file path. Used with --keystore.
+    /// The keystore password file path.
+    ///
+    /// Used with --keystore.
     #[clap(
         long = "password-file",
         help_heading = "Wallet options - keystore",
@@ -120,16 +128,16 @@ pub struct Wallet {
     )]
     pub keystore_password_file: Option<String>,
 
-    /// Use a Ledger hardware wallet
-    #[clap(short, long, help_heading = "Wallet options - hardware wallet")]
+    /// Use a Ledger hardware wallet.
+    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
     pub ledger: bool,
 
-    /// Use a Trezor hardware wallet
-    #[clap(short, long = "trezor", help_heading = "Wallet options - hardware wallet")]
+    /// Use a Trezor hardware wallet.
+    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
     pub trezor: bool,
 
-    /// Use AWS Key Management Service
-    #[clap(long = "aws", help_heading = "Wallet options - remote")]
+    /// Use AWS Key Management Service.
+    #[clap(long, help_heading = "Wallet options - remote")]
     pub aws: bool,
 }
 

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -27,22 +27,16 @@ pub use multi_wallet::*;
 
 pub mod error;
 
+/// The wallet options can either be:
+/// 1. Ledger
+/// 2. Trezor
+/// 3. Mnemonic (via file path)
+/// 4. Keystore (via file path)
+/// 5. Private Key (cleartext in CLI)
+/// 6. Private Key (interactively via secure prompt)
+/// 7. AWS KMS
 #[derive(Parser, Debug, Default, Clone, Serialize)]
-#[cfg_attr(not(doc), allow(missing_docs))]
-#[cfg_attr(
-    doc,
-    doc = r#"
-The wallet options can either be:
-1. Ledger
-2. Trezor
-3. Mnemonic (via file path)
-4. Keystore (via file path)
-5. Private Key (cleartext in CLI)
-6. Private Key (interactively via secure prompt)
-7. AWS KMS
-"#
-)]
-#[clap(next_help_heading = "Wallet options")]
+#[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct Wallet {
     /// The sender account
     #[clap(

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -59,6 +59,22 @@ macro_rules! create_hw_wallets {
     };
 }
 
+/*
+Given a list of Rust struct fields and their attributes (example:
+```rust
+#[clap(long, help = "Does something.")]
+field: bool,
+```),
+create a new list of the same attributes, but with the `help = "<DOC_STRING>"` attribute
+replaced with a doc comment containing `DOC_STRING` (example:
+```rust
+/// Does something.
+#[clap(long)]
+field: bool,
+```
+). NOTE: I am asking you to convert the list yourself, not to create a function that does that.
+*/
+
 #[derive(Parser, Debug, Clone, Serialize, Default)]
 #[cfg_attr(not(doc), allow(missing_docs))]
 #[cfg_attr(
@@ -74,30 +90,31 @@ The wallet options can either be:
 "#
 )]
 pub struct MultiWallet {
+    /// Open an interactive prompt to enter your private key.
+    ///
+    /// Takes a value for the number of keys to enter.
     #[clap(
         long,
         short,
         help_heading = "Wallet options - raw",
-        help = "Open an interactive prompt to enter your private key. Takes a value for the number of keys to enter",
         default_value = "0",
         value_name = "NUM"
     )]
     pub interactives: u32,
 
+    /// Use the provided private keys.
     #[clap(
         long = "private-keys",
         help_heading = "Wallet options - raw",
-        help = "Use the provided private keys.",
         value_name = "RAW_PRIVATE_KEYS",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix,
-        action = ArgAction::Append,
     )]
     pub private_keys: Option<Vec<String>>,
 
+    /// Use the provided private key.
     #[clap(
         long = "private-key",
         help_heading = "Wallet options - raw",
-        help = "Use the provided private key.",
         conflicts_with = "private_keys",
         value_name = "RAW_PRIVATE_KEY",
         value_parser = foundry_common::clap_helpers::strip_0x_prefix,
@@ -114,36 +131,36 @@ pub struct MultiWallet {
     )]
     pub mnemonics: Option<Vec<String>>,
 
+    /// Use a BIP39 passphrases for the mnemonic.
     #[clap(
         long = "mnemonic-passphrases",
         help_heading = "Wallet options - raw",
-        help = "Use a BIP39 passphrases for the mnemonic.",
         value_name = "PASSPHRASE",
         action = ArgAction::Append,
     )]
     pub mnemonic_passphrases: Option<Vec<String>>,
 
+    /// The wallet derivation path. Works with both --mnemonic-path and hardware wallets.
     #[clap(
         long = "mnemonic-derivation-paths",
         alias = "hd-paths",
         help_heading = "Wallet options - raw",
-        help = "The wallet derivation path. Works with both --mnemonic-path and hardware wallets.",
-        value_name = "PATHS",
-        action = ArgAction::Append,
+        value_name = "PATHS"
     )]
     pub hd_paths: Option<Vec<String>>,
 
+    /// Use the private key from the given mnemonic index. Used with --mnemonics.
     #[clap(
         long = "mnemonic-indexes",
         conflicts_with = "hd_paths",
+        requires = "mnemonic-paths",
         help_heading = "Wallet options - raw",
-        help = "Use the private key from the given mnemonic index. Used with --mnemonic-paths.",
         default_value = "0",
-        value_name = "INDEXES",
-        action = ArgAction::Append,
+        value_name = "INDEXES"
     )]
     pub mnemonic_indexes: Option<Vec<u32>>,
 
+    /// Use the keystore in the given folder or file.
     #[clap(
         env = "ETH_KEYSTORE",
         long = "keystore",

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -117,11 +117,7 @@ pub struct MultiWallet {
     pub mnemonics: Option<Vec<String>>,
 
     /// Use a BIP39 passphrases for the mnemonic.
-    #[clap(
-        long = "mnemonic-passphrases",
-        help_heading = "Wallet options - raw",
-        value_name = "PASSPHRASE"
-    )]
+    #[clap(long, help_heading = "Wallet options - raw", value_name = "PASSPHRASE")]
     pub mnemonic_passphrases: Option<Vec<String>>,
 
     /// The wallet derivation path.

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -84,7 +84,7 @@ pub struct EvmArgs {
     pub sender: Option<Address>,
 
     /// Enable the FFI cheatcode.
-    #[clap(help = "Enables the FFI cheatcode.", long)]
+    #[clap(long)]
     #[serde(skip)]
     pub ffi: bool,
 

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 /// # }
 /// ```
 #[derive(Debug, Clone, Default, Parser, Serialize)]
-#[clap(next_help_heading = "EVM options", about = None)] // override doc
+#[clap(next_help_heading = "EVM options", about = None, long_about = None)] // override doc
 pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
@@ -106,8 +106,7 @@ pub struct EvmArgs {
     ///
     /// default value: 330
     ///
-    /// See --fork-url.
-    /// See also, https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups
+    /// See also --fork-url and https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups
     #[clap(
         long,
         requires = "fork_url",
@@ -119,15 +118,11 @@ pub struct EvmArgs {
 
     /// Disables rate limiting for this node's provider.
     ///
-    /// default value: false
-    ///
-    /// See --fork-url.
-    /// See also, https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups
+    /// See also --fork-url and https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups
     #[clap(
         long,
         requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
-        help = "Disables rate limiting for this node provider.",
         help_heading = "Fork config",
         visible_alias = "no-rate-limit"
     )]

--- a/config/src/macros.rs
+++ b/config/src/macros.rs
@@ -215,6 +215,7 @@ macro_rules! impl_figment_convert_basic {
             fn metadata(&self) -> $crate::figment::Metadata {
                 $crate::figment::Metadata::named(stringify!($name))
             }
+
             fn data(
                 &self,
             ) -> Result<


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

These attributes are very inconsistent throughout the whole repo, this PR attempts to fix that, improving readability. Also improves some documentation along the way.

## Solution

1. Rewrite `{help,long_help,about,long_about} = "<doc>"` to `/// <doc>`
    - clap preprocesses doc attrs: `/// <{help,about}>\n///\n/// <long_{help,about}>`
2. Remove useless args when the default does the same. Full list:
    - `long = <s>`: remove `= <s>` if `<s> == field_name.kebab_case()`
    - `short = <c>`: remove `= <c>` if `<c> == field_name[0]`
    - `name = <s>`: remove arg if `<s> == field_name.to_lowercase()`
    - `value_name = <s>`: remove arg if `<s> == screaming_snake_case(field_name)`
3. Merge multiple `#[clap(...)]` into one

Most of the changes were automatically generated using the above described rules, and each were manually checked.

<!--

I tried using this Copilot prompt, but it generates proc macro code instead of actually doing it itself:
/*
For each field's `clap(help)` attribute:
```rust
#[clap(help = "<DOC>")]
field: ...,
```

Create a new Rust struct with the same exact fields as the input, but with the
`help` attribute removed, and replace with a doc comment, only if the
`help` attribute exists, like so:
```rust
/// <doc>
/// field: ...,
*/

-->
