### PR TITLE
feat(`evm`): more built-in labels

### DIFF
--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -7,6 +7,7 @@ use crate::{
     decode,
     executor::inspector::DEFAULT_CREATE2_DEPLOYER,
     trace::{node::CallTraceNode, utils},
+    CALLER, TEST_CONTRACT_ADDRESS,
 };
 use ethers::{
     abi::{Abi, Address, Event, Function, Param, ParamType, Token},
@@ -136,6 +137,8 @@ impl CallTraceDecoder {
                 (CHEATCODE_ADDRESS, "VM".to_string()),
                 (HARDHAT_CONSOLE_ADDRESS, "console".to_string()),
                 (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
+                (CALLER, "DefaultSender".to_string()),
+                (TEST_CONTRACT_ADDRESS, "DefaultTestContract".to_string()),
             ]
             .into(),
 


### PR DESCRIPTION
Closes #916.

Adds a few more built in labels as requested in the issue. Keeping it simple and not adding #640 to this as we might wanna do that in a separate PR