### PR TITLE
fix: rm leftover block_on

### DIFF
--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -229,7 +229,7 @@ impl TestArgs {
                         opts,
                         evm_opts: self.evm_opts,
                     };
-                    utils::block_on(debugger.debug(breakpoints))?;
+                    debugger.debug(breakpoints).await?;
 
                     Ok(TestOutcome::new(results, self.allow_failure))
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #5271

test is now async, this removes leftover block_on

ref https://github.com/foundry-rs/foundry/pull/5263
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
