### PR TITLE
debian dockerfile

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -48,7 +48,7 @@ COPY --from=build-environment /opt/foundry/out/forge /usr/local/bin/forge
 COPY --from=build-environment /opt/foundry/out/cast /usr/local/bin/cast
 COPY --from=build-environment /opt/foundry/out/anvil /usr/local/bin/anvil
 
-RUN adduser --uid 1000 --disabled-password --gecos '' foundry
+RUN adduser -Du 1000 foundry
 
 ENTRYPOINT ["/bin/sh", "-c"]
 

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -2,14 +2,16 @@
 # based on @dboreham's docker file (https://github.com/dboreham/foundry/blob/cerc-release/Dockerfile-debian)
 # discussion in https://github.com/foundry-rs/foundry/issues/2358
 
-ARG DEBIAN_VERSION=bullseye-20230502
 ARG TARGETARCH
+ARG DEBIAN_VERSION=bullseye-20230502
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 FROM debian:$DEBIAN_VERSION as build-environment
 
-WORKDIR /opt
-
 SHELL ["/bin/bash", "-c"]
+
+WORKDIR /opt
 
 RUN apt-get update \
     && apt-get install -y clang lld curl build-essential \
@@ -22,6 +24,7 @@ RUN apt-get update \
 RUN set -e; [[ "$TARGETARCH" = "arm64" || $(uname -m) = "aarch64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true
 
 WORKDIR /opt/foundry
+
 COPY . .
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
@@ -38,7 +41,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 
 FROM debian:$DEBIAN_VERSION-slim as foundry-client
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN apt-get update \
     && apt-get -y install --no-install-recommends git
 
 COPY --from=build-environment /opt/foundry/out/forge /usr/local/bin/forge

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.4
+# based on @dboreham's docker file (https://github.com/dboreham/foundry/blob/cerc-release/Dockerfile-debian)
+# discussion in https://github.com/foundry-rs/foundry/issues/2358
+FROM rust:1-bullseye as build-environment
+
+ARG TARGETARCH
+WORKDIR /opt
+
+SHELL ["/bin/bash", "-c"]
+
+# Works around an arm-specific rust bug, see: https://github.com/cross-rs/cross/issues/598
+RUN set -e; [[ "$TARGETARCH" = "arm64" || $(uname -m) = "aarch64" ]] && echo "export CFLAGS=-mno-outline-atomics" >> $HOME/.profile || true
+
+WORKDIR /opt/foundry
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/opt/foundry/target \
+    source $HOME/.profile && cargo build --release \
+    && mkdir out \
+    && mv target/release/forge out/forge \
+    && mv target/release/cast out/cast \
+    && mv target/release/anvil out/anvil \
+    && strip out/forge \
+    && strip out/cast \
+    && strip out/anvil;
+
+FROM debian:bullseye-20230502-slim as foundry-client
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends git
+
+COPY --from=build-environment /opt/foundry/out/forge /usr/local/bin/forge
+COPY --from=build-environment /opt/foundry/out/cast /usr/local/bin/cast
+COPY --from=build-environment /opt/foundry/out/anvil /usr/local/bin/anvil
+
+RUN adduser --uid 1000 --disabled-password --gecos '' foundry
+
+ENTRYPOINT ["/bin/sh", "-c"]
+
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Foundry" \
+      org.label-schema.description="Foundry" \
+      org.label-schema.url="https://getfoundry.sh" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/foundry-rs/foundry.git" \
+      org.label-schema.vendor="Foundry-rs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"


### PR DESCRIPTION
As someone who routinely switches languages and toolchains on a Mac M1, I rely on development docker images (primarily with VS Code devcontainers).

Alpine images in general do not play well with VS Code. Nor does the current (alpine) image work on an M1 chip.

This PR contains a Debian Dockerfile which solves both problems. Based on the discussion in issue #2358 , I have adapted [@dboreham's Dockerfile](https://github.com/dboreham/foundry/blob/cerc-release/Dockerfile-debian) to create this [multi-arch image](https://hub.docker.com/r/restlessronin/foundry).

closes #2358 