### PR TITLE
fix(`4byte`): use new db url

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -532,23 +532,21 @@ pub enum Subcommands {
         rpc: RpcOpts,
     },
 
-    /// Get the function signatures for the given selector from https://sig.eth.samczsun.com.
+    /// Get the function signatures for the given selector from https://openchain.xyz.
     #[clap(name = "4byte", visible_aliases = &["4", "4b"])]
     FourByte {
         /// The function selector.
         selector: Option<String>,
     },
 
-    /// Decode ABI-encoded calldata using https://sig.eth.samczsun.com.
+    /// Decode ABI-encoded calldata using https://openchain.xyz.
     #[clap(name = "4byte-decode", visible_aliases = &["4d", "4bd"])]
     FourByteDecode {
         /// The ABI-encoded calldata.
         calldata: Option<String>,
     },
 
-    /// Get the event signature for a given topic 0 from https://sig.
-    ///
-    /// eth.samczsun.com.
+    /// Get the event signature for a given topic 0 from https://openchain.xyz.
     #[clap(name = "4byte-event", visible_aliases = &["4e", "4be"])]
     FourByteEvent {
         /// Topic 0
@@ -556,7 +554,7 @@ pub enum Subcommands {
         topic: Option<String>,
     },
 
-    /// Upload the given signatures to https://sig.eth.samczsun.com.
+    /// Upload the given signatures to https://openchain.xyz.
     ///
     /// Example inputs:
     /// - "transfer(address,uint256)"
@@ -574,13 +572,13 @@ pub enum Subcommands {
 
     /// Pretty print calldata.
     ///
-    /// Tries to decode the calldata using https://sig.eth.samczsun.com unless --offline is passed.
+    /// Tries to decode the calldata using https://openchain.xyz unless --offline is passed.
     #[clap(visible_alias = "pc")]
     PrettyCalldata {
         /// The calldata.
         calldata: Option<String>,
 
-        /// Skip the https://sig.eth.samczsun.com lookup.
+        /// Skip the https://openchain.xyz lookup.
         #[clap(long, short)]
         offline: bool,
     },

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -142,7 +142,7 @@ pub enum Subcommands {
     #[clap(visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 
-    /// Uploads abi of given contract to the https://sig.eth.samczsun.com
+    /// Uploads abi of given contract to the https://api.openchain.xyz
     /// function selector database.
     #[clap(visible_alias = "up")]
     UploadSelectors(UploadSelectorsArgs),

--- a/cli/tests/it/script.rs
+++ b/cli/tests/it/script.rs
@@ -754,7 +754,7 @@ forgetest_async!(
         let run_log = re.replace_all(&run_log, "");
 
         // Clean up carriage return OS differences
-        let re = Regex::new(r#"\\r\\n"#).unwrap();
+        let re = Regex::new(r"\\r\\n").unwrap();
         let fixtures_log = re.replace_all(&fixtures_log, "\n");
         let run_log = re.replace_all(&run_log, "\n");
 

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -15,8 +15,8 @@ use std::{
 };
 use tracing::warn;
 
-static SELECTOR_DATABASE_URL: &str = "https://sig.eth.samczsun.com/api/v1/signatures";
-static SELECTOR_IMPORT_URL: &str = "https://sig.eth.samczsun.com/api/v1/import";
+static SELECTOR_DATABASE_URL: &str = "https://api.openchain.xyz/signature-database/v1/";
+static SELECTOR_IMPORT_URL: &str = "https://api.openchain.xyz/signature-database/v1/import";
 
 /// The standard request timeout for API requests
 const REQ_TIMEOUT: Duration = Duration::from_secs(15);
@@ -165,8 +165,8 @@ impl SignEthClient {
         // using samczsun signature database over 4byte
         // see https://github.com/foundry-rs/foundry/issues/1672
         let url = match selector_type {
-            SelectorType::Function => format!("{SELECTOR_DATABASE_URL}?function={selector}"),
-            SelectorType::Event => format!("{SELECTOR_DATABASE_URL}?event={selector}"),
+            SelectorType::Function => format!("{SELECTOR_DATABASE_URL}lookup?function={selector}"),
+            SelectorType::Event => format!("{SELECTOR_DATABASE_URL}lookup?event={selector}"),
         };
 
         let res = self.get_text(&url).await?;

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -295,15 +295,14 @@ impl SignEthClient {
             SelectorImportData::Abi(abis) => {
                 let names: Vec<String> = abis
                     .iter()
-                    .map(|abi| {
+                    .flat_map(|abi| {
                         abi.abi
                             .functions()
                             .map(|func| {
-                                func.signature().split(":").next().unwrap_or("").to_string()
+                                func.signature().split(':').next().unwrap_or("").to_string()
                             })
                             .collect::<Vec<_>>()
                     })
-                    .flatten()
                     .collect();
                 SelectorImportRequest { function: names, event: Default::default() }
             }

--- a/common/src/selectors.rs
+++ b/common/src/selectors.rs
@@ -24,7 +24,7 @@ const REQ_TIMEOUT: Duration = Duration::from_secs(15);
 /// How many request can time out before we decide this is a spurious connection
 const MAX_TIMEDOUT_REQ: usize = 4usize;
 
-/// A client that can request API data from `https://sig.eth.samczsun.com/api`
+/// A client that can request API data from `https://api.openchain.xyz`
 #[derive(Debug, Clone)]
 pub struct SignEthClient {
     inner: reqwest::Client,
@@ -110,7 +110,7 @@ impl SignEthClient {
         }
 
         if is_connectivity_err(err) {
-            warn!("spurious network detected for sig.eth.samczsun.com");
+            warn!("spurious network detected for https://api.openchain.xyz");
             let previous = self.timedout_requests.fetch_add(1, Ordering::SeqCst);
             if previous >= self.max_timedout_requests {
                 self.set_spurious();
@@ -135,7 +135,7 @@ impl SignEthClient {
         Ok(())
     }
 
-    /// Decodes the given function or event selector using sig.eth.samczsun.com
+    /// Decodes the given function or event selector using https://api.openchain.xyz
     pub async fn decode_selector(
         &self,
         selector: &str,
@@ -162,7 +162,7 @@ impl SignEthClient {
             result: ApiResult,
         }
 
-        // using samczsun signature database over 4byte
+        // using openchain.xyz signature database over 4byte
         // see https://github.com/foundry-rs/foundry/issues/1672
         let url = match selector_type {
             SelectorType::Function => format!("{SELECTOR_DATABASE_URL}lookup?function={selector}"),
@@ -194,7 +194,7 @@ impl SignEthClient {
             .collect::<Vec<String>>())
     }
 
-    /// Fetches a function signature given the selector using sig.eth.samczsun.com
+    /// Fetches a function signature given the selector using https://api.openchain.xyz
     pub async fn decode_function_selector(&self, selector: &str) -> eyre::Result<Vec<String>> {
         let stripped_selector = selector.strip_prefix("0x").unwrap_or(selector);
         let prefixed_selector = format!("0x{}", stripped_selector);
@@ -228,7 +228,7 @@ impl SignEthClient {
             .collect::<Vec<String>>())
     }
 
-    /// Fetches an event signature given the 32 byte topic using sig.eth.samczsun.com
+    /// Fetches an event signature given the 32 byte topic using https://api.openchain.xyz
     pub async fn decode_event_topic(&self, topic: &str) -> eyre::Result<Vec<String>> {
         let prefixed_topic = format!("0x{}", topic.strip_prefix("0x").unwrap_or(topic));
         if prefixed_topic.len() != 66 {
@@ -284,19 +284,31 @@ impl SignEthClient {
         Ok(possible_info)
     }
 
-    /// uploads selectors to sig.eth.samczsun.com using the given data
+    /// uploads selectors to https://api.openchain.xyz using the given data
     pub async fn import_selectors(
         &self,
         data: SelectorImportData,
     ) -> eyre::Result<SelectorImportResponse> {
         self.ensure_not_spurious()?;
 
-        let request = match &data {
-            SelectorImportData::Abi(_) => {
-                SelectorImportRequest { import_type: "abi".to_string(), data }
+        let request = match data {
+            SelectorImportData::Abi(abis) => {
+                let names: Vec<String> = abis
+                    .iter()
+                    .map(|abi| {
+                        abi.abi
+                            .functions()
+                            .map(|func| {
+                                func.signature().split(":").next().unwrap_or("").to_string()
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .flatten()
+                    .collect();
+                SelectorImportRequest { function: names, event: Default::default() }
             }
-            SelectorImportData::Raw(_) => {
-                SelectorImportRequest { import_type: "raw".to_string(), data }
+            SelectorImportData::Raw(raw) => {
+                SelectorImportRequest { function: raw.function, event: raw.event }
             }
         };
 
@@ -350,7 +362,7 @@ pub enum SelectorType {
     Event,
 }
 
-/// Decodes the given function or event selector using sig.eth.samczsun.com
+/// Decodes the given function or event selector using https://api.openchain.xyz
 pub async fn decode_selector(
     selector: &str,
     selector_type: SelectorType,
@@ -358,7 +370,7 @@ pub async fn decode_selector(
     SignEthClient::new()?.decode_selector(selector, selector_type).await
 }
 
-/// Fetches a function signature given the selector using sig.eth.samczsun.com
+/// Fetches a function signature given the selector https://api.openchain.xyz
 pub async fn decode_function_selector(selector: &str) -> eyre::Result<Vec<String>> {
     SignEthClient::new()?.decode_function_selector(selector).await
 }
@@ -368,7 +380,7 @@ pub async fn decode_calldata(calldata: &str) -> eyre::Result<Vec<String>> {
     SignEthClient::new()?.decode_calldata(calldata).await
 }
 
-/// Fetches an event signature given the 32 byte topic using sig.eth.samczsun.com
+/// Fetches an event signature given the 32 byte topic using https://api.openchain.xyz
 pub async fn decode_event_topic(topic: &str) -> eyre::Result<Vec<String>> {
     SignEthClient::new()?.decode_event_topic(topic).await
 }
@@ -413,26 +425,25 @@ pub enum SelectorImportData {
     Raw(RawSelectorImportData),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Default, Serialize)]
 struct SelectorImportRequest {
-    #[serde(rename = "type")]
-    import_type: String,
-    data: SelectorImportData,
+    function: Vec<String>,
+    event: Vec<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct SelectorImportEffect {
     imported: HashMap<String, String>,
     duplicated: HashMap<String, String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct SelectorImportResult {
     function: SelectorImportEffect,
     event: SelectorImportEffect,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct SelectorImportResponse {
     result: SelectorImportResult,
 }
@@ -457,11 +468,11 @@ impl SelectorImportResponse {
             .iter()
             .for_each(|(k, v)| println!("Duplicated: Event {k}: {v}"));
 
-        println!("Selectors successfully uploaded to https://sig.eth.samczsun.com");
+        println!("Selectors successfully uploaded to https://api.openchain.xyz");
     }
 }
 
-/// uploads selectors to sig.eth.samczsun.com using the given data
+/// uploads selectors to https://api.openchain.xyz using the given data
 pub async fn import_selectors(data: SelectorImportData) -> eyre::Result<SelectorImportResponse> {
     SignEthClient::new()?.import_selectors(data).await
 }
@@ -570,8 +581,9 @@ mod tests {
             "0xa9059cbb"
         );
 
-        let abi: LosslessAbi = serde_json::from_str(r#"[{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]"#).unwrap();
+        let abi: LosslessAbi = serde_json::from_str(r#"[{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function", "methodIdentifiers": {"transfer(address,uint256)(uint256)": "0xa9059cbb"}}]"#).unwrap();
         let result = import_selectors(SelectorImportData::Abi(vec![abi])).await;
+        println!("{:?}", result);
         assert_eq!(
             result.unwrap().result.function.duplicated.get("transfer(address,uint256)").unwrap(),
             "0xa9059cbb"

--- a/evm/src/trace/identifier/signatures.rs
+++ b/evm/src/trace/identifier/signatures.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 pub type SingleSignaturesIdentifier = Arc<RwLock<SignaturesIdentifier>>;
 
 /// An identifier that tries to identify functions and events using signatures found at
-/// `sig.eth.samczsun.com`.
+/// `https://openchain.xyz`.
 #[derive(Debug)]
 pub struct SignaturesIdentifier {
     /// Cached selectors for functions and events
@@ -132,13 +132,13 @@ impl SignaturesIdentifier {
         }
     }
 
-    /// Identifies `Function` from its cache or `sig.eth.samczsun.com`
+    /// Identifies `Function` from its cache or `https://api.openchain.xyz`
     pub async fn identify_function(&mut self, identifier: &[u8]) -> Option<Function> {
         self.ensure_not_offline()?;
         self.identify(SelectorType::Function, identifier, get_func).await
     }
 
-    /// Identifies `Event` from its cache or `sig.eth.samczsun.com`
+    /// Identifies `Event` from its cache or `https://api.openchain.xyz`
     pub async fn identify_event(&mut self, identifier: &[u8]) -> Option<Event> {
         self.ensure_not_offline()?;
         self.identify(SelectorType::Event, identifier, get_event).await


### PR DESCRIPTION
Closes #4177.

The new API URL moved—this switches to using the new db.