### PR TITLE
feat(`cheatcodes`): disallow usage of `expectRevert` with `expectCall` and `expectEmit` 

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -770,6 +770,15 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
+            // Irrespective of whether a revert will be matched or not, disallow having expected reverts
+            // alongside expected emits or calls.
+            if !self.expected_calls.is_empty() || !self.expected_emits.is_empty() {
+                return (
+                    InstructionResult::Revert,
+                    remaining_gas,
+                    "Cannot expect a function to revert while trying to match expected calls or events.".to_string().encode().into(),
+                )
+            }
             if data.journaled_state.depth() == expected_revert.depth {
                 let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match handle_expect_revert(

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -770,8 +770,8 @@ where
 
         // Handle expected reverts
         if let Some(expected_revert) = &self.expected_revert {
-            // Irrespective of whether a revert will be matched or not, disallow having expected reverts
-            // alongside expected emits or calls.
+            // Irrespective of whether a revert will be matched or not, disallow having expected
+            // reverts alongside expected emits or calls.
             if !self.expected_calls.is_empty() || !self.expected_emits.is_empty() {
                 return (
                     InstructionResult::Revert,

--- a/testdata/cheats/ExpectCall.t.sol
+++ b/testdata/cheats/ExpectCall.t.sol
@@ -254,6 +254,14 @@ contract ExpectCallTest is DSTest {
         cheats.expectCallMinGas(address(inner), 0, 50_001, abi.encodeWithSelector(inner.add.selector, 1, 1));
         this.exposed_addHardGasLimit(target);
     }
+
+    /// Ensure that you cannot use expectCall with an expectRevert.
+    function testFailExpectCallWithRevertDisallowed() public {
+        Contract target = new Contract();
+        cheats.expectRevert();
+        cheats.expectCall(address(target), abi.encodeWithSelector(target.add.selector));
+        this.exposed_callTargetNTimes(target, 5, 5, 1);
+    }
 }
 
 contract ExpectCallCountTest is DSTest {

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -569,6 +569,15 @@ contract ExpectEmitTest is DSTest {
         emitter.emitWindowAndOnTest(this);
     }
 
+    /// We should not be able to expect emits if we're expecting the function reverts, no matter
+    /// if the function reverts or not.
+    function testFailEmitWindowWithRevertDisallowed() public {
+        cheats.expectRevert();
+        cheats.expectEmit(true, false, false, true);
+        emit A(1);
+        emitter.emitWindow();
+    }
+
     /// This test will fail if we check that all expected logs were emitted
     /// after every call from the same depth as the call that invoked the cheatcode.
     ///


### PR DESCRIPTION
## Motivation

Closes #5138, but will go into the 1.0 branch.

When a function reverts, it's like it never happened as it gets rolled back—but we're still matching calls/events.

## Solution

This completely disallows matching calls or events if the user has previously used `expectRevert`. This restriction will be in place until the `expectRevert` is "filled", meaning until after the next call, by which either the test will fail due to a non-reverting call, or end execution as it effectively reverted.