### PR TITLE
feat(script): Use code_size_limit for in deployment scripts

### DIFF
--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -517,7 +517,8 @@ impl ScriptArgs {
         Ok((func.clone(), data))
     }
 
-    /// Checks if the transaction is a deployment with either a size above the `CONTRACT_MAX_SIZE` or specified `code_size_limit`.
+    /// Checks if the transaction is a deployment with either a size above the `CONTRACT_MAX_SIZE`
+    /// or specified `code_size_limit`.
     ///
     /// If `self.broadcast` is enabled, it asks confirmation of the user. Otherwise, it just warns
     /// the user.
@@ -855,7 +856,7 @@ mod tests {
             "http://localhost:8545",
             "--broadcast",
             "--code-size-limit",
-            "50000"
+            "50000",
         ]);
         assert_eq!(args.evm_opts.env.code_size_limit, Some(50000));
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

While running deployment scripts in CI, I had no way to bypass code size limits - without the use of some terminal keystroke logger, like `expect`.

A user should be able to bypass `forge script`'s contract size check via an inline argument.

## Solution

Use `code_size_limit` on the `evm_opts.env` object for the contract size check, and the hardcoded EIP-170 size as a fallback value.
