### PR TITLE
Compressed state dumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "ethers",
  "ethers-solc",
  "fdlimit",
+ "flate2",
  "forge",
  "foundry-common",
  "foundry-config",

--- a/anvil/Cargo.toml
+++ b/anvil/Cargo.toml
@@ -49,6 +49,7 @@ futures = "0.3"
 async-trait = "0.1"
 
 # misc
+flate2 = "1.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -638,7 +638,8 @@ impl Backend {
     pub async fn dump_state(&self) -> Result<Bytes, BlockchainError> {
         let state = self.serialized_state().await?;
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(&serde_json::to_vec(&state).unwrap_or_default())
+        encoder
+            .write_all(&serde_json::to_vec(&state).unwrap_or_default())
             .map_err(|_| BlockchainError::DataUnavailable)?;
         Ok(encoder.finish().unwrap_or_default().into())
     }
@@ -650,7 +651,9 @@ impl Backend {
         let mut decoded_data = Vec::new();
 
         let state: SerializableState = serde_json::from_slice(if decoder.header().is_some() {
-            decoder.read_to_end(decoded_data.as_mut()).map_err(|_| BlockchainError::FailedToDecodeStateDump)?;
+            decoder
+                .read_to_end(decoded_data.as_mut())
+                .map_err(|_| BlockchainError::FailedToDecodeStateDump)?;
             &decoded_data
         } else {
             &buf.0

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -54,10 +54,7 @@ use ethers::{
     },
     utils::{get_contract_address, hex, keccak256, rlp},
 };
-use flate2::{
-    read::GzDecoder,
-    write::GzEncoder, Compression,
-};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use forge::{
     executor::inspector::AccessListTracer,
     hashbrown,
@@ -83,7 +80,13 @@ use foundry_evm::{
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use hash_db::HashDB;
 use parking_lot::{Mutex, RwLock};
-use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration, io::{Read, Write}};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+    ops::Deref,
+    sync::Arc,
+    time::Duration,
+};
 use storage::{Blockchain, MinedTransaction};
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{trace, warn};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

9 months ago I wrote the code for `anvil_dumpState` and `anvil_loadState`. During the time, I mentioned the possible benefits of compressing the state dumps.

Recently, my state dumps have been getting so big that they no longre seem to work with the JSON RPC API (getting errors like "Invalid request" even though there should be no limit on the size of requests).

Whatever the reason, much larger state dumps could be much, much smaller by compressing the blob returned by `dumpState` and loaded by `loadState`. This improves the efficiency of data handling for tools outside of anvil, as well as eliminating the above described request issue due to request size.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Using the `flate2` cargo package, compress the state dump returned by anvil on `anvil_dumpState` with `GzEncoder`. Use default compression options.

On `anvil_loadState`, use `GzDecoder`. If the state is not compressed, `GzDecoder` will fail to parse a header, and anvil will assume the state is not compressed and load it directly. This allows for backwards compatibility.

This change is not forward compatible (ie, state dumps created with newer versions of anvil after this change will not be loadable by older versions of anvil)

The gzip compression algorithm is so commonplace that it is often used by web servers/browsers for transparent compression, so it is a good choice for standardization of the format.

There is no streaming on either the serde_json encode/decode, nor the JSON RPC API, so there is no streaming used while compressing/decompressing. Its not super efficient, but that isn't such a big deal.