### PR TITLE
chore: fix clippy warnings + bump ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1796,7 +1796,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1878,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#df165b84229cdc1c65e8522e0c1aeead3746d9a8"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -71,14 +71,14 @@ pub const VERSION_MESSAGE: &str = concat!(
     ")"
 );
 
-const BANNER: &str = r#"
+const BANNER: &str = r"
                              _   _
                             (_) | |
       __ _   _ __   __   __  _  | |
      / _` | | '_ \  \ \ / / | | | |
     | (_| | | | | |  \ V /  | | | |
      \__,_| |_| |_|   \_/   |_| |_|
-"#;
+";
 
 /// Configurations of the EVM node
 #[derive(Debug, Clone)]

--- a/anvil/src/eth/sign.rs
+++ b/anvil/src/eth/sign.rs
@@ -54,7 +54,7 @@ pub struct DevSigner {
 impl DevSigner {
     pub fn new(accounts: Vec<Wallet<SigningKey>>) -> Self {
         let addresses = accounts.iter().map(|wallet| wallet.address()).collect::<Vec<_>>();
-        let accounts = addresses.iter().cloned().zip(accounts.into_iter()).collect();
+        let accounts = addresses.iter().cloned().zip(accounts).collect();
         Self { addresses, accounts }
     }
 }

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -297,7 +297,7 @@ mod tests {
             _method: &str,
             _params: T,
         ) -> Result<R, Self::Error> {
-            unreachable!("There is no `request`");
+            Err(ProviderError::CustomError(format!("There is no request")))
         }
     }
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -297,7 +297,7 @@ mod tests {
             _method: &str,
             _params: T,
         ) -> Result<R, Self::Error> {
-            Err(ProviderError::CustomError(format!("There is no request")))
+            Err(ProviderError::CustomError("There is no request".to_string()))
         }
     }
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -181,7 +181,7 @@ impl ScriptArgs {
         // Merge with user provided libraries
         let mut new_libraries = Libraries::parse(&new_libraries)?;
         for (file, libraries) in libraries_addresses.libs.into_iter() {
-            new_libraries.libs.entry(file).or_default().extend(libraries.into_iter())
+            new_libraries.libs.entry(file).or_default().extend(libraries)
         }
 
         Ok(BuildOutput {

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -81,7 +81,7 @@ impl ScriptRunner {
             .deploy(CALLER, code.0, 0u32.into(), None)
             .map_err(|err| eyre::eyre!("Failed to deploy script:\n{}", err))?;
 
-        traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
+        traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
         self.executor.set_balance(address, self.initial_balance)?;
 
         // Optionally call the `setUp` function
@@ -110,7 +110,7 @@ impl ScriptRunner {
                     ..
                 }) => {
                     traces
-                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)).into_iter());
+                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
                     self.maybe_correct_nonce(sender_nonce, libraries.len())?;
@@ -137,7 +137,7 @@ impl ScriptRunner {
                         ..
                     } = *err;
                     traces
-                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)).into_iter());
+                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
                     self.maybe_correct_nonce(sender_nonce, libraries.len())?;

--- a/cli/src/cmd/forge/script/runner.rs
+++ b/cli/src/cmd/forge/script/runner.rs
@@ -109,8 +109,7 @@ impl ScriptRunner {
                     script_wallets,
                     ..
                 }) => {
-                    traces
-                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
+                    traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
                     self.maybe_correct_nonce(sender_nonce, libraries.len())?;
@@ -136,8 +135,7 @@ impl ScriptRunner {
                         script_wallets,
                         ..
                     } = *err;
-                    traces
-                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
+                    traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
                     self.maybe_correct_nonce(sender_nonce, libraries.len())?;

--- a/cli/src/cmd/forge/verify/etherscan/mod.rs
+++ b/cli/src/cmd/forge/verify/etherscan/mod.rs
@@ -33,7 +33,7 @@ use std::{
 use tracing::{error, trace, warn};
 
 pub static RE_BUILD_COMMIT: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"(?P<commit>commit\.[0-9,a-f]{8})"#).unwrap());
+    Lazy::new(|| Regex::new(r"(?P<commit>commit\.[0-9,a-f]{8})").unwrap());
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]

--- a/cli/src/suggestions.rs
+++ b/cli/src/suggestions.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[test]
     fn possible_artifacts_match() {
-        let candidates = vec!["MyContract", "Erc20"];
+        let candidates = ["MyContract", "Erc20"];
         assert_eq!(
             did_you_mean("MyCtrac", candidates.iter()).pop(),
             Some("MyContract".to_string())
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn possible_artifacts_nomatch() {
-        let candidates = vec!["MyContract", "Erc20", "Greeter"];
+        let candidates = ["MyContract", "Erc20", "Greeter"];
         assert!(did_you_mean("Vault", candidates.iter()).pop().is_none());
     }
 }

--- a/common/src/shell.rs
+++ b/common/src/shell.rs
@@ -216,6 +216,7 @@ impl ShellOut {
     /// Creates a new shell that writes to memory
     pub fn memory() -> Self {
         #[allow(clippy::box_default)]
+        #[allow(clippy::arc_with_non_send_sync)]
         ShellOut::Write(WriteShellOut(Arc::new(Mutex::new(Box::new(Vec::new())))))
     }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -4246,7 +4246,7 @@ mod tests {
         fake_block_cache(chain_dir.path(), "2", 500);
         // Pollution file that should not show up in the cached block
         let mut pol_file = File::create(chain_dir.path().join("pol.txt")).unwrap();
-        writeln!(pol_file, "{}", vec![' '; 10].iter().collect::<String>()).unwrap();
+        writeln!(pol_file, "{}", [' '; 10].iter().collect::<String>()).unwrap();
 
         let result = Config::get_cached_blocks(chain_dir.path())?;
 

--- a/doc/src/parser/mod.rs
+++ b/doc/src/parser/mod.rs
@@ -114,7 +114,7 @@ impl Parser {
         for comment in parse_doccomments(&self.comments, start, end) {
             match comment {
                 DocComment::Line { comment } => res.push(comment),
-                DocComment::Block { comments } => res.extend(comments.into_iter()),
+                DocComment::Block { comments } => res.extend(comments),
             }
         }
 

--- a/evm/src/executor/inspector/access_list.rs
+++ b/evm/src/executor/inspector/access_list.rs
@@ -28,7 +28,7 @@ impl AccessListTracer {
         precompiles: Vec<Address>,
     ) -> Self {
         AccessListTracer {
-            excluded: vec![from, to].iter().chain(precompiles.iter()).copied().collect(),
+            excluded: [from, to].iter().chain(precompiles.iter()).copied().collect(),
             access_list: access_list
                 .0
                 .iter()

--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -257,6 +257,7 @@ impl PartialOrd for MockCallDataContext {
 
 fn expect_safe_memory(state: &mut Cheatcodes, start: u64, end: u64, depth: u64) -> Result {
     ensure!(start < end, "Invalid memory range: [{start}:{end}]");
+    #[allow(clippy::single_range_in_vec_init)]
     let offsets = state.allowed_mem_writes.entry(depth).or_insert_with(|| vec![0..0x60]);
     offsets.push(start..end);
     Ok(Bytes::new())

--- a/fmt/src/buffer.rs
+++ b/fmt/src/buffer.rs
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_preserves_original_content_with_default_settings() -> std::fmt::Result {
-        let contents = vec![
+        let contents = [
             "simple line",
             r#"
             some 

--- a/fmt/src/comments.rs
+++ b/fmt/src/comments.rs
@@ -266,7 +266,7 @@ impl Comments {
     pub(crate) fn remove_all_comments_before(&mut self, byte: usize) -> Vec<CommentWithMetadata> {
         self.remove_prefixes_before(byte)
             .into_iter()
-            .merge(self.remove_postfixes_before(byte).into_iter())
+            .merge(self.remove_postfixes_before(byte))
             .collect()
     }
 

--- a/forge/tests/it/fuzz.rs
+++ b/forge/tests/it/fuzz.rs
@@ -12,7 +12,7 @@ async fn test_fuzz() {
     let suite_result = runner
         .test(
             &Filter::new(".*", ".*", ".*fuzz/")
-                .exclude_tests(r#"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)"#)
+                .exclude_tests(r"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)")
                 .exclude_paths("invariant"),
             None,
             test_opts(),


### PR DESCRIPTION
Some new clippy lints were affecting CI.

This also bumps ethers to latest that also has clippy fixes.
