### PR TITLE
fix(forge): `expectCall` with no count

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -211,7 +211,7 @@ pub struct ExpectedCallData {
     /// The expected *minimum* gas supplied to the call
     pub min_gas: Option<u64>,
     /// The number of times the call is expected to be made
-    pub count: u64,
+    pub count: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -301,7 +301,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: None,
                     gas: None,
                     min_gas: None,
-                    count: 1,
+                    count: None,
                 },
                 0,
             ));
@@ -314,7 +314,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: None,
                     gas: None,
                     min_gas: None,
-                    count: inner.2,
+                    count: Some(inner.2),
                 },
                 0,
             ));
@@ -327,7 +327,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(inner.1),
                     gas: None,
                     min_gas: None,
-                    count: 1,
+                    count: None,
                 },
                 0,
             ));
@@ -340,7 +340,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(inner.1),
                     gas: None,
                     min_gas: None,
-                    count: inner.3,
+                    count: Some(inner.3),
                 },
                 0,
             ));
@@ -359,7 +359,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(value),
                     gas: Some(inner.2 + positive_value_cost_stipend),
                     min_gas: None,
-                    count: 1,
+                    count: None,
                 },
                 0,
             ));
@@ -374,7 +374,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(value),
                     gas: Some(inner.2 + positive_value_cost_stipend),
                     min_gas: None,
-                    count: inner.4,
+                    count: Some(inner.4),
                 },
                 0,
             ));
@@ -393,7 +393,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(value),
                     gas: None,
                     min_gas: Some(inner.2 + positive_value_cost_stipend),
-                    count: 1,
+                    count: None,
                 },
                 0,
             ));
@@ -408,7 +408,7 @@ pub fn apply<DB: DatabaseExt>(
                     value: Some(value),
                     gas: None,
                     min_gas: Some(inner.2 + positive_value_cost_stipend),
-                    count: inner.4,
+                    count: Some(inner.4),
                 },
                 0,
             ));

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -766,7 +766,11 @@ where
                             Return::Revert,
                             remaining_gas,
                             format!(
-                                "Expected call to {address:?} with {expected_values} to be made {count:?} time(s), but was called {actual_count} time(s)"
+                                "Expected call to {:?} with {} to be made {} time(s), but was called {} time(s)",
+                                address,
+                                expected_values,
+                                count.unwrap(),
+                                actual_count,
                             )
                             .encode()
                             .into(),

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -742,21 +742,31 @@ where
                 for (expected, actual_count) in expecteds {
                     let ExpectedCallData { calldata, gas, min_gas, value, count } = expected;
                     let calldata = ethers::types::Bytes::from(calldata.clone());
-                    if *count != *actual_count {
-                        let expected_values = [
-                            Some(format!("data {calldata}")),
-                            value.map(|v| format!("value {v}")),
-                            gas.map(|g| format!("gas {g}")),
-                            min_gas.map(|g| format!("minimum gas {g}")),
-                        ]
-                        .into_iter()
-                        .flatten()
-                        .join(" and ");
+                    let expected_values = [
+                        Some(format!("data {calldata}")),
+                        value.map(|v| format!("value {v}")),
+                        gas.map(|g| format!("gas {g}")),
+                        min_gas.map(|g| format!("minimum gas {g}")),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .join(" and ");
+                    if count.is_none() {
+                        if *actual_count == 0 {
+                            return (
+                                Return::Revert,
+                                remaining_gas,
+                                format!("Expected at least one call to {address:?} with {expected_values}, but got none")
+                                    .encode()
+                                    .into(),
+                            )
+                        }
+                    } else if *count != Some(*actual_count) {
                         return (
                             Return::Revert,
                             remaining_gas,
                             format!(
-                                "Expected call to {address:?} with {expected_values} to be called {count} time(s), but was called {actual_count} time(s)"
+                                "Expected call to {address:?} with {expected_values} to be made {count:?} time(s), but was called {actual_count} time(s)"
                             )
                             .encode()
                             .into(),

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -55,6 +55,13 @@ contract ExpectCallTest is DSTest {
         target.add(1, 2);
     }
 
+    function testExpectMultipleCallsWithData() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
     function testFailExpectCallWithData() public {
         Contract target = new Contract();
         cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
#4833 introduced a breaking change to `expectCall` whereby if no `count` was specified it would default to 1. This PR preserves the older behaviour of checking that a call is made at least once if `count` is not specified.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Change `count` type to `Option<u64>` and revert to older behaviour if `is_none()`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
