### PR TITLE
fix(`linking`): handle workspace setups by adding a fallback for artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ dependencies = [
 name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
+ "dunce",
  "ethers-addressbook",
  "ethers-contract",
  "ethers-core",

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -171,6 +171,7 @@ impl ScriptArgs {
                 highlevel_known_contracts.insert(id, tc.unwrap());
                 Ok(())
             },
+            project.root(),
         )?;
 
         let target = extra_info

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -242,7 +242,6 @@ impl MultiContractRunnerBuilder {
             .iter()
             .map(|(i, _)| (i.identifier(), root.as_ref().join(&i.source).to_string_lossy().into()))
             .collect::<BTreeMap<String, String>>();
-
         // create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
 
@@ -307,6 +306,7 @@ impl MultiContractRunnerBuilder {
                     .and_then(|bytes| known_contracts.insert(id.clone(), (abi, bytes.to_vec())));
                 Ok(())
             },
+            root,
         )?;
 
         let execution_info = known_contracts.flatten();

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -29,6 +29,7 @@ serde = "1"
 serde_json = { version = "1", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
+dunce = "1"
 
 [dev-dependencies]
 foundry-common = { path = "./../common" }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -277,7 +277,7 @@ fn recurse_link<'a>(
                         // In this case, imported dependencies from outside the root might not have their paths tripped correctly.
                         // Therefore, we fall back to a manual path join to locate the file.
                         let fallback_path =  dunce::canonicalize(root.join(file)).unwrap_or_else(|e| panic!("No artifact for contract \"{next_target}\". Attempted to compose fallback path but got got error {e}"));
-                        let fallback_path = fallback_path.to_str().unwrap_or_else(|| "No artifact for contract \"{next_target}\". Attempted to compose fallback path but could not create valid string");
+                        let fallback_path = fallback_path.to_str().unwrap_or("No artifact for contract \"{next_target}\". Attempted to compose fallback path but could not create valid string");
                         let fallback_target = format!("{fallback_path}:{key}");
 
                         trace!(target : "forge::link", fallback_dependency = fallback_target, file, key, version=?dependencies.artifact_id.version,  "get dependency with fallback path");

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -269,9 +269,12 @@ fn recurse_link<'a>(
             let ArtifactDependency {  file, key, .. } = dep;
             let next_target = format!("{file}:{key}");
             let root = PathBuf::from(root.as_ref().to_str().unwrap());
-            let path_file =  dunce::canonicalize(root.join(file)).unwrap_or_else(|_| panic!("No file named {file}"));
-            let path_file = path_file.to_str().expect("Could not convert fallback path to string");
-            let fallback_target = format!("{path_file}:{key}");
+            // In some project setups, like JS-style workspaces, you might not have node_modules available at the root of the foundry project.
+            // In this case, imported dependencies from outside the root might not have their paths tripped correctly.
+            // Therefore, we fall back to a manual path join to locate the file.
+            let fallback_path =  dunce::canonicalize(root.join(file)).unwrap_or_else(|_| panic!("No file named {file}"));
+            let fallback_path = fallback_path.to_str().expect("Could not convert fallback path to string");
+            let fallback_target = format!("{fallback_path}:{key}");
             // get the dependency
             trace!(target : "forge::link", dependency = next_target, fallback_dependency = fallback_target, file, key, version=?dependencies.artifact_id.version,  "get dependency");
             let  artifact = match artifacts

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -270,11 +270,10 @@ fn recurse_link<'a>(
             let next_target = format!("{file}:{key}");
             let root = PathBuf::from(root.as_ref().to_str().unwrap());
             let path_file =  dunce::canonicalize(root.join(file)).unwrap_or_else(|_| panic!("No file named {file}"));
-            let path_file = path_file.to_str().unwrap();
+            let path_file = path_file.to_str().expect("Could not convert fallback path to string");
             let fallback_target = format!("{path_file}:{key}");
             // get the dependency
-            trace!(target: "forge::link", ?fallback_target);
-            trace!(target : "forge::link", dependency = next_target, file, key, version=?dependencies.artifact_id.version,  "get dependency");
+            trace!(target : "forge::link", dependency = next_target, fallback_dependency = fallback_target, file, key, version=?dependencies.artifact_id.version,  "get dependency");
             let  artifact = match artifacts
                 .find_code(&next_target) {
                     Some(artifact) => artifact,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -267,21 +267,25 @@ fn recurse_link<'a>(
             let ArtifactDependency {  file, key, .. } = dep;
             let next_target = format!("{file}:{key}");
             let root = PathBuf::from(root.as_ref().to_str().unwrap());
-            // In some project setups, like JS-style workspaces, you might not have node_modules available at the root of the foundry project.
-            // In this case, imported dependencies from outside the root might not have their paths tripped correctly.
-            // Therefore, we fall back to a manual path join to locate the file.
-            let fallback_path =  dunce::canonicalize(root.join(file)).unwrap_or_else(|_| panic!("No file named {file}"));
-            let fallback_path = fallback_path.to_str().expect("Could not convert fallback path to string");
-            let fallback_target = format!("{fallback_path}:{key}");
             // get the dependency
-            trace!(target : "forge::link", dependency = next_target, fallback_dependency = fallback_target, file, key, version=?dependencies.artifact_id.version,  "get dependency");
+            trace!(target : "forge::link", dependency = next_target, file, key, version=?dependencies.artifact_id.version,  "get dependency");
             let  artifact = match artifacts
                 .find_code(&next_target) {
                     Some(artifact) => artifact,
-                    None => match artifacts.find_code(&fallback_target) {
+                    None => {
+                        // In some project setups, like JS-style workspaces, you might not have node_modules available at the root of the foundry project.
+                        // In this case, imported dependencies from outside the root might not have their paths tripped correctly.
+                        // Therefore, we fall back to a manual path join to locate the file.
+                        let fallback_path =  dunce::canonicalize(root.join(file)).unwrap_or_else(|e| panic!("No artifact for contract \"{next_target}\". Attempted to compose fallback path but got got error {e}"));
+                        let fallback_path = fallback_path.to_str().unwrap_or_else(|| "No artifact for contract \"{next_target}\". Attempted to compose fallback path but could not create valid string");
+                        let fallback_target = format!("{fallback_path}:{key}");
+
+                        trace!(target : "forge::link", fallback_dependency = fallback_target, file, key, version=?dependencies.artifact_id.version,  "get dependency with fallback path");
+
+                        match artifacts.find_code(&fallback_target) {
                         Some(artifact) => artifact,
                         None => panic!("No artifact for contract {next_target}"),
-                    },
+                    }},
                 };
             let mut next_target_bytecode = artifact
                 .bytecode

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -157,8 +157,6 @@ pub fn link_with_nonce_or_address<T, U>(
         })
         .collect();
 
-    // println!("link tree: {:#?}", link_tree);
-
     let artifacts_by_slug = AllArtifactsBySlug {
         inner: contracts
             .iter()


### PR DESCRIPTION

## Motivation

Closes #5396.

The new linking fixes broke workspace setups that have files imported from outside the project root.

## Solution

Add a fallback that is composed of the project root + the relative path obtained.
