### PR TITLE
fix(`config`): properly sanitize evm and solc version if both are set

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -561,16 +561,13 @@ impl Config {
 
     /// Sanitizes the EVM version and solc version combination used in the config if both are set.
     pub fn sanitize_evm_version(&mut self) -> Result<(), ExtractConfigError> {
-        if let Some(solc_req) = &self.solc {
-            match solc_req {
-                SolcReq::Version(version) => {
-                    // Users should not be able to both specify a solc version equal or higher to
-                    // 0.8.20 and an EVM version lower than Shanghai, as this
-                    // could introduce PUSH0 opcodes into the code that would be
-                    // considered invalid in a chain that does not support EIP 3855.
-                    if version >= &Version::new(0, 8, 20) && self.evm_version < EvmVersion::Shanghai
-                    {
-                        return Err(ExtractConfigError::new(
+        if let Some(SolcReq::Version(version)) = &self.solc {
+            // Users should not be able to both specify a solc version equal or higher to
+            // 0.8.20 and an EVM version lower than Shanghai, as this
+            // could introduce PUSH0 opcodes into the code that would be
+            // considered invalid in a chain that does not support EIP 3855.
+            if version >= &Version::new(0, 8, 20) && self.evm_version < EvmVersion::Shanghai {
+                return Err(ExtractConfigError::new(
                             format!(
                                 "Solc version {} requires EVM version {} or higher. You can fix this by specifying evm_version = \"shanghai\" in your config file.",
                                 version,
@@ -578,12 +575,8 @@ impl Config {
                             )
                             .into(),
                         ))
-                    }
-                }
-                _ => {}
             }
         }
-
         Ok(())
     }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -469,6 +469,7 @@ impl Config {
     pub fn try_from<T: Provider>(provider: T) -> Result<Self, ExtractConfigError> {
         let figment = Figment::from(provider);
         let mut config = figment.extract::<Self>().map_err(ExtractConfigError::new)?;
+        config.sanitize_evm_version()?;
         config.profile = figment.profile().clone();
         Ok(config)
     }
@@ -556,6 +557,34 @@ impl Config {
         config.libs.dedup();
 
         config
+    }
+
+    /// Sanitizes the EVM version and solc version combination used in the config if both are set.
+    pub fn sanitize_evm_version(&mut self) -> Result<(), ExtractConfigError> {
+        if let Some(solc_req) = &self.solc {
+            match solc_req {
+                SolcReq::Version(version) => {
+                    // Users should not be able to both specify a solc version equal or higher to
+                    // 0.8.20 and an EVM version lower than Shanghai, as this
+                    // could introduce PUSH0 opcodes into the code that would be
+                    // considered invalid in a chain that does not support EIP 3855.
+                    if version >= &Version::new(0, 8, 20) && self.evm_version < EvmVersion::Shanghai
+                    {
+                        return Err(ExtractConfigError::new(
+                            format!(
+                                "Solc version {} requires EVM version {} or higher. You can fix this by specifying evm_version = \"shanghai\" in your config file.",
+                                version,
+                                EvmVersion::Shanghai
+                            )
+                            .into(),
+                        ))
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
     }
 
     /// Cleans up any duplicate `Remapping` and sorts them
@@ -3448,6 +3477,38 @@ mod tests {
             assert_eq!(config.solc, Some(SolcReq::Version("0.6.6".parse().unwrap())));
             Ok(())
         });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sanitize_evm_version() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                solc_version = "0.8.12"
+            "#,
+            )?;
+
+            let config = Config::load();
+            assert_eq!(config.solc, Some(SolcReq::Version("0.8.12".parse().unwrap())));
+            assert_eq!(config.evm_version, EvmVersion::Paris); // OK, compatible solc/evm versions
+
+            // This should panic, as you should not be able to compile solidity with solc 0.8.20
+            // and use an EVM version lower than shanghai
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                solc_version = "0.8.20"
+                evm_version = "london"
+            "#,
+            )?;
+            let _ = Config::load();
+
+            Ok(())
+        })
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Closes #4954. Note that this does not handle the case when the solc version is autodetected—I think this might need a change in ethers-solc?

If both solc and evm version are set in the foundry config, we should ensure both are compatible. A solc/evm version combo is compatible when using an specific solc version won't introduce invalid opcodes that the EVM version can't handle. In the solc versions currently supported by forge, this only really happens with using `>=0.8.20` on evm versions less than Shanghai.*

* Technically, different evm chains also could have problems with newer specs, but handling this at a multi-chain level is another conversation in itself.

## Solution

Sanitize the EVM version / solc combo if both are set.