### PR TITLE
fix(cast): disable base fee checks and skip 0xa4b05 address txs

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use ethers::{
     abi::Address,
     prelude::{artifacts::ContractBytecodeSome, ArtifactId, Middleware},
+    types::H160,
 };
 use eyre::WrapErr;
 use forge::{
@@ -25,6 +26,11 @@ use std::{collections::BTreeMap, str::FromStr};
 use tracing::trace;
 use ui::{TUIExitReason, Tui, Ui};
 use yansi::Paint;
+
+const ARBITRUM_SENDER: H160 = H160([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x0a, 0x4b, 0x05,
+]);
 
 /// CLI arguments for `cast run`.
 #[derive(Debug, Clone, Parser)]
@@ -125,7 +131,7 @@ impl RunArgs {
                 for (index, tx) in block.transactions.into_iter().enumerate() {
                     // arbitrum L1 transaction at the start of every block that has gas price 0
                     // and gas limit 0 which causes reverts, so we skip it
-                    if tx.from == "0x00000000000000000000000000000000000a4b05".parse::<Address>()? {
+                    if tx.from == ARBITRUM_SENDER.into() {
                         continue
                     }
                     if tx.hash().eq(&tx_hash) {

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -131,7 +131,7 @@ impl RunArgs {
                 for (index, tx) in block.transactions.into_iter().enumerate() {
                     // arbitrum L1 transaction at the start of every block that has gas price 0
                     // and gas limit 0 which causes reverts, so we skip it
-                    if tx.from == ARBITRUM_SENDER.into() {
+                    if tx.from == ARBITRUM_SENDER {
                         update_progress!(pb, index);
                         continue
                     }

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -132,6 +132,7 @@ impl RunArgs {
                     // arbitrum L1 transaction at the start of every block that has gas price 0
                     // and gas limit 0 which causes reverts, so we skip it
                     if tx.from == ARBITRUM_SENDER.into() {
+                        update_progress!(pb, index);
                         continue
                     }
                     if tx.hash().eq(&tx_hash) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fixes https://github.com/foundry-rs/foundry/issues/5122

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Optimism and arbitrum both have a fixed first transaction that is made from/to specific special addresses. Optimism tx has gas price 0, arbitrum tx has gas price and gas limit both 0 which violates the basefee and gas used checks in revm. 

## Solution

Specifically for `cast run` we can skip the base fee checks and assume they always pass because those transactions are already confirmed by the network and hence _valid_. Hardcoded a tx skip from `a4b05` address but there's probably a better and cleaner way to do this.  
