### PR TITLE
fix(doc): move all flattened options to end of argument lists

### DIFF
--- a/anvil/src/cmd.rs
+++ b/anvil/src/cmd.rs
@@ -28,9 +28,6 @@ use tracing::{error, trace};
 
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {
-    #[clap(flatten)]
-    pub evm_opts: AnvilEvmArgs,
-
     /// Port number to listen on.
     #[clap(long, short, default_value = "8545", value_name = "NUM")]
     pub port: u16,
@@ -56,9 +53,6 @@ pub struct NodeArgs {
     /// [default: m/44'/60'/0'/0/]
     #[clap(long)]
     pub derivation_path: Option<String>,
-
-    #[clap(flatten)]
-    pub server_config: ServerConfig,
 
     /// Don't print anything on startup and don't print logs
     #[clap(long)]
@@ -150,6 +144,12 @@ pub struct NodeArgs {
     /// Number of blocks with transactions to keep in memory.
     #[clap(long)]
     pub transaction_block_keeper: Option<usize>,
+
+    #[clap(flatten)]
+    pub evm_opts: AnvilEvmArgs,
+
+    #[clap(flatten)]
+    pub server_config: ServerConfig,
 }
 
 #[cfg(windows)]

--- a/chisel/src/bin/chisel.rs
+++ b/chisel/src/bin/chisel.rs
@@ -40,14 +40,14 @@ pub(crate) const VERSION_MESSAGE: &str = concat!(
 #[derive(Debug, Parser)]
 #[clap(name = "chisel", version = VERSION_MESSAGE)]
 pub struct ChiselParser {
+    #[command(subcommand)]
+    pub sub: Option<ChiselParserSub>,
+
     #[clap(flatten)]
     pub opts: BuildArgs,
 
     #[clap(flatten)]
     pub evm_opts: EvmArgs,
-
-    #[command(subcommand)]
-    pub sub: Option<ChiselParserSub>,
 }
 
 /// Chisel binary subcommands

--- a/cli/src/cmd/cast/access_list.rs
+++ b/cli/src/cmd/cast/access_list.rs
@@ -40,12 +40,6 @@ pub struct AccessListArgs {
     )]
     data: Option<String>,
 
-    #[clap(flatten)]
-    tx: TransactionOpts,
-
-    #[clap(flatten)]
-    eth: EthereumOpts,
-
     /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
@@ -55,6 +49,12 @@ pub struct AccessListArgs {
     /// Print the access list as JSON.
     #[clap(long, short, help_heading = "Display options")]
     json: bool,
+
+    #[clap(flatten)]
+    tx: TransactionOpts,
+
+    #[clap(flatten)]
+    eth: EthereumOpts,
 }
 
 impl AccessListArgs {

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -10,6 +10,7 @@ use eyre::WrapErr;
 use foundry_config::Config;
 use std::str::FromStr;
 
+/// CLI arguments for `cast call`.
 #[derive(Debug, Parser)]
 pub struct CallArgs {
     /// The destination of the transaction.
@@ -30,12 +31,6 @@ pub struct CallArgs {
     )]
     data: Option<String>,
 
-    #[clap(flatten)]
-    tx: TransactionOpts,
-
-    #[clap(flatten)]
-    eth: EthereumOpts,
-
     /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
@@ -45,6 +40,12 @@ pub struct CallArgs {
     /// Simulate a contract deployment.
     #[clap(subcommand)]
     command: Option<CallSubcommands>,
+
+    #[clap(flatten)]
+    tx: TransactionOpts,
+
+    #[clap(flatten)]
+    eth: EthereumOpts,
 }
 
 #[derive(Debug, Parser)]

--- a/cli/src/cmd/cast/logs.rs
+++ b/cli/src/cmd/cast/logs.rs
@@ -18,11 +18,9 @@ use itertools::Itertools;
 
 use std::str::FromStr;
 
-/// CLI arguments for `cast access-list`.
+/// CLI arguments for `cast logs`.
 #[derive(Debug, Parser)]
 pub struct LogsArgs {
-    #[clap(flatten)]
-    eth: EthereumOpts,
     /// The block height to start query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
@@ -55,6 +53,9 @@ pub struct LogsArgs {
     /// Print the logs as JSON.
     #[clap(long, short, help_heading = "Display options")]
     json: bool,
+
+    #[clap(flatten)]
+    eth: EthereumOpts,
 }
 
 impl LogsArgs {

--- a/cli/src/cmd/cast/send.rs
+++ b/cli/src/cmd/cast/send.rs
@@ -31,12 +31,6 @@ pub struct SendTxArgs {
     #[clap(name = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
     cast_async: bool,
 
-    #[clap(flatten)]
-    tx: TransactionOpts,
-
-    #[clap(flatten)]
-    eth: EthereumOpts,
-
     /// The number of confirmations until the receipt is fetched.
     #[clap(long, default_value = "1")]
     confirmations: usize,
@@ -55,6 +49,12 @@ pub struct SendTxArgs {
     /// Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM as sender
     #[clap(long, requires = "from")]
     unlocked: bool,
+
+    #[clap(flatten)]
+    tx: TransactionOpts,
+
+    #[clap(flatten)]
+    eth: EthereumOpts,
 }
 
 #[derive(Debug, Parser)]

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -31,10 +31,6 @@ pub struct CoreBuildArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub compiler: CompilerArgs,
-
     /// Ignore solc warnings by error code.
     #[clap(long, help_heading = "Compiler options", value_name = "ERROR_CODES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -68,10 +64,6 @@ pub struct CoreBuildArgs {
     #[clap(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub via_ir: bool,
-
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub project_paths: ProjectPathsArgs,
 
     /// The path to the contract artifacts folder.
     #[clap(
@@ -112,6 +104,14 @@ pub struct CoreBuildArgs {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_info_path: Option<PathBuf>,
+
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub compiler: CompilerArgs,
+
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub project_paths: ProjectPathsArgs,
 }
 
 impl CoreBuildArgs {

--- a/cli/src/cmd/forge/build/mod.rs
+++ b/cli/src/cmd/forge/build/mod.rs
@@ -56,10 +56,6 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 #[derive(Debug, Clone, Parser, Serialize, Default)]
 #[clap(next_help_heading = "Build options", about = None, long_about = None)] // override doc
 pub struct BuildArgs {
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub args: CoreBuildArgs,
-
     /// Print compiled contract names.
     #[clap(long)]
     #[serde(skip)]
@@ -76,6 +72,10 @@ pub struct BuildArgs {
     #[clap(long, num_args(1..))]
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
+
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub args: CoreBuildArgs,
 
     #[clap(flatten)]
     #[serde(skip)]

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -45,15 +45,6 @@ pub struct CreateArgs {
     )]
     constructor_args_path: Option<PathBuf>,
 
-    #[clap(flatten)]
-    opts: CoreBuildArgs,
-
-    #[clap(flatten)]
-    tx: TransactionOpts,
-
-    #[clap(flatten)]
-    eth: EthereumOpts,
-
     /// Print the deployment information as JSON.
     #[clap(long, help_heading = "Display options")]
     json: bool,
@@ -65,6 +56,15 @@ pub struct CreateArgs {
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
     #[clap(long, requires = "from")]
     unlocked: bool,
+
+    #[clap(flatten)]
+    opts: CoreBuildArgs,
+
+    #[clap(flatten)]
+    tx: TransactionOpts,
+
+    #[clap(flatten)]
+    eth: EthereumOpts,
 
     #[clap(flatten)]
     pub verifier: verify::VerifierArgs,

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -22,9 +22,6 @@ pub struct InitArgs {
     #[clap(long, short)]
     template: Option<String>,
 
-    #[clap(flatten)]
-    opts: DependencyInstallOpts,
-
     /// Do not install dependencies from the network.
     #[clap(long, conflicts_with = "template", visible_alias = "no-deps")]
     offline: bool,
@@ -37,6 +34,9 @@ pub struct InitArgs {
     /// file.
     #[clap(long, conflicts_with = "template")]
     vscode: bool,
+
+    #[clap(flatten)]
+    opts: DependencyInstallOpts,
 }
 
 impl Cmd for InitArgs {

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -44,15 +44,15 @@ pub struct InstallArgs {
     /// The dependency will installed to `lib/<alias>`.
     dependencies: Vec<Dependency>,
 
-    #[clap(flatten)]
-    opts: DependencyInstallOpts,
-
     /// The project's root path.
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
+
+    #[clap(flatten)]
+    opts: DependencyInstallOpts,
 }
 
 impl_figment_convert_basic!(InstallArgs);

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -134,15 +134,6 @@ pub struct ScriptArgs {
     #[clap(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
 
-    #[clap(flatten)]
-    pub opts: BuildArgs,
-
-    #[clap(flatten)]
-    pub wallets: MultiWallet,
-
-    #[clap(flatten)]
-    pub evm_opts: EvmArgs,
-
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
     #[clap(
         long,
@@ -183,9 +174,6 @@ pub struct ScriptArgs {
     #[clap(long)]
     pub verify: bool,
 
-    #[clap(flatten)]
-    pub verifier: super::verify::VerifierArgs,
-
     /// Output results in JSON format.
     #[clap(long)]
     pub json: bool,
@@ -198,6 +186,18 @@ pub struct ScriptArgs {
         value_name = "PRICE",
     )]
     pub with_gas_price: Option<U256>,
+
+    #[clap(flatten)]
+    pub opts: BuildArgs,
+
+    #[clap(flatten)]
+    pub wallets: MultiWallet,
+
+    #[clap(flatten)]
+    pub evm_opts: EvmArgs,
+
+    #[clap(flatten)]
+    pub verifier: super::verify::VerifierArgs,
 
     #[clap(flatten)]
     pub retry: RetryArgs,

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -33,14 +33,6 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
 /// CLI arguments for `forge snapshot`.
 #[derive(Debug, Clone, Parser)]
 pub struct SnapshotArgs {
-    /// All test arguments are supported
-    #[clap(flatten)]
-    pub(crate) test: test::TestArgs,
-
-    /// Additional configs for test results
-    #[clap(flatten)]
-    config: SnapshotConfig,
-
     /// Output a diff against a pre-existing snapshot.
     ///
     /// By default, the comparison is done with .gas-snapshot.
@@ -86,6 +78,14 @@ pub struct SnapshotArgs {
         value_name = "SNAPSHOT_THRESHOLD"
     )]
     tolerance: Option<u32>,
+
+    /// All test arguments are supported
+    #[clap(flatten)]
+    pub(crate) test: test::TestArgs,
+
+    /// Additional configs for test results
+    #[clap(flatten)]
+    config: SnapshotConfig,
 }
 
 impl SnapshotArgs {

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -48,9 +48,6 @@ foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
 #[derive(Debug, Clone, Parser)]
 #[clap(next_help_heading = "Test options")]
 pub struct TestArgs {
-    #[clap(flatten)]
-    filter: FilterArgs,
-
     /// Run a test in the debugger.
     ///
     /// The argument passed to this flag is the name of the test function you want to run, and it
@@ -85,18 +82,9 @@ pub struct TestArgs {
     #[clap(long)]
     pub fail_fast: bool,
 
-    #[clap(flatten)]
-    evm_opts: EvmArgs,
-
     /// The Etherscan (or equivalent) API key
     #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     etherscan_api_key: Option<String>,
-
-    #[clap(flatten)]
-    opts: CoreBuildArgs,
-
-    #[clap(flatten)]
-    pub watch: WatchArgs,
 
     /// List tests instead of running them
     #[clap(long, short, help_heading = "Display options")]
@@ -108,6 +96,18 @@ pub struct TestArgs {
 
     #[clap(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]
     pub fuzz_runs: Option<u64>,
+
+    #[clap(flatten)]
+    filter: FilterArgs,
+
+    #[clap(flatten)]
+    evm_opts: EvmArgs,
+
+    #[clap(flatten)]
+    opts: CoreBuildArgs,
+
+    #[clap(flatten)]
+    pub watch: WatchArgs,
 }
 
 impl TestArgs {

--- a/cli/src/cmd/forge/verify/mod.rs
+++ b/cli/src/cmd/forge/verify/mod.rs
@@ -62,9 +62,6 @@ pub struct VerifyArgs {
     #[clap(long, visible_alias = "optimizer-runs", value_name = "NUM")]
     pub num_of_optimizations: Option<usize>,
 
-    #[clap(flatten)]
-    pub etherscan: EtherscanOpts,
-
     /// Flatten the source code before verifying.
     #[clap(long)]
     pub flatten: bool,
@@ -77,9 +74,6 @@ pub struct VerifyArgs {
     #[clap(long)]
     pub watch: bool,
 
-    #[clap(flatten)]
-    pub retry: RetryArgs,
-
     /// Set pre-linked libraries.
     #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     pub libraries: Vec<String>,
@@ -91,15 +85,21 @@ pub struct VerifyArgs {
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
-    #[clap(flatten)]
-    pub verifier: VerifierArgs,
-
     /// Prints the standard json compiler input.
     ///
     /// The standard json compiler input can be used to manually submit contract verification in
     /// the browser.
     #[clap(long, conflicts_with = "flatten")]
     pub show_standard_json_input: bool,
+
+    #[clap(flatten)]
+    pub etherscan: EtherscanOpts,
+
+    #[clap(flatten)]
+    pub retry: RetryArgs,
+
+    #[clap(flatten)]
+    pub verifier: VerifierArgs,
 }
 
 impl_figment_convert!(VerifyArgs);

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -276,12 +276,12 @@ pub enum Subcommands {
         "2r"]
     )]
     ToBase {
-        #[clap(flatten)]
-        base: ToBaseArgs,
-
         /// The output base.
         #[clap(value_name = "BASE")]
         base_out: Option<String>,
+
+        #[clap(flatten)]
+        base: ToBaseArgs,
     },
     /// Create an access list for a transaction.
     #[clap(visible_aliases = &["ac", "acl"])]

--- a/common/src/evm.rs
+++ b/common/src/evm.rs
@@ -101,11 +101,6 @@ pub struct EvmArgs {
     #[serde(skip)]
     pub verbosity: u8,
 
-    /// All ethereum environment related arguments
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub env: EnvArgs,
-
     /// Sets the number of assumed available compute units per second for this provider
     ///
     /// default value: 330
@@ -132,6 +127,11 @@ pub struct EvmArgs {
     )]
     #[serde(skip)]
     pub no_rpc_rate_limit: bool,
+
+    /// All ethereum environment related arguments
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub env: EnvArgs,
 }
 
 // Make this set of options a `figment::Provider` so that it can be merged into the `Config`


### PR DESCRIPTION
## Motivation

Arguments that use `#[clap(flatten)]` result in all subsequent options falling under the same heading as the last flattened option. As an example `cast send --help` lists all the command specific options under `Wallet options` instead of `Options`. 

```
cast send --help

Wallet options:
      --confirmations <CONFIRMATIONS>
          The number of confirmations until the receipt is fetched
          
          [default: 1]

      --resend
          Reuse the latest nonce for the sender account

      --unlocked
          Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM as
          sender
```


## Solution

Ensure that all cases where options are added using `#clap(flatten)` that they are at the end of the argument list. Currently will list all command specific options under `Options` heading. Worth considering rewriting it to `Command Options`?

```
Options:
      --async
          Only print the transaction hash and exit immediately
          
          [env: CAST_ASYNC=]

      --confirmations <CONFIRMATIONS>
          The number of confirmations until the receipt is fetched
          
          [default: 1]

      --resend
          Reuse the latest nonce for the sender account

      --unlocked
          Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM as
          sender

  -h, --help
          Print help (see a summary with '-h')

```
