### PR TITLE
feat(`cheatcodes`): modify emit/call failure message depending on status

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -855,14 +855,15 @@ where
                                 .into_iter()
                                 .flatten()
                                 .join(" and ");
+                                let failure_message = match status {
+                                    InstructionResult::Continue | InstructionResult::Stop | InstructionResult::Return | InstructionResult::SelfDestruct =>
+                                    format!("Expected call to {address:?} with {expected_values} to be called {count} time(s), but was called {actual_count} time(s)"),
+                                    _ => format!("Expected call to {address:?} with {expected_values} to be called {count} time(s), but the call reverted instead. Ensure you're testing the happy path when using the expectCall cheatcode"),
+                                };
                                 return (
                                     InstructionResult::Revert,
                                     remaining_gas,
-                                    format!(
-                                        "Expected call to {address:?} with {expected_values} to be called {count} time(s), but was called {actual_count} time(s)"
-                                    )
-                                    .encode()
-                                    .into(),
+                                    failure_message.encode().into(),
                                 )
                             }
                         }
@@ -881,14 +882,15 @@ where
                                 .into_iter()
                                 .flatten()
                                 .join(" and ");
+                                let failure_message = match status {
+                                    InstructionResult::Continue | InstructionResult::Stop | InstructionResult::Return | InstructionResult::SelfDestruct =>
+                                    format!("Expected call to {address:?} with {expected_values} to be called {count} time(s), but was called {actual_count} time(s)"),
+                                    _ => format!("Expected call to {address:?} with {expected_values} to be called {count} time(s), but the call reverted instead. Ensure you're testing the happy path when using the expectCall cheatcode"),
+                                };
                                 return (
                                     InstructionResult::Revert,
                                     remaining_gas,
-                                    format!(
-                                        "Expected call to {address:?} with {expected_values} to be called at least {count} time(s), but was called {actual_count} time(s)"
-                                    )
-                                    .encode()
-                                    .into(),
+                                    failure_message.encode().into(),
                                 )
                             }
                         }
@@ -901,13 +903,15 @@ where
             self.expected_emits.retain(|expected| !expected.found);
             // If not empty, we got mismatched emits
             if !self.expected_emits.is_empty() {
+                let failure_message = match status {
+                    InstructionResult::Continue | InstructionResult::Stop | InstructionResult::Return | InstructionResult::SelfDestruct =>
+                    "Expected an emit, but no logs were emitted afterward. You might have mismatched events or not enough events were emitted.",
+                    _ => "Expected an emit, but the call reverted instead. Ensure you're testing the happy path when using the `expectEmit` cheatcode.",
+                };
                 return (
                     InstructionResult::Revert,
                     remaining_gas,
-                    "Expected an emit, but no logs were emitted afterward. You might have mismatched events or not enough events were emitted."
-                        .to_string()
-                        .encode()
-                        .into(),
+                    failure_message.to_string().encode().into(),
                 )
             }
         }


### PR DESCRIPTION
Fixes #5308.

Improves the error message on the `expectEmit`/`expectCall` cheatcodes to point out the call where the cheatcodes where expected to happen reverted.

Example for `expectCall`:
<img width="1572" alt="Screenshot 2023-07-05 at 19 10 50" src="https://github.com/foundry-rs/foundry/assets/26014927/d3509afe-0d2a-444b-a7d5-f6d07d358d1c">

Example for `expectEmit`:
<img width="990" alt="Screenshot 2023-07-05 at 19 11 25" src="https://github.com/foundry-rs/foundry/assets/26014927/cfdacc11-e9e7-44ea-884c-ca9649d61217">
