### PR TITLE
fix(`chisel`): Override set solc and Install post-merge solc version if needed

### DIFF
--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -1488,10 +1488,10 @@ mod tests {
             let mut is_preinstalled = PRE_INSTALL_SOLC_LOCK.lock().unwrap();
             if !*is_preinstalled {
                 let solc =
-                    Solc::find_or_install_svm_version("0.8.17").and_then(|solc| solc.version());
+                    Solc::find_or_install_svm_version("0.8.19").and_then(|solc| solc.version());
                 if solc.is_err() {
                     // try reinstalling
-                    let solc = Solc::blocking_install(&"0.8.17".parse().unwrap());
+                    let solc = Solc::blocking_install(&"0.8.19".parse().unwrap());
                     if solc.map_err(SolcError::from).and_then(|solc| solc.version()).is_ok() {
                         *is_preinstalled = true;
                         break
@@ -1503,7 +1503,7 @@ mod tests {
             }
         }
 
-        let solc = Solc::find_or_install_svm_version("0.8.17").expect("could not install solc");
+        let solc = Solc::find_or_install_svm_version("0.8.19").expect("could not install solc");
         SessionSource::new(solc, Default::default())
     }
 

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -101,18 +101,19 @@ impl SessionSourceConfig {
         match solc_req {
             SolcReq::Version(version) => {
                 // We now need to verify if the solc version provided is supported by the evm
-                // version set. If not, we need to install the latest version of
-                // solc that is supported by the evm version.
+                // version set. If not, we bail and ask the user to provide a newer version.
                 // 1. Do we need solc 0.8.18 or higher?
-                let needs_post_merge_solc = self.foundry_config.evm_version >= EvmVersion::Paris;
-                // 2. Check if the version provided is less than 0.8.18 and override it,
+                let evm_version = self.foundry_config.evm_version;
+                let needs_post_merge_solc = evm_version >= EvmVersion::Paris;
+                // 2. Check if the version provided is less than 0.8.18 and bail,
                 // or leave it as-is if we don't need a post merge solc version or the version we
                 // have is good enough.
                 let v = if needs_post_merge_solc && version < Version::new(0, 8, 18) {
                     // If we do need a new version, install 0.8.19 (Paris)
                     // NOTE: This needs to be bumped to 0.8.20 once we upgrade all tooling to
                     // Shanghai.
-                    Version::new(0, 8, 19).to_string()
+                    eyre::bail!("solc {version} is not supported by the set evm version: {evm_version}. Please install and use a version of solc higher or equal to 0.8.18.
+You can also set the solc version in your foundry.toml.")
                 } else {
                     version.to_string()
                 };

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -108,16 +108,17 @@ impl SessionSourceConfig {
                 // 2. Check if the version provided is less than 0.8.18 and override it,
                 // or leave it as-is if we don't need a post merge solc version or the version we
                 // have is good enough.
-                if let v = needs_solc_18 && version < Version::new(0, 8, 18) {
+                let v = if needs_post_merge_solc && version < Version::new(0, 8, 18) {
                     // If we do need a new version, install 0.8.19 (Paris)
-                    // NOTE: This needs to be bumped to 0.8.20 once we upgrade all tooling to Shanghai.
-                   Version::new(0, 8, 19)
+                    // NOTE: This needs to be bumped to 0.8.20 once we upgrade all tooling to
+                    // Shanghai.
+                    Version::new(0, 8, 19).to_string()
                 } else {
-                    version
+                    version.to_string()
                 };
 
-                let v = version.to_string();
                 let mut solc = Solc::find_svm_installed_version(&v)?;
+
                 if solc.is_none() {
                     if self.foundry_config.offline {
                         eyre::bail!("can't install missing solc {version} in offline mode")

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -100,12 +100,14 @@ impl SessionSourceConfig {
 
         match solc_req {
             SolcReq::Version(version) => {
-                // We now need to verify if the solc version provided is supported by the evm version set.
-                // If not, we need to install the latest version of solc that is supported by the evm version.
+                // We now need to verify if the solc version provided is supported by the evm
+                // version set. If not, we need to install the latest version of
+                // solc that is supported by the evm version.
                 // 1. Do we need solc 0.8.18 or higher?
                 let needs_post_merge_solc = self.foundry_config.evm_version >= EvmVersion::Paris;
                 // 2. Check if the version provided is less than 0.8.18 and override it,
-                // or leave it as-is if we don't need a post merge solc version or the version we have is good enough.
+                // or leave it as-is if we don't need a post merge solc version or the version we
+                // have is good enough.
                 if let v = needs_solc_18 && version < Version::new(0, 8, 18) {
                     // If we do need a new version, install 0.8.19 (Paris)
                     // NOTE: This needs to be bumped to 0.8.20 once we upgrade all tooling to Shanghai.

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -6,7 +6,7 @@
 
 use ethers_solc::{
     artifacts::{Source, Sources},
-    CompilerInput, CompilerOutput, Solc,
+    CompilerInput, CompilerOutput, EvmVersion, Solc,
 };
 use eyre::Result;
 use forge::executor::{opts::EvmOpts, Backend};
@@ -100,6 +100,20 @@ impl SessionSourceConfig {
 
         match solc_req {
             SolcReq::Version(version) => {
+                // We now need to verify if the solc version provided is supported by the evm version set.
+                // If not, we need to install the latest version of solc that is supported by the evm version.
+                // 1. Do we need solc 0.8.18 or higher?
+                let needs_post_merge_solc = self.foundry_config.evm_version >= EvmVersion::Paris;
+                // 2. Check if the version provided is less than 0.8.18 and override it,
+                // or leave it as-is if we don't need a post merge solc version or the version we have is good enough.
+                if let v = needs_solc_18 && version < Version::new(0, 8, 18) {
+                    // If we do need a new version, install 0.8.19 (Paris)
+                    // NOTE: This needs to be bumped to 0.8.20 once we upgrade all tooling to Shanghai.
+                   Version::new(0, 8, 19)
+                } else {
+                    version
+                };
+
                 let v = version.to_string();
                 let mut solc = Solc::find_svm_installed_version(&v)?;
                 if solc.is_none() {

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use chisel::{session::ChiselSession, session_source::SessionSourceConfig};
+use ethers_solc::{Solc, PARIS_SOLC};
 use forge::executor::opts::EvmOpts;
 use foundry_config::Config;
 use serial_test::serial;
@@ -95,12 +96,15 @@ fn test_clear_cache() {
     assert_eq!(num_items, 0);
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_list_sessions() {
+async fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
+
+    // Ensure we have a paris-compatible solc version
+    Solc::install(&PARIS_SOLC).await.unwrap();
 
     // Create a new session
     let mut env = ChiselSession::new(SessionSourceConfig::default())
@@ -116,12 +120,15 @@ fn test_list_sessions() {
     assert_eq!(sessions[0].1, "chisel-0.json");
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_load_cache() {
+async fn test_load_cache() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
+
+    // Ensure we have a paris-compatible solc version
+    Solc::install(&PARIS_SOLC).await.unwrap();
 
     // Create a new session
     let mut env = ChiselSession::new(SessionSourceConfig::default())

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -80,7 +80,7 @@ fn test_write_session_with_name() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
     env.id = Some(String::from("test"));
 
     // Write the session
@@ -105,7 +105,7 @@ fn test_clear_cache() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
     env.write().unwrap();
 
     // Clear the cache
@@ -132,7 +132,7 @@ fn test_list_sessions() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
+    .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
 
     env.write().unwrap();
 
@@ -160,7 +160,7 @@ fn test_load_cache() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
+    .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
 
     // Load the session
@@ -192,7 +192,7 @@ fn test_write_same_session_multiple_times() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
+    .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
     env.write().unwrap();
     env.write().unwrap();
@@ -216,7 +216,7 @@ fn test_load_latest_cache() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
+    .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
 
     let wait_time = std::time::Duration::from_millis(100);
@@ -226,7 +226,7 @@ fn test_load_latest_cache() {
         foundry_config: Config::default(),
         ..Default::default()
     })
-        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
+    .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env2.write().unwrap();
 
     // Load the latest session

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -90,11 +90,13 @@ fn test_write_session_with_name() {
     assert_eq!(cached_session_name, format!("{cache_dir}chisel-test.json"));
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_clear_cache() {
+async fn test_clear_cache() {
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
+
+    Solc::install(&Version::new(0, 8, 19)).await.unwrap();
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
@@ -116,12 +118,14 @@ fn test_clear_cache() {
     assert_eq!(num_items, 0);
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_list_sessions() {
+async fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
+
+    Solc::install(&Version::new(0, 8, 19)).await.unwrap();
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -104,7 +104,7 @@ fn test_list_sessions() {
 
     // Create a new session
     let mut env = ChiselSession::new(SessionSourceConfig::default())
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
 
     env.write().unwrap();
 

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use chisel::{session::ChiselSession, session_source::SessionSourceConfig};
 use ethers_solc::{Solc, PARIS_SOLC};
 use forge::executor::opts::EvmOpts;
-use foundry_config::Config;
+use foundry_config::{Config, SolcReq};
+use semver::Version;
 use serial_test::serial;
 
 #[test]
@@ -38,6 +39,10 @@ fn test_write_session() {
     let cache_dir = ChiselSession::cache_dir().unwrap();
     ChiselSession::create_cache_dir().unwrap();
 
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
         foundry_config: Config::default(),
@@ -66,8 +71,15 @@ fn test_write_session_with_name() {
     let cache_dir = ChiselSession::cache_dir().unwrap();
     ChiselSession::create_cache_dir().unwrap();
 
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+
     // Create a new session
-    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig::default())
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
         .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
     env.id = Some(String::from("test"));
 
@@ -83,8 +95,16 @@ fn test_write_session_with_name() {
 fn test_clear_cache() {
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
+
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+
     ChiselSession::create_cache_dir().unwrap();
-    let mut env = ChiselSession::new(SessionSourceConfig::default())
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
         .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
     env.write().unwrap();
 
@@ -96,18 +116,22 @@ fn test_clear_cache() {
     assert_eq!(num_items, 0);
 }
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn test_list_sessions() {
+fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
 
-    // Ensure we have a paris-compatible solc version
-    Solc::install(&PARIS_SOLC).await.unwrap();
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
 
     // Create a new session
-    let mut env = ChiselSession::new(SessionSourceConfig::default())
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
         .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
 
     env.write().unwrap();
@@ -120,19 +144,23 @@ async fn test_list_sessions() {
     assert_eq!(sessions[0].1, "chisel-0.json");
 }
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn test_load_cache() {
+fn test_load_cache() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
 
-    // Ensure we have a paris-compatible solc version
-    Solc::install(&PARIS_SOLC).await.unwrap();
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
 
     // Create a new session
-    let mut env = ChiselSession::new(SessionSourceConfig::default())
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
+        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
 
     // Load the session
@@ -155,9 +183,16 @@ fn test_write_same_session_multiple_times() {
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
 
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+
     // Create a new session
-    let mut env = ChiselSession::new(SessionSourceConfig::default())
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
+        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
     env.write().unwrap();
     env.write().unwrap();
@@ -172,16 +207,26 @@ fn test_load_latest_cache() {
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
 
+    // Force the solc version to be 0.8.19
+    let mut foundry_config = Config::default();
+    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+
     // Create sessions
-    let mut env = ChiselSession::new(SessionSourceConfig::default())
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
+        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env.write().unwrap();
 
     let wait_time = std::time::Duration::from_millis(100);
     std::thread::sleep(wait_time);
 
-    let mut env2 = ChiselSession::new(SessionSourceConfig::default())
-        .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
+    let mut env2 = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config: Config::default(),
+        ..Default::default()
+    })
+        .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
     env2.write().unwrap();
 
     // Load the latest session

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -191,8 +191,7 @@ pub fn setup_cast_project(test: TestProject) -> (TestProject, TestCommand) {
 fn install_commonly_used_solc() {
     let mut is_preinstalled = PRE_INSTALL_SOLC_LOCK.lock();
     if !*is_preinstalled {
-        let v0_8_10 = std::thread::spawn(|| Solc::blocking_install(&"0.8.10".parse().unwrap()));
-        let v0_8_13 = std::thread::spawn(|| Solc::blocking_install(&"0.8.13".parse().unwrap()));
+        let v0_8_18 = std::thread::spawn(|| Solc::blocking_install(&"0.8.18".parse().unwrap()));
         let v0_8_19 = std::thread::spawn(|| Solc::blocking_install(&"0.8.19".parse().unwrap()));
 
         let wait = |res: std::thread::JoinHandle<_>| -> Result<(), ()> {
@@ -208,7 +207,7 @@ fn install_commonly_used_solc() {
         };
 
         // only set to installed if succeeded
-        *is_preinstalled = wait(v0_8_10).and(wait(v0_8_13)).and(wait(v0_8_19)).is_ok();
+        *is_preinstalled = wait(v0_8_18).and(wait(v0_8_19)).is_ok();
     }
 }
 

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -193,6 +193,7 @@ fn install_commonly_used_solc() {
     if !*is_preinstalled {
         let v0_8_10 = std::thread::spawn(|| Solc::blocking_install(&"0.8.10".parse().unwrap()));
         let v0_8_13 = std::thread::spawn(|| Solc::blocking_install(&"0.8.13".parse().unwrap()));
+        let v0_8_19 = std::thread::spawn(|| Solc::blocking_install(&"0.8.19".parse().unwrap()));
 
         let wait = |res: std::thread::JoinHandle<_>| -> Result<(), ()> {
             if let Err(err) = res.join().unwrap() {
@@ -207,7 +208,7 @@ fn install_commonly_used_solc() {
         };
 
         // only set to installed if succeeded
-        *is_preinstalled = wait(v0_8_10).and(wait(v0_8_13)).is_ok();
+        *is_preinstalled = wait(v0_8_10).and(wait(v0_8_13)).and(wait(v0_8_19)).is_ok();
     }
 }
 


### PR DESCRIPTION
## Motivation

Closes #4888 .

Seems people still are having issues with the issue linked above. It's caused by a mismatch between the used solc and evm version required.

## Solution

Introduces a check to ensure that the user is using/installing an solc version that is compatible the merge onwards if the evm version is higher or equal to Paris. This overrides the solc option set by the user if it's not recent enough, but it will *not* override a local solc path.

cc @clabby looping you in! this should hopefully fix this—lmk if i missed any other solc checks elsewhere
