### PR TITLE
chore: Clean up docs for `abi-decode` & `calldata-decode` 

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1340,6 +1340,8 @@ impl SimpleCast {
 
     /// Decodes abi-encoded hex input or output
     ///
+    /// When `input=true`, `calldata` string MUST not be prefixed with function selector
+    ///
     /// # Example
     ///
     /// ```
@@ -1374,7 +1376,8 @@ impl SimpleCast {
     }
 
     /// Decodes calldata-encoded hex input or output
-    /// Similar to `abi_decode`, but does requires a function signature prefixed for "calldata"
+    ///
+    /// Similar to `abi_decode`, but `calldata` string MUST be prefixed with function selector
     ///
     /// # Example
     ///

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -443,6 +443,8 @@ pub enum Subcommands {
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
+    ///
+    /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata` string
     #[clap(visible_aliases = &["--calldata-decode","cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
@@ -454,8 +456,9 @@ pub enum Subcommands {
 
     /// Decode ABI-encoded input or output data.
     ///
-    /// Defaults to decoding output data. To decode input data pass --input or use cast
-    /// --calldata-decode.
+    /// Defaults to decoding output data. To decode input data pass --input.
+    ///
+    /// When passing `--input`, function selector must NOT be prefixed in `calldata` string
     #[clap(name = "abi-decode", visible_alias = "ad")]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -444,7 +444,8 @@ pub enum Subcommands {
 
     /// Decode ABI-encoded input data.
     ///
-    /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata` string
+    /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata`
+    /// string
     #[clap(visible_aliases = &["--calldata-decode","cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.


### PR DESCRIPTION
## Motivation

Follows up on PR https://github.com/foundry-rs/foundry/pull/5178 to clean up the docs to explain the `cast` methods 

@Evalir as requested https://github.com/foundry-rs/foundry/pull/5178#pullrequestreview-1493319690

