### PR TITLE
fix(`tests`): force install solidity 0.8.19 through svm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,15 @@ jobs:
               with:
                   name: ${{ matrix.archive.name }}
                   path: ${{ matrix.archive.file }}
+    install-svm-solc:
+        name: install svm and solidity 0.8.19 / ${{ matrix.job.name }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+          - name: Install svm
+            run: cargo install svm-rs
+          - name: Install Solidity 0.8.19
+            run: svm install 0.8.19
 
     unit:
         name: unit tests / ${{ matrix.job.name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
                   name: ${{ matrix.archive.name }}
                   path: ${{ matrix.archive.file }}
     install-svm-solc:
-        name: install svm and solidity 0.8.19 / ${{ matrix.job.name }}
+        name: install svm and solidity / ${{ matrix.job.name }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
@@ -56,6 +56,8 @@ jobs:
             run: cargo install svm-rs
           - name: Install Solidity 0.8.19
             run: svm install 0.8.19
+          - name: Install Solidity 0.8.20
+            run: svm install 0.8.20
           - name: Use Solidity 0.8.19
             run: svm use 0.8.19
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
             run: cargo install svm-rs
           - name: Install Solidity 0.8.19
             run: svm install 0.8.19
+          - name: Use Solidity 0.8.19
+            run: svm use 0.8.19
 
     unit:
         name: unit tests / ${{ matrix.job.name }}


### PR DESCRIPTION
## Motivation

Part of the issue regarding consistency and flakyness in the CI is due to using random solidity versions. This forces a solidity 0.8.19 install through the CI to default to this version.

## Solution

Install SVM and use 0.8.19
