### PR TITLE
chore: remove infura test keys

### DIFF
--- a/utils/src/rpc.rs
+++ b/utils/src/rpc.rs
@@ -7,9 +7,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 // List of general purpose infura keys to rotate through
 static INFURA_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
     let mut keys = vec![
-        "16a8be88795540b9b3903d8de0f7baa5",
-        "f4a0bdad42674adab5fc0ac077ffab2b",
-        "5c812e02193c4ba793f8c214317582bd",
+        // "16a8be88795540b9b3903d8de0f7baa5",
+        // "f4a0bdad42674adab5fc0ac077ffab2b",
+        // "5c812e02193c4ba793f8c214317582bd",
     ];
 
     keys.shuffle(&mut rand::thread_rng());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
remove infura keys because very long, the auto backoff of 30s is likely the root cause for slow CI
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
