### PR TITLE
feat(repo): `stale.yml`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '00 12 * * *'
+  - cron: '00 1 * * *'
 
 jobs:
   stale:
@@ -27,5 +27,7 @@ jobs:
         days-before-pr-stale: 30
         days-before-close: 15
         exempt-issue-labels: 'P-high,T-feature,T-debt,T-meta,T-perf,T-question,good first issue'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
+        stale-issue-label: 'S-stale'
+        stale-pr-label: 'S-stale'
+        exempt-all-milestones: true
+        exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '00 12 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale as it has not received any activity recently. It will be closed soon if no more activity occurs.'
+        stale-pr-message: 'This PR has been marked as stale as it has not received any activity recently. It will be closed soon if no more activity occurs.'
+        days-before-issue-stale: 14
+        days-before-pr-stale: 14
+        days-before-close: 7
+        exempt-issue-labels: 'P-high,T-feature,T-debt,T-meta,T-perf,T-question,good first issue'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,9 +23,9 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale as it has not received any activity recently. It will be closed soon if no more activity occurs.'
         stale-pr-message: 'This PR has been marked as stale as it has not received any activity recently. It will be closed soon if no more activity occurs.'
-        days-before-issue-stale: 14
-        days-before-pr-stale: 14
-        days-before-close: 7
+        days-before-issue-stale: 30
+        days-before-pr-stale: 30
+        days-before-close: 15
         exempt-issue-labels: 'P-high,T-feature,T-debt,T-meta,T-perf,T-question,good first issue'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'


### PR DESCRIPTION
Adds a `stale.yml` workflow, which will mark issues automatically as stale.

Right now the setup is extremely permissive—any issue marked with any `T` label (`T-performance`, `T-meta`, etc) will not be marked as stale automatically, ever. This is to avoid closing historical issues which might have context and require discussion before closing. We can clamp it down as we close these.

