### PR TITLE
feat(cheatcodes): ensure `vm.difficulty` and `vm.prevrandao` fail if not using the correct EVM Version

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -206,7 +206,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::Difficulty(inner) => {
             ensure!(
                 data.env.cfg.spec_id < SpecId::MERGE,
-                "Difficulty is not supported after the merge. Please use vm.prevrandao instead."
+                "Difficulty is not supported after the Paris hard fork. Please use vm.prevrandao instead. For more information, please see https://eips.ethereum.org/EIPS/eip-4399"
             );
             data.env.block.difficulty = inner.0.into();
             Bytes::new()
@@ -214,7 +214,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::Prevrandao(inner) => {
             ensure!(
                 data.env.cfg.spec_id >= SpecId::MERGE,
-                "Prevrandao is not supported before the merge. Please use vm.difficulty instead."
+                "Prevrandao is not supported before the Paris hard fork. Please use vm.difficulty instead. For more information, please see https://eips.ethereum.org/EIPS/eip-4399"
             );
             data.env.block.prevrandao = Some(B256::from(inner.0));
             Bytes::new()

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -14,7 +14,7 @@ use ethers::{
 };
 use foundry_config::Config;
 use revm::{
-    primitives::{Bytecode, B256},
+    primitives::{Bytecode, SpecId, B256},
     Database, EVMData,
 };
 use std::collections::BTreeMap;
@@ -204,10 +204,18 @@ pub fn apply<DB: DatabaseExt>(
             Bytes::new()
         }
         HEVMCalls::Difficulty(inner) => {
+            ensure!(
+                data.env.cfg.spec_id < SpecId::MERGE,
+                "Difficulty is not supported after the merge. Please use vm.prevrandao instead."
+            );
             data.env.block.difficulty = inner.0.into();
             Bytes::new()
         }
         HEVMCalls::Prevrandao(inner) => {
+            ensure!(
+                data.env.cfg.spec_id >= SpecId::MERGE,
+                "Prevrandao is not supported before the merge. Please use vm.difficulty instead."
+            );
             data.env.block.prevrandao = Some(B256::from(inner.0));
             Bytes::new()
         }


### PR DESCRIPTION
## Motivation

Right now,  the `vm.difficulty`/`vm.prevrandao` just do not work if the correct EVM version is not being used and give no warnings. See https://github.com/foundry-rs/forge-std/pull/373

## Solution

Make them completely fail if not using the correct EVM version, to avoid unexpected behavior during tests.

Feel free to nit over the fail message!