### PR TITLE
fix(cheatcodes): Fix `expectCall` behavior

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -328,7 +328,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::ExpectCall0(inner) => expect_call(
             state,
             inner.0,
-            inner.1.to_vec().into(),
+            inner.1.to_vec(),
             None,
             None,
             None,
@@ -338,7 +338,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::ExpectCall1(inner) => expect_call(
             state,
             inner.0,
-            inner.1.to_vec().into(),
+            inner.1.to_vec(),
             None,
             None,
             None,
@@ -348,7 +348,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::ExpectCall2(inner) => expect_call(
             state,
             inner.0,
-            inner.2.to_vec().into(),
+            inner.2.to_vec(),
             Some(inner.1),
             None,
             None,
@@ -358,7 +358,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::ExpectCall3(inner) => expect_call(
             state,
             inner.0,
-            inner.2.to_vec().into(),
+            inner.2.to_vec(),
             Some(inner.1),
             None,
             None,
@@ -374,7 +374,7 @@ pub fn apply<DB: DatabaseExt>(
             expect_call(
                 state,
                 inner.0,
-                inner.3.to_vec().into(),
+                inner.3.to_vec(),
                 Some(value),
                 Some(inner.2 + positive_value_cost_stipend),
                 None,
@@ -391,7 +391,7 @@ pub fn apply<DB: DatabaseExt>(
             expect_call(
                 state,
                 inner.0,
-                inner.3.to_vec().into(),
+                inner.3.to_vec(),
                 Some(value),
                 Some(inner.2 + positive_value_cost_stipend),
                 None,
@@ -408,7 +408,7 @@ pub fn apply<DB: DatabaseExt>(
             expect_call(
                 state,
                 inner.0,
-                inner.3.to_vec().into(),
+                inner.3.to_vec(),
                 Some(value),
                 None,
                 Some(inner.2 + positive_value_cost_stipend),
@@ -425,7 +425,7 @@ pub fn apply<DB: DatabaseExt>(
             expect_call(
                 state,
                 inner.0,
-                inner.3.to_vec().into(),
+                inner.3.to_vec(),
                 Some(value),
                 None,
                 Some(inner.2 + positive_value_cost_stipend),

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -234,7 +234,7 @@ fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) 
 fn expect_call(
     state: &mut Cheatcodes,
     target: H160,
-    calldata: Bytes,
+    calldata: Vec<u8>,
     value: Option<U256>,
     gas: Option<u64>,
     min_gas: Option<u64>,

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -168,16 +168,26 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
 
 #[derive(Clone, Debug, Default)]
 pub struct ExpectedCallData {
-    /// The expected calldata
-    pub calldata: Bytes,
     /// The expected value sent in the call
     pub value: Option<U256>,
     /// The expected gas supplied to the call
     pub gas: Option<u64>,
     /// The expected *minimum* gas supplied to the call
     pub min_gas: Option<u64>,
-    /// The number of times the call is expected to be made
-    pub count: Option<u64>,
+    /// The number of times the call is expected to be made.
+    /// If the type of call is `NonCount`, this is the lower bound for the number of calls
+    /// that must be seen.
+    /// If the type of call is `Count`, this is the exact number of calls that must be seen.
+    pub count: u64,
+    /// The type of call
+    pub call_type: ExpectedCallType,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ExpectedCallType {
+    #[default]
+    Count,
+    NonCount,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -218,6 +228,53 @@ fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) 
     let offsets = state.allowed_mem_writes.entry(depth).or_insert_with(|| vec![0..0x60]);
     offsets.push(start..end);
     Ok(Bytes::new())
+}
+
+fn expect_call(
+    state: &mut Cheatcodes,
+    target: H160,
+    calldata: Bytes,
+    value: Option<U256>,
+    gas: Option<u64>,
+    min_gas: Option<u64>,
+    count: u64,
+    call_type: ExpectedCallType,
+) -> Result {
+    match call_type {
+        ExpectedCallType::Count => {
+            // Get the expected calls for this target.
+            let expecteds = state.expected_calls.entry(target).or_default();
+            // In this case, as we're using counted expectCalls, we should not be able to set them
+            // more than once.
+            ensure!(
+                !expecteds.contains_key(&calldata),
+                "Counted expected calls can only bet set once."
+            );
+            expecteds
+                .insert(calldata, (ExpectedCallData { value, gas, min_gas, count, call_type }, 0));
+            Ok(Bytes::new())
+        }
+        ExpectedCallType::NonCount => {
+            let expecteds = state.expected_calls.entry(target).or_default();
+            // Check if the expected calldata exists.
+            // If it does, increment the count by one as we expect to see it one more time.
+            if let Some(expected) = expecteds.get_mut(&calldata) {
+                // Ensure we're not overwriting a counted expectCall.
+                ensure!(
+                    expected.0.call_type == ExpectedCallType::NonCount,
+                    "Cannot overwrite a counted expectCall with a non-counted expectCall."
+                );
+                expected.0.count += 1;
+            } else {
+                // If it does not exist, then create it.
+                expecteds.insert(
+                    calldata,
+                    (ExpectedCallData { value, gas, min_gas, count, call_type }, 0),
+                );
+            }
+            Ok(Bytes::new())
+        }
+    }
 }
 
 pub fn apply<DB: DatabaseExt>(
@@ -267,125 +324,113 @@ pub fn apply<DB: DatabaseExt>(
             });
             Ok(Bytes::new())
         }
-        HEVMCalls::ExpectCall0(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.1.to_vec().into(),
-                    value: None,
-                    gas: None,
-                    min_gas: None,
-                    count: None,
-                },
-                0,
-            ));
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectCall1(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.1.to_vec().into(),
-                    value: None,
-                    gas: None,
-                    min_gas: None,
-                    count: Some(inner.2),
-                },
-                0,
-            ));
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectCall2(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.2.to_vec().into(),
-                    value: Some(inner.1),
-                    gas: None,
-                    min_gas: None,
-                    count: None,
-                },
-                0,
-            ));
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectCall3(inner) => {
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.2.to_vec().into(),
-                    value: Some(inner.1),
-                    gas: None,
-                    min_gas: None,
-                    count: Some(inner.3),
-                },
-                0,
-            ));
-            Ok(Bytes::new())
-        }
+        HEVMCalls::ExpectCall0(inner) => expect_call(
+            state,
+            inner.0,
+            inner.1.to_vec().into(),
+            None,
+            None,
+            None,
+            1,
+            ExpectedCallType::NonCount,
+        ),
+        HEVMCalls::ExpectCall1(inner) => expect_call(
+            state,
+            inner.0,
+            inner.1.to_vec().into(),
+            None,
+            None,
+            None,
+            inner.2,
+            ExpectedCallType::Count,
+        ),
+        HEVMCalls::ExpectCall2(inner) => expect_call(
+            state,
+            inner.0,
+            inner.2.to_vec().into(),
+            Some(inner.1),
+            None,
+            None,
+            1,
+            ExpectedCallType::NonCount,
+        ),
+        HEVMCalls::ExpectCall3(inner) => expect_call(
+            state,
+            inner.0,
+            inner.2.to_vec().into(),
+            Some(inner.1),
+            None,
+            None,
+            inner.3,
+            ExpectedCallType::Count,
+        ),
         HEVMCalls::ExpectCall4(inner) => {
             let value = inner.1;
-
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
 
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.3.to_vec().into(),
-                    value: Some(value),
-                    gas: Some(inner.2 + positive_value_cost_stipend),
-                    min_gas: None,
-                    count: None,
-                },
-                0,
-            ));
-            Ok(Bytes::new())
+            expect_call(
+                state,
+                inner.0,
+                inner.3.to_vec().into(),
+                Some(value),
+                Some(inner.2 + positive_value_cost_stipend),
+                None,
+                1,
+                ExpectedCallType::NonCount,
+            )
         }
         HEVMCalls::ExpectCall5(inner) => {
             let value = inner.1;
-            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.3.to_vec().into(),
-                    value: Some(value),
-                    gas: Some(inner.2 + positive_value_cost_stipend),
-                    min_gas: None,
-                    count: Some(inner.4),
-                },
-                0,
-            ));
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectCallMinGas0(inner) => {
-            let value = inner.1;
-
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
 
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.3.to_vec().into(),
-                    value: Some(value),
-                    gas: None,
-                    min_gas: Some(inner.2 + positive_value_cost_stipend),
-                    count: None,
-                },
-                0,
-            ));
-            Ok(Bytes::new())
+            expect_call(
+                state,
+                inner.0,
+                inner.3.to_vec().into(),
+                Some(value),
+                Some(inner.2 + positive_value_cost_stipend),
+                None,
+                inner.4,
+                ExpectedCallType::Count,
+            )
+        }
+        HEVMCalls::ExpectCallMinGas0(inner) => {
+            let value = inner.1;
+            // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
+            // to ensure that the basic fallback function can be called.
+            let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
+
+            expect_call(
+                state,
+                inner.0,
+                inner.3.to_vec().into(),
+                Some(value),
+                None,
+                Some(inner.2 + positive_value_cost_stipend),
+                1,
+                ExpectedCallType::NonCount,
+            )
         }
         HEVMCalls::ExpectCallMinGas1(inner) => {
             let value = inner.1;
+            // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
+            // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-            state.expected_calls.entry(inner.0).or_default().push((
-                ExpectedCallData {
-                    calldata: inner.3.to_vec().into(),
-                    value: Some(value),
-                    gas: None,
-                    min_gas: Some(inner.2 + positive_value_cost_stipend),
-                    count: Some(inner.4),
-                },
-                0,
-            ));
-            Ok(Bytes::new())
+
+            expect_call(
+                state,
+                inner.0,
+                inner.3.to_vec().into(),
+                Some(value),
+                None,
+                Some(inner.2 + positive_value_cost_stipend),
+                inner.4,
+                ExpectedCallType::Count,
+            )
         }
         HEVMCalls::MockCall0(inner) => {
             // TODO: Does this increase gas usage?

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -230,6 +230,7 @@ fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) 
     Ok(Bytes::new())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn expect_call(
     state: &mut Cheatcodes,
     target: H160,

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -230,6 +230,23 @@ fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) 
     Ok(Bytes::new())
 }
 
