### PR TITLE
feat(cheatcodes): restrict cheatcode usage on precompiles

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -3,7 +3,10 @@ use crate::{
     abi::HEVMCalls,
     executor::{
         backend::DatabaseExt,
-        inspector::cheatcodes::{util::with_journaled_account, DealRecord},
+        inspector::cheatcodes::{
+            util::{is_potential_precompile, with_journaled_account},
+            DealRecord,
+        },
     },
     utils::{b160_to_h160, h160_to_b160, ru256_to_u256, u256_to_ru256},
 };
@@ -224,6 +227,7 @@ pub fn apply<DB: DatabaseExt>(
             Bytes::new()
         }
         HEVMCalls::Store(inner) => {
+            ensure!(!is_potential_precompile(inner.0), "Store cannot be used on precompile addresses (N < 10). Please use an address bigger than 10 instead");
             data.journaled_state.load_account(h160_to_b160(inner.0), data.db)?;
             // ensure the account is touched
             data.journaled_state.touch(&h160_to_b160(inner.0));
@@ -237,6 +241,7 @@ pub fn apply<DB: DatabaseExt>(
             Bytes::new()
         }
         HEVMCalls::Load(inner) => {
+            ensure!(!is_potential_precompile(inner.0), "Load cannot be used on precompile addresses (N < 10). Please use an address bigger than 10 instead");
             // TODO: Does this increase gas usage?
             data.journaled_state.load_account(h160_to_b160(inner.0), data.db)?;
             let (val, _) = data.journaled_state.sload(
@@ -249,6 +254,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::Breakpoint0(inner) => add_breakpoint(state, caller, &inner.0, true)?,
         HEVMCalls::Breakpoint1(inner) => add_breakpoint(state, caller, &inner.0, inner.1)?,
         HEVMCalls::Etch(inner) => {
+            ensure!(!is_potential_precompile(inner.0), "Etch cannot be used on precompile addresses (N < 10). Please use an address bigger than 10 instead");
             let code = inner.1.clone();
             trace!(address=?inner.0, code=?hex::encode(&code), "etch cheatcode");
             // TODO: Does this increase gas usage?
@@ -258,6 +264,7 @@ pub fn apply<DB: DatabaseExt>(
             Bytes::new()
         }
         HEVMCalls::Deal(inner) => {
+            ensure!(!is_potential_precompile(inner.0), "Deal cannot be used on precompile addresses (N < 10). Please use an address bigger than 10 instead");
             let who = inner.0;
             let value = inner.1;
             trace!(?who, ?value, "deal cheatcode");

--- a/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/evm/src/executor/inspector/cheatcodes/util.rs
@@ -350,6 +350,11 @@ pub fn check_if_fixed_gas_limit<DB: DatabaseExt>(
         && call_gas_limit > 2300
 }
 
+/// Small utility function that checks if an address is a potential precompile.
+pub fn is_potential_precompile(address: H160) -> bool {
+    address < H160::from_low_u64_be(10)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Motivation

Closes #1159.

## Solution

Restricts certain cheatcodes on precompile addresses (`etch`, `load`, `store`, `deal`).

Some convo remains if we also wanna restrict the other addresses mentioned in the issue:
```
address(0xCe71065D4017F316EC606Fe4422e11eB2c47c246), // FuzzerDict
address(0x4e59b44847b379578588920cA78FbF26c0B4956C), // CREATE2 Factory (?)
address(0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84), // address(this)
address(0x185a4dc360CE69bDCceE33b3784B0282f7961aea), // default sender account
address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D) // cheatcodes addr```
