### PR TITLE
feat(forge): implement glob pattern for forge build --skip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "eyre",
  "foundry-config",
  "foundry-macros",
+ "globset",
  "is-terminal",
  "once_cell",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,7 +55,6 @@ async-trait = "0.1"
 # disk / paths
 walkdir = "2"
 dunce = "1"
-globset = "0.4"
 path-slash = "0.2"
 tempfile = "3"
 
@@ -89,6 +88,7 @@ toml = "0.7"
 serial_test = "2"
 criterion = "0.4"
 svm = { package = "svm-rs", version = "0.2", default-features = false, features = ["rustls"] }
+globset = "0.4"
 
 [features]
 default = ["rustls"]

--- a/cli/src/cmd/forge/test/filter.rs
+++ b/cli/src/cmd/forge/test/filter.rs
@@ -2,8 +2,9 @@ use crate::utils::FoundryPathExt;
 use clap::Parser;
 use ethers::solc::{FileFilter, ProjectPathsConfig};
 use forge::TestFilter;
+use foundry_common::glob::GlobMatcher;
 use foundry_config::Config;
-use std::{fmt, path::Path, str::FromStr};
+use std::{fmt, path::Path};
 
 /// The filter to use during testing.
 ///
@@ -212,69 +213,5 @@ impl TestFilter for ProjectPathsAwareFilter {
 impl fmt::Display for ProjectPathsAwareFilter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.args_filter.fmt(f)
-    }
-}
-
-/// A `globset::Glob` that creates its `globset::GlobMatcher` when its created, so it doesn't need
-/// to be compiled when the filter functions `TestFilter` functions are called.
-#[derive(Debug, Clone)]
-pub struct GlobMatcher {
-    /// The parsed glob
-    pub glob: globset::Glob,
-    /// The compiled `glob`
-    pub matcher: globset::GlobMatcher,
-}
-
-// === impl GlobMatcher ===
-
-impl GlobMatcher {
-    /// Tests whether the given path matches this pattern or not.
-    ///
-    /// The glob `./test/*` won't match absolute paths like `test/Contract.sol`, which is common
-    /// format here, so we also handle this case here
-    pub fn is_match(&self, path: &str) -> bool {
-        let mut matches = self.matcher.is_match(path);
-        if !matches && !path.starts_with("./") && self.as_str().starts_with("./") {
-            matches = self.matcher.is_match(format!("./{path}"));
-        }
-        matches
-    }
-
-    /// Returns the `Glob` string used to compile this matcher.
-    pub fn as_str(&self) -> &str {
-        self.glob.glob()
-    }
-}
-
-impl fmt::Display for GlobMatcher {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.glob.fmt(f)
-    }
-}
-
-impl FromStr for GlobMatcher {
-    type Err = globset::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<globset::Glob>().map(Into::into)
-    }
-}
-
-impl From<globset::Glob> for GlobMatcher {
-    fn from(glob: globset::Glob) -> Self {
-        let matcher = glob.compile_matcher();
-        Self { glob, matcher }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn can_match_glob_paths() {
-        let matcher: GlobMatcher = "./test/*".parse().unwrap();
-        assert!(matcher.is_match("test/Contract.sol"));
-        assert!(matcher.is_match("./test/Contract.sol"));
     }
 }

--- a/cli/tests/fixtures/can_build_skip_glob.stdout
+++ b/cli/tests/fixtures/can_build_skip_glob.stdout
@@ -1,0 +1,3 @@
+Compiling 1 files with 0.8.17
+Solc 0.8.17 finished in 33.25ms
+Compiler run successful!

--- a/cli/tests/it/cmd.rs
+++ b/cli/tests/it/cmd.rs
@@ -1575,6 +1575,29 @@ forgetest_init!(can_build_skip_contracts, |prj: TestProject, mut cmd: TestComman
     assert!(out.trim().contains("No files changed, compilation skipped"), "{}", out);
 });
 
