### PR TITLE
(feat) add conditional breakpoints

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -1,4 +1,7 @@
-use ethers::types::{Address, Selector, H160};
+use ethers::{
+    contract::abigen,
+    types::{Address, Selector, H160},
+};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
@@ -12,185 +15,204 @@ pub const CHEATCODE_ADDRESS: Address = H160([
 ]);
 
 // Bindings for cheatcodes
-ethers::contract::abigen!(
+abigen!(
     HEVM,
-    r#"[
-            struct Log {bytes32[] topics; bytes data;}
-            struct Rpc {string name; string url;}
-            struct FsMetadata {bool isDir; bool isSymlink; uint256 length; bool readOnly; uint256 modified; uint256 accessed; uint256 created;}
-            roll(uint256)
-            warp(uint256)
-            difficulty(uint256)
-            fee(uint256)
-            coinbase(address)
-            store(address,bytes32,bytes32)
-            load(address,bytes32)(bytes32)
-            ffi(string[])(bytes)
-            setEnv(string,string)
-            breakpoint(string)
-            breakpoint(string,bool)
-            envBool(string)(bool)
-            envUint(string)(uint256)
-            envInt(string)(int256)
-            envAddress(string)(address)
-            envBytes32(string)(bytes32)
-            envString(string)(string)
-            envBytes(string)(bytes)
-            envBool(string,string)(bool[])
-            envUint(string,string)(uint256[])
-            envInt(string,string)(int256[])
-            envAddress(string,string)(address[])
-            envBytes32(string,string)(bytes32[])
-            envString(string,string)(string[])
-            envBytes(string,string)(bytes[])
-            envOr(string,bool)(bool)
-            envOr(string,uint256)(uint256)
-            envOr(string,int256)(int256)
-            envOr(string,address)(address)
-            envOr(string,bytes32)(bytes32)
-            envOr(string,string)(string)
-            envOr(string,bytes)(bytes)
-            envOr(string,string,bool[])(bool[])
-            envOr(string,string,uint256[])(uint256[])
-            envOr(string,string,int256[])(int256[])
-            envOr(string,string,address[])(address[])
-            envOr(string,string,bytes32[])(bytes32[])
-            envOr(string,string,string[])(string[])
-            envOr(string,string,bytes[])(bytes[])
-            addr(uint256)(address)
-            sign(uint256,bytes32)(uint8,bytes32,bytes32)
-            deriveKey(string,uint32)(uint256)
-            deriveKey(string,string,uint32)(uint256)
-            rememberKey(uint256)(address)
-            prank(address)
-            startPrank(address)
-            prank(address,address)
-            startPrank(address,address)
-            stopPrank()
-            deal(address,uint256)
-            etch(address,bytes)
-            expectRevert()
-            expectRevert(bytes)
-            expectRevert(bytes4)
-            record()
-            accesses(address)(bytes32[],bytes32[])
-            recordLogs()
-            getRecordedLogs()(Log[])
-            expectEmit()
-            expectEmit(address)
-            expectEmit(bool,bool,bool,bool)
-            expectEmit(bool,bool,bool,bool,address)
-            mockCall(address,bytes,bytes)
-            mockCall(address,uint256,bytes,bytes)
-            mockCallRevert(address,bytes,bytes)
-            mockCallRevert(address,uint256,bytes,bytes)
-            clearMockedCalls()
-            expectCall(address,bytes)
-            expectCall(address,uint256,bytes)
-            expectCall(address,uint256,uint64,bytes)
-            expectCallMinGas(address,uint256,uint64,bytes)
-            expectSafeMemory(uint64,uint64)
-            expectSafeMemoryCall(uint64,uint64)
-            getCode(string)
-            getDeployedCode(string)
-            label(address,string)
-            assume(bool)
-            setNonce(address,uint64)
-            getNonce(address)
-            chainId(uint256)
-            txGasPrice(uint256)
-            broadcast()
-            broadcast(address)
-            broadcast(uint256)
-            startBroadcast()
-            startBroadcast(address)
-            startBroadcast(uint256)
-            stopBroadcast()
-            projectRoot()(string)
-            readFile(string)(string)
-            readFileBinary(string)(bytes)
-            writeFile(string,string)
-            writeFileBinary(string,bytes)
-            openFile(string)
-            readLine(string)(string)
-            writeLine(string,string)
-            closeFile(string)
-            removeFile(string)
-            fsMetadata(string)(FsMetadata)
-            toString(bytes)
-            toString(address)
-            toString(uint256)
-            toString(int256)
-            toString(bytes32)
-            toString(bool)
-            parseBytes(string)(bytes)
-            parseAddress(string)(address)
-            parseUint(string)(uint256)
-            parseInt(string)(int256)
-            parseBytes32(string)(bytes32)
-            parseBool(string)(bool)
-            snapshot()(uint256)
-            revertTo(uint256)(bool)
-            createFork(string,uint256)(uint256)
-            createFork(string,bytes32)(uint256)
-            createFork(string)(uint256)
-            createSelectFork(string,uint256)(uint256)
-            createSelectFork(string,bytes32)(uint256)
-            createSelectFork(string)(uint256)
-            selectFork(uint256)
-            activeFork()(uint256)
-            transact(bytes32)
-            transact(uint256,bytes32)
-            makePersistent(address)
-            makePersistent(address,address)
-            makePersistent(address,address,address)
-            makePersistent(address[])
-            revokePersistent(address)
-            revokePersistent(address[])
-            isPersistent(address)(bool)
-            rollFork(uint256)
-            rollFork(bytes32)
-            rollFork(uint256,uint256)
-            rollFork(uint256,bytes32)
-            rpcUrl(string)(string)
-            rpcUrls()(string[2][])
-            rpcUrlStructs()(Rpc[])
-            parseJson(string)(bytes)
-            parseJson(string, string)(bytes)
-            parseJsonUint(string, string)(uint256)
-            parseJsonUintArray(string, string)(uint256[])
-            parseJsonInt(string, string)(int256)
-            parseJsonIntArray(string, string)(int256[])
-            parseJsonString(string, string)(string)
-            parseJsonStringArray(string, string)(string[])
-            parseJsonAddress(string, string)(address)
-            parseJsonAddressArray(string, string)(address[])
-            parseJsonBool(string, string)(bool)
-            parseJsonBoolArray(string, string)(bool[])
-            parseJsonBytes(string, string)(bytes)
-            parseJsonBytesArray(string, string)(bytes[])
-            parseJsonBytes32(string, string)(bytes32)
-            parseJsonBytes32Array(string, string)(bytes32[])
-            allowCheatcodes(address)
-            serializeBool(string,string,bool)(string)
-            serializeBool(string,string,bool[])(string)
-            serializeUint(string,string,uint256)(string)
-            serializeUint(string,string,uint256[])(string)
-            serializeInt(string,string,int256)(string)
-            serializeInt(string,string,int256[])(string)
-            serializeAddress(string,string,address)(string)
-            serializeAddress(string,string,address[])(string)
-            serializeBytes32(string,string,bytes32)(string)
-            serializeBytes32(string,string,bytes32[])(string)
-            serializeString(string,string,string)(string)
-            serializeString(string,string,string[])(string)
-            serializeBytes(string,string,bytes)(string)
-            serializeBytes(string,string,bytes[])(string)
-            writeJson(string, string)
-            writeJson(string, string, string)
-            pauseGasMetering()
-            resumeGasMetering()
-    ]"#,
+    "[
+        struct Log { bytes32[] topics; bytes data; }
+        struct Rpc { string name; string url; }
+        struct FsMetadata { bool isDir; bool isSymlink; uint256 length; bool readOnly; uint256 modified; uint256 accessed; uint256 created; }
+
+        allowCheatcodes(address)
+
+        ffi(string[])(bytes)
+
+        breakpoint(string)
+        breakpoint(string,bool)
+
+        roll(uint256)
+        warp(uint256)
+        difficulty(uint256)
+        fee(uint256)
+        coinbase(address)
+        store(address,bytes32,bytes32)
+        load(address,bytes32)(bytes32)
+
+        setEnv(string,string)
+        envBool(string)(bool)
+        envUint(string)(uint256)
+        envInt(string)(int256)
+        envAddress(string)(address)
+        envBytes32(string)(bytes32)
+        envString(string)(string)
+        envBytes(string)(bytes)
+        envBool(string,string)(bool[])
+        envUint(string,string)(uint256[])
+        envInt(string,string)(int256[])
+        envAddress(string,string)(address[])
+        envBytes32(string,string)(bytes32[])
+        envString(string,string)(string[])
+        envBytes(string,string)(bytes[])
+        envOr(string,bool)(bool)
+        envOr(string,uint256)(uint256)
+        envOr(string,int256)(int256)
+        envOr(string,address)(address)
+        envOr(string,bytes32)(bytes32)
+        envOr(string,string)(string)
+        envOr(string,bytes)(bytes)
+        envOr(string,string,bool[])(bool[])
+        envOr(string,string,uint256[])(uint256[])
+        envOr(string,string,int256[])(int256[])
+        envOr(string,string,address[])(address[])
+        envOr(string,string,bytes32[])(bytes32[])
+        envOr(string,string,string[])(string[])
+        envOr(string,string,bytes[])(bytes[])
+
+        addr(uint256)(address)
+        sign(uint256,bytes32)(uint8,bytes32,bytes32)
+        deriveKey(string,uint32)(uint256)
+        deriveKey(string,string,uint32)(uint256)
+        rememberKey(uint256)(address)
+
+        prank(address)
+        prank(address,address)
+        startPrank(address)
+        startPrank(address,address)
+        stopPrank()
+
+        deal(address,uint256)
+        etch(address,bytes)
+        expectRevert()
+        expectRevert(bytes)
+        expectRevert(bytes4)
+        record()
+        accesses(address)(bytes32[],bytes32[])
+
+        recordLogs()
+        getRecordedLogs()(Log[])
+
+        expectEmit()
+        expectEmit(address)
+        expectEmit(bool,bool,bool,bool)
+        expectEmit(bool,bool,bool,bool,address)
+
+        mockCall(address,bytes,bytes)
+        mockCall(address,uint256,bytes,bytes)
+        mockCallRevert(address,bytes,bytes)
+        mockCallRevert(address,uint256,bytes,bytes)
+        clearMockedCalls()
+
+        expectCall(address,bytes)
+        expectCall(address,uint256,bytes)
+        expectCall(address,uint256,uint64,bytes)
+        expectCallMinGas(address,uint256,uint64,bytes)
+        expectSafeMemory(uint64,uint64)
+        expectSafeMemoryCall(uint64,uint64)
+
+        getCode(string)
+        getDeployedCode(string)
+        label(address,string)
+        assume(bool)
+        setNonce(address,uint64)
+        getNonce(address)
+        chainId(uint256)
+        txGasPrice(uint256)
+
+        broadcast()
+        broadcast(address)
+        broadcast(uint256)
+        startBroadcast()
+        startBroadcast(address)
+        startBroadcast(uint256)
+        stopBroadcast()
+
+        projectRoot()(string)
+        readFile(string)(string)
+        readFileBinary(string)(bytes)
+        writeFile(string,string)
+        writeFileBinary(string,bytes)
+        openFile(string)
+        readLine(string)(string)
+        writeLine(string,string)
+        closeFile(string)
+        removeFile(string)
+        fsMetadata(string)(FsMetadata)
+
+        toString(bytes)
+        toString(address)
+        toString(uint256)
+        toString(int256)
+        toString(bytes32)
+        toString(bool)
+        parseBytes(string)(bytes)
+        parseAddress(string)(address)
+        parseUint(string)(uint256)
+        parseInt(string)(int256)
+        parseBytes32(string)(bytes32)
+        parseBool(string)(bool)
+
+        snapshot()(uint256)
+        revertTo(uint256)(bool)
+        createFork(string,uint256)(uint256)
+        createFork(string,bytes32)(uint256)
+        createFork(string)(uint256)
+        createSelectFork(string,uint256)(uint256)
+        createSelectFork(string,bytes32)(uint256)
+        createSelectFork(string)(uint256)
+        selectFork(uint256)
+        activeFork()(uint256)
+        transact(bytes32)
+        transact(uint256,bytes32)
+        makePersistent(address)
+        makePersistent(address,address)
+        makePersistent(address,address,address)
+        makePersistent(address[])
+        revokePersistent(address)
+        revokePersistent(address[])
+        isPersistent(address)(bool)
+        rollFork(uint256)
+        rollFork(bytes32)
+        rollFork(uint256,uint256)
+        rollFork(uint256,bytes32)
+        rpcUrl(string)(string)
+        rpcUrls()(string[2][])
+        rpcUrlStructs()(Rpc[])
+
+        writeJson(string, string)
+        writeJson(string, string, string)
+        parseJson(string)(bytes)
+        parseJson(string, string)(bytes)
+        parseJsonUint(string, string)(uint256)
+        parseJsonUintArray(string, string)(uint256[])
+        parseJsonInt(string, string)(int256)
+        parseJsonIntArray(string, string)(int256[])
+        parseJsonString(string, string)(string)
+        parseJsonStringArray(string, string)(string[])
+        parseJsonAddress(string, string)(address)
+        parseJsonAddressArray(string, string)(address[])
+        parseJsonBool(string, string)(bool)
+        parseJsonBoolArray(string, string)(bool[])
+        parseJsonBytes(string, string)(bytes)
+        parseJsonBytesArray(string, string)(bytes[])
+        parseJsonBytes32(string, string)(bytes32)
+        parseJsonBytes32Array(string, string)(bytes32[])
+        serializeBool(string,string,bool)(string)
+        serializeBool(string,string,bool[])(string)
+        serializeUint(string,string,uint256)(string)
+        serializeUint(string,string,uint256[])(string)
+        serializeInt(string,string,int256)(string)
+        serializeInt(string,string,int256[])(string)
+        serializeAddress(string,string,address)(string)
+        serializeAddress(string,string,address[])(string)
+        serializeBytes32(string,string,bytes32)(string)
+        serializeBytes32(string,string,bytes32[])(string)
+        serializeString(string,string,string)(string)
+        serializeString(string,string,string[])(string)
+        serializeBytes(string,string,bytes)(string)
+        serializeBytes(string,string,bytes[])(string)
+
+        pauseGasMetering()
+        resumeGasMetering()
+    ]",
 );
 pub use hevm::{HEVMCalls, HEVM_ABI};
 
