### PR TITLE
feat(`anvil`): pretty print `withdrawalsRoot`

### DIFF
--- a/macros/src/fmt/ui.rs
+++ b/macros/src/fmt/ui.rs
@@ -222,6 +222,7 @@ sha3Uncles           {}
 size                 {}
 stateRoot            {}
 timestamp            {}
+withdrawalsRoot      {}
 totalDifficulty      {}{}",
         block.base_fee_per_gas.pretty(),
         block.difficulty.pretty(),
@@ -241,6 +242,7 @@ totalDifficulty      {}{}",
         block.size.pretty(),
         block.state_root.pretty(),
         block.timestamp.pretty(),
+        block.withdrawals_root.pretty(),
         block.total_difficulty.pretty(),
         block.other.pretty()
     )


### PR DESCRIPTION
Closes #5142.

`withdrawalsRoot` was missing from the pretty print formatting.