### PR TITLE
fix(forge): use proper path for .gitmodules

### DIFF
--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -189,7 +189,12 @@ pub(crate) fn install(
 
                     // this changed the .gitmodules files
                     trace!("git add .gitmodules");
-                    Command::new("git").current_dir(&root).args(["add", ".gitmodules"]).exec()?;
+                    let git_root = Command::new("git")
+                        .current_dir(&root)
+                        .args(["rev-parse", "--show-toplevel"])
+                        .get_stdout_lossy()?;
+                    trace!(?git_root, "git root dir");
+                    Command::new("git").current_dir(&git_root).args(["add", ".gitmodules"]).exec()?;
                 }
             }
 

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -194,7 +194,10 @@ pub(crate) fn install(
                         .args(["rev-parse", "--show-toplevel"])
                         .get_stdout_lossy()?;
                     trace!(?git_root, "git root dir");
-                    Command::new("git").current_dir(&git_root).args(["add", ".gitmodules"]).exec()?;
+                    Command::new("git")
+                        .current_dir(&git_root)
+                        .args(["add", ".gitmodules"])
+                        .exec()?;
                 }
             }
 


### PR DESCRIPTION
Fix for #4552. Now `init`/`install` will add the proper `.gitmodules` when in an existing git repo ex. a monorepo.

## Motivation

Support using `forge` in monorepos.

## Solution

When adding the `.gitmodules` file, use the path of the top-level directory of the working tree [0] as the `current_dir`.

[0] https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-toplevel