+forgetest_init!(can_build_skip_glob, |prj: TestProject, mut cmd: TestCommand| {
+    // explicitly set to run with 0.8.17 for consistent output
+    let config = Config { solc: Some("0.8.17".into()), ..Default::default() };
+    prj.write_config(config);
+    prj.inner()
+        .add_test(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+contract TestDemo {
+function test_run() external {}
+}"#,
+        )
+        .unwrap();
+    // only builds the single template contract `src/*` even if `*.t.sol` or `.s.sol` is absent
+    cmd.args(["build", "--skip", "*/test/**", "--skip", "*/script/**"]);
+
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/can_build_skip_glob.stdout"),
+    );
+});
+
 // checks that build --sizes includes all contracts even if unchanged
 forgetest_init!(can_build_sizes_repeatedly, |_prj: TestProject, mut cmd: TestCommand| {
     cmd.args(["build", "--sizes"]);

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -41,6 +41,7 @@ semver = "1"
 once_cell = "1"
 dunce = "1"
 regex = "1"
+globset = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -525,7 +525,7 @@ impl FromStr for SkipBuildFilter {
 impl FileFilter for SkipBuildFilter {
     /// Matches file only if the filter does not apply
     ///
-    /// This is returns the inverse of `file.name.contains(pattern)`
+    /// This is returns the inverse of `file.name.contains(pattern) || matcher.is_match(file)`
     fn is_match(&self, file: &Path) -> bool {
         fn exclude(file: &Path, pattern: &str) -> Option<bool> {
             let matcher: GlobMatcher = pattern.parse().unwrap();
@@ -553,9 +553,9 @@ mod tests {
         assert!(!SkipBuildFilter::Scripts.is_match(file));
         assert!(!SkipBuildFilter::Custom("A.s".to_string()).is_match(file));
 
-        let file = Path::new("/private/var/folders/test/Foo.sol");
+        let file = Path::new("/home/test/Foo.sol");
         assert!(!SkipBuildFilter::Custom("*/test/**".to_string()).is_match(file));
-        let file = Path::new("script/Contract.sol");
+        let file = Path::new("/home/script/Contract.sol");
         assert!(!SkipBuildFilter::Custom("*/script/**".to_string()).is_match(file));
     }
 }

--- a/common/src/glob.rs
+++ b/common/src/glob.rs
@@ -6,7 +6,7 @@ use std::{fmt, str::FromStr};
 pub struct GlobMatcher {
     /// The parsed glob
     pub glob: globset::Glob,
-    /// The compiled `glob`
+    /// The compiled glob
     pub matcher: globset::GlobMatcher,
 }
 

--- a/common/src/glob.rs
+++ b/common/src/glob.rs
@@ -1,0 +1,64 @@
+//! Contains `globset::Glob` wrapper functions used for filtering
+use std::{fmt, str::FromStr};
+/// A `globset::Glob` that creates its `globset::GlobMatcher` when its created, so it doesn't need
+/// to be compiled when the filter functions `TestFilter` functions are called.
+#[derive(Debug, Clone)]
+pub struct GlobMatcher {
+    /// The parsed glob
+    pub glob: globset::Glob,
+    /// The compiled `glob`
+    pub matcher: globset::GlobMatcher,
+}
+
+// === impl GlobMatcher ===
+
+impl GlobMatcher {
+    /// Tests whether the given path matches this pattern or not.
+    ///
+    /// The glob `./test/*` won't match absolute paths like `test/Contract.sol`, which is common
+    /// format here, so we also handle this case here
+    pub fn is_match(&self, path: &str) -> bool {
+        let mut matches = self.matcher.is_match(path);
+        if !matches && !path.starts_with("./") && self.as_str().starts_with("./") {
+            matches = self.matcher.is_match(format!("./{path}"));
+        }
+        matches
+    }
+
+    /// Returns the `Glob` string used to compile this matcher.
+    pub fn as_str(&self) -> &str {
+        self.glob.glob()
+    }
+}
+
+impl fmt::Display for GlobMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.glob.fmt(f)
+    }
+}
+
+impl FromStr for GlobMatcher {
+    type Err = globset::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<globset::Glob>().map(Into::into)
+    }
+}
+
+impl From<globset::Glob> for GlobMatcher {
+    fn from(glob: globset::Glob) -> Self {
+        let matcher = glob.compile_matcher();
+        Self { glob, matcher }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_match_glob_paths() {
+        let matcher: GlobMatcher = "./test/*".parse().unwrap();
+        assert!(matcher.is_match("test/Contract.sol"));
+        assert!(matcher.is_match("./test/Contract.sol"));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,6 +11,7 @@ pub mod errors;
 pub mod evm;
 pub mod fmt;
 pub mod fs;
+pub mod glob;
 pub mod provider;
 pub mod selectors;
 pub mod shell;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, `forge build --skip test --skip script` is unreliable as some projects do not consistently use `.t.sol` or `.s.sol`. This PR enables glob patterns like `--skip */test/** --skip */script/**` to enable only building `src`.

Closes https://github.com/foundry-rs/foundry/issues/4628
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I moved an existing glob matcher util to `common` and used it in the the `FileFilter` impl
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
