### PR TITLE
fix(fmt): `Variable{Declaration,Definition}` visit and fmt implementations

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -154,10 +154,11 @@ impl Cmd for FmtArgs {
 
                 solang_parser::parse(&output, 0).map_err(|diags| {
                     eyre::eyre!(
-                            "Failed to construct valid Solidity code for {}. Leaving source unchanged.\nDebug info: {:?}",
-                            input,
-                            diags
-                        )
+                        "Failed to construct valid Solidity code for {}. Leaving source unchanged.\n\
+                         Debug info: {:?}",
+                        input,
+                        diags,
+                    )
                 })?;
 
                 if self.check || matches!(input, Input::Stdin(_)) {

--- a/cli/src/cmd/forge/geiger/visitor.rs
+++ b/cli/src/cmd/forge/geiger/visitor.rs
@@ -260,17 +260,12 @@ impl Visitor for CheatcodeVisitor {
         _: Loc,
         declaration: &mut VariableDeclaration,
         expr: &mut Option<Expression>,
-        _semicolon: bool,
     ) -> Result<(), Self::Error> {
         declaration.visit(self)?;
         expr.visit(self)
     }
 
-    fn visit_var_declaration(
-        &mut self,
-        var: &mut VariableDeclaration,
-        _is_assignment: bool,
-    ) -> Result<(), Self::Error> {
+    fn visit_var_declaration(&mut self, var: &mut VariableDeclaration) -> Result<(), Self::Error> {
         var.ty.visit(self)
     }
 

--- a/fmt/src/macros.rs
+++ b/fmt/src/macros.rs
@@ -90,6 +90,7 @@ macro_rules! return_source_if_disabled {
     ($self:expr, $loc:expr) => {{
         let loc = $loc;
         if $self.inline_config.is_disabled(loc) {
+            trace!("Returning because disabled: {loc:?}");
             return $self.visit_source(loc)
         }
     }};
@@ -98,6 +99,7 @@ macro_rules! return_source_if_disabled {
         let has_suffix = $self.extend_loc_until(&mut loc, $suffix);
         if $self.inline_config.is_disabled(loc) {
             $self.visit_source(loc)?;
+            trace!("Returning because disabled: {loc:?}");
             if !has_suffix {
                 write!($self.buf(), "{}", $suffix)?;
             }

--- a/fmt/src/visit.rs
+++ b/fmt/src/visit.rs
@@ -120,21 +120,12 @@ pub trait Visitor {
         loc: Loc,
         _declaration: &mut VariableDeclaration,
         _expr: &mut Option<Expression>,
-        _semicolon: bool,
     ) -> Result<(), Self::Error> {
         self.visit_source(loc)?;
-        self.visit_stray_semicolon()?;
-
-        Ok(())
+        self.visit_stray_semicolon()
     }
 
-    /// Don't write semicolon at the end because variable declarations can appear in both
-    /// struct definition and function body as a statement
-    fn visit_var_declaration(
-        &mut self,
-        var: &mut VariableDeclaration,
-        _is_assignment: bool,
-    ) -> Result<(), Self::Error> {
+    fn visit_var_declaration(&mut self, var: &mut VariableDeclaration) -> Result<(), Self::Error> {
         self.visit_source(var.loc)
     }
 
@@ -539,7 +530,7 @@ impl Visitable for Statement {
                 v.visit_stray_semicolon()
             }
             Statement::VariableDefinition(loc, declaration, expr) => {
-                v.visit_var_definition_stmt(*loc, declaration, expr, true)
+                v.visit_var_definition_stmt(*loc, declaration, expr)
             }
             Statement::For(loc, init, cond, update, body) => {
                 v.visit_for(*loc, init, cond, update, body)
@@ -593,7 +584,7 @@ impl Visitable for VariableDeclaration {
     where
         V: Visitor,
     {
-        v.visit_var_declaration(self, false)
+        v.visit_var_declaration(self)
     }
 }
 

--- a/fmt/testdata/InlineDisable/fmt.sol
+++ b/fmt/testdata/InlineDisable/fmt.sol
@@ -229,6 +229,9 @@ function literalTest() {
             hex"001122FF";
         0xc02aaa39b223Fe8D0A0e5C4F27ead9083c756Cc2;
     // forgefmt: disable-end
+
+    // forgefmt: disable-next-line
+    bytes memory bytecode = hex"ff";
 }
 
 function returnTest() {

--- a/fmt/testdata/InlineDisable/original.sol
+++ b/fmt/testdata/InlineDisable/original.sol
@@ -209,6 +209,10 @@ function literalTest() {
             hex"001122FF";
         0xc02aaa39b223Fe8D0A0e5C4F27ead9083c756Cc2;
     // forgefmt: disable-end
+
+    // forgefmt: disable-next-line
+    bytes memory bytecode = 
+        hex"ff";
 }
 
 function returnTest() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes (the comment) https://github.com/foundry-rs/foundry/issues/3830#issuecomment-1516391215

This happens because `visit_var_declaration` doesn't write the ' =' if it gets skipped in inline config

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`VariableDeclaration` should not write the eq, and `Statement::VariableDefinition` should always write a semicolon since it's a statement, instead of having perma false/true arguments

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
