### PR TITLE
fix(forge): shortcuts footer not showing in debug mode

### DIFF
--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -146,7 +146,7 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
-        help: bool,
+        show_shortcuts: bool,
     ) {
         let total_size = f.size();
         if total_size.width < 225 {
@@ -164,7 +164,7 @@ impl Tui {
                 draw_memory,
                 stack_labels,
                 mem_utf,
-                help,
+                show_shortcuts,
             );
         } else {
             Tui::square_layout(
@@ -181,7 +181,7 @@ impl Tui {
                 draw_memory,
                 stack_labels,
                 mem_utf,
-                help,
+                show_shortcuts,
             );
         }
     }
@@ -201,10 +201,10 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
-        help: bool,
+        show_shortcuts: bool,
     ) {
         let total_size = f.size();
-        let h_height = if help { 4 } else { 0 };
+        let h_height = if show_shortcuts { 4 } else { 0 };
 
         if let [app, footer] = Layout::default()
             .constraints(
@@ -226,7 +226,7 @@ impl Tui {
                 )
                 .split(app)[..]
             {
-                if help {
+                if show_shortcuts {
                     Tui::draw_footer(f, footer);
                 }
                 Tui::draw_src(
@@ -281,10 +281,10 @@ impl Tui {
         draw_memory: &mut DrawMemory,
         stack_labels: bool,
         mem_utf: bool,
-        help: bool,
+        show_shortcuts: bool,
     ) {
         let total_size = f.size();
-        let h_height = if help { 4 } else { 0 };
+        let h_height = if show_shortcuts { 4 } else { 0 };
 
         // split in 2 vertically
 
@@ -311,7 +311,7 @@ impl Tui {
                         .constraints([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)].as_ref())
                         .split(right_pane)[..]
                     {
-                        if help {
+                        if show_shortcuts {
                             Tui::draw_footer(f, footer)
                         };
                         Tui::draw_src(
@@ -1052,7 +1052,7 @@ impl Ui for Tui {
 
         let mut stack_labels = false;
         let mut mem_utf = false;
-        let mut help = false;
+        let mut show_shortcuts = true;
         // UI thread that manages drawing
         loop {
             if last_index != draw_memory.inner_call_index {
@@ -1249,7 +1249,7 @@ impl Ui for Tui {
                         }
                         // toggle help notice
                         KeyCode::Char('h') => {
-                            help = !help;
+                            show_shortcuts = !show_shortcuts;
                         }
                         KeyCode::Char(other) => match other {
                             '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '\'' => {
@@ -1313,7 +1313,7 @@ impl Ui for Tui {
                     &mut draw_memory,
                     stack_labels,
                     mem_utf,
-                    help,
+                    show_shortcuts,
                 )
             })?;
         }


### PR DESCRIPTION
## Motivation

#5310 

## Solution

It seems that in a previous PR,  a new keystroke was added to hide the footer with the shortcuts in the debug mode. The variable responsible for this functionality was set to `false` by default, to fix the bug I changed it to true so that once someone opens the debug window can optionally hide it by typing `h`.
I also renamed the variable in order to make it clearer what aspect of the UI it manages.

When opening the debug window the first time:
![image](https://github.com/foundry-rs/foundry/assets/42520800/4c41eac3-b31d-4561-892c-4d1eb4948691)

After typing `h`:
![image](https://github.com/foundry-rs/foundry/assets/42520800/ec0f92dc-b8a9-4ad6-91b6-54dcd1615739)
