### PR TITLE
perf(`runner`): check last fuzz result instead of adding aditional run

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -537,30 +537,24 @@ impl<'a> ContractRunner<'a> {
     ) -> TestResult {
         let TestSetup { address, mut logs, mut traces, mut labeled_addresses, .. } = setup;
 
-        let skip_fuzz_config = FuzzConfig { runs: 1, ..Default::default() };
-
-        // Fuzz the test with only 1 run to check if it needs to be skipped.
-        let result =
-            FuzzedExecutor::new(&self.executor, runner.clone(), self.sender, skip_fuzz_config)
-                .fuzz(func, address, should_fail, self.errors);
-        if let Some(reason) = result.reason {
-            if matches!(reason.as_str(), "SKIPPED") {
-                return TestResult {
-                    status: TestStatus::Skipped,
-                    reason: None,
-                    decoded_logs: decode_console_logs(&logs),
-                    traces,
-                    labeled_addresses,
-                    kind: TestKind::Standard(0),
-                    ..Default::default()
-                }
-            }
-        }
-
         // Run fuzz test
         let start = Instant::now();
         let mut result = FuzzedExecutor::new(&self.executor, runner, self.sender, fuzz_config)
             .fuzz(func, address, should_fail, self.errors);
+
+        // Check the last test result and skip the test
+        // if it's marked as so.
+        if let Some("SKIPPED") = result.reason.as_deref() {
+            return TestResult {
+                status: TestStatus::Skipped,
+                reason: None,
+                decoded_logs: decode_console_logs(&logs),
+                traces,
+                labeled_addresses,
+                kind: TestKind::Standard(0),
+                ..Default::default()
+            }
+        }
 
         let kind = TestKind::Fuzz {
             median_gas: result.median_gas(false),


### PR DESCRIPTION
Closes #5262 — removes the additional run added for checking if the test was skipped, and checks the last fuzz run instead. cc @DaniPopes  