### PR TITLE
chore: change outdated clap::_derive reference

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Foundry CLIs
 
-The CLIs are written using [clap's](https://docs.rs/clap) [derive feature](https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md).
+The CLIs are written using [clap's](https://docs.rs/clap) [derive feature](https://docs.rs/clap/latest/clap/_derive).
 
 ## Installation
 


### PR DESCRIPTION
## Motivation

After https://github.com/clap-rs/clap/commit/d43f1dbf6f1f7865dccfece0e1605a12efb76670#diff-941dad1b645f696e69334cbff5b923dd8905d3981d6d23872d56da67f9110c50, all doc files were moved to `docs.rs`, removing the referenced README

## Solution

Just changing the reference to point to docs.rs
