### PR TITLE
perf: spawn tokio runtime once

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,3 +1,5 @@
+name: deny
+
 on:
     push:
         branches: [master]
@@ -18,3 +20,4 @@ jobs:
             - uses: EmbarkStudios/cargo-deny-action@v1
               with:
                   command: check all
+                  arguments: "" # removing this would pass `--all-features` to `cargo deny`

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -20,4 +20,6 @@ jobs:
             - uses: EmbarkStudios/cargo-deny-action@v1
               with:
                   command: check all
-                  arguments: "" # removing this would pass `--all-features` to `cargo deny`
+                  # Clear out arguments to not pass `--all-features` to `cargo deny`.
+                  # `foundry-cli` has an `openssl` feature which enables banned dependencies
+                  arguments: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
                   cargo nextest run --retries 3 --archive-file nextest-unit.tar.zst -E '${{ matrix.job.filter }}'
 
     issue-repros-tests:
-        name: issue reproduction tests / ${{ matrix.job.name }}
+        name: issue reproduction tests / ${{ matrix.job.name }} / ${{ matrix.job.partition }}
         runs-on: ubuntu-latest
         needs: build-tests
         strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
 name = "foundry-common"
 version = "0.1.0"
 dependencies = [
+ "auto_impl",
  "clap 4.3.5",
  "comfy-table",
  "dunce",

--- a/anvil/tests/it/sign.rs
+++ b/anvil/tests/it/sign.rs
@@ -295,7 +295,7 @@ async fn rejects_different_chain_id() {
     assert!(err.to_string().contains("signed for another chain"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rejects_invalid_chain_id() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap().with_chain_id(99u64);

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -319,7 +319,7 @@ mod tests {
             }
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn builder_new_non_legacy() -> eyre::Result<()> {
         let provider = MyProvider {};
         let builder =
@@ -338,7 +338,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn builder_new_legacy() -> eyre::Result<()> {
         let provider = MyProvider {};
         let builder =
@@ -354,7 +354,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn builder_fields() -> eyre::Result<()> {
         let provider = MyProvider {};
         let mut builder =
@@ -376,7 +376,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn builder_args() -> eyre::Result<()> {
         let provider = MyProvider {};
         let mut builder =

--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -239,13 +239,17 @@ impl SessionSource {
         let env = self.config.evm_opts.evm_env().await;
 
         // Create an in-memory backend
-        let backend = self.config.backend.take().unwrap_or_else(|| {
-            let backend = Backend::spawn(
-                self.config.evm_opts.get_fork(&self.config.foundry_config, env.clone()),
-            );
-            self.config.backend = Some(backend.clone());
-            backend
-        });
+        let backend = match self.config.backend.take() {
+            Some(backend) => backend,
+            None => {
+                let backend = Backend::spawn(
+                    self.config.evm_opts.get_fork(&self.config.foundry_config, env.clone()),
+                )
+                .await;
+                self.config.backend = Some(backend.clone());
+                backend
+            }
+        };
 
         // Build a new executor
         let executor = ExecutorBuilder::default()

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -98,7 +98,7 @@ impl RunArgs {
         // can safely disable base fee checks on replaying txs because can
         // assume those checks already passed on confirmed txs
         env.cfg.disable_base_fee = true;
-        let db = Backend::spawn(evm_opts.get_fork(&config, env.clone()));
+        let db = Backend::spawn(evm_opts.get_fork(&config, env.clone())).await;
 
         // configures a bare version of the evm executor: no cheatcode inspector is enabled,
         // tracing will be enabled only for the targeted transaction

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -291,7 +291,8 @@ impl ScriptArgs {
                 None => {
                     let backend = Backend::spawn(
                         script_config.evm_opts.get_fork(&script_config.config, env.clone()),
-                    );
+                    )
+                    .await;
                     script_config.backends.insert(url.clone(), backend);
                     script_config.backends.get(url).unwrap().clone()
                 }
@@ -301,6 +302,7 @@ impl ScriptArgs {
                 // no need to cache it, since there won't be any onchain simulation that we'd need
                 // to cache the backend for.
                 Backend::spawn(script_config.evm_opts.get_fork(&script_config.config, env.clone()))
+                    .await
             }
         };
 

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -1,12 +1,9 @@
 //! Snapshot command
 use crate::{
-    cmd::{
-        forge::{
-            build::CoreBuildArgs,
-            test,
-            test::{Test, TestOutcome},
-        },
-        Cmd,
+    cmd::forge::{
+        build::CoreBuildArgs,
+        test,
+        test::{Test, TestOutcome},
     },
     utils::STATIC_FUZZ_SEED,
 };
@@ -107,16 +104,12 @@ impl SnapshotArgs {
     pub fn build_args(&self) -> &CoreBuildArgs {
         self.test.build_args()
     }
-}
 
-impl Cmd for SnapshotArgs {
-    type Output = ();
-
-    fn run(mut self) -> eyre::Result<()> {
+    pub async fn run(mut self) -> eyre::Result<()> {
         // Set fuzz seed so gas snapshots are deterministic
         self.test.fuzz_seed = Some(U256::from_big_endian(&STATIC_FUZZ_SEED));
 
-        let outcome = self.test.execute_tests()?;
+        let outcome = self.test.execute_tests().await?;
         outcome.ensure_ok()?;
         let tests = self.config.apply(outcome);
 

--- a/cli/src/cmd/forge/verify/etherscan/mod.rs
+++ b/cli/src/cmd/forge/verify/etherscan/mod.rs
@@ -534,7 +534,7 @@ mod tests {
         assert!(format!("{client:?}").contains("dummykey"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn fails_on_disabled_cache_and_missing_info() {
         let temp = tempdir().unwrap();
         let root = temp.path();

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -22,7 +22,7 @@ fn main() -> eyre::Result<()> {
             if cmd.is_watch() {
                 utils::block_on(watch::watch_test(cmd))
             } else {
-                let outcome = cmd.run()?;
+                let outcome = utils::block_on(cmd.run())?;
                 outcome.ensure_ok()
             }
         }
@@ -34,7 +34,7 @@ fn main() -> eyre::Result<()> {
             ))?;
             utils::block_on(cmd.run_script(Default::default()))
         }
-        Subcommands::Coverage(cmd) => cmd.run(),
+        Subcommands::Coverage(cmd) => utils::block_on(cmd.run()),
         Subcommands::Bind(cmd) => cmd.run(),
         Subcommands::Build(cmd) => {
             if cmd.is_watch() {
@@ -78,7 +78,7 @@ fn main() -> eyre::Result<()> {
             if cmd.is_watch() {
                 utils::block_on(watch::watch_snapshot(cmd))
             } else {
-                cmd.run()
+                utils::block_on(cmd.run())
             }
         }
         Subcommands::Fmt(cmd) => cmd.run(),

--- a/cli/tests/it/svm.rs
+++ b/cli/tests/it/svm.rs
@@ -16,7 +16,7 @@ const LATEST_SOLC: Version = Version::new(0, 8, 20);
 macro_rules! ensure_svm_releases {
     ($($test:ident => $platform:ident),*) => {
         $(
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread")]
         async fn $test() {
             ensure_latest_release(Platform::$platform).await
         }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,6 +31,7 @@ yansi = "0.5"
 tempfile = "3"
 
 #  misc
+auto_impl = "1.1.0"
 serde = "1"
 serde_json = "1"
 thiserror = "1"

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -526,7 +526,7 @@ pub fn parse_signatures(tokens: Vec<String>) -> ParsedSignatures {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_decode_selector() {
         let sigs = decode_function_selector("0xa9059cbb").await;
         assert_eq!(sigs.unwrap()[0], "transfer(address,uint256)".to_string());
@@ -542,7 +542,7 @@ mod tests {
             .ok();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_decode_calldata() {
         let decoded = decode_calldata("0xa9059cbb0000000000000000000000000a2ac0c368dc8ec680a0c98c907656bd970675950000000000000000000000000000000000000000000000000000000767954a79").await;
         assert_eq!(decoded.unwrap()[0], "transfer(address,uint256)".to_string());
@@ -551,7 +551,7 @@ mod tests {
         assert_eq!(decoded.unwrap()[0], "transfer(address,uint256)".to_string());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_import_selectors() {
         let mut data = RawSelectorImportData::default();
         data.function.push("transfer(address,uint256)".to_string());
@@ -569,7 +569,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_parse_signatures() {
         let result = parse_signatures(vec!["transfer(address,uint256)".to_string()]);
         assert_eq!(
@@ -625,7 +625,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_decode_event_topic() {
         let decoded = decode_event_topic(
             "0x7e1db2a1cd12f0506ecd806dba508035b290666b84b096a87af2fd2a1516ede6",

--- a/common/src/traits.rs
+++ b/common/src/traits.rs
@@ -3,6 +3,7 @@
 use ethers_core::abi::Function;
 
 /// Extension trait for matching tests
+#[auto_impl::auto_impl(&)]
 pub trait TestFilter: Send + Sync {
     /// Returns whether the test should be included
     fn matches_test(&self, test_name: impl AsRef<str>) -> bool;
@@ -13,6 +14,7 @@ pub trait TestFilter: Send + Sync {
 }
 
 /// Extension trait for `Function`
+#[auto_impl::auto_impl(&)]
 pub trait TestFunctionExt {
     /// Whether this function should be executed as invariant test
     fn is_invariant_test(&self) -> bool;

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -390,9 +390,9 @@ pub struct Backend {
 // === impl Backend ===
 
 impl Backend {
-    /// Creates a new Backend with a spawned multi fork thread
-    pub fn spawn(fork: Option<CreateFork>) -> Self {
-        Self::new(MultiFork::spawn(), fork)
+    /// Creates a new Backend with a spawned multi fork thread.
+    pub async fn spawn(fork: Option<CreateFork>) -> Self {
+        Self::new(MultiFork::spawn().await, fork)
     }
 
     /// Creates a new instance of `Backend`
@@ -435,8 +435,12 @@ impl Backend {
 
     /// Creates a new instance of `Backend` with fork added to the fork database and sets the fork
     /// as active
-    pub(crate) fn new_with_fork(id: &ForkId, fork: Fork, journaled_state: JournaledState) -> Self {
-        let mut backend = Self::spawn(None);
+    pub(crate) async fn new_with_fork(
+        id: &ForkId,
+        fork: Fork,
+        journaled_state: JournaledState,
+    ) -> Self {
+        let mut backend = Self::spawn(None).await;
         let fork_ids = backend.inner.insert_new_fork(id.clone(), fork.db, journaled_state);
         backend.inner.launched_with_fork = Some((id.clone(), fork_ids.0, fork_ids.1));
         backend.active_fork_ids = Some(fork_ids);
@@ -1752,7 +1756,10 @@ fn commit_transaction(
         let mut evm = EVM::new();
         evm.env = env;
 
-        let db = Backend::new_with_fork(fork_id, fork.clone(), journaled_state.clone());
+        let fork = fork.clone();
+        let journaled_state = journaled_state.clone();
+        let db = crate::utils::RuntimeOrHandle::new()
+            .block_on(async move { Backend::new_with_fork(fork_id, fork, journaled_state).await });
         evm.database(db);
 
         if let Some(inspector) = cheatcodes_inspector {

--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -775,7 +775,7 @@ mod tests {
             evm_opts,
         };
 
-        let backend = Backend::spawn(Some(fork));
+        let backend = Backend::spawn(Some(fork)).await;
 
         // some rng contract from etherscan
         let address: B160 = "63091244180ae240c87d1f528f5f269134cb07b3".parse().unwrap();

--- a/evm/src/executor/fork/backend.rs
+++ b/evm/src/executor/fork/backend.rs
@@ -550,7 +550,7 @@ impl SharedBackend {
 
         // spawn a light-weight thread with a thread-local async runtime just for
         // sending and receiving data from the remote client
-        let _ = std::thread::Builder::new()
+        std::thread::Builder::new()
             .name("fork-backend-thread".to_string())
             .spawn(move || {
                 let rt = tokio::runtime::Builder::new_current_thread()

--- a/evm/src/executor/fork/multi.rs
+++ b/evm/src/executor/fork/multi.rs
@@ -81,16 +81,14 @@ impl MultiFork {
         (Self { handler, _shutdown }, MultiForkHandler::new(handler_rx))
     }
 
-    /// Creates a new pair and spawns the `MultiForkHandler` on a background thread
-    ///
-    /// Also returns the `JoinHandle` of the spawned thread.
-    pub fn spawn() -> Self {
+    /// Creates a new pair and spawns the `MultiForkHandler` on a background thread.
+    pub async fn spawn() -> Self {
         trace!(target: "fork::multi", "spawning multifork");
 
         let (fork, mut handler) = Self::new();
         // spawn a light-weight thread with a thread-local async runtime just for
         // sending and receiving data from the remote client(s)
-        let _ = std::thread::Builder::new()
+        std::thread::Builder::new()
             .name("multi-fork-backend-thread".to_string())
             .spawn(move || {
                 let rt = tokio::runtime::Builder::new_current_thread()

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -67,19 +67,6 @@ impl EvmOpts {
         }
     }
 
-    /// Convenience implementation to configure a `revm::Env` from non async code
-    ///
-    /// This only attaches are creates a temporary tokio runtime if `fork_url` is set
-    ///
-    /// Returns an error if a RPC request failed, or the fork url is not a valid url
-    pub fn evm_env_blocking(&self) -> eyre::Result<revm::primitives::Env> {
-        if let Some(ref fork_url) = self.fork_url {
-            RuntimeOrHandle::new().block_on(self.fork_evm_env(fork_url)).map(|res| res.0)
-        } else {
-            Ok(self.local_evm_env())
-        }
-    }
-
     /// Returns the `revm::Env` that is configured with settings retrieved from the endpoint.
     /// And the block that was used to configure the environment.
     pub async fn fork_evm_env(

--- a/evm/src/trace/identifier/signatures.rs
+++ b/evm/src/trace/identifier/signatures.rs
@@ -161,7 +161,7 @@ pub struct CachedSignatures {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_query_signatures() {
         let tmp = tempfile::tempdir().unwrap();
         {

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -11,7 +11,7 @@ foundry-config = { path = "./../config" }
 foundry-evm = { path = "./../evm" }
 
 # TODO: Trim down
-ethers = { workspace = true, features = ["solc-full", "rustls"] }
+ethers = { workspace = true, features = ["solc-full"] }
 
 comfy-table = "6"
 eyre = "0.6"
@@ -32,5 +32,5 @@ tracing-subscriber = "0.3"
 yansi = "0.5"
 
 [dev-dependencies]
-ethers = { workspace = true, features = ["solc-full", "solc-tests"] }
+ethers = { workspace = true, features = ["solc-full", "solc-tests", "rustls"] }
 foundry-utils = { path = "./../utils" }

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -11,7 +11,7 @@ foundry-config = { path = "./../config" }
 foundry-evm = { path = "./../evm" }
 
 # TODO: Trim down
-ethers = { workspace = true, features = ["solc-full"] }
+ethers = { workspace = true, features = ["solc-full", "rustls"] }
 
 comfy-table = "6"
 eyre = "0.6"

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -170,7 +170,7 @@ impl<'a> ContractRunner<'a> {
     /// Runs all tests for a contract whose names match the provided regular expression
     pub fn run_tests(
         mut self,
-        filter: &impl TestFilter,
+        filter: impl TestFilter,
         test_options: TestOptions,
         known_contracts: Option<&ContractsByArtifact>,
     ) -> SuiteResult {

--- a/forge/tests/it/cheats.rs
+++ b/forge/tests/it/cheats.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Executes all cheat code tests but not fork cheat codes
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_local() {
     let filter =
         Filter::new(".*", "Skip*", &format!(".*cheats{RE_PATH_SEPARATOR}*")).exclude_paths("Fork");

--- a/forge/tests/it/cheats.rs
+++ b/forge/tests/it/cheats.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 
 /// Executes all cheat code tests but not fork cheat codes
-#[test]
-fn test_cheats_local() {
+#[tokio::test]
+async fn test_cheats_local() {
     let filter =
         Filter::new(".*", "Skip*", &format!(".*cheats{RE_PATH_SEPARATOR}*")).exclude_paths("Fork");
 
@@ -15,5 +15,5 @@ fn test_cheats_local() {
     #[cfg(windows)]
     let filter = filter.exclude_tests("(Ffi|File|Line|Root)");
 
-    TestConfig::filter(filter).run();
+    TestConfig::filter(filter).await.run().await;
 }

--- a/forge/tests/it/core.rs
+++ b/forge/tests/it/core.rs
@@ -7,10 +7,10 @@ use forge::result::SuiteResult;
 use foundry_evm::trace::TraceKind;
 use std::{collections::BTreeMap, env};
 
-#[test]
-fn test_core() {
-    let mut runner = runner();
-    let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, test_opts());
+#[tokio::test]
+async fn test_core() {
+    let mut runner = runner().await;
+    let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, test_opts()).await;
 
     assert_multiple(
         &results,
@@ -83,10 +83,10 @@ fn test_core() {
     );
 }
 
-#[test]
-fn test_logs() {
-    let mut runner = runner();
-    let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, test_opts());
+#[tokio::test]
+async fn test_logs() {
+    let mut runner = runner().await;
+    let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, test_opts()).await;
 
     assert_multiple(
         &results,
@@ -643,13 +643,13 @@ fn test_logs() {
     );
 }
 
-#[test]
-fn test_env_vars() {
-    let mut runner = runner();
+#[tokio::test]
+async fn test_env_vars() {
+    let mut runner = runner().await;
 
     // test `setEnv` first, and confirm that it can correctly set environment variables,
     // so that we can use it in subsequent `env*` tests
-    runner.test(&Filter::new("testSetEnv", ".*", ".*"), None, test_opts());
+    runner.test(&Filter::new("testSetEnv", ".*", ".*"), None, test_opts()).await;
     let env_var_key = "_foundryCheatcodeSetEnvTestKey";
     let env_var_val = "_foundryCheatcodeSetEnvTestVal";
     let res = env::var(env_var_key);
@@ -660,22 +660,20 @@ Reason: `setEnv` failed to set an environment variable `{env_var_key}={env_var_v
     );
 }
 
-#[test]
-fn test_doesnt_run_abstract_contract() {
-    let mut runner = runner();
-    let results = runner.test(
-        &Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str()),
-        None,
-        test_opts(),
-    );
+#[tokio::test]
+async fn test_doesnt_run_abstract_contract() {
+    let mut runner = runner().await;
+    let results = runner
+        .test(&Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str()), None, test_opts())
+        .await;
     assert!(results.get("core/Abstract.t.sol:AbstractTestBase").is_none());
     assert!(results.get("core/Abstract.t.sol:AbstractTest").is_some());
 }
 
-#[test]
-fn test_trace() {
-    let mut runner = tracing_runner();
-    let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, test_opts());
+#[tokio::test]
+async fn test_trace() {
+    let mut runner = tracing_runner().await;
+    let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, test_opts()).await;
 
     // TODO: This trace test is very basic - it is probably a good candidate for snapshot
     // testing.

--- a/forge/tests/it/core.rs
+++ b/forge/tests/it/core.rs
@@ -7,7 +7,7 @@ use forge::result::SuiteResult;
 use foundry_evm::trace::TraceKind;
 use std::{collections::BTreeMap, env};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_core() {
     let mut runner = runner().await;
     let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, test_opts()).await;
@@ -83,7 +83,7 @@ async fn test_core() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_logs() {
     let mut runner = runner().await;
     let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, test_opts()).await;
@@ -643,7 +643,7 @@ async fn test_logs() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_env_vars() {
     let mut runner = runner().await;
 
@@ -660,7 +660,7 @@ Reason: `setEnv` failed to set an environment variable `{env_var_key}={env_var_v
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_doesnt_run_abstract_contract() {
     let mut runner = runner().await;
     let results = runner
@@ -670,7 +670,7 @@ async fn test_doesnt_run_abstract_contract() {
     assert!(results.get("core/Abstract.t.sol:AbstractTest").is_some());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_trace() {
     let mut runner = tracing_runner().await;
     let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, test_opts()).await;

--- a/forge/tests/it/fork.rs
+++ b/forge/tests/it/fork.rs
@@ -7,7 +7,7 @@ use crate::{
 use forge::result::SuiteResult;
 
 /// Executes reverting fork test
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_fork_revert() {
     let mut runner = runner().await;
     let suite_result = runner
@@ -34,7 +34,7 @@ async fn test_cheats_fork_revert() {
 }
 
 /// Executes all non-reverting fork cheatcodes
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}Fork"))
         .exclude_tests(".*Revert");
@@ -42,7 +42,7 @@ async fn test_cheats_fork() {
 }
 
 /// Tests that we can launch in forking mode
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_launch_fork() {
     let rpc_url = foundry_utils::rpc::next_http_archive_rpc_endpoint();
     let runner = forked_runner(&rpc_url).await;
@@ -51,14 +51,14 @@ async fn test_launch_fork() {
 }
 
 /// Tests that we can transact transactions in forking mode
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_transact_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}Transact"));
     TestConfig::filter(filter).await.run().await;
 }
 
 /// Tests that we can create the same fork (provider,block) concurretnly in different tests
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_create_same_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}ForkSame"));
     TestConfig::filter(filter).await.run().await;

--- a/forge/tests/it/fork.rs
+++ b/forge/tests/it/fork.rs
@@ -7,18 +7,20 @@ use crate::{
 use forge::result::SuiteResult;
 
 /// Executes reverting fork test
-#[test]
-fn test_cheats_fork_revert() {
-    let mut runner = runner();
-    let suite_result = runner.test(
-        &Filter::new(
-            "testNonExistingContractRevert",
-            ".*",
-            &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
-        ),
-        None,
-        test_opts(),
-    );
+#[tokio::test]
+async fn test_cheats_fork_revert() {
+    let mut runner = runner().await;
+    let suite_result = runner
+        .test(
+            &Filter::new(
+                "testNonExistingContractRevert",
+                ".*",
+                &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
+            ),
+            None,
+            test_opts(),
+        )
+        .await;
     assert_eq!(suite_result.len(), 1);
 
     for (_, SuiteResult { test_results, .. }) in suite_result {
@@ -32,32 +34,32 @@ fn test_cheats_fork_revert() {
 }
 
 /// Executes all non-reverting fork cheatcodes
-#[test]
-fn test_cheats_fork() {
+#[tokio::test]
+async fn test_cheats_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}Fork"))
         .exclude_tests(".*Revert");
-    TestConfig::filter(filter).run();
+    TestConfig::filter(filter).await.run().await;
 }
 
 /// Tests that we can launch in forking mode
-#[test]
-fn test_launch_fork() {
+#[tokio::test]
+async fn test_launch_fork() {
     let rpc_url = foundry_utils::rpc::next_http_archive_rpc_endpoint();
-    let runner = forked_runner(&rpc_url);
+    let runner = forked_runner(&rpc_url).await;
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}Launch"));
-    TestConfig::with_filter(runner, filter).run();
+    TestConfig::with_filter(runner, filter).run().await;
 }
 
 /// Tests that we can transact transactions in forking mode
-#[test]
-fn test_transact_fork() {
+#[tokio::test]
+async fn test_transact_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}Transact"));
-    TestConfig::filter(filter).run();
+    TestConfig::filter(filter).await.run().await;
 }
 
 /// Tests that we can create the same fork (provider,block) concurretnly in different tests
-#[test]
-fn test_create_same_fork() {
+#[tokio::test]
+async fn test_create_same_fork() {
     let filter = Filter::new(".*", ".*", &format!(".*fork{RE_PATH_SEPARATOR}ForkSame"));
-    TestConfig::filter(filter).run();
+    TestConfig::filter(filter).await.run().await;
 }

--- a/forge/tests/it/fs.rs
+++ b/forge/tests/it/fs.rs
@@ -6,19 +6,20 @@ use crate::{
 };
 use foundry_config::{fs_permissions::PathPermission, Config, FsPermissions};
 
-#[test]
-fn test_fs_disabled() {
+#[tokio::test]
+async fn test_fs_disabled() {
     let mut config = Config::with_root(PROJECT.root());
     config.fs_permissions = FsPermissions::new(vec![PathPermission::none("./")]);
-    let runner = runner_with_config(config);
+    let runner = runner_with_config(config).await;
     let filter = Filter::new(".*", ".*", ".*fs/Disabled");
-    TestConfig::with_filter(runner, filter).run();
+    TestConfig::with_filter(runner, filter).run().await;
 }
-#[test]
-fn test_fs_default() {
+
+#[tokio::test]
+async fn test_fs_default() {
     let mut config = Config::with_root(PROJECT.root());
     config.fs_permissions = FsPermissions::new(vec![PathPermission::read("./fixtures")]);
     let runner = runner_with_config(config);
     let filter = Filter::new(".*", ".*", ".*fs/Default");
-    TestConfig::with_filter(runner, filter).run();
+    TestConfig::with_filter(runner.await, filter).run().await;
 }

--- a/forge/tests/it/fs.rs
+++ b/forge/tests/it/fs.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use foundry_config::{fs_permissions::PathPermission, Config, FsPermissions};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fs_disabled() {
     let mut config = Config::with_root(PROJECT.root());
     config.fs_permissions = FsPermissions::new(vec![PathPermission::none("./")]);
@@ -15,7 +15,7 @@ async fn test_fs_disabled() {
     TestConfig::with_filter(runner, filter).run().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fs_default() {
     let mut config = Config::with_root(PROJECT.root());
     config.fs_permissions = FsPermissions::new(vec![PathPermission::read("./fixtures")]);

--- a/forge/tests/it/fuzz.rs
+++ b/forge/tests/it/fuzz.rs
@@ -5,7 +5,7 @@ use ethers::types::U256;
 use forge::result::{SuiteResult, TestStatus};
 use std::collections::BTreeMap;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fuzz() {
     let mut runner = runner().await;
 
@@ -48,7 +48,7 @@ async fn test_fuzz() {
 
 /// Test that showcases PUSH collection on normal fuzzing. Ignored until we collect them in a
 /// smarter way.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_fuzz_collection() {
     let mut runner = runner().await;

--- a/forge/tests/it/fuzz.rs
+++ b/forge/tests/it/fuzz.rs
@@ -5,17 +5,19 @@ use ethers::types::U256;
 use forge::result::{SuiteResult, TestStatus};
 use std::collections::BTreeMap;
 
-#[test]
-fn test_fuzz() {
-    let mut runner = runner();
+#[tokio::test]
+async fn test_fuzz() {
+    let mut runner = runner().await;
 
-    let suite_result = runner.test(
-        &Filter::new(".*", ".*", ".*fuzz/")
-            .exclude_tests(r#"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)"#)
-            .exclude_paths("invariant"),
-        None,
-        test_opts(),
-    );
+    let suite_result = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/")
+                .exclude_tests(r#"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)"#)
+                .exclude_paths("invariant"),
+            None,
+            test_opts(),
+        )
+        .await;
 
     assert!(!suite_result.is_empty());
 
@@ -46,10 +48,10 @@ fn test_fuzz() {
 
 /// Test that showcases PUSH collection on normal fuzzing. Ignored until we collect them in a
 /// smarter way.
-#[test]
+#[tokio::test]
 #[ignore]
-fn test_fuzz_collection() {
-    let mut runner = runner();
+async fn test_fuzz_collection() {
+    let mut runner = runner().await;
 
     let mut opts = test_opts();
     opts.invariant.depth = 100;
@@ -58,7 +60,8 @@ fn test_fuzz_collection() {
     opts.fuzz.seed = Some(U256::from(6u32));
     runner.test_options = opts.clone();
 
-    let results = runner.test(&Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol"), None, opts);
+    let results =
+        runner.test(&Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol"), None, opts).await;
 
     assert_multiple(
         &results,

--- a/forge/tests/it/inline.rs
+++ b/forge/tests/it/inline.rs
@@ -10,7 +10,7 @@ mod tests {
     };
     use foundry_config::{FuzzConfig, InvariantConfig};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn inline_config_run_fuzz() {
         let opts = test_options();
 
@@ -34,7 +34,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn inline_config_run_invariant() {
         const ROOT: &str = "inline/InvariantInlineConf.t.sol";
 

--- a/forge/tests/it/inline.rs
+++ b/forge/tests/it/inline.rs
@@ -10,16 +10,16 @@ mod tests {
     };
     use foundry_config::{FuzzConfig, InvariantConfig};
 
-    #[test]
-    fn inline_config_run_fuzz() {
+    #[tokio::test]
+    async fn inline_config_run_fuzz() {
         let opts = test_options();
 
         let filter = Filter::new(".*", ".*", ".*inline/FuzzInlineConf.t.sol");
 
-        let mut runner = runner();
+        let mut runner = runner().await;
         runner.test_options = opts.clone();
 
-        let result = runner.test(&filter, None, opts);
+        let result = runner.test(&filter, None, opts).await;
         let suite_result: &SuiteResult =
             result.get("inline/FuzzInlineConf.t.sol:FuzzInlineConf").unwrap();
         let test_result: &TestResult =
@@ -34,16 +34,16 @@ mod tests {
         }
     }
 
-    #[test]
-    fn inline_config_run_invariant() {
+    #[tokio::test]
+    async fn inline_config_run_invariant() {
         const ROOT: &str = "inline/InvariantInlineConf.t.sol";
 
         let opts = test_options();
         let filter = Filter::new(".*", ".*", ".*inline/InvariantInlineConf.t.sol");
-        let mut runner = runner();
+        let mut runner = runner().await;
         runner.test_options = opts.clone();
 
-        let result = runner.test(&filter, None, opts);
+        let result = runner.test(&filter, None, opts).await;
 
         let suite_result_1 =
             result.get(&format!("{ROOT}:InvariantInlineConf")).expect("Result exists");

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -5,7 +5,7 @@ use ethers::types::U256;
 use forge::fuzz::CounterExample;
 use std::collections::BTreeMap;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_invariant() {
     let mut runner = runner().await;
 
@@ -84,7 +84,7 @@ async fn test_invariant() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_override() {
     let mut runner = runner().await;
 
@@ -109,7 +109,7 @@ async fn test_invariant_override() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_storage() {
     let mut runner = runner().await;
 
@@ -140,7 +140,7 @@ async fn test_invariant_storage() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 // for some reason there's different rng
 #[cfg(not(windows))]
 async fn test_invariant_shrink() {

--- a/forge/tests/it/invariant.rs
+++ b/forge/tests/it/invariant.rs
@@ -5,15 +5,17 @@ use ethers::types::U256;
 use forge::fuzz::CounterExample;
 use std::collections::BTreeMap;
 
-#[test]
-fn test_invariant() {
-    let mut runner = runner();
+#[tokio::test]
+async fn test_invariant() {
+    let mut runner = runner().await;
 
-    let results = runner.test(
-        &Filter::new(".*", ".*", ".*fuzz/invariant/(target|targetAbi|common)"),
-        None,
-        test_opts(),
-    );
+    let results = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/invariant/(target|targetAbi|common)"),
+            None,
+            test_opts(),
+        )
+        .await;
 
     assert_multiple(
         &results,
@@ -82,19 +84,21 @@ fn test_invariant() {
     );
 }
 
-#[test]
-fn test_invariant_override() {
-    let mut runner = runner();
+#[tokio::test]
+async fn test_invariant_override() {
+    let mut runner = runner().await;
 
     let mut opts = test_opts();
     opts.invariant.call_override = true;
     runner.test_options = opts.clone();
 
-    let results = runner.test(
-        &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantReentrancy.t.sol"),
-        None,
-        opts,
-    );
+    let results = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantReentrancy.t.sol"),
+            None,
+            opts,
+        )
+        .await;
 
     assert_multiple(
         &results,
@@ -105,20 +109,22 @@ fn test_invariant_override() {
     );
 }
 
-#[test]
-fn test_invariant_storage() {
-    let mut runner = runner();
+#[tokio::test]
+async fn test_invariant_storage() {
+    let mut runner = runner().await;
 
     let mut opts = test_opts();
     opts.invariant.depth = 100;
     opts.fuzz.seed = Some(U256::from(6u32));
     runner.test_options = opts.clone();
 
-    let results = runner.test(
-        &Filter::new(".*", ".*", ".*fuzz/invariant/storage/InvariantStorageTest.t.sol"),
-        None,
-        opts,
-    );
+    let results = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/invariant/storage/InvariantStorageTest.t.sol"),
+            None,
+            opts,
+        )
+        .await;
 
     assert_multiple(
         &results,
@@ -134,21 +140,23 @@ fn test_invariant_storage() {
     );
 }
 
-#[test]
+#[tokio::test]
 // for some reason there's different rng
 #[cfg(not(windows))]
-fn test_invariant_shrink() {
-    let mut runner = runner();
+async fn test_invariant_shrink() {
+    let mut runner = runner().await;
 
     let mut opts = test_opts();
     opts.fuzz.seed = Some(U256::from(102u32));
     runner.test_options = opts.clone();
 
-    let results = runner.test(
-        &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantInnerContract.t.sol"),
-        None,
-        opts,
-    );
+    let results = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantInnerContract.t.sol"),
+            None,
+            opts,
+        )
+        .await;
 
     let results =
         results.values().last().expect("`InvariantInnerContract.t.sol` should be testable.");

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -61,103 +61,103 @@ macro_rules! run_test_repro {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2623>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2623() {
     test_repro!("Issue2623");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2629>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2629() {
     test_repro!("Issue2629");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2723>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2723() {
     test_repro!("Issue2723");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2898>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2898() {
     test_repro!("Issue2898");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2956>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2956() {
     test_repro!("Issue2956");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2984>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2984() {
     test_repro!("Issue2984");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4640>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_4640() {
     test_repro!("Issue4640");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3077>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3077() {
     test_repro!("Issue3077");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3055>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3055() {
     test_repro_fail!("Issue3055");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3192>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3192() {
     test_repro!("Issue3192");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3110>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3110() {
     test_repro!("Issue3110");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3189>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3189() {
     test_repro_fail!("Issue3189");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3119>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3119() {
     test_repro!("Issue3119");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3190>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3190() {
     test_repro!("Issue3190");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3221>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3221() {
     test_repro!("Issue3221");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3708>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3708() {
     test_repro!("Issue3708");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3221>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3223() {
     test_repro_with_sender!(
         "Issue3223",
@@ -166,13 +166,13 @@ async fn test_issue_3223() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3220>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3220() {
     test_repro!("Issue3220");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3347>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3347() {
     let mut res = run_test_repro!("Issue3347");
     let mut res = res.remove("repros/Issue3347.sol:Issue3347Test").unwrap();
@@ -201,31 +201,31 @@ async fn test_issue_3347() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3685>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3685() {
     test_repro!("Issue3685");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3653>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3653() {
     test_repro!("Issue3653");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3596>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3596() {
     test_repro!("Issue3596", true, None);
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3661>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3661() {
     test_repro!("Issue3661");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3674>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3674() {
     test_repro_with_sender!(
         "Issue3674",
@@ -234,31 +234,31 @@ async fn test_issue_3674() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3703>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3703() {
     test_repro!("Issue3703");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3753>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_3753() {
     test_repro!("Issue3753");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4630>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_4630() {
     test_repro!("Issue4630");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4586>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_4586() {
     test_repro!("Issue4586");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/5038>
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_issue_5038() {
     test_repro!("Issue5038");
 }

--- a/forge/tests/it/repros.rs
+++ b/forge/tests/it/repros.rs
@@ -23,9 +23,9 @@ macro_rules! test_repro {
             config.sender = sender;
         }
 
-        let mut config = TestConfig::with_filter(runner_with_config(config), filter)
+        let mut config = TestConfig::with_filter(runner_with_config(config).await, filter)
             .set_should_fail($should_fail);
-        config.run();
+        config.run().await;
     };
 }
 
@@ -54,110 +54,111 @@ macro_rules! run_test_repro {
             config.sender = sender;
         }
 
-        let mut config = TestConfig::with_filter(runner_with_config(config), filter)
+        let mut config = TestConfig::with_filter(runner_with_config(config).await, filter)
             .set_should_fail($should_fail);
-        config.test()
+        config.test().await
     }};
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2623>
-#[test]
-fn test_issue_2623() {
+#[tokio::test]
+async fn test_issue_2623() {
     test_repro!("Issue2623");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2629>
-#[test]
-fn test_issue_2629() {
+#[tokio::test]
+async fn test_issue_2629() {
     test_repro!("Issue2629");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2723>
-#[test]
-fn test_issue_2723() {
+#[tokio::test]
+async fn test_issue_2723() {
     test_repro!("Issue2723");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2898>
-#[test]
-fn test_issue_2898() {
+#[tokio::test]
+async fn test_issue_2898() {
     test_repro!("Issue2898");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2956>
-#[test]
-fn test_issue_2956() {
+#[tokio::test]
+async fn test_issue_2956() {
     test_repro!("Issue2956");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2984>
-#[test]
-fn test_issue_2984() {
+#[tokio::test]
+async fn test_issue_2984() {
     test_repro!("Issue2984");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4640>
-#[test]
-fn test_issue_4640() {
+#[tokio::test]
+async fn test_issue_4640() {
     test_repro!("Issue4640");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3077>
-#[test]
-fn test_issue_3077() {
+#[tokio::test]
+async fn test_issue_3077() {
     test_repro!("Issue3077");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3055>
-#[test]
-fn test_issue_3055() {
+#[tokio::test]
+async fn test_issue_3055() {
     test_repro_fail!("Issue3055");
 }
+
 // <https://github.com/foundry-rs/foundry/issues/3192>
-#[test]
-fn test_issue_3192() {
+#[tokio::test]
+async fn test_issue_3192() {
     test_repro!("Issue3192");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3110>
-#[test]
-fn test_issue_3110() {
+#[tokio::test]
+async fn test_issue_3110() {
     test_repro!("Issue3110");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3189>
-#[test]
-fn test_issue_3189() {
+#[tokio::test]
+async fn test_issue_3189() {
     test_repro_fail!("Issue3189");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3119>
-#[test]
-fn test_issue_3119() {
+#[tokio::test]
+async fn test_issue_3119() {
     test_repro!("Issue3119");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3190>
-#[test]
-fn test_issue_3190() {
+#[tokio::test]
+async fn test_issue_3190() {
     test_repro!("Issue3190");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3221>
-#[test]
-fn test_issue_3221() {
+#[tokio::test]
+async fn test_issue_3221() {
     test_repro!("Issue3221");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3708>
-#[test]
-fn test_issue_3708() {
+#[tokio::test]
+async fn test_issue_3708() {
     test_repro!("Issue3708");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3221>
-#[test]
-fn test_issue_3223() {
+#[tokio::test]
+async fn test_issue_3223() {
     test_repro_with_sender!(
         "Issue3223",
         Address::from_str("0xF0959944122fb1ed4CfaBA645eA06EED30427BAA").unwrap()
@@ -165,14 +166,14 @@ fn test_issue_3223() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3220>
-#[test]
-fn test_issue_3220() {
+#[tokio::test]
+async fn test_issue_3220() {
     test_repro!("Issue3220");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3347>
-#[test]
-fn test_issue_3347() {
+#[tokio::test]
+async fn test_issue_3347() {
     let mut res = run_test_repro!("Issue3347");
     let mut res = res.remove("repros/Issue3347.sol:Issue3347Test").unwrap();
     let test = res.test_results.remove("test()").unwrap();
@@ -200,32 +201,32 @@ fn test_issue_3347() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3685>
-#[test]
-fn test_issue_3685() {
+#[tokio::test]
+async fn test_issue_3685() {
     test_repro!("Issue3685");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3653>
-#[test]
-fn test_issue_3653() {
+#[tokio::test]
+async fn test_issue_3653() {
     test_repro!("Issue3653");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3596>
-#[test]
-fn test_issue_3596() {
+#[tokio::test]
+async fn test_issue_3596() {
     test_repro!("Issue3596", true, None);
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3661>
-#[test]
-fn test_issue_3661() {
+#[tokio::test]
+async fn test_issue_3661() {
     test_repro!("Issue3661");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3674>
-#[test]
-fn test_issue_3674() {
+#[tokio::test]
+async fn test_issue_3674() {
     test_repro_with_sender!(
         "Issue3674",
         Address::from_str("0xF0959944122fb1ed4CfaBA645eA06EED30427BAA").unwrap()
@@ -233,31 +234,31 @@ fn test_issue_3674() {
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3703>
-#[test]
-fn test_issue_3703() {
+#[tokio::test]
+async fn test_issue_3703() {
     test_repro!("Issue3703");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/3753>
-#[test]
-fn test_issue_3753() {
+#[tokio::test]
+async fn test_issue_3753() {
     test_repro!("Issue3753");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4630>
-#[test]
-fn test_issue_4630() {
+#[tokio::test]
+async fn test_issue_4630() {
     test_repro!("Issue4630");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/4586>
-#[test]
-fn test_issue_4586() {
+#[tokio::test]
+async fn test_issue_4586() {
     test_repro!("Issue4586");
 }
 
 // <https://github.com/foundry-rs/foundry/issues/5038>
-#[test]
-fn test_issue_5038() {
+#[tokio::test]
+async fn test_issue_5038() {
     test_repro!("Issue5038");
 }

--- a/forge/tests/it/spec.rs
+++ b/forge/tests/it/spec.rs
@@ -1,8 +1,8 @@
 use crate::{config::*, test_helpers::filter::Filter};
 use forge::revm::primitives::SpecId;
 
-#[test]
-fn test_shanghai_compat() {
+#[tokio::test]
+async fn test_shanghai_compat() {
     let filter = Filter::new("", "ShanghaiCompat", ".*spec");
-    TestConfig::filter(filter).evm_spec(SpecId::SHANGHAI).run();
+    TestConfig::filter(filter).await.evm_spec(SpecId::SHANGHAI).run().await;
 }

--- a/forge/tests/it/spec.rs
+++ b/forge/tests/it/spec.rs
@@ -1,7 +1,7 @@
 use crate::{config::*, test_helpers::filter::Filter};
 use forge::revm::primitives::SpecId;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_shanghai_compat() {
     let filter = Filter::new("", "ShanghaiCompat", ".*spec");
     TestConfig::filter(filter).await.evm_spec(SpecId::SHANGHAI).run().await;

--- a/forge/tests/it/test_helpers.rs
+++ b/forge/tests/it/test_helpers.rs
@@ -3,7 +3,7 @@
 use super::*;
 use ethers::{
     prelude::{artifacts::Settings, Lazy, ProjectCompileOutput, SolcConfig},
-    solc::{artifacts::Libraries, utils::RuntimeOrHandle, Project, ProjectPathsConfig},
+    solc::{artifacts::Libraries, Project, ProjectPathsConfig},
     types::{Address, U256},
 };
 use foundry_config::Config;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We're spawning thousands of tokio runtimes which accounts for ~50-60% of the time spent in the main thread. These calls happen both in parallel (where there is almost no gain), and in the end clean up (which speeds it up significantly). This happens in `RuntimeOrHandle::new().block_on(...)` which spawns a new tokio runtime to run a single future, then drops it

Before (41% + 17%):

![image](https://github.com/foundry-rs/foundry/assets/57450786/e1996de8-a79a-46a0-962b-2dd8f1e8de8d)


After (no recorded calls):

![image](https://github.com/foundry-rs/foundry/assets/57450786/f8e19cff-5b71-4742-9f26-85112937c025)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make test functions async and create a runtime in the CLI dispatch

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
