### PR TITLE
chore(`cast`): improve `abi-encode` error messages

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1381,11 +1381,17 @@ impl SimpleCast {
                     }
                 } else {
                     // we return the `Function` parse error as this case is more likely
-                    return Err(err.into())
+                    eyre::bail!("Could not process human-readable ABI. Please check if you've left the parenthesis unclosed or if some type is incomplete.\nError:\n{}", err)
+                    // return Err(err.into()).wrap_err("Could not process human-readable ABI. Please
+                    // check if you've left the parenthesis unclosed or if some type is
+                    // incomplete.")
                 }
             }
         };
-        let calldata = encode_args(&func, args)?.to_hex::<String>();
+        let calldata = match encode_args(&func, args) {
+            Ok(res) => res.to_hex::<String>(),
+            Err(e) => eyre::bail!("Could not ABI encode the function and arguments. Did you pass in the right types?\nError\n{}", e),
+        };
         let encoded = &calldata[8..];
         Ok(format!("0x{encoded}"))
     }


### PR DESCRIPTION
Closes #5143.

Improves the `abi-encode` error messages, like so:

<img width="874" alt="Screenshot 2023-06-12 at 19 47 09" src="https://github.com/foundry-rs/foundry/assets/26014927/b19dcbf0-1b22-406e-8410-3799f405d542">
