### PR TITLE
fix(`anvil`): properly make block gas limit unlimited if disabled

### DIFF
--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -871,7 +871,7 @@ latest block number: {latest_block}"
                 // limit is enabled, since there are networks where this is not used and is always
                 // `0x0` which would inevitably result in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
                 let gas_limit = if self.disable_block_gas_limit || block.gas_limit.is_zero() {
-                    u256_to_ru256(U256::max_value())
+                    u256_to_ru256(u64::MAX.into())
                 } else {
                     u256_to_ru256(block.gas_limit)
                 };

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -867,10 +867,10 @@ latest block number: {latest_block}"
                     panic!("Failed to get block for block number: {fork_block_number}")
                 };
 
-                // we only use the gas limit value of the block if it is non-zero, since there are networks where this is not used and is always `0x0` which would inevitably result in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
-
-                let gas_limit = if block.gas_limit.is_zero() {
-                    env.block.gas_limit
+                // we only use the gas limit value of the block if it is non-zero and the block gas limit is enabled, since there are networks where this is not used and is always `0x0` which would inevitably result
+                // in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
+                let gas_limit = if self.disable_block_gas_limit || block.gas_limit.is_zero() {
+                    u256_to_ru256(U256::max_value())
                 } else {
                     u256_to_ru256(block.gas_limit)
                 };

--- a/anvil/src/config.rs
+++ b/anvil/src/config.rs
@@ -867,8 +867,9 @@ latest block number: {latest_block}"
                     panic!("Failed to get block for block number: {fork_block_number}")
                 };
 
-                // we only use the gas limit value of the block if it is non-zero and the block gas limit is enabled, since there are networks where this is not used and is always `0x0` which would inevitably result
-                // in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
+                // we only use the gas limit value of the block if it is non-zero and the block gas
+                // limit is enabled, since there are networks where this is not used and is always
+                // `0x0` which would inevitably result in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
                 let gas_limit = if self.disable_block_gas_limit || block.gas_limit.is_zero() {
                     u256_to_ru256(U256::max_value())
                 } else {

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -2177,7 +2177,8 @@ impl TransactionValidator for Backend {
             return Err(InvalidTransactionError::GasTooLow)
         }
 
-        if tx.gas_limit() > env.block.gas_limit.into() {
+        // Check gas limit, iff block gas limit is set.
+        if !env.cfg.disable_block_gas_limit && tx.gas_limit() > env.block.gas_limit.into() {
             warn!(target: "backend", "[{:?}] gas too high", tx.hash());
             return Err(InvalidTransactionError::GasTooHigh)
         }


### PR DESCRIPTION
## Motivation

Closes #5341 

Right now, anvil does not properly set everything to handle unlimited block gas limit, if the `disable_block_gas_limit` flag is passed in.

## Solution

properly set all the require configs