### PR TITLE
chore: move formatting logic to foundry-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "ethers-solc",
  "eyre",
  "foundry-config",
+ "foundry-macros",
  "is-terminal",
  "once_cell",
  "regex",
@@ -2575,8 +2576,9 @@ name = "foundry-macros"
 version = "0.1.0"
 dependencies = [
  "ethers-core",
- "foundry-common",
  "foundry-macros-impl",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/foundry-rs/foundry"
 [dependencies]
 # foundry internal
 foundry-config = { path = "../config" }
+foundry-macros = { path = "../macros" }
 
 # eth
 ethers-core = { workspace = true }

--- a/common/src/fmt.rs
+++ b/common/src/fmt.rs
@@ -1,0 +1,50 @@
+//! Helpers for formatting ethereum types
+
+use crate::TransactionReceiptWithRevertReason;
+
+pub use foundry_macros::fmt::*;
+
+impl UIfmt for TransactionReceiptWithRevertReason {
+    fn pretty(&self) -> String {
+        if let Some(revert_reason) = &self.revert_reason {
+            format!(
+                "{}
+revertReason            {}",
+                self.receipt.pretty(),
+                revert_reason
+            )
+        } else {
+            self.receipt.pretty()
+        }
+    }
+}
+
+/// Returns the ``UiFmt::pretty()` formatted attribute of the transaction receipt
+pub fn get_pretty_tx_receipt_attr(
+    receipt: &TransactionReceiptWithRevertReason,
+    attr: &str,
+) -> Option<String> {
+    match attr {
+        "blockHash" | "block_hash" => Some(receipt.receipt.block_hash.pretty()),
+        "blockNumber" | "block_number" => Some(receipt.receipt.block_number.pretty()),
+        "contractAddress" | "contract_address" => Some(receipt.receipt.contract_address.pretty()),
+        "cumulativeGasUsed" | "cumulative_gas_used" => {
+            Some(receipt.receipt.cumulative_gas_used.pretty())
+        }
+        "effectiveGasPrice" | "effective_gas_price" => {
+            Some(receipt.receipt.effective_gas_price.pretty())
+        }
+        "gasUsed" | "gas_used" => Some(receipt.receipt.gas_used.pretty()),
+        "logs" => Some(receipt.receipt.logs.pretty()),
+        "logsBloom" | "logs_bloom" => Some(receipt.receipt.logs_bloom.pretty()),
+        "root" => Some(receipt.receipt.root.pretty()),
+        "status" => Some(receipt.receipt.status.pretty()),
+        "transactionHash" | "transaction_hash" => Some(receipt.receipt.transaction_hash.pretty()),
+        "transactionIndex" | "transaction_index" => {
+            Some(receipt.receipt.transaction_index.pretty())
+        }
+        "type" | "transaction_type" => Some(receipt.receipt.transaction_type.pretty()),
+        "revertReason" | "revert_reason" => Some(receipt.revert_reason.pretty()),
+        _ => None,
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,11 +14,12 @@ pub mod fs;
 pub mod provider;
 pub mod selectors;
 pub mod shell;
-pub use provider::*;
 pub mod term;
 pub mod traits;
+pub mod transactions;
+
 pub use constants::*;
 pub use contracts::*;
+pub use provider::*;
 pub use traits::*;
-pub mod transactions;
 pub use transactions::*;

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/foundry-rs/foundry"
 
 [dependencies]
 foundry-macros-impl = { path = "./impl" }
-foundry-common = { path = "../common" }
 
 ethers-core = { workspace = true }
+serde = "1.0"
+serde_json = "1.0"

--- a/macros/src/fmt/console_fmt.rs
+++ b/macros/src/fmt/console_fmt.rs
@@ -1,5 +1,5 @@
+use super::UIfmt;
 use ethers_core::types::{Address, Bytes, H256, I256, U256};
-use foundry_common::fmt::UIfmt;
 
 /// A format specifier.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -167,10 +167,14 @@ impl<const N: usize> ConsoleFmt for [u8; N] {
 /// Formatting rules are the same as Hardhat. The supported format specifiers are as follows:
 /// - %s: Converts the value using its String representation. This is equivalent to applying
 ///   [`UIfmt::pretty()`] on the format string.
-/// - %d, %i: Converts the value to an integer. If a non-numeric value, such as String or Address,
-///   is passed, then the spec is formatted as `NaN`.
 /// - %o: Treats the format value as a javascript "object" and converts it to its string
 ///   representation.
+/// - %d, %i: Converts the value to an integer. If a non-numeric value, such as String or Address,
+///   is passed, then the spec is formatted as `NaN`.
+/// - %x: Converts the value to a hexadecimal string. If a non-numeric value, such as String or
+///   Address, is passed, then the spec is formatted as `NaN`.
+/// - %e: Converts the value to an exponential notation string. If a non-numeric value, such as
+///   String or Address, is passed, then the spec is formatted as `NaN`.
 /// - %%: This is parsed as a single percent sign ('%') without consuming any input value.
 ///
 /// Unformatted values are appended to the end of the formatted output using [`UIfmt::pretty()`].

--- a/macros/src/fmt/mod.rs
+++ b/macros/src/fmt/mod.rs
@@ -5,3 +5,6 @@ pub use ui::*;
 
 mod token;
 pub use token::*;
+
+mod console_fmt;
+pub use console_fmt::{console_format, ConsoleFmt, FormatSpec};

--- a/macros/src/fmt/token.rs
+++ b/macros/src/fmt/token.rs
@@ -1,4 +1,4 @@
-//! Formatting helpers for [`Token`](ethers_core::abi::Token)
+//! Formatting helpers for [`Token`]s.
 
 use ethers_core::{abi::Token, types::I256, utils, utils::hex};
 use std::{fmt, fmt::Write};
@@ -6,12 +6,13 @@ use std::{fmt, fmt::Write};
 /// Wrapper that pretty formats a token
 pub struct TokenDisplay<'a>(pub &'a Token);
 
-impl<'a> fmt::Display for TokenDisplay<'a> {
+impl fmt::Display for TokenDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt_token(f, self.0)
     }
 }
 
+/// Recursively formats an ABI token.
 fn fmt_token(f: &mut fmt::Formatter, item: &Token) -> fmt::Result {
     match item {
         Token::Address(inner) => {

--- a/macros/src/fmt/ui.rs
+++ b/macros/src/fmt/ui.rs
@@ -14,7 +14,7 @@ const NAME_COLUMN_LEN: usize = 20usize;
 /// # Examples
 ///
 /// ```
-/// use foundry_common::fmt::UIfmt;
+/// use foundry_macros::fmt::UIfmt;
 /// let boolean: bool = true;
 /// let string = boolean.pretty();
 /// ```

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,9 @@
 //! Foundry's procedural macros.
+//! 
+//! Also includes traits and other utilities used by the macros.
 
-// TODO: Remove dependency on foundry-common (currently only used for the UIfmt trait).
+pub mod fmt;
+pub use fmt::{console_format, ConsoleFmt, FormatSpec, TokenDisplay, UIfmt};
 
-mod console_fmt;
-pub use console_fmt::{console_format, ConsoleFmt, FormatSpec};
-
+#[doc(inline)]
 pub use foundry_macros_impl::ConsoleFmt;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
 //! Foundry's procedural macros.
-//! 
+//!
 //! Also includes traits and other utilities used by the macros.
 
 pub mod fmt;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`foundry-macros` depends on `foundry-config` for just the UIFmt trait, thus any user of the simple macro crate would have hundreds of other unrelated dependencies.

Part of #4928, helps with #4935

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
