### PR TITLE
fix(chisel): upgrade default solc version to 0.8.19

### DIFF
--- a/anvil/server/src/ipc.rs
+++ b/anvil/server/src/ipc.rs
@@ -150,11 +150,8 @@ impl tokio_util::codec::Decoder for JsonRpcCodec {
             } else if is_whitespace(byte) {
                 whitespaces += 1;
             }
-            if byte == b'\\' && !is_escaped && in_str {
-                is_escaped = true;
-            } else {
-                is_escaped = false;
-            }
+
+            is_escaped = byte == b'\\' && !is_escaped && in_str;
 
             if depth == 0 && idx != start_idx && idx - start_idx + 1 > whitespaces {
                 let bts = buf.split_to(idx + 1);

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -84,7 +84,7 @@ impl SessionSourceConfig {
     /// Solc version precedence
     /// - Foundry configuration / `--use` flag
     /// - Latest installed version via SVM
-    /// - Default: Latest 0.8.17
+    /// - Default: Latest 0.8.19
     pub(crate) fn solc(&self) -> Result<Solc> {
         let solc_req = if let Some(solc_req) = self.foundry_config.solc.clone() {
             solc_req
@@ -95,7 +95,7 @@ impl SessionSourceConfig {
                 print!("{}", Paint::green("No solidity versions installed! "));
             }
             // use default
-            SolcReq::Version("0.8.17".parse().unwrap())
+            SolcReq::Version("0.8.19".parse().unwrap())
         };
 
         match solc_req {

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -325,7 +325,7 @@ impl CoverageArgs {
                 CoverageReportKind::Lcov => {
                     LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
                 }
-                CoverageReportKind::Debug => DebugReporter::default().report(&report),
+                CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;
         }
         Ok(())

--- a/common/src/provider.rs
+++ b/common/src/provider.rs
@@ -168,7 +168,7 @@ impl ProviderBuilder {
                 .rate_limit_retries(max_retry)
                 .timeout_retries(timeout_retry)
                 .compute_units_per_second(compute_units_per_second)
-                .build(provider, Box::new(HttpRateLimitRetryPolicy::default())),
+                .build(provider, Box::new(HttpRateLimitRetryPolicy)),
         );
 
         if is_local {


### PR DESCRIPTION
## Motivation

Seems to be the last thing that slipped through—chisel is installing 0.8.17 by default and should install at least 0.8.19

Closes #4888 

## Solution

Makes chisel install 0.8.19 by default for paris support, which is our default EVM version now. Users might still see errors if they have an older compiler version installed by default—wondering if we should give out a warning message in chisel too.