### PR TITLE
docs: document auto_detect_remappings

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -66,6 +66,7 @@ test = 'test'
 script = 'script'
 out = 'out'
 libs = ['lib']
+auto_detect_remappings = true # recursive auto-detection of remappings
 remappings = []
 # list of libraries to link in the form of `<path to lib>:<lib name>:<address>`: `"src/MyLib.sol:MyLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"`
 # the <path to lib> supports remappings


### PR DESCRIPTION
Adds missing docs for `auto_detect_remappings`.

Ref https://github.com/foundry-rs/foundry/pull/3036.