### PR TITLE
refactor(`cast`): remove double dashes from cast commands

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -30,7 +30,7 @@ pub struct Opts {
 )]
 pub enum Subcommands {
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "max-int", visible_aliases = &["max-int", "maxi"])]
+    #[clap(name = "max-int", visible_aliases = &["--max-int", "maxi"])]
     MaxInt {
         /// The integer type to get the maximum value of.
         #[clap(default_value = "int256")]
@@ -38,7 +38,7 @@ pub enum Subcommands {
     },
 
     /// Prints the minimum value of the given integer type.
-    #[clap(name = "min-int", visible_aliases = &["min-int", "mini"])]
+    #[clap(name = "min-int", visible_aliases = &["--min-int", "mini"])]
     MinInt {
         /// The integer type to get the minimum value of.
         #[clap(default_value = "int256")]
@@ -46,7 +46,7 @@ pub enum Subcommands {
     },
 
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "max-uint", visible_aliases = &["max-uint", "maxu"])]
+    #[clap(name = "max-uint", visible_aliases = &["--max-uint", "maxu"])]
     MaxUint {
         /// The unsigned integer type to get the maximum value of.
         #[clap(default_value = "uint256")]
@@ -54,11 +54,11 @@ pub enum Subcommands {
     },
 
     /// Prints the zero address.
-    #[clap(name = "address-zero", visible_aliases = &["address-zero", "az"])]
+    #[clap(name = "address-zero", visible_aliases = &["--address-zero", "az"])]
     AddressZero,
 
     /// Prints the zero hash.
-    #[clap(name = "hash-zero", visible_aliases = &["hash-zero", "hz"])]
+    #[clap(name = "hash-zero", visible_aliases = &["--hash-zero", "hz"])]
     HashZero,
 
     /// Convert UTF8 text to hex.
@@ -76,14 +76,14 @@ pub enum Subcommands {
     },
 
     /// Concatenate hex strings.
-    #[clap(name = "concat-hex", visible_aliases = &["concat-hex", "ch"])]
+    #[clap(name = "concat-hex", visible_aliases = &["--concat-hex", "ch"])]
     ConcatHex {
         /// The data to concatenate.
         data: Vec<String>,
     },
 
     /// "Convert binary data into hex data."
-    #[clap(name = "from-bin", visible_aliases = &["from-binx", "fb"])]
+    #[clap(name = "from-bin", visible_aliases = &["--from-binx", "fb"])]
     FromBin,
 
     /// Normalize the input to lowercase, 0x-prefixed hex.
@@ -93,7 +93,7 @@ pub enum Subcommands {
     /// - 0x prefixed hex, concatenated with a ':'
     /// - an absolute path to file
     /// - @tag, where the tag is defined in an environment variable
-    #[clap(name = "to-hexdata", visible_aliases = &["to-hexdata", "thd", "2hd"])]
+    #[clap(name = "to-hexdata", visible_aliases = &["--to-hexdata", "thd", "2hd"])]
     ToHexdata {
         /// The input to normalize.
         input: Option<String>,
@@ -114,14 +114,14 @@ pub enum Subcommands {
     },
 
     /// Convert hex data to an ASCII string.
-    #[clap(name = "to-ascii", visible_aliases = &["to-ascii", "tas", "2as"])]
+    #[clap(name = "to-ascii", visible_aliases = &["--to-ascii", "tas", "2as"])]
     ToAscii {
         /// The hex data to convert.
         hexdata: Option<String>,
     },
 
     /// Convert a fixed point number into an integer.
-    #[clap(name = "from-fix", visible_aliases = &["from-fix", "ff"])]
+    #[clap(name = "from-fix", visible_aliases = &["--from-fix", "ff"])]
     FromFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -132,14 +132,14 @@ pub enum Subcommands {
     },
 
     /// Right-pads hex data to 32 bytes.
-    #[clap(name = "to-bytes32", visible_aliases = &["to-bytes32", "tb", "2b"])]
+    #[clap(name = "to-bytes32", visible_aliases = &["--to-bytes32", "tb", "2b"])]
     ToBytes32 {
         /// The hex data to convert.
         bytes: Option<String>,
     },
 
     /// Convert an integer into a fixed point number.
-    #[clap(name = "to-fix", visible_aliases = &["to-fix", "tf", "2f"])]
+    #[clap(name = "to-fix", visible_aliases = &["--to-fix", "tf", "2f"])]
     ToFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -150,14 +150,14 @@ pub enum Subcommands {
     },
 
     /// Convert a number to a hex-encoded uint256.
-    #[clap(name = "to-uint256", visible_aliases = &["to-uint256", "tu", "2u"])]
+    #[clap(name = "to-uint256", visible_aliases = &["--to-uint256", "tu", "2u"])]
     ToUint256 {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Convert a number to a hex-encoded int256.
-    #[clap(name = "to-int256", visible_aliases = &["to-int256", "ti", "2i"])]
+    #[clap(name = "to-int256", visible_aliases = &["--to-int256", "ti", "2i"])]
     ToInt256 {
         /// The value to convert.
         value: Option<String>,
@@ -207,7 +207,7 @@ pub enum Subcommands {
     /// - 1ether
     /// - 1 gwei
     /// - 1gwei ether
-    #[clap(name = "to-unit", visible_aliases = &["to-unit", "tun", "2un"])]
+    #[clap(name = "to-unit", visible_aliases = &["--to-unit", "tun", "2un"])]
     ToUnit {
         /// The value to convert.
         value: Option<String>,
@@ -220,7 +220,7 @@ pub enum Subcommands {
     /// Convert an ETH amount to wei.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "to-wei", visible_aliases = &["to-wei", "tw", "2w"])]
+    #[clap(name = "to-wei", visible_aliases = &["--to-wei", "tw", "2w"])]
     ToWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -234,7 +234,7 @@ pub enum Subcommands {
     /// Convert wei into an ETH amount.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "from-wei", visible_aliases = &["from-wei", "fw"])]
+    #[clap(name = "from-wei", visible_aliases = &["--from-wei", "fw"])]
     FromWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -246,7 +246,7 @@ pub enum Subcommands {
     },
 
     /// RLP encodes hex data, or an array of hex data
-    #[clap(name = "to-rlp")]
+    #[clap(name = "to-rlp", visible_aliases = &["--to-rlp"])]
     ToRlp {
         /// The value to convert.
         value: Option<String>,
@@ -255,24 +255,24 @@ pub enum Subcommands {
     /// Decodes RLP encoded data.
     ///
     /// Input must be hexadecimal.
-    #[clap(name = "from-rlp")]
+    #[clap(name = "from-rlp", visible_aliases = &["--from-rlp"])]
     FromRlp {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Converts a number of one base to another
-    #[clap(name = "to-hex", visible_aliases = &["to-hex", "th", "2h"])]
+    #[clap(name = "to-hex", visible_aliases = &["--to-hex", "th", "2h"])]
     ToHex(ToBaseArgs),
 
     /// Converts a number of one base to decimal
-    #[clap(name = "to-dec", visible_aliases = &["to-dec", "td", "2d"])]
+    #[clap(name = "to-dec", visible_aliases = &["--to-dec", "td", "2d"])]
     ToDec(ToBaseArgs),
 
     /// Converts a number of one base to another
     #[clap(
         name = "to-base",
-        visible_aliases = &["to-base",
+        visible_aliases = &["--to-base",
         "--to-radix",
         "to-radix",
         "tr",
@@ -447,7 +447,7 @@ pub enum Subcommands {
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
-    #[clap(name = "calldata-decode", visible_alias = "cdd")]
+    #[clap(name = "calldata-decode", visible_aliases = &["--calldata-decode","cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -460,7 +460,7 @@ pub enum Subcommands {
     ///
     /// Defaults to decoding output data. To decode input data pass --input or use cast
     /// --calldata-decode.
-    #[clap(name = "abi-decode", visible_alias = "ad")]
+    #[clap(name = "abi-decode", visible_aliases = &["--abi-decode","ad"])]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -827,19 +827,19 @@ pub enum Subcommands {
     Rpc(RpcArgs),
 
     /// Formats a string into bytes32 encoding.
-    #[clap(name = "format-bytes32-string")]
+    #[clap(name = "format-bytes32-string", visible_aliases = &["--format-bytes32-string"])]
     FormatBytes32String {
         /// The string to format.
         string: Option<String>,
     },
 
     /// Parses a string from bytes32 encoding.
-    #[clap(name = "parse-bytes32-string")]
+    #[clap(name = "parse-bytes32-string", visible_aliases = &["--parse-bytes32-string"])]
     ParseBytes32String {
         /// The string to parse.
         bytes: Option<String>,
     },
-    #[clap(name = "parse-bytes32-address")]
+    #[clap(name = "parse-bytes32-address", visible_aliases = &["--parse-bytes32-address"])]
     #[clap(about = "Parses a checksummed address from bytes32 encoding.")]
     ParseBytes32Address {
         #[clap(value_name = "BYTES")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -30,7 +30,7 @@ pub struct Opts {
 )]
 pub enum Subcommands {
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "--max-int", visible_aliases = &["max-int", "maxi"])]
+    #[clap(name = "max-int", visible_aliases = &["max-int", "maxi"])]
     MaxInt {
         /// The integer type to get the maximum value of.
         #[clap(default_value = "int256")]
@@ -38,7 +38,7 @@ pub enum Subcommands {
     },
 
     /// Prints the minimum value of the given integer type.
-    #[clap(name = "--min-int", visible_aliases = &["min-int", "mini"])]
+    #[clap(name = "min-int", visible_aliases = &["min-int", "mini"])]
     MinInt {
         /// The integer type to get the minimum value of.
         #[clap(default_value = "int256")]
@@ -46,7 +46,7 @@ pub enum Subcommands {
     },
 
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "--max-uint", visible_aliases = &["max-uint", "maxu"])]
+    #[clap(name = "max-uint", visible_aliases = &["max-uint", "maxu"])]
     MaxUint {
         /// The unsigned integer type to get the maximum value of.
         #[clap(default_value = "uint256")]
@@ -54,11 +54,11 @@ pub enum Subcommands {
     },
 
     /// Prints the zero address.
-    #[clap(name = "--address-zero", visible_aliases = &["address-zero", "az"])]
+    #[clap(name = "address-zero", visible_aliases = &["address-zero", "az"])]
     AddressZero,
 
     /// Prints the zero hash.
-    #[clap(name = "--hash-zero", visible_aliases = &["hash-zero", "hz"])]
+    #[clap(name = "hash-zero", visible_aliases = &["hash-zero", "hz"])]
     HashZero,
 
     /// Convert UTF8 text to hex.
@@ -76,14 +76,14 @@ pub enum Subcommands {
     },
 
     /// Concatenate hex strings.
-    #[clap(name = "--concat-hex", visible_aliases = &["concat-hex", "ch"])]
+    #[clap(name = "concat-hex", visible_aliases = &["concat-hex", "ch"])]
     ConcatHex {
         /// The data to concatenate.
         data: Vec<String>,
     },
 
     /// "Convert binary data into hex data."
-    #[clap(name = "--from-bin", visible_aliases = &["from-binx", "fb"])]
+    #[clap(name = "from-bin", visible_aliases = &["from-binx", "fb"])]
     FromBin,
 
     /// Normalize the input to lowercase, 0x-prefixed hex.
@@ -93,7 +93,7 @@ pub enum Subcommands {
     /// - 0x prefixed hex, concatenated with a ':'
     /// - an absolute path to file
     /// - @tag, where the tag is defined in an environment variable
-    #[clap(name = "--to-hexdata", visible_aliases = &["to-hexdata", "thd", "2hd"])]
+    #[clap(name = "to-hexdata", visible_aliases = &["to-hexdata", "thd", "2hd"])]
     ToHexdata {
         /// The input to normalize.
         input: Option<String>,
@@ -101,9 +101,9 @@ pub enum Subcommands {
 
     /// Convert an address to a checksummed format (EIP-55).
     #[clap(
-        name = "--to-checksum-address",
+        name = "to-checksum-address",
         visible_aliases = &["to-checksum-address",
-        "--to-checksum",
+        "to-checksum",
         "to-checksum",
         "ta",
         "2a"]
@@ -114,14 +114,14 @@ pub enum Subcommands {
     },
 
     /// Convert hex data to an ASCII string.
-    #[clap(name = "--to-ascii", visible_aliases = &["to-ascii", "tas", "2as"])]
+    #[clap(name = "to-ascii", visible_aliases = &["to-ascii", "tas", "2as"])]
     ToAscii {
         /// The hex data to convert.
         hexdata: Option<String>,
     },
 
     /// Convert a fixed point number into an integer.
-    #[clap(name = "--from-fix", visible_aliases = &["from-fix", "ff"])]
+    #[clap(name = "from-fix", visible_aliases = &["from-fix", "ff"])]
     FromFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -132,14 +132,14 @@ pub enum Subcommands {
     },
 
     /// Right-pads hex data to 32 bytes.
-    #[clap(name = "--to-bytes32", visible_aliases = &["to-bytes32", "tb", "2b"])]
+    #[clap(name = "to-bytes32", visible_aliases = &["to-bytes32", "tb", "2b"])]
     ToBytes32 {
         /// The hex data to convert.
         bytes: Option<String>,
     },
 
     /// Convert an integer into a fixed point number.
-    #[clap(name = "--to-fix", visible_aliases = &["to-fix", "tf", "2f"])]
+    #[clap(name = "to-fix", visible_aliases = &["to-fix", "tf", "2f"])]
     ToFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -150,14 +150,14 @@ pub enum Subcommands {
     },
 
     /// Convert a number to a hex-encoded uint256.
-    #[clap(name = "--to-uint256", visible_aliases = &["to-uint256", "tu", "2u"])]
+    #[clap(name = "to-uint256", visible_aliases = &["to-uint256", "tu", "2u"])]
     ToUint256 {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Convert a number to a hex-encoded int256.
-    #[clap(name = "--to-int256", visible_aliases = &["to-int256", "ti", "2i"])]
+    #[clap(name = "to-int256", visible_aliases = &["to-int256", "ti", "2i"])]
     ToInt256 {
         /// The value to convert.
         value: Option<String>,
@@ -207,7 +207,7 @@ pub enum Subcommands {
     /// - 1ether
     /// - 1 gwei
     /// - 1gwei ether
-    #[clap(name = "--to-unit", visible_aliases = &["to-unit", "tun", "2un"])]
+    #[clap(name = "to-unit", visible_aliases = &["to-unit", "tun", "2un"])]
     ToUnit {
         /// The value to convert.
         value: Option<String>,
@@ -220,7 +220,7 @@ pub enum Subcommands {
     /// Convert an ETH amount to wei.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "--to-wei", visible_aliases = &["to-wei", "tw", "2w"])]
+    #[clap(name = "to-wei", visible_aliases = &["to-wei", "tw", "2w"])]
     ToWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -234,7 +234,7 @@ pub enum Subcommands {
     /// Convert wei into an ETH amount.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "--from-wei", visible_aliases = &["from-wei", "fw"])]
+    #[clap(name = "from-wei", visible_aliases = &["from-wei", "fw"])]
     FromWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -246,7 +246,7 @@ pub enum Subcommands {
     },
 
     /// RLP encodes hex data, or an array of hex data
-    #[clap(name = "--to-rlp")]
+    #[clap(name = "to-rlp")]
     ToRlp {
         /// The value to convert.
         value: Option<String>,
@@ -255,23 +255,23 @@ pub enum Subcommands {
     /// Decodes RLP encoded data.
     ///
     /// Input must be hexadecimal.
-    #[clap(name = "--from-rlp")]
+    #[clap(name = "from-rlp")]
     FromRlp {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Converts a number of one base to another
-    #[clap(name = "--to-hex", visible_aliases = &["to-hex", "th", "2h"])]
+    #[clap(name = "to-hex", visible_aliases = &["to-hex", "th", "2h"])]
     ToHex(ToBaseArgs),
 
     /// Converts a number of one base to decimal
-    #[clap(name = "--to-dec", visible_aliases = &["to-dec", "td", "2d"])]
+    #[clap(name = "to-dec", visible_aliases = &["to-dec", "td", "2d"])]
     ToDec(ToBaseArgs),
 
     /// Converts a number of one base to another
     #[clap(
-        name = "--to-base",
+        name = "to-base",
         visible_aliases = &["to-base",
         "--to-radix",
         "to-radix",
@@ -447,7 +447,7 @@ pub enum Subcommands {
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
-    #[clap(name = "--calldata-decode", visible_alias = "cdd")]
+    #[clap(name = "calldata-decode", visible_alias = "cdd")]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -460,7 +460,7 @@ pub enum Subcommands {
     ///
     /// Defaults to decoding output data. To decode input data pass --input or use cast
     /// --calldata-decode.
-    #[clap(name = "--abi-decode", visible_alias = "ad")]
+    #[clap(name = "abi-decode", visible_alias = "ad")]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -827,19 +827,19 @@ pub enum Subcommands {
     Rpc(RpcArgs),
 
     /// Formats a string into bytes32 encoding.
-    #[clap(name = "--format-bytes32-string")]
+    #[clap(name = "format-bytes32-string")]
     FormatBytes32String {
         /// The string to format.
         string: Option<String>,
     },
 
     /// Parses a string from bytes32 encoding.
-    #[clap(name = "--parse-bytes32-string")]
+    #[clap(name = "parse-bytes32-string")]
     ParseBytes32String {
         /// The string to parse.
         bytes: Option<String>,
     },
-    #[clap(name = "--parse-bytes32-address")]
+    #[clap(name = "parse-bytes32-address")]
     #[clap(about = "Parses a checksummed address from bytes32 encoding.")]
     ParseBytes32Address {
         #[clap(value_name = "BYTES")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -83,7 +83,7 @@ pub enum Subcommands {
     },
 
     /// "Convert binary data into hex data."
-    #[clap(name = "from-bin", visible_aliases = &["--from-binx", "fb"])]
+    #[clap(name = "from-bin", visible_aliases = &["--from-bin", "from-binx", "fb"])]
     FromBin,
 
     /// Normalize the input to lowercase, 0x-prefixed hex.
@@ -102,8 +102,8 @@ pub enum Subcommands {
     /// Convert an address to a checksummed format (EIP-55).
     #[clap(
         name = "to-checksum-address",
-        visible_aliases = &["to-checksum-address",
-        "to-checksum",
+        visible_aliases = &["--to-checksum-address",
+        "--to-checksum",
         "to-checksum",
         "ta",
         "2a"]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -30,7 +30,7 @@ pub struct Opts {
 )]
 pub enum Subcommands {
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "max-int", visible_aliases = &["--max-int", "maxi"])]
+    #[clap(visible_aliases = &["--max-int", "maxi"])]
     MaxInt {
         /// The integer type to get the maximum value of.
         #[clap(default_value = "int256")]
@@ -38,7 +38,7 @@ pub enum Subcommands {
     },
 
     /// Prints the minimum value of the given integer type.
-    #[clap(name = "min-int", visible_aliases = &["--min-int", "mini"])]
+    #[clap(visible_aliases = &["--min-int", "mini"])]
     MinInt {
         /// The integer type to get the minimum value of.
         #[clap(default_value = "int256")]
@@ -46,7 +46,7 @@ pub enum Subcommands {
     },
 
     /// Prints the maximum value of the given integer type.
-    #[clap(name = "max-uint", visible_aliases = &["--max-uint", "maxu"])]
+    #[clap(visible_aliases = &["--max-uint", "maxu"])]
     MaxUint {
         /// The unsigned integer type to get the maximum value of.
         #[clap(default_value = "uint256")]
@@ -54,17 +54,16 @@ pub enum Subcommands {
     },
 
     /// Prints the zero address.
-    #[clap(name = "address-zero", visible_aliases = &["--address-zero", "az"])]
+    #[clap(visible_aliases = &["--address-zero", "az"])]
     AddressZero,
 
     /// Prints the zero hash.
-    #[clap(name = "hash-zero", visible_aliases = &["--hash-zero", "hz"])]
+    #[clap(visible_aliases = &["--hash-zero", "hz"])]
     HashZero,
 
     /// Convert UTF8 text to hex.
     #[clap(
-        name = "--from-utf8",
-        visible_aliases = &["from-utf8",
+        visible_aliases = &[
         "--from-ascii",
         "from-ascii",
         "fu",
@@ -76,14 +75,14 @@ pub enum Subcommands {
     },
 
     /// Concatenate hex strings.
-    #[clap(name = "concat-hex", visible_aliases = &["--concat-hex", "ch"])]
+    #[clap(visible_aliases = &["--concat-hex", "ch"])]
     ConcatHex {
         /// The data to concatenate.
         data: Vec<String>,
     },
 
     /// "Convert binary data into hex data."
-    #[clap(name = "from-bin", visible_aliases = &["--from-bin", "from-binx", "fb"])]
+    #[clap(visible_aliases = &["--from-bin", "from-binx", "fb"])]
     FromBin,
 
     /// Normalize the input to lowercase, 0x-prefixed hex.
@@ -93,7 +92,7 @@ pub enum Subcommands {
     /// - 0x prefixed hex, concatenated with a ':'
     /// - an absolute path to file
     /// - @tag, where the tag is defined in an environment variable
-    #[clap(name = "to-hexdata", visible_aliases = &["--to-hexdata", "thd", "2hd"])]
+    #[clap(visible_aliases = &["--to-hexdata", "thd", "2hd"])]
     ToHexdata {
         /// The input to normalize.
         input: Option<String>,
@@ -101,7 +100,6 @@ pub enum Subcommands {
 
     /// Convert an address to a checksummed format (EIP-55).
     #[clap(
-        name = "to-checksum-address",
         visible_aliases = &["--to-checksum-address",
         "--to-checksum",
         "to-checksum",
@@ -114,14 +112,14 @@ pub enum Subcommands {
     },
 
     /// Convert hex data to an ASCII string.
-    #[clap(name = "to-ascii", visible_aliases = &["--to-ascii", "tas", "2as"])]
+    #[clap(visible_aliases = &["--to-ascii", "tas", "2as"])]
     ToAscii {
         /// The hex data to convert.
         hexdata: Option<String>,
     },
 
     /// Convert a fixed point number into an integer.
-    #[clap(name = "from-fix", visible_aliases = &["--from-fix", "ff"])]
+    #[clap(visible_aliases = &["--from-fix", "ff"])]
     FromFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -132,14 +130,14 @@ pub enum Subcommands {
     },
 
     /// Right-pads hex data to 32 bytes.
-    #[clap(name = "to-bytes32", visible_aliases = &["--to-bytes32", "tb", "2b"])]
+    #[clap(visible_aliases = &["--to-bytes32", "tb", "2b"])]
     ToBytes32 {
         /// The hex data to convert.
         bytes: Option<String>,
     },
 
     /// Convert an integer into a fixed point number.
-    #[clap(name = "to-fix", visible_aliases = &["--to-fix", "tf", "2f"])]
+    #[clap(visible_aliases = &["--to-fix", "tf", "2f"])]
     ToFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
@@ -207,7 +205,7 @@ pub enum Subcommands {
     /// - 1ether
     /// - 1 gwei
     /// - 1gwei ether
-    #[clap(name = "to-unit", visible_aliases = &["--to-unit", "tun", "2un"])]
+    #[clap(visible_aliases = &["--to-unit", "tun", "2un"])]
     ToUnit {
         /// The value to convert.
         value: Option<String>,
@@ -220,7 +218,7 @@ pub enum Subcommands {
     /// Convert an ETH amount to wei.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "to-wei", visible_aliases = &["--to-wei", "tw", "2w"])]
+    #[clap(visible_aliases = &["--to-wei", "tw", "2w"])]
     ToWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -234,7 +232,7 @@ pub enum Subcommands {
     /// Convert wei into an ETH amount.
     ///
     /// Consider using --to-unit.
-    #[clap(name = "from-wei", visible_aliases = &["--from-wei", "fw"])]
+    #[clap(visible_aliases = &["--from-wei", "fw"])]
     FromWei {
         /// The value to convert.
         #[clap(allow_hyphen_values = true)]
@@ -246,7 +244,7 @@ pub enum Subcommands {
     },
 
     /// RLP encodes hex data, or an array of hex data
-    #[clap(name = "to-rlp", visible_aliases = &["--to-rlp"])]
+    #[clap(visible_aliases = &["--to-rlp"])]
     ToRlp {
         /// The value to convert.
         value: Option<String>,
@@ -255,23 +253,22 @@ pub enum Subcommands {
     /// Decodes RLP encoded data.
     ///
     /// Input must be hexadecimal.
-    #[clap(name = "from-rlp", visible_aliases = &["--from-rlp"])]
+    #[clap(visible_aliases = &["--from-rlp"])]
     FromRlp {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Converts a number of one base to another
-    #[clap(name = "to-hex", visible_aliases = &["--to-hex", "th", "2h"])]
+    #[clap(visible_aliases = &["--to-hex", "th", "2h"])]
     ToHex(ToBaseArgs),
 
     /// Converts a number of one base to decimal
-    #[clap(name = "to-dec", visible_aliases = &["--to-dec", "td", "2d"])]
+    #[clap(visible_aliases = &["--to-dec", "td", "2d"])]
     ToDec(ToBaseArgs),
 
     /// Converts a number of one base to another
     #[clap(
-        name = "to-base",
         visible_aliases = &["--to-base",
         "--to-radix",
         "to-radix",
@@ -287,10 +284,9 @@ pub enum Subcommands {
         base_out: Option<String>,
     },
     /// Create an access list for a transaction.
-    #[clap(name = "access-list", visible_aliases = &["ac", "acl"])]
+    #[clap(visible_aliases = &["ac", "acl"])]
     AccessList(AccessListArgs),
     /// Create an access list for a transaction.
-    #[clap(name = "logs")]
     Logs(LogsArgs),
     /// Get information about a block.
     #[clap(visible_alias = "bl")]
@@ -316,7 +312,7 @@ pub enum Subcommands {
     },
 
     /// Get the latest block number.
-    #[clap(name = "block-number", visible_alias = "bn")]
+    #[clap(visible_alias = "bn")]
     BlockNumber {
         #[clap(flatten)]
         rpc: RpcOpts,
@@ -344,7 +340,7 @@ pub enum Subcommands {
     },
 
     /// Get the Ethereum chain ID.
-    #[clap(name = "chain-id", visible_aliases = &["ci", "cid"])]
+    #[clap(visible_aliases = &["ci", "cid"])]
     ChainId {
         #[clap(flatten)]
         rpc: RpcOpts,
@@ -358,7 +354,7 @@ pub enum Subcommands {
     },
 
     /// Compute the contract address from a given nonce and deployer address.
-    #[clap(name = "compute-address", visible_alias = "ca")]
+    #[clap(visible_alias = "ca")]
     ComputeAddress {
         /// The deployer address.
         address: Option<String>,
@@ -447,7 +443,7 @@ pub enum Subcommands {
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
-    #[clap(name = "calldata-decode", visible_aliases = &["--calldata-decode","cdd"])]
+    #[clap(visible_aliases = &["--calldata-decode","cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -460,7 +456,7 @@ pub enum Subcommands {
     ///
     /// Defaults to decoding output data. To decode input data pass --input or use cast
     /// --calldata-decode.
-    #[clap(name = "abi-decode", visible_aliases = &["--abi-decode","ad"])]
+    #[clap(visible_aliases = &["--abi-decode","ad"])]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -474,7 +470,7 @@ pub enum Subcommands {
     },
 
     /// ABI encode the given function argument, excluding the selector.
-    #[clap(name = "abi-encode", visible_alias = "ae")]
+    #[clap(visible_alias = "ae")]
     AbiEncode {
         /// The function signature.
         sig: String,
@@ -562,7 +558,7 @@ pub enum Subcommands {
     /// - "function transfer(address,uint256)"
     /// - "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
     /// - "./out/Contract.sol/Contract.json"
-    #[clap(name = "upload-signature", visible_aliases = &["ups"])]
+    #[clap(visible_aliases = &["ups"])]
     UploadSignature {
         /// The signatures to upload.
         ///
@@ -574,7 +570,7 @@ pub enum Subcommands {
     /// Pretty print calldata.
     ///
     /// Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline is passed.
-    #[clap(name = "pretty-calldata", visible_alias = "pc")]
+    #[clap(visible_alias = "pc")]
     PrettyCalldata {
         /// The calldata.
         calldata: Option<String>,
@@ -668,14 +664,14 @@ pub enum Subcommands {
     },
 
     /// Get the current gas price.
-    #[clap(name = "gas-price", visible_alias = "g")]
+    #[clap(visible_alias = "g")]
     GasPrice {
         #[clap(flatten)]
         rpc: RpcOpts,
     },
 
     /// Generate event signatures from event string.
-    #[clap(name = "sig-event", visible_alias = "se")]
+    #[clap(visible_alias = "se")]
     SigEvent {
         /// The event string.
         event_string: Option<String>,
@@ -689,7 +685,7 @@ pub enum Subcommands {
     },
 
     /// Perform an ENS lookup.
-    #[clap(name = "resolve-name", visible_alias = "rn")]
+    #[clap(visible_alias = "rn")]
     ResolveName {
         /// The name to lookup.
         who: Option<String>,
@@ -703,7 +699,7 @@ pub enum Subcommands {
     },
 
     /// Perform an ENS reverse lookup.
-    #[clap(name = "lookup-address", visible_alias = "l")]
+    #[clap(visible_alias = "l")]
     LookupAddress {
         /// The account to perform the lookup for.
         who: Option<Address>,
@@ -759,7 +755,7 @@ pub enum Subcommands {
     },
 
     /// Get the source code of a contract from Etherscan.
-    #[clap(name = "etherscan-source", visible_aliases = &["et", "src"])]
+    #[clap(visible_aliases = &["et", "src"])]
     EtherscanSource {
         /// The contract's address.
         address: String,
@@ -804,7 +800,7 @@ pub enum Subcommands {
     Create2(Create2Args),
 
     /// Get the block number closest to the provided timestamp.
-    #[clap(name = "find-block", visible_alias = "f")]
+    #[clap(visible_alias = "f")]
     FindBlock(FindBlockArgs),
 
     /// Generate shell completions script.


### PR DESCRIPTION
## Motivation

This standardizes cast commands to not use `--`, but rather their name, and adds the dash version as an alias instead.

The motivation for this is that some commands had this, and some didn't. As we're gonna do V1 soon it's a good time to standardize it.

## Solution

Remove `--` from cast commands and set the dashed version as an alias.
