### PR TITLE
fix(anvil): properly estimate gas instead of bailing on `GasTooHigh`

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -999,7 +999,9 @@ impl Backend {
         evm.database(state);
         let result_and_state = match evm.inspect_ref(&mut inspector) {
             Ok(result_and_state) => result_and_state,
-            Err(_) => return Err(BlockchainError::EvmError(InstructionResult::FatalExternalError)),
+            Err(_) => {
+                return Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh))
+            }
         };
         let state = result_and_state.state;
         let state: hashbrown::HashMap<H160, Account> =

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -69,7 +69,7 @@ impl GasReport {
                 (!self.ignore.contains(&contract_name) && self.report_for.is_empty()) ||
                 (self.report_for.contains(&contract_name));
             if report_contract {
-                let mut contract_report =
+                let contract_report =
                     self.contracts.entry(name.to_string()).or_insert_with(Default::default);
 
                 match &trace.data {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Anvil is improperly bailing out of estimating gas if we run into a `GasTooHigh` error—we should treat it like other `revert/OOG/OOF` errors and just adjust the gas price accordingly. This was due to an improperly mapped error type when performing a call with state.

## Solution

Properly maps the error to `InvalidTransactionError::GasTooHigh` and refactors the binary search to also include the case when this happens.

