### PR TITLE
fix(forge): exit with error code on fail fast (#4883)

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -532,6 +532,8 @@ fn test(
             SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
 
         'outer: for (contract_name, suite_result) in rx {
+            results.insert(contract_name.clone(), suite_result.clone());
+
             let mut tests = suite_result.test_results.clone();
             println!();
             for warning in suite_result.warnings.iter() {
@@ -617,12 +619,9 @@ fn test(
                     }
                 }
             }
-            let block_outcome = TestOutcome::new(
-                [(contract_name.clone(), suite_result.clone())].into(),
-                allow_failure,
-            );
+            let block_outcome =
+                TestOutcome::new([(contract_name, suite_result)].into(), allow_failure);
             println!("{}", block_outcome.summary());
-            results.insert(contract_name, suite_result);
         }
 
         if gas_reporting {

--- a/cli/tests/it/test_cmd.rs
+++ b/cli/tests/it/test_cmd.rs
@@ -366,3 +366,41 @@ contract ContractTest is Test {
             .join("tests/fixtures/can_use_libs_in_multi_fork.stdout"),
     );
 });
+
+static FAILING_TEST: &str = r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+contract FailingTest is Test {
+    function testShouldFail() public {
+        assertTrue(false);
+    }
+}
+"#;
+
+forgetest_init!(exit_code_error_on_fail_fast, |prj: TestProject, mut cmd: TestCommand| {
+    prj.wipe_contracts();
+    prj.inner().add_source("failing_test", FAILING_TEST).unwrap();
+
+    // set up command
+    cmd.args(["test", "--fail-fast"]);
+
+    // run command and assert error exit code
+    cmd.assert_err();
+});
+
+forgetest_init!(
+    exit_code_error_on_fail_fast_with_json,
+    |prj: TestProject, mut cmd: TestCommand| {
+        prj.wipe_contracts();
+
+        prj.inner().add_source("failing_test", FAILING_TEST).unwrap();
+        // set up command
+        cmd.args(["test", "--fail-fast", "--json"]);
+
+        // run command and assert error exit code
+        cmd.assert_err();
+    }
+);


### PR DESCRIPTION
## Motivation

Fix wrong exit code when `forge test` is ran with `--fail-test` flag and `forge` exits early. Reported in #4883.

## Solution

The solution is to exit with an error code if a test fails and the `--fail-test` flag is specified.

The cause of the bug was that the failing test suite wasn't added in the loop that aggregates test results due to breaking early when the `--fail-test` flag is specified. I moved inserting the test suite to the results to the top of the loop to fix it.

Also added CLI tests to check if `forge test` exits with an error on `--fail-fast`. 

Note that the `--json` option invokes a different code path for aggregating results, but failing fast is not supported currently in json mode. I added the test with the `"--fail-fast --json"` flags  for future proofing in case support is added later.
