### PR TITLE
fix(forge): `vm.parseJson` and error while parsing powers of ten

### DIFF
--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -255,3 +255,9 @@ fn test_issue_4630() {
 fn test_issue_4586() {
     test_repro!("Issue4586");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/5038>
+#[test]
+fn test_issue_5038() {
+    test_repro!("Issue5038");
+}

--- a/testdata/repros/Issue5038.t.sol
+++ b/testdata/repros/Issue5038.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Cheats.sol";
+
+struct Value {
+    uint256 value;
+}
+
+// https://github.com/foundry-rs/foundry/issues/5038
+contract Issue5038Test is DSTest {
+    Cheats constant vm = Cheats(HEVM_ADDRESS);
+
+    function testParseMaxUint64() public {
+        string memory json = '{"value": 18446744073709551615}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 18446744073709551615);
+    }
+
+    function testParse18446744073709551616000() public {
+        string memory json = '{"value": 18446744073709551616000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 18446744073709551616000);
+    }
+
+    function testParse1e19() public {
+        string memory json = '{"value": 10000000000000000000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 10000000000000000000);
+    }
+
+    function test_parse_1e20() public {
+        string memory json = '{"value": 100000000000000000000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 100000000000000000000);
+    }
+
+    function testParse1e21() public {
+        string memory json = '{"value": 1000000000000000000000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 1000000000000000000000);
+    }
+
+    function testParse1e42() public {
+        string memory json = '{"value": 1000000000000000000000000000000000000000000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 1000000000000000000000000000000000000000000);
+    }
+
+    function testParse1e42plusOne() public {
+        string memory json = '{"value": 1000000000000000000000000000000000000000001}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 1000000000000000000000000000000000000000001);
+    }
+
+    function testParse1e43plus5() public {
+        string memory json = '{"value": 10000000000000000000000000000000000000000005}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 10000000000000000000000000000000000000000005);
+    }
+
+    function testParse1e76() public {
+        string memory json = '{"value": 10000000000000000000000000000000000000000000000000000000000000000000000000000}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 10000000000000000000000000000000000000000000000000000000000000000000000000000);
+    }
+
+    function testParse1e76Plus10() public {
+        string memory json = '{"value": 10000000000000000000000000000000000000000000000000000000000000000000000000010}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 10000000000000000000000000000000000000000000000000000000000000000000000000010);
+    }
+
+    function testParseMinUint256() public {
+        string memory json = '{"value": -57896044618658097711785492504343953926634992332820282019728792003956564819968}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+
+        assertEq(int256(data.value), -57896044618658097711785492504343953926634992332820282019728792003956564819968);
+    }
+
+    function testParseMaxUint256() public {
+        string memory json = '{"value": 115792089237316195423570985008687907853269984665640564039457584007913129639935}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 115792089237316195423570985008687907853269984665640564039457584007913129639935);
+    }
+}


### PR DESCRIPTION
Fixes #5038

## Motivation

Parsing powers of ten failed even if the number was a correct json value

## Solution

It seems that `Number::to_string` from `serde_json` formats big numbers powers of 10 to use the scientific notation. After parsing the number to a string and giving it to `U256::from_dec_str` or `U256::from_dec_str`, the conversion failed because the expected string should be in decimal format. 

In any other case, the conversion worked perfectly because `Number::to_string` is not trying to use scientific notation. In order to avoid a wrong string formatting I'm using the floating point representation of the number and then parsing it into string using the `format!` macro. Although this does work for powers of ten, it fails in other scenarios. Common shenanigans found while debugging were the following ones:
- `18446744073709551615` parsed to f64 was rounded up to `18446744073709552000`
- `10000000000000000000000000000000000000000005` parsed to f64 was rounded down to `10000000000000000000000000000000000000000000`
- Calling `Number::to_string` on any power of ten grater than `1e20` stringified it as `1e[number of 0 here]`
So in the end I implemented a hybrid approach that uses the existing logic to parse numbers and then falls back to using floats.

It feels a bit hacky so if someone has a better approach, it'd be very welcome.
