### PR TITLE
fix: dedupe linker outputs

### DIFF
--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -131,11 +131,9 @@ impl ScriptArgs {
                     let mut filtered = Vec::new();
                     let mut seen = HashSet::new();
                     for (dep, bytes) in deps {
-                        if seen.contains(&dep) {
+                        if !seen.insert(&dep) {
                             continue
                         }
-
-                        seen.insert(dep.clone());
                         filtered.push((dep, bytes));
                     }
 

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -331,7 +331,6 @@ struct ExtraLinkingInfo<'a> {
     target_fname: String,
     contract: &'a mut CompactContractBytecode,
     dependencies: &'a mut Vec<(String, ethers::types::Bytes)>,
-    seen_dependencies: HashSet<String>,
     matched: bool,
     target_id: Option<ArtifactId>,
 }

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -179,8 +179,6 @@ impl ScriptArgs {
 
         let (new_libraries, predeploy_libraries): (Vec<_>, Vec<_>) =
             run_dependencies.into_iter().unzip();
-        dbg!(&new_libraries);
-        dbg!(&predeploy_libraries);
 
         // Merge with user provided libraries
         let mut new_libraries = Libraries::parse(&new_libraries)?;

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -131,7 +131,7 @@ impl ScriptArgs {
                     let mut filtered = Vec::new();
                     let mut seen = HashSet::new();
                     for (dep, bytes) in deps {
-                        if !seen.insert(&dep) {
+                        if !seen.insert(dep.clone()) {
                             continue
                         }
                         filtered.push((dep, bytes));

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -122,7 +122,7 @@ impl AllArtifactsBySlug {
 /// Instead, you must deduplicate *and* preserve the deployment order by pushing the dependencies to
 /// a `Vec` iff it has not been seen before.
 ///
-/// For an example of this, see [here](https://github.com/foundry-rs/foundry/blob/c3a8057a2ddf4bb9e4374811cd304f5a1c5efdb9/cli/src/cmd/forge/script/build.rs#L131-L148).
+/// For an example of this, see [here](https://github.com/foundry-rs/foundry/blob/2308972dbc3a89c03488a05aceb3c428bb3e08c0/cli/src/cmd/forge/script/build.rs#L130-L151C9).
 #[allow(clippy::too_many_arguments)]
 pub fn link_with_nonce_or_address<T, U>(
     contracts: ArtifactContracts,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -93,7 +93,7 @@ impl AllArtifactsBySlug {
 pub fn link_with_nonce_or_address<T, U>(
     contracts: ArtifactContracts,
     known_contracts: &mut BTreeMap<ArtifactId, T>,
-    deployed_library_addresses: Libraries,
+    mut deployed_library_addresses: Libraries,
     sender: Address,
     nonce: U256,
     extra: &mut U,
@@ -162,7 +162,7 @@ pub fn link_with_nonce_or_address<T, U>(
                         &artifacts_by_slug,
                         &link_tree,
                         &mut dependencies,
-                        &deployed_library_addresses,
+                        &mut deployed_library_addresses,
                         nonce,
                         sender,
                     );
@@ -207,7 +207,7 @@ fn recurse_link<'a>(
     // library deployment vector (file:contract:address, bytecode)
     deployment: &'a mut Vec<(String, Bytes)>,
     // deployed library addresses fname => adddress
-    deployed_library_addresses: &'a Libraries,
+    deployed_library_addresses: &'a mut Libraries,
     // nonce to start at
     init_nonce: U256,
     // sender
@@ -274,6 +274,7 @@ fn recurse_link<'a>(
 
             if deployed_address.is_none() {
                 let library = format!("{file}:{key}:0x{}", hex::encode(address));
+                deployed_library_addresses.libs.entry(PathBuf::from_str(file).expect("Invalid library path.")).or_default().insert(key.clone(), hex::encode(address));
 
                 // push the dependency into the library deployment vector
                 deployment.push((

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -103,7 +103,7 @@ impl AllArtifactsBySlug {
 /// libraries (specified by the user) 2. Otherwise, computing the address the library would live at
 /// if deployed by `sender`, given a starting nonce of `nonce`.
 ///
-/// If the library was already deployed previously in step 2., the linker will re-use the previously
+/// If the library was already deployed previously in step 2, the linker will re-use the previously
 /// computed address instead of re-computing it.
 ///
 /// The linker will call `post_link` for each linked artifact, providing:


### PR DESCRIPTION
## Motivation

Sometimes the linking process would result in libraries being deployed more than once, which could also lead to verification issues on block explorers.

Ref https://github.com/foundry-rs/foundry/issues/4443

## Solution

~A really quick hack to deduplicate deployed contracts is in this PR. Essentially we hijack the "dynamic linking" part of the linker, where the user can supply pre-determined library addresses, since we already check this structure to see if the library has been deployed before. When we finish linking a new object, we add it to the list.~

☝🏻  Unfortunately this did not work, since we just collect the addresses and slugs of deployed libraries from the linker for all contracts we want to deploy. Since some contracts may deploy on the same library, the library would show up twice in the list of contracts to deploy, even though the linker correctly figured out that it only needed to deploy the library once with the above fix.

The real fix then is to keep 1) a list of predeployed contracts (specified by the user, this already exists), 2) a list of libraries the linker has already computed an address for (this PR adds that), and 3) deduplicating the libraries to deploy *once more* at the actual deployment site (e.g. in the build command).

This code is pure spaghetti, no meatballs, and we need to fix it once we have the time.

## Validation

Since our linker has very few tests (and honestly, I do not really know how to add new ones), I opted to validate using this repository: https://github.com/hexonaut/library-issue-example

The broadcast log for the script before this PR incorrectly wants to deploy a specific library twice. With this PR, it correctly only deploys it once (for a total of 2 library deployments, 2 contract deployments).