### PR TITLE
fix(`cheatcodes`): keep applying broadcast sender replacement at increased depths

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -957,7 +957,7 @@ where
 
         // Apply our broadcast
         if let Some(broadcast) = &self.broadcast {
-            if data.journaled_state.depth() == broadcast.depth &&
+            if data.journaled_state.depth() >= broadcast.depth &&
                 call.caller == h160_to_b160(broadcast.original_caller)
             {
                 if let Err(err) =
@@ -973,37 +973,43 @@ where
 
                 data.env.tx.caller = h160_to_b160(broadcast.new_origin);
 
-                let (bytecode, to, nonce) = match process_create(
-                    broadcast.new_origin,
-                    call.init_code.clone(),
-                    data,
-                    call,
-                ) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        return (
-                            InstructionResult::Revert,
-                            None,
-                            Gas::new(call.gas_limit),
-                            err.encode_string().0,
-                        )
-                    }
-                };
+                if data.journaled_state.depth() == broadcast.depth {
+                    let (bytecode, to, nonce) = match process_create(
+                        broadcast.new_origin,
+                        call.init_code.clone(),
+                        data,
+                        call,
+                    ) {
+                        Ok(val) => val,
+                        Err(err) => {
+                            return (
+                                InstructionResult::Revert,
+                                None,
+                                Gas::new(call.gas_limit),
+                                err.encode_string().0,
+                            )
+                        }
+                    };
 
-                let is_fixed_gas_limit = check_if_fixed_gas_limit(data, call.gas_limit);
+                    let is_fixed_gas_limit = check_if_fixed_gas_limit(data, call.gas_limit);
 
-                self.broadcastable_transactions.push_back(BroadcastableTransaction {
-                    rpc: data.db.active_fork_url(),
-                    transaction: TypedTransaction::Legacy(TransactionRequest {
-                        from: Some(broadcast.new_origin),
-                        to,
-                        value: Some(call.value.into()),
-                        data: Some(bytecode.into()),
-                        nonce: Some(nonce.into()),
-                        gas: if is_fixed_gas_limit { Some(call.gas_limit.into()) } else { None },
-                        ..Default::default()
-                    }),
-                });
+                    self.broadcastable_transactions.push_back(BroadcastableTransaction {
+                        rpc: data.db.active_fork_url(),
+                        transaction: TypedTransaction::Legacy(TransactionRequest {
+                            from: Some(broadcast.new_origin),
+                            to,
+                            value: Some(call.value.into()),
+                            data: Some(bytecode.into()),
+                            nonce: Some(nonce.into()),
+                            gas: if is_fixed_gas_limit {
+                                Some(call.gas_limit.into())
+                            } else {
+                                None
+                            },
+                            ..Default::default()
+                        }),
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
This bug was cursed.

## Motivation

So, in #5062 it was described that nested CREATES cause the nonce to not increase and the `tx.origin` to become wrong. This fixes the first part—as I believe we might need a revm change for solving the latter part.

## Solution

What's happening here is that the nonce was not being incremented because even though we're only cleaning up broadcasts at the depth they were created, we still need to reapply them at increased depths even if we're not using them for txs (as we only need the tx of the broadcast level). This PR therefore makes the `create` hook reapply broadcasts at increased depths, but only create the first tx.
