### PR TITLE
feat: remapping contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1759,6 +1760,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1769,6 +1771,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1787,6 +1790,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1809,6 +1813,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1823,6 +1828,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1851,6 +1857,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1865,6 +1872,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1890,6 +1898,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1926,6 +1935,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1952,6 +1962,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,8 +1745,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b4026b97da8281276744741fac7eb385da905f6093c583331fa2953fdd4253"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1761,8 +1760,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcb6ffefc230d8c42874c51b28dc11dbb8de50b27a8fdf92648439d6baa68dc"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1773,8 +1771,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4719a44c3d37ab07c6dea99ab174068d8c35e441b60b6c20ce4e48357273e8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1793,8 +1790,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155ea1b84d169d231317ed86e307af6f2bed6b40dd17e5e94bc84da21cadb21c"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1817,8 +1813,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8567ff196c4a37c1a8c90ec73bda0ad2062e191e4f0a6dc4d943e2ec4830fc88"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1833,8 +1828,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1863,8 +1857,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b3a8269d3df0ed6364bc05b4735b95f4bf830ce3aef87d5e760fb0e93e5b91"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1879,8 +1872,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c339aad74ae5c451d27e0e49c7a3c7d22620b119b4f9291d7aa21f72d7f366"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1906,8 +1898,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b411b119f1cf0efb69e2190883dee731251882bb21270f893ee9513b3a697c48"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1944,8 +1935,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4864d387456a9c09a1157fa10e1528b29d90f1d859443acf06a1b23365fb518c"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1972,8 +1962,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6c2b9625a2c639d46625f88acc2092a3cb35786c37f7c2128b3ca20f639b3c"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1760,7 +1760,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#67147d56c4ce3ce3f2c30d089747b59ab7d2df4f"
+source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,8 +1744,8 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1759,8 +1759,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1770,8 +1770,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1789,8 +1789,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1812,8 +1812,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1827,8 +1827,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1856,8 +1856,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1871,8 +1871,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1897,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1934,8 +1934,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1961,8 +1961,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.7"
-source = "git+https://github.com/onbjerg/ethers-rs?branch=onbjerg/remapping-context#9c5488421f4df55ea7347994ad2d154df3d9bf1e"
+version = "2.0.8"
+source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,8 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b4026b97da8281276744741fac7eb385da905f6093c583331fa2953fdd4253"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1760,7 +1761,8 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcb6ffefc230d8c42874c51b28dc11dbb8de50b27a8fdf92648439d6baa68dc"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1771,7 +1773,8 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4719a44c3d37ab07c6dea99ab174068d8c35e441b60b6c20ce4e48357273e8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1790,7 +1793,8 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155ea1b84d169d231317ed86e307af6f2bed6b40dd17e5e94bc84da21cadb21c"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1813,7 +1817,8 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8567ff196c4a37c1a8c90ec73bda0ad2062e191e4f0a6dc4d943e2ec4830fc88"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1828,7 +1833,8 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1857,7 +1863,8 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b3a8269d3df0ed6364bc05b4735b95f4bf830ce3aef87d5e760fb0e93e5b91"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1872,7 +1879,8 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c339aad74ae5c451d27e0e49c7a3c7d22620b119b4f9291d7aa21f72d7f366"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1898,7 +1906,8 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b411b119f1cf0efb69e2190883dee731251882bb21270f893ee9513b3a697c48"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1935,7 +1944,8 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4864d387456a9c09a1157fa10e1528b29d90f1d859443acf06a1b23365fb518c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1962,7 +1972,8 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#030bf439a100dcacd2e968e3114de0612229056b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6c2b9625a2c639d46625f88acc2092a3cb35786c37f7c2128b3ca20f639b3c"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,6 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1760,7 +1759,6 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1771,7 +1769,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1790,7 +1787,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1813,7 +1809,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1828,7 +1823,6 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1857,7 +1851,6 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1872,7 +1865,6 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1898,7 +1890,6 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1935,7 +1926,6 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1962,7 +1952,6 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.7"
-source = "git+https://github.com/gakonst/ethers-rs#f9c72f222cbf82219101c8772cfa49ba4205ef1d"
 dependencies = [
  "cfg-if",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,21 +61,21 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers = { path = "../../gakonst/ethers-rs/ethers", default-features = false }
+ethers-addressbook = { path = "../../gakonst/ethers-rs/ethers-addressbook", default-features = false }
+ethers-core = { path = "../../gakonst/ethers-rs/ethers-core", default-features = false }
+ethers-contract = { path = "../../gakonst/ethers-rs/ethers-contract", default-features = false }
+ethers-contract-abigen = { path = "../../gakonst/ethers-rs/ethers-contract/ethers-contract-abigen", default-features = false }
+ethers-providers = { path = "../../gakonst/ethers-rs/ethers-providers", default-features = false }
+ethers-signers = { path = "../../gakonst/ethers-rs/ethers-signers", default-features = false }
+ethers-middleware = { path = "../../gakonst/ethers-rs/ethers-middleware", default-features = false }
+ethers-etherscan = { path = "../../gakonst/ethers-rs/ethers-etherscan", default-features = false }
+ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc", default-features = false }
 
 solang-parser = "=0.3.1"
 
 [patch.crates-io]
-# ethers = { path = "../ethers-rs/ethers" }
+# ethers = { path = "../../gakonst/ethers-rs/ethers" }
 # ethers-addressbook = { path = "../ethers-rs/ethers-addressbook" }
 # ethers-contract = { path = "../ethers-rs/ethers-contract" }
 # ethers-contract-abigen = { path = "../ethers-rs/ethers-contract/ethers-contract-abigen" }
@@ -84,5 +84,5 @@ solang-parser = "=0.3.1"
 # ethers-middleware = { path = "../ethers-rs/ethers-middleware" }
 # ethers-providers = { path = "../ethers-rs/ethers-providers" }
 # ethers-signers = { path = "../ethers-rs/ethers-signers" }
-# ethers-solc = { path = "../ethers-rs/ethers-solc" }
+# ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc" }
 revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,16 +61,16 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { version = "2.0.8", default-features = false }
-ethers-addressbook = { version = "2.0.8", default-features = false }
-ethers-core = { version = "2.0.8", default-features = false }
-ethers-contract = { version = "2.0.8", default-features = false }
-ethers-contract-abigen = { version = "2.0.8", default-features = false }
-ethers-providers = { version = "2.0.8", default-features = false }
-ethers-signers = { version = "2.0.8", default-features = false }
-ethers-middleware = { version = "2.0.8", default-features = false }
-ethers-etherscan = { version = "2.0.8", default-features = false }
-ethers-solc = { version = "2.0.8", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 solang-parser = "=0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,16 +61,16 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers = { version = "2.0.8", default-features = false }
+ethers-addressbook = { version = "2.0.8", default-features = false }
+ethers-core = { version = "2.0.8", default-features = false }
+ethers-contract = { version = "2.0.8", default-features = false }
+ethers-contract-abigen = { version = "2.0.8", default-features = false }
+ethers-providers = { version = "2.0.8", default-features = false }
+ethers-signers = { version = "2.0.8", default-features = false }
+ethers-middleware = { version = "2.0.8", default-features = false }
+ethers-etherscan = { version = "2.0.8", default-features = false }
+ethers-solc = { version = "2.0.8", default-features = false }
 
 solang-parser = "=0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,16 +61,16 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-addressbook = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-core = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-contract = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-contract-abigen = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-providers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-signers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-middleware = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-etherscan = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
-ethers-solc = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 solang-parser = "=0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,21 +61,21 @@ panic = "abort"
 codegen-units = 1
 
 [workspace.dependencies]
-ethers = { path = "../../gakonst/ethers-rs/ethers", default-features = false }
-ethers-addressbook = { path = "../../gakonst/ethers-rs/ethers-addressbook", default-features = false }
-ethers-core = { path = "../../gakonst/ethers-rs/ethers-core", default-features = false }
-ethers-contract = { path = "../../gakonst/ethers-rs/ethers-contract", default-features = false }
-ethers-contract-abigen = { path = "../../gakonst/ethers-rs/ethers-contract/ethers-contract-abigen", default-features = false }
-ethers-providers = { path = "../../gakonst/ethers-rs/ethers-providers", default-features = false }
-ethers-signers = { path = "../../gakonst/ethers-rs/ethers-signers", default-features = false }
-ethers-middleware = { path = "../../gakonst/ethers-rs/ethers-middleware", default-features = false }
-ethers-etherscan = { path = "../../gakonst/ethers-rs/ethers-etherscan", default-features = false }
-ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc", default-features = false }
+ethers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-addressbook = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-core = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-contract = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-contract-abigen = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-providers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-signers = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-middleware = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-etherscan = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
+ethers-solc = { git = "https://github.com/onbjerg/ethers-rs", branch = "onbjerg/remapping-context", default-features = false }
 
 solang-parser = "=0.3.1"
 
 [patch.crates-io]
-# ethers = { path = "../../gakonst/ethers-rs/ethers" }
+# ethers = { path = "../ethers-rs/ethers" }
 # ethers-addressbook = { path = "../ethers-rs/ethers-addressbook" }
 # ethers-contract = { path = "../ethers-rs/ethers-contract" }
 # ethers-contract-abigen = { path = "../ethers-rs/ethers-contract/ethers-contract-abigen" }
@@ -84,5 +84,5 @@ solang-parser = "=0.3.1"
 # ethers-middleware = { path = "../ethers-rs/ethers-middleware" }
 # ethers-providers = { path = "../ethers-rs/ethers-providers" }
 # ethers-signers = { path = "../ethers-rs/ethers-signers" }
-# ethers-solc = { path = "../../gakonst/ethers-rs/ethers-solc" }
+# ethers-solc = { path = "../ethers-rs/ethers-solc" }
 revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -292,7 +292,7 @@ pub fn filter_sources_and_artifacts(
         .filter_map(|(id, path)| {
             let mut resolved = project
                 .paths
-                .resolve_library_import(&PathBuf::from(&path))
+                .resolve_library_import(project.root(), &PathBuf::from(&path))
                 .unwrap_or_else(|| PathBuf::from(&path));
 
             if !resolved.is_absolute() {

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -144,26 +144,36 @@ forgetest_init!(
         let foundry_toml = prj.root().join(Config::FILE_NAME);
         assert!(foundry_toml.exists());
 
-        let profile = Config::load_with_root(prj.root());
+        let mut profile = Config::load_with_root(prj.root());
+        // ensure that the auto-generated internal remapping for forge-std's ds-test exists
+        assert_eq!(profile.remappings.len(), 3);
+        pretty_eq!(
+            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/",
+            profile.remappings[2].to_string()
+        );
+
+        // remove the auto-generated remapping to compare with `forge config` since `forge config`
+        // does not include the auto-generated remappings
+        profile.remappings.remove(2);
+        assert_eq!(profile.remappings.len(), 2);
 
         // ensure remappings contain test
-        assert_eq!(profile.remappings.len(), 2);
-        assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());
+        pretty_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());
         // the loaded config has resolved, absolute paths
-        assert_eq!(
+        pretty_eq!(
             "ds-test/=lib/forge-std/lib/ds-test/src/",
             Remapping::from(profile.remappings[0].clone()).to_string()
         );
 
         cmd.arg("config");
         let expected = profile.to_string_pretty().unwrap();
-        assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
+        pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
         // remappings work
         let remappings_txt =
             prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
         let config = forge_utils::load_config_with_root(Some(prj.root().into()));
-        assert_eq!(
+        pretty_eq!(
             format!(
                 "ds-test/={}/",
                 prj.root().join("lib/forge-std/lib/ds-test/from-file").to_slash_lossy()
@@ -174,7 +184,7 @@ forgetest_init!(
         // env vars work
         std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
         let config = forge_utils::load_config_with_root(Some(prj.root().into()));
-        assert_eq!(
+        pretty_eq!(
             format!(
                 "ds-test/={}/",
                 prj.root().join("lib/forge-std/lib/ds-test/from-env").to_slash_lossy()
@@ -184,7 +194,7 @@ forgetest_init!(
 
         let config =
             prj.config_from_output(["--remappings", "ds-test/=lib/forge-std/lib/ds-test/from-cli"]);
-        assert_eq!(
+        pretty_eq!(
             format!(
                 "ds-test/={}/",
                 prj.root().join("lib/forge-std/lib/ds-test/from-cli").to_slash_lossy()
@@ -194,7 +204,7 @@ forgetest_init!(
 
         let config = prj.config_from_output(["--remappings", "other-key/=lib/other/"]);
         assert_eq!(config.remappings.len(), 3);
-        assert_eq!(
+        pretty_eq!(
             format!("other-key/={}/", prj.root().join("lib/other").to_slash_lossy()),
             Remapping::from(config.remappings[2].clone()).to_string()
         );
@@ -400,11 +410,12 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
     pretty_assertions::assert_eq!(
         remappings,
         vec![
+            // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
         ]
     );
-    // create a new lib directly in the `lib` folder
+    // create a new lib directly in the `lib` folder with a remapping
     let mut config = config;
     config.remappings = vec![Remapping::from_str("nested/=lib/nested").unwrap().into()];
     let nested = prj.paths().libraries[0].join("nested-lib");
@@ -417,10 +428,12 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
     pretty_assertions::assert_eq!(
         remappings,
         vec![
+            // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
-            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            // remapping is local to the lib
+            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 
@@ -438,12 +451,17 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
     pretty_assertions::assert_eq!(
         remappings,
         vec![
-            "another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
+            // local to the lib
+            "lib/nested-lib:another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
+            // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
-            "nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/".parse().unwrap(),
-            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            // remappings local to the lib
+            "lib/nested-lib:nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/"
+                .parse()
+                .unwrap(),
+            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 
@@ -454,12 +472,19 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
     pretty_assertions::assert_eq!(
         remappings,
         vec![
-            "another-lib/=lib/nested-lib/lib/another-lib/custom-source-dir/".parse().unwrap(),
+            // local to the lib
+            "lib/nested-lib:another-lib/=lib/nested-lib/lib/another-lib/custom-source-dir/"
+                .parse()
+                .unwrap(),
+            // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
-            "nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/".parse().unwrap(),
-            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            // remappings local to the lib
+            "lib/nested-lib:nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/"
+                .parse()
+                .unwrap(),
+            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 });

--- a/common/src/compile.rs
+++ b/common/src/compile.rs
@@ -444,6 +444,7 @@ pub fn etherscan_project(metadata: &Metadata, target_path: impl AsRef<Path>) -> 
     // add missing remappings
     if !settings.remappings.iter().any(|remapping| remapping.name.starts_with("@openzeppelin/")) {
         let oz = Remapping {
+            context: None,
             name: "@openzeppelin/".into(),
             path: sources_path.join("@openzeppelin").display().to_string(),
         };

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -90,7 +90,6 @@ impl<'a> RemappingsProvider<'a> {
             let mut lib_remappings = Vec::new();
             // find all remappings of from libs that use a foundry.toml
             for r in self.lib_foundry_toml_remappings() {
-                println!("{:#?}", r);
                 lib_remappings.push(r);
                 //insert_closest(&mut lib_remappings, r.name, r.path.into());
             }
@@ -195,7 +194,6 @@ impl<'a> Provider for RemappingsProvider<'a> {
             .into_iter()
             .map(|r| RelativeRemapping::new(r, self.root).to_string())
             .collect::<Vec<_>>();
-        println!("relative remappings: {:#?}", remappings);
 
         Ok(Map::from([(
             Config::selected_profile(),

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -159,7 +159,11 @@ pub fn foundry_toml_dirs(root: impl AsRef<Path>) -> Vec<PathBuf> {
 pub(crate) fn get_dir_remapping(dir: impl AsRef<Path>) -> Option<Remapping> {
     let dir = dir.as_ref();
     if let Some(dir_name) = dir.file_name().and_then(|s| s.to_str()).filter(|s| !s.is_empty()) {
-        let mut r = Remapping { name: format!("{dir_name}/"), path: format!("{}", dir.display()) };
+        let mut r = Remapping {
+            context: None,
+            name: format!("{dir_name}/"),
+            path: format!("{}", dir.display()),
+        };
         if !r.path.ends_with('/') {
             r.path.push('/')
         }


### PR DESCRIPTION
## Motivation

Dependencies in projects using Foundry can mess with how imports are resolved through the project because remappings from dependencies are just merged with remappings defined in the root folder.

To solve this, we make use of solc's remapping contexts.

## Solution

This PR adds support for specifying remapping contexts if necessary, but ideally it should never be. Instead, this PR also automatically scopes each remapping defined in dependencies to files in the dependency itself.

Global remappings (`context: None`) are still automatically generated for each installed dependency, making it possible to import them as usual.

This PR in other words just makes the following user-facing change: remappings defined in dependencies/libraries can no longer override remappings defined in `foundry.toml`/`remappings.txt`, and it should no longer be necessary to copy over remappings from dependencies to `foundry.toml`/`remappings.txt` for dependencies with weird remappings.

This PR also adds a `--pretty` flag to `forge remappings` that groups remappings by context. Global remappings apply to *every file* (including dependencies), and remappings with a context only apply to the paths defined by the context. The default is to *not* pretty print since a common use case of `forge remappings` is to pipe the output to a file or other command.

## Todo

- [ ] Add tests
- [x] Merge ethers PR
- [x] Remove patch

Closes https://github.com/foundry-rs/foundry/issues/3440, closes #1855

Depends on https://github.com/gakonst/ethers-rs/pull/2509