### PR TITLE
fix(ci): remove ensure solc from chisel tests

### DIFF
--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -3,8 +3,7 @@ use std::path::Path;
 use chisel::session::ChiselSession;
 use ethers_solc::EvmVersion;
 use forge::executor::opts::EvmOpts;
-use foundry_config::{Config, SolcReq};
-use semver::Version;
+use foundry_config::Config;
 use serial_test::serial;
 
 #[test]
@@ -41,12 +40,11 @@ fn test_write_session() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         evm_opts: EvmOpts::default(),
         backend: None,
         traces: false,
@@ -74,12 +72,11 @@ fn test_write_session_with_name() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
@@ -100,12 +97,11 @@ fn test_clear_cache() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     ChiselSession::create_cache_dir().unwrap();
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|_| panic!("Failed to create ChiselSession!"));
@@ -128,12 +124,11 @@ fn test_list_sessions() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
@@ -157,12 +152,11 @@ fn test_load_cache() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
@@ -190,12 +184,11 @@ fn test_write_same_session_multiple_times() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
@@ -215,12 +208,11 @@ fn test_load_latest_cache() {
 
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
-    foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
     foundry_config.evm_version = EvmVersion::London;
 
     // Create sessions
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config: foundry_config.clone(),
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));
@@ -230,7 +222,7 @@ fn test_load_latest_cache() {
     std::thread::sleep(wait_time);
 
     let mut env2 = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config: Config::default(),
+        foundry_config,
         ..Default::default()
     })
     .unwrap_or_else(|e| panic!("Failed to create ChiselSession! {}", e));

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -1,22 +1,14 @@
 use std::path::Path;
 
 use chisel::session::ChiselSession;
-use ethers_solc::Solc;
 use forge::executor::opts::EvmOpts;
 use foundry_config::{Config, SolcReq};
-use semver::{Version, VersionReq};
+use semver::Version;
 use serial_test::serial;
-
-/// Needed for subsequent tests so we use a compatible solc version.
-/// If not, we'll use 0.8.13, which will cause CI failures.
-fn ensure_solc() {
-    Solc::ensure_installed(&VersionReq::parse("0.8.19").unwrap()).unwrap();
-}
 
 #[test]
 #[serial]
 fn test_cache_directory() {
-    ensure_solc();
     // Get the cache dir
     // Should be ~/.foundry/cache/chisel
     let cache_dir = ChiselSession::cache_dir().unwrap();
@@ -29,7 +21,6 @@ fn test_cache_directory() {
 #[test]
 #[serial]
 fn test_create_cache_directory() {
-    ensure_solc();
     // Get the cache dir
     let cache_dir = ChiselSession::cache_dir().unwrap();
 
@@ -43,7 +34,6 @@ fn test_create_cache_directory() {
 #[test]
 #[serial]
 fn test_write_session() {
-    ensure_solc();
     // Create the cache directory if it doesn't exist
     let cache_dir = ChiselSession::cache_dir().unwrap();
     ChiselSession::create_cache_dir().unwrap();
@@ -76,7 +66,6 @@ fn test_write_session() {
 #[test]
 #[serial]
 fn test_write_session_with_name() {
-    ensure_solc();
     // Create the cache directory if it doesn't exist
     let cache_dir = ChiselSession::cache_dir().unwrap();
     ChiselSession::create_cache_dir().unwrap();
@@ -103,7 +92,6 @@ fn test_write_session_with_name() {
 #[test]
 #[serial]
 fn test_clear_cache() {
-    ensure_solc();
     // Create a session to validate clearing a non-empty cache directory
     let cache_dir = ChiselSession::cache_dir().unwrap();
 
@@ -130,7 +118,6 @@ fn test_clear_cache() {
 #[test]
 #[serial]
 fn test_list_sessions() {
-    ensure_solc();
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
@@ -159,7 +146,6 @@ fn test_list_sessions() {
 #[test]
 #[serial]
 fn test_load_cache() {
-    ensure_solc();
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
@@ -192,7 +178,6 @@ fn test_load_cache() {
 #[test]
 #[serial]
 fn test_write_same_session_multiple_times() {
-    ensure_solc();
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();
@@ -217,7 +202,6 @@ fn test_write_same_session_multiple_times() {
 #[test]
 #[serial]
 fn test_load_latest_cache() {
-    ensure_solc();
     // Create and clear the cache directory
     ChiselSession::create_cache_dir().unwrap();
     ChiselSession::clear_cache().unwrap();

--- a/chisel/tests/cache.rs
+++ b/chisel/tests/cache.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use chisel::session::ChiselSession;
+use ethers_solc::EvmVersion;
 use forge::executor::opts::EvmOpts;
 use foundry_config::{Config, SolcReq};
 use semver::Version;
@@ -41,6 +42,7 @@ fn test_write_session() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -73,6 +75,7 @@ fn test_write_session_with_name() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -98,6 +101,7 @@ fn test_clear_cache() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     ChiselSession::create_cache_dir().unwrap();
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -125,6 +129,7 @@ fn test_list_sessions() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -153,6 +158,7 @@ fn test_load_cache() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -185,6 +191,7 @@ fn test_write_same_session_multiple_times() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create a new session
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {
@@ -209,6 +216,7 @@ fn test_load_latest_cache() {
     // Force the solc version to be 0.8.19
     let mut foundry_config = Config::default();
     foundry_config.solc = Some(SolcReq::Version(Version::new(0, 8, 19)));
+    foundry_config.evm_version = EvmVersion::London;
 
     // Create sessions
     let mut env = ChiselSession::new(chisel::session_source::SessionSourceConfig {


### PR DESCRIPTION
## Motivation

The last flaky parts of the CI have been these chisel CI tests—we were forcing a 0.8.19 install so they don't complain about the EVM version being too new (Paris). This seemed to cause a wreck on the CI fs and gave weird errors. So this tries the other way around—sets up foundry to use an older evm version (London) to let these tests use 0.8.13, which is what they default to.

## Solution

Removes the forced installation of 0.8.19 from the chisel tests and forces the chisel session to use London.