### PR TITLE
feat: add count to `expectCall` cheatcodes

### DIFF
--- a/evm/src/executor/abi/mod.rs
+++ b/evm/src/executor/abi/mod.rs
@@ -102,9 +102,13 @@ abigen!(
         clearMockedCalls()
 
         expectCall(address,bytes)
+        expectCall(address,bytes,uint64)
         expectCall(address,uint256,bytes)
+        expectCall(address,uint256,bytes,uint64)
         expectCall(address,uint256,uint64,bytes)
+        expectCall(address,uint256,uint64,bytes,uint64)
         expectCallMinGas(address,uint256,uint64,bytes)
+        expectCallMinGas(address,uint256,uint64,bytes,uint64)
         expectSafeMemory(uint64,uint64)
         expectSafeMemoryCall(uint64,uint64)
 

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -210,6 +210,8 @@ pub struct ExpectedCallData {
     pub gas: Option<u64>,
     /// The expected *minimum* gas supplied to the call
     pub min_gas: Option<u64>,
+    /// The number of times the call is expected to be made
+    pub count: u64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -293,51 +295,123 @@ pub fn apply<DB: DatabaseExt>(
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectCall0(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push(ExpectedCallData {
-                calldata: inner.1.to_vec().into(),
-                value: None,
-                gas: None,
-                min_gas: None,
-            });
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.1.to_vec().into(),
+                    value: None,
+                    gas: None,
+                    min_gas: None,
+                    count: 1,
+                },
+                0,
+            ));
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectCall1(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push(ExpectedCallData {
-                calldata: inner.2.to_vec().into(),
-                value: Some(inner.1),
-                gas: None,
-                min_gas: None,
-            });
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.1.to_vec().into(),
+                    value: None,
+                    gas: None,
+                    min_gas: None,
+                    count: inner.2,
+                },
+                0,
+            ));
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectCall2(inner) => {
-            let value = inner.1;
-
-            // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
-            // to ensure that the basic fallback function can be called.
-            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-
-            state.expected_calls.entry(inner.0).or_default().push(ExpectedCallData {
-                calldata: inner.3.to_vec().into(),
-                value: Some(value),
-                gas: Some(inner.2 + positive_value_cost_stipend),
-                min_gas: None,
-            });
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.2.to_vec().into(),
+                    value: Some(inner.1),
+                    gas: None,
+                    min_gas: None,
+                    count: 1,
+                },
+                0,
+            ));
             Ok(Bytes::new())
         }
