### PR TITLE
feat(cheatcodes): Make `expectEmit` only work for the next call

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -131,11 +131,11 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
 
     // if there's anything to fill, we need to pop back.
     let event_to_fill_or_check =
-        if state.expected_emits.0.iter().any(|expected| expected.log.is_none()) {
-            state.expected_emits.0.pop_back()
+        if state.expected_emits.iter().any(|expected| expected.log.is_none()) {
+            state.expected_emits.pop_back()
         } else {
             // Else, we need to pop from the front in the order the events were added to the queue.
-            state.expected_emits.0.pop_front()
+            state.expected_emits.pop_front()
         };
 
     let mut event_to_fill_or_check =
@@ -178,7 +178,7 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
         }
     }
 
-    state.expected_emits.0.push_back(event_to_fill_or_check);
+    state.expected_emits.push_back(event_to_fill_or_check);
 }
 
 #[derive(Clone, Debug, Default)]
@@ -249,7 +249,7 @@ pub fn apply<DB: DatabaseExt>(
             expect_revert(state, Some(inner.0.into()), data.journaled_state.depth())
         }
         HEVMCalls::ExpectEmit0(_) => {
-            state.expected_emits.0.push_back(ExpectedEmit {
+            state.expected_emits.push_back(ExpectedEmit {
                 depth: data.journaled_state.depth(),
                 checks: [true, true, true, true],
                 ..Default::default()
@@ -257,7 +257,7 @@ pub fn apply<DB: DatabaseExt>(
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectEmit1(inner) => {
-            state.expected_emits.0.push_back(ExpectedEmit {
+            state.expected_emits.push_back(ExpectedEmit {
                 depth: data.journaled_state.depth(),
                 checks: [true, true, true, true],
                 address: Some(inner.0),
@@ -266,7 +266,7 @@ pub fn apply<DB: DatabaseExt>(
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectEmit2(inner) => {
-            state.expected_emits.0.push_back(ExpectedEmit {
+            state.expected_emits.push_back(ExpectedEmit {
                 depth: data.journaled_state.depth(),
                 checks: [inner.0, inner.1, inner.2, inner.3],
                 ..Default::default()
@@ -274,7 +274,7 @@ pub fn apply<DB: DatabaseExt>(
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectEmit3(inner) => {
-            state.expected_emits.0.push_back(ExpectedEmit {
+            state.expected_emits.push_back(ExpectedEmit {
                 depth: data.journaled_state.depth(),
                 checks: [inner.0, inner.1, inner.2, inner.3],
                 address: Some(inner.4),

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -186,10 +186,10 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
             if event_to_fill_or_check.found {
                 state.expected_emits.push_back(event_to_fill_or_check);
             } else {
-                // We did not match this event, so we need to keep waiting for the right one to appear.
+                // We did not match this event, so we need to keep waiting for the right one to
+                // appear.
                 state.expected_emits.push_front(event_to_fill_or_check);
             }
-
         }
         // Fill the event.
         None => {

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -133,7 +133,7 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
     // First, we can return early if all events have been matched.
     // This allows a contract to arbitrarily emit more events than expected (additive behavior),
     // as long as all the previous events were matched in the order they were expected to be.
-    if !state.expected_emits.iter().any(|expected| !expected.found) {
+    if state.expected_emits.iter().all(|expected| expected.found) {
         return
     }
 

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -180,13 +180,23 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
                     event_to_fill_or_check.found &= expected.data == log.data;
                 }
             }
+
+            // If we found the event, we can push it to the back of the queue
+            // and begin expecting the next event.
+            if event_to_fill_or_check.found {
+                state.expected_emits.push_back(event_to_fill_or_check);
+            } else {
+                // We did not match this event, so we need to keep waiting for the right one to appear.
+                state.expected_emits.push_front(event_to_fill_or_check);
+            }
+
         }
         // Fill the event.
         None => {
             event_to_fill_or_check.log = Some(log);
+            state.expected_emits.push_back(event_to_fill_or_check);
         }
     }
-    state.expected_emits.push_back(event_to_fill_or_check);
 }
 
 #[derive(Clone, Debug, Default)]

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -30,7 +30,6 @@ use revm::{
 use serde_json::Value;
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
-    f32::consts::E,
     fs::File,
     io::BufReader,
     ops::Range,
@@ -773,11 +772,11 @@ where
         if should_check_emits {
             // Not all emits were matched.
             if self.expected_emits.iter().any(|expected| !expected.found) {
-                    return (
-                        InstructionResult::Revert,
-                        remaining_gas,
-                        "Log != expected log".to_string().encode().into(),
-                    )
+                return (
+                    InstructionResult::Revert,
+                    remaining_gas,
+                    "Log != expected log".to_string().encode().into(),
+                )
             } else {
                 // All emits were found, we're good.
                 // Clear the queue, as we expect the user to declare more events for the next call

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -767,7 +767,9 @@ where
         let should_check_emits = self
             .expected_emits
             .iter()
-            .any(|expected| expected.depth == data.journaled_state.depth());
+            .any(|expected| expected.depth == data.journaled_state.depth()) &&
+            // Ignore staticcalls
+            !call.is_static;
         // If so, check the emits
         if should_check_emits {
             // Not all emits were matched.

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -527,7 +527,6 @@ where
         topics: &[B256],
         data: &bytes::Bytes,
     ) {
-        // Match logs if `expectEmit` has been called
         if !self.expected_emits.is_empty() {
             handle_expect_emit(
                 self,
@@ -831,6 +830,9 @@ where
             }
 
             // Check if we have any leftover expected emits
+            // First, if any emits were found at the root call, then we its ok and we remove them.
+            self.expected_emits.retain(|expected| !expected.found);
+            // If not empty, we got mismatched emits
             if !self.expected_emits.is_empty() {
                 return (
                     InstructionResult::Revert,

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -774,28 +774,18 @@ where
             .any(|expected| expected.depth == data.journaled_state.depth());
         // If so, check the emits
         if should_check_emits {
-            // Not all emits were found.
+            // Not all emits were matched.
             if self.expected_emits.0.iter().any(|expected| !expected.found) {
-                // Not enough emits were found
-                if self.expected_emits.0.len() as u64 > self.expected_emits.1 {
-                    return (
-                        InstructionResult::Revert,
-                        remaining_gas,
-                        "Not enough events were emitted".to_string().encode().into(),
-                    )
-                } else {
-                    // The wrong emits were found
                     return (
                         InstructionResult::Revert,
                         remaining_gas,
                         "Log != expected log".to_string().encode().into(),
                     )
-                }
             } else {
                 // All emits were found, we're good.
                 // Clear the queue, as we expect the user to declare more events for the next call
                 // if they wanna match further events.
-                self.expected_emits.0.clear();
+                self.expected_emits.0.clear()
             }
         }
 
@@ -847,7 +837,7 @@ where
                 return (
                     InstructionResult::Revert,
                     remaining_gas,
-                    "Expected an emit, but no logs were emitted afterward"
+                    "Expected an emit, but no logs were emitted afterward. You might have mismatched events or not enough events were emitted."
                         .to_string()
                         .encode()
                         .into(),

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -4,14 +4,6 @@ pragma solidity >=0.8.18;
 import "ds-test/test.sol";
 import "./Cheats.sol";
 
-contract NestedEmitter {
-    event SomethingDifferent(uint256 indexed topic1, uint256 indexed topic2, uint256 indexed topic3, uint256 data);
-
-    function emitEvent(uint256 topic1, uint256 topic2, uint256 topic3, uint256 data) public {
-        emit SomethingDifferent(topic1, topic2, topic3, data);
-    }
-}
-
 contract Emitter {
     event Something(uint256 indexed topic1, uint256 indexed topic2, uint256 indexed topic3, uint256 data);
 
@@ -71,8 +63,6 @@ contract ExpectEmitTest is DSTest {
     event Something(uint256 indexed topic1, uint256 indexed topic2, uint256 indexed topic3, uint256 data);
 
     event SomethingElse(uint256 indexed topic1);
-
-    event SomethingDifferent(uint256 indexed topic1, uint256 indexed topic2, uint256 indexed topic3, uint256 data);
 
     function setUp() public {
         emitter = new Emitter();

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -240,7 +240,7 @@ contract ExpectEmitTest is DSTest {
     function testFailExpectEmitCanMatchWithoutExactOrder() public {
         cheats.expectEmit(true, true, true, true);
         emit Something(1, 2, 3, 4);
-        // This should fail, as this event is never emitted 
+        // This should fail, as this event is never emitted
         // in between the other two Something events.
         cheats.expectEmit(true, true, true, true);
         emit SomethingElse(1);

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -38,6 +38,10 @@ contract Emitter {
         inner.emitEvent(topic1, topic2, topic3, data);
     }
 
+    function getVar() public view returns (uint256) {
+        return 1;
+    }
+
     /// Ref: issue #1214
     function doesNothing() public pure {}
 
@@ -267,6 +271,13 @@ contract ExpectEmitTest is DSTest {
         // and in the `Emitter` contract have differing
         // amounts of indexed topics.
         emitter.emitSomethingElse(1);
+    }
+
+    function testCanDoStaticCall() public {
+        cheats.expectEmit(true, true, true, true);
+        emit Something(emitter.getVar(), 2, 3, 4);
+
+        emitter.emitEvent(1, 2, 3, 4);
     }
 
     /// This test will fail if we check that all expected logs were emitted

--- a/testdata/cheats/GetDeployedCode.t.sol
+++ b/testdata/cheats/GetDeployedCode.t.sol
@@ -33,8 +33,8 @@ contract GetDeployedCodeTest is DSTest {
         Override over = Override(overrideAddress);
 
         vm.expectEmit(true, false, false, true);
-        over.emitPayload(address(0), "hello");
         emit Payload(address(this), address(0), "hello");
+        over.emitPayload(address(0), "hello");
     }
 }
 

--- a/testdata/fork/Transact.t.sol
+++ b/testdata/fork/Transact.t.sol
@@ -71,7 +71,6 @@ contract TransactOnForkTest is DSTest {
         // expect a call to USDT's transfer
         vm.expectCall(address(USDT), abi.encodeWithSelector(IERC20.transfer.selector, recipient, transferAmount));
 
-
         // expect a Transfer event to be emitted
         vm.expectEmit(true, true, false, true, address(USDT));
         emit Transfer(address(sender), address(recipient), transferAmount);

--- a/testdata/fork/Transact.t.sol
+++ b/testdata/fork/Transact.t.sol
@@ -71,6 +71,7 @@ contract TransactOnForkTest is DSTest {
         // expect a call to USDT's transfer
         vm.expectCall(address(USDT), abi.encodeWithSelector(IERC20.transfer.selector, recipient, transferAmount));
 
+
         // expect a Transfer event to be emitted
         vm.expectEmit(true, true, false, true, address(USDT));
         emit Transfer(address(sender), address(recipient), transferAmount);


### PR DESCRIPTION
*This is a big breaking change.*

Partially closes #1745. `expectCall` is left and needs #4912 to be merged before it can be reworked to support this. 

Makes `expectEmit` only work for the _immediate_ next call after the cheatcode has been called.

# Behavior

`expectEmit` remains _additive_. Calling `expectEmit` `N` times will set a lower bound of `N` events that must be seen for the cheatcode to pass successfully.

The current behavior of `expectEmit` allows to:
- declare the cheatcode before all events are emitted.
- "fill" the expected emits _before_ the test ends.
- match events after the tests ends.

The intended behavior is that it only works for the *next immediate call*. This new behavior only allows to:
- Call the cheatcode AND fill the expected emit right after calling the cheatcode. Declaring the cheatcode `N` times and then filling `N` events will fail.
- match events after the next CALL is triggered. Events not triggered by a call will be ignored. Events nested in the triggered CALL subtree will be matched. If the events defined are not matched, the execution will revert.

It's important to note the restriction imposed by this, namely that after the cheatcode is declared, no CALLs other than the one the cheatcode is intended to "match" must happen. This means that #1214 is now illegal behavior. Specifically, this means that this is now illegal:

```
function testEmitMyEvent_v2() external {
    cheatcodes.expectEmit(true, true, true, true);
    // myContract.myVar() is a call made after the cheatcode was called. This is illegal.
    // To fix this, move the call to before the cheatcode and use a variable.
    emit MyEvent(myContract.myVar(), address(this), address(this), block.timestamp);
    myContract.emitMyEvent();
}
````

## Why are now expect emits being pushed without subtracting 1 from the depth?
https://github.com/foundry-rs/foundry/pull/1215 is a great read to reason about depth. After this, the reason is that currently, `depth - 1` is being used is so that `expectEmit` checks the events after the call that invoked the cheatcode ends. However, we now wanna check the events after the next CALL (which will have more depth) ends, which means that we need to check for `depth`, not `depth - 1`.

When we're happy with this and merge it we should definitely prepare a telegram message & a tweetstorm for this change, as this might confuse people.