### PR TITLE
feat(forge): improve fuzz corpus

### DIFF
--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -116,11 +116,11 @@ pub fn build_initial_state<DB: DatabaseRef>(
                 state.values_mut().insert(utils::u256_to_h256_be(value).into());
                 // also add the value below and above the storage value to the dictionary.
                 if value != U256::zero() {
-                    let below_value = U256::from(value) - U256::one();
+                    let below_value = value - U256::one();
                     state.values_mut().insert(utils::u256_to_h256_be(below_value).into());
                 }
                 if value != U256::max_value() {
-                    let above_value = U256::from(value) + U256::one();
+                    let above_value = value + U256::one();
                     state.values_mut().insert(utils::u256_to_h256_be(above_value).into());
                 }
             }
@@ -172,11 +172,11 @@ pub fn collect_state_from_call(
                 state.values_mut().insert(utils::u256_to_h256_be(value).into());
                 // also add the value below and above the storage value to the dictionary.
                 if value != U256::zero() {
-                    let below_value = U256::from(value) - U256::one();
+                    let below_value = value - U256::one();
                     state.values_mut().insert(utils::u256_to_h256_be(below_value).into());
                 }
                 if value != U256::max_value() {
-                    let above_value = U256::from(value) + U256::one();
+                    let above_value = value + U256::one();
                     state.values_mut().insert(utils::u256_to_h256_be(above_value).into());
                 }
             }

--- a/evm/src/fuzz/strategies/state.rs
+++ b/evm/src/fuzz/strategies/state.rs
@@ -114,6 +114,15 @@ pub fn build_initial_state<DB: DatabaseRef>(
                 let value = (*value).into();
                 state.values_mut().insert(utils::u256_to_h256_be(slot).into());
                 state.values_mut().insert(utils::u256_to_h256_be(value).into());
+                // also add the value below and above the storage value to the dictionary.
+                if value != U256::zero() {
+                    let below_value = U256::from(value) - U256::one();
+                    state.values_mut().insert(utils::u256_to_h256_be(below_value).into());
+                }
+                if value != U256::max_value() {
+                    let above_value = U256::from(value) + U256::one();
+                    state.values_mut().insert(utils::u256_to_h256_be(above_value).into());
+                }
             }
         }
     }
@@ -161,6 +170,15 @@ pub fn collect_state_from_call(
                 let value = ru256_to_u256(value.present_value());
                 state.values_mut().insert(utils::u256_to_h256_be(slot).into());
                 state.values_mut().insert(utils::u256_to_h256_be(value).into());
+                // also add the value below and above the storage value to the dictionary.
+                if value != U256::zero() {
+                    let below_value = U256::from(value) - U256::one();
+                    state.values_mut().insert(utils::u256_to_h256_be(below_value).into());
+                }
+                if value != U256::max_value() {
+                    let above_value = U256::from(value) + U256::one();
+                    state.values_mut().insert(utils::u256_to_h256_be(above_value).into());
+                }
             }
         } else {
             return
@@ -210,7 +228,15 @@ fn collect_push_bytes(code: Bytes) -> Vec<[u8; 32]> {
                 return bytes
             }
 
-            bytes.push(U256::from_big_endian(&code[push_start..push_end]).into());
+            let push_value = U256::from_big_endian(&code[push_start..push_end]);
+            bytes.push(push_value.into());
+            // also add the value below and above the push value to the dictionary.
+            if push_value != U256::zero() {
+                bytes.push((push_value - U256::one()).into());
+            }
+            if push_value != U256::max_value() {
+                bytes.push((push_value + U256::one()).into());
+            }
 
             i += push_size;
         }


### PR DESCRIPTION
This pr provides a small update to the fuzz corpus that should allow higher effectiveness in fuzzing to find bugs, hit assertions, cause failures, etc.


## Motivation

The fuzz corpus uses the values for the `push`, `slot`, `slot_value`, and log `topics` for relevant `accounts` in the state db.

