### PR TITLE
feat(cast): switch chain before sending tx if current chain is different

### DIFF
--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 use ethers::{
     prelude::MiddlewareBuilder, providers::Middleware, signers::Signer, types::NameOrAddress,
 };
+use foundry_common::cli_warn;
 use foundry_config::{Chain, Config};
 use std::str::FromStr;
 
@@ -115,8 +116,10 @@ impl SendTxArgs {
             if let Some(config_chain) = config.chain_id {
                 let current_chain_id = provider.get_chainid().await?.as_u64();
                 let config_chain_id = config_chain.id();
-                // switch chain if current chain id is not the same as the one specified in the config
+                // switch chain if current chain id is not the same as the one specified in the
+                // config
                 if config_chain_id != current_chain_id {
+                    cli_warn!("Switching to chain {}", config_chain);
                     provider
                         .request(
                             "wallet_switchEthereumChain",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
If user specifies a chain ID, with this change it will check if the current chain id returned by the RPC is the same as user provided chain id. If not will attempt to switch it with `wallet_switchEthereumChain`.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This change particularly allows me to use https://frame.sh/ to sign transactions using the unlocked signers on local node method. Ex: https://gist.github.com/0xdapper/7461f2b0f0100b6508938cfff4db2dad

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Switch the chain if necessary.