### PR TITLE
feat(anvil): Anvil `--unlocked` for auto-impersonation on instance creation

### DIFF
--- a/anvil/core/src/eth/mod.rs
+++ b/anvil/core/src/eth/mod.rs
@@ -305,8 +305,8 @@ pub enum EthRequest {
             with = "sequence"
         )
     )]
-    /// Will make every account impersonated
     StopImpersonatingAccount(Address),
+    /// Will make every account impersonated
     #[cfg_attr(
         feature = "serde",
         serde(

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -197,7 +197,7 @@ impl NodeArgs {
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm_opts.steps_tracing)
-            .with_unlocked(self.evm_opts.unlocked)
+            .with_auto_impersonate(self.evm_opts.auto_impersonate)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm_opts.code_size_limit)
             .set_pruned_history(self.prune_history)
@@ -445,8 +445,8 @@ pub struct AnvilEvmArgs {
     pub steps_tracing: bool,
 
     /// Enable autoImpersonate on startup
-    #[clap(long, short, visible_alias = "unlocked")]
-    pub unlocked: bool,
+    #[clap(long, visible_alias = "auto-impersonate")]
+    pub auto_impersonate: bool,
 }
 
 /// Resolves an alias passed as fork-url to the matching url defined in the rpc_endpoints section

--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -197,6 +197,7 @@ impl NodeArgs {
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm_opts.steps_tracing)
+            .with_unlocked(self.evm_opts.unlocked)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm_opts.code_size_limit)
             .set_pruned_history(self.prune_history)
@@ -442,6 +443,10 @@ pub struct AnvilEvmArgs {
     /// Enable steps tracing used for debug calls returning geth-style traces
     #[clap(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
+
+    /// Enable autoImpersonate on startup
+    #[clap(long, short, visible_alias = "unlocked")]
+    pub unlocked: bool,
 }
 
 /// Resolves an alias passed as fork-url to the matching url defined in the rpc_endpoints section

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -147,8 +147,8 @@ pub struct NodeConfig {
     pub ipc_path: Option<Option<String>>,
     /// Enable transaction/call steps tracing for debug calls returning geth-style traces
     pub enable_steps_tracing: bool,
-    /// Enable autoImpersonate on start up
-    pub enable_unlocked: bool,
+    /// Enable auto impersonation of accounts on startup
+    pub enable_auto_impersonate: bool,
     /// Configure the code size limit
     pub code_size_limit: Option<usize>,
     /// Configures how to remove historic state.
@@ -376,7 +376,7 @@ impl Default for NodeConfig {
             base_fee: None,
             enable_tracing: true,
             enable_steps_tracing: false,
-            enable_unlocked: false,
+            enable_auto_impersonate: false,
             no_storage_caching: false,
             server_config: Default::default(),
             host: None,
@@ -704,8 +704,8 @@ impl NodeConfig {
 
     /// Sets whether to enable autoImpersonate
     #[must_use]
-    pub fn with_unlocked(mut self, enable_unlocked: bool) -> Self {
-        self.enable_unlocked = enable_unlocked;
+    pub fn with_auto_impersonate(mut self, enable_auto_impersonate: bool) -> Self {
+        self.enable_auto_impersonate = enable_auto_impersonate;
         self
     }
 

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -147,6 +147,8 @@ pub struct NodeConfig {
     pub ipc_path: Option<Option<String>>,
     /// Enable transaction/call steps tracing for debug calls returning geth-style traces
     pub enable_steps_tracing: bool,
+    /// Enable autoImpersonate on start up
+    pub enable_unlocked: bool,
     /// Configure the code size limit
     pub code_size_limit: Option<usize>,
     /// Configures how to remove historic state.
@@ -374,6 +376,7 @@ impl Default for NodeConfig {
             base_fee: None,
             enable_tracing: true,
             enable_steps_tracing: false,
+            enable_unlocked: false,
             no_storage_caching: false,
             server_config: Default::default(),
             host: None,
@@ -696,6 +699,13 @@ impl NodeConfig {
     #[must_use]
     pub fn with_steps_tracing(mut self, enable_steps_tracing: bool) -> Self {
         self.enable_steps_tracing = enable_steps_tracing;
+        self
+    }
+
+    /// Sets whether to enable autoImpersonate
+    #[must_use]
+    pub fn with_unlocked(mut self, enable_unlocked: bool) -> Self {
+        self.enable_unlocked = enable_unlocked;
         self
     }
 

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -1384,7 +1384,7 @@ impl EthApi {
     /// Handler for ETH RPC call: `anvil_autoImpersonateAccount`
     pub async fn anvil_auto_impersonate_account(&self, enabled: bool) -> Result<()> {
         node_info!("anvil_autoImpersonateAccount");
-        self.backend.auto_impersonate_account(enabled).await?;
+        self.backend.auto_impersonate_account(enabled).await;
         Ok(())
     }
 

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -316,9 +316,8 @@ impl Backend {
     }
 
     /// If set to true will make every account impersonated
-    pub async fn auto_impersonate_account(&self, enabled: bool) -> DatabaseResult<()> {
+    pub async fn auto_impersonate_account(&self, enabled: bool) {
         self.cheats.set_auto_impersonate_account(enabled);
-        Ok(())
     }
 
     /// Returns the configured fork, if any

--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -96,6 +96,10 @@ pub async fn spawn(mut config: NodeConfig) -> (EthApi, NodeHandle) {
 
     let backend = Arc::new(config.setup().await);
 
+    if config.enable_auto_impersonate {
+        let _ = backend.auto_impersonate_account(true).await;
+    }
+
     let fork = backend.get_fork().cloned();
 
     let NodeConfig {

--- a/anvil/src/lib.rs
+++ b/anvil/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn spawn(mut config: NodeConfig) -> (EthApi, NodeHandle) {
     let backend = Arc::new(config.setup().await);
 
     if config.enable_auto_impersonate {
-        let _ = backend.auto_impersonate_account(true).await;
+        backend.auto_impersonate_account(true).await;
     }
 
     let fork = backend.get_fork().cloned();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
It should be possible to auto-impersonate accounts upon the initial spawning of Anvil instances.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR introduces an `--auto-impersonate` flag which enables auto impersonation of accounts when the anvil instance is created. This helps avoid the need to use `curl` or `cast rpc` to set `anvil_autoImpersonateAccount` to true when the Anvil instance is spawned. Resolves #5334 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