+/// Handles expected calls specified by the `vm.expectCall` cheatcode.
+///
+/// It can handle calls in two ways:
+/// - If the cheatcode was used with a `count` argument, it will expect the call to be made exactly
+///   `count` times.
+/// e.g. `vm.expectCall(address(0xc4f3), abi.encodeWithSelector(0xd34db33f), 4)` will expect the
+/// call to address(0xc4f3) with selector `0xd34db33f` to be made exactly 4 times. If the amount of
+/// calls is less or more than 4, the test will fail. Note that the `count` argument cannot be
+/// overwritten with another `vm.expectCall`. If this is attempted, `expectCall` will revert.
+/// - If the cheatcode was used without a `count` argument, it will expect the call to be made at
+///   least the amount of times the cheatcode
+/// was called. This means that `vm.expectCall` without a count argument can be called many times,
+/// but cannot be called with a `count` argument after it was called without one. If the latter
+/// happens, `expectCall` will revert. e.g `vm.expectCall(address(0xc4f3),
+/// abi.encodeWithSelector(0xd34db33f))` will expect the call to address(0xc4f3) and selector
+/// `0xd34db33f` to be made at least once. If the amount of calls is 0, the test will fail. If the
+/// call is made more than once, the test will pass.
 #[allow(clippy::too_many_arguments)]
 fn expect_call(
     state: &mut Cheatcodes,

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -126,7 +126,7 @@ pub struct Cheatcodes {
     pub mocked_calls: BTreeMap<Address, BTreeMap<MockCallDataContext, MockCallReturnData>>,
 
     /// Expected calls
-    pub expected_calls: BTreeMap<Address, BTreeMap<Bytes, (ExpectedCallData, u64)>>,
+    pub expected_calls: BTreeMap<Address, BTreeMap<Vec<u8>, (ExpectedCallData, u64)>>,
 
     /// Expected emits
     pub expected_emits: Vec<ExpectedEmit>,
@@ -789,7 +789,7 @@ where
             for (address, calldatas) in &self.expected_calls {
                 for (calldata, (expected, actual_count)) in calldatas {
                     let ExpectedCallData { gas, min_gas, value, count, call_type } = expected;
-                    let calldata = calldata.clone();
+                    let calldata = Bytes::from(calldata.clone());
                     match call_type {
                         // We must match exactly what has been specified.
                         ExpectedCallType::Count => {

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -62,6 +62,33 @@ contract ExpectCallTest is DSTest {
         target.add(1, 2);
     }
 
+    function testExpectMultipleCallsWithDataAdditive() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testExpectMultipleCallsWithDataAdditiveLowerBound() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        target.add(1, 2);
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testFailExpectMultipleCallsWithDataAdditive() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        // Not enough calls to satisfy the additive expectCall, which expects 3 calls.
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
     function testFailExpectCallWithData() public {
         Contract target = new Contract();
         cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
@@ -310,5 +337,56 @@ contract ExpectCallCountTest is DSTest {
 
         cheats.expectCallMinGas(address(inner), 0, 50_001, abi.encodeWithSelector(inner.add.selector, 1, 1), 1);
         target.addHardGasLimit();
+    }
+}
+
+contract ExpectCallMixedTest is DSTest {
+    Cheats constant cheats = Cheats(HEVM_ADDRESS);
+
+    function testFailOverrideNoCountWithCount() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        // You should not be able to overwrite a expectCall that had no count with some count.
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testFailOverrideCountWithCount() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
+        // You should not be able to overwrite a expectCall that had a count with some count.
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 1);
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testFailOverrideCountWithNoCount() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
+        // You should not be able to overwrite a expectCall that had a count with no count.
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testExpectMatchPartialAndFull() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector), 2);
+        // Even if a partial match is speciifed, you should still be able to look for full matches
+        // as one does not override the other.
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
+        target.add(1, 2);
+        target.add(1, 2);
+    }
+
+    function testExpectMatchPartialAndFullFlipped() public {
+        Contract target = new Contract();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector));
+        // Even if a partial match is speciifed, you should still be able to look for full matches
+        // as one does not override the other.
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
+        target.add(1, 2);
+        target.add(1, 2);
     }
 }


