### PR TITLE
chore(deps): bump all individual ethers packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,14 @@ codegen-units = 1
 
 [workspace.dependencies]
 ethers = { version = "2.0.4", default-features = false }
-ethers-addressbook = { version = "2", default-features = false }
-ethers-core = { version = "2", default-features = false }
-ethers-contract = { version = "2", default-features = false }
-ethers-providers = { version = "2", default-features = false }
-ethers-signers = { version = "2", default-features = false }
-ethers-middleware = { version = "2", default-features = false }
-ethers-etherscan = { version = "2", default-features = false }
-ethers-solc = { version = "2", default-features = false }
+ethers-addressbook = { version = "2.0.4", default-features = false }
+ethers-core = { version = "2.0.4", default-features = false }
+ethers-contract = { version = "2.0.4", default-features = false }
+ethers-providers = { version = "2.0.4", default-features = false }
+ethers-signers = { version = "2.0.4", default-features = false }
+ethers-middleware = { version = "2.0.4", default-features = false }
+ethers-etherscan = { version = "2.0.4", default-features = false }
+ethers-solc = { version = "2.0.4", default-features = false }
 
 #[patch.crates-io]
 # ethers = { path = "../ethers-rs/ethers" }


### PR DESCRIPTION
We bumped the main ethers package, but did not bump the other subpackages. This bumps them.
