### PR TITLE
feat(forge): print formatted interface when using `forge inspect <contract> abi --pretty`

### DIFF
--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -92,7 +92,11 @@ impl Cmd for InspectArgs {
         // Match on ContractArtifactFields and Pretty Print
         match field {
             ContractArtifactField::Abi => {
-                print_abi(&artifact.abi, pretty)?;
+                let abi = artifact
+                    .abi
+                    .as_ref()
+                    .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
+                print_abi(abi, pretty)?;
             }
             ContractArtifactField::Bytecode => {
                 let tval: Value = to_value(&artifact.bytecode)?;
@@ -203,11 +207,7 @@ impl Cmd for InspectArgs {
     }
 }
 
-pub fn print_abi(abi: &Option<LosslessAbi>, pretty: bool) -> eyre::Result<()> {
-    if abi.is_none() {
-        eyre::bail!("Could not get abi")
-    }
-
+pub fn print_abi(abi: &LosslessAbi, pretty: bool) -> eyre::Result<()> {
     let abi_json = to_value(abi)?;
     if !pretty {
         println!("{}", serde_json::to_string_pretty(&abi_json)?);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Issue: https://github.com/foundry-rs/foundry/issues/2433

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Allow `--pretty` flag to print a specified contract's abi which is formatted using `foundry_utils::abi::abi_to_solidity` _(same way as `cast interface`)_

_example_
```bash
$ cat src/Counter.sol
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

contract Counter {
    uint256 public number;

    function setNumber(uint256 newNumber) public {
        number = newNumber;
    }

    function increment() public {
        number++;
    }
}

$ ~/Documents/GitHub/foundry/target/debug/forge inspect Counter abi --pretty
interface Interface {
    function increment() external;
    function number() external view returns (uint256);
    function setNumber(uint256 newNumber) external;
}
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
