### PR TITLE
fix(anvil): disable basefee if manually set to 0

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1021,6 +1021,13 @@ impl Backend {
             nonce: nonce.map(|n| n.as_u64()),
             access_list: to_revm_access_list(access_list.unwrap_or_default()),
         };
+
+        if env.block.basefee == revm::primitives::U256::ZERO {
+            // this is an edge case because the evm fails if `tx.effective_gas_price < base_fee`
+            // 0 is only possible if it's manually set
+            env.cfg.disable_base_fee = true;
+        }
+
         env
     }
 

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -781,7 +781,14 @@ impl Backend {
         let (outcome, header, block_hash) = {
             let current_base_fee = self.base_fee();
 
-            let mut env = self.env.read().clone();
+            let mut env = self.env().read().clone();
+
+            if env.block.basefee == revm::primitives::U256::ZERO {
+                // this is an edge case because the evm fails if `tx.effective_gas_price < base_fee`
+                // 0 is only possible if it's manually set
+                env.cfg.disable_base_fee = true;
+            }
+
             // increase block number for this block
             env.block.number = env.block.number.saturating_add(rU256::from(1));
             env.block.basefee = current_base_fee.into();

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -43,6 +43,7 @@ revm = { version = "3", default-features = false, features = [
   "memory_limit",
   "optional_eip3607",
   "optional_block_gas_limit",
+  "optional_no_base_fee"
 ] }
 
 # Fuzzer

--- a/evm/src/executor/fork/cache.rs
+++ b/evm/src/executor/fork/cache.rs
@@ -177,6 +177,11 @@ impl<'de> Deserialize<'de> for BlockchainDbMeta {
                         // keep default value
                         obj.insert(key.to_string(), false.into());
                     }
+                    let key = "disable_base_fee";
+                    if !obj.contains_key(key) {
+                        // keep default value
+                        obj.insert(key.to_string(), false.into());
+                    }
                 }
 
                 let cfg_env: revm::primitives::CfgEnv =


### PR DESCRIPTION
should close https://github.com/foundry-rs/foundry/issues/5125

we disable basefee check if basefee is 0

https://github.com/bluealloy/revm/blob/69f417f15755d7fcf9fac8dd2df3dc4cb2cd6bad/crates/primitives/src/env.rs#L282

this can never happen naturally because the lower limit technically possible is `7`