### PR TITLE
feat(forge): shallow clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,6 @@ dependencies = [
  "vergen",
  "walkdir",
  "watchexec",
- "which",
  "yansi",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,11 +8,7 @@ repository = "https://github.com/foundry-rs/foundry"
 keywords = ["ethereum", "web3"]
 
 [build-dependencies]
-vergen = { version = "8", default-features = false, features = [
-  "build",
-  "git",
-  "git2",
-] }
+vergen = { version = "8", default-features = false, features = ["build", "git", "git2"] }
 
 [dependencies]
 # foundry internal
@@ -36,11 +32,7 @@ clap_complete = "4"
 clap_complete_fig = "4"
 yansi = "0.5"
 tracing-error = "0.2"
-tracing-subscriber = { version = "0.3", features = [
-  "registry",
-  "env-filter",
-  "fmt",
-] }
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
 tracing = "0.1"
 console = "0.15"
 watchexec = "2"
@@ -86,7 +78,6 @@ bytes = "1.4"
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 indicatif = "0.17"
-which = "4"
 parking_lot = "0.12"
 
 [dev-dependencies]
@@ -97,9 +88,7 @@ pretty_assertions = "1"
 toml = "0.7"
 serial_test = "2"
 criterion = "0.4"
-svm = { package = "svm-rs", version = "0.2", default-features = false, features = [
-  "rustls",
-] }
+svm = { package = "svm-rs", version = "0.2", default-features = false, features = ["rustls"] }
 
 [features]
 default = ["rustls"]

--- a/cli/src/cmd/cast/wallet/mod.rs
+++ b/cli/src/cmd/cast/wallet/mod.rs
@@ -193,8 +193,8 @@ mod tests {
         match args {
             WalletSubcommands::Sign { message, data, from_file, .. } => {
                 assert_eq!(message, "deadbeef".to_string());
-                assert_eq!(data, false);
-                assert_eq!(from_file, false);
+                assert!(!data);
+                assert!(!from_file);
             }
             _ => panic!("expected WalletSubcommands::Sign"),
         }
@@ -206,8 +206,8 @@ mod tests {
         match args {
             WalletSubcommands::Sign { message, data, from_file, .. } => {
                 assert_eq!(message, "0xdeadbeef".to_string());
-                assert_eq!(data, false);
-                assert_eq!(from_file, false);
+                assert!(!data);
+                assert!(!from_file);
             }
             _ => panic!("expected WalletSubcommands::Sign"),
         }
@@ -219,8 +219,8 @@ mod tests {
         match args {
             WalletSubcommands::Sign { message, data, from_file, .. } => {
                 assert_eq!(message, "{ ... }".to_string());
-                assert_eq!(data, true);
-                assert_eq!(from_file, false);
+                assert!(data);
+                assert!(!from_file);
             }
             _ => panic!("expected WalletSubcommands::Sign"),
         }
@@ -238,8 +238,8 @@ mod tests {
         match args {
             WalletSubcommands::Sign { message, data, from_file, .. } => {
                 assert_eq!(message, "tests/data/typed_data.json".to_string());
-                assert_eq!(data, true);
-                assert_eq!(from_file, true);
+                assert!(data);
+                assert!(from_file);
             }
             _ => panic!("expected WalletSubcommands::Sign"),
         }

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -89,7 +89,7 @@ impl Cmd for BuildArgs {
         let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;
 
-        if install::install_missing_dependencies(&mut config, &project, self.args.silent) &&
+        if install::install_missing_dependencies(&mut config, self.args.silent) &&
             config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -68,10 +68,9 @@ impl Cmd for CoverageArgs {
 
     fn run(self) -> eyre::Result<Self::Output> {
         let (mut config, evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
-        let project = config.project()?;
 
         // install missing dependencies
-        if install::install_missing_dependencies(&mut config, &project, self.build_args().silent) &&
+        if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings

--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -75,14 +75,7 @@ impl Cmd for DocArgs {
             }
         }
 
-        let commit =
-            Command::new("git").args(["rev-parse", "HEAD"]).output().ok().and_then(|output| {
-                if !output.stdout.is_empty() {
-                    String::from_utf8(output.stdout).ok().map(|commit| commit.trim().to_owned())
-                } else {
-                    None
-                }
-            });
+        let commit = crate::utils::Git::new(&root).commit_hash(false).ok();
 
         let mut builder = DocBuilder::new(root.clone(), config.project_paths().sources)
             .with_should_build(self.build)

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -1,22 +1,14 @@
 //! init command
 
 use crate::{
-    cmd::{
-        forge::install::{ensure_git_status_clean, install, DependencyInstallOpts},
-        Cmd,
-    },
-    opts::Dependency,
-    utils::{p_println, CommandUtils},
+    cmd::{forge::install::DependencyInstallOpts, Cmd},
+    utils::{p_println, Git},
 };
 use clap::{Parser, ValueHint};
 use ethers::solc::remappings::Remapping;
 use foundry_common::fs;
 use foundry_config::Config;
-use std::{
-    path::{Path, PathBuf},
-    process::{Command, Stdio},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 use yansi::Paint;
 
 /// CLI arguments for `forge init`.
@@ -30,17 +22,8 @@ pub struct InitArgs {
     #[clap(long, short)]
     template: Option<String>,
 
-    /// Do not create a git repository.
-    #[clap(long, conflicts_with = "template")]
-    no_git: bool,
-
-    /// Do not create an initial commit.
-    #[clap(long, conflicts_with = "template")]
-    no_commit: bool,
-
-    /// Do not print any messages.
-    #[clap(long, short)]
-    quiet: bool,
+    #[clap(flatten)]
+    opts: DependencyInstallOpts,
 
     /// Do not install dependencies from the network.
     #[clap(long, conflicts_with = "template", visible_alias = "no-deps")]
@@ -60,49 +43,40 @@ impl Cmd for InitArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let InitArgs { root, template, no_git, no_commit, quiet, offline, force, vscode } = self;
+        let InitArgs { root, template, opts, offline, force, vscode } = self;
+        let DependencyInstallOpts { deep, no_git, no_commit, quiet } = opts;
 
         // create the root dir if it does not exist
         if !root.exists() {
             fs::create_dir_all(&root)?;
         }
         let root = dunce::canonicalize(root)?;
+        let git = Git::new(&root).quiet(quiet).deep(deep);
 
         // if a template is provided, then this command clones the template repo, removes the .git
         // folder, and initializes a new git repo—-this ensures there is no history from the
         // template and the template is not set as a remote.
         if let Some(template) = template {
-            let template = if template.starts_with("https://") {
+            let template = if template.contains("://") {
                 template
             } else {
                 "https://github.com/".to_string() + &template
             };
             p_println!(!quiet => "Initializing {} from {}...", root.display(), template);
 
-            Command::new("git")
-                .args(["clone", "--recursive", &template, &root.display().to_string()])
-                .exec()?;
-
-            // Navigate to the newly cloned repo.
-            let initial_dir = std::env::current_dir()?;
-            std::env::set_current_dir(&root)?;
+            Git::clone(!deep, &template, Some(&root))?;
 
             // Modify the git history.
-            let git_output =
-                Command::new("git").args(["rev-parse", "--short", "HEAD"]).output()?.stdout;
-            let commit_hash = String::from_utf8(git_output)?;
+            let commit_hash = git.commit_hash(true)?;
             std::fs::remove_dir_all(".git")?;
-            Command::new("git").arg("init").exec()?;
-            Command::new("git").args(["add", "--all"]).exec()?;
 
+            git.init()?;
+            git.add(Some("--all"))?;
             let commit_msg = format!("chore: init from {template} at {commit_hash}");
-            Command::new("git").args(["commit", "-m", &commit_msg]).exec()?;
-
-            // Navigate back.
-            std::env::set_current_dir(initial_dir)?;
+            git.commit(&commit_msg)?;
         } else {
             // if target is not empty
-            if root.read_dir().map(|mut i| i.next().is_some()).unwrap_or(false) {
+            if root.read_dir().map_or(false, |mut i| i.next().is_some()) {
                 if !force {
                     eyre::bail!(
                         "Cannot run `init` on a non-empty directory.\n\
@@ -114,8 +88,8 @@ impl Cmd for InitArgs {
             }
 
             // ensure git status is clean before generating anything
-            if !no_git && !no_commit && !force && is_git(&root)? {
-                ensure_git_status_clean(&root)?;
+            if !no_git && !no_commit && !force && git.is_in_repo()? {
+                git.ensure_clean()?;
             }
 
             p_println!(!quiet => "Initializing {}...", root.display());
@@ -146,22 +120,21 @@ impl Cmd for InitArgs {
             if !dest.exists() {
                 fs::write(dest, config.clone().into_basic().to_string_pretty()?)?;
             }
+            let git = self.opts.git(&config);
 
-            // sets up git
+            // set up the repo
             if !no_git {
-                init_git_repo(&root, no_commit)?;
+                init_git_repo(git, no_commit)?;
             }
 
             // install forge-std
             if !offline {
-                let opts = DependencyInstallOpts { no_git, no_commit, quiet };
-
                 if root.join("lib/forge-std").exists() {
                     p_println!(!quiet => "\"lib/forge-std\" already exists, skipping install....");
-                    install(&mut config, vec![], opts)?;
+                    self.opts.install(&mut config, vec![])?;
                 } else {
-                    Dependency::from_str("https://github.com/foundry-rs/forge-std")
-                        .and_then(|dependency| install(&mut config, vec![dependency], opts))?;
+                    let dep = "https://github.com/foundry-rs/forge-std".parse()?;
+                    self.opts.install(&mut config, vec![dep])?;
                 }
             }
 
@@ -171,37 +144,14 @@ impl Cmd for InitArgs {
             }
         }
 
-        p_println!(!quiet => "    {} forge project.",   Paint::green("Initialized"));
+        p_println!(!quiet => "    {} forge project",   Paint::green("Initialized"));
         Ok(())
     }
 }
 
-/// Returns `true` if `root` is already in an existing git repository
-fn is_git(root: &Path) -> eyre::Result<bool> {
-    let is_git = Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(root)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()?;
-
-    Ok(is_git.success())
-}
-
 /// Returns the commit hash of the project if it exists
 pub fn get_commit_hash(root: &Path) -> Option<String> {
-    if is_git(root).ok()? {
-        let output = Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .current_dir(root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .get_stdout_lossy()
-            .ok()?;
-        Some(output)
-    } else {
-        None
-    }
+    Git::new(root).commit_hash(true).ok()
 }
 
 /// Initialises `root` as a git repository, if it isn't one already.
@@ -209,30 +159,29 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
 /// Creates `.gitignore` and `.github/workflows/test.yml`, if they don't exist already.
 ///
 /// Commits everything in `root` if `no_commit` is false.
-fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
+fn init_git_repo(git: Git<'_>, no_commit: bool) -> eyre::Result<()> {
     // git init
-    if !is_git(root)? {
-        Command::new("git").arg("init").current_dir(root).exec()?;
+    if !git.is_in_repo()? {
+        git.init()?;
     }
 
     // .gitignore
-    let gitignore = root.join(".gitignore");
+    let gitignore = git.root.join(".gitignore");
     if !gitignore.exists() {
         fs::write(gitignore, include_str!("../../../assets/.gitignoreTemplate"))?;
     }
 
     // github workflow
-    let gh = root.join(".github").join("workflows");
-    if !gh.exists() {
-        fs::create_dir_all(&gh)?;
-        let workflow_path = gh.join("test.yml");
-        fs::write(workflow_path, include_str!("../../../assets/workflowTemplate.yml"))?;
+    let workflow = git.root.join(".github/workflows/test.yml");
+    if !workflow.exists() {
+        fs::create_dir_all(workflow.parent().unwrap())?;
+        fs::write(workflow, include_str!("../../../assets/workflowTemplate.yml"))?;
     }
 
     // commit everything
     if !no_commit {
-        Command::new("git").args(["add", "."]).current_dir(root).exec()?;
-        Command::new("git").args(["commit", "-m", "chore: forge init"]).current_dir(root).exec()?;
+        git.add(Some("--all"))?;
+        git.commit("chore: forge init")?;
     }
 
     Ok(())
@@ -242,12 +191,12 @@ fn init_git_repo(root: &Path, no_commit: bool) -> eyre::Result<()> {
 fn init_vscode(root: &Path) -> eyre::Result<()> {
     let remappings_file = root.join("remappings.txt");
     if !remappings_file.exists() {
-        let mut remappings = relative_remappings(&root.join("lib"), root)
+        let mut remappings = Remapping::find_many(root.join("lib"))
             .into_iter()
-            .map(|r| r.to_string())
+            .map(|r| r.into_relative(root).to_relative_remapping().to_string())
             .collect::<Vec<_>>();
-        remappings.sort();
         if !remappings.is_empty() {
+            remappings.sort();
             let content = remappings.join("\n");
             fs::write(remappings_file, content)?;
         }
@@ -279,13 +228,4 @@ fn init_vscode(root: &Path) -> eyre::Result<()> {
     fs::write(settings_file, content)?;
 
     Ok(())
-}
-
-/// Returns all remappings found in the `lib` path relative to `root`
-fn relative_remappings(lib: &Path, root: &Path) -> Vec<Remapping> {
-    Remapping::find_many(lib)
-        .into_iter()
-        .map(|r| r.into_relative(root).to_relative_remapping())
-        .map(Into::into)
-        .collect()
 }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -3,10 +3,10 @@ use crate::{
     cmd::{Cmd, LoadConfig},
     opts::Dependency,
     prompt,
-    utils::{p_println, CommandUtils},
+    utils::{p_println, CommandUtils, Git},
 };
 use clap::{Parser, ValueHint};
-use ethers::solc::Project;
+use eyre::{Context, Result};
 use foundry_common::fs;
 use foundry_config::{impl_figment_convert_basic, Config};
 use once_cell::sync::Lazy;
@@ -14,7 +14,6 @@ use regex::Regex;
 use semver::Version;
 use std::{
     path::{Path, PathBuf},
-    process::Command,
     str,
 };
 use tracing::{trace, warn};
@@ -61,15 +60,18 @@ impl_figment_convert_basic!(InstallArgs);
 impl Cmd for InstallArgs {
     type Output = ();
 
-    fn run(self) -> eyre::Result<Self::Output> {
+    fn run(self) -> Result<Self::Output> {
         let mut config = self.try_load_config_emit_warnings()?;
-        install(&mut config, self.dependencies, self.opts)?;
-        Ok(())
+        self.opts.install(&mut config, self.dependencies)
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Parser)]
+#[derive(Debug, Clone, Default, Copy, Parser)]
 pub struct DependencyInstallOpts {
+    /// Perform deep clones instead of shallow ones.
+    #[clap(long)]
+    pub deep: bool,
+
     /// Install without adding the dependency as a submodule.
     #[clap(long)]
     pub no_git: bool,
@@ -83,565 +85,408 @@ pub struct DependencyInstallOpts {
     pub quiet: bool,
 }
 
-/// Auto installs missing dependencies
-///
-/// Note: Since the install-process requires `git` this is only executed if an existing installation
-/// of `git` could be found
-///
-/// See also [`install`]
-///
-/// Returns whether missing dependencies where installed
-pub fn install_missing_dependencies(config: &mut Config, project: &Project, quiet: bool) -> bool {
-    // try to auto install missing submodules in the default install dir but only if git is
-    // installed
-    if which::which("git").is_ok() &&
-        has_missing_dependencies(project.root(), config.install_lib_dir())
-    {
-        // The extra newline is needed, otherwise the compiler output will overwrite the
-        // message
-        p_println!(!quiet => "Missing dependencies found. Installing now...\n");
-        let opts = DependencyInstallOpts { quiet, no_commit: true, ..Default::default() };
-        if install(config, Vec::new(), opts).is_err() && !quiet {
-            eprintln!(
-                "{}",
-                Paint::yellow("Your project has missing dependencies that could not be installed.")
-            )
-        }
-        return true
+impl DependencyInstallOpts {
+    pub fn git(self, config: &Config) -> Git<'_> {
+        Git::from_config(config).quiet(self.quiet).deep(self.deep)
     }
 
-    false
-}
-
-/// Installs all dependencies
-#[tracing::instrument(name = "install dependencies", skip_all, fields(dependencies, opts))]
-pub(crate) fn install(
-    config: &mut Config,
-    dependencies: Vec<Dependency>,
-    opts: DependencyInstallOpts,
-) -> eyre::Result<()> {
-    let root = config.__root.0.clone();
-
-    let install_lib_dir = config.install_lib_dir();
-    let libs = root.join(&install_lib_dir);
-
-    if dependencies.is_empty() && !opts.no_git {
-        p_println!(!opts.quiet => "Updating dependencies in {:?}", libs);
-        let mut cmd = Command::new("git");
-        cmd.current_dir(&root).args([
-            "submodule",
-            "update",
-            "--init",
-            "--recursive",
-            libs.display().to_string().as_str(),
-        ]);
-        trace!(?cmd, "updating submodules");
-        cmd.exec()?;
-    }
-    fs::create_dir_all(&libs)?;
-
-    for dep in dependencies {
-        if dep.url.is_none() {
-            eyre::bail!("Could not determine URL for dependency \"{}\"!", dep.name);
-        }
-        let target_dir = if let Some(alias) = &dep.alias { alias } else { &dep.name };
-        let DependencyInstallOpts { no_git, no_commit, quiet } = opts;
-        p_println!(!quiet => "Installing {} in {:?} (url: {:?}, tag: {:?})", dep.name, &libs.join(target_dir), dep.url, dep.tag);
-
-        // this tracks the actual installed tag
-        let installed_tag;
-
-        if no_git {
-            installed_tag = install_as_folder(&dep, &libs, target_dir)?;
-        } else {
-            if !no_commit {
-                ensure_git_status_clean(&root)?;
+    /// Installs all missing dependencies.
+    ///
+    /// See also [`Self::install`].
+    ///
+    /// Returns true if any dependency was installed.
+    pub fn install_missing_dependencies(mut self, config: &mut Config) -> bool {
+        let DependencyInstallOpts { quiet, .. } = self;
+        let lib = config.install_lib_dir();
+        if self.git(config).has_missing_dependencies(Some(lib)).unwrap_or(false) {
+            // The extra newline is needed, otherwise the compiler output will overwrite the message
+            p_println!(!quiet => "Missing dependencies found. Installing now...\n");
+            self.no_commit = true;
+            if self.install(config, Vec::new()).is_err() && !quiet {
+                eprintln!(
+                    "{}",
+                    Paint::yellow(
+                        "Your project has missing dependencies that could not be installed."
+                    )
+                )
             }
-            installed_tag = install_as_submodule(&root, &dep, &libs, target_dir, no_commit)?;
+            true
+        } else {
+            false
+        }
+    }
 
-            // Pin branch to submodule if branch is used
-            if let Some(ref branch) = installed_tag {
-                if !branch.is_empty() {
+    /// Installs all dependencies
+    pub fn install(self, config: &mut Config, dependencies: Vec<Dependency>) -> Result<()> {
+        let DependencyInstallOpts { no_git, no_commit, quiet, .. } = self;
+
+        let git = self.git(config);
+        // let root = Git::root_of(git.root)?;
+
+        let install_lib_dir = config.install_lib_dir();
+        let libs = git.root.join(install_lib_dir);
+
+        if dependencies.is_empty() && !self.no_git {
+            p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
+            git.submodule_update(false, Some(&libs))?;
+        }
+        fs::create_dir_all(&libs)?;
+
+        // git.root = &root;
+        let installer = Installer { git, no_commit };
+        for dep in dependencies {
+            let path = libs.join(dep.name());
+            p_println!(!quiet => "Installing {} in {} (url: {:?}, tag: {:?})", dep.name, path.display(), dep.url, dep.tag);
+
+            // this tracks the actual installed tag
+            let installed_tag;
+            if no_git {
+                installed_tag = installer.install_as_folder(&dep, &path)?;
+            } else {
+                if !no_commit {
+                    git.ensure_clean()?;
+                }
+                installed_tag = installer.install_as_submodule(&dep, &path)?;
+
+                // Pin branch to submodule if branch is used
+                if let Some(branch) = &installed_tag {
                     // First, check if this tag has a branch
-                    let mut check_for_branch = Command::new("git");
-                    check_for_branch.current_dir(&root).args([
-                        "branch",
-                        "--list",
-                        branch.as_str(),
-                        libs.join(target_dir).to_str().unwrap(),
-                    ]);
-                    trace!(?check_for_branch, "check if tag has branch");
-                    let output = check_for_branch.exec()?;
-                    let branch_found = String::from_utf8(output.stdout)?;
-                    if !branch_found.is_empty() {
-                        let libs = libs.strip_prefix(&root).unwrap_or(&libs);
-                        let mut cmd = Command::new("git");
-                        cmd.current_dir(&root).args([
-                            "submodule",
-                            "set-branch",
-                            "-b",
-                            branch.as_str(),
-                            libs.join(target_dir).to_str().unwrap(),
-                        ]);
-                        trace!(?cmd, "submodule set branch");
-                        cmd.exec()?;
+                    eprintln!("d");
+                    if git.has_branch(branch)? {
+                        eprintln!("e");
+                        git.cmd()
+                            .args(["submodule", "set-branch", "-b", branch.as_str()])
+                            .arg(path)
+                            .exec()?;
+                        eprintln!("f");
                     }
 
+                    eprintln!("g");
                     // this changed the .gitmodules files
-                    trace!("git add .gitmodules");
-                    let git_root = Command::new("git")
-                        .current_dir(&root)
-                        .args(["rev-parse", "--show-toplevel"])
-                        .get_stdout_lossy()?;
-                    trace!(?git_root, "git root dir");
-                    Command::new("git")
-                        .current_dir(&git_root)
-                        .args(["add", ".gitmodules"])
-                        .exec()?;
+                    git.add(Some(".gitmodules"))?;
+                    eprintln!("h");
+                }
+
+                // commit the installation
+                if !no_commit {
+                    let mut msg = String::with_capacity(128);
+                    msg.push_str("forge install: ");
+                    msg.push_str(dep.name());
+                    if let Some(tag) = &installed_tag {
+                        msg.push_str("\n\n");
+                        msg.push_str(tag);
+                    }
+                    eprintln!("i");
+                    git.commit(&msg)?;
+                    eprintln!("j");
                 }
             }
 
-            // commit the installation
-            if !no_commit {
-                commit_after_install(&libs, target_dir, installed_tag.as_deref())?;
+            if !quiet {
+                let mut msg = format!("    {} {}", Paint::green("Installed"), dep.name);
+                if let Some(tag) = dep.tag.or(installed_tag) {
+                    msg.push(' ');
+                    msg.push_str(tag.as_str());
+                }
+                println!("{msg}");
             }
         }
 
-        // constructs the message `Installed <name> <branch>?`
-        let mut msg = format!("    {} {}", Paint::green("Installed"), dep.name);
-
-        if let Some(tag) = dep.tag.or(installed_tag) {
-            msg.push(' ');
-            msg.push_str(tag.as_str());
+        // update `libs` in config if not included yet
+        if !config.libs.iter().any(|p| p == install_lib_dir) {
+            config.libs.push(install_lib_dir.to_path_buf());
+            config.update_libs()?;
         }
-
-        p_println!(!quiet => "{}", msg);
+        Ok(())
     }
-
-    // update `libs` in config if not included yet
-    if !config.libs.contains(&install_lib_dir) {
-        config.libs.push(install_lib_dir);
-        config.update_libs()?;
-    }
-    Ok(())
 }
 
-/// Checks if any submodules have not been initialized yet.
-///
-/// `git submodule status <lib dir>` will return a new line per submodule in the repository. If any
-/// line starts with `-` then it has not been initialized yet.
-pub fn has_missing_dependencies(root: impl AsRef<Path>, lib_dir: impl AsRef<Path>) -> bool {
-    Command::new("git")
-        .args(["submodule", "status"])
-        .arg(lib_dir.as_ref())
-        .current_dir(root)
-        .output()
-        .map(|output| {
-            String::from_utf8_lossy(&output.stdout).lines().any(|line| line.starts_with('-'))
-        })
-        .unwrap_or(false)
+pub fn install_missing_dependencies(config: &mut Config, quiet: bool) -> bool {
+    DependencyInstallOpts { quiet, ..Default::default() }.install_missing_dependencies(config)
 }
 
-/// Installs the dependency as an ordinary folder instead of a submodule
-fn install_as_folder(
-    dep: &Dependency,
-    libs: &Path,
-    target_dir: &str,
-) -> eyre::Result<Option<String>> {
-    let repo = git_clone(dep, libs, target_dir)?;
-    let mut dep = dep.clone();
-
-    if dep.tag.is_none() {
-        // try to find latest semver release tag
-        dep.tag = git_semver_tags(&repo).ok().and_then(|mut tags| tags.pop().map(|(tag, _)| tag));
-    }
-
-    // checkout the tag if necessary
-    git_checkout(&dep, libs, target_dir, false)?;
-
-    // remove git artifacts
-    fs::remove_dir_all(repo.join(".git"))?;
-
-    Ok(dep.tag.take())
-}
-
-/// Installs the dependency as new submodule.
-///
-/// This will add the git submodule to the given dir, initialize it and checkout the tag if provided
-/// or try to find the latest semver, release tag.
-fn install_as_submodule(
-    root: &Path,
-    dep: &Dependency,
-    libs: &Path,
-    target_dir: &str,
+#[derive(Clone, Copy, Debug)]
+struct Installer<'a> {
+    git: Git<'a>,
     no_commit: bool,
-) -> eyre::Result<Option<String>> {
-    // install the dep
-    let submodule = git_submodule(dep, libs, target_dir)?;
+}
 
-    let mut dep = dep.clone();
-    if dep.tag.is_none() {
-        // try to find latest semver release tag
-        dep.tag =
-            git_semver_tags(&submodule).ok().and_then(|mut tags| tags.pop().map(|(tag, _)| tag));
+impl Installer<'_> {
+    /// Installs the dependency as an ordinary folder instead of a submodule
+    fn install_as_folder(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
+        let url = dep.require_url()?;
+        Git::clone(dep.tag.is_none(), url, Some(&path))?;
+        let mut dep = dep.clone();
+
+        if dep.tag.is_none() {
+            // try to find latest semver release tag
+            dep.tag = self.last_tag(path);
+        }
+
+        // checkout the tag if necessary
+        self.git_checkout(&dep, path, false)?;
+
+        // remove git artifacts
+        fs::remove_dir_all(path.join(".git"))?;
+
+        Ok(dep.tag)
     }
 
-    // checkout the tag if necessary
-    if dep.tag.is_some() {
-        git_checkout(&dep, libs, target_dir, true)?;
-        if !no_commit {
-            trace!("git add {:?}", libs);
-            Command::new("git")
-                .current_dir(root)
-                .args(["add", &libs.display().to_string()])
-                .exec()?;
+    /// Installs the dependency as new submodule.
+    ///
+    /// This will add the git submodule to the given dir, initialize it and checkout the tag if
+    /// provided or try to find the latest semver, release tag.
+    fn install_as_submodule(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
+        // install the dep
+        eprintln!("a");
+        self.git_submodule(dep, path)?;
+
+        let mut dep = dep.clone();
+        if dep.tag.is_none() {
+            // try to find latest semver release tag
+            dep.tag = self.last_tag(path);
+        }
+
+        // checkout the tag if necessary
+        if dep.tag.is_some() {
+            eprintln!("b");
+            self.git_checkout(&dep, path, true)?;
+            eprintln!("c");
+        }
+
+        if !self.no_commit {
+            self.git.add(Some(path))?;
+        }
+
+        Ok(dep.tag)
+    }
+
+    fn last_tag(self, path: &Path) -> Option<String> {
+        if self.git.shallow {
+            None
+        } else {
+            self.git_semver_tags(&path).ok().and_then(|mut tags| tags.pop()).map(|(tag, _)| tag)
         }
     }
 
-    Ok(dep.tag.take())
-}
-
-/// Commits the git submodule install
-fn commit_after_install(libs: &Path, target_dir: &str, tag: Option<&str>) -> eyre::Result<()> {
-    let message = if let Some(tag) = tag {
-        format!("forge install: {target_dir}\n\n{tag}")
-    } else {
-        format!("forge install: {target_dir}")
-    };
-    trace!(?libs, ?message, "git commit -m");
-
-    let output = Command::new("git").args(["commit", "-m", &message]).current_dir(libs).output()?;
-
-    if !output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!(?stdout, ?stderr, "git commit -m");
-
-        if !stdout.contains("nothing to commit") {
-            eyre::bail!("Failed to commit `{message}`:\n{stdout}\n{stderr}");
-        }
-    }
-    Ok(())
-}
-
-pub fn ensure_git_status_clean(root: impl AsRef<Path>) -> eyre::Result<()> {
-    if !git_status_clean(root)? {
-        eyre::bail!(
-            "\
-The target directory is a part of or on its own an already initialized git repository,
-and it requires clean working and staging areas, including no untracked files.
-
-Check the current git repository's status with `git status`.
-Then, you can track files with `git add ...` and then commit them with `git commit`,
-ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
-
-If none of the previous steps worked, please open an issue at:
-https://github.com/foundry-rs/foundry/issues/new/choose"
-        )
-    }
-    Ok(())
-}
-
-// check that there are no modification in git working/staging area
-fn git_status_clean(root: impl AsRef<Path>) -> eyre::Result<bool> {
-    let stdout =
-        Command::new("git").args(["status", "--short"]).current_dir(root).get_stdout_lossy()?;
-    Ok(stdout.trim().is_empty())
-}
-
-/// Executes a git clone
-///
-/// Returns the directory of the cloned repository
-fn git_clone(dep: &Dependency, libs: &Path, target_dir: &str) -> eyre::Result<PathBuf> {
-    let url = dep.url.as_ref().unwrap();
-
-    let output = Command::new("git")
-        .args(["clone", "--recursive", url, target_dir])
-        .current_dir(libs)
-        .output()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("remote: Repository not found") {
-        eyre::bail!("Repo: \"{}\" not found!", url)
-    } else if stderr.contains("already exists and is not an empty directory") {
-        eyre::bail!(
-            "Destination path \"{}\" already exists and is not an empty directory.",
-            &dep.name
-        )
-    } else if !&output.status.success() {
-        eyre::bail!("{}", stderr.trim())
-    }
-
-    Ok(libs.join(target_dir))
-}
-
-/// Returns all semver git tags sorted in ascending order
-fn git_semver_tags(repo: &Path) -> eyre::Result<Vec<(String, Version)>> {
-    trace!(?repo, "`git tag`");
-    let output = Command::new("git").arg("tag").current_dir(repo).output()?;
-    let mut tags = Vec::new();
-    let out = String::from_utf8_lossy(&output.stdout);
-    // tags are commonly prefixed which would make them not semver: v1.2.3 is not a semantic version
-    let common_prefixes = &["v-", "v", "release-", "release"];
-    for tag in out.lines() {
-        let mut maybe_semver = tag;
-        for &prefix in common_prefixes {
-            if let Some(rem) = tag.strip_prefix(prefix) {
-                maybe_semver = rem;
-                break
-            }
-        }
-        match Version::parse(maybe_semver) {
-            Ok(v) => {
-                // ignore if additional metadata, like rc, beta, etc...
-                if v.build.is_empty() && v.pre.is_empty() {
-                    tags.push((tag.to_string(), v));
+    /// Returns all semver git tags sorted in ascending order
+    fn git_semver_tags(self, path: &Path) -> Result<Vec<(String, Version)>> {
+        let out = self.git.root(path).tag()?;
+        let mut tags = Vec::new();
+        // tags are commonly prefixed which would make them not semver: v1.2.3 is not a semantic
+        // version
+        let common_prefixes = &["v-", "v", "release-", "release"];
+        for tag in out.lines() {
+            let mut maybe_semver = tag;
+            for &prefix in common_prefixes {
+                if let Some(rem) = tag.strip_prefix(prefix) {
+                    maybe_semver = rem;
+                    break
                 }
             }
-            Err(err) => {
-                warn!(?err, ?maybe_semver, "No semver tag");
+            match Version::parse(maybe_semver) {
+                Ok(v) => {
+                    // ignore if additional metadata, like rc, beta, etc...
+                    if v.build.is_empty() && v.pre.is_empty() {
+                        tags.push((tag.to_string(), v));
+                    }
+                }
+                Err(err) => {
+                    warn!(?err, ?maybe_semver, "No semver tag");
+                }
             }
         }
+
+        tags.sort_by(|(_, a), (_, b)| a.cmp(b));
+
+        Ok(tags)
     }
 
-    tags.sort_by(|(_, a), (_, b)| a.cmp(b));
+    /// Install the given dependency as git submodule in `target_dir`.
+    fn git_submodule(self, dep: &Dependency, path: &Path) -> Result<()> {
+        let url = dep.require_url()?;
 
-    Ok(tags)
-}
+        // make path relative to the git root
+        let path = path
+            .strip_prefix(self.git.root)
+            .wrap_err("Library directory is not relative to the repository root")?;
 
-/// Install the given dependency as git submodule in the `target_dir`
-fn git_submodule(dep: &Dependency, libs: &Path, target_dir: &str) -> eyre::Result<PathBuf> {
-    let url = dep.url.as_ref().ok_or_else(|| eyre::eyre!("No dependency url"))?;
-    trace!("installing git submodule {dep:?} in {target_dir} from `{url}`");
+        trace!(?dep, ?path, url, "installing git submodule");
+        self.git.submodule_add(true, url, path)?;
 
-    let output = Command::new("git")
-        .args(["submodule", "add", "--force", url, target_dir])
-        .current_dir(libs)
-        .output()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    trace!(?stderr, "`git submodule add --force {url} {target_dir}`");
-
-    if stderr.contains("remote: Repository not found") {
-        eyre::bail!("Repo: \"{}\" not found!", url)
-    } else if stderr.contains("already exists in the index") {
-        eyre::bail!(
-            "\"lib/{}\" already exists in the index, you can update it using forge update.",
-            &target_dir
-        )
-    } else if stderr.contains("not a git repository") {
-        eyre::bail!("{stderr}")
-    } else if stderr.contains("paths are ignored by one of your .gitignore files") {
-        let error =
-            stderr.lines().filter(|l| !l.starts_with("hint:")).collect::<Vec<&str>>().join("\n");
-        eyre::bail!("{error}")
-    } else if !output.status.success() {
-        eyre::bail!("{}", stderr.trim())
+        trace!("updating submodule recursively");
+        self.git.submodule_update(false, Some(path))
     }
 
-    trace!(?dep, "successfully installed");
+    fn git_checkout(self, dep: &Dependency, path: &Path, recurse: bool) -> Result<String> {
+        // no need to checkout if there is no tag
+        let Some(mut tag) = dep.tag.clone() else {
+            return Ok(String::new())
+        };
 
-    let output = Command::new("git")
-        .args(["submodule", "update", "--init", "--recursive", target_dir])
-        .current_dir(libs)
-        .output()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    trace!(?stderr, ?libs, "`git submodule update --init --recursive` {}", target_dir);
-
-    Ok(libs.join(target_dir))
-}
-
-fn git_checkout(
-    dep: &Dependency,
-    libs: &Path,
-    target_dir: &str,
-    recurse: bool,
-) -> eyre::Result<String> {
-    // no need to checkout if there is no tag
-    if dep.tag.is_none() {
-        return Ok(String::new())
-    }
-
-    let mut tag = dep.tag.clone().unwrap();
-    let mut is_branch = false;
-    // only try to match tag if current terminal is a tty
-    if is_terminal::is_terminal(&std::io::stdout()) {
-        if tag.is_empty() {
-            tag = match_tag(&tag, libs, target_dir)?;
-        } else if let Some(branch) = match_branch(&tag, libs, target_dir)? {
-            trace!(?tag, ?branch, "selecting branch for given tag");
-            tag = branch;
-            is_branch = true;
+        let mut is_branch = false;
+        // only try to match tag if current terminal is a tty
+        if is_terminal::is_terminal(&std::io::stdout()) {
+            if tag.is_empty() {
+                tag = self.match_tag(&tag, path)?;
+            } else if let Some(branch) = self.match_branch(&tag, path)? {
+                trace!(?tag, ?branch, "selecting branch for given tag");
+                tag = branch;
+                is_branch = true;
+            }
         }
-    }
-    let url = dep.url.as_ref().unwrap();
+        let url = dep.url.as_ref().unwrap();
 
-    trace!(?tag, ?recurse, "git checkout");
+        let res = self.git.root(path).checkout(recurse, &tag);
+        if let Err(mut e) = res {
+            // remove dependency on failed checkout
+            fs::remove_dir_all(path)?;
+            if e.to_string().contains("did not match any file(s) known to git") {
+                e = eyre::eyre!("Tag: \"{tag}\" not found for repo \"{url}\"!")
+            }
+            return Err(e)
+        }
 
-    let mut args = vec!["checkout", tag.as_str()];
-    if recurse {
-        args.push("--recurse-submodules");
-    }
-    let output = Command::new("git").args(args).current_dir(libs.join(target_dir)).output()?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    trace!(?stderr, ?tag, "checked out");
-
-    if !output.status.success() {
-        // remove dependency on failed checkout
-        fs::remove_dir_all(libs.join(target_dir))?;
-
-        if stderr.contains(
-            format!("error: pathspec '{tag}' did not match any file(s) known to git").as_str(),
-        ) {
-            eyre::bail!("Tag: \"{}\" not found for repo: \"{}\"!", tag, url)
+        if is_branch {
+            Ok(tag)
         } else {
-            eyre::bail!("{}", stderr.trim())
+            Ok(String::new())
         }
     }
 
-    if is_branch {
-        Ok(tag)
-    } else {
-        Ok(String::new())
-    }
-}
-
-/// disambiguate tag if it is a version tag
-fn match_tag(tag: &String, libs: &Path, target_dir: &str) -> eyre::Result<String> {
-    // only try to match if it looks like a version tag
-    if !DEPENDENCY_VERSION_TAG_REGEX.is_match(tag) {
-        return Ok(tag.into())
-    }
-
-    // generate candidate list by filtering `git tag` output, valid ones are those "starting with"
-    // the user-provided tag (ignoring the starting 'v'), for example, if the user specifies 1.5,
-    // then v1.5.2 is a valid candidate, but v3.1.5 is not
-    let trimmed_tag = tag.trim_start_matches('v').to_string();
-    let output =
-        Command::new("git").arg("tag").current_dir(&libs.join(target_dir)).get_stdout_lossy()?;
-    let mut candidates: Vec<String> = output
-        .trim()
-        .split('\n')
-        .filter(|x| x.trim_start_matches('v').starts_with(&trimmed_tag))
-        .map(|x| x.to_string())
-        .rev()
-        .collect();
-
-    // no match found, fall back to the user-provided tag
-    if candidates.is_empty() {
-        return Ok(tag.into())
-    }
-
-    // have exact match
-    for candidate in candidates.iter() {
-        if candidate == tag {
+    /// disambiguate tag if it is a version tag
+    fn match_tag(self, tag: &str, path: &Path) -> Result<String> {
+        // only try to match if it looks like a version tag
+        if !DEPENDENCY_VERSION_TAG_REGEX.is_match(tag) {
             return Ok(tag.into())
         }
+
+        // generate candidate list by filtering `git tag` output, valid ones are those "starting
+        // with" the user-provided tag (ignoring the starting 'v'), for example, if the user
+        // specifies 1.5, then v1.5.2 is a valid candidate, but v3.1.5 is not
+        let trimmed_tag = tag.trim_start_matches('v').to_string();
+        let output = self.git.root(path).tag()?;
+        let mut candidates: Vec<String> = output
+            .trim()
+            .lines()
+            .filter(|x| x.trim_start_matches('v').starts_with(&trimmed_tag))
+            .map(|x| x.to_string())
+            .rev()
+            .collect();
+
+        // no match found, fall back to the user-provided tag
+        if candidates.is_empty() {
+            return Ok(tag.into())
+        }
+
+        // have exact match
+        for candidate in candidates.iter() {
+            if candidate == tag {
+                return Ok(tag.into())
+            }
+        }
+
+        // only one candidate, ask whether the user wants to accept or not
+        if candidates.len() == 1 {
+            let matched_tag = &candidates[0];
+            let input = prompt!(
+                "Found a similar version tag: {matched_tag}, do you want to use this instead? [Y/n] "
+            )?;
+            return if match_yn(input) { Ok(matched_tag.clone()) } else { Ok(tag.into()) }
+        }
+
+        // multiple candidates, ask the user to choose one or skip
+        candidates.insert(0, String::from("SKIP AND USE ORIGINAL TAG"));
+        println!("There are multiple matching tags:");
+        for (i, candidate) in candidates.iter().enumerate() {
+            println!("[{i}] {candidate}");
+        }
+
+        let n_candidates = candidates.len();
+        loop {
+            let input: String =
+                prompt!("Please select a tag (0-{}, default: 1): ", n_candidates - 1)?;
+            let s = input.trim();
+            // default selection, return first candidate
+            let n = if s.is_empty() { Ok(1) } else { s.parse() };
+            // match user input, 0 indicates skipping and use original tag
+            match n {
+                Ok(i) if i == 0 => return Ok(tag.into()),
+                Ok(i) if (1..=n_candidates).contains(&i) => {
+                    let c = &candidates[i];
+                    println!("[{i}] {c} selected");
+                    return Ok(c.clone())
+                }
+                _ => continue,
+            }
+        }
     }
 
-    // only one candidate, ask whether the user wants to accept or not
-    if candidates.len() == 1 {
-        let matched_tag = &candidates[0];
-        let input = prompt!(
-            "Found a similar version tag: {matched_tag}, do you want to use this instead? [Y/n] "
+    fn match_branch(self, tag: &str, path: &Path) -> Result<Option<String>> {
+        // fetch remote branches and check for tag
+        let output = self.git.root(path).cmd().args(["branch", "-r"]).get_stdout_lossy()?;
+
+        let mut candidates = output
+            .lines()
+            .map(|x| x.trim().trim_start_matches("origin/"))
+            .filter(|x| x.starts_with(tag))
+            .map(ToString::to_string)
+            .rev()
+            .collect::<Vec<_>>();
+
+        trace!(?candidates, ?tag, "found branch candidates");
+
+        // no match found, fall back to the user-provided tag
+        if candidates.is_empty() {
+            return Ok(None)
+        }
+
+        // have exact match
+        for candidate in candidates.iter() {
+            if candidate == tag {
+                return Ok(Some(tag.to_string()))
+            }
+        }
+
+        // only one candidate, ask whether the user wants to accept or not
+        if candidates.len() == 1 {
+            let matched_tag = &candidates[0];
+            let input = prompt!(
+                "Found a similar branch: {matched_tag}, do you want to use this instead? [Y/n] "
+            )?;
+            return if match_yn(input) { Ok(Some(matched_tag.clone())) } else { Ok(None) }
+        }
+
+        // multiple candidates, ask the user to choose one or skip
+        candidates.insert(0, format!("{tag} (original branch)"));
+        println!("There are multiple matching branches:");
+        for (i, candidate) in candidates.iter().enumerate() {
+            println!("[{i}] {candidate}");
+        }
+
+        let n_candidates = candidates.len();
+        let input: String = prompt!(
+            "Please select a tag (0-{}, default: 1, Press <enter> to cancel): ",
+            n_candidates - 1
         )?;
-        return if match_yn(input) { Ok(matched_tag.clone()) } else { Ok(tag.into()) }
-    }
+        let input = input.trim();
 
-    // multiple candidates, ask the user to choose one or skip
-    candidates.insert(0, String::from("SKIP AND USE ORIGINAL TAG"));
-    println!("There are multiple matching tags:");
-    for (i, candidate) in candidates.iter().enumerate() {
-        println!("[{i}] {candidate}");
-    }
+        // default selection, return None
+        if input.is_empty() {
+            println!("Canceled branch matching");
+            return Ok(None)
+        }
 
-    let n_candidates = candidates.len();
-    loop {
-        let input: String = prompt!("Please select a tag (0-{}, default: 1): ", n_candidates - 1)?;
-        let s = input.trim();
-        // default selection, return first candidate
-        let n = if s.is_empty() { Ok(1) } else { s.parse() };
         // match user input, 0 indicates skipping and use original tag
-        match n {
-            Ok(i) if i == 0 => return Ok(tag.into()),
+        match input.parse::<usize>() {
+            Ok(i) if i == 0 => Ok(Some(tag.into())),
             Ok(i) if (1..=n_candidates).contains(&i) => {
                 let c = &candidates[i];
                 println!("[{i}] {c} selected");
-                return Ok(c.clone())
+                Ok(Some(c.clone()))
             }
-            _ => continue,
+            _ => Ok(None),
         }
-    }
-}
-
-fn match_branch(tag: &str, libs: &Path, target_dir: &str) -> eyre::Result<Option<String>> {
-    // fetch remote branches and check for tag
-    let output = Command::new("git")
-        .args(["branch", "-r"])
-        .current_dir(&libs.join(target_dir))
-        .get_stdout_lossy()?;
-
-    let mut candidates = output
-        .lines()
-        .map(|x| x.trim().trim_start_matches("origin/"))
-        .filter(|x| x.starts_with(tag))
-        .map(ToString::to_string)
-        .rev()
-        .collect::<Vec<_>>();
-
-    trace!(?candidates, ?tag, "found branch candidates");
-
-    // no match found, fall back to the user-provided tag
-    if candidates.is_empty() {
-        return Ok(None)
-    }
-
-    // have exact match
-    for candidate in candidates.iter() {
-        if candidate == tag {
-            return Ok(Some(tag.to_string()))
-        }
-    }
-
-    // only one candidate, ask whether the user wants to accept or not
-    if candidates.len() == 1 {
-        let matched_tag = &candidates[0];
-        let input = prompt!(
-            "Found a similar branch: {matched_tag}, do you want to use this instead? [Y/n] "
-        )?;
-        return if match_yn(input) { Ok(Some(matched_tag.clone())) } else { Ok(None) }
-    }
-
-    // multiple candidates, ask the user to choose one or skip
-    candidates.insert(0, format!("{tag} (original branch)"));
-    println!("There are multiple matching branches:");
-    for (i, candidate) in candidates.iter().enumerate() {
-        println!("[{i}] {candidate}");
-    }
-
-    let n_candidates = candidates.len();
-    let input: String = prompt!(
-        "Please select a tag (0-{}, default: 1, Press <enter> to cancel): ",
-        n_candidates - 1
-    )?;
-    let input = input.trim();
-
-    // default selection, return None
-    if input.is_empty() {
-        println!("Canceled branch matching");
-        return Ok(None)
-    }
-
-    // match user input, 0 indicates skipping and use original tag
-    match input.parse::<usize>() {
-        Ok(i) if i == 0 => Ok(Some(tag.into())),
-        Ok(i) if (1..=n_candidates).contains(&i) => {
-            let c = &candidates[i];
-            println!("[{i}] {c} selected");
-            Ok(Some(c.clone()))
-        }
-        _ => Ok(None),
     }
 }
 
@@ -661,16 +506,33 @@ mod tests {
     #[test]
     fn get_oz_tags() {
         let tmp = tempdir().unwrap();
-        Command::new("git").arg("init").current_dir(tmp.path()).exec().unwrap();
+        let git = Git::new(tmp.path());
+        let installer = Installer { git, no_commit: true };
+
+        git.init().unwrap();
+
         let dep: Dependency = "openzeppelin/openzeppelin-contracts".parse().unwrap();
         let libs = tmp.path().join("libs");
         fs::create_dir(&libs).unwrap();
-        let target = libs.join("openzeppelin-contracts");
-        let submodule = git_submodule(&dep, &libs, "openzeppelin-contracts").unwrap();
-        assert!(target.exists());
+        let submodule = libs.join("openzeppelin-contracts");
+        installer.git_submodule(&dep, &submodule).unwrap();
         assert!(submodule.exists());
 
-        let tags = git_semver_tags(&submodule).unwrap();
+        // no tags because shallow clone
+        let tags = installer.git_semver_tags(&submodule).unwrap();
+        assert!(tags.is_empty());
+
+        // fetch tags
+        git.root(&submodule)
+            .cmd()
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .args(["fetch", "--tags"])
+            .exec()
+            .unwrap();
+
+        let tags = installer.git_semver_tags(&submodule).unwrap();
         assert!(!tags.is_empty());
         let v480: Version = "4.8.0".parse().unwrap();
         assert!(tags.iter().any(|(_, v)| v == &v480));

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -151,20 +151,15 @@ impl DependencyInstallOpts {
                 // Pin branch to submodule if branch is used
                 if let Some(branch) = &installed_tag {
                     // First, check if this tag has a branch
-                    eprintln!("d");
                     if git.has_branch(branch)? {
-                        eprintln!("e");
                         git.cmd()
                             .args(["submodule", "set-branch", "-b", branch.as_str()])
                             .arg(path)
                             .exec()?;
-                        eprintln!("f");
                     }
 
-                    eprintln!("g");
                     // this changed the .gitmodules files
                     git.add(Some(".gitmodules"))?;
-                    eprintln!("h");
                 }
 
                 // commit the installation
@@ -176,9 +171,7 @@ impl DependencyInstallOpts {
                         msg.push_str("\n\n");
                         msg.push_str(tag);
                     }
-                    eprintln!("i");
                     git.commit(&msg)?;
-                    eprintln!("j");
                 }
             }
 
@@ -238,7 +231,6 @@ impl Installer<'_> {
     /// provided or try to find the latest semver, release tag.
     fn install_as_submodule(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
         // install the dep
-        eprintln!("a");
         self.git_submodule(dep, path)?;
 
         let mut dep = dep.clone();
@@ -249,9 +241,7 @@ impl Installer<'_> {
 
         // checkout the tag if necessary
         if dep.tag.is_some() {
-            eprintln!("b");
             self.git_checkout(&dep, path, true)?;
-            eprintln!("c");
         }
 
         if !self.no_commit {

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -121,7 +121,6 @@ impl DependencyInstallOpts {
         let DependencyInstallOpts { no_git, no_commit, quiet, .. } = self;
 
         let git = self.git(config);
-        // let root = Git::root_of(git.root)?;
 
         let install_lib_dir = config.install_lib_dir();
         let libs = git.root.join(install_lib_dir);
@@ -132,7 +131,6 @@ impl DependencyInstallOpts {
         }
         fs::create_dir_all(&libs)?;
 
-        // git.root = &root;
         let installer = Installer { git, no_commit };
         for dep in dependencies {
             let path = libs.join(dep.name());
@@ -158,8 +156,10 @@ impl DependencyInstallOpts {
                             .exec()?;
                     }
 
-                    // this changed the .gitmodules files
-                    git.add(Some(".gitmodules"))?;
+                    // update .gitmodules which is at the root of the repo,
+                    // not necessarily at the root of the current Foundry project
+                    let root = Git::root_of(git.root)?;
+                    git.root(&root).add(Some(".gitmodules"))?;
                 }
 
                 // commit the installation

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -255,7 +255,7 @@ impl Installer<'_> {
         if self.git.shallow {
             None
         } else {
-            self.git_semver_tags(&path).ok().and_then(|mut tags| tags.pop()).map(|(tag, _)| tag)
+            self.git_semver_tags(path).ok().and_then(|mut tags| tags.pop()).map(|(tag, _)| tag)
         }
     }
 

--- a/cli/src/cmd/forge/remove.rs
+++ b/cli/src/cmd/forge/remove.rs
@@ -1,12 +1,11 @@
 use crate::{
     cmd::{Cmd, LoadConfig},
     opts::Dependency,
-    utils::CommandUtils,
+    utils::Git,
 };
 use clap::{Parser, ValueHint};
-use eyre::WrapErr;
-use foundry_config::{find_git_root_path, impl_figment_convert_basic};
-use std::{fs, path::PathBuf, process::Command};
+use foundry_config::impl_figment_convert_basic;
+use std::path::PathBuf;
 
 /// CLI arguments for `forge remove`.
 #[derive(Debug, Clone, Parser)]
@@ -32,34 +31,17 @@ impl Cmd for RemoveArgs {
 
     fn run(self) -> eyre::Result<Self::Output> {
         let config = self.try_load_config_emit_warnings()?;
-        let git_root =
-            find_git_root_path(&config.__root.0).wrap_err("Unable to detect git root directory")?;
-        let libs = config.install_lib_dir();
-        let git_modules = git_root.join(".git/modules");
+        let (root, paths) = super::update::dependencies_paths(&self.dependencies, &config)?;
+        eprintln!("root={root:?} paths={paths:?}");
+        let git_modules = root.join(".git/modules");
 
-        let base_args: &[&str] = if self.force { &["rm", "--force"] } else { &["rm"] };
-        for dep in &self.dependencies {
-            eprintln!("rm {dep:#?}");
-            let name = dep.name();
-            let dep_path = libs.join(name);
-            let path = dep_path.display().to_string();
-            let rel_path = dep_path
-                .strip_prefix(&git_root)
-                .wrap_err("Library directory is not relative to the repository root")?;
-            if !dep_path.exists() {
-                eyre::bail!("Could not find dependency {name:?} in {path}");
-            }
+        // remove all the dependencies by invoking `git rm` only once with all the paths
+        Git::new(&root).rm(self.force, &paths)?;
 
-            println!("Removing '{}' in {path}, (url: {:?}, tag: {:?})", dep.name, dep.url, dep.tag);
-
-            // completely remove the submodule:
-            // git rm <path> && rm -rf .git/modules/<path>
-            let mut args = base_args.to_vec();
-            args.push(&path);
-            Command::new("git").args(args).current_dir(&git_root).exec()?;
-
-            fs::remove_dir_all(git_modules.join(rel_path))
-                .wrap_err("Failed removing .git submodule directory")?;
+        // remove all the dependencies from .git/modules
+        for (Dependency { name, url, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
+            println!("Removing '{name}' in {}, (url: {url:?}, tag: {tag:?})", path.display());
+            std::fs::remove_dir_all(git_modules.join(path))?;
         }
 
         Ok(())

--- a/cli/src/cmd/forge/remove.rs
+++ b/cli/src/cmd/forge/remove.rs
@@ -32,7 +32,6 @@ impl Cmd for RemoveArgs {
     fn run(self) -> eyre::Result<Self::Output> {
         let config = self.try_load_config_emit_warnings()?;
         let (root, paths) = super::update::dependencies_paths(&self.dependencies, &config)?;
-        eprintln!("root={root:?} paths={paths:?}");
         let git_modules = root.join(".git/modules");
 
         // remove all the dependencies by invoking `git rm` only once with all the paths

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -134,7 +134,7 @@ impl TestArgs {
         let mut project = config.project()?;
 
         // install missing dependencies
-        if install::install_missing_dependencies(&mut config, &project, self.build_args().silent) &&
+        if install::install_missing_dependencies(&mut config, self.build_args().silent) &&
             config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings

--- a/cli/src/cmd/forge/update.rs
+++ b/cli/src/cmd/forge/update.rs
@@ -1,26 +1,60 @@
 //! Update command
-use crate::{cmd::Cmd, utils::CommandUtils};
+use crate::{
+    cmd::{Cmd, LoadConfig},
+    opts::Dependency,
+    utils::Git,
+};
 use clap::{Parser, ValueHint};
-use std::{path::PathBuf, process::Command};
+use eyre::{Context, Result};
+use foundry_config::{impl_figment_convert_basic, Config};
+use std::path::PathBuf;
 
 /// CLI arguments for `forge update`.
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
-    /// The path to the dependency you want to update.
-    #[clap(value_hint = ValueHint::DirPath, value_name = "PATH")]
-    lib: Option<PathBuf>,
+    /// The dependencies you want to update.
+    dependencies: Vec<Dependency>,
+
+    /// The project's root path.
+    ///
+    /// By default root of the Git repository, if in one,
+    /// or the current working directory.
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    root: Option<PathBuf>,
+
+    /// Override the up-to-date check.
+    #[clap(short, long)]
+    force: bool,
 }
+impl_figment_convert_basic!(UpdateArgs);
 
 impl Cmd for UpdateArgs {
     type Output = ();
 
-    fn run(self) -> eyre::Result<Self::Output> {
-        let mut cmd = Command::new("git");
-        cmd.args(["submodule", "update", "--remote", "--init"]);
-        // if a lib is specified, open it
-        if let Some(lib) = self.lib {
-            cmd.args(["--", lib.display().to_string().as_str()]);
-        }
-        cmd.exec().map(|_| ())
+    fn run(self) -> Result<Self::Output> {
+        let config = self.try_load_config_emit_warnings()?;
+        let (root, paths) = dependencies_paths(&self.dependencies, &config)?;
+        Git::new(&root).submodule_update(self.force, paths)
     }
+}
+
+/// Returns `(root, paths)` where `root` is the root of the Git repository and `paths` are the
+/// relative paths of the dependencies.
+pub fn dependencies_paths(deps: &[Dependency], config: &Config) -> Result<(PathBuf, Vec<PathBuf>)> {
+    let git_root = Git::root_of(&config.__root.0)?;
+    let libs = config.install_lib_dir();
+
+    let mut paths = Vec::with_capacity(deps.len());
+    for dep in deps {
+        let name = dep.name();
+        let dep_path = libs.join(name);
+        let rel_path = dep_path
+            .strip_prefix(&git_root)
+            .wrap_err("Library directory is not relative to the repository root")?;
+        if !dep_path.exists() {
+            eyre::bail!("Could not find dependency {name:?} in {}", dep_path.display());
+        }
+        paths.push(rel_path.to_owned());
+    }
+    Ok((git_root, paths))
 }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -252,11 +252,12 @@ pub trait CommandUtils {
 impl CommandUtils for Command {
     #[track_caller]
     fn exec(&mut self) -> Result<Output> {
-        // eprintln!("$ {self:?}");
         tracing::trace!(command=?self, "executing");
+
         let output = self.output()?;
-        // eprintln!("  {:?} {output:?}", output.status.code());
+
         tracing::trace!(code=?output.status.code(), ?output);
+
         if output.status.success() {
             Ok(output)
         } else {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -9,10 +9,11 @@ use ethers::{
 use eyre::Result;
 use foundry_config::{Chain, Config};
 use std::{
+    ffi::OsStr,
     future::Future,
     ops::Mul,
-    path::Path,
-    process::{Command, Output},
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
     str::FromStr,
     time::Duration,
 };
@@ -251,12 +252,41 @@ pub trait CommandUtils {
 impl CommandUtils for Command {
     #[track_caller]
     fn exec(&mut self) -> Result<Output> {
+        // eprintln!("$ {self:?}");
+        tracing::trace!(command=?self, "executing");
         let output = self.output()?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eyre::bail!("{}", stderr.trim())
+        // eprintln!("  {:?} {output:?}", output.status.code());
+        tracing::trace!(code=?output.status.code(), ?output);
+        if output.status.success() {
+            Ok(output)
+        } else {
+            let mut stderr = String::from_utf8_lossy(&output.stderr);
+            let mut msg = stderr.trim();
+            if msg.is_empty() {
+                stderr = String::from_utf8_lossy(&output.stdout);
+                msg = stderr.trim();
+            }
+
+            let mut name = self.get_program().to_string_lossy();
+            if let Some(arg) = self.get_args().next() {
+                let arg = arg.to_string_lossy();
+                if !arg.starts_with('-') {
+                    let name = name.to_mut();
+                    name.push(' ');
+                    name.push_str(&arg);
+                }
+            }
+
+            let mut err = match output.status.code() {
+                Some(code) => format!("{name} exited with code {code}"),
+                None => format!("{name} terminated by a signal"),
+            };
+            if !msg.is_empty() {
+                err.push_str(": ");
+                err.push_str(msg);
+            }
+            Err(eyre::eyre!(err))
         }
-        Ok(output)
     }
 
     #[track_caller]
@@ -264,6 +294,227 @@ impl CommandUtils for Command {
         let output = self.exec()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(stdout.trim().into())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Git<'a> {
+    pub root: &'a Path,
+    pub quiet: bool,
+    pub shallow: bool,
+}
+
+impl<'a> Git<'a> {
+    #[inline]
+    pub fn new(root: &'a Path) -> Self {
+        Self { root, quiet: false, shallow: true }
+    }
+
+    #[inline]
+    pub fn from_config(config: &'a Config) -> Self {
+        Self::new(config.__root.0.as_path())
+    }
+
+    pub fn root_of(relative_to: &Path) -> Result<PathBuf> {
+        let output = Self::cmd_no_root()
+            .current_dir(relative_to)
+            .args(["rev-parse", "--show-toplevel"])
+            .get_stdout_lossy()?;
+        Ok(PathBuf::from(output))
+    }
+
+    pub fn clone(
+        shallow: bool,
+        from: impl AsRef<OsStr>,
+        to: Option<impl AsRef<OsStr>>,
+    ) -> Result<()> {
+        Self::cmd_no_root()
+            .stderr(Stdio::inherit())
+            .args(["clone", "--recurse-submodules"])
+            .args(shallow.then_some("--depth=1"))
+            .args(shallow.then_some("--no-single-branch"))
+            .args(shallow.then_some("--shallow-submodules"))
+            .arg(from)
+            .args(to)
+            .exec()
+            .map(drop)
+    }
+
+    #[inline]
+    pub fn root<'b>(self, root: &'b Path) -> Git<'b> {
+        Git { root, ..self }
+    }
+
+    #[inline]
+    pub fn quiet(self, quiet: bool) -> Self {
+        Self { quiet, ..self }
+    }
+
+    /// False to perform shallow clones
+    #[inline]
+    pub fn deep(self, deep: bool) -> Self {
+        Self { shallow: !deep, ..self }
+    }
+
+    pub fn checkout(self, recursive: bool, tag: impl AsRef<OsStr>) -> Result<()> {
+        self.cmd()
+            .arg("checkout")
+            .args(recursive.then_some("--recurse-submodules"))
+            .arg(tag)
+            .exec()
+            .map(drop)
+    }
+
+    pub fn init(self) -> Result<()> {
+        self.cmd().arg("init").exec().map(drop)
+    }
+
+    pub fn add<I, S>(self, paths: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.cmd().arg("add").args(paths).exec().map(drop)
+    }
+
+    pub fn rm<I, S>(self, force: bool, paths: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.cmd().arg("rm").args(force.then_some("--force")).args(paths).exec().map(drop)
+    }
+
+    pub fn commit(self, msg: &str) -> Result<()> {
+        let output = self
+            .cmd()
+            .args(["commit", "-m", msg])
+            .args(cfg!(any(test, debug_assertions)).then_some("--no-gpg-sign"))
+            .output()?;
+        if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // ignore "nothing to commit" error
+            let msg = "nothing to commit, working tree clean";
+            if !(stdout.contains(msg) || stderr.contains(msg)) {
+                return Err(eyre::eyre!(
+                    "failed to commit (code={:?}, stdout={:?}, stderr={:?})",
+                    output.status.code(),
+                    stdout.trim(),
+                    stderr.trim()
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    pub fn is_in_repo(self) -> std::io::Result<bool> {
+        self.cmd().args(["rev-parse", "--is-inside-work-tree"]).status().map(|s| s.success())
+    }
+
+    pub fn is_clean(self) -> Result<bool> {
+        self.cmd().args(["status", "--porcelain"]).exec().map(|out| out.stdout.is_empty())
+    }
+
+    pub fn has_branch(self, branch: impl AsRef<OsStr>) -> Result<bool> {
+        self.cmd()
+            .args(["branch", "--list", "--no-color"])
+            .arg(branch)
+            .get_stdout_lossy()
+            .map(|stdout| !stdout.is_empty())
+    }
+
+    pub fn ensure_clean(self) -> Result<()> {
+        if self.is_clean()? {
+            Ok(())
+        } else {
+            Err(eyre::eyre!(
+                "\
+The target directory is a part of or on its own an already initialized git repository,
+and it requires clean working and staging areas, including no untracked files.
+
+Check the current git repository's status with `git status`.
+Then, you can track files with `git add ...` and then commit them with `git commit`,
+ignore them in the `.gitignore` file, or run this command again with the `--no-commit` flag.
+
+If none of the previous steps worked, please open an issue at:
+https://github.com/foundry-rs/foundry/issues/new/choose"
+            ))
+        }
+    }
+
+    pub fn commit_hash(self, short: bool) -> Result<String> {
+        self.cmd().arg("rev-parse").args(short.then_some("--short")).arg("HEAD").get_stdout_lossy()
+    }
+
+    pub fn tag(self) -> Result<String> {
+        self.cmd().arg("tag").get_stdout_lossy()
+    }
+
+    pub fn has_missing_dependencies<I, S>(self, paths: I) -> Result<bool>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.cmd()
+            .args(["submodule", "status"])
+            .args(paths)
+            .get_stdout_lossy()
+            .map(|stdout| stdout.lines().any(|line| line.starts_with('-')))
+    }
+
+    pub fn submodule_add(
+        self,
+        force: bool,
+        url: impl AsRef<OsStr>,
+        path: impl AsRef<OsStr>,
+    ) -> Result<()> {
+        self.cmd()
+            .stderr(self.stderr())
+            .args(["submodule", "add"])
+            .args(self.shallow.then_some("--depth=1"))
+            .args(force.then_some("--force"))
+            .arg(url)
+            .arg(path)
+            .exec()
+            .map(drop)
+    }
+
+    pub fn submodule_update<I, S>(self, force: bool, paths: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.cmd()
+            .stderr(self.stderr())
+            .args(["submodule", "update", "--progress", "--init", "--recursive"])
+            .args(self.shallow.then_some("--depth=1"))
+            .args(self.shallow.then_some("--no-single-branch"))
+            .args(force.then_some("--force"))
+            .args(paths)
+            .exec()
+            .map(drop)
+    }
+
+    pub fn cmd(self) -> Command {
+        let mut cmd = Self::cmd_no_root();
+        cmd.current_dir(self.root);
+        cmd
+    }
+
+    pub fn cmd_no_root() -> Command {
+        let mut cmd = Command::new("git");
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd
+    }
+
+    // don't set this in cmd() because it's not wanted for all commands
+    fn stderr(self) -> Stdio {
+        if self.quiet {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        }
     }
 }
 
@@ -287,7 +538,7 @@ mod tests {
     #[test]
     fn can_load_dotenv() {
         let temp = tempdir().unwrap();
-        Command::new("git").arg("init").current_dir(temp.path()).exec().unwrap();
+        Git::new(temp.path()).init().unwrap();
         let cwd_env = temp.path().join(".env");
         fs::create_file(temp.path().join("foundry.toml")).unwrap();
         let nested = temp.path().join("nested");

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -342,7 +342,7 @@ impl<'a> Git<'a> {
     }
 
     #[inline]
-    pub fn root<'b>(self, root: &'b Path) -> Git<'b> {
+    pub fn root(self, root: &Path) -> Git<'_> {
         Git { root, ..self }
     }
 
@@ -370,6 +370,7 @@ impl<'a> Git<'a> {
         self.cmd().arg("init").exec().map(drop)
     }
 
+    #[allow(clippy::should_implement_trait)] // this is not std::ops::Add clippy
     pub fn add<I, S>(self, paths: I) -> Result<()>
     where
         I: IntoIterator<Item = S>,

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -242,14 +242,7 @@ forgetest!(can_detect_dirty_git_status_on_init, |prj: TestProject, mut cmd: Test
     prj.wipe();
 
     // initialize new git repo
-    let status = Command::new("git")
-        .arg("init")
-        .current_dir(prj.root())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .expect("could not run git init");
-    assert!(status.success());
+    cmd.git_init();
 
     std::fs::write(prj.root().join("untracked.text"), "untracked").unwrap();
 
@@ -958,7 +951,7 @@ forgetest!(can_install_repeatedly, |_prj: TestProject, mut cmd: TestCommand| {
 // <https://github.com/openzeppelin/openzeppelin-contracts>
 forgetest!(can_install_latest_release_tag, |prj: TestProject, mut cmd: TestCommand| {
     cmd.git_init();
-    cmd.forge_fuse().args(["install", "openzeppelin/openzeppelin-contracts"]);
+    cmd.forge_fuse().args(["install", "--deep", "openzeppelin/openzeppelin-contracts"]);
     cmd.assert_success();
 
     let dep = prj.paths().libraries[0].join("openzeppelin-contracts");

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -578,12 +578,12 @@ impl Config {
     /// Returns the directory in which dependencies should be installed
     ///
     /// Returns the first dir from `libs` that is not `node_modules` or `lib` if `libs` is empty
-    pub fn install_lib_dir(&self) -> PathBuf {
+    pub fn install_lib_dir(&self) -> &Path {
         self.libs
             .iter()
             .find(|p| !p.ends_with("node_modules"))
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("lib"))
+            .map(|p| p.as_path())
+            .unwrap_or_else(|| Path::new("lib"))
     }
 
     /// Serves as the entrypoint for obtaining the project.
@@ -2425,9 +2425,10 @@ impl BasicConfig {
     pub fn to_string_pretty(&self) -> Result<String, toml::ser::Error> {
         let s = toml::to_string_pretty(self)?;
         Ok(format!(
-            r#"[profile.{}]
+            "\
+[profile.{}]
 {s}
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config"#,
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config",
             self.profile
         ))
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5095

Best reviewed with whitespace disabled in github viewer

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Refactor git commands in foundry-cli (see `Git` struct)
- Add `--depth=1` to clone and submodule commands
  - note that this is technically breaking, since tags are fetched at the given depth, so now the default behaviour won't automatically switch to the latest tagged version branch unless `--deep` is specified
- clone commands (which are likely to "hang") now print git progress by default, silenced by `--quiet`

TODO: `--deep` with shallow by default, or viceversa? cc @mattsse @Evalir

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
