### PR TITLE
chore(deps): pin ethers to branch & commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,8 +1751,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a58ce802c65cf3d0756dee5a61094a92cde53c1583b246e9ee5b37226c7fc15"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1767,8 +1766,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b856b7b8ff5c961093cb8efe151fbcce724b451941ce20781de11a531ccd578"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1779,13 +1777,13 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e066a0d9cfc70c454672bf16bb433b0243427420076dc5b2f49c448fb5a10628"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
  "ethers-core",
  "ethers-providers",
+ "ethers-signers",
  "futures-util",
  "hex",
  "once_cell",
@@ -1798,8 +1796,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c113e3e86b6bc16d98484b2c3bb2d01d6fed9f489fe2e592e5cc87c3024d616b"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1822,8 +1819,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3fb5adee25701c79ec58fcf2c63594cd8829bc9ad6037ff862d5a111101ed2"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1838,8 +1834,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da5fa198af0d3be20c19192df2bd9590b92ce09a8421e793bec8851270f1b05"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1868,8 +1863,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ebb401ba97c6f5af278c2c9936c4546cad75dec464b439ae6df249906f4caa"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1884,8 +1878,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740f4a773c19dd6d6a68c8c2e0996c096488d38997d524e21dc612c55da3bd24"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1911,8 +1904,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b498fd2a6c019d023e43e83488cd1fb0721f299055975aa6bac8dbf1e95f2c"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1949,8 +1941,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c4b7e15f212fa7cc2e1251868320221d4ff77a3d48068e69f47ce1c491df2d"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1977,8 +1968,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81c89f121595cf8959e746045bb8b25a6a38d72588561e1a3b7992fc213f674"
+source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1796,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs?rev=0d10768#0d107688689ec860c391c65ff426ed8157225092"
+source = "git+https://github.com/gakonst/ethers-rs#0d107688689ec860c391c65ff426ed8157225092"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,16 +61,16 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { version = "2.0.7", default-features = false }
-ethers-addressbook = { version = "2.0.7", default-features = false }
-ethers-core = { version = "2.0.7", default-features = false }
-ethers-contract = { version = "2.0.7", default-features = false }
-ethers-contract-abigen = { version = "2.0.7", default-features = false }
-ethers-providers = { version = "2.0.7", default-features = false }
-ethers-signers = { version = "2.0.7", default-features = false }
-ethers-middleware = { version = "2.0.7", default-features = false }
-ethers-etherscan = { version = "2.0.7", default-features = false }
-ethers-solc = { version = "2.0.7", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
 
 solang-parser = "=0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,15 @@ codegen-units = 1
 
 [workspace.dependencies]
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 solang-parser = "=0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }
 ethers-contract = { git = "https://github.com/gakonst/ethers-rs", rev = "0d10768", default-features = false }


### PR DESCRIPTION
We need to upstream some verification fixes from ethers—so we're repinning ethers to a specific commit until further notice.