### PR TITLE
fix(`ci`): use single line command for windows test

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -74,9 +74,7 @@ jobs:
 
             - name: Build archive (unit tests)
               run: |
-                  cargo nextest archive \
-                  --locked ${{ matrix.job.flags }} \
-                  --archive-file ${{ matrix.job.target }}-${{ matrix.archive.file }}
+                  cargo nextest archive --locked ${{ matrix.job.flags }} --archive-file ${{ matrix.job.target }}-${{ matrix.archive.file }}
             - name: Upload archive
               uses: actions/upload-artifact@v3
               with:


### PR DESCRIPTION
Windows cross plat builds are failing due to using a multi line command—let's just put everything in a single line, doesn't hurt

Should start to alleviate CI and let these tests build
