### PR TITLE
wip: forge script warns when calling eoa

### DIFF
--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -191,6 +191,17 @@ impl ScriptArgs {
                         println!("Gas limit was set in script to {:}", tx.gas.unwrap());
                     }
 
+                    if let Some(NameOrAddress::Address(to)) = tx.to {                        
+                        // when calling a known contract, we check if it has code deployed
+                        if address_to_abi.contains_key(&to) {
+                            let fork = runner.executor.backend().active_fork().unwrap();
+                            if !fork.is_contract(to) {
+                                let contract_name = address_to_abi.get(&to).unwrap().contract_name.clone();
+                                shell::println(Paint::yellow(format!("Contract {:} has no code deployed!", contract_name)))?;
+                            }
+                        }
+                    }
+
                     let tx = TransactionWithMetadata::new(
                         tx.into(),
                         transaction.rpc,


### PR DESCRIPTION
## Motivation

Deployment scripts [do not verify the existence of a contract before invoking its functions](https://github.com/ethereum/solidity/issues/4823). 
This can lead to challenges  in determining the success or failure of a deployment script, as every call to an call to an externally owned accounts (EOAs) return a success flag,

For example, the script below will not issue an error when getting deployed and decodes the `setNum` calls as if they were regular function calls.

 ```solidity
 contract C {
    function setNum(uint256 _num) public returns (uint256){
        num = _num;
    }
}
contract Deploy is Script {
    function run() external {
        C c = new C(); // contract is not deployed!
        vm.startBroadcast( );
        require(c.setNum(1) == 1, "setNum failed");
    }
}
```


## Solution

Issue a warning when calling a address [with available abi](https://github.com/foundry-rs/foundry/blob/a26edce5d2e1ad28d833328b22e857ecb7075e63/cli/src/cmd/forge/script/executor.rs#L115) and no code deployed.