### PR TITLE
StopPrank iff there is a prank started

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -330,6 +330,9 @@ pub fn apply<DB: DatabaseExt>(
             false,
         )?,
         HEVMCalls::StopPrank(_) => {
+            if state.prank.is_none() {
+                return Err("No prank in progress to stop".to_string().encode().into())
+            }
             state.prank = None;
             Bytes::new()
         }


### PR DESCRIPTION
## Motivation

Match logic of `StopBroadcast` (which fails if a broadcast is not in progress)

## Solution

Fail to `StopPrank` if there is no prank in progress to stop.