### PR TITLE
fix(coverage): fix missing items in indirectly used libraries

### DIFF
--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -516,55 +516,54 @@ impl SourceAnalyzer {
         // Flatten the data
         let mut flattened: HashMap<ContractId, Vec<usize>> = HashMap::new();
         for contract_id in self.contract_items.keys() {
-
             let mut item_ids: Vec<usize> = Vec::new();
 
-            // 
-            // for a specific contract (id == contract_id): 
             //
-            // self.contract_bases.get(contract_id) includes the following contracts: 
-            //   1. all the ancestors of this contract (including parent, grandparent, ... contracts)
-            //   2. the libraries **directly** used by this contract 
-            // 
-            // The missing contracts are: 
-            //   1. libraries used in ancestors of this contracts 
+            // for a specific contract (id == contract_id):
+            //
+            // self.contract_bases.get(contract_id) includes the following contracts:
+            //   1. all the ancestors of this contract (including parent, grandparent, ...
+            //      contracts)
+            //   2. the libraries **directly** used by this contract
+            //
+            // The missing contracts are:
+            //   1. libraries used in ancestors of this contracts
             //   2. libraries used in libaries (i.e libs indirectly used by this contract)
-            // 
+            //
             // We want to find out all the above contracts and libraries related to this contract.
 
-
             for contract_or_lib in {
-
-                // A set of contracts and libraries related to this contract (will include "this" contract itself)
+                // A set of contracts and libraries related to this contract (will include "this"
+                // contract itself)
                 let mut contracts_libraries: HashSet<&ContractId> = HashSet::new();
 
-                // we use a stack for depth-first search. 
+                // we use a stack for depth-first search.
                 let mut stack: Vec<&ContractId> = Vec::new();
 
                 // push "this" contract onto the stack
                 stack.push(contract_id);
 
-
-                while let Some(contract_or_lib) = stack.pop(){
-
+                while let Some(contract_or_lib) = stack.pop() {
                     // whenever a contract_or_lib is removed from the stack, it is added to the set
                     contracts_libraries.insert(contract_or_lib);
 
-                    // push all ancestors of contract_or_lib and libraries used by contract_or_lib onto the stack
+                    // push all ancestors of contract_or_lib and libraries used by contract_or_lib
+                    // onto the stack
                     if let Some(bases) = self.contract_bases.get(contract_or_lib) {
-                        stack.extend(bases.iter().filter(|base|!contracts_libraries.contains(base)));
+                        stack.extend(
+                            bases.iter().filter(|base| !contracts_libraries.contains(base)),
+                        );
                     }
-
                 }
-  
+
                 contracts_libraries
-            }{
+            } {
                 // get items of each contract or library
                 if let Some(items) = self.contract_items.get(contract_or_lib) {
                     item_ids.extend(items.iter());
                 }
             }
-            
+
             // If there are no items for this contract, then it was most likely filtered
             if !item_ids.is_empty() {
                 flattened.insert(contract_id.clone(), item_ids);

--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -281,12 +281,32 @@ impl<'a> ContractVisitor<'a> {
         //  tupleexpression
         //  yulfunctioncall
         match node.node_type {
-            NodeType::Assignment | NodeType::UnaryOperation | NodeType::BinaryOperation => {
+            NodeType::Assignment | NodeType::UnaryOperation => {
                 self.push_item(CoverageItem {
                     kind: CoverageItemKind::Statement,
                     loc: self.source_location_for(&node.src),
                     hits: 0,
                 });
+                Ok(())
+            }
+            NodeType::BinaryOperation => {
+                self.push_item(CoverageItem {
+                    kind: CoverageItemKind::Statement,
+                    loc: self.source_location_for(&node.src),
+                    hits: 0,
+                });
+
+                // visit left and right expressions
+                // There could possibly a function call in the left or right expression
+                // e.g: callFunc(a) + callFunc(b)
+                if let Some(expr) = node.attribute("leftExpression") {
+                    self.visit_expression(expr)?;
+                }
+
+                if let Some(expr) = node.attribute("rightExpression") {
+                    self.visit_expression(expr)?;
+                }
+
                 Ok(())
             }
             NodeType::FunctionCall => {
@@ -495,16 +515,59 @@ impl SourceAnalyzer {
 
         // Flatten the data
         let mut flattened: HashMap<ContractId, Vec<usize>> = HashMap::new();
-        for (contract_id, own_item_ids) in &self.contract_items {
-            let mut item_ids = own_item_ids.clone();
-            if let Some(base_contract_ids) = self.contract_bases.get(contract_id) {
-                for item_id in
-                    base_contract_ids.iter().filter_map(|id| self.contract_items.get(id)).flatten()
-                {
-                    item_ids.push(*item_id);
+        for (contract_id, _ ) in &self.contract_items {
+
+            let mut item_ids: Vec<usize> = Vec::new();
+
+            // 
+            // for a specific contract (id == contract_id): 
+            //
+            // self.contract_bases.get(contract_id) includes the following contracts: 
+            //   1. all the ancestors of this contract (including parent, grandparent, ... contracts)
+            //   2. the libraries **directly** used by this contract 
+            // 
+            // The missing contracts are: 
+            //   1. libraries used in ancestors of this contracts 
+            //   2. libraries used in libaries (i.e libs indirectly used by this contract)
+            // 
+            // We want to find out all the above contracts and libraries related to this contract.
+
+
+            for contract_or_lib in {
+
+                // A set of contracts and libraries related to this contract (will include "this" contract itself)
+                let mut contracts_libraries: HashSet<&ContractId> = HashSet::new();
+
+                // we use a stack for depth-first search. 
+                let mut stack: Vec<&ContractId> = Vec::new();
+
+                // push "this" contract onto the stack
+                stack.push(contract_id);
+
+
+                while !stack.is_empty(){
+
+                    // pop the last element from the stack
+                    let contract_or_lib = stack.pop().unwrap();
+
+                    // whenever a contract_or_lib is removed from the stack, it is added to the set
+                    contracts_libraries.insert(contract_or_lib);
+
+                    // push all ancestors of contract_or_lib and libraries used by contract_or_lib onto the stack
+                    if let Some(bases) = self.contract_bases.get(contract_or_lib) {
+                        stack.extend(bases.iter());
+                    }
+
+                }
+  
+                contracts_libraries
+            }{
+                // get items of each contract or library
+                if let Some(items) = self.contract_items.get(contract_or_lib) {
+                    item_ids.extend(items.iter());
                 }
             }
-
+            
             // If there are no items for this contract, then it was most likely filtered
             if !item_ids.is_empty() {
                 flattened.insert(contract_id.clone(), item_ids);

--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -555,7 +555,7 @@ impl SourceAnalyzer {
 
                     // push all ancestors of contract_or_lib and libraries used by contract_or_lib onto the stack
                     if let Some(bases) = self.contract_bases.get(contract_or_lib) {
-                        stack.extend(bases.iter());
+                        stack.extend(bases.iter().filter(|base|!contracts_libraries.contains(base)));
                     }
 
                 }

--- a/evm/src/coverage/analysis.rs
+++ b/evm/src/coverage/analysis.rs
@@ -515,7 +515,7 @@ impl SourceAnalyzer {
 
         // Flatten the data
         let mut flattened: HashMap<ContractId, Vec<usize>> = HashMap::new();
-        for (contract_id, _ ) in &self.contract_items {
+        for contract_id in self.contract_items.keys() {
 
             let mut item_ids: Vec<usize> = Vec::new();
 
@@ -545,10 +545,7 @@ impl SourceAnalyzer {
                 stack.push(contract_id);
 
 
-                while !stack.is_empty(){
-
-                    // pop the last element from the stack
-                    let contract_or_lib = stack.pop().unwrap();
+                while let Some(contract_or_lib) = stack.pop(){
 
                     // whenever a contract_or_lib is removed from the stack, it is added to the set
                     contracts_libraries.insert(contract_or_lib);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I found the following bugs in `forge test coverage` :  

1.  The hits of a library used in a base contract is missing in the coverage report 
2.  The hits of a library used in a library is missing in the coverage report  
3.  The hits of a function call in a binary operation is missing in the coverage report 

The fix for 2 also works for 1.  

Here is a simple project to replicate 2 & 3: 

`LibA` is the base contract of `LibB`, and `LibB` is the base contract of `LibC`.  
Only `LibC` is directly used in the contract `useLib`:  

```solidity

// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

library LibA {

    function get() internal view returns (uint256 result) {
        assembly {
            result := sload(0xa)
        }
    }
    
}

```

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "./LibA.sol";

library LibB {

    function get() internal view returns (uint256 result) {

        uint b = 0;
        assembly {
           b := sload(0xb)
        }

        // function call in left expression in binary operation 
        return LibA.get() + b;
    }
    
}
```

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "./LibB.sol";

library LibC {

    function get() internal view returns (uint256 result) {

        uint c = 0;
        assembly {
            c := sload(0xc)
        }

        // function call in right expression in binary operation 
        return c + LibB.get();
    }
    
}
```

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "./LibC.sol";

contract useLib {

    function get() public view returns (uint256 result) {
        return LibC.get();
    }
    
}
```

And the simple test.t.sol is as follows: 


```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import "forge-std/Test.sol";
import "../src/useLib.sol";

contract CoverageTest is Test {

   useLib sut;
   
   function setUp() external{
        sut = new useLib();
   }

    function testGet() external {
        uint256 result = sut.get();
        assertEq(result, 0);
    }
}

```

And the debug coverage report is as follows: 


```
Uncovered for src/LibA.sol:
- Function "get" (location: source ID 17, line 6, chars 85-208, hits: 0)
- Line (location: source ID 17, line 8, chars 172-192, hits: 0)
- Statement (location: source ID 17, line 8, chars 172-192, hits: 0)

Uncovered for src/LibB.sol:
- Function "get" (location: source ID 18, line 8, chars 107-348, hits: 0)
- Line (location: source ID 18, line 10, chars 172-182, hits: 0)
- Statement (location: source ID 18, line 10, chars 172-182, hits: 0)
- Line (location: source ID 18, line 12, chars 215-235, hits: 0)
- Statement (location: source ID 18, line 12, chars 215-235, hits: 0)
- Line (location: source ID 18, line 16, chars 320-341, hits: 0)
- Statement (location: source ID 18, line 16, chars 320-341, hits: 0)
- Statement (location: source ID 18, line 16, chars 327-341, hits: 0)

Uncovered for src/LibC.sol:

Uncovered for src/useLib.sol:

Anchors for Contract "LibA" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 17):

Anchors for Contract "useLib" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 20):
- IC 48 -> Item 11
  - Refers to item: Function "get" (location: source ID 20, line 8, chars 110-196, hits: 1)
- IC 81 -> Item 12
  - Refers to item: Line (location: source ID 20, line 9, chars 172-189, hits: 1)
- IC 81 -> Item 13
  - Refers to item: Statement (location: source ID 20, line 9, chars 172-189, hits: 1)
- IC 81 -> Item 14
  - Refers to item: Statement (location: source ID 20, line 9, chars 179-189, hits: 1)
- IC 93 -> Item 0
  - Refers to item: Function "get" (location: source ID 19, line 8, chars 107-349, hits: 1)
- IC 96 -> Item 1
  - Refers to item: Line (location: source ID 19, line 10, chars 172-182, hits: 1)
- IC 96 -> Item 2
  - Refers to item: Statement (location: source ID 19, line 10, chars 172-182, hits: 1)
- IC 101 -> Item 3
  - Refers to item: Line (location: source ID 19, line 12, chars 215-235, hits: 1)
- IC 101 -> Item 4
  - Refers to item: Statement (location: source ID 19, line 12, chars 215-235, hits: 1)
- IC 106 -> Item 5
  - Refers to item: Line (location: source ID 19, line 16, chars 321-342, hits: 1)
- IC 106 -> Item 6
  - Refers to item: Statement (location: source ID 19, line 16, chars 321-342, hits: 1)
- IC 106 -> Item 7
  - Refers to item: Statement (location: source ID 19, line 16, chars 328-342, hits: 1)

Anchors for Contract "LibC" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 19):

Anchors for Contract "LibB" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 18):


```

As you can see from the debug coverage report above, all the hits in the `LibB` and `LibC` are missing in the coverage report. 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. to fix bug 1 & 2, I walk through the inheritance graph to collect items from all the related contracts and libraries.  
2. to fix bug 3, I simply go further to visit the left and right expressions in a binary operator.  

And here is the debug coverage report with my fix: 

```
Uncovered for src/LibA.sol:

Uncovered for src/LibB.sol:

Uncovered for src/LibC.sol:

Uncovered for src/useLib.sol:

Anchors for Contract "LibB" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 18):

Anchors for Contract "useLib" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 20):
- IC 48 -> Item 9
  - Refers to item: Function "get" (location: source ID 20, line 8, chars 110-196, hits: 1)
- IC 81 -> Item 10
  - Refers to item: Line (location: source ID 20, line 9, chars 172-189, hits: 1)
- IC 81 -> Item 11
  - Refers to item: Statement (location: source ID 20, line 9, chars 172-189, hits: 1)
- IC 81 -> Item 12
  - Refers to item: Statement (location: source ID 20, line 9, chars 179-189, hits: 1)
- IC 130 -> Item 0
  - Refers to item: Function "get" (location: source ID 18, line 8, chars 107-343, hits: 1)
- IC 133 -> Item 1
  - Refers to item: Line (location: source ID 18, line 10, chars 172-182, hits: 1)
- IC 133 -> Item 2
  - Refers to item: Statement (location: source ID 18, line 10, chars 172-182, hits: 1)
- IC 138 -> Item 3
  - Refers to item: Line (location: source ID 18, line 12, chars 215-230, hits: 1)
- IC 138 -> Item 4
  - Refers to item: Statement (location: source ID 18, line 12, chars 215-230, hits: 1)
- IC 143 -> Item 5
  - Refers to item: Line (location: source ID 18, line 16, chars 315-336, hits: 1)
- IC 143 -> Item 6
  - Refers to item: Statement (location: source ID 18, line 16, chars 315-336, hits: 1)
- IC 143 -> Item 7
  - Refers to item: Statement (location: source ID 18, line 16, chars 322-336, hits: 1)
- IC 144 -> Item 8
  - Refers to item: Statement (location: source ID 18, line 16, chars 322-332, hits: 1)
- IC 167 -> Item 13
  - Refers to item: Function "get" (location: source ID 17, line 6, chars 85-208, hits: 1)
- IC 170 -> Item 14
  - Refers to item: Line (location: source ID 17, line 8, chars 172-192, hits: 1)
- IC 170 -> Item 15
  - Refers to item: Statement (location: source ID 17, line 8, chars 172-192, hits: 1)
- IC 93 -> Item 16
  - Refers to item: Function "get" (location: source ID 19, line 8, chars 107-344, hits: 1)
- IC 96 -> Item 17
  - Refers to item: Line (location: source ID 19, line 10, chars 172-182, hits: 1)
- IC 96 -> Item 18
  - Refers to item: Statement (location: source ID 19, line 10, chars 172-182, hits: 1)
- IC 101 -> Item 19
  - Refers to item: Line (location: source ID 19, line 12, chars 215-230, hits: 1)
- IC 101 -> Item 20
  - Refers to item: Statement (location: source ID 19, line 12, chars 215-230, hits: 1)
- IC 106 -> Item 21
  - Refers to item: Line (location: source ID 19, line 16, chars 316-337, hits: 1)
- IC 106 -> Item 22
  - Refers to item: Statement (location: source ID 19, line 16, chars 316-337, hits: 1)
- IC 106 -> Item 23
  - Refers to item: Statement (location: source ID 19, line 16, chars 323-337, hits: 1)
- IC 106 -> Item 24
  - Refers to item: Statement (location: source ID 19, line 16, chars 327-337, hits: 1)

Anchors for Contract "LibA" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 17):

Anchors for Contract "LibC" (solc 0.8.20+commit.a1b79de6.Darwin.appleclang, source ID 19):


```
