### PR TITLE
fix(cast): Harden `cast send` and provide more accurate error messages

### DIFF
--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -111,8 +111,6 @@ impl SendTxArgs {
         // This should be the only way this RPC method is used as it requires a local node
         // or remote RPC with unlocked accounts.
         if unlocked {
-            // Checking if signer isn't the default value
-            // 00a329c0648769A73afAc7F9381E08FB43dBEA72.
             if resend {
                 tx.nonce = Some(provider.get_transaction_count(config.sender, None).await?);
             }
@@ -144,12 +142,14 @@ impl SendTxArgs {
             // user-specified --from
             if let Some(specified_from) = eth.wallet.from {
                 if specified_from != from {
-                    eyre::bail!("\
-                        The specified sender via CLI/env vars does not match the sender configured via\n\
-                        the hardware wallet's HD Path.\n\
-                        Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which\n\
-                        corresponds to the sender, or let foundry automatically detect it by not specifying any sender address.\n\
-                    ")
+                    eyre::bail!(
+r#"
+The specified sender via CLI/env vars does not match the sender configured via
+the hardware wallet's HD Path.
+Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which
+corresponds to the sender, or let foundry automatically detect it by not specifying any sender address.
+"#
+                    )
                 }
             }
 

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -143,12 +143,11 @@ impl SendTxArgs {
             if let Some(specified_from) = eth.wallet.from {
                 if specified_from != from {
                     eyre::bail!(
-                        r#"
+                        "\
 The specified sender via CLI/env vars does not match the sender configured via
 the hardware wallet's HD Path.
 Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which
-corresponds to the sender, or let foundry automatically detect it by not specifying any sender address.
-"#
+corresponds to the sender, or let foundry automatically detect it by not specifying any sender address."
                     )
                 }
             }

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -143,7 +143,7 @@ impl SendTxArgs {
             if let Some(specified_from) = eth.wallet.from {
                 if specified_from != from {
                     eyre::bail!(
-r#"
+                        r#"
 The specified sender via CLI/env vars does not match the sender configured via
 the hardware wallet's HD Path.
 Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -202,7 +202,7 @@ impl Wallet {
                 None => LedgerHDPath::LedgerLive(self.mnemonic_index as usize),
             };
             let ledger = Ledger::new(derivation, chain_id).await.wrap_err_with(|| {
-r#"
+                r#"
 Could not connect to Ledger device.
 Make sure it's connected and unlocked, with no other desktop wallet apps open.
 "#
@@ -217,7 +217,7 @@ Make sure it's connected and unlocked, with no other desktop wallet apps open.
 
             // cached to ~/.ethers-rs/trezor/cache/trezor.session
             let trezor = Trezor::new(derivation, chain_id, None).await.wrap_err_with(|| {
-r#"
+                r#"
 Could not connect to Trezor device.
 Make sure it's connected and unlocked, with no other conflicting desktop wallet apps open."#
             })?;
@@ -239,8 +239,9 @@ Make sure it's connected and unlocked, with no other conflicting desktop wallet 
 
             let maybe_local = self.try_resolve_local_wallet()?;
 
-            let local = maybe_local
-                .ok_or_else(|| eyre::eyre!(r#"
+            let local = maybe_local.ok_or_else(|| {
+                eyre::eyre!(
+                    r#"
 Error accessing local wallet. Did you set a private key, mnemonic or keystore?
 Run `cast send --help` or `forge create --help` and use the corresponding CLI
 flag to set your key via:
@@ -248,7 +249,9 @@ flag to set your key via:
 Alternatively, if you're using a local node with unlocked accounts,
 use the --unlocked flag and either set the `ETH_FROM` environment variable to the address
 of the unlocked account you want to use, or provide the --from flag with the address directly.
-                "#))?;
+                "#
+                )
+            })?;
 
             Ok(WalletSigner::Local(local.with_chain_id(chain_id)))
         }

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -13,7 +13,7 @@ use ethers::{
         Address, Signature,
     },
 };
-use eyre::{bail, eyre, Result, WrapErr};
+use eyre::{bail, Result, WrapErr};
 use foundry_common::fs;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -35,7 +35,6 @@ pub mod error;
 /// 5. Private Key (cleartext in CLI)
 /// 6. Private Key (interactively via secure prompt)
 /// 7. AWS KMS
-/// 8. Remote (Local node that holds keys or an RPC that holds keys).
 #[derive(Parser, Debug, Default, Clone, Serialize)]
 #[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct Wallet {
@@ -136,12 +135,6 @@ pub struct Wallet {
     /// Use AWS Key Management Service.
     #[clap(long, help_heading = "Wallet options - AWS KMS")]
     pub aws: bool,
-
-    /// Enable remote signing.
-    /// Useful when using a local node or an RPC that has keys able to sign the transaction.
-    /// This will allow the tx to fallback to eth_sendTransaction.
-    #[clap(long, short, help_heading = "Wallet options - Remote node signing")]
-    pub remote: bool,
 }
 
 impl Wallet {
@@ -187,10 +180,6 @@ impl Wallet {
         }
     }
 
-    pub fn local_signer_selected(&self) -> bool {
-        return !self.remote
-    }
-
     /// Tries to resolve a local wallet from the provided options.
     #[track_caller]
     fn try_resolve_local_wallet(&self) -> Result<Option<LocalWallet>> {
@@ -212,7 +201,13 @@ impl Wallet {
                 Some(hd_path) => LedgerHDPath::Other(hd_path.clone()),
                 None => LedgerHDPath::LedgerLive(self.mnemonic_index as usize),
             };
-            let ledger = Ledger::new(derivation, chain_id).await?;
+            let ledger = Ledger::new(derivation, chain_id).await.wrap_err_with(|| {
+                "\
+            Could not connect to Ledger device.\n\
+            Make sure it's connected and unlocked, with no other desktop wallet apps open.\
+            "
+                .to_string()
+            })?;
 
             Ok(WalletSigner::Ledger(ledger))
         } else if self.trezor {
@@ -249,8 +244,8 @@ impl Wallet {
                     --private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.\n\
                     \n\
                     Alternatively, if you're using a local node with unlocked accounts,\n\
-                    use the --unlocked flag and set the `ETH_FROM` environment variable to the address\n\
-                    of the unlocked account you want to use.\
+                    use the --unlocked flag and either set the `ETH_FROM` environment variable to the address\n\
+                    of the unlocked account you want to use, or provide the --from flag with the address directly.\
                 "))?;
 
             Ok(WalletSigner::Local(local.with_chain_id(chain_id)))
@@ -327,10 +322,10 @@ pub trait WalletTrait {
         Ok(builder.build()?)
     }
 
-    /// Attempts to find the actual path of the keystore file.
+    /// Ensures the path to the keystore exists.
     ///
-    /// If the path is a directory then we try to find the first keystore file with the correct
-    /// sender address
+    /// if the path is a directory, it bails and asks the user to specify the keystore file
+    /// directly.
     fn find_keystore_file(&self, path: impl AsRef<Path>) -> Result<PathBuf> {
         let path = path.as_ref();
         if !path.exists() {
@@ -338,24 +333,7 @@ pub trait WalletTrait {
         }
 
         if path.is_dir() {
-            let sender =
-                self.sender().ok_or_else(|| eyre!("No sender account configured: $ETH_FROM"))?;
-
-            let (_, file) = walkdir::WalkDir::new(path)
-                .max_depth(2)
-                .into_iter()
-                .filter_map(Result::ok)
-                .filter(|e| e.file_type().is_file())
-                .filter_map(|e| {
-                    fs::read_json_file::<KeystoreFile>(e.path())
-                        .map(|keystore| (keystore, e.path().to_path_buf()))
-                        .ok()
-                })
-                .find(|(keystore, _)| keystore.address == sender)
-                .ok_or_else(|| {
-                    eyre!("No matching keystore file found for {sender:?} in {path:?}")
-                })?;
-            return Ok(file)
+            bail!("Keystore path `{path:?}` is a directory. Please specify the keystore file directly.")
         }
 
         Ok(path.to_path_buf())

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -202,10 +202,9 @@ impl Wallet {
                 None => LedgerHDPath::LedgerLive(self.mnemonic_index as usize),
             };
             let ledger = Ledger::new(derivation, chain_id).await.wrap_err_with(|| {
-                r#"
+                "\
 Could not connect to Ledger device.
-Make sure it's connected and unlocked, with no other desktop wallet apps open.
-"#
+Make sure it's connected and unlocked, with no other desktop wallet apps open."
             })?;
 
             Ok(WalletSigner::Ledger(ledger))
@@ -217,9 +216,9 @@ Make sure it's connected and unlocked, with no other desktop wallet apps open.
 
             // cached to ~/.ethers-rs/trezor/cache/trezor.session
             let trezor = Trezor::new(derivation, chain_id, None).await.wrap_err_with(|| {
-                r#"
+                "\
 Could not connect to Trezor device.
-Make sure it's connected and unlocked, with no other conflicting desktop wallet apps open."#
+Make sure it's connected and unlocked, with no other conflicting desktop wallet apps open."
             })?;
 
             Ok(WalletSigner::Trezor(trezor))
@@ -241,15 +240,14 @@ Make sure it's connected and unlocked, with no other conflicting desktop wallet 
 
             let local = maybe_local.ok_or_else(|| {
                 eyre::eyre!(
-                    r#"
+                    "\
 Error accessing local wallet. Did you set a private key, mnemonic or keystore?
 Run `cast send --help` or `forge create --help` and use the corresponding CLI
 flag to set your key via:
 --private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.
 Alternatively, if you're using a local node with unlocked accounts,
 use the --unlocked flag and either set the `ETH_FROM` environment variable to the address
-of the unlocked account you want to use, or provide the --from flag with the address directly.
-                "#
+of the unlocked account you want to use, or provide the --from flag with the address directly."
                 )
             })?;
 

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -202,11 +202,10 @@ impl Wallet {
                 None => LedgerHDPath::LedgerLive(self.mnemonic_index as usize),
             };
             let ledger = Ledger::new(derivation, chain_id).await.wrap_err_with(|| {
-                "\
-            Could not connect to Ledger device.\n\
-            Make sure it's connected and unlocked, with no other desktop wallet apps open.\
-            "
-                .to_string()
+r#"
+Could not connect to Ledger device.
+Make sure it's connected and unlocked, with no other desktop wallet apps open.
+"#
             })?;
 
             Ok(WalletSigner::Ledger(ledger))
@@ -217,7 +216,11 @@ impl Wallet {
             };
 
             // cached to ~/.ethers-rs/trezor/cache/trezor.session
-            let trezor = Trezor::new(derivation, chain_id, None).await?;
+            let trezor = Trezor::new(derivation, chain_id, None).await.wrap_err_with(|| {
+r#"
+Could not connect to Trezor device.
+Make sure it's connected and unlocked, with no other conflicting desktop wallet apps open."#
+            })?;
 
             Ok(WalletSigner::Trezor(trezor))
         } else if self.aws {
@@ -237,16 +240,15 @@ impl Wallet {
             let maybe_local = self.try_resolve_local_wallet()?;
 
             let local = maybe_local
-                .ok_or_else(|| eyre::eyre!("\
-                    Error accessing local wallet. Did you set a private key, mnemonic or keystore?\n\
-                    Run `cast send --help` or `forge create --help` and use the corresponding CLI\n\
-                    flag to set your key via:\n\
-                    --private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.\n\
-                    \n\
-                    Alternatively, if you're using a local node with unlocked accounts,\n\
-                    use the --unlocked flag and either set the `ETH_FROM` environment variable to the address\n\
-                    of the unlocked account you want to use, or provide the --from flag with the address directly.\
-                "))?;
+                .ok_or_else(|| eyre::eyre!(r#"
+Error accessing local wallet. Did you set a private key, mnemonic or keystore?
+Run `cast send --help` or `forge create --help` and use the corresponding CLI
+flag to set your key via:
+--private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.
+Alternatively, if you're using a local node with unlocked accounts,
+use the --unlocked flag and either set the `ETH_FROM` environment variable to the address
+of the unlocked account you want to use, or provide the --from flag with the address directly.
+                "#))?;
 
             Ok(WalletSigner::Local(local.with_chain_id(chain_id)))
         }

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -542,9 +542,6 @@ mod tests {
             "--from",
             "560d246fcddc9ea98a8b032c9a2f474efb493c28",
         ]);
-        let file = wallet.find_keystore_file(&keystore).unwrap();
-        assert_eq!(file, keystore_file);
-
         let file = wallet.find_keystore_file(&keystore_file).unwrap();
         assert_eq!(file, keystore_file);
     }

--- a/cli/src/opts/wallet/mod.rs
+++ b/cli/src/opts/wallet/mod.rs
@@ -35,6 +35,7 @@ pub mod error;
 /// 5. Private Key (cleartext in CLI)
 /// 6. Private Key (interactively via secure prompt)
 /// 7. AWS KMS
+/// 8. Remote (Local node that holds keys or an RPC that holds keys).
 #[derive(Parser, Debug, Default, Clone, Serialize)]
 #[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct Wallet {
@@ -133,8 +134,14 @@ pub struct Wallet {
     pub trezor: bool,
 
     /// Use AWS Key Management Service.
-    #[clap(long, help_heading = "Wallet options - remote")]
+    #[clap(long, help_heading = "Wallet options - AWS KMS")]
     pub aws: bool,
+
+    /// Enable remote signing.
+    /// Useful when using a local node or an RPC that has keys able to sign the transaction.
+    /// This will allow the tx to fallback to eth_sendTransaction.
+    #[clap(long, short, help_heading = "Wallet options - Remote node signing")]
+    pub remote: bool,
 }
 
 impl Wallet {
@@ -178,6 +185,10 @@ impl Wallet {
         } else {
             self.from.unwrap_or_else(Address::zero)
         }
+    }
+
+    pub fn local_signer_selected(&self) -> bool {
+        return !self.remote
     }
 
     /// Tries to resolve a local wallet from the provided options.


### PR DESCRIPTION
## Motivation

Closes #4831.

`cast send` right now assumes that if a signer can't be constructed, it must fall back to `eth_sendTransaction` in all cases. This is not exactly true, and will result in misleading error messages depending on the combination of flags passed in for the wanted signing method. Particular highlights were:

- If a path to a folder that contains a keystore was passed in, it would try and walk the directory to try and find it. However, keystores no longer contain the `address` field that was being used to identify the correct keystore, so they were never found. This caused `cast send` to fall back to `eth_sendTransaction` hoping the remote RPC had the unlocked account to sign the tx.
- If the ledger option was passed in but the ledger was not available or connected, `cast send` would again fall back to `eth_sendTransaction`. This would happen similarly with other available local signing methods.
- If a `--from` address is passed in and no other information is provided, `cast send` would again fall back to `eth_sendTransaction`. This is actually "correct" behavior, but the user is kept in the dark as to why this is and is not given enough context. 

## Solution

The send command was lightly refactored and commented for future reference. The main changes are:
- Defaulting to `eth_sendTransaction` is now only possible by passing the `--unlocked` flag, matching `forge script`'s behavior. This flag also requires the `--from` flag to be passed, to ensure enough information is passed in by the user.
- If not defaulting to `eth_sendTransaction`, we must now be able to construct a signer with the flags passed in, or we will bail and inform the user something is wrong.
- **THIS BREAKS COMPATIBILITY WITH DAPPTOOLS**: We now don't walk directories looking for keystores if only a directory is passed in with the `--keystore` flag, and instead bail and tell the user to provide the keystore file directly. This is because keystores are no longer generated with the `address` inside of them. (This is a big discussion point, and while I favor being more strict, we could also try and decrypt all the keystores found and use the first one to succeed, but this has edge cases that could lead to bad scenarios).
- If a ledger is not available for whatever reason, instead of defaulting to `eth_sendTransaction`, we bail and inform the user that they must only have the ledger unlocked and connected with no other conflicting wallet apps open.

EDIT: @DaniPopes @0xMelkor can't seem to be able to add you as reviewers, but as always, feel free to review!