### PR TITLE
Expose storage altering functions in EVM Executor Backend

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -467,6 +467,23 @@ impl Backend {
         }
     }
 
+    pub fn insert_account_storage(
+        &mut self,
+        address: H160,
+        slot: U256,
+        value: U256,
+    ) -> Result<(), DatabaseError> {
+        let ret = if let Some(db) = self.active_fork_db_mut() {
+            db.insert_account_storage(h160_to_b160(address), slot.into(), value.into())
+        } else {
+            self.mem_db.insert_account_storage(h160_to_b160(address), slot.into(), value.into())
+        };
+
+        debug_assert!(self.storage(h160_to_b160(address), slot.into()).unwrap() == value.into());
+
+        ret
+    }
+
     /// Returns all snapshots created in this backend
     pub fn snapshots(&self) -> &Snapshots<BackendSnapshot<BackendDatabaseSnapshot>> {
         &self.inner.snapshots

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -655,7 +655,7 @@ impl Backend {
     }
 
     /// Returns the currently active `ForkDB`, if any
-    fn active_fork_db_mut(&mut self) -> Option<&mut ForkDB> {
+    pub fn active_fork_db_mut(&mut self) -> Option<&mut ForkDB> {
         self.active_fork_mut().map(|f| &mut f.db)
     }
 

--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -467,6 +467,7 @@ impl Backend {
         }
     }
 
+    /// Inserts a value on an account's storage without overriding account info
     pub fn insert_account_storage(
         &mut self,
         address: H160,


### PR DESCRIPTION
## Motivation

Working with Foundry EVM Executor, one can alter balance, nonce and code of an account, but not the storage.

## Solution

This PR exposes two functions
1. `active_fork_db_mut` will be `pub` (same as `active_fork_mut`)
2. Added the function `insert_account_storage` to the Backend
