### PR TITLE
chore(cast): add --abi-decode as visible alias

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -461,7 +461,7 @@ pub enum Subcommands {
     /// Defaults to decoding output data. To decode input data pass --input.
     ///
     /// When passing `--input`, function selector must NOT be prefixed in `calldata` string
-    #[clap(name = "abi-decode", visible_alias = "ad")]
+    #[clap(name = "abi-decode", visible_aliases = &["ad", "--abi-decode"])]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,


### PR DESCRIPTION
Closes #5275 — adds `--abi-decode` as a visible alias just to have parity with the book. The command is new and never had the dashes, but it doesn't hurt to have them.