### PR TITLE
fix: individual crate compilation

### DIFF
--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -17,5 +17,5 @@ syn = "2.0"
 foundry-macros = { path = "../macros" }
 
 ethers-core = { workspace = true }
-ethers-contract = { workspace = true }
+ethers-contract = { workspace = true, features = ["abigen"] }
 ethers-providers = { workspace = true }

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -723,11 +723,11 @@ forgetest_async!(
                 .join("../testdata/fixtures/broadcast.log.json"),
         )
         .unwrap();
-        let fixtures_log = re.replace_all(&fixtures_log, "");
+        let _fixtures_log = re.replace_all(&fixtures_log, "");
 
         let run_log =
             std::fs::read_to_string("broadcast/Broadcast.t.sol/31337/run-latest.json").unwrap();
-        let run_log = re.replace_all(&run_log, "");
+        let _run_log = re.replace_all(&run_log, "");
 
         // pretty_assertions::assert_eq!(fixtures_log, run_log);
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/foundry-rs/foundry"
 forge-fmt = { path = "../fmt" }
 
 ethers-core = { workspace = true }
-ethers-contract = { workspace = true }
+ethers-contract = { workspace = true, features = ["abigen"] }
 ethers-etherscan = { workspace = true }
 ethers-addressbook = { workspace = true }
 ethers-providers = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

some crates don't build individually (`cargo c -p crate`) because of certain features that are unified in the workspace

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

```sh
#!/usr/bin/env bash

crates=(
    anvil
    anvil/core
    anvil/rpc
    anvil/server
    abi
    binder
    cast
    chisel
    cli
    cli/test-utils
    common
    config
    doc
    evm
    fmt
    forge
    macros
    macros/impl
    ui
    utils
)

for crate in "${crates[@]}"; do
    echo "--- $crate ---"
    cargo c --manifest-path $crate/Cargo.toml
done
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
