### PR TITLE
chore(cast): added cast base-fee alias for basefee

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -618,7 +618,7 @@ pub enum Subcommands {
     },
 
     /// Get the basefee of a block.
-    #[clap(visible_aliases = &["ba", "fee"])]
+    #[clap(visible_aliases = &["ba", "fee", "basefee"])]
     BaseFee {
         /// The block height to query at.
         ///


### PR DESCRIPTION
## Motivation

- Added alias `cast base-fee` to `cast basefee`.
- Suggestion for this change by @mattsse in https://github.com/foundry-rs/book/pull/925
