### PR TITLE
feat(`ci`): add auto issue on release failure

### DIFF
--- a/.github/RELEASE_FAILURE_ISSUE_TEMPLATE.md
+++ b/.github/RELEASE_FAILURE_ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "bug: release workflow failed"
+labels: P-high, T-bug
+---
+
+The release workflow has failed. Some or all binaries might have not been published correctly.
+
+Check the [release workflow page]({{env.WORKFLOW_URL}}) for details.
+
+This issue was raised by the workflow at `.github/workflows/release.yml`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,18 @@ jobs:
                       ${{ steps.artifacts.outputs.file_name }}
                       ${{ steps.man.outputs.foundry_man }}
 
+            # If any of the steps fail, this will create a high-priority issue
+            # to signal so.
+            - uses: JasonEtco/create-an-issue@v2
+              if: ${{ failure() }}
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              with:
+                update_existing: true
+                filename: .github/RELEASE_FAILURE_ISSUE_TEMPLATE.md
+
+
     cleanup:
         name: Release cleanup
         runs-on: ubuntu-20.04


### PR DESCRIPTION
Closes #5154 

Motivated by the recent release failure we had—we should be notified automatically if this happens