### PR TITLE
Read dotenv when running chisel

### DIFF
--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -9,6 +9,7 @@ use chisel::{
 };
 use clap::Parser;
 use foundry_cli::cmd::{forge::build::BuildArgs, LoadConfig};
+use foundry_cli::{utils};
 use foundry_common::evm::EvmArgs;
 use foundry_config::{
     figment::{
@@ -75,6 +76,8 @@ async fn main() -> eyre::Result<()> {
     if !Paint::enable_windows_ascii() {
         Paint::disable()
     }
+
+    utils::load_dotenv();
 
     // Parse command args
     let args = ChiselParser::parse();

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -8,8 +8,10 @@ use chisel::{
     prelude::{ChiselCommand, ChiselDispatcher, DispatchResult, SolidityHelper},
 };
 use clap::Parser;
-use foundry_cli::cmd::{forge::build::BuildArgs, LoadConfig};
-use foundry_cli::{utils};
+use foundry_cli::{
+    cmd::{forge::build::BuildArgs, LoadConfig},
+    utils,
+};
 use foundry_common::evm::EvmArgs;
 use foundry_config::{
     figment::{


### PR DESCRIPTION
## Motivation

RIght now, chisel ignores dotenv files (at least on startup), and this leads to it being unable to fork chain which RPC_URL is set in config via .env variable.

For example:

```
foundry.toml:

[profile.default]
src = "src"
out = "out"
libs = ["lib"]

[rpc_endpoints]
goerli = "${GOERLI_RPC}"
```

```
.env:

GOERLI_RPC=some_rpc
```

In such context `chisel --fork-url goerli` will fail with following error `Failed to resolve env var GOERLI_RPC in ${GOERLI_RPC}: environment variable not found` until the GOERLI_URL will not be explicitely set to environment via `export GOERLI_RPC=some_rpc`

## Solution

Add `utils::load_dotenv` to startup of chisel
