### PR TITLE
fix(fuzzing): persist snapshot failures when fuzzing

### DIFF
--- a/evm/src/executor/backend/fuzz.rs
+++ b/evm/src/executor/backend/fuzz.rs
@@ -73,10 +73,16 @@ impl<'a> FuzzBackendWrapper<'a> {
         }
     }
 
+    /// Returns whether there was a snapshot failure in the fuzz backend.
+    ///
+    /// This is bubbled up from the underlying Copy-On-Write backend when a revert occurs.
     pub fn has_snapshot_failure(&self) -> bool {
         self.has_snapshot_failure
     }
 
+    /// Sets whether there was a snapshot failure in the fuzz backend.
+    ///
+    /// This is bubbled up from the underlying Copy-On-Write backend when a revert occurs.
     pub fn set_snapshot_failure(&mut self, has_snapshot_failure: bool) {
         self.has_snapshot_failure = has_snapshot_failure;
     }
@@ -109,7 +115,8 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     ) -> Option<JournaledState> {
         trace!(?id, "fuzz: revert snapshot");
         let journaled_state = self.backend_mut(current).revert(id, journaled_state, current);
-        // Persist the snapshot failure
+        // Persist the snapshot failure in the fuzz backend, as the underlying backend state is lost
+        // after the call.
         self.set_snapshot_failure(self.has_snapshot_failure || self.backend.has_snapshot_failure());
         journaled_state
     }

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -858,7 +858,7 @@ impl DatabaseExt for Backend {
                 .map(|addr| self.is_failed_test_contract_state(addr, current_state))
                 .unwrap_or_default()
             {
-                self.inner.has_snapshot_failure.fetch_or(true, Ordering::Relaxed);
+                self.inner.has_snapshot_failure.store(true, Ordering::Relaxed);
             }
 
             // merge additional logs

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -25,7 +25,13 @@ use revm::{
     },
     Database, DatabaseCommit, Inspector, JournaledState, EVM,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 mod fuzz;
 pub mod snapshot;
@@ -513,7 +519,11 @@ impl Backend {
     ///
     /// This returns whether there was a reverted snapshot that recorded an error
     pub fn has_snapshot_failure(&self) -> bool {
-        self.inner.has_snapshot_failure
+        self.inner.has_snapshot_failure.load(Ordering::Relaxed)
+    }
+
+    pub fn set_snapshot_failure(&self, has_snapshot_failure: bool) {
+        self.inner.has_snapshot_failure.store(has_snapshot_failure, Ordering::Relaxed);
     }
 
     /// Checks if the test contract associated with this backend failed, See
@@ -848,7 +858,7 @@ impl DatabaseExt for Backend {
                 .map(|addr| self.is_failed_test_contract_state(addr, current_state))
                 .unwrap_or_default()
             {
-                self.inner.has_snapshot_failure = true;
+                self.inner.has_snapshot_failure.fetch_or(true, Ordering::Relaxed);
             }
 
             // merge additional logs
@@ -1422,7 +1432,7 @@ pub struct BackendInner {
     /// reverted we get the _current_ `revm::JournaledState` which contains the state that we can
     /// check if the `_failed` variable is set,
     /// additionally
-    pub has_snapshot_failure: bool,
+    pub has_snapshot_failure: Arc<AtomicBool>,
     /// Tracks the address of a Test contract
     ///
     /// This address can be used to inspect the state of the contract when a test is being
@@ -1619,7 +1629,7 @@ impl Default for BackendInner {
             created_forks: Default::default(),
             forks: vec![],
             snapshots: Default::default(),
-            has_snapshot_failure: false,
+            has_snapshot_failure: Arc::new(AtomicBool::new(false)),
             test_contract_address: None,
             caller: None,
             next_fork_id: Default::default(),

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -362,6 +362,11 @@ impl Executor {
         let mut db = FuzzBackendWrapper::new(self.backend());
         let result = db.inspect_ref(&mut env, &mut inspector)?;
 
+        // Persist the snapshot failure recorded on the fuzz backend wrapper.
+        self.backend().set_snapshot_failure(
+            self.backend().has_snapshot_failure() || db.has_snapshot_failure(),
+        );
+
         convert_executed_result(env, inspector, result)
     }
 

--- a/testdata/repros/Issue3055.t.sol
+++ b/testdata/repros/Issue3055.t.sol
@@ -23,6 +23,8 @@ contract Issue3055Test is DSTest {
 
     function test_snapshot3(uint256) public {
         vm.expectRevert();
+        // Call exposed_snapshot3() using this to perform an external call,
+        // so we can properly test for reverts.
         this.exposed_snapshot3();
     }
 

--- a/testdata/repros/Issue3055.t.sol
+++ b/testdata/repros/Issue3055.t.sol
@@ -20,4 +20,15 @@ contract Issue3055Test is DSTest {
         vm.revertTo(snapshot);
         assertTrue(true);
     }
+
+    function test_snapshot3(uint256) public {
+        vm.expectRevert();
+        this.exposed_snapshot3();
+    }
+
+    function exposed_snapshot3() public {
+        uint256 snapshot = vm.snapshot();
+        assertTrue(false);
+        vm.revertTo(snapshot);
+    }
 }


### PR DESCRIPTION
## Motivation

Closes #3055.

Fuzzing was having soundness issues with snapshot failures. This is because snapshot failures were not being persisted throughout fuzz runs, and when the Fuzz Backend Wrapper we use was dropped, this information was lost, leading to inconsistent test PASS states.

## Solution

Persist snapshot failures when fuzzing.