### PR TITLE
fix: dont use default etherscan identifier

### DIFF
--- a/evm/src/trace/identifier/etherscan.rs
+++ b/evm/src/trace/identifier/etherscan.rs
@@ -106,9 +106,7 @@ impl TraceIdentifier for EtherscanIdentifier {
     ) -> Vec<AddressIdentity> {
         trace!(target: "etherscanidentifier", "identify {} addresses", addresses.len());
 
-        let client = if let Some(client) = self.client.clone() {
-            client
-        } else {
+        let Some(client) = self.client.clone() else {
             // no client was configured
             return Vec::new()
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/5082

for some reason we were using default etherscan client if none was configured...

not sure if this is the root cause of the issue but this is definitely a bug.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
