### PR TITLE
change etherscan root folder

### DIFF
--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -454,9 +454,9 @@ pub fn etherscan_project(metadata: &Metadata, target_path: impl AsRef<Path>) -> 
     //   ContractName/
     //     [source code]
     let paths = ProjectPathsConfig::builder()
-        .sources(sources_path)
+        .sources(sources_path.clone())
         .remappings(settings.remappings.clone())
-        .build_with_root(target_path);
+        .build_with_root(sources_path);
 
     let v = metadata.compiler_version()?;
     let v = format!("{}.{}.{}", v.major, v.minor, v.patch);


### PR DESCRIPTION
## Motivation

Currently, etherscan verified contract with with [Direct Imports](https://docs.soliditylang.org/en/v0.8.20/path-resolution.html#direct-imports) fails to compile
https://etherscan.io/address/0x15afc6fb4b76727a725709d7cd61742e4c3d2897#code as an example

## Solution

Set the root path of the project to be the source path (haven't found any better way)
