### PR TITLE
fix(chisel/ci): un-async chisel tests for filesystem consistency

### DIFF
--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use chisel::{session::ChiselSession, session_source::SessionSourceConfig};
-use ethers_solc::{Solc, PARIS_SOLC};
+use chisel::{session::ChiselSession};
+use ethers_solc::{Solc};
 use forge::executor::opts::EvmOpts;
 use foundry_config::{Config, SolcReq};
 use semver::Version;

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -90,12 +90,13 @@ fn test_write_session_with_name() {
     assert_eq!(cached_session_name, format!("{cache_dir}chisel-test.json"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_clear_cache() {
+#[test]
+#[serial]
+fn test_clear_cache() {
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
 
-    Solc::install(&Version::new(0, 8, 19)).await.unwrap();
+    Solc::blocking_install(&Version::new(0, 8, 19)).unwrap();
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
@@ -117,13 +118,14 @@ async fn test_clear_cache() {
     assert_eq!(num_items, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_list_sessions() {
+#[test]
+#[serial]
+fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
 
-    Solc::install(&Version::new(0, 8, 19)).await.unwrap();
+    Solc::blocking_install(&Version::new(0, 8, 19)).unwrap();
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -90,8 +90,7 @@ fn test_write_session_with_name() {
     assert_eq!(cached_session_name, format!("{cache_dir}chisel-test.json"));
 }
 
-#[tokio::test]
-#[serial]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_clear_cache() {
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -118,8 +117,7 @@ async fn test_clear_cache() {
     assert_eq!(num_items, 0);
 }
 
-#[tokio::test]
-#[serial]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_sessions() {
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use chisel::{session::ChiselSession};
-use ethers_solc::{Solc};
+use chisel::session::ChiselSession;
+use ethers_solc::Solc;
 use forge::executor::opts::EvmOpts;
 use foundry_config::{Config, SolcReq};
 use semver::Version;


### PR DESCRIPTION
## Motivation

Seems #4949 introduced some regressions in the integration tests, probably due to async usage with tokio on tests.

## Solution

Revert to original serial behavior on tests and use `blocking_install` to not need to run tests asynchronously.