### PR TITLE
feat(cast-wallet-sign): add 0x-prefixed data read

### DIFF
--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -120,8 +120,16 @@ impl WalletSubcommands {
             }
             WalletSubcommands::Sign { message, wallet } => {
                 let wallet = wallet.signer(0).await?;
-                let sig = wallet.sign_message(message).await?;
-                println!("Signature: 0x{sig}");
+                let sig = match message.strip_prefix("0x") {
+                    Some(data) => {
+                        let data_bytes: Vec<u8> = hex::decode(data).wrap_err("Could not decode 0x-prefixed string.")?;
+                        wallet.sign_message(data_bytes).await?
+                    }
+                    None => {
+                        wallet.sign_message(message).await?
+                    }
+                };
+                println!("0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
                 let pubkey: Address = address.parse().wrap_err("Invalid address")?;

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -85,6 +85,32 @@ casttest!(wallet_address_keystore_with_password_file, |_: TestProject, mut cmd: 
     assert!(out.contains("0xeC554aeAFE75601AaAb43Bd4621A22284dB566C2"));
 });
 
+// tests that `cast wallet sign` outputs the expected signature
+casttest!(wallet_sign_correct_signature, |_: TestProject, mut cmd: TestCommand| {
+    cmd.args([
+        "wallet",
+        "sign",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "test"
+    ]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0xfe28833983d6faa0715c7e8c3873c725ddab6fa5bf84d40e780676e463e6bea20fc6aea97dc273a98eb26b0914e224c8dd5c615ceaab69ddddcf9b0ae3de0e371c");
+});
+
+// tests that `cast wallet sign` outputs the expected signature, given a 0x-prefixed data
+casttest!(wallet_sign_correct_signature, |_: TestProject, mut cmd: TestCommand| {
+    cmd.args([
+        "wallet",
+        "sign",
+        "--private-key",
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+    ]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0x23a42ca5616ee730ff3735890c32fc7b9491a9f633faca9434797f2c845f5abf4d9ba23bd7edb8577acebaa3644dc5a4995296db420522bb40060f1693c33c9b1c");
+});
+
 // tests that `cast estimate` is working correctly.
 casttest!(estimate_function_gas, |_: TestProject, mut cmd: TestCommand| {
     let eth_rpc_url = next_http_rpc_endpoint();


### PR DESCRIPTION
## Motivation

Fixes the issue #4817

## Solution

Reads bytes if the given string is 0x-prefixed