-        HEVMCalls::ExpectCallMinGas(inner) => {
+        HEVMCalls::ExpectCall3(inner) => {
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.2.to_vec().into(),
+                    value: Some(inner.1),
+                    gas: None,
+                    min_gas: None,
+                    count: inner.3,
+                },
+                0,
+            ));
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectCall4(inner) => {
             let value = inner.1;
 
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
 
-            state.expected_calls.entry(inner.0).or_default().push(ExpectedCallData {
-                calldata: inner.3.to_vec().into(),
-                value: Some(value),
-                gas: None,
-                min_gas: Some(inner.2 + positive_value_cost_stipend),
-            });
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.3.to_vec().into(),
+                    value: Some(value),
+                    gas: Some(inner.2 + positive_value_cost_stipend),
+                    min_gas: None,
+                    count: 1,
+                },
+                0,
+            ));
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectCall5(inner) => {
+            let value = inner.1;
+            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.3.to_vec().into(),
+                    value: Some(value),
+                    gas: Some(inner.2 + positive_value_cost_stipend),
+                    min_gas: None,
+                    count: inner.4,
+                },
+                0,
+            ));
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectCallMinGas0(inner) => {
+            let value = inner.1;
+
+            // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
+            // to ensure that the basic fallback function can be called.
+            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
+
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.3.to_vec().into(),
+                    value: Some(value),
+                    gas: None,
+                    min_gas: Some(inner.2 + positive_value_cost_stipend),
+                    count: 1,
+                },
+                0,
+            ));
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ExpectCallMinGas1(inner) => {
+            let value = inner.1;
+            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
+            state.expected_calls.entry(inner.0).or_default().push((
+                ExpectedCallData {
+                    calldata: inner.3.to_vec().into(),
+                    value: Some(value),
+                    gas: None,
+                    min_gas: Some(inner.2 + positive_value_cost_stipend),
+                    count: inner.4,
+                },
+                0,
+            ));
             Ok(Bytes::new())
         }
         HEVMCalls::MockCall0(inner) => {

--- a/forge/README.md
+++ b/forge/README.md
@@ -318,13 +318,23 @@ interface Hevm {
     function clearMockedCalls() external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
-    function expectCall(address,bytes calldata) external;
+    function expectCall(address, bytes calldata) external;
+    // Expect given number of calls to an address with the specified calldata.
+    // Calldata can either be strict or a partial match
+    function expectCall(address, bytes calldata, uint64) external;
     // Expect a call to an address with the specified msg.value and calldata
-    function expectCall(address,uint256,bytes calldata) external;
+    function expectCall(address, uint256, bytes calldata) external;
+    // Expect a given number of calls to an address with the specified msg.value and calldata
+    function expectCall(address, uint256, bytes calldata, uint64) external;
     // Expect a call to an address with the specified msg.value, gas, and calldata.
     function expectCall(address, uint256, uint64, bytes calldata) external;
+    // Expect a given number of calls to an address with the specified msg.value, gas, and calldata.
+    function expectCall(address, uint256, uint64, bytes calldata, uint64) external;
     // Expect a call to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
     function expectCallMinGas(address, uint256, uint64, bytes calldata) external;
+    // Expect a given number of calls to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
+    function expectCallMinGas(address, uint256, uint64, bytes calldata, uint64) external;
+
     // Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the current subcontext. If any other
     // memory is written to, the test will fail.
     function expectSafeMemory(uint64, uint64) external;

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -208,14 +208,27 @@ interface Cheats {
     // Calldata can either be strict or a partial match
     function expectCall(address, bytes calldata) external;
 
+    // Expect given number of calls to an address with the specified calldata.
+    // Calldata can either be strict or a partial match
+    function expectCall(address, bytes calldata, uint64) external;
+
     // Expect a call to an address with the specified msg.value and calldata
     function expectCall(address, uint256, bytes calldata) external;
+
+    // Expect a given number of calls to an address with the specified msg.value and calldata
+    function expectCall(address, uint256, bytes calldata, uint64) external;
 
     // Expect a call to an address with the specified msg.value, gas, and calldata.
     function expectCall(address, uint256, uint64, bytes calldata) external;
 
+    // Expect a given number of calls to an address with the specified msg.value, gas, and calldata.
+    function expectCall(address, uint256, uint64, bytes calldata, uint64) external;
+
     // Expect a call to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
     function expectCallMinGas(address, uint256, uint64, bytes calldata) external;
+
+    // Expect a given number of calls to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
+    function expectCallMinGas(address, uint256, uint64, bytes calldata, uint64) external;
 
     // Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the current subcontext. If any other
     // memory is written to, the test will fail.

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -161,3 +161,147 @@ contract ExpectCallTest is DSTest {
         target.addHardGasLimit();
     }
 }
+
+contract ExpectCallCountTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function testExpectCallCountWithData() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 3);
+        target.add(1, 2);
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testExpectZeroCallCountAssert() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 0);
+        target.add(3, 3);
+    }
+
+    function testFailExpectCallCountWithWrongCount() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
+        target.add(1, 2);
+    }
+
+    function testExpectCountInnerCall() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), abi.encodeWithSelector(inner.numberB.selector), 1);
+        target.sum();
+    }
+
+    function testFailExpectCountInnerCall() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), abi.encodeWithSelector(inner.numberB.selector), 1);
+
+        // this function does not call inner
+        target.hello();
+    }
+
+    function testExpectCountInnerAndOuterCalls() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), abi.encodeWithSelector(inner.numberB.selector), 2);
+        inner.numberB();
+        target.sum();
+    }
+
+    function testExpectCallCountWithValue() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), 1, abi.encodeWithSelector(target.pay.selector, 2), 1);
+        target.pay{value: 1}(2);
+    }
+
+    function testExpectZeroCallCountValue() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), 1, abi.encodeWithSelector(target.pay.selector, 2), 0);
+        target.pay{value: 2}(2);
+    }
+
+    function testFailExpectCallCountValue() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), 1, abi.encodeWithSelector(target.pay.selector, 2), 1);
+        target.pay{value: 2}(2);
+    }
+
+    function testExpectCallCountWithValueWithoutParameters() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), 3, abi.encodeWithSelector(target.pay.selector), 3);
+        target.pay{value: 3}(100);
+        target.pay{value: 3}(100);
+        target.pay{value: 3}(100);
+    }
+
+    function testExpectCallCountWithValueAndGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), 1, 50_000, abi.encodeWithSelector(inner.pay.selector, 1), 2);
+        target.forwardPay{value: 1}();
+        target.forwardPay{value: 1}();
+    }
+
+    function testExpectCallCountWithNoValueAndGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), 0, 50_000, abi.encodeWithSelector(inner.add.selector, 1, 1), 1);
+        target.addHardGasLimit();
+    }
+
+    function testExpectZeroCallCountWithNoValueAndWrongGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), 0, 25_000, abi.encodeWithSelector(inner.add.selector, 1, 1), 0);
+        target.addHardGasLimit();
+    }
+
+    function testFailExpectCallCountWithNoValueAndWrongGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCall(address(inner), 0, 25_000, abi.encodeWithSelector(inner.add.selector, 1, 1), 2);
+        target.addHardGasLimit();
+        target.addHardGasLimit();
+    }
+
+    function testExpectCallCountWithValueAndMinGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCallMinGas(address(inner), 1, 50_000, abi.encodeWithSelector(inner.pay.selector, 1), 1);
+        target.forwardPay{value: 1}();
+    }
+
+    function testExpectCallCountWithNoValueAndMinGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCallMinGas(address(inner), 0, 25_000, abi.encodeWithSelector(inner.add.selector, 1, 1), 2);
+        target.addHardGasLimit();
+        target.addHardGasLimit();
+    }
+
+    function testExpectCallZeroCountWithNoValueAndWrongMinGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCallMinGas(address(inner), 0, 50_001, abi.encodeWithSelector(inner.add.selector, 1, 1), 0);
+        target.addHardGasLimit();
+    }
+
+    function testFailExpectCallCountWithNoValueAndWrongMinGas() public {
+        Contract inner = new Contract();
+        NestedContract target = new NestedContract(inner);
+
+        cheats.expectCallMinGas(address(inner), 0, 50_001, abi.encodeWithSelector(inner.add.selector, 1, 1), 1);
+        target.addHardGasLimit();
+    }
+}


### PR DESCRIPTION
Closes #4513 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently we can only assert that a call is made to a function using expectCall(), it would be nice to have another cheatcode to check the number of time a call was made, which can also be useful to assert if a call is not made.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Overriding the `expectCall` cheatcodes to also accept the number of times it is expected to be called and enforce the same.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
