### PR TITLE
feat(forge): add aggregate summary to test result

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -672,7 +672,12 @@ fn test(
         if num_test_suites > 0 {
             println!(
                 "{}",
-                format_aggregated_summary(num_test_suites, total_passed, total_failed, total_skipped)
+                format_aggregated_summary(
+                    num_test_suites,
+                    total_passed,
+                    total_failed,
+                    total_skipped
+                )
             );
         }
 

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -475,9 +475,10 @@ fn format_aggregated_summary(
     total_failed: usize,
     total_skipped: usize,
 ) -> String {
-    format!(
-        "Test suites: {}. Total passed: {}. Total failed: {}. Total skipped: {}",
-        num_test_suites, total_passed, total_failed, total_skipped
+    let total_tests = total_passed + total_failed + total_skipped;
+    return format!(
+        "Ran {} test suites. {} tests passed, {} failed, {} skipped ({} total tests)",
+        num_test_suites, total_passed, total_failed, total_skipped, total_tests
     )
 }
 

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -559,7 +559,6 @@ fn test(
         let sig_identifier =
             SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
 
-        let mut num_test_suites = 0;
         let mut total_passed = 0;
         let mut total_failed = 0;
         let mut total_skipped = 0;
@@ -657,8 +656,6 @@ fn test(
             let block_outcome =
                 TestOutcome::new([(contract_name, suite_result)].into(), allow_failure);
 
-            num_test_suites += 1;
-
             total_passed += block_outcome.successes().count();
             total_failed += block_outcome.failures().count();
             total_skipped += block_outcome.skips().count();
@@ -670,10 +667,14 @@ fn test(
             println!("{}", gas_report.finalize());
         }
 
-        println!(
-            "{}",
-            format_aggregated_summary(num_test_suites, total_passed, total_failed, total_skipped)
-        );
+        let num_test_suites = results.len();
+
+        if num_test_suites > 0 {
+            println!(
+                "{}",
+                format_aggregated_summary(num_test_suites, total_passed, total_failed, total_skipped)
+            );
+        }
 
         // reattach the thread
         let _ = handle.join();

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -476,7 +476,7 @@ fn format_aggregated_summary(
     total_skipped: usize,
 ) -> String {
     let total_tests = total_passed + total_failed + total_skipped;
-    return format!(
+    format!(
         "Ran {} test suites. {} tests passed, {} failed, {} skipped ({} total tests)",
         num_test_suites, total_passed, total_failed, total_skipped, total_tests
     )

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -473,10 +473,11 @@ fn format_aggregated_summary(
     num_test_suites: usize,
     total_passed: usize,
     total_failed: usize,
+    total_skipped: usize,
 ) -> String {
     format!(
-        "Test suites: {}. Total passed: {}. Total failed: {}",
-        num_test_suites, total_passed, total_failed
+        "Test suites: {}. Total passed: {}. Total failed: {}. Total skipped: {}",
+        num_test_suites, total_passed, total_failed, total_skipped
     )
 }
 
@@ -561,6 +562,7 @@ fn test(
         let mut num_test_suites = 0;
         let mut total_passed = 0;
         let mut total_failed = 0;
+        let mut total_skipped = 0;
 
         'outer: for (contract_name, suite_result) in rx {
             results.insert(contract_name.clone(), suite_result.clone());
@@ -659,6 +661,7 @@ fn test(
 
             total_passed += block_outcome.successes().count();
             total_failed += block_outcome.failures().count();
+            total_skipped += block_outcome.skips().count();
 
             println!("{}", block_outcome.summary());
         }
@@ -667,7 +670,10 @@ fn test(
             println!("{}", gas_report.finalize());
         }
 
-        println!("{}", format_aggregated_summary(num_test_suites, total_passed, total_failed));
+        println!(
+            "{}",
+            format_aggregated_summary(num_test_suites, total_passed, total_failed, total_skipped)
+        );
 
         // reattach the thread
         let _ = handle.join();

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -477,7 +477,7 @@ fn format_aggregated_summary(
 ) -> String {
     let total_tests = total_passed + total_failed + total_skipped;
     format!(
-        "Ran {} test suites. {} tests passed, {} failed, {} skipped ({} total tests)",
+        "Ran {} test suites: {} tests passed, {} failed, {} skipped ({} total tests)",
         num_test_suites, total_passed, total_failed, total_skipped, total_tests
     )
 }

--- a/cli/tests/fixtures/can_check_snapshot.stdout
+++ b/cli/tests/fixtures/can_check_snapshot.stdout
@@ -5,3 +5,4 @@ Compiler run successful!
 Running 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
+Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0

--- a/cli/tests/fixtures/can_check_snapshot.stdout
+++ b/cli/tests/fixtures/can_check_snapshot.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
-Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/can_check_snapshot.stdout
+++ b/cli/tests/fixtures/can_check_snapshot.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
-Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
+++ b/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
@@ -5,3 +5,4 @@ Compiler run successful!
 Running 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
+Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0

--- a/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
+++ b/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
-Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
+++ b/cli/tests/fixtures/can_run_test_in_custom_test_folder.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
-Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/can_test_repeatedly.stdout
+++ b/cli/tests/fixtures/can_test_repeatedly.stdout
@@ -4,3 +4,4 @@ Running 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testIncrement() (gas: 28334)
 [PASS] testSetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
+Test suites: 1. Total passed: 2. Total failed: 0. Total skipped: 0

--- a/cli/tests/fixtures/can_test_repeatedly.stdout
+++ b/cli/tests/fixtures/can_test_repeatedly.stdout
@@ -4,4 +4,4 @@ Running 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testIncrement() (gas: 28334)
 [PASS] testSetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
-Ran 1 test suites. 2 tests passed, 0 failed, 0 skipped (2 total tests)
+Ran 1 test suites: 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/cli/tests/fixtures/can_test_repeatedly.stdout
+++ b/cli/tests/fixtures/can_test_repeatedly.stdout
@@ -4,4 +4,4 @@ Running 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testIncrement() (gas: 28334)
 [PASS] testSetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
-Test suites: 1. Total passed: 2. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -5,3 +5,4 @@ Compiler run successful!
 Running 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70373)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
+Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0

--- a/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70373)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
-Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/cli/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70373)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
-Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -5,3 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0
+Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -5,4 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-Ran 1 test suites. 1 tests passed, 0 failed, 0 skipped (1 total tests)
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/cli/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -5,3 +5,4 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+Test suites: 1. Total passed: 1. Total failed: 0. Total skipped: 0


### PR DESCRIPTION
## Motivation

Add aggregated summary to the test results for all test suites in the format:
`Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)` 

https://github.com/foundry-rs/foundry/issues/5195

## Questions:
- ~How should we write tests for this? Is there a place to write tests for `test` command (no pun intended 😄)~