### PR TITLE
chore: silence contract init code size error by default

### DIFF
--- a/config/src/error.rs
+++ b/config/src/error.rs
@@ -105,6 +105,8 @@ pub enum SolidityErrorCode {
     /// Warning that contract code size exceeds 24576 bytes (a limit introduced in Spurious
     /// Dragon).
     ContractExceeds24576Bytes,
+    /// Warning after shanghai if init code size exceeds 49152 bytes
+    ContractInitCodeSizeExceeds49152Bytes,
     /// Warning that Function state mutability can be restricted to [view,pure]
     FunctionStateMutabilityCanBeRestricted,
     /// Warning: Unused local variable
@@ -143,6 +145,7 @@ impl SolidityErrorCode {
         let s = match self {
             SolidityErrorCode::SpdxLicenseNotProvided => "license",
             SolidityErrorCode::ContractExceeds24576Bytes => "code-size",
+            SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes => "init-code-size",
             SolidityErrorCode::FunctionStateMutabilityCanBeRestricted => "func-mutability",
             SolidityErrorCode::UnusedLocalVariable => "unused-var",
             SolidityErrorCode::UnusedFunctionParameter => "unused-param",
@@ -176,6 +179,7 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::UnnamedReturnVariable => 6321,
             SolidityErrorCode::Unreachable => 5740,
             SolidityErrorCode::PragmaSolidity => 3420,
+            SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes => 3860,
             SolidityErrorCode::Other(code) => code,
         }
     }
@@ -200,6 +204,7 @@ impl FromStr for SolidityErrorCode {
             "unused-param" => SolidityErrorCode::UnusedFunctionParameter,
             "unused-var" => SolidityErrorCode::UnusedLocalVariable,
             "code-size" => SolidityErrorCode::ContractExceeds24576Bytes,
+            "init-code-size" => SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes,
             "shadowing" => SolidityErrorCode::ShadowsExistingDeclaration,
             "func-mutability" => SolidityErrorCode::FunctionStateMutabilityCanBeRestricted,
             "license" => SolidityErrorCode::SpdxLicenseNotProvided,
@@ -219,6 +224,7 @@ impl From<u64> for SolidityErrorCode {
         match code {
             1878 => SolidityErrorCode::SpdxLicenseNotProvided,
             5574 => SolidityErrorCode::ContractExceeds24576Bytes,
+            3860 => SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes,
             2018 => SolidityErrorCode::FunctionStateMutabilityCanBeRestricted,
             2072 => SolidityErrorCode::UnusedLocalVariable,
             5667 => SolidityErrorCode::UnusedFunctionParameter,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1771,6 +1771,7 @@ impl Default for Config {
             ignored_error_codes: vec![
                 SolidityErrorCode::SpdxLicenseNotProvided,
                 SolidityErrorCode::ContractExceeds24576Bytes,
+                SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes,
             ],
             deny_warnings: false,
             via_ir: false,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/5088 silence contract init code size error by default
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
