### PR TITLE
fix(forge): fix the --debug flag in `forge debug`, default to off

### DIFF
--- a/cli/src/cmd/forge/debug.rs
+++ b/cli/src/cmd/forge/debug.rs
@@ -50,7 +50,7 @@ impl DebugArgs {
             gas_estimate_multiplier: 130,
             opts: BuildArgs { args: self.opts, ..Default::default() },
             evm_opts: self.evm_opts,
-            debug: true,
+            debug: self.debug,
             retry: RETRY_VERIFY_ON_CREATE,
             ..Default::default()
         };


### PR DESCRIPTION
'forge debug' was ignoring the --debug flag. This change fixes that, so without running without --debug will print a trace, and running with --debug will run in the debugger. This is as already described in the documentation.

## Motivation

I wanted to run 'forge debug' without the debugger, and was confused that the behavior did not match the documentation.

## Solution

Just plumb the command line arg through.