### PR TITLE
docs: update default "sender" and "tx_origin"

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -113,8 +113,9 @@ no_match_contract = "Bar"
 match_path = "*/Foo*"
 no_match_path = "*/Bar*"
 ffi = false
-sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
-tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+# These are the default callers, generated using `address(uint160(uint256(keccak256("foundry default caller"))))`
+sender = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
+tx_origin = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
 initial_balance = '0xffffffffffffffffffffffff'
 block_number = 0
 fork_block_number = 0


### PR DESCRIPTION
As shown by https://github.com/foundry-rs/foundry/issues/3661 and [this StackExchange Q&A](https://ethereum.stackexchange.com/q/147319/24693), Foundry users are confused about the default value that `msg.sender` has in the testing call contexts.

This PR aims to bring a little clarity to the README by:

- Displaying the actual default value that `sender` and `tx_origin` have now (the address removed by this PR is the historical sender used by DappTools, which is no longer used by Foundry)
- Explaining how the default value was chosen

I will confess that I was personally confused by this, too, although I have been using Foundry for >1 year now.