### PR TITLE
fix(tracer): store revert reason data for create

### DIFF
--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -273,6 +273,7 @@ where
         gas: Gas,
         retdata: Bytes,
     ) -> (InstructionResult, Option<B160>, Gas, Bytes) {
+        let success = matches!(status, return_ok!());
         let code = match address {
             Some(address) => data
                 .journaled_state
@@ -286,7 +287,7 @@ where
         self.fill_trace(
             status,
             gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
-            code,
+            if success { code } else { retdata.to_vec() },
             address.map(b160_to_h160),
         );
 


### PR DESCRIPTION
## Motivation

This PR fixes an issue when there are missing revert reason data for CREATE transactions in `debug_traceTransaction`.

Before this PR, a `debug_traceTransaction` call for a tx creating this contract:

```solidity
contract Foo {
    constructor() {
        revert("aaa");
    }
}
```

would return `0x` as `returnValue`.

After this PR, `returnValue` is set to `0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036161610000000000000000000000000000000000000000000000000000000000` (revert reason data). This is the same behavior as for non-CREATE transactions.

## Solution

The transaction tracer has been modified so that it returns the contract code if the contract creation was successful and revert reason data if the contract creation failed.