### PR DESCRIPTION
**This is a breaking change.**

Closes #4879.

Implements the intended behavior for the `expectCall` cheatcode, with and without count.

# Behavior

`expectCall` will be invoked in two different modes depending on how the cheatcode was used:
- If no count was provided, the mode will be `NonCount`. The behavior of this mode is:
  - It is **additive**. Calling `expectCall(...)` `N` times, will set a lower bound of expected calls of `N`, but will _not_ revert if more than `N` calls are matched. This is the legacy `expectCall` behavior.
  - For the same calldata, **cannot** be overwritten with a `Count` `expectCall` cheatcode call.

Example of `NonCount` additive behavior:

```
// this will PASS
cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
target.add(1, 2);
target.add(1, 2);
target.add(1, 2);
```

Example of how it cannot be overwritten:
```
// this will FAIL
cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2));
// Cannot overwrite a non-count expectCall cheatcode call with a count one.
cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector, 1, 2), 2);
target.add(1, 2);
target.add(1, 2);
target.add(1, 2);
```


- If a count is provided, the mode will be `Count`. The behavior of this mode is:
  - It will match exactly **N** calls and revert if more are found, `N` being the amount of calls to match specified.
  - It is **NOT** additive. Calling `expectCall(..., N)` `M` times will fail. It can only be called **once** if it has a count, even if it is 0.
  - For the same calldata, it cannot be overwritten with any other `expectCall` cheatcode call, with or without count.

This essentially means that for any different calldata, there is only one `expectCall` cheatcode "mode" active. It is either `NonCount` and additive, or `Count` and non-additive. Note that a partial match and a full match is considered different calldata, so you could additively match partial-matches and strictly match full-matches. Tests have been added for each of these cases.