### PR TITLE
Script: ensure prevrandao is set, even if no mixHash in response

### DIFF
--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -67,7 +67,7 @@ where
             timestamp: block.timestamp.into(),
             coinbase: h160_to_b160(block.author.unwrap_or_default()),
             difficulty: block.difficulty.into(),
-            prevrandao: Some(block.mix_hash.unwrap_or_default()).map(h256_to_b256),
+            prevrandao: h256_to_b256(block.mix_hash.unwrap_or_default()),
             basefee: block.base_fee_per_gas.unwrap_or_default().into(),
             gas_limit: block.gas_limit.into(),
         },

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -67,7 +67,7 @@ where
             timestamp: block.timestamp.into(),
             coinbase: h160_to_b160(block.author.unwrap_or_default()),
             difficulty: block.difficulty.into(),
-            prevrandao: block.mix_hash.map(h256_to_b256),
+            prevrandao: Some(block.mix_hash.unwrap_or_default()).map(h256_to_b256),
             basefee: block.base_fee_per_gas.unwrap_or_default().into(),
             gas_limit: block.gas_limit.into(),
         },

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -67,7 +67,7 @@ where
             timestamp: block.timestamp.into(),
             coinbase: h160_to_b160(block.author.unwrap_or_default()),
             difficulty: block.difficulty.into(),
-            prevrandao: h256_to_b256(block.mix_hash.unwrap_or_default()),
+            prevrandao: Some(block.mix_hash.unwrap_or_default()),
             basefee: block.base_fee_per_gas.unwrap_or_default().into(),
             gas_limit: block.gas_limit.into(),
         },

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -67,7 +67,7 @@ where
             timestamp: block.timestamp.into(),
             coinbase: h160_to_b160(block.author.unwrap_or_default()),
             difficulty: block.difficulty.into(),
-            prevrandao: Some(block.mix_hash.unwrap_or_default()),
+            prevrandao: Some(block.mix_hash.map(u256_to_ru256).unwrap_or_default()),
             basefee: block.base_fee_per_gas.unwrap_or_default().into(),
             gas_limit: block.gas_limit.into(),
         },


### PR DESCRIPTION
## Motivation
ref https://github.com/foundry-rs/foundry/issues/4238

ensure prevrandao is set, even if no mixHash in response

## Solution
same fix as anvil but when running forge script.
