### PR TITLE
Disable solc version auto detection in etherscan project

### DIFF
--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -464,6 +464,7 @@ pub fn etherscan_project(metadata: &Metadata, target_path: impl AsRef<Path>) -> 
 
     Ok(Project::builder()
         .solc_config(SolcConfig::builder().settings(settings).build())
+        .no_auto_detect()
         .paths(paths)
         .solc(solc)
         .ephemeral()


### PR DESCRIPTION


## Motivation

When compiling an etherscan project, we want solc version to be taken from etherscan, and not be automatically chosen.

## Solution

disable automatic detection
