### PR TITLE
Fix: exponential notation formatting in broadcast JSON

### DIFF
--- a/cli/src/cmd/forge/script/transaction.rs
+++ b/cli/src/cmd/forge/script/transaction.rs
@@ -7,7 +7,10 @@ use ethers::{
     types::transaction::eip2718::TypedTransaction,
 };
 use eyre::{ContextCompat, WrapErr};
-use foundry_common::{abi::format_token, RpcUrl, SELECTOR_LEN};
+use foundry_common::{
+    abi::{format_token, format_token_raw},
+    RpcUrl, SELECTOR_LEN,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tracing::error;
@@ -148,7 +151,7 @@ impl TransactionWithMetadata {
                     self.arguments = Some(
                         function
                             .decode_input(&data.0[SELECTOR_LEN..])
-                            .map(|tokens| tokens.iter().map(format_token).collect())
+                            .map(|tokens| tokens.iter().map(format_token_raw).collect())
                             .map_err(|_| eyre::eyre!("Failed to decode CREATE2 call arguments"))?,
                     );
                 }

--- a/common/src/abi.rs
+++ b/common/src/abi.rs
@@ -153,15 +153,6 @@ pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
     tokens.iter().map(format_token)
 }
 
-/// Gets pretty print strings for tokens, without adding
-/// exponential notation hints for large numbers (e.g. [1e7] for 10000000)
-pub fn format_token_raw(param: &Token) -> String {
-    match param {
-        Token::Uint(num) => format!("{}", num),
-        _ => format_token(param),
-    }
-}
-
 /// Gets pretty print strings for tokens
 pub fn format_token(param: &Token) -> String {
     match param {
@@ -184,6 +175,27 @@ pub fn format_token(param: &Token) -> String {
             let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
             format!("({string})")
         }
+    }
+}
+
+/// Gets pretty print strings for tokens, without adding
+/// exponential notation hints for large numbers (e.g. [1e7] for 10000000)
+pub fn format_token_raw(param: &Token) -> String {
+    match param {
+        Token::Uint(num) => format!("{}", num),
+        Token::FixedArray(tokens) => {
+            let string = tokens.iter().map(format_token_raw).collect::<Vec<String>>().join(", ");
+            format!("[{string}]")
+        }
+        Token::Array(tokens) => {
+            let string = tokens.iter().map(format_token_raw).collect::<Vec<String>>().join(", ");
+            format!("[{string}]")
+        }
+        Token::Tuple(tokens) => {
+            let string = tokens.iter().map(format_token_raw).collect::<Vec<String>>().join(", ");
+            format!("({string})")
+        }
+        _ => format_token(param),
     }
 }
 

--- a/common/src/abi.rs
+++ b/common/src/abi.rs
@@ -153,6 +153,15 @@ pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
     tokens.iter().map(format_token)
 }
 
+/// Gets pretty print strings for tokens, without adding
+/// exponential notation hints for large numbers (e.g. [1e7] for 10000000)
+pub fn format_token_raw(param: &Token) -> String {
+    match param {
+        Token::Uint(num) => format!("{}", num),
+        _ => format_token(param),
+    }
+}
+
 /// Gets pretty print strings for tokens
 pub fn format_token(param: &Token) -> String {
     match param {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #5150

## Solution

Added a version of `format_token` which doesn't use exponential notation hints, which could break some json output
