### PR TITLE
fix(cast) `cast run` panicks when encountering failed contract deployment

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -1,5 +1,8 @@
 use crate::{init_progress, opts::RpcOpts, update_progress, utils};
-use cast::trace::{identifier::SignaturesIdentifier, CallTraceDecoder, Traces};
+use cast::{
+    executor::{EvmError, ExecutionErr},
+    trace::{identifier::SignaturesIdentifier, CallTraceDecoder, Traces},
+};
 use clap::Parser;
 use ethers::{
     abi::Address,
@@ -168,14 +171,24 @@ impl RunArgs {
                 }
             } else {
                 trace!(tx=?tx.hash, "executing create transaction");
-                let DeployResult { gas_used, traces, debug: run_debug, .. }: DeployResult =
-                    executor.deploy_with_env(env, None).unwrap();
-
-                RunResult {
-                    success: true,
-                    traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
-                    debug: run_debug.unwrap_or_default(),
-                    gas_used,
+                match executor.deploy_with_env(env, None) {
+                    Ok(DeployResult { gas_used, traces, debug: run_debug, .. }) => RunResult {
+                        success: true,
+                        traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
+                        debug: run_debug.unwrap_or_default(),
+                        gas_used,
+                    },
+                    Err(EvmError::Execution(inner)) => match *inner {
+                        ExecutionErr { reverted, gas_used, traces, debug: run_debug, .. } => {
+                            RunResult {
+                                success: !reverted,
+                                traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
+                                debug: run_debug.unwrap_or_default(),
+                                gas_used,
+                            }
+                        }
+                    },
+                    Err(err) => panic!("unexpected error when running create transaction: {:?}", err),
                 }
             }
         };

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -189,7 +189,7 @@ impl RunArgs {
                         }
                     }
                     Err(err) => {
-                        panic!("unexpected error when running create transaction: {:?}", err)
+                        eyre::bail!("unexpected error when running create transaction: {:?}", err)
                     }
                 }
             }

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -178,17 +178,19 @@ impl RunArgs {
                         debug: run_debug.unwrap_or_default(),
                         gas_used,
                     },
-                    Err(EvmError::Execution(inner)) => match *inner {
-                        ExecutionErr { reverted, gas_used, traces, debug: run_debug, .. } => {
-                            RunResult {
-                                success: !reverted,
-                                traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
-                                debug: run_debug.unwrap_or_default(),
-                                gas_used,
-                            }
+                    Err(EvmError::Execution(inner)) => {
+                        let ExecutionErr { reverted, gas_used, traces, debug: run_debug, .. } =
+                            *inner;
+                        RunResult {
+                            success: !reverted,
+                            traces: vec![(TraceKind::Execution, traces.unwrap_or_default())],
+                            debug: run_debug.unwrap_or_default(),
+                            gas_used,
                         }
-                    },
-                    Err(err) => panic!("unexpected error when running create transaction: {:?}", err),
+                    }
+                    Err(err) => {
+                        panic!("unexpected error when running create transaction: {:?}", err)
+                    }
                 }
             }
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently cast run panicks when trying to simulate a failed contract deployment, due to a misplaced "unwrap" call.
This fixes that.

## Solution

Remove the offending `unwrap` and replace with a pattern match.
### Before 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15629702/235902611-4feb8f77-4ef4-4ff2-8dd6-0cb1e04f208b.png">

### After 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/15629702/235902703-21341982-596d-49a5-b8ca-8068f7f10bc0.png">


closes https://github.com/foundry-rs/foundry/issues/4870
