### PR TITLE
chore(packages): bump ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "solang-parser",
+ "solang-parser 0.2.4",
  "strum",
  "time 0.3.21",
  "tokio",
@@ -1365,6 +1365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "der"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5486fdc149826f38c388f26a7df72534ee3f20d3a3f72539376fa7b3bbc43d"
+checksum = "9c3a2483be182a1deacc9b7daa727594c8977f4d6c6df2d762eac3280cfa67c5"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1753,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c66a426b824a0f6d1361ad74b6b01adfd26c44ee1e14c3662dcf28406763ec5"
+checksum = "b4a57fb532a6833eaa086a72049a5638a3baf593b2687e7ad726d983f793fb18"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1765,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa43e2e69632492d7b38e59465d125a0066cf4c477390ece00d3acbd11b338b"
+checksum = "80ef33619fb0732617a84e05a02da32a1b212239a4bdba3af5e57aa9caf55929"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1784,16 +1790,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edb8fdbf77459819a443234b461171a024476bfc12f1853b889a62c6e1185ff"
+checksum = "b284d9fb6f654f8a12f46e85d14f7f6f867f5bbb7de5780cdda45d39e75809c0"
 dependencies = [
  "Inflector",
  "dunce",
  "ethers-core",
  "ethers-etherscan",
  "eyre",
- "getrandom 0.2.9",
  "hex",
  "prettyplease",
  "proc-macro2",
@@ -1803,17 +1808,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.16",
- "tokio",
  "toml 0.7.3",
- "url",
  "walkdir",
 ]
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939b0c37746929f869285ee37d270b7c998d80cc7404c2e20dda8efe93e3b295"
+checksum = "542b65f2d45be9ae1676ba129baba60d76d440acb6e933e76b0b6dcada266415"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1827,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198ea9efa8480fa69f73d31d41b1601dace13d053c6fe4be6f5878d9dfcf0108"
+checksum = "949df06c5bdc23361f12f58af748e62839d579fd650ce734bff2ccaedec992a9"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1838,7 +1841,6 @@ dependencies = [
  "elliptic-curve",
  "ethabi",
  "generic-array",
- "getrandom 0.2.9",
  "hex",
  "k256",
  "num_enum",
@@ -1858,13 +1860,12 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196a21d6939ab78b7a1e4c45c2b33b0c2dd821a2e1af7c896f06721e1ba2a0c7"
+checksum = "f93971f8de6430ce591f6e8af3a6c0a64d3ee5cd2efa384ebc0d662ac6d9da10"
 dependencies = [
  "ethers-core",
  "ethers-solc",
- "getrandom 0.2.9",
  "reqwest",
  "semver",
  "serde",
@@ -1875,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75594cc450992fc7de701c9145de612325fd8a18be765b8ae78767ba2b74876f"
+checksum = "b47e5929cec99aa8cb4b93fd13d990d6d243ba389a803fbfd4806d69ad6d7980"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1902,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1009041f40476b972b5d79346cc512e97c662b1a0a2f78285eabe9a122909783"
+checksum = "e9a404215845d474defb3c0466ec3e695ce6122702158e87343f4308c026de81"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1916,7 +1917,6 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
- "getrandom 0.2.9",
  "hashers",
  "hex",
  "http",
@@ -1928,7 +1928,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.18.0",
+ "tokio-tungstenite 0.19.0",
  "tracing",
  "tracing-futures",
  "url",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd11ad6929f01f01be74bb00d02bbd6552f22de030865c898b340a3a592db1"
+checksum = "97d849cf868651243a26442af8a5b8a63cd4c85f4e8d5c5f72994a702abc3fd9"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1969,16 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2284784306de73d8ad1bc792ecc1b87da0268185683698d60fd096d23d168c99"
+checksum = "8aa3fd8abbcc84013d8199524d3b89bf123d7a48ed984b00b80c72ef1a47b691"
 dependencies = [
  "cfg-if",
  "dunce",
  "ethers-core",
  "fs_extra",
  "futures-util",
- "getrandom 0.2.9",
  "glob",
  "hex",
  "home",
@@ -1993,7 +1992,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "solang-parser",
+ "solang-parser 0.3.0",
  "svm-rs",
  "svm-rs-builds",
  "tempfile",
@@ -2218,7 +2217,7 @@ dependencies = [
  "mdbook",
  "once_cell",
  "rayon",
- "solang-parser",
+ "solang-parser 0.2.4",
  "thiserror",
  "tokio",
  "toml 0.7.3",
@@ -2236,7 +2235,7 @@ dependencies = [
  "itertools",
  "pretty_assertions",
  "semver",
- "solang-parser",
+ "solang-parser 0.2.4",
  "thiserror",
  "toml 0.7.3",
  "tracing",
@@ -2329,7 +2328,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "similar",
- "solang-parser",
+ "solang-parser 0.2.4",
  "strsim",
  "strum",
  "svm-rs",
@@ -4836,9 +4835,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "pulldown-cmark"
@@ -5110,7 +5123,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -5931,6 +5944,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solang-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a94494913728908efa7a25a2dd2e4f037e714897985c24273c40596638ed909"
+dependencies = [
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "phf 0.11.1",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6379,14 +6406,25 @@ checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
+ "tokio",
+ "tungstenite 0.18.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+dependencies = [
+ "futures-util",
+ "log",
  "native-tls",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
- "tungstenite 0.18.0",
- "webpki",
- "webpki-roots",
+ "tokio-rustls 0.24.0",
+ "tungstenite 0.19.0",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -6604,17 +6642,17 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.0.7"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3e4b569b95a8d24d10b2e8f60196348eb15023d50d2b38a4463e7f150afd27"
+checksum = "2cddb76a030b141d9639470eca2a236f3057a651bba78227cfa77830037a8286"
 dependencies = [
  "byteorder",
  "hex",
- "hidapi-rusb",
- "log",
  "primitive-types",
  "protobuf",
  "rusb",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -6699,9 +6737,28 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
  "native-tls",
  "rand 0.8.5",
- "rustls 0.20.8",
+ "rustls 0.21.1",
  "sha1",
  "thiserror",
  "url",
@@ -7103,6 +7160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,16 +60,16 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { version = "2.0.4", default-features = false }
-ethers-addressbook = { version = "2.0.4", default-features = false }
-ethers-core = { version = "2.0.4", default-features = false }
-ethers-contract = { version = "2.0.4", default-features = false }
-ethers-contract-abigen = { version = "2.0.4", default-features = false }
-ethers-providers = { version = "2.0.4", default-features = false }
-ethers-signers = { version = "2.0.4", default-features = false }
-ethers-middleware = { version = "2.0.4", default-features = false }
-ethers-etherscan = { version = "2.0.4", default-features = false }
-ethers-solc = { version = "2.0.4", default-features = false }
+ethers = { version = "2.0.6", default-features = false }
+ethers-addressbook = { version = "2.0.6", default-features = false }
+ethers-core = { version = "2.0.6", default-features = false }
+ethers-contract = { version = "2.0.6", default-features = false }
+ethers-contract-abigen = { version = "2.0.6", default-features = false }
+ethers-providers = { version = "2.0.6", default-features = false }
+ethers-signers = { version = "2.0.6", default-features = false }
+ethers-middleware = { version = "2.0.6", default-features = false }
+ethers-etherscan = { version = "2.0.6", default-features = false }
+ethers-solc = { version = "2.0.6", default-features = false }
 
 #[patch.crates-io]
 # ethers = { path = "../ethers-rs/ethers" }


### PR DESCRIPTION
Ethers 2.0.6 was recently released, and contains a few useful bugfixes, especially regarding verification.