### PR TITLE
fix(`cheatcodes`): make `parseJson` revert if key does not exist

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -273,6 +273,9 @@ fn parse_json(json_str: &str, key: &str, coerce: Option<ParamType>) -> Result {
         } else {
             util::parse(&to_string(values[0]), &coercion_type)
         }
+    } else {
+        // If the user did not specify a coercion type, we should ensure it exists as sanity check.
+        ensure!(!values.is_empty(), "No matching value or array found for key {key}");
     }
 
     let res = values


### PR DESCRIPTION
## Motivation

Closes #5369. 

Right now, it's possible to use `parseJson` to look up inexistent keys. Ideally, this should revert, as this will "fail" silently leading to unexpected situations.


## Solution

Make `parseJson` revert if key does not exist.

Should we consider this breaking @mds1 ?