@@ -204,51 +226,51 @@ pub static HARDHAT_CONSOLE_ADDRESS: Address = H160([
 
 // Bindings for DS-style event logs. Note that the array logs below are not actually part of DSTest,
 // but are part of forge-std, so are included here to ensure they are decoded in output logs.
-ethers::contract::abigen!(
+abigen!(
     Console,
     r#"[
-            event log(string)
-            event logs                   (bytes)
-            event log_address            (address)
-            event log_bytes32            (bytes32)
-            event log_int                (int)
-            event log_uint               (uint)
-            event log_bytes              (bytes)
-            event log_string             (string)
-            event log_array              (uint256[] val)
-            event log_array              (int256[] val)
-            event log_array              (address[] val)
-            event log_named_address      (string key, address val)
-            event log_named_bytes32      (string key, bytes32 val)
-            event log_named_decimal_int  (string key, int val, uint decimals)
-            event log_named_decimal_uint (string key, uint val, uint decimals)
-            event log_named_int          (string key, int val)
-            event log_named_uint         (string key, uint val)
-            event log_named_bytes        (string key, bytes val)
-            event log_named_string       (string key, string val)
-            event log_named_array        (string key, uint256[] val)
-            event log_named_array        (string key, int256[] val)
-            event log_named_array        (string key, address[] val)
+        event log(string)
+        event logs                   (bytes)
+        event log_address            (address)
+        event log_bytes32            (bytes32)
+        event log_int                (int)
+        event log_uint               (uint)
+        event log_bytes              (bytes)
+        event log_string             (string)
+        event log_array              (uint256[] val)
+        event log_array              (int256[] val)
+        event log_array              (address[] val)
+        event log_named_address      (string key, address val)
+        event log_named_bytes32      (string key, bytes32 val)
+        event log_named_decimal_int  (string key, int val, uint decimals)
+        event log_named_decimal_uint (string key, uint val, uint decimals)
+        event log_named_int          (string key, int val)
+        event log_named_uint         (string key, uint val)
+        event log_named_bytes        (string key, bytes val)
+        event log_named_string       (string key, string val)
+        event log_named_array        (string key, uint256[] val)
+        event log_named_array        (string key, int256[] val)
+        event log_named_array        (string key, address[] val)
     ]"#,
 );
 pub use console::{ConsoleEvents, CONSOLE_ABI};
 
 // Bindings for Hardhat console
-ethers::contract::abigen!(HardhatConsole, "./abi/console.json", event_derives (foundry_macros::ConsoleFmt););
+abigen!(HardhatConsole, "./abi/console.json", event_derives(foundry_macros::ConsoleFmt));
 pub use hardhat_console::HARDHATCONSOLE_ABI as HARDHAT_CONSOLE_ABI;
 
 /// If the input starts with a known `hardhat/console.log` `uint` selector, then this will replace
 /// it with the selector `abigen!` bindings expect.
-pub fn patch_hardhat_console_selector(mut input: Vec<u8>) -> Vec<u8> {
+pub fn patch_hardhat_console_selector(input: &mut [u8]) {
     if input.len() < 4 {
-        return input
+        return
     }
 
-    let selector = Selector::try_from(&input[..4]).unwrap();
-    if let Some(abigen_selector) = HARDHAT_CONSOLE_SELECTOR_PATCHES.get(&selector) {
-        input.splice(..4, *abigen_selector);
+    // SAFETY: length checked above; see [<[T]>::split_array_mut].
+    let selector = unsafe { &mut *(input.get_unchecked_mut(..4) as *mut [u8] as *mut [u8; 4]) };
+    if let Some(abigen_selector) = HARDHAT_CONSOLE_SELECTOR_PATCHES.get(selector) {
+        *selector = *abigen_selector;
     }
-    input
 }
 
 /// This contains a map with all the  `hardhat/console.log` log selectors that use `uint` or `int`
@@ -778,8 +800,9 @@ mod tests {
     #[test]
     fn hardhat_console_path_works() {
         for (hh, abigen) in HARDHAT_CONSOLE_SELECTOR_PATCHES.iter() {
-            let patched = patch_hardhat_console_selector(hh.to_vec());
-            assert_eq!(abigen.to_vec(), patched);
+            let mut hh = *hh;
+            patch_hardhat_console_selector(&mut hh);
+            assert_eq!(*abigen, hh);
         }
     }
 }

--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -28,6 +28,7 @@ ethers::contract::abigen!(
             ffi(string[])(bytes)
             setEnv(string,string)
             breakpoint(string)
+            breakpoint(string,bool)
             envBool(string)(bool)
             envUint(string)(uint256)
             envInt(string)(int256)

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -70,7 +70,7 @@ fn broadcast(
     }
 
     if state.broadcast.is_some() {
-        return Err("You have an active broadcast already.".to_string().encode().into());
+        return Err("You have an active broadcast already.".to_string().encode().into())
     }
 
     state.broadcast = Some(broadcast);
@@ -89,7 +89,7 @@ fn broadcast_key(
     single_call: bool,
 ) -> Result<Bytes, Bytes> {
     if private_key.is_zero() {
-        return Err("Private key cannot be 0.".to_string().encode().into());
+        return Err("Private key cannot be 0.".to_string().encode().into())
     }
 
     if private_key >= U256::from_big_endian(&Secp256k1::ORDER.to_be_bytes()) {
@@ -121,7 +121,7 @@ fn prank(
     let prank = Prank { prank_caller, prank_origin, new_caller, new_origin, depth, single_call };
 
     if state.prank.is_some() {
-        return Err("You have an active prank already.".encode().into());
+        return Err("You have an active prank already.".encode().into())
     }
 
     if state.broadcast.is_some() {
@@ -206,11 +206,11 @@ fn add_breakpoint(
     })?;
 
     if chars.next().is_some() {
-        return Err("Please provide only one char for the breakpoint".encode().into());
+        return Err("Please provide only one char for the breakpoint".encode().into())
     }
 
     if !point.is_alphabetic() {
-        return Err("Only alphabetic chars are accepted".encode().into());
+        return Err("Only alphabetic chars are accepted".encode().into())
     }
 
     // add a breakpoint from the interpreter
@@ -385,7 +385,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::ChainId(inner) => {
             if inner.0 > U256::from(u64::MAX) {
-                return Err("Chain ID must be less than 2^64".to_string().encode().into());
+                return Err("Chain ID must be less than 2^64".to_string().encode().into())
             }
             data.env.cfg.chain_id = inner.0;
             Bytes::new()
@@ -500,7 +500,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::StopBroadcast(_) => {
             if state.broadcast.is_none() {
-                return Err("No broadcast in progress to stop".to_string().encode().into());
+                return Err("No broadcast in progress to stop".to_string().encode().into())
             }
             state.broadcast = None;
             Bytes::new()

--- a/evm/src/executor/inspector/logs.rs
+++ b/evm/src/executor/inspector/logs.rs
@@ -18,9 +18,9 @@ pub struct LogCollector {
 }
 
 impl LogCollector {
-    fn hardhat_log(&mut self, input: Vec<u8>) -> (Return, Bytes) {
+    fn hardhat_log(&mut self, mut input: Vec<u8>) -> (Return, Bytes) {
         // Patch the Hardhat-style selectors
-        let input = patch_hardhat_console_selector(input.to_vec());
+        patch_hardhat_console_selector(&mut input);
         let decoded = match HardhatConsoleCalls::decode(input) {
             Ok(inner) => inner,
             Err(err) => {
@@ -77,10 +77,8 @@ const TOPIC: H256 = H256([
 /// Converts a call to Hardhat's `console.log` to a DSTest `log(string)` event.
 fn convert_hh_log_to_event(call: HardhatConsoleCalls) -> Log {
     // Convert the parameters of the call to their string representation using `ConsoleFmt`.
-    let data = {
-        let fmt = call.fmt(Default::default());
-        let token = Token::String(fmt);
-        ethers::abi::encode(&[token]).into()
-    };
+    let fmt = call.fmt(Default::default());
+    let token = Token::String(fmt);
+    let data = ethers::abi::encode(&[token]).into();
     Log { topics: vec![TOPIC], data, ..Default::default() }
 }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -450,8 +450,8 @@ impl Tui {
                                     let mut before = source[..std::cmp::min(offset, max)]
                                         .split_inclusive('\n')
                                         .collect::<Vec<&str>>();
-                                    let actual = source[std::cmp::min(offset, max)
-                                        ..std::cmp::min(offset + len, max)]
+                                    let actual = source[std::cmp::min(offset, max)..
+                                        std::cmp::min(offset + len, max)]
                                         .split_inclusive('\n')
                                         .map(|s| s.to_string())
                                         .collect::<Vec<String>>();
@@ -1018,18 +1018,18 @@ impl Ui for Tui {
                     let event = event::read().unwrap();
                     if let Event::Key(key) = event {
                         if tx.send(Interrupt::KeyPressed(key)).is_err() {
-                            return;
+                            return
                         }
                     } else if let Event::Mouse(mouse) = event {
                         if tx.send(Interrupt::MouseEvent(mouse)).is_err() {
-                            return;
+                            return
                         }
                     }
                 }
                 // Force update if time has passed
                 if last_tick.elapsed() > tick_rate {
                     if tx.send(Interrupt::IntervalElapsed).is_err() {
-                        return;
+                        return
                     }
                     last_tick = Instant::now();
                 }
@@ -1073,7 +1073,7 @@ impl Ui for Tui {
                                 {
                                     draw_memory.inner_call_index = i;
                                     self.current_step = step;
-                                    break;
+                                    break
                                 }
                             }
                         }
@@ -1089,7 +1089,7 @@ impl Ui for Tui {
                                 LeaveAlternateScreen,
                                 DisableMouseCapture
                             )?;
-                            return Ok(TUIExitReason::CharExit);
+                            return Ok(TUIExitReason::CharExit)
                         }
                         // Move down
                         KeyCode::Char('j') | KeyCode::Down => {
@@ -1099,9 +1099,9 @@ impl Ui for Tui {
                                     let max_mem = (debug_call[draw_memory.inner_call_index].1
                                         [self.current_step]
                                         .memory
-                                        .len()
-                                        / 32)
-                                        .saturating_sub(1);
+                                        .len() /
+                                        32)
+                                    .saturating_sub(1);
                                     if draw_memory.current_mem_startline < max_mem {
                                         draw_memory.current_mem_startline += 1;
                                     }
@@ -1218,8 +1218,8 @@ impl Ui for Tui {
                                     .find_map(|(i, op)| {
                                         if i > 0 {
                                             match (
-                                                prev_ops[i - 1].contains("JUMP")
-                                                    && prev_ops[i - 1] != "JUMPDEST",
+                                                prev_ops[i - 1].contains("JUMP") &&
+                                                    prev_ops[i - 1] != "JUMPDEST",
                                                 &**op,
                                             ) {
                                                 (true, "JUMPDEST") => Some(i - 1),
@@ -1326,7 +1326,7 @@ impl Interrupt {
         if let Self::KeyPressed(event) = &self {
             if let KeyCode::Char(c) = event.code {
                 if c.is_alphanumeric() || c == '\'' {
-                    return Some(c);
+                    return Some(c)
                 }
             }
         }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -364,12 +364,22 @@ impl Tui {
 
     fn draw_footer<B: Backend>(f: &mut Frame<B>, area: Rect) {
         let block_controls = Block::default();
+        let dim = Style::default().add_modifier(Modifier::DIM);
 
-        let text_output = Text::from(Span::styled(
-            "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end\n
-[t]: stack labels | [m]: memory decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll memory | ['<char>]: goto breakpoint",
-            Style::default().add_modifier(Modifier::DIM),
-        ));
+        let text_output = vec![
+            Spans::from(
+                Span::styled(
+                    "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end",
+                    dim,
+                ),
+            ),
+            Spans::from(
+                Span::styled(
+                    "[t]: stack labels | [m]: memory decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll memory | ['<char>]: goto breakpoint | [h] close help",
+                    dim,
+                )
+            )
+        ];
 
         let paragraph = Paragraph::new(text_output)
             .block(block_controls)

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -146,6 +146,7 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
+        help: bool,
     ) {
         let total_size = f.size();
         if total_size.width < 225 {
@@ -163,6 +164,7 @@ impl Tui {
                 draw_memory,
                 stack_labels,
                 mem_utf,
+                help,
             );
         } else {
             Tui::square_layout(
@@ -179,6 +181,7 @@ impl Tui {
                 draw_memory,
                 stack_labels,
                 mem_utf,
+                help,
             );
         }
     }
@@ -198,11 +201,16 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
+        help: bool,
     ) {
         let total_size = f.size();
+        let h_height = if help { 4 } else { 0 };
+
         if let [app, footer] = Layout::default()
+            .constraints(
+                [Constraint::Ratio(100 - h_height, 100), Constraint::Ratio(h_height, 100)].as_ref(),
+            )
             .direction(Direction::Vertical)
-            .constraints([Constraint::Ratio(98, 100), Constraint::Ratio(2, 100)].as_ref())
             .split(total_size)[..]
         {
             if let [op_pane, stack_pane, memory_pane, src_pane] = Layout::default()
@@ -218,7 +226,9 @@ impl Tui {
                 )
                 .split(app)[..]
             {
-                Tui::draw_footer(f, footer);
+                if help {
+                    Tui::draw_footer(f, footer);
+                }
                 Tui::draw_src(
                     f,
                     address,
@@ -253,7 +263,7 @@ impl Tui {
             }
         } else {
             panic!("unable to create footer / app")
-        }
+        };
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -271,14 +281,18 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
+        help: bool,
     ) {
         let total_size = f.size();
+        let h_height = if help { 4 } else { 0 };
 
         // split in 2 vertically
 
         if let [app, footer] = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Ratio(98, 100), Constraint::Ratio(2, 100)].as_ref())
+            .constraints(
+                [Constraint::Ratio(100 - h_height, 100), Constraint::Ratio(h_height, 100)].as_ref(),
+            )
             .split(total_size)[..]
         {
             if let [left_pane, right_pane] = Layout::default()
@@ -297,7 +311,9 @@ impl Tui {
                         .constraints([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)].as_ref())
                         .split(right_pane)[..]
                     {
-                        Tui::draw_footer(f, footer);
+                        if help {
+                            Tui::draw_footer(f, footer)
+                        };
                         Tui::draw_src(
                             f,
                             address,
@@ -350,13 +366,16 @@ impl Tui {
         let block_controls = Block::default();
 
         let text_output = Text::from(Span::styled(
-            "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [t]: toggle stack labels | [m]: toggle memory decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll memory",
-            Style::default().add_modifier(Modifier::DIM)
+            "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end\n
+[t]: stack labels | [m]: memory decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll memory | ['<char>]: goto breakpoint",
+            Style::default().add_modifier(Modifier::DIM),
         ));
+
         let paragraph = Paragraph::new(text_output)
             .block(block_controls)
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: false });
+
         f.render_widget(paragraph, area);
     }
 
@@ -1017,6 +1036,7 @@ impl Ui for Tui {
 
         let mut stack_labels = false;
         let mut mem_utf = false;
+        let mut help = false;
         // UI thread that manages drawing
         loop {
             if last_index != draw_memory.inner_call_index {
@@ -1211,6 +1231,10 @@ impl Ui for Tui {
                         KeyCode::Char('m') => {
                             mem_utf = !mem_utf;
                         }
+                        // toggle help notice
+                        KeyCode::Char('h') => {
+                            help = !help;
+                        }
                         KeyCode::Char(other) => match other {
                             '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '\'' => {
                                 self.key_buffer.push(other);
@@ -1273,6 +1297,7 @@ impl Ui for Tui {
                     &mut draw_memory,
                     stack_labels,
                     mem_utf,
+                    help,
                 )
             })?;
         }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -381,6 +381,12 @@ impl Tui {
             )
         ];
 
+        let text_output = Text::from(Span::styled(
+            "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end\n
+[t]: stack labels | [m]: memory decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll memory | ['<char>]: goto breakpoint",
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+
         let paragraph = Paragraph::new(text_output)
             .block(block_controls)
             .alignment(Alignment::Center)

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -450,8 +450,8 @@ impl Tui {
                                     let mut before = source[..std::cmp::min(offset, max)]
                                         .split_inclusive('\n')
                                         .collect::<Vec<&str>>();
-                                    let actual = source[std::cmp::min(offset, max)..
-                                        std::cmp::min(offset + len, max)]
+                                    let actual = source[std::cmp::min(offset, max)
+                                        ..std::cmp::min(offset + len, max)]
                                         .split_inclusive('\n')
                                         .map(|s| s.to_string())
                                         .collect::<Vec<String>>();
@@ -1018,18 +1018,18 @@ impl Ui for Tui {
                     let event = event::read().unwrap();
                     if let Event::Key(key) = event {
                         if tx.send(Interrupt::KeyPressed(key)).is_err() {
-                            return
+                            return;
                         }
                     } else if let Event::Mouse(mouse) = event {
                         if tx.send(Interrupt::MouseEvent(mouse)).is_err() {
-                            return
+                            return;
                         }
                     }
                 }
                 // Force update if time has passed
                 if last_tick.elapsed() > tick_rate {
                     if tx.send(Interrupt::IntervalElapsed).is_err() {
-                        return
+                        return;
                     }
                     last_tick = Instant::now();
                 }
@@ -1073,7 +1073,7 @@ impl Ui for Tui {
                                 {
                                     draw_memory.inner_call_index = i;
                                     self.current_step = step;
-                                    break
+                                    break;
                                 }
                             }
                         }
@@ -1089,7 +1089,7 @@ impl Ui for Tui {
                                 LeaveAlternateScreen,
                                 DisableMouseCapture
                             )?;
-                            return Ok(TUIExitReason::CharExit)
+                            return Ok(TUIExitReason::CharExit);
                         }
                         // Move down
                         KeyCode::Char('j') | KeyCode::Down => {
@@ -1099,9 +1099,9 @@ impl Ui for Tui {
                                     let max_mem = (debug_call[draw_memory.inner_call_index].1
                                         [self.current_step]
                                         .memory
-                                        .len() /
-                                        32)
-                                    .saturating_sub(1);
+                                        .len()
+                                        / 32)
+                                        .saturating_sub(1);
                                     if draw_memory.current_mem_startline < max_mem {
                                         draw_memory.current_mem_startline += 1;
                                     }
@@ -1218,8 +1218,8 @@ impl Ui for Tui {
                                     .find_map(|(i, op)| {
                                         if i > 0 {
                                             match (
-                                                prev_ops[i - 1].contains("JUMP") &&
-                                                    prev_ops[i - 1] != "JUMPDEST",
+                                                prev_ops[i - 1].contains("JUMP")
+                                                    && prev_ops[i - 1] != "JUMPDEST",
                                                 &**op,
                                             ) {
                                                 (true, "JUMPDEST") => Some(i - 1),
@@ -1326,7 +1326,7 @@ impl Interrupt {
         if let Self::KeyPressed(event) = &self {
             if let KeyCode::Char(c) = event.code {
                 if c.is_alphanumeric() || c == '\'' {
-                    return Some(c)
+                    return Some(c);
                 }
             }
         }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -366,7 +366,7 @@ impl Tui {
         let block_controls = Block::default();
         let dim = Style::default().add_modifier(Modifier::DIM);
 
-        let text_output = vec![
+        let _text_output = vec![
             Spans::from(
                 Span::styled(
                     "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end",


### PR DESCRIPTION
## Motivation

Implementing @mds1 's ideas about extending breakpoints, ref: https://github.com/foundry-rs/foundry/pull/4679#issuecomment-1503455791

## Changes

1. Add conditional breakpoints (`vm.breakpoint("a", true)` to switch on and `vm.breakpoint("a", false)` to switch off)
2. Write the `['<char>]: goto breakpoint` notice on debugger footer

## About the notice

It's getting somewhat big and I cannot see the whole footer (about 2/3 currently) at once. Why not adding a `h` to toggle help that would take more space, but could be collapsable ?