### PR TITLE
feat(cast): output raw tx

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -676,8 +676,13 @@ where
             .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?;
 
         Ok(if let Some(ref field) = field {
-            get_pretty_tx_attr(&tx, field)
-                .ok_or_else(|| eyre::eyre!("invalid tx field: {}", field))?
+            match field.as_ref() {
+                "raw" => {
+                    format!("0x{}", hex::encode(tx.rlp()))
+                }
+                _ => get_pretty_tx_attr(&tx, field)
+                    .ok_or_else(|| eyre::eyre!("invalid tx field: {}", field.to_string()))?,
+            }
         } else if to_json {
             // to_value first to sort json object keys
             serde_json::to_value(&tx)?.to_string()

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -657,7 +657,7 @@ where
     /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
     /// let cast = Cast::new(provider);
     /// let tx_hash = "0xf8d1713ea15a81482958fb7ddf884baee8d3bcc478c5f2f604e008dc788ee4fc";
-    /// let tx = cast.transaction(tx_hash.to_string(), None, false).await?;
+    /// let tx = cast.transaction(tx_hash.to_string(), None, false, false).await?;
     /// println!("{}", tx);
     /// # Ok(())
     /// # }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -10,7 +10,7 @@ use ethers::{
 use foundry_cli::{
     cmd::Cmd,
     handler,
-    opts::cast::{Opts, Subcommands, ToBaseArgs, TransactionFields},
+    opts::cast::{Opts, Subcommands, ToBaseArgs},
     prompt, stdin, utils,
 };
 use foundry_common::{
@@ -346,12 +346,9 @@ async fn main() -> eyre::Result<()> {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
 
-            let raw = raw || matches!(field, Some(TransactionFields::Raw));
+            // Can use either --raw or specify raw as a field
+            let raw = raw || field.as_ref().is_some_and(|f| f == "raw");
 
-            let field = field.and_then(|field| match field {
-                TransactionFields::Other(field) => Some(field),
-                _ => None,
-            });
             println!("{}", Cast::new(&provider).transaction(tx_hash, field, raw, json).await?)
         }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -385,7 +385,8 @@ pub enum Subcommands {
         /// The transaction hash.
         tx_hash: String,
 
-        /// If specified, only get the given field of the transaction.
+        /// If specified, only get the given field of the transaction. If "raw", the RLP encoded
+        /// transaction will be printed.
         field: Option<String>,
 
         /// Print as JSON.

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -390,7 +390,7 @@ pub enum Subcommands {
         field: Option<String>,
 
         /// Print the raw RLP encoded transaction.
-        #[clap(long)]
+        #[clap(long, conflicts_with = "field")]
         raw: bool,
 
         /// Print as JSON.

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -387,7 +387,11 @@ pub enum Subcommands {
 
         /// If specified, only get the given field of the transaction. If "raw", the RLP encoded
         /// transaction will be printed.
-        field: Option<String>,
+        field: Option<TransactionFields>,
+
+        /// Print the raw RLP encoded transaction.
+        #[clap(long)]
+        raw: bool,
 
         /// Print as JSON.
         #[clap(long, short, help_heading = "Display options")]
@@ -845,6 +849,24 @@ pub enum Subcommands {
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
     },
+}
+
+/// Known transaction fields with special handling.
+#[derive(Debug, Clone)]
+pub enum TransactionFields {
+    Raw, // Raw transaction data as hex-encoded RLP.
+    Other(String),
+}
+
+impl FromStr for TransactionFields {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "raw" => Ok(TransactionFields::Raw),
+            _ => Ok(TransactionFields::Other(s.to_string())),
+        }
+    }
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -387,7 +387,7 @@ pub enum Subcommands {
 
         /// If specified, only get the given field of the transaction. If "raw", the RLP encoded
         /// transaction will be printed.
-        field: Option<TransactionFields>,
+        field: Option<String>,
 
         /// Print the raw RLP encoded transaction.
         #[clap(long)]
@@ -849,24 +849,6 @@ pub enum Subcommands {
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
     },
-}
-
-/// Known transaction fields with special handling.
-#[derive(Debug, Clone)]
-pub enum TransactionFields {
-    Raw, // Raw transaction data as hex-encoded RLP.
-    Other(String),
-}
-
-impl FromStr for TransactionFields {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "raw" => Ok(TransactionFields::Raw),
-            _ => Ok(TransactionFields::Other(s.to_string())),
-        }
-    }
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -480,3 +480,24 @@ casttest!(cast_logs_sig_2, |_: TestProject, mut cmd: TestCommand| {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cast_logs.stdout"),
     );
 });
+
+// tests that the raw encoded transaction is returned
+casttest!(cast_tx_raw, |_: TestProject, mut cmd: TestCommand| {
+    let rpc = next_http_rpc_endpoint();
+
+    // <https://etherscan.io/tx/0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e>
+    cmd.cast_fuse().args([
+        "tx",
+        "0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e",
+        "raw",
+        "--rpc-url",
+        rpc.as_str(),
+    ]);
+    let output = cmd.stdout_lossy();
+
+    // <https://etherscan.io/getRawTx?tx=0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e>
+    assert_eq!(
+        output.trim(),
+        "0xf86d824c548502743b65088275309491da5bf3f8eb72724e6f50ec6c3d199c6355c59c87a0a73f33e9e4cc8025a0428518b1748a08bbeb2392ea055b418538944d30adfc2accbbfa8362a401d3a4a07d6093ab2580efd17c11b277de7664fce56e6953cae8e925bec3313399860470"
+    );
+});

--- a/cli/tests/it/cast.rs
+++ b/cli/tests/it/cast.rs
@@ -500,4 +500,14 @@ casttest!(cast_tx_raw, |_: TestProject, mut cmd: TestCommand| {
         output.trim(),
         "0xf86d824c548502743b65088275309491da5bf3f8eb72724e6f50ec6c3d199c6355c59c87a0a73f33e9e4cc8025a0428518b1748a08bbeb2392ea055b418538944d30adfc2accbbfa8362a401d3a4a07d6093ab2580efd17c11b277de7664fce56e6953cae8e925bec3313399860470"
     );
+
+    cmd.cast_fuse().args([
+        "tx",
+        "0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e",
+        "--raw",
+        "--rpc-url",
+        rpc.as_str(),
+    ]);
+    let output2 = cmd.stdout_lossy();
+    assert_eq!(output, output2);
 });


### PR DESCRIPTION
## Motivation

Often it is useful to get the raw encoded transaction from an RPC provider. 

## Solution

Implement the "raw" field for `cast tx` which if specified returns the RLP transaction instead of the transaction fields. 

```
cast tx 0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e raw
0xf86d824c548502743b65088275309491da5bf3f8eb72724e6f50ec6c3d199c6355c59c87a0a73f33e9e4cc8025a0428518b1748a08bbeb2392ea055b418538944d30adfc2accbbfa8362a401d3a4a07d6093ab2580efd17c11b277de7664fce56e6953cae8e925bec3313399860470
```

This is the same output as:

https://etherscan.io/getRawTx?tx=0x44f2aaa351460c074f2cb1e5a9e28cbc7d83f33e425101d2de14331c7b7ec31e

Some RPC (`geth`) endpoints support `eth_GetRawTransactionByHash` but this is not always available, as is the case with Alchemy. 
