### PR TITLE
CI: Separate issue reproduction & forge-std tests into their own jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,11 +99,50 @@ jobs:
             - name: Download archives
               uses: actions/download-artifact@v3
               with:
-                  name: issue-repro-tests
+                  name: integration-tests
 
             - name: Forge RPC cache
               uses: actions/cache@v3
-              if: matrix.job.name != 'non-forking'
+              if: matrix.job.name != 'issue-repros'
+              with:
+                  path: "$HOME/.foundry/cache"
+                  key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
+            - name: Setup git config
+              run: |
+                  git config --global user.name "GitHub Actions Bot"
+                  git config --global user.email "<>"
+
+            - name: cargo nextest
+              run: |
+                # see https://github.com/foundry-rs/foundry/pull/3959
+                export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib"
+                cargo nextest run --partition count:${{ matrix.partition }}/2 --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
+
+    forge-std-tests:
+        name: forge std tests / ${{ matrix.job.name }}
+        runs-on: ubuntu-latest
+        needs: build-tests
+        strategy:
+            matrix:
+                job:
+                    - name: forge-std-test
+                      filter: "test(~forge_std)"
+        env:
+            ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v2
+            - name: Install nextest
+              uses: taiki-e/install-action@nextest
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Download archives
+              uses: actions/download-artifact@v3
+              with:
+                  name: integration-tests
+
+            - name: Forge RPC cache
+              uses: actions/cache@v3
+              if: matrix.job.name != 'forge-std-test'
               with:
                   path: "$HOME/.foundry/cache"
                   key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,6 @@ jobs:
                 job:
                     - name: forge-std-test
                       filter: "test(~forge_std)"
-                partition: [1, 1]
         env:
             ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
         steps:
@@ -157,7 +156,7 @@ jobs:
               run: |
                 # see https://github.com/foundry-rs/foundry/pull/3959
                 export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib"
-                cargo nextest run --partition count:${{ matrix.partition }}/2 --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
+                cargo nextest run --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
 
     integration:
         name: integration tests / ${{ matrix.job.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
                 job:
                     - name: forge-std-test
                       filter: "test(~forge_std)"
-                partition: [1, 2]
+                partition: [1, 1]
         env:
             ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
         steps:
@@ -167,7 +167,7 @@ jobs:
             matrix:
                 job:
                     - name: non-forking
-                      filter: "!test(~fork) & !test(~live) & !test(~issue)"
+                      filter: "!test(~fork) & !test(~live) & !test(~issue) & !test(~forge_std)"
                     - name: forking
                       filter: "test(~fork) & !test(~live)"
                 partition: [1, 2]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,45 @@ jobs:
                 export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib"
                 cargo nextest run --retries 3 --archive-file nextest-unit.tar.zst -E '${{ matrix.job.filter }}'
 
+    issue-repros-tests:
+        name: issue reproduction tests / ${{ matrix.job.name }}
+        runs-on: ubuntu-latest
+        needs: build-tests
+        strategy:
+            matrix:
+                job:
+                    - name: issue-repros
+                      filter: "test(~issue)"
+        env:
+            ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v2
+            - name: Install nextest
+              uses: taiki-e/install-action@nextest
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Download archives
+              uses: actions/download-artifact@v3
+              with:
+                  name: issue-repro-tests
+
+            - name: Forge RPC cache
+              uses: actions/cache@v3
+              if: matrix.job.name != 'non-forking'
+              with:
+                  path: "$HOME/.foundry/cache"
+                  key: rpc-cache-${{ hashFiles('cli/tests/rpc-cache-keyfile') }}
+            - name: Setup git config
+              run: |
+                  git config --global user.name "GitHub Actions Bot"
+                  git config --global user.email "<>"
+
+            - name: cargo nextest
+              run: |
+                # see https://github.com/foundry-rs/foundry/pull/3959
+                export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib"
+                cargo nextest run --partition count:${{ matrix.partition }}/2 --retries 3 --archive-file nextest-integration.tar.zst -E '${{ matrix.job.filter }}'
+
     integration:
         name: integration tests / ${{ matrix.job.name }}
         runs-on: ubuntu-latest
@@ -87,7 +126,7 @@ jobs:
             matrix:
                 job:
                     - name: non-forking
-                      filter: "!test(~fork) & !test(~live)"
+                      filter: "!test(~fork) & !test(~live) & !test(~issue)"
                     - name: forking
                       filter: "test(~fork) & !test(~live)"
                 partition: [1, 2]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
                 job:
                     - name: issue-repros
                       filter: "test(~issue)"
+                partition: [1, 2]
         env:
             ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
         steps:
@@ -127,6 +128,7 @@ jobs:
                 job:
                     - name: forge-std-test
                       filter: "test(~forge_std)"
+                partition: [1, 2]
         env:
             ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
         steps:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Issue reproduction & forge-std tests can take quite a long time to finish & stall CI. Ideally we should be able to make sure that only these tests are the ones clogging the CI other than looking at the `SLOW` output on logs.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Creates new jobs for forge-std and issue reproduction tests.

Closes #4782.