The fuzz corpus can be minorly improved by also inserting values that are +/- 1 of the value, in order to pass through conditional statements that use `<` or `>`.

For example:

Challenge:
```solidity
pragma solidity ^0.8.13;
contract MagicNumber {
    uint256 public target = 0;

    function check_against_magic(uint256 number) public {

        if (number > 100_098) { 
            if (number < 100_100) {
                target = 1;
            }
        }
    }

    function is_solved() public view returns (bool){
        return target == 1;
    }
}
```

Test:
```solidity
pragma solidity ^0.8.13;

import "forge-std/Test.sol";
import "../src/MagicNumber.sol";

contract MagicNumberTest is Test {
    MagicNumber public magic_number;

    function setUp() public {
        magic_number = new MagicNumber();
    }

    function testFuzz(uint number) public {
        magic_number.check_against_magic(number);
        assertFalse(magic_number.is_solved());
    }
}
```

Fuzzing profile of:
```toml
[fuzz]
runs = 100_000
dictionary = 90
```

Current fuzzer:
```
❯ forge test --fuzz-runs 100000 --mc MagicNumber                    
[⠢] Compiling...
No files changed, compilation skipped

Running 1 test for test/MagicNumber.t.sol:MagicNumberTest
[PASS] testFuzz(uint256) (runs: 100000, μ: 8346, ~: 8340)
Test result: ok. 1 passed; 0 failed; finished in 2.48s
```

After PR Changes:
```
❯ forge test --fuzz-runs 100000 --mc MagicNumber                    
[⠢] Compiling...
No files changed, compilation skipped

Running 1 test for test/MagicNumber.t.sol:MagicNumberTest
[FAIL. Reason: Assertion failed. Counterexample: calldata=0x32f92a0300000000000000000000000000000000000000000000000000000000000188fb, args=[100603 [1.006e5]]] testFuzz(uint256) (runs: 305, μ: 8345, ~: 8340)
Test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in 384.89ms

Failing tests:
Encountered 1 failing test in test/MagicNumber.t.sol:MagicNumberTest
[FAIL. Reason: Assertion failed. Counterexample: calldata=0x32f92a0300000000000000000000000000000000000000000000000000000000000188fb, args=[100603 [1.006e5]]] testFuzz(uint256) (runs: 305, μ: 8345, ~: 8340)

Encountered a total of 1 failing tests, 0 tests succeeded
```

## Solution

My initial feeling is that only the `push` and `slot_value` values should be considered for the +/- 1 insertion. Practically, log topics and slot_keys are never used for logical flow or comparisons, and adding them would increase bloat in the fuzzing corpus which drags down effectiveness.

I don't like how I polluted the `collect_push_values()` fn with returning more than just the push values. I think that the `push` and `slot_value` values should instead be iterated over separately and have the +/- 1 values inserted.


## Better Solution
While this +/- 1 business definitely aids the initial skyrocket of finding bugs in a fuzzing marathon, it could also lead to a flatter tail where the excess bloat of the dictionary leads to less useful values being picked over a long period of time.

<img width="849" alt="image" src="https://github.com/foundry-rs/foundry/assets/98172525/349d65f0-9448-458b-ab64-9eacfd218620">
[Source: Daedaluzz](https://consensys.net/diligence/blog/2023/04/benchmarking-smart-contract-fuzzers/)


A better solution entirely would be to do a static analysis pass over the bytecode and track push values that are concretely modified + consumed by conditional statements. A static pass can be a surgical way to find the real values that are checked against.

Without doing a static pass, there could also be interesting REVM inspectors that track the stack values consumed in `lt`, `gt`, `eq`, etc opcodes, and add these values to the dictionary when the run is finished.

Example where a static pass shines:
```
pragma solidity ^0.8.13;
contract StaticPassRequired {
    uint256 public target = 0;
    uint256 constant magic_number = 1337;

    function check_against_magic(uint256 number) public {
        if (number == magic_number * 1337) { // value not found in push
            target = 1;
        }
    }

    function is_solved() public view returns (bool){
        return target == 1;
    }
}
```



