### PR TITLE
fix(chisel): include evm version on solc compiler input

### DIFF
--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -334,6 +334,9 @@ impl SessionSource {
             .filter(|remapping| !remapping.name.starts_with("forge-std"))
             .collect();
 
+        // We also need to enforce the EVM version that the user has specified.
+        compiler_input.settings.evm_version = Some(self.config.foundry_config.evm_version.clone());
+
         compiler_input
     }
 

--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -335,7 +335,7 @@ impl SessionSource {
             .collect();
 
         // We also need to enforce the EVM version that the user has specified.
-        compiler_input.settings.evm_version = Some(self.config.foundry_config.evm_version.clone());
+        compiler_input.settings.evm_version = Some(self.config.foundry_config.evm_version);
 
         compiler_input
     }

--- a/testdata/cheats/Cheats.sol
+++ b/testdata/cheats/Cheats.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.18;
+pragma solidity >=0.8.0;
 
 interface Cheats {
     // This allows us to getRecordedLogs()


### PR DESCRIPTION
## Motivation

Closes #5051. Chisel was not respecting the EVM version configured when compiling, as it was not included in the compiler input. 

## Solution

include the EVM version in the compiler input.

**A caveat:** I see some people wanting to use chisel with versions < 0.8, but this is not possible because we're using the `testdata` `Cheats.sol` for the cheatcodes, which is set to `>=0.8`. Maybe this is what we want and we should let people know that solidity versions lower than 0.8 are not accepted, or should we just use the same pragma that is on forge std (`>=0.6.2 <0.9.0`)?
