### PR TITLE
feat(cast): cast `codesize`

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -41,6 +41,7 @@
 -   [x] `chain-id`
 -   [x] `client`
 -   [x] `code`
+-   [x] `codesize`
 -   [ ] `debug`
 -   [x] `estimate`
 -   [x] `etherscan-source`

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -621,6 +621,31 @@ where
         }
     }
 
+    /// Example
+    /// 
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa")?;
+    /// let code = cast.codesize(addr, None).await?;
+    /// println!("{}", codesize);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn codesize<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>
+    ) -> Result<String> {
+        let code = self.provider.get_code(who, block).await?.to_vec();
+        Ok(format!("{}", code.len()))
+    }
     /// # Example
     ///
     /// ```no_run

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -622,7 +622,7 @@ where
     }
 
     /// Example
-    /// 
+    ///
     /// ```no_run
     /// use cast::Cast;
     /// use ethers_providers::{Provider, Http};
@@ -633,7 +633,7 @@ where
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
     /// let cast = Cast::new(provider);
     /// let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa")?;
-    /// let code = cast.codesize(addr, None).await?;
+    /// let codesize = cast.codesize(addr, None).await?;
     /// println!("{}", codesize);
     /// # Ok(())
     /// # }
@@ -641,11 +641,12 @@ where
     pub async fn codesize<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         who: T,
-        block: Option<BlockId>
+        block: Option<BlockId>,
     ) -> Result<String> {
         let code = self.provider.get_code(who, block).await?.to_vec();
         Ok(format!("{}", code.len()))
     }
+
     /// # Example
     ///
     /// ```no_run

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -259,6 +259,11 @@ async fn main() -> eyre::Result<()> {
             let provider = utils::get_provider(&config)?;
             println!("{}", Cast::new(provider).code(who, block, disassemble).await?);
         }
+        Subcommands::Codesize { block, who, rpc } => {
+            let config = Config::from(&rpc);
+            let provider = utils::get_provider(&config)?;
+            println!("{}", Cast::new(provider).codesize(who, block).await?);
+        }
         Subcommands::ComputeAddress { address, nonce, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -646,6 +646,23 @@ pub enum Subcommands {
         rpc: RpcOpts,
     },
 
+    /// Get the runtime bytecode size of a contract.
+    #[clap(visible_alias = "cs")]
+    Codesize {
+        /// The block height to query at.
+        /// 
+        /// Can also be the tags earliest, finalized, safe, latest, or pending.
+        #[clap(long, short ='B')]
+        block: Option<BlockId>,
+
+        /// The contract address.
+        #[clap(value_parser = NameOrAddress::from_str)]
+        who: NameOrAddress,
+
+        #[clap(flatten)]
+        rpc: RpcOpts,
+    },
+
     /// Get the current gas price.
     #[clap(name = "gas-price", visible_alias = "g")]
     GasPrice {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -650,9 +650,9 @@ pub enum Subcommands {
     #[clap(visible_alias = "cs")]
     Codesize {
         /// The block height to query at.
-        /// 
+        ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short ='B')]
+        #[clap(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The contract address.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
To my knowledge, there's not an easy way to get the codesize of a contract outside of Solidity's `extcodesize()` assembly function. As of right now, you need a build artifact and then need to take the size of it by trimming it by 2 to remove the '0x' and then dividing by 2 to get the value in bytes. This is far more clumsy than it should be.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This `cast codesize` command makes it easy to immediately query the runtime codesize in bytes for a contract while only providing the address.

![image](https://github.com/foundry-rs/foundry/assets/24715302/9fd0d16d-3ecd-454c-ad15-a3b49d05abae)

I elected to only return the number of bytes as a string for maximum flexibility. 

Earlier I had a more advanced implementation: 
```rust
    pub async fn codesize<T: Into<NameOrAddress> + Send + Sync>(
        &self,
        who: T,
        block: Option<BlockId>
    ) -> Result<String> {
        let who = who.into();
        let who_str = match &who {
            NameOrAddress::Name(name) => name.clone(),
            NameOrAddress::Address(address) => address.to_string(),
        };
        let code = self.provider.get_code(who, block).await?.to_vec();
        Ok(format!("Address at {} has a codesize of {} bytes", who_str, code.len()))
    }
``` 

Let me know which version you guys prefer or if there's anything I forgot to add for this.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
