### PR TITLE
Revert "ci: Fix use of parameter in conditionals (#4984)"

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -61,13 +61,13 @@ jobs:
                   git config --global user.email "<>"
 
             - name: Apple M1 setup
-              if: matrix.job.target == 'aarch64-apple-darwin'
+              if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
               run: |
                   echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
                   echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
             - name: Linux ARM setup
-              if: matrix.job.target == 'aarch64-unknown-linux-gnu'
+              if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
               run: |
                   sudo apt-get update -y
                   sudo apt-get install -y gcc-aarch64-linux-gnu
@@ -75,7 +75,7 @@ jobs:
 
             # For some reason the FFI cheatcode uses WSL bash instead of Git bash, so we need to install a WSL distribution
             - name: Windows setup
-              if: matrix.job.target == 'x86_64-pc-windows-msvc'
+              if: ${{ matrix.job.target == 'x86_64-pc-windows-msvc' }}
               uses: Vampire/setup-wsl@v1
               with:
                 distribution: Ubuntu-20.04
@@ -195,7 +195,7 @@ jobs:
                   git config --global user.email "<>"
 
             - name: cargo nextest
-              if: matrix.job.target == 'aarch64-apple-darwin'
+              if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
               shell: bash
               run: |
                 # see https://github.com/foundry-rs/foundry/pull/3959
@@ -203,7 +203,7 @@ jobs:
                 cargo nextest run --retries 3 --archive-file ${{ matrix.job.target }}-${{ matrix.archive.file }} -E '${{ matrix.nextest.macos-aarch-filter }}'
 
             - name: cargo nextest
-              if: matrix.job.target != 'aarch64-apple-darwin'
+              if: ${{ matrix.job.target != 'aarch64-apple-darwin' }}
               shell: bash
               run: |
                 # see https://github.com/foundry-rs/foundry/pull/3959

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,10 +62,10 @@ jobs:
             - name: Finalize Docker Metadata
               id: docker_tagging
               run: |
-                  if [[ "${{ github.event_name }}" == "schedule" ]]; then
+                  if [[ "${{ github.event_name }}" == 'schedule' ]]; then
                     echo "cron trigger, assigning nightly tag"
                     echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}"
-                  elif [[ "${GITHUB_REF##*/}" == "main" || "${GITHUB_REF##*/}" == "master" ]]; then
+                  elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ ${GITHUB_REF##*/} == "master" ]]; then
                     echo "manual trigger from master/main branch, assigning latest tag"
                     echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
                   else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     workflow_dispatch:
 
 env:
-    IS_NIGHTLY: ${{ github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' ) }}
+    IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     CARGO_TERM_COLOR: always
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
             - name: Compute release name and tag
               id: release_info
               run: |
-                  if $IS_NIGHTLY; then
+                  if [[ $IS_NIGHTLY ]]; then
                     echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
                     echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
                   else
@@ -44,7 +44,7 @@ jobs:
             # which allows users to roll back. It is also used to build
             # the changelog.
             - name: Create build-specific nightly tag
-              if: env.IS_NIGHTLY == true
+              if: ${{ env.IS_NIGHTLY }}
               uses: actions/github-script@v5
               env:
                   TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
@@ -58,7 +58,7 @@ jobs:
               uses: mikepenz/release-changelog-builder-action@v2
               with:
                   configuration: "./.github/changelog.json"
-                  fromTag: ${{ env.IS_NIGHTLY == true && 'nightly' || '' }}
+                  fromTag: ${{ env.IS_NIGHTLY && 'nightly' || '' }}
                   toTag: ${{ steps.release_info.outputs.tag_name }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -122,13 +122,13 @@ jobs:
                   cache-on-failure: true
 
             - name: Apple M1 setup
-              if: matrix.job.target == 'aarch64-apple-darwin'
+              if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
               run: |
                   echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
                   echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
             - name: Linux ARM setup
-              if: matrix.job.target == 'aarch64-unknown-linux-gnu'
+              if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
               run: |
                   sudo apt-get update -y
                   sudo apt-get install -y gcc-aarch64-linux-gnu
@@ -148,7 +148,7 @@ jobs:
                   PLATFORM_NAME: ${{ matrix.job.platform }}
                   TARGET: ${{ matrix.job.target }}
                   ARCH: ${{ matrix.job.arch }}
-                  VERSION_NAME: ${{ (env.IS_NIGHTLY == true && 'nightly') || needs.prepare.outputs.tag_name }}
+                  VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
               run: |
                   if [ "$PLATFORM_NAME" == "linux" ]; then
                     tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast anvil chisel
@@ -168,11 +168,11 @@ jobs:
 
             - name: Build man page
               id: man
-              if: matrix.job.target == 'x86_64-unknown-linux-gnu'
+              if: ${{ matrix.job.target == 'x86_64-unknown-linux-gnu' }}
               env:
                   PLATFORM_NAME: ${{ matrix.job.platform }}
                   TARGET: ${{ matrix.job.target }}
-                  VERSION_NAME: ${{ (env.IS_NIGHTLY == true && 'nightly') || needs.prepare.outputs.tag_name }}
+                  VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
               run: |
                   sudo apt-get -y install help2man
                   help2man -N ./target/${TARGET}/release/forge > forge.1
@@ -202,7 +202,7 @@ jobs:
             # If this is a nightly release, it also updates the release
             # tagged `nightly` for compatibility with `foundryup`
             - name: Update nightly release
-              if: env.IS_NIGHTLY == true
+              if: ${{ env.IS_NIGHTLY }}
               uses: softprops/action-gh-release@v1
               with:
                   name: "Nightly"
@@ -224,7 +224,7 @@ jobs:
 
             # Moves the `nightly` tag to `HEAD`
             - name: Move nightly tag
-              if: env.IS_NIGHTLY == true
+              if: ${{ env.IS_NIGHTLY }}
               uses: actions/github-script@v5
               with:
                   script: |


### PR DESCRIPTION
This reverts commit 557f5d57695dcda123218192e82f478e44387443.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
@tolbrino I'm reverting this because this broke releases. 

the file names include the full sha tag when they should only be nightly
see https://github.com/foundry-rs/foundry/releases/tag/nightly-4f9369f876c70cefe53c9fea5919e078b50e29ae
vs https://github.com/foundry-rs/foundry/releases/tag/nightly-e15e33a07c0920189fc336391f538c3dad53da73 

also one of these is wrong
```
IS_NIGHTLY: ${{ github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && github.ref_type != 'tag' ) }}
if: env.IS_NIGHTLY == true
```

as mentioned my bash skills are kinda limited, hence the revert.
feel free to reopen and we'll test this before merging again.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
