### PR TITLE
fix: Fix self signed certificates in chain by using correct Reqwest feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ comfy-table = "6.1"
 reqwest = { version = "0.11.16", default-features = false, features = [
     "json",
     "rustls",
-    "rustls-tls-native-root",
+    "rustls-tls-native-roots",
 ] }
 dotenvy = "0.15"
 dialoguer = { version = "0.10", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ comfy-table = "6.1"
 reqwest = { version = "0.11.16", default-features = false, features = [
     "json",
     "rustls",
-    "rustls-native-certs",
+    "rustls-tls-native-root",
 ] }
 dotenvy = "0.15"
 dialoguer = { version = "0.10", default-features = false }


### PR DESCRIPTION
This change fixes the bug reported in https://github.com/foundry-rs/foundry/issues/4446 by using the feature specified in Reqwest's documentation specified here https://docs.rs/reqwest/latest/reqwest/#optional-features

Motivation
This fixes the original fix from this issue https://github.com/foundry-rs/foundry/issues/2873 in this PR https://github.com/foundry-rs/foundry/pull/2939

Using the functionality of rustls-native-certs such as using the environment variable to include your certificate had no effect and caused requests to still fail.

Solution
Reqwest's documentation providers a different string for the feature than what was originally added. Built and tested locally with the SSL_CERT_FILE environment variable and it now picks it up and works.