### PR TITLE
Add support for forge-std imports in chisel

### DIFF
--- a/chisel/src/session_source.rs
+++ b/chisel/src/session_source.rs
@@ -312,12 +312,18 @@ impl SessionSource {
     pub fn compiler_input(&self) -> CompilerInput {
         let mut sources = Sources::new();
         sources.insert(self.file_name.clone(), Source::new(self.to_repl_source()));
-        
+
         // Include Vm.sol if forge-std remapping is not available
-        if !self.config.foundry_config.get_all_remappings().into_iter().any(|r| r.name.starts_with("forge-std")) {
+        if !self
+            .config
+            .foundry_config
+            .get_all_remappings()
+            .into_iter()
+            .any(|r| r.name.starts_with("forge-std"))
+        {
             sources.insert(PathBuf::from("forge-std/Vm.sol"), Source::new(VM_SOURCE.to_owned()));
         }
-        
+
         // we only care about the solidity source, so we can safely unwrap
         let mut compiler_input = CompilerInput::with_sources(sources)
             .into_iter()
@@ -325,10 +331,7 @@ impl SessionSource {
             .expect("Solidity source not found");
 
         // get all remappings from the config
-        compiler_input.settings.remappings = self
-            .config
-            .foundry_config
-            .get_all_remappings();
+        compiler_input.settings.remappings = self.config.foundry_config.get_all_remappings();
 
         // We also need to enforce the EVM version that the user has specified.
         compiler_input.settings.evm_version = Some(self.config.foundry_config.evm_version);


### PR DESCRIPTION
## Motivation

Closes #5326 

## Solution

Explicitly includes `forge-std/Vm.sol` into sources list only in case when `forge-std` is not available in remappings
