### PR TITLE
chore(deps): bump `svm-rs`, `svm-rs-builds` and update `LATEST_SOLC`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,14 +802,9 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
  "textwrap",
 ]
 
@@ -820,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
+ "clap_derive",
  "once_cell",
 ]
 
@@ -836,7 +831,7 @@ dependencies = [
  "clap_lex 0.4.1",
  "once_cell",
  "strsim",
- "terminal_size 0.2.6",
+ "terminal_size",
  "unicase",
  "unicode-width",
 ]
@@ -858,19 +853,6 @@ checksum = "f3af28956330989baa428ed4d3471b853715d445c62de21b67292e22cf8a41fa"
 dependencies = [
  "clap 4.2.7",
  "clap_complete",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1060,21 +1042,6 @@ dependencies = [
  "async-trait",
  "nix",
  "tokio",
- "winapi",
-]
-
-[[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size 0.1.17",
- "unicode-width",
  "winapi",
 ]
 
@@ -1422,23 +1389,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
-dependencies = [
- "console 0.14.1",
- "lazy_static",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
- "console 0.15.5",
+ "console",
  "shell-words",
 ]
 
@@ -2338,9 +2293,9 @@ dependencies = [
  "clap_complete_fig",
  "color-eyre",
  "comfy-table",
- "console 0.15.5",
+ "console",
  "criterion",
- "dialoguer 0.10.4",
+ "dialoguer",
  "dotenvy",
  "dunce",
  "ethers",
@@ -2356,7 +2311,7 @@ dependencies = [
  "futures",
  "globset",
  "hex",
- "indicatif 0.17.3",
+ "indicatif",
  "is-terminal",
  "itertools",
  "once_cell",
@@ -3462,23 +3417,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console 0.15.5",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
- "console 0.15.5",
+ "console",
  "number_prefix",
  "portable-atomic 0.3.20",
  "unicode-width",
@@ -6090,40 +6033,29 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
+checksum = "3a04fc4f5cd35c700153b233f5575ccb3237e0f941fa5049d9e98254d10bf2fe"
 dependencies = [
- "anyhow",
- "cfg-if",
- "clap 3.2.25",
- "console 0.14.1",
- "dialoguer 0.8.0",
  "fs2",
  "hex",
  "home",
- "indicatif 0.16.2",
- "itertools",
  "once_cell",
- "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "tempfile",
+ "sha2 0.10.6",
  "thiserror",
- "tokio",
- "tracing",
  "url",
  "zip",
 ]
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e69c19996b709c881de264a6ce64609ff305ef0bf59fc45243ac5a67291afd1"
+checksum = "32deae08684d03d8a4ba99b8a3b0a1575364820339930f6fa2afdfa3a6d98c84"
 dependencies = [
  "build_const",
  "hex",
@@ -6220,16 +6152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/cli/tests/it/svm.rs
+++ b/cli/tests/it/svm.rs
@@ -11,7 +11,7 @@ use svm::{self, Platform};
 ///     2. svm updated with all build info
 ///     3. svm bumped in ethers-rs
 ///     4. ethers bumped in foundry + update the `LATEST_SOLC`
-const LATEST_SOLC: Version = Version::new(0, 8, 19);
+const LATEST_SOLC: Version = Version::new(0, 8, 20);
 
 macro_rules! ensure_svm_releases {
     ($($test:ident => $platform:ident),*) => {


### PR DESCRIPTION
## Motivation

svm-rs has been bumped, so we should update things accordingly.

## Solution

bump related packages & latest solc