### PR TITLE
chore: remove function selector requirement for `abi_decode`

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1343,7 +1343,44 @@ impl SimpleCast {
     /// }
     /// ```
     pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {
-        foundry_common::abi::abi_decode(sig, calldata, input)
+        foundry_common::abi::abi_decode(sig, calldata, input, false)
+    }
+
+
+    /// Decodes calldata-encoded hex input or output
+    /// Similar to `abi_decode`, but does requires a function signature prefixed for "calldata"
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     // Passing `input = false` will decode the data as the output type.
+    ///     // The input data types and the full function sig are ignored, i.e.
+    ///     // you could also pass `balanceOf()(uint256)` and it'd still work.
+    ///     let data = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    ///     let sig = "balanceOf(address, uint256)(uint256)";
+    ///     let decoded = Cast::abi_decode(sig, data, false)?[0].to_string();
+    ///     assert_eq!(decoded, "1");
+    ///
+    ///     // Passing `input = true` will decode the data with the input function signature.
+    ///     // We exclude the "prefixed" function selector from the data field (the first 4 bytes).
+    ///     let data = "0x0000000000000000000000008dbd1b711dc621e1404633da156fcc779e1c6f3e000000000000000000000000d9f3c9cc99548bf3b44a43e0a2d07399eb918adc000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000";
+    ///     let sig = "safeTransferFrom(address, address, uint256, uint256, bytes)";
+    ///     let decoded = Cast::abi_decode(sig, data, true)?;
+    ///     let decoded = decoded.iter().map(ToString::to_string).collect::<Vec<_>>();
+    ///     assert_eq!(
+    ///         decoded,
+    ///         vec!["8dbd1b711dc621e1404633da156fcc779e1c6f3e", "d9f3c9cc99548bf3b44a43e0a2d07399eb918adc", "2a", "1", ""]
+    ///     );
+    ///
+    ///
+    ///     # Ok(())
+    /// }
+    /// ```
+    pub fn calldata_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {
+        foundry_common::abi::abi_decode(sig, calldata, input, true)
     }
 
     /// Performs ABI encoding based off of the function signature. Does not include
@@ -1719,7 +1756,7 @@ impl SimpleCast {
     ///
     ///     Ok(())
     /// }
-    /// ```    
+    /// ```
     pub fn get_selector(signature: &str, optimize: Option<usize>) -> Result<(String, String)> {
         let optimize = optimize.unwrap_or(0);
         if optimize > 4 {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -172,7 +172,7 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
         Subcommands::CalldataDecode { sig, calldata } => {
-            let tokens = SimpleCast::abi_decode(&sig, &calldata, true)?;
+            let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;
             let tokens = format_tokens(&tokens);
             tokens.for_each(|t| println!("{t}"));
         }
@@ -368,7 +368,7 @@ async fn main() -> eyre::Result<()> {
                 }
             };
 
-            let tokens = SimpleCast::abi_decode(sig, &calldata, true)?;
+            let tokens = SimpleCast::calldata_decode(sig, &calldata, true)?;
             for token in format_tokens(&tokens) {
                 println!("{token}");
             }

--- a/common/src/abi.rs
+++ b/common/src/abi.rs
@@ -33,13 +33,17 @@ pub fn encode_args(func: &Function, args: &[impl AsRef<str>]) -> Result<Vec<u8>>
 /// # Panics
 ///
 /// If the `sig` is an invalid function signature
-pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {
+pub fn abi_decode(sig: &str, calldata: &str, input: bool, fn_selector: bool) -> Result<Vec<Token>> {
     let func = IntoFunction::into(sig);
     let calldata = calldata.strip_prefix("0x").unwrap_or(calldata);
     let calldata = hex::decode(calldata)?;
     let res = if input {
-        // need to strip the function selector
-        func.decode_input(&calldata[4..])?
+        // If contains function selector, remove it
+        if fn_selector {
+            func.decode_input(&calldata[4..])?
+        } else {
+            func.decode_input(&calldata)?
+        }
     } else {
         func.decode_output(&calldata)?
     };

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -220,7 +220,7 @@ impl SignEthClient {
         Ok(sigs
             .iter()
             .cloned()
-            .filter(|sig| abi_decode(sig, calldata, true).is_ok())
+            .filter(|sig| abi_decode(sig, calldata, true, true).is_ok())
             .collect::<Vec<String>>())
     }
 
@@ -236,7 +236,7 @@ impl SignEthClient {
     /// Pretty print calldata and if available, fetch possible function signatures
     ///
     /// ```no_run
-    /// 
+    ///
     /// use foundry_common::selectors::SignEthClient;
     ///
     /// # async fn foo() -> eyre::Result<()> {
@@ -372,7 +372,7 @@ pub async fn decode_event_topic(topic: &str) -> eyre::Result<Vec<String>> {
 /// Pretty print calldata and if available, fetch possible function signatures
 ///
 /// ```no_run
-/// 
+///
 /// use foundry_common::selectors::pretty_calldata;
 ///
 /// # async fn foo() -> eyre::Result<()> {


### PR DESCRIPTION

## Motivation

- Standardize input field requirement for `--abi-decode --input` to behave similar to `abi-encode`
- This includes removing the function selector prefix in `calldata` when using `--abi-decode --input`, similar to the `abi-encode` output
- Fixes https://github.com/foundry-rs/foundry/issues/4987

Example below for ERC20 transferFrom, when using `--abi-decode --input`, we are removing the 4 bytes function selector

Before:
`calldata: 0xa9059cbb0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a7640000`

After:
`calldata:
0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a7640000`


### Questions:
- Where to write tests for `abi-decode` in the repository


