### PR TITLE
chore(cast): use checksum-case when print addr

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -4,7 +4,7 @@ use ethers::{
     prelude::TransactionReceipt,
     providers::Middleware,
     types::U256,
-    utils::format_units,
+    utils::{format_units, to_checksum},
 };
 use eyre::Result;
 use foundry_config::{Chain, Config};
@@ -204,7 +204,7 @@ pub fn enable_paint() {
 pub fn print_receipt(chain: Chain, receipt: &TransactionReceipt) {
     let contract_address = receipt
         .contract_address
-        .map(|addr| format!("\nContract Address: 0x{}", hex::encode(addr.as_bytes())))
+        .map(|addr| format!("\nContract Address: {}", to_checksum(&addr, None)))
         .unwrap_or_default();
 
     let gas_used = receipt.gas_used.unwrap_or_default();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Cast outputs contract addresses in lowercase, rather than checksum-case:
![image](https://github.com/foundry-rs/foundry/assets/3280221/7865e1e6-1f9f-4de8-b464-5942dc4f087a)

## Solution

Use checksum case:
![image](https://github.com/foundry-rs/foundry/assets/3280221/58c70e2c-4abe-4a79-b969-8f03ff3e1b85)

