### PR TITLE
More intuitive cast 4byte error message when selector is too short

### DIFF
--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -541,7 +541,12 @@ mod tests {
         // invalid signature
         decode_function_selector("0xa9059c")
             .await
-            .map_err(|e| assert_eq!(e.to_string(), "Invalid selector: expected 8 characters (excluding 0x prefix), got 8 characters (including 0x prefix)."))
+            .map_err(|e| {
+                assert_eq!(
+                    e.to_string(),
+                    "Invalid selector: expected 8 characters (excluding 0x prefix), got 6."
+                )
+            })
             .map(|_| panic!("Expected fourbyte error"))
             .ok();
     }

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -196,9 +196,13 @@ impl SignEthClient {
 
     /// Fetches a function signature given the selector using sig.eth.samczsun.com
     pub async fn decode_function_selector(&self, selector: &str) -> eyre::Result<Vec<String>> {
-        let prefixed_selector = format!("0x{}", selector.strip_prefix("0x").unwrap_or(selector));
+        let stripped_selector = selector.strip_prefix("0x").unwrap_or(selector);
+        let prefixed_selector = format!("0x{}", stripped_selector);
         if prefixed_selector.len() != 10 {
-            eyre::bail!("Invalid selector: expected 8 characters (excluding 0x prefix), got {} characters (including 0x prefix).", prefixed_selector.len())
+            eyre::bail!(
+                "Invalid selector: expected 8 characters (excluding 0x prefix), got {}.",
+                stripped_selector.len()
+            )
         }
 
         self.decode_selector(&prefixed_selector[..10], SelectorType::Function).await


### PR DESCRIPTION
## Motivation

This error message is somewhat counterintuitive:

```
❯ cast 4byte 0x098866
Error:
Invalid selector: expected 8 characters (excluding 0x prefix), got 8 characters (including 0x prefix).
```

It is also inconsistent with similar behaviour in the `decode_calldata`, which always considers length excluding the prefix