### PR TITLE
fix(forge): remove required `mnemonics` flag when using `--mnemonic-indexes`

### DIFF
--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -133,7 +133,7 @@ pub struct MultiWallet {
 
     /// Use the private key from the given mnemonic index.
     ///
-    /// Used with --mnemonics.
+    /// Can be used with --mnemonics, --ledger, --aws and --trezor.
     #[clap(
         long,
         conflicts_with = "hd_paths",

--- a/cli/src/opts/wallet/multi_wallet.rs
+++ b/cli/src/opts/wallet/multi_wallet.rs
@@ -137,7 +137,6 @@ pub struct MultiWallet {
     #[clap(
         long,
         conflicts_with = "hd_paths",
-        requires = "mnemonics",
         help_heading = "Wallet options - raw",
         default_value = "0",
         value_name = "INDEXES"
@@ -458,5 +457,36 @@ mod tests {
             wallets[0].address(),
             "ec554aeafe75601aaab43bd4621a22284db566c2".parse().unwrap()
         );
+    }
+
+    // https://github.com/foundry-rs/foundry/issues/5179
+    #[test]
+    fn should_not_require_the_mnemonics_flag_with_mnemonic_indexes() {
+        let wallet_options = vec![
+            ("ledger", "--mnemonic-indexes", 1),
+            ("trezor", "--mnemonic-indexes", 2),
+            ("aws", "--mnemonic-indexes", 10),
+        ];
+
+        for test_case in wallet_options {
+            let args: MultiWallet = MultiWallet::parse_from([
+                "foundry-cli",
+                &format!("--{}", test_case.0),
+                test_case.1,
+                &test_case.2.to_string(),
+            ]);
+
+            match test_case.0 {
+                "ledger" => assert!(args.ledger),
+                "trezor" => assert!(args.trezor),
+                "aws" => assert!(args.aws),
+                _ => panic!("Should have matched one of the previous wallet options"),
+            }
+
+            assert_eq!(
+                args.mnemonic_indexes.expect("--mnemonic-indexes should have been set")[0],
+                test_case.2
+            )
+        }
     }
 }


### PR DESCRIPTION
## Motivation

As explained in #5179 when using the `--mnemonic-indexes` flag if not providing the `mnemonics` flags foundry complains that the arg is required even if another wallet option like `ledger` or `trezor` is used which also can use the  `--mnemonic-indexes` flag.

## Solution

It seems that in [4768](https://github.com/foundry-rs/foundry/pull/4768/files#diff-da1bbdee19948a843fedbd01d62893be3b2557c23d07333649a1c60816d9a9aaR140) the `requires = "mnemonics"` constraint was added to the  `--mnemonic-indexes` args which seems to be the cause of  #5179 because the constraint wasn't there before so I simply removed it.
