### PR TITLE
script: support sending batches to optimism

### DIFF
--- a/cli/src/cmd/utils.rs
+++ b/cli/src/cmd/utils.rs
@@ -174,15 +174,7 @@ pub fn has_different_gas_calc(chain: u64) -> bool {
 /// True if it supports broadcasting in batches.
 pub fn has_batch_support(chain: u64) -> bool {
     if let ConfigChain::Named(chain) = ConfigChain::from(chain) {
-        return !matches!(
-            chain,
-            Chain::Arbitrum |
-                Chain::ArbitrumTestnet |
-                Chain::ArbitrumGoerli |
-                Chain::Optimism |
-                Chain::OptimismKovan |
-                Chain::OptimismGoerli
-        )
+        return !matches!(chain, Chain::Arbitrum | Chain::ArbitrumTestnet | Chain::ArbitrumGoerli)
     }
     true
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Optimism after upgraded to bedrock has much better devex

After bedrock, transactions are held in a mempool meaning that it is possible to send batches of transactions. There is no need to wait for each transaction to be confirmed before sending the next like in the legacy system. This commit removes the need to send transactions sequentially when using optimism with `forge script`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Remove the force sending of txs sequentially when using optimism