### PR TITLE
chore(`script`): disable etherscan tracing if no API key is provided, provide warning

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -231,16 +231,8 @@ impl ScriptArgs {
 
         // Decoding traces using etherscan is costly as we run into rate limits,
         // causing scripts to run for a very long time unnecesarily.
-        // Therefore, we only try and use etherscan if the user has provided an API key,
-        // and will warn the user about so.
+        // Therefore, we only try and use etherscan if the user has provided an API key.
         let should_use_etherscan_traces = script_config.config.etherscan_api_key.is_some();
-        if should_use_etherscan_traces {
-            shell::println(Paint::yellow(
-                "\
-Etherscan API key detected, using it to decode traces.
-This could be a slow process and might cause your scripts to run for a longer time than expected.",
-            ))?;
-        }
 
         for (_, trace) in &mut result.traces {
             decoder.identify(trace, &mut local_identifier);


### PR DESCRIPTION
Closes #5119.

## Motivation

Decoding traces using etherscan is slow, as we run into rate limits. We should make this opt in by only using them an etherscan API key is provided.

## Solution

Detect if an api key is provided, and warn/use etherscan appropiately.
