### PR TITLE
test: use assert_eq for flaky test

### DIFF
--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -729,7 +729,7 @@ forgetest_async!(
             std::fs::read_to_string("broadcast/Broadcast.t.sol/31337/run-latest.json").unwrap();
         let run_log = re.replace_all(&run_log, "");
 
-        assert!(fixtures_log == run_log);
+        assert_eq!(fixtures_log, run_log);
 
         // Uncomment to recreate the sensitive log
         // std::fs::copy(
@@ -753,7 +753,7 @@ forgetest_async!(
             std::fs::read_to_string("cache/Broadcast.t.sol/31337/run-latest.json").unwrap();
         let run_log = re.replace_all(&run_log, "");
 
-        assert!(fixtures_log == run_log);
+        assert_eq!(fixtures_log, run_log);
     }
 );
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
this test is flaky on windows:

--- TRY 4 STDERR:        foundry-cli::it script::check_broadcast_log ---
thread 'script::check_broadcast_log' panicked at 'assertion failed: fixtures_log == run_log', 

using assert_eq should provide more context
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
