### PR TITLE
feat(invariant): add `statefulFuzz` as an alias to `invariant`

### DIFF
--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -51,7 +51,7 @@ impl TestFunctionExt for Function {
 
 impl<'a> TestFunctionExt for &'a str {
     fn is_invariant_test(&self) -> bool {
-        self.starts_with("invariant")
+        self.starts_with("invariant") || self.starts_with("statefulFuzz")
     }
 
     fn is_fuzz_test(&self) -> bool {

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -30,7 +30,16 @@ fn test_invariant() {
             ),
             (
                 "fuzz/invariant/common/InvariantTest1.t.sol:InvariantTest",
-                vec![("invariant_neverFalse()", false, Some("false.".into()), None, None)],
+                vec![
+                    ("invariant_neverFalse()", false, Some("false.".into()), None, None),
+                    (
+                        "statefulFuzz_neverFalseWithInvariantAlias()",
+                        false,
+                        Some("false.".into()),
+                        None,
+                        None,
+                    ),
+                ],
             ),
             (
                 "fuzz/invariant/target/ExcludeContracts.t.sol:ExcludeContracts",

--- a/testdata/fuzz/invariant/common/InvariantTest1.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantTest1.t.sol
@@ -32,4 +32,8 @@ contract InvariantTest is DSTest {
     function invariant_neverFalse() public {
         require(inv.flag1(), "false.");
     }
+
+    function statefulFuzz_neverFalseWithInvariantAlias() public {
+        require(inv.flag1(), "false.");
+    }
 }


### PR DESCRIPTION
## Motivation

Closes #4650

There's been repeated discussion about how to call fuzz/invariant tests. One of the things proposed for invariants is to add some alias that could be used instead of invariant to more properly narrow down its meaning, without necessarily removing the usage of `invariant` yet.

## Solution

Adds `statefulFuzz` as an alias to `invariant`, as suggested in the linked issue.

I personally do not have strong opinions on what alias we should use, and `statefulFuzz` feels a tad long—feel free to nitpick!

Proposed plan is:
- Foundry 1.0 will support both.
- Foundry 1.1+ will support both, but will warn users that `invariant` might not be supported in a future 2.0 release.
- Foundry 2.0 and beyond: remove the `invariant` keyword.