### PR TITLE
fix: don't set block env's difficulty with fork's total difficulty

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1609,7 +1609,6 @@ impl Backend {
 
                     block.number = block_number.into();
                     block.timestamp = rU256::from(fork.timestamp());
-                    block.difficulty = fork.total_difficulty().into();
                     block.basefee = fork.base_fee().unwrap_or_default().into();
 
                     return Ok(f(Box::new(&gen_db), block))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the env's difficulty is pinned to the forked blocks difficulty during startup.

this removes in incorrect update where we set the blocked envs difficulty to the total difficulty at the forked block which lead to saturated total difficulty over time:

https://github.com/foundry-rs/foundry/blob/master/anvil/src/eth/backend/mem/mod.rs#L845-L845

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
remove incorrect value write for block difficulty
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
