### PR TITLE
Revert "feat(cheatcodes): Make `expectCall` only work for the next call's subcalls"

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -213,8 +213,6 @@ pub struct ExpectedCallData {
     pub count: u64,
     /// The type of call
     pub call_type: ExpectedCallType,
-    /// The depth at which this call must be checked
-    pub depth: u64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -291,7 +289,6 @@ fn expect_call(
     min_gas: Option<u64>,
     count: u64,
     call_type: ExpectedCallType,
-    depth: u64,
 ) -> Result {
     match call_type {
         ExpectedCallType::Count => {
@@ -303,10 +300,8 @@ fn expect_call(
                 !expecteds.contains_key(&calldata),
                 "Counted expected calls can only bet set once."
             );
-            expecteds.insert(
-                calldata,
-                (ExpectedCallData { value, gas, min_gas, count, call_type, depth }, 0),
-            );
+            expecteds
+                .insert(calldata, (ExpectedCallData { value, gas, min_gas, count, call_type }, 0));
             Ok(Bytes::new())
         }
         ExpectedCallType::NonCount => {
@@ -324,7 +319,7 @@ fn expect_call(
                 // If it does not exist, then create it.
                 expecteds.insert(
                     calldata,
-                    (ExpectedCallData { value, gas, min_gas, count, call_type, depth }, 0),
+                    (ExpectedCallData { value, gas, min_gas, count, call_type }, 0),
                 );
             }
             Ok(Bytes::new())
@@ -389,7 +384,6 @@ pub fn apply<DB: DatabaseExt>(
             None,
             1,
             ExpectedCallType::NonCount,
-            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall1(inner) => expect_call(
             state,
@@ -400,7 +394,6 @@ pub fn apply<DB: DatabaseExt>(
             None,
             inner.2,
             ExpectedCallType::Count,
-            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall2(inner) => expect_call(
             state,
@@ -411,7 +404,6 @@ pub fn apply<DB: DatabaseExt>(
             None,
             1,
             ExpectedCallType::NonCount,
-            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall3(inner) => expect_call(
             state,
@@ -422,7 +414,6 @@ pub fn apply<DB: DatabaseExt>(
             None,
             inner.3,
             ExpectedCallType::Count,
-            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall4(inner) => {
             let value = inner.1;
@@ -439,7 +430,6 @@ pub fn apply<DB: DatabaseExt>(
                 None,
                 1,
                 ExpectedCallType::NonCount,
-                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCall5(inner) => {
@@ -457,7 +447,6 @@ pub fn apply<DB: DatabaseExt>(
                 None,
                 inner.4,
                 ExpectedCallType::Count,
-                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCallMinGas0(inner) => {
@@ -475,7 +464,6 @@ pub fn apply<DB: DatabaseExt>(
                 Some(inner.2 + positive_value_cost_stipend),
                 1,
                 ExpectedCallType::NonCount,
-                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCallMinGas1(inner) => {
@@ -493,7 +481,6 @@ pub fn apply<DB: DatabaseExt>(
                 Some(inner.2 + positive_value_cost_stipend),
                 inner.4,
                 ExpectedCallType::Count,
-                data.journaled_state.depth(),
             )
         }
         HEVMCalls::MockCall0(inner) => {

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -591,10 +591,7 @@ where
                         // The gas matches, if provided
                         expected.gas.map_or(true, |gas| gas == call.gas_limit) &&
                         // The minimum gas matches, if provided
-                        expected.min_gas.map_or(true, |min_gas| min_gas <= call.gas_limit) &&
-                        // The expected depth is smaller than the actual depth,
-                        // which means we're in the subcalls of the call were we expect to find the matches.
-                        expected.depth < data.journaled_state.depth()
+                        expected.min_gas.map_or(true, |min_gas| min_gas <= call.gas_limit)
                     {
                         *actual_count += 1;
                     }
@@ -821,18 +818,14 @@ where
             }
         }
 
-        // Match expected calls
-        for (address, calldatas) in &self.expected_calls {
-            // Loop over each address, and for each address, loop over each calldata it expects.
-            for (calldata, (expected, actual_count)) in calldatas {
-                // Grab the values we expect to see
-                let ExpectedCallData { gas, min_gas, value, count, call_type, depth } = expected;
-                // Only check calls in the corresponding depth,
-                // or if the expected depth is higher than the current depth. This is correct, as
-                // the expected depth can only be bigger than the current depth if
-                // we're either terminating the root call (the test itself), or exiting the intended
-                // call that contained the calls we expected to see.
-                if depth >= &data.journaled_state.depth() {
+        // If the depth is 0, then this is the root call terminating
+        if data.journaled_state.depth() == 0 {
+            // Match expected calls
+            for (address, calldatas) in &self.expected_calls {
+                // Loop over each address, and for each address, loop over each calldata it expects.
+                for (calldata, (expected, actual_count)) in calldatas {
+                    // Grab the values we expect to see
+                    let ExpectedCallData { gas, min_gas, value, count, call_type } = expected;
                     let calldata = Bytes::from(calldata.clone());
 
                     // We must match differently depending on the type of call we expect.
@@ -891,10 +884,7 @@ where
                     }
                 }
             }
-        }
 
-        // If the depth is 0, then this is the root call terminating
-        if data.journaled_state.depth() == 0 {
             // Check if we have any leftover expected emits
             // First, if any emits were found at the root call, then we its ok and we remove them.
             self.expected_emits.retain(|expected| !expected.found);

--- a/testdata/fork/Transact.t.sol
+++ b/testdata/fork/Transact.t.sol
@@ -69,11 +69,7 @@ contract TransactOnForkTest is DSTest {
         uint256 expectedSenderBalance = senderBalance - transferAmount;
 
         // expect a call to USDT's transfer
-        // With the current expect call behavior, in which we expect calls to be matched in the next call's subcalls,
-        // expecting calls on vm.transact is impossible. This is because transact essentially creates another call context
-        // that operates independently of the current one, meaning that depths won't match and will trigger a panic on REVM,
-        // as the transact storage is not persisted as well and can't be checked.
-        // vm.expectCall(address(USDT), abi.encodeWithSelector(IERC20.transfer.selector, recipient, transferAmount));
+        vm.expectCall(address(USDT), abi.encodeWithSelector(IERC20.transfer.selector, recipient, transferAmount));
 
         // expect a Transfer event to be emitted
         vm.expectEmit(true, true, false, true, address(USDT));


### PR DESCRIPTION
Reverts foundry-rs/foundry#4986

this was blocked for 1.0 and should not have been merged yet.