### PR TITLE
docs: fix docs for `cast logs`

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -286,7 +286,8 @@ pub enum Subcommands {
     /// Create an access list for a transaction.
     #[clap(visible_aliases = &["ac", "acl"])]
     AccessList(AccessListArgs),
-    /// Create an access list for a transaction.
+    /// Get logs by signature or topic.
+    #[clap(visible_alias = "l")]
     Logs(LogsArgs),
     /// Get information about a block.
     #[clap(visible_alias = "bl")]
@@ -703,7 +704,7 @@ pub enum Subcommands {
     },
 
     /// Perform an ENS reverse lookup.
-    #[clap(visible_alias = "l")]
+    #[clap(visible_alias = "la")]
     LookupAddress {
         /// The account to perform the lookup for.
         who: Option<Address>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, the `cast logs` command erroneously uses the same description as `cast access-list` and lacks a short-hand alias.
![image](https://github.com/foundry-rs/foundry/assets/24715302/acbbaa4b-8a76-46e8-b2a4-950db6c45881)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR corrects the `cast logs` description and adds the short-hand alias `l`. Since this alias was already occupied by `cast lookup-address`, I opted to give it the replacement `la` which I believe is incidentally more appropriate.
![image](https://github.com/foundry-rs/foundry/assets/24715302/6a741f16-08a4-4c8c-bba5-51b91a5dc66e)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
