### PR TITLE
fix(coverage): return values assigned to library calls

### DIFF
--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -115,7 +115,6 @@ impl<'a> ContractVisitor<'a> {
             NodeType::Continue |
             NodeType::EmitStatement |
             NodeType::PlaceholderStatement |
-            NodeType::Return |
             NodeType::RevertStatement |
             NodeType::YulAssignment |
             NodeType::YulBreak |
@@ -128,6 +127,20 @@ impl<'a> ContractVisitor<'a> {
                 });
                 Ok(())
             }
+
+            // Return with eventual subcall
+            NodeType::Return  => {
+                self.push_item(CoverageItem {
+                    kind: CoverageItemKind::Statement,
+                    loc: self.source_location_for(&node.src),
+                    hits: 0,
+                });
+                if let Some(expr) = node.attribute("expression") {
+                    self.visit_expression(expr)?;
+                }
+                Ok(())
+            }
+
             // Variable declaration
             NodeType::VariableDeclarationStatement => {
                 self.push_item(CoverageItem {

--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -129,7 +129,7 @@ impl<'a> ContractVisitor<'a> {
             }
 
             // Return with eventual subcall
-            NodeType::Return  => {
+            NodeType::Return => {
                 self.push_item(CoverageItem {
                     kind: CoverageItemKind::Statement,
                     loc: self.source_location_for(&node.src),


### PR DESCRIPTION
Fix for https://github.com/foundry-rs/foundry/issues/4305

## Motivation

We need this fix to properly track our coverage.

## Solution

Coverage analysis doesn't travel through the library when the path in the AST is Return -> FunctionCall -> MemberAccess -> Library Call
