### PR TITLE
chore(`tests`): add `sparklend` as external forking integration test

### DIFF
--- a/cli/tests/it/integration.rs
+++ b/cli/tests/it/integration.rs
@@ -33,4 +33,5 @@ mod fork_integration {
     );
     forgetest_external!(gunilev, "hexonaut/guni-lev", 13633752);
     forgetest_external!(convex, "mds1/convex-shutdown-simulation", 14445961);
+    forgetest_external!(sparklend, "marsfoundation/sparklend");
 }


### PR DESCRIPTION

## Motivation

Sparklend is a pretty complex repo that is still straightforward to run tests on—and has managed to uncover several edge cases in our linking code. We should include it from now on to ensure new changes are good

## Solution

Include `sparklend` as a forking integration test (as it needs an external rpc url to run some of the tests)