### PR TITLE
fix(forge): `test` result/error handling

### DIFF
--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -282,8 +282,7 @@ impl CoverageArgs {
         // Run tests
         let known_contracts = runner.known_contracts.clone();
         let (tx, rx) = channel::<(String, SuiteResult)>();
-        let handle =
-            thread::spawn(move || runner.test(&self.filter, Some(tx), Default::default()).unwrap());
+        let handle = thread::spawn(move || runner.test(&self.filter, Some(tx), Default::default()));
 
         // Add hit data to the coverage report
         for (artifact_id, hits) in rx

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -1,8 +1,7 @@
 use super::*;
-use cast::executor::ExecutionErr;
 use ethers::types::{Address, Bytes, NameOrAddress, U256};
 use forge::{
-    executor::{CallResult, DeployResult, EvmError, Executor, RawCallResult},
+    executor::{CallResult, DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
     revm::interpreter::{return_ok, InstructionResult},
     trace::{TraceKind, Traces},
     CALLER,
@@ -227,7 +226,7 @@ impl ScriptRunner {
 
                     (Address::zero(), gas_used, logs, traces, debug)
                 }
-                e => eyre::bail!("Unrecoverable error: {:?}", e),
+                Err(e) => eyre::bail!("Failed deploying contract: {e:?}"),
             };
 
             Ok(ScriptResult {

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -187,7 +187,7 @@ impl TestArgs {
             match runner.count_filtered_tests(&filter) {
                 1 => {
                     // Run the test
-                    let results = runner.test(&filter, None, test_options)?;
+                    let results = runner.test(&filter, None, test_options);
 
                     // Get the result of the single test
                     let (id, sig, test_kind, counterexample, breakpoints) = results.iter().map(|(id, SuiteResult{ test_results, .. })| {
@@ -510,7 +510,7 @@ fn test(
     }
 
     if json {
-        let results = runner.test(&filter, None, test_options)?;
+        let results = runner.test(&filter, None, test_options);
         println!("{}", serde_json::to_string(&results)?);
         Ok(TestOutcome::new(results, allow_failure))
     } else {
@@ -524,7 +524,7 @@ fn test(
         let (tx, rx) = channel::<(String, SuiteResult)>();
 
         // Run tests
-        let handle = thread::spawn(move || runner.test(&filter, Some(tx), test_options).unwrap());
+        let handle = thread::spawn(move || runner.test(&filter, Some(tx), test_options));
 
         let mut results: BTreeMap<String, SuiteResult> = BTreeMap::new();
         let mut gas_report = GasReport::new(config.gas_reports, config.gas_reports_ignore);

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -67,7 +67,7 @@ impl<'a> TestFunctionExt for &'a str {
     }
 
     fn is_setup(&self) -> bool {
-        self.to_lowercase() == "setup"
+        self.eq_ignore_ascii_case("setup")
     }
 }
 

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -82,7 +82,7 @@ impl<'a> InvariantExecutor<'a> {
     pub fn invariant_fuzz(
         &mut self,
         invariant_contract: InvariantContract,
-    ) -> eyre::Result<Option<InvariantFuzzTestResult>> {
+    ) -> eyre::Result<InvariantFuzzTestResult> {
         let (fuzz_state, targeted_contracts, strat) = self.prepare_fuzzing(&invariant_contract)?;
 
         // Stores the consumed gas and calldata of every successful fuzz call.
@@ -149,7 +149,7 @@ impl<'a> InvariantExecutor<'a> {
 
                     // Collect data for fuzzing from the state changeset.
                     let mut state_changeset =
-                        call_result.state_changeset.to_owned().expect("to have a state changeset.");
+                        call_result.state_changeset.to_owned().expect("no changesets");
 
                     collect_data(
                         &mut state_changeset,
@@ -223,12 +223,12 @@ impl<'a> InvariantExecutor<'a> {
 
         let (reverts, invariants) = failures.into_inner().into_inner();
 
-        Ok(Some(InvariantFuzzTestResult {
+        Ok(InvariantFuzzTestResult {
             invariants,
             cases: fuzz_cases.into_inner(),
             reverts,
             last_call_results: last_call_results.take(),
-        }))
+        })
     }
 
     /// Prepares certain structures to execute the invariant tests:

--- a/evm/src/fuzz/mod.rs
+++ b/evm/src/fuzz/mod.rs
@@ -63,7 +63,7 @@ impl<'a> FuzzedExecutor<'a> {
         address: Address,
         should_fail: bool,
         errors: Option<&Abi>,
-    ) -> Result<FuzzTestResult> {
+    ) -> FuzzTestResult {
         // Stores the first Fuzzcase
         let first_case: RefCell<Option<FuzzCase>> = RefCell::default();
 
@@ -160,14 +160,12 @@ impl<'a> FuzzedExecutor<'a> {
                 // case to find a minimal failure case.
                 *counterexample.borrow_mut() = (calldata, call);
                 Err(TestCaseError::fail(
-                    match decode::decode_revert(
+                    decode::decode_revert(
                         counterexample.borrow().1.result.as_ref(),
                         errors,
                         Some(status),
-                    ) {
-                        Ok(e) => e,
-                        Err(_) => "".to_string(),
-                    },
+                    )
+                    .unwrap_or_default(),
                 ))
             }
         });
@@ -202,10 +200,7 @@ impl<'a> FuzzedExecutor<'a> {
                 let reason = reason.to_string();
                 result.reason = if reason.is_empty() { None } else { Some(reason) };
 
-                let args = func
-                    .decode_input(&calldata.as_ref()[4..])
-                    .map_err(|_| FuzzError::FailedDecodeInput)?;
-
+                let args = func.decode_input(&calldata.as_ref()[4..]).unwrap_or_default();
                 result.counterexample = Some(CounterExample::Single(BaseCounterExample {
                     sender: None,
                     addr: None,
@@ -216,10 +211,10 @@ impl<'a> FuzzedExecutor<'a> {
                     args,
                 }));
             }
-            _ => (),
+            _ => {}
         }
 
-        Ok(result)
+        result
     }
 }
 

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,12 +1,13 @@
-use std::path::Path;
-
 use ethers::solc::ProjectCompileOutput;
 use foundry_config::{
     validate_profiles, Config, FuzzConfig, InlineConfig, InlineConfigError, InlineConfigParser,
     InvariantConfig, NatSpec,
 };
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
-use tracing::trace;
+use std::path::Path;
+
+#[macro_use]
+extern crate tracing;
 
 /// Gas reports
 pub mod gas_report;

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -120,21 +120,20 @@ impl MultiContractRunner {
         filter: &impl TestFilter,
         stream_result: Option<Sender<(String, SuiteResult)>>,
         test_options: TestOptions,
-    ) -> Result<BTreeMap<String, SuiteResult>> {
-        tracing::trace!("start all tests");
+    ) -> BTreeMap<String, SuiteResult> {
+        tracing::trace!("running all tests");
 
         // the db backend that serves all the data, each contract gets its own instance
         let db = Backend::spawn(self.fork.take());
 
-        let results = self
-            .contracts
+        self.contracts
             .par_iter()
             .filter(|(id, _)| {
                 filter.matches_path(id.source.to_string_lossy()) &&
                     filter.matches_contract(&id.name)
             })
             .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
-            .map(|(id, (abi, deploy_code, libs))| {
+            .map_with(stream_result, |stream_result, (id, (abi, deploy_code, libs))| {
                 let executor = ExecutorBuilder::default()
                     .with_cheatcodes(self.cheats_config.clone())
                     .with_config(self.env.clone())
@@ -152,29 +151,23 @@ impl MultiContractRunner {
                     executor,
                     deploy_code.clone(),
                     libs,
-                    (filter, test_options.clone()),
-                )?;
-
+                    filter,
+                    test_options.clone(),
+                );
                 tracing::trace!(contract= ?identifier, "executed all tests in contract");
-                Ok((identifier, result))
-            })
-            .filter_map(Result::<_>::ok)
-            .filter(|(_, results)| !results.is_empty())
-            .map_with(stream_result, |stream_result, (name, result)| {
-                if let Some(stream_result) = stream_result.as_ref() {
-                    let _ = stream_result.send((name.clone(), result.clone()));
-                }
-                (name, result)
-            })
-            .collect::<BTreeMap<_, _>>();
 
-        Ok(results)
+                if let Some(stream_result) = stream_result {
+                    let _ = stream_result.send((identifier.clone(), result.clone()));
+                }
+
+                (identifier, result)
+            })
+            .collect()
     }
 
     #[tracing::instrument(
         name = "contract",
         skip_all,
-        err,
         fields(name = %name)
     )]
     fn run_tests(
@@ -184,8 +177,9 @@ impl MultiContractRunner {
         executor: Executor,
         deploy_code: Bytes,
         libs: &[Bytes],
-        (filter, test_options): (&impl TestFilter, TestOptions),
-    ) -> Result<SuiteResult> {
+        filter: &impl TestFilter,
+        test_options: TestOptions,
+    ) -> SuiteResult {
         let runner = ContractRunner::new(
             name,
             executor,

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -121,7 +121,7 @@ impl MultiContractRunner {
         stream_result: Option<Sender<(String, SuiteResult)>>,
         test_options: TestOptions,
     ) -> BTreeMap<String, SuiteResult> {
-        tracing::trace!("running all tests");
+        trace!("running all tests");
 
         // the db backend that serves all the data, each contract gets its own instance
         let db = Backend::spawn(self.fork.take());
@@ -143,7 +143,7 @@ impl MultiContractRunner {
                     .set_coverage(self.coverage)
                     .build(db.clone());
                 let identifier = id.identifier();
-                tracing::trace!(contract= ?identifier, "start executing all tests in contract");
+                trace!(contract= ?identifier, "start executing all tests in contract");
 
                 let result = self.run_tests(
                     &identifier,
@@ -154,7 +154,7 @@ impl MultiContractRunner {
                     filter,
                     test_options.clone(),
                 );
-                tracing::trace!(contract= ?identifier, "executed all tests in contract");
+                trace!(contract= ?identifier, "executed all tests in contract");
 
                 if let Some(stream_result) = stream_result {
                     let _ = stream_result.send((identifier.clone(), result.clone()));
@@ -165,11 +165,7 @@ impl MultiContractRunner {
             .collect()
     }
 
-    #[tracing::instrument(
-        name = "contract",
-        skip_all,
-        fields(name = %name)
-    )]
+    #[instrument(skip_all, fields(name = %name))]
     fn run_tests(
         &self,
         name: &str,

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -166,6 +166,7 @@ impl MultiContractRunner {
     }
 
     #[instrument(skip_all, fields(name = %name))]
+    #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
         name: &str,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -2,7 +2,6 @@ use crate::{
     result::{SuiteResult, TestKind, TestResult, TestSetup},
     TestFilter, TestOptions,
 };
-use error;
 use ethers::{
     abi::{Abi, Function},
     types::{Address, Bytes, U256},

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -6,7 +6,7 @@ use ethers::{
     abi::{Abi, Function},
     types::{Address, Bytes, U256},
 };
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     TestFunctionExt,
@@ -14,7 +14,7 @@ use foundry_common::{
 use foundry_config::{FuzzConfig, InvariantConfig};
 use foundry_evm::{
     decode::decode_console_logs,
-    executor::{CallResult, DeployResult, EvmError, ExecutionErr, Executor},
+    executor::{CallResult, EvmError, ExecutionErr, Executor},
     fuzz::{
         invariant::{
             InvariantContract, InvariantExecutor, InvariantFuzzError, InvariantFuzzTestResult,
@@ -25,7 +25,7 @@ use foundry_evm::{
     CALLER,
 };
 use proptest::test_runner::{TestError, TestRunner};
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::prelude::*;
 use std::{
     collections::{BTreeMap, HashMap},
     time::Instant,
@@ -81,7 +81,14 @@ impl<'a> ContractRunner<'a> {
 impl<'a> ContractRunner<'a> {
     /// Deploys the test contract inside the runner from the sending account, and optionally runs
     /// the `setUp` function on the test contract.
-    pub fn setup(&mut self, setup: bool) -> Result<TestSetup> {
+    pub fn setup(&mut self, setup: bool) -> TestSetup {
+        match self._setup(setup) {
+            Ok(setup) => setup,
+            Err(err) => TestSetup::failed(err.to_string()),
+        }
+    }
+
+    fn _setup(&mut self, setup: bool) -> Result<TestSetup> {
         trace!(?setup, "Setting test contract");
 
         // We max out their balance so that they can deploy and make calls.
@@ -92,58 +99,36 @@ impl<'a> ContractRunner<'a> {
         self.executor.set_nonce(self.sender, 1)?;
 
         // Deploy libraries
+        let mut logs = Vec::new();
         let mut traces = Vec::with_capacity(self.predeploy_libs.len());
         for code in self.predeploy_libs.iter() {
             match self.executor.deploy(self.sender, code.0.clone(), 0u32.into(), self.errors) {
-                Ok(DeployResult { traces: tmp_traces, .. }) => {
-                    if let Some(tmp_traces) = tmp_traces {
-                        traces.push((TraceKind::Deployment, tmp_traces));
-                    }
+                Ok(d) => {
+                    logs.extend(d.logs);
+                    traces.extend(d.traces.map(|traces| (TraceKind::Deployment, traces)));
                 }
-                Err(EvmError::Execution(err)) => {
-                    let ExecutionErr { reason, traces, logs, labels, .. } = *err;
-                    // If we failed to call the constructor, force the tracekind to be setup so
-                    // a trace is shown.
-                    let traces =
-                        traces.map(|traces| vec![(TraceKind::Setup, traces)]).unwrap_or_default();
-
-                    return Ok(TestSetup {
-                        address: Address::zero(),
-                        logs,
-                        traces,
-                        labeled_addresses: labels,
-                        setup_failed: true,
-                        reason: Some(reason),
-                    })
+                Err(e) => {
+                    return Ok(TestSetup::from_evm_error_with(e, logs, traces, Default::default()))
                 }
-                e => eyre::bail!("Unrecoverable error: {:?}", e),
             }
         }
 
-        // Deploy an instance of the contract
-        let DeployResult { address, mut logs, traces: constructor_traces, .. } = match self
-            .executor
-            .deploy(self.sender, self.code.0.clone(), 0u32.into(), self.errors)
-        {
-            Ok(d) => d,
-            Err(EvmError::Execution(err)) => {
-                let ExecutionErr { reason, traces, logs, labels, .. } = *err;
-                let traces =
-                    traces.map(|traces| vec![(TraceKind::Setup, traces)]).unwrap_or_default();
-
-                return Ok(TestSetup {
-                    address: Address::zero(),
-                    logs,
-                    traces,
-                    labeled_addresses: labels,
-                    setup_failed: true,
-                    reason: Some(reason),
-                })
+        // Deploy the test contract
+        let address = match self.executor.deploy(
+            self.sender,
+            self.code.0.clone(),
+            0u32.into(),
+            self.errors,
+        ) {
+            Ok(d) => {
+                logs.extend(d.logs);
+                traces.extend(d.traces.map(|traces| (TraceKind::Deployment, traces)));
+                d.address
             }
-            e => eyre::bail!("Unrecoverable error: {:?}", e),
+            Err(e) => {
+                return Ok(TestSetup::from_evm_error_with(e, logs, traces, Default::default()))
+            }
         };
-
-        traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
 
         // Now we set the contracts initial balance, and we also reset `self.sender`s and `CALLER`s
         // balance to the initial balance we want
@@ -156,34 +141,28 @@ impl<'a> ContractRunner<'a> {
         // Optionally call the `setUp` function
         let setup = if setup {
             trace!("setting up");
-            let (setup_failed, setup_logs, setup_traces, labeled_addresses, reason) =
+            let (setup_logs, setup_traces, labeled_addresses, reason) =
                 match self.executor.setup(None, address) {
                     Ok(CallResult { traces, labels, logs, .. }) => {
-                        trace!(contract=?address, "successfully setUp test");
-                        (false, logs, traces, labels, None)
+                        trace!(contract = ?address, "successfully setUp test");
+                        (logs, traces, labels, None)
                     }
                     Err(EvmError::Execution(err)) => {
                         let ExecutionErr { traces, labels, logs, reason, .. } = *err;
-                        error!(reason=?reason, contract= ?address, "setUp failed");
-                        (true, logs, traces, labels, Some(format!("Setup failed: {reason}")))
+                        error!(reason = ?reason, contract = ?address, "setUp failed");
+                        (logs, traces, labels, Some(format!("Setup failed: {reason}")))
                     }
                     Err(err) => {
                         error!(reason=?err, contract= ?address, "setUp failed");
-                        (
-                            true,
-                            Vec::new(),
-                            None,
-                            BTreeMap::new(),
-                            Some(format!("Setup failed: {}", &err.to_string())),
-                        )
+                        (Vec::new(), None, BTreeMap::new(), Some(format!("Setup failed: {err}")))
                     }
                 };
-            traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)).into_iter());
+            traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
             logs.extend(setup_logs);
 
-            TestSetup { address, logs, traces, labeled_addresses, setup_failed, reason }
+            TestSetup { address, logs, traces, labeled_addresses, reason }
         } else {
-            TestSetup { address, logs, traces, ..Default::default() }
+            TestSetup::success(address, logs, traces, Default::default())
         };
 
         Ok(setup)
@@ -195,7 +174,7 @@ impl<'a> ContractRunner<'a> {
         filter: &impl TestFilter,
         test_options: TestOptions,
         known_contracts: Option<&ContractsByArtifact>,
-    ) -> Result<SuiteResult> {
+    ) -> SuiteResult {
         tracing::info!("starting tests");
         let start = Instant::now();
         let mut warnings = Vec::new();
@@ -217,30 +196,19 @@ impl<'a> ContractRunner<'a> {
 
         // There are multiple setUp function, so we return a single test result for `setUp`
         if setup_fns.len() > 1 {
-            return Ok(SuiteResult::new(
+            return SuiteResult::new(
                 start.elapsed(),
                 [(
                     "setUp()".to_string(),
-                    TestResult {
-                        success: false,
-                        reason: Some("Multiple setUp functions".to_string()),
-                        counterexample: None,
-                        logs: vec![],
-                        decoded_logs: vec![],
-                        kind: TestKind::Standard(0),
-                        traces: vec![],
-                        coverage: None,
-                        labeled_addresses: BTreeMap::new(),
-                        // TODO-f: get the breakpoints here
-                        breakpoints: Default::default(),
-                    },
+                    // TODO-f: get the breakpoints here
+                    TestResult::fail("Multiple setUp functions".to_string()),
                 )]
                 .into(),
                 warnings,
-            ))
+            )
         }
 
-        let has_invariants = self.contract.functions().any(|func| func.name.is_invariant_test());
+        let has_invariants = self.contract.functions().any(|func| func.is_invariant_test());
 
         // Invariant testing requires tracing to figure out what contracts were created.
         let original_tracing = self.executor.inspector_config().tracing;
@@ -248,12 +216,12 @@ impl<'a> ContractRunner<'a> {
             self.executor.set_tracing(true);
         }
 
-        let setup = self.setup(needs_setup)?;
+        let setup = self.setup(needs_setup);
         self.executor.set_tracing(original_tracing);
 
-        if setup.setup_failed {
+        if setup.reason.is_some() {
             // The setup failed, so we return a single test result for `setUp`
-            return Ok(SuiteResult::new(
+            return SuiteResult::new(
                 start.elapsed(),
                 [(
                     "setUp()".to_string(),
@@ -272,84 +240,51 @@ impl<'a> ContractRunner<'a> {
                 )]
                 .into(),
                 warnings,
-            ))
+            )
         }
 
-        // Collect valid test functions
-        let tests: Vec<_> = self
+        let mut test_results = self
             .contract
-            .functions()
-            .filter(|func| func.is_test() && filter.matches_test(func.signature()))
-            .map(|func| (func, func.is_test_fail()))
-            .collect();
-
-        let mut test_results = BTreeMap::new();
-        if !tests.is_empty() {
-            test_results.extend(
-                tests
-                    .par_iter()
-                    .flat_map(|(func, should_fail)| {
-                        if func.is_fuzz_test() {
-                            let fn_name = &func.name;
-                            let runner = test_options.fuzz_runner(self.name, fn_name);
-                            let fuzz_config = test_options.fuzz_config(self.name, fn_name);
-
-                            self.run_fuzz_test(
-                                func,
-                                *should_fail,
-                                runner,
-                                setup.clone(),
-                                *fuzz_config,
-                            )
-                        } else {
-                            self.clone().run_test(func, *should_fail, setup.clone())
-                        }
-                        .map(|result| Ok((func.signature(), result)))
-                    })
-                    .collect::<Result<BTreeMap<_, _>>>()?,
-            );
-        }
+            .functions
+            .par_iter()
+            .flat_map(|(_, f)| f)
+            .filter(|&func| func.is_test() && filter.matches_test(func.signature()))
+            .map(|func| {
+                let should_fail = func.is_test_fail();
+                let res = if func.is_fuzz_test() {
+                    let runner = test_options.fuzz_runner(self.name, &func.name);
+                    let fuzz_config = test_options.fuzz_config(self.name, &func.name);
+                    self.run_fuzz_test(func, should_fail, runner, setup.clone(), *fuzz_config)
+                } else {
+                    self.clone().run_test(func, should_fail, setup.clone())
+                };
+                (func.signature(), res)
+            })
+            .collect::<BTreeMap<_, _>>();
 
         if has_invariants {
             let identified_contracts = load_contracts(setup.traces.clone(), known_contracts);
 
-            let functions: Vec<&Function> = self
+            // TODO: par_iter ?
+            let functions = self
                 .contract
                 .functions()
-                .filter(|func| {
-                    func.name.is_invariant_test() && filter.matches_test(func.signature())
-                })
-                .collect();
-
-            let mut results: Vec<TestResult> = vec![];
-
-            for func in functions.iter() {
-                let fn_name = &func.name;
-                let runner = test_options.invariant_runner(self.name, fn_name);
-                let invariant_config = test_options.invariant_config(self.name, fn_name);
-
-                let invariant_results = self.run_invariant_test(
+                .filter(|&func| func.is_invariant_test() && filter.matches_test(func.signature()));
+            for func in functions {
+                let runner = test_options.invariant_runner(self.name, &func.name);
+                let invariant_config = test_options.invariant_config(self.name, &func.name);
+                let results = self.run_invariant_test(
                     runner,
                     setup.clone(),
                     *invariant_config,
                     vec![func],
                     known_contracts,
                     identified_contracts.clone(),
-                )?;
-
-                for test_result in invariant_results {
-                    results.push(test_result);
+                );
+                for result in results {
+                    test_results.insert(func.signature(), result);
                 }
             }
-
-            results.into_iter().zip(functions.iter()).for_each(|(result, function)| {
-                match result.kind {
-                    TestKind::Invariant { .. } => {
-                        test_results.insert(function.signature(), result);
-                    }
-                    _ => unreachable!(),
-                }
-            });
         }
 
         let duration = start.elapsed();
@@ -363,7 +298,7 @@ impl<'a> ContractRunner<'a> {
             );
         }
 
-        Ok(SuiteResult::new(duration, test_results, warnings))
+        SuiteResult::new(duration, test_results, warnings)
     }
 
     /// Runs a single test
@@ -373,33 +308,15 @@ impl<'a> ContractRunner<'a> {
     /// State modifications are not committed to the evm database but discarded after the call,
     /// similar to `eth_call`.
     #[tracing::instrument(name = "test", skip_all, fields(name = %func.signature(), %should_fail))]
-    pub fn run_test(
-        mut self,
-        func: &Function,
-        should_fail: bool,
-        setup: TestSetup,
-    ) -> Result<TestResult> {
+    pub fn run_test(mut self, func: &Function, should_fail: bool, setup: TestSetup) -> TestResult {
         let TestSetup { address, mut logs, mut traces, mut labeled_addresses, .. } = setup;
 
         // Run unit test
         let start = Instant::now();
-        let (
-            reverted,
-            reason,
-            gas,
-            stipend,
-            execution_traces,
-            coverage,
-            state_changeset,
-            breakpoints,
-        ) = match self.executor.execute_test::<(), _, _>(
-            self.sender,
-            address,
-            func.clone(),
-            (),
-            0.into(),
-            self.errors,
-        ) {
+        let (reverted, reason, gas, stipend, coverage, state_changeset, breakpoints) = match self
+            .executor
+            .execute_test::<(), _, _>(self.sender, address, func.clone(), (), 0.into(), self.errors)
+        {
             Ok(CallResult {
                 reverted,
                 gas_used: gas,
@@ -412,50 +329,37 @@ impl<'a> ContractRunner<'a> {
                 breakpoints,
                 ..
             }) => {
+                traces.extend(execution_trace.map(|traces| (TraceKind::Execution, traces)));
                 labeled_addresses.extend(new_labels);
                 logs.extend(execution_logs);
-                (
-                    reverted,
-                    None,
-                    gas,
-                    stipend,
-                    execution_trace,
-                    coverage,
-                    state_changeset,
-                    breakpoints,
-                )
+                (reverted, None, gas, stipend, coverage, state_changeset, breakpoints)
             }
             Err(EvmError::Execution(err)) => {
-                let ExecutionErr {
-                    reverted,
-                    reason,
-                    gas_used: gas,
-                    stipend,
-                    logs: execution_logs,
-                    traces: execution_trace,
-                    labels: new_labels,
-                    state_changeset,
-                    ..
-                } = *err;
-                labeled_addresses.extend(new_labels);
-                logs.extend(execution_logs);
+                traces.extend(err.traces.map(|traces| (TraceKind::Execution, traces)));
+                labeled_addresses.extend(err.labels);
+                logs.extend(err.logs);
                 (
-                    reverted,
-                    Some(reason),
-                    gas,
-                    stipend,
-                    execution_trace,
+                    err.reverted,
+                    Some(err.reason),
+                    err.gas_used,
+                    err.stipend,
                     None,
-                    state_changeset,
+                    err.state_changeset,
                     HashMap::new(),
                 )
             }
             Err(err) => {
-                error!(?err);
-                return Err(err.into())
+                return TestResult {
+                    success: false,
+                    reason: Some(err.to_string()),
+                    decoded_logs: decode_console_logs(&logs),
+                    traces,
+                    labeled_addresses,
+                    kind: TestKind::Standard(0),
+                    ..Default::default()
+                }
             }
         };
-        traces.extend(execution_traces.map(|traces| (TraceKind::Execution, traces)).into_iter());
 
         let success = self.executor.is_success(
             setup.address,
@@ -471,7 +375,7 @@ impl<'a> ContractRunner<'a> {
             %gas
         );
 
-        Ok(TestResult {
+        TestResult {
             success,
             reason,
             counterexample: None,
@@ -482,7 +386,7 @@ impl<'a> ContractRunner<'a> {
             coverage,
             labeled_addresses,
             breakpoints,
-        })
+        }
     }
 
     #[tracing::instrument(name = "invariant-test", skip_all)]
@@ -494,7 +398,7 @@ impl<'a> ContractRunner<'a> {
         functions: Vec<&Function>,
         known_contracts: Option<&ContractsByArtifact>,
         identified_contracts: ContractsByAddress,
-    ) -> Result<Vec<TestResult>> {
+    ) -> Vec<TestResult> {
         trace!(target: "forge::test::fuzz", "executing invariant test with invariant functions {:?}",  functions.iter().map(|f|&f.name).collect::<Vec<_>>());
         let empty = ContractsByArtifact::default();
         let project_contracts = known_contracts.unwrap_or(&empty);
@@ -511,81 +415,78 @@ impl<'a> ContractRunner<'a> {
         let invariant_contract =
             InvariantContract { address, invariant_functions: functions, abi: self.contract };
 
-        if let Some(InvariantFuzzTestResult { invariants, cases, reverts, mut last_call_results }) =
-            evm.invariant_fuzz(invariant_contract)?
-        {
-            let results = invariants
-                .into_iter()
-                .map(|(func_name, test_error)| {
-                    let mut counterexample = None;
-                    let mut logs = logs.clone();
-                    let mut traces = traces.clone();
+        let Ok(InvariantFuzzTestResult { invariants, cases, reverts, mut last_call_results }) =
+            evm.invariant_fuzz(invariant_contract) else { return vec![] };
 
-                    let success = test_error.is_none();
-                    let reason = test_error.as_ref().and_then(|err| {
-                        (!err.revert_reason.is_empty()).then(|| err.revert_reason.clone())
-                    });
+        invariants
+            .into_iter()
+            .map(|(func_name, test_error)| {
+                let mut counterexample = None;
+                let mut logs = logs.clone();
+                let mut traces = traces.clone();
 
-                    match test_error {
-                        // If invariants were broken, replay the error to collect logs and traces
-                        Some(
-                            error @ InvariantFuzzError { test_error: TestError::Fail(_, _), .. },
-                        ) => {
-                            counterexample = error.replay(
-                                self.executor.clone(),
-                                known_contracts,
-                                identified_contracts.clone(),
-                                &mut logs,
-                                &mut traces,
-                            )?;
+                let success = test_error.is_none();
+                let reason = test_error.as_ref().and_then(|err| {
+                    (!err.revert_reason.is_empty()).then(|| err.revert_reason.clone())
+                });
 
-                            logs.extend(error.logs);
-
-                            if let Some(error_traces) = error.traces {
-                                traces.push((TraceKind::Execution, error_traces));
+                match test_error {
+                    // If invariants were broken, replay the error to collect logs and traces
+                    Some(error @ InvariantFuzzError { test_error: TestError::Fail(_, _), .. }) => {
+                        match error.replay(
+                            self.executor.clone(),
+                            known_contracts,
+                            identified_contracts.clone(),
+                            &mut logs,
+                            &mut traces,
+                        ) {
+                            Ok(c) => counterexample = c,
+                            Err(err) => {
+                                error!(?err, "Failed to replay invariant error")
                             }
-                        }
-                        // If invariants ran successfully, collect last call logs and traces
-                        _ => {
-                            if let Some(last_call_result) = last_call_results
-                                .as_mut()
-                                .and_then(|call_results| call_results.remove(&func_name))
-                            {
-                                logs.extend(last_call_result.logs);
+                        };
 
-                                if let Some(last_call_traces) = last_call_result.traces {
-                                    traces.push((TraceKind::Execution, last_call_traces));
-                                }
+                        logs.extend(error.logs);
+
+                        if let Some(error_traces) = error.traces {
+                            traces.push((TraceKind::Execution, error_traces));
+                        }
+                    }
+                    // If invariants ran successfully, collect last call logs and traces
+                    _ => {
+                        if let Some(last_call_result) = last_call_results
+                            .as_mut()
+                            .and_then(|call_results| call_results.remove(&func_name))
+                        {
+                            logs.extend(last_call_result.logs);
+
+                            if let Some(last_call_traces) = last_call_result.traces {
+                                traces.push((TraceKind::Execution, last_call_traces));
                             }
                         }
                     }
+                }
 
-                    let kind = TestKind::Invariant {
-                        runs: cases.len(),
-                        calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
-                        reverts,
-                    };
+                let kind = TestKind::Invariant {
+                    runs: cases.len(),
+                    calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
+                    reverts,
+                };
 
-                    Ok(TestResult {
-                        success,
-                        reason,
-                        counterexample,
-                        decoded_logs: decode_console_logs(&logs),
-                        logs,
-                        kind,
-                        coverage: None, // todo?
-                        traces,
-                        labeled_addresses: labeled_addresses.clone(),
-                        breakpoints: Default::default(),
-                    })
-                })
-                .collect::<Result<Vec<TestResult>>>()
-                .wrap_err("Failed to replay counter examples")?;
-
-            Ok(results)
-        } else {
-            Ok(vec![])
-        }
+                TestResult {
+                    success,
+                    reason,
+                    counterexample,
+                    decoded_logs: decode_console_logs(&logs),
+                    logs,
+                    kind,
+                    coverage: None, // TODO ?
+                    traces,
+                    labeled_addresses: labeled_addresses.clone(),
+                    breakpoints: Default::default(),
+                }
+            })
+            .collect()
     }
 
     #[tracing::instrument(name = "fuzz-test", skip_all, fields(name = %func.signature(), %should_fail))]
@@ -596,14 +497,13 @@ impl<'a> ContractRunner<'a> {
         runner: TestRunner,
         setup: TestSetup,
         fuzz_config: FuzzConfig,
-    ) -> Result<TestResult> {
+    ) -> TestResult {
         let TestSetup { address, mut logs, mut traces, mut labeled_addresses, .. } = setup;
 
         // Run fuzz test
         let start = Instant::now();
         let mut result = FuzzedExecutor::new(&self.executor, runner, self.sender, fuzz_config)
-            .fuzz(func, address, should_fail, self.errors)
-            .wrap_err("Failed to run fuzz test")?;
+            .fuzz(func, address, should_fail, self.errors);
 
         let kind = TestKind::Fuzz {
             median_gas: result.median_gas(false),
@@ -623,7 +523,7 @@ impl<'a> ContractRunner<'a> {
             success = %result.success
         );
 
-        Ok(TestResult {
+        TestResult {
             success: result.success,
             reason: result.reason,
             counterexample: result.counterexample,
@@ -634,6 +534,6 @@ impl<'a> ContractRunner<'a> {
             coverage: result.coverage,
             labeled_addresses,
             breakpoints: Default::default(),
-        })
+        }
     }
 }

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -2,6 +2,7 @@ use crate::{
     result::{SuiteResult, TestKind, TestResult, TestSetup},
     TestFilter, TestOptions,
 };
+use error;
 use ethers::{
     abi::{Abi, Function},
     types::{Address, Bytes, U256},
@@ -30,7 +31,6 @@ use std::{
     collections::{BTreeMap, HashMap},
     time::Instant,
 };
-use tracing::{error, trace};
 
 /// A type that executes all tests of a contract
 #[derive(Debug, Clone)]
@@ -175,7 +175,7 @@ impl<'a> ContractRunner<'a> {
         test_options: TestOptions,
         known_contracts: Option<&ContractsByArtifact>,
     ) -> SuiteResult {
-        tracing::info!("starting tests");
+        info!("starting tests");
         let start = Instant::now();
         let mut warnings = Vec::new();
 
@@ -290,7 +290,7 @@ impl<'a> ContractRunner<'a> {
         let duration = start.elapsed();
         if !test_results.is_empty() {
             let successful = test_results.iter().filter(|(_, tst)| tst.success).count();
-            tracing::info!(
+            info!(
                 duration = ?duration,
                 "done. {}/{} successful",
                 successful,
@@ -307,7 +307,7 @@ impl<'a> ContractRunner<'a> {
     ///
     /// State modifications are not committed to the evm database but discarded after the call,
     /// similar to `eth_call`.
-    #[tracing::instrument(name = "test", skip_all, fields(name = %func.signature(), %should_fail))]
+    #[instrument(name = "test", skip_all, fields(name = %func.signature(), %should_fail))]
     pub fn run_test(mut self, func: &Function, should_fail: bool, setup: TestSetup) -> TestResult {
         let TestSetup { address, mut logs, mut traces, mut labeled_addresses, .. } = setup;
 
@@ -369,7 +369,7 @@ impl<'a> ContractRunner<'a> {
         );
 
         // Record test execution time
-        tracing::debug!(
+        debug!(
             duration = ?start.elapsed(),
             %success,
             %gas
@@ -389,7 +389,7 @@ impl<'a> ContractRunner<'a> {
         }
     }
 
-    #[tracing::instrument(name = "invariant-test", skip_all)]
+    #[instrument(name = "invariant-test", skip_all)]
     pub fn run_invariant_test(
         &mut self,
         runner: TestRunner,
@@ -489,7 +489,7 @@ impl<'a> ContractRunner<'a> {
             .collect()
     }
 
-    #[tracing::instrument(name = "fuzz-test", skip_all, fields(name = %func.signature(), %should_fail))]
+    #[instrument(name = "fuzz-test", skip_all, fields(name = %func.signature(), %should_fail))]
     pub fn run_fuzz_test(
         &self,
         func: &Function,
@@ -518,7 +518,7 @@ impl<'a> ContractRunner<'a> {
         traces.extend(result.traces.map(|traces| (TraceKind::Execution, traces)));
 
         // Record test execution time
-        tracing::debug!(
+        debug!(
             duration = ?start.elapsed(),
             success = %result.success
         );

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -55,7 +55,7 @@ impl TestConfig {
 
     /// Executes the test runner
     pub fn test(&mut self) -> BTreeMap<String, SuiteResult> {
-        self.runner.test(&self.filter, None, self.opts.clone()).unwrap()
+        self.runner.test(&self.filter, None, self.opts.clone())
     }
 
     #[track_caller]
@@ -69,7 +69,7 @@ impl TestConfig {
     ///    * filter matched 0 test cases
     ///    * a test results deviates from the configured `should_fail` setting
     pub fn try_run(&mut self) -> eyre::Result<()> {
-        let suite_result = self.runner.test(&self.filter, None, self.opts.clone()).unwrap();
+        let suite_result = self.runner.test(&self.filter, None, self.opts.clone());
         if suite_result.is_empty() {
             eyre::bail!("empty test result");
         }

--- a/forge/tests/it/core.rs
+++ b/forge/tests/it/core.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, env};
 #[test]
 fn test_core() {
     let mut runner = runner();
-    let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, test_opts()).unwrap();
+    let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, test_opts());
 
     assert_multiple(
         &results,
@@ -86,7 +86,7 @@ fn test_core() {
 #[test]
 fn test_logs() {
     let mut runner = runner();
-    let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, test_opts()).unwrap();
+    let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, test_opts());
 
     assert_multiple(
         &results,
@@ -649,7 +649,7 @@ fn test_env_vars() {
 
     // test `setEnv` first, and confirm that it can correctly set environment variables,
     // so that we can use it in subsequent `env*` tests
-    runner.test(&Filter::new("testSetEnv", ".*", ".*"), None, test_opts()).unwrap();
+    runner.test(&Filter::new("testSetEnv", ".*", ".*"), None, test_opts());
     let env_var_key = "_foundryCheatcodeSetEnvTestKey";
     let env_var_val = "_foundryCheatcodeSetEnvTestVal";
     let res = env::var(env_var_key);
@@ -663,9 +663,11 @@ Reason: `setEnv` failed to set an environment variable `{env_var_key}={env_var_v
 #[test]
 fn test_doesnt_run_abstract_contract() {
     let mut runner = runner();
-    let results = runner
-        .test(&Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str()), None, test_opts())
-        .unwrap();
+    let results = runner.test(
+        &Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str()),
+        None,
+        test_opts(),
+    );
     assert!(results.get("core/Abstract.t.sol:AbstractTestBase").is_none());
     assert!(results.get("core/Abstract.t.sol:AbstractTest").is_some());
 }
@@ -673,7 +675,7 @@ fn test_doesnt_run_abstract_contract() {
 #[test]
 fn test_trace() {
     let mut runner = tracing_runner();
-    let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, test_opts()).unwrap();
+    let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, test_opts());
 
     // TODO: This trace test is very basic - it is probably a good candidate for snapshot
     // testing.

--- a/forge/tests/it/fork.rs
+++ b/forge/tests/it/fork.rs
@@ -10,17 +10,15 @@ use forge::result::SuiteResult;
 #[test]
 fn test_cheats_fork_revert() {
     let mut runner = runner();
-    let suite_result = runner
-        .test(
-            &Filter::new(
-                "testNonExistingContractRevert",
-                ".*",
-                &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
-            ),
-            None,
-            test_opts(),
-        )
-        .unwrap();
+    let suite_result = runner.test(
+        &Filter::new(
+            "testNonExistingContractRevert",
+            ".*",
+            &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
+        ),
+        None,
+        test_opts(),
+    );
     assert_eq!(suite_result.len(), 1);
 
     for (_, SuiteResult { test_results, .. }) in suite_result {

--- a/forge/tests/it/fuzz.rs
+++ b/forge/tests/it/fuzz.rs
@@ -9,15 +9,13 @@ use std::collections::BTreeMap;
 fn test_fuzz() {
     let mut runner = runner();
 
-    let suite_result = runner
-        .test(
-            &Filter::new(".*", ".*", ".*fuzz/")
-                .exclude_tests(r#"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)"#)
-                .exclude_paths("invariant"),
-            None,
-            test_opts(),
-        )
-        .unwrap();
+    let suite_result = runner.test(
+        &Filter::new(".*", ".*", ".*fuzz/")
+            .exclude_tests(r#"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)"#)
+            .exclude_paths("invariant"),
+        None,
+        test_opts(),
+    );
 
     assert!(!suite_result.is_empty());
 
@@ -60,8 +58,7 @@ fn test_fuzz_collection() {
     opts.fuzz.seed = Some(U256::from(6u32));
     runner.test_options = opts.clone();
 
-    let results =
-        runner.test(&Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol"), None, opts).unwrap();
+    let results = runner.test(&Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol"), None, opts);
 
     assert_multiple(
         &results,

--- a/forge/tests/it/inline.rs
+++ b/forge/tests/it/inline.rs
@@ -19,7 +19,7 @@ mod tests {
         let mut runner = runner();
         runner.test_options = opts.clone();
 
-        let result = runner.test(&filter, None, opts).expect("Test ran");
+        let result = runner.test(&filter, None, opts);
         let suite_result: &SuiteResult =
             result.get("inline/FuzzInlineConf.t.sol:FuzzInlineConf").unwrap();
         let test_result: &TestResult =
@@ -43,7 +43,7 @@ mod tests {
         let mut runner = runner();
         runner.test_options = opts.clone();
 
-        let result = runner.test(&filter, None, opts).expect("Test ran");
+        let result = runner.test(&filter, None, opts);
 
         let suite_result_1 =
             result.get(&format!("{ROOT}:InvariantInlineConf")).expect("Result exists");

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -9,13 +9,11 @@ use std::collections::BTreeMap;
 fn test_invariant() {
     let mut runner = runner();
 
-    let results = runner
-        .test(
-            &Filter::new(".*", ".*", ".*fuzz/invariant/(target|targetAbi|common)"),
-            None,
-            test_opts(),
-        )
-        .unwrap();
+    let results = runner.test(
+        &Filter::new(".*", ".*", ".*fuzz/invariant/(target|targetAbi|common)"),
+        None,
+        test_opts(),
+    );
 
     assert_multiple(
         &results,
@@ -92,13 +90,11 @@ fn test_invariant_override() {
     opts.invariant.call_override = true;
     runner.test_options = opts.clone();
 
-    let results = runner
-        .test(
-            &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantReentrancy.t.sol"),
-            None,
-            opts,
-        )
-        .unwrap();
+    let results = runner.test(
+        &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantReentrancy.t.sol"),
+        None,
+        opts,
+    );
 
     assert_multiple(
         &results,
@@ -118,13 +114,11 @@ fn test_invariant_storage() {
     opts.fuzz.seed = Some(U256::from(6u32));
     runner.test_options = opts.clone();
 
-    let results = runner
-        .test(
-            &Filter::new(".*", ".*", ".*fuzz/invariant/storage/InvariantStorageTest.t.sol"),
-            None,
-            opts,
-        )
-        .unwrap();
+    let results = runner.test(
+        &Filter::new(".*", ".*", ".*fuzz/invariant/storage/InvariantStorageTest.t.sol"),
+        None,
+        opts,
+    );
 
     assert_multiple(
         &results,
@@ -150,13 +144,11 @@ fn test_invariant_shrink() {
     opts.fuzz.seed = Some(U256::from(102u32));
     runner.test_options = opts.clone();
 
-    let results = runner
-        .test(
-            &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantInnerContract.t.sol"),
-            None,
-            opts,
-        )
-        .unwrap();
+    let results = runner.test(
+        &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantInnerContract.t.sol"),
+        None,
+        opts,
+    );
 
     let results =
         results.values().last().expect("`InvariantInnerContract.t.sol` should be testable.");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

All `Result::Err` variants are currently ignored (other than an error log) when running any test: https://github.com/foundry-rs/foundry/blob/a5c27411c7e5d1dd574df758060da8ad501ecbde/forge/src/multi_runner.rs#L161

This PR makes methods that execute tests return only the `Ok` type, which includes a `success` or similar field. This heavily simplifies logic around these methods and avoids `unwrap` calls in callers or silent failures in CLI.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
