### PR TITLE
Expect revert from address

### DIFF
--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -79,6 +79,9 @@ etch(address,bytes)
 expectRevert()
 expectRevert(bytes)
 expectRevert(bytes4)
+expectRevert(bytes,address)
+expectRevert(bytes4, address);
+expectRevert(address);
 record()
 accesses(address)(bytes32[],bytes32[])
 skip(bool)

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -1950,6 +1950,57 @@ pub mod hevm {
                             constant: ::core::option::Option::None,
                             state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
                         },
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("expectRevert"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Bytes,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("expectRevert"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::FixedBytes(
+                                        4usize,
+                                    ),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("expectRevert"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
                     ],
                 ),
                 (
@@ -6034,6 +6085,35 @@ pub mod hevm {
                 .method_hash([195, 30, 176, 224], p0)
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `expectRevert` (0x61ebcf12) function
+        pub fn expect_revert_4(
+            &self,
+            p0: ::ethers_core::types::Bytes,
+            p1: ::ethers_core::types::Address,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([97, 235, 207, 18], (p0, p1))
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `expectRevert` (0x260bc5de) function
+        pub fn expect_revert_5(
+            &self,
+            p0: [u8; 4],
+            p1: ::ethers_core::types::Address,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([38, 11, 197, 222], (p0, p1))
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `expectRevert` (0xd814f38a) function
+        pub fn expect_revert_3(
+            &self,
+            p0: ::ethers_core::types::Address,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([216, 20, 243, 138], p0)
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `expectSafeMemory` (0x6d016688) function
         pub fn expect_safe_memory(
             &self,
@@ -8465,6 +8545,48 @@ pub mod hevm {
     )]
     #[ethcall(name = "expectRevert", abi = "expectRevert(bytes4)")]
     pub struct ExpectRevert2Call(pub [u8; 4]);
+    ///Container type for all input parameters for the `expectRevert` function with signature `expectRevert(bytes,address)` and selector `0x61ebcf12`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "expectRevert", abi = "expectRevert(bytes,address)")]
+    pub struct ExpectRevert4Call(
+        pub ::ethers_core::types::Bytes,
+        pub ::ethers_core::types::Address,
+    );
+    ///Container type for all input parameters for the `expectRevert` function with signature `expectRevert(bytes4,address)` and selector `0x260bc5de`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "expectRevert", abi = "expectRevert(bytes4,address)")]
+    pub struct ExpectRevert5Call(pub [u8; 4], pub ::ethers_core::types::Address);
+    ///Container type for all input parameters for the `expectRevert` function with signature `expectRevert(address)` and selector `0xd814f38a`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "expectRevert", abi = "expectRevert(address)")]
+    pub struct ExpectRevert3Call(pub ::ethers_core::types::Address);
     ///Container type for all input parameters for the `expectSafeMemory` function with signature `expectSafeMemory(uint64,uint64)` and selector `0x6d016688`
     #[derive(
         Clone,
@@ -10411,6 +10533,9 @@ pub mod hevm {
         ExpectRevert0(ExpectRevert0Call),
         ExpectRevert1(ExpectRevert1Call),
         ExpectRevert2(ExpectRevert2Call),
+        ExpectRevert4(ExpectRevert4Call),
+        ExpectRevert5(ExpectRevert5Call),
+        ExpectRevert3(ExpectRevert3Call),
         ExpectSafeMemory(ExpectSafeMemoryCall),
         ExpectSafeMemoryCall(ExpectSafeMemoryCallCall),
         Fee(FeeCall),
@@ -10861,6 +10986,18 @@ pub mod hevm {
             if let Ok(decoded)
                 = <ExpectRevert2Call as ::ethers_core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ExpectRevert2(decoded));
+            }
+            if let Ok(decoded)
+                = <ExpectRevert4Call as ::ethers_core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::ExpectRevert4(decoded));
+            }
+            if let Ok(decoded)
+                = <ExpectRevert5Call as ::ethers_core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::ExpectRevert5(decoded));
+            }
+            if let Ok(decoded)
+                = <ExpectRevert3Call as ::ethers_core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::ExpectRevert3(decoded));
             }
             if let Ok(decoded)
                 = <ExpectSafeMemoryCall as ::ethers_core::abi::AbiDecode>::decode(data) {
@@ -11600,6 +11737,15 @@ pub mod hevm {
                 Self::ExpectRevert2(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
+                Self::ExpectRevert4(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
+                Self::ExpectRevert5(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
+                Self::ExpectRevert3(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
                 Self::ExpectSafeMemory(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
@@ -12011,6 +12157,9 @@ pub mod hevm {
                 Self::ExpectRevert0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ExpectRevert1(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ExpectRevert2(element) => ::core::fmt::Display::fmt(element, f),
+                Self::ExpectRevert4(element) => ::core::fmt::Display::fmt(element, f),
+                Self::ExpectRevert5(element) => ::core::fmt::Display::fmt(element, f),
+                Self::ExpectRevert3(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ExpectSafeMemory(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ExpectSafeMemoryCall(element) => {
                     ::core::fmt::Display::fmt(element, f)
@@ -12543,6 +12692,21 @@ pub mod hevm {
     impl ::core::convert::From<ExpectRevert2Call> for HEVMCalls {
         fn from(value: ExpectRevert2Call) -> Self {
             Self::ExpectRevert2(value)
+        }
+    }
+    impl ::core::convert::From<ExpectRevert4Call> for HEVMCalls {
+        fn from(value: ExpectRevert4Call) -> Self {
+            Self::ExpectRevert4(value)
+        }
+    }
+    impl ::core::convert::From<ExpectRevert5Call> for HEVMCalls {
+        fn from(value: ExpectRevert5Call) -> Self {
+            Self::ExpectRevert5(value)
+        }
+    }
+    impl ::core::convert::From<ExpectRevert3Call> for HEVMCalls {
+        fn from(value: ExpectRevert3Call) -> Self {
+            Self::ExpectRevert3(value)
         }
     }
     impl ::core::convert::From<ExpectSafeMemoryCall> for HEVMCalls {

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -133,6 +133,8 @@ fn handle_expect_revert_with_address(
         ));
     }
 
+    // TODO: fix this
+    #[allow(clippy::mutable_key_type)]
     let address_reverts = address_reverts.unwrap();
 
     // If None, accept any revert

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -77,16 +77,6 @@ fn expect_revert(state: &mut Cheatcodes, reason: Option<Bytes>, depth: u64) -> R
     Ok(Bytes::new())
 }
 
-fn expect_emit(
-    state: &mut Cheatcodes,
-    address: Option<H160>,
-    depth: u64,
-    checks: [bool; 4],
-) -> Result {
-    state.expected_emits.push_back(ExpectedEmit { depth, address, checks, ..Default::default() });
-    Ok(Bytes::new())
-}
-
 macro_rules! success_return {
     ($is_create:expr) => {
         Ok(if $is_create {

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -52,7 +52,7 @@ pub struct ExpectedRevertWithAddress {
 impl ExpectedRevertWithAddress {
     pub fn compare_revert(&mut self, other: H160, data: Bytes) -> bool {
         if self.address != other {
-            return false;
+            return false
         }
 
         if let Some(ref expected_data) = self.reason {
@@ -61,7 +61,7 @@ impl ExpectedRevertWithAddress {
 
             self.captured_revert_data = Some(raw_error_data);
 
-            return check;
+            return check
         }
 
         true
@@ -101,7 +101,7 @@ fn stringify(data: &[u8]) -> String {
 fn get_raw_error(data: Bytes) -> Bytes {
     if data.len() >= 4 && matches!(data[..4].try_into(), Ok(ERROR_PREFIX | REVERT_PREFIX)) {
         if let Ok(bytes) = Bytes::decode(&data[4..]) {
-            return bytes;
+            return bytes
         }
     }
 
@@ -184,7 +184,7 @@ pub fn handle_expected_reverts_with_address(
 ) {
     // If this is empty we don't need to match any revert
     if state.expected_reverts_with_address.is_empty() {
-        return;
+        return
     }
 
     // Take the first expected revert and...
@@ -243,7 +243,7 @@ pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address
     // This allows a contract to arbitrarily emit more events than expected (additive behavior),
     // as long as all the previous events were matched in the order they were expected to be.
     if state.expected_emits.iter().all(|expected| expected.found) {
-        return;
+        return
     }
 
     // if there's anything to fill, we need to pop back.
@@ -620,7 +620,7 @@ pub fn apply<DB: DatabaseExt>(
         HEVMCalls::MockCall0(inner) => {
             // TODO: Does this increase gas usage?
             if let Err(err) = data.journaled_state.load_account(h160_to_b160(inner.0), data.db) {
-                return Some(Err(err.into()));
+                return Some(Err(err.into()))
             }
 
             // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
@@ -644,7 +644,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::MockCall1(inner) => {
             if let Err(err) = data.journaled_state.load_account(h160_to_b160(inner.0), data.db) {
-                return Some(Err(err.into()));
+                return Some(Err(err.into()))
             }
 
             state.mocked_calls.entry(inner.0).or_default().insert(

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -155,30 +155,33 @@ pub fn handle_expect_revert(
 pub fn build_expect_revert_with_address_failure_message(
     expected_revert: ExpectedRevertWithAddress,
 ) -> String {
-    if let Some(captured_revert_data) = expected_revert.captured_revert_data {
-        if captured_revert_data.is_empty() {
-            format!(
-                "The expected revert address {:#?} reverted as expected, but without data",
-                expected_revert.address
-            )
-        } else if let Some(expected_revert_reason) = expected_revert.reason {
-            format!(
+    match expected_revert.captured_revert_data {
+        Some(captured_revert_data) => {
+            if captured_revert_data.is_empty() {
+                format!(
+                    "The expected revert address {:#?} reverted as expected, but without data",
+                    expected_revert.address
+                )
+            } else if let Some(expected_revert_reason) = expected_revert.reason {
+                format!(
                 "The expected revert address {:#?} did not revert with the expected revert data. Expected: {} but found: {}",
                 expected_revert.address,
                 stringify(&expected_revert_reason),
                 stringify(&captured_revert_data),
             )
-        }
-        // Technically this scenario shouldn't happen because if the expected revert data is None
-        // and the address of the revert matches then the test should pass.
-        else {
-            format!(
+            }
+            // Technically this scenario shouldn't happen because if the expected revert data is
+            // None and the address of the revert matches then the test should pass.
+            else {
+                format!(
                 "The expected revert address {:#?} did not revert with the expected revert data.",
                 expected_revert.address
             )
+            }
         }
-    } else {
-        format!("The expected revert address {:#?} did not revert", expected_revert.address,)
+        None => {
+            format!("The expected revert address {:#?} did not revert", expected_revert.address,)
+        }
     }
 }
 

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -30,52 +30,44 @@ static DUMMY_CREATE_ADDRESS: Address =
 
 #[derive(Clone, Debug, Default)]
 pub struct ExpectedRevert {
-    /// The address from which the revert is expected to be thrown, None being any address
-    /// is valid.
-    pub address: Option<H160>,
     /// The expected data returned by the revert, None being any
     pub reason: Option<Bytes>,
     /// The depth at which the revert is expected
     pub depth: u64,
 }
 
-// TODO remove address logic
 #[derive(Clone, Debug, Default)]
-pub struct ExpectRevertWithAddress {
-    /// The address from which the revert is expected to be thrown.
+pub struct ExpectedRevertWithAddress {
+    /// The address from which the revert is expected to be thrown
     pub address: H160,
 
     /// The expected data returned by the revert, None being any
     pub reason: Option<Bytes>,
 
+    /// Tracks if the revert has been matched during EVM execution
     pub found: bool,
 }
 
-impl ExpectRevertWithAddress {
-    pub fn compare_revert(&self, other: H160, data: &Bytes) -> bool {
+impl ExpectedRevertWithAddress {
+    pub fn compare_revert(&self, other: H160, data: Bytes) -> bool {
         if self.address != other {
             return false;
         }
 
         if let Some(ref expected_data) = self.reason {
-            return expected_data == &get_raw_error(data.clone());
+            return expected_data == &get_raw_error(data);
         }
 
         true
     }
 }
 
-fn expect_revert(
-    state: &mut Cheatcodes,
-    reason: Option<Bytes>,
-    depth: u64,
-    address: Option<H160>,
-) -> Result {
+fn expect_revert(state: &mut Cheatcodes, reason: Option<Bytes>, depth: u64) -> Result {
     ensure!(
         state.expected_revert.is_none(),
         "You must call another function prior to expecting a second revert."
     );
-    state.expected_revert = Some(ExpectedRevert { reason, depth, address });
+    state.expected_revert = Some(ExpectedRevert { reason, depth });
     Ok(Bytes::new())
 }
 
@@ -145,21 +137,32 @@ fn get_raw_error(data: Bytes) -> Bytes {
 pub fn handle_expect_revert(
     is_create: bool,
     expected_revert: Option<&Bytes>,
-    expected_revert_address: Option<H160>,
     status: InstructionResult,
-    reverts_by_address: BTreeMap<H160, HashSet<Bytes>>,
     retdata: Bytes,
 ) -> Result<(Option<Address>, Bytes)> {
     trace!("handle expect revert");
 
-    match expected_revert_address {
-        Some(expected_revert_address) => handle_expect_revert_with_address(
-            is_create,
-            expected_revert,
-            expected_revert_address,
-            reverts_by_address,
-        ),
-        None => handle_expect_revert_with_data(is_create, expected_revert, status, retdata),
+    ensure!(!matches!(status, return_ok!()), "Call did not revert as expected");
+
+    // If None, accept any revert
+    let expected_revert = match expected_revert {
+        Some(x) => x,
+        None => return success_return!(is_create),
+    };
+
+    if !expected_revert.is_empty() && retdata.is_empty() {
+        bail!("Call reverted as expected, but without data");
+    }
+
+    let actual_revert = get_raw_error(retdata);
+    if actual_revert == *expected_revert {
+        success_return!(is_create)
+    } else {
+        Err(fmt_err!(
+            "Error != expected error: {} != {}",
+            stringify(&actual_revert),
+            stringify(expected_revert),
+        ))
     }
 }
 
@@ -212,58 +215,35 @@ fn handle_expect_revert_with_address(
     }
 }
 
-/// Verifies that the current call is reverting and that it reverted with `expected_revert`
-fn handle_expect_revert_with_data(
-    is_create: bool,
-    expected_revert: Option<&Bytes>,
-    status: InstructionResult,
-    retdata: Bytes,
-) -> Result<(Option<Address>, Bytes)> {
-    ensure!(!matches!(status, return_ok!()), "Call did not revert as expected");
-
-    // If None, accept any revert
-    let expected_revert = match expected_revert {
-        Some(x) => x,
-        None => return success_return!(is_create),
-    };
-
-    if !expected_revert.is_empty() && retdata.is_empty() {
-        bail!("Call reverted as expected, but without data");
-    }
-
-    let actual_revert = get_raw_error(retdata);
-    if actual_revert == *expected_revert {
-        success_return!(is_create)
-    } else {
-        Err(fmt_err!(
-            "Error != expected error: {} != {}",
-            stringify(&actual_revert),
-            stringify(expected_revert),
-        ))
-    }
-}
-
-pub fn handle_expect_reverts_with_address(
+pub fn handle_expected_reverts_with_address(
     state: &mut Cheatcodes,
     current_contract: H160,
-    revert_data: Bytes,
+    current_revert_data: Bytes,
 ) {
+    // If this is empty we don't need to match any revert
     if state.expected_reverts_with_address.is_empty() {
         return;
     }
 
+    // Take the first expected revert and...
     if let Some(mut first) = state.expected_reverts_with_address.pop_front() {
-        // If the first element hasn't been matched yet then we proceed to compare it
-        // against the current revert
+        // ... verify if it has been alredy matched.
         if !first.found {
-            if first.compare_revert(current_contract, &revert_data) {
+            // if it matches with the current revert mark found as true and push the current
+            // expected revert to the end of the queue to match any other pending expected
+            // revert.
+            if first.compare_revert(current_contract, current_revert_data) {
                 first.found = true;
                 state.expected_reverts_with_address.push_back(first);
-            } else {
+            }
+            // If the current expected revert does not match we push it to the front of the queue to
+            // try to match it again with the next revert.
+            else {
                 state.expected_reverts_with_address.push_front(first);
             }
         }
-        // Else we clear the expected reverts becasue they have been all matched
+        // If the first expected revert has already been matched it means that all the expected
+        // reverts of the queue have been matched and we can safely clear the queque.
         else {
             state.matched_all_expected_reverts_with_address = true;
             state.expected_reverts_with_address.clear();
@@ -503,23 +483,21 @@ pub fn apply<DB: DatabaseExt>(
     call: &HEVMCalls,
 ) -> Option<Result> {
     let result = match call {
-        HEVMCalls::ExpectRevert0(_) => {
-            expect_revert(state, None, data.journaled_state.depth(), None)
-        }
+        HEVMCalls::ExpectRevert0(_) => expect_revert(state, None, data.journaled_state.depth()),
         HEVMCalls::ExpectRevert1(inner) => {
-            expect_revert(state, Some(inner.0.clone()), data.journaled_state.depth(), None)
+            expect_revert(state, Some(inner.0.clone()), data.journaled_state.depth())
         }
         HEVMCalls::ExpectRevert2(inner) => {
-            expect_revert(state, Some(inner.0.into()), data.journaled_state.depth(), None)
+            expect_revert(state, Some(inner.0.into()), data.journaled_state.depth())
         }
         HEVMCalls::ExpectRevert3(inner) => {
             state
                 .expected_reverts_with_address
-                .push_back(ExpectRevertWithAddress { address: inner.0, ..Default::default() });
+                .push_back(ExpectedRevertWithAddress { address: inner.0, ..Default::default() });
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectRevert4(inner) => {
-            state.expected_reverts_with_address.push_back(ExpectRevertWithAddress {
+            state.expected_reverts_with_address.push_back(ExpectedRevertWithAddress {
                 address: inner.1,
                 reason: Some(inner.0.clone()),
                 ..Default::default()
@@ -527,7 +505,7 @@ pub fn apply<DB: DatabaseExt>(
             Ok(Bytes::new())
         }
         HEVMCalls::ExpectRevert5(inner) => {
-            state.expected_reverts_with_address.push_back(ExpectRevertWithAddress {
+            state.expected_reverts_with_address.push_back(ExpectedRevertWithAddress {
                 address: inner.1,
                 reason: Some(inner.0.into()),
                 ..Default::default()

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -126,7 +126,7 @@ fn handle_expect_revert_with_address(
 
     if address_reverts.is_none() {
         return Err(fmt_err!(
-            "The expected revert address {} did not revert",
+            "The expected revert address {:#?} did not revert",
             expected_revert_address,
         ));
     }
@@ -147,14 +147,16 @@ fn handle_expect_revert_with_address(
 
     if address_reverts.contains(&expected_revert.to_string()) {
         success_return!(is_create)
-    } else if address_reverts.contains("") {
+    }
+    // Empty revert data
+    else if address_reverts.contains("0x") {
         bail!(
-            "The expected revert address {} reverted as expected, but without data",
+            "The expected revert address {:#?} reverted as expected, but without data",
             expected_revert_address
         );
     } else {
         Err(fmt_err!(
-            "Expected revert address {} did not revert with the expected revert data: {}",
+            "The expected revert address {:#?} did not revert with the expected revert data: {}",
             expected_revert_address,
             stringify(expected_revert),
         ))

--- a/crates/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -127,7 +127,9 @@ pub struct Cheatcodes {
     /// Expected revert information
     pub expected_revert: Option<ExpectedRevert>,
 
-    /// Tracks the reverts that happen during evm execution if a there is an expected revert
+    /// Keeps track of the reverts thrown by an address during EVM execution if there is an
+    /// expected revert. It is used by [handle_expect_revert] to check if
+    /// `expected_reverted_address` reverted as specified by `expected_revert`.
     pub revert_per_address: BTreeMap<H160, HashSet<Bytes>>,
 
     /// Additional diagnostic for reverts

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -581,4 +581,24 @@ contract ExpectRevertWithAddressTest is DSTest {
         vm.expectRevert(CustomError.selector, address(middleWrapper));
         outerWrapper.revertWithCustomError();
     }
+
+    function testFailExpectRevertWithAddressCombinedWithExpectRevertIfCallDoesNotRevert(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
+
+        vm.expectRevert(bytes(data), reverterAddress);
+        vm.expectRevert(bytes(data), address(middleWrapper));
+        vm.expectRevert(bytes(data));
+        outerWrapper.revertWithMessage(data);
+    }
+
+    function testExpectRevertWithAddressCombinedWithExpectRevert(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
+
+        vm.expectRevert(bytes(data), reverterAddress);
+        vm.expectRevert(bytes(data), address(middleWrapper));
+        vm.expectRevert(bytes(data));
+        outerWrapper.revertWithMessage(data);
+    }
 }

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -261,6 +261,12 @@ contract ExpectRevertWithAddressTest is DSTest {
     }
 
     // Simple revert tests
+    function testFailExpectRevertWithAddressNotOnImmediateNextCall(string memory data) public {
+        vm.expectRevert(bytes(data), reverterAddress);
+        reverter.doNotRevert();
+        reverter.revertWithMessage(data);
+    }
+
     function testFailExpectRevertWithNoDataAndWrongAddress(address wrongAddress) external {
         vm.assume(wrongAddress != reverterAddress);
 

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -520,4 +520,65 @@ contract ExpectRevertWithAddressTest is DSTest {
         vm.expectRevert(CustomError.selector, address(middleWrapper));
         outerWrapper.revertWithCustomError();
     }
+
+    // Misc
+    function testFailMultipleExpectWithWrongRevertOrder(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
+
+        vm.expectRevert(address(outerWrapper));
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        outerWrapper.revertWithMessage(data);
+    }
+
+    function testMultipleExpectAnyRevertAtMultipleNestingLevels(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
+
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        vm.expectRevert(address(outerWrapper));
+        outerWrapper.revertWithoutReason();
+
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        vm.expectRevert(address(outerWrapper));
+        outerWrapper.revertWithCustomError();
+
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        vm.expectRevert(address(outerWrapper));
+        outerWrapper.revertWithMessage(data);
+    }
+
+    function testMultipleExpectAnyRevertOnlyAtThe2LowestLevels(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
+
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        outerWrapper.revertWithoutReason();
+
+        vm.expectRevert(reverterAddress);
+        vm.expectRevert(address(middleWrapper));
+        outerWrapper.revertWithCustomError();
+
+        vm.expectRevert(bytes(data), reverterAddress);
+        vm.expectRevert(bytes(data), address(middleWrapper));
+        outerWrapper.revertWithMessage(data);
+    }
+
+    function testMultipleExpectRevertCallsWithDataOnlyAtThe2LowestLevels(string memory data) external {
+        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
+        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
+
+        vm.expectRevert(bytes(data), reverterAddress);
+        vm.expectRevert(bytes(data), address(middleWrapper));
+        outerWrapper.revertWithMessage(data);
+
+        vm.expectRevert(CustomError.selector, reverterAddress);
+        vm.expectRevert(CustomError.selector, address(middleWrapper));
+        outerWrapper.revertWithCustomError();
+    }
 }

--- a/testdata/cheats/ExpectRevert.t.sol
+++ b/testdata/cheats/ExpectRevert.t.sol
@@ -278,6 +278,10 @@ contract ExpectRevertWithAddressTest is DSTest {
     }
 
     // Simple revert tests
+    function testFailExpectRevertWithAddressAndNotCallingFunction(address randomAddress) external {
+        vm.expectRevert(randomAddress);
+    }
+
     function testFailExpectRevertWithAddressNotOnImmediateNextCall(string memory data) public {
         vm.expectRevert(bytes(data), reverterAddress);
         reverter.doNotRevert();
@@ -536,98 +540,5 @@ contract ExpectRevertWithAddressTest is DSTest {
 
         vm.expectRevert(CustomError.selector, address(middleWrapper));
         outerWrapper.revertWithCustomError();
-    }
-
-    // Misc
-    function testFailMultipleExpectWithWrongRevertOrder(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
-
-        vm.expectRevert(address(outerWrapper));
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        outerWrapper.revertWithMessage(data);
-    }
-
-    function testMultipleExpectAnyRevertAtMultipleNestingLevels(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        vm.expectRevert(address(outerWrapper));
-        outerWrapper.revertWithoutReason();
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        vm.expectRevert(address(outerWrapper));
-        outerWrapper.revertWithCustomError();
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        vm.expectRevert(address(outerWrapper));
-        outerWrapper.revertWithMessage(data);
-    }
-
-    function testMultipleExpectAnyRevertOnlyAtThe2LowestLevels(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        outerWrapper.revertWithoutReason();
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        outerWrapper.revertWithCustomError();
-
-        vm.expectRevert(bytes(data), reverterAddress);
-        vm.expectRevert(bytes(data), address(middleWrapper));
-        outerWrapper.revertWithMessage(data);
-    }
-
-    function testMultipleExpectRevertCallsWithDataOnlyAtThe2LowestLevels(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
-
-        vm.expectRevert(bytes(data), reverterAddress);
-        vm.expectRevert(bytes(data), address(middleWrapper));
-        outerWrapper.revertWithMessage(data);
-
-        vm.expectRevert(CustomError.selector, reverterAddress);
-        vm.expectRevert(CustomError.selector, address(middleWrapper));
-        outerWrapper.revertWithCustomError();
-    }
-
-    function testFailExpectRevertWithAddressCombinedWithExpectRevertIfCallDoesNotRevert(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        RevertCatcher outerWrapper = new RevertCatcher(middleWrapper);
-
-        vm.expectRevert(bytes(data), reverterAddress);
-        vm.expectRevert(bytes(data), address(middleWrapper));
-        vm.expectRevert(bytes(data));
-        outerWrapper.revertWithMessage(data);
-    }
-
-    function testExpectRevertWithAddressCombinedWithExpectRevert(string memory data) external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        ReverterWrapper outerWrapper = new ReverterWrapper(middleWrapper);
-
-        vm.expectRevert(bytes(data), reverterAddress);
-        vm.expectRevert(bytes(data), address(middleWrapper));
-        vm.expectRevert(bytes(data));
-        outerWrapper.revertWithMessage(data);
-    }
-
-    function testExpectEmitCombinedWithExpectRevertWithAddress() external {
-        ReverterWrapper middleWrapper = new ReverterWrapper(reverter);
-        Emitter emitter = new Emitter(middleWrapper);
-
-        vm.expectEmit();
-        emit CustomEvent();
-
-        vm.expectRevert(reverterAddress);
-        vm.expectRevert(address(middleWrapper));
-        emitter.revertWithNoDataAndEmit();
     }
 }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -238,6 +238,12 @@ interface Vm {
 
     function expectRevert(bytes4) external;
 
+    function expectRevert(bytes calldata, address) external;
+
+    function expectRevert(bytes4, address) external;
+
+    function expectRevert(address) external;
+
     // Record all storage reads and writes
     function record() external;
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -238,6 +238,7 @@ interface Vm {
 
     function expectRevert(bytes4) external;
 
+    // Expect a revert at any depth of the call stack at the specified address
     function expectRevert(bytes calldata, address) external;
 
     function expectRevert(bytes4, address) external;


### PR DESCRIPTION
## Motivation

As requested in #5299, this pr adds the following `expectRevert` cheat code overloads to verify that the specified address reverted:

```solidity
function expectRevert(bytes calldata revertData, address reverter) external;
function expectRevert(bytes4 revertData, address reverter) external;
function expectRevert(address reverter) external;
``` 

## Solution

Track the reverts that happen during contract execution and store them in `reverts_by_address`. 
The process to check if an address reverted is as follows:
- Check that there is an entry in `reverts_by_address` for the selected address:
    - If there isn't an entry for the address it is a failure because the address did not revert.
    - If the is an entry, check if the user is expecting any revert  or a specific one:
        - If the user is expecting any revert (`expected_revert` is `None`) it is a success.
        - If the user is expecting a revert with specific data check if that data is in the set associated with `expected_revert_address` and if it is then it is a success, otherwise it is a failure.  
 
Note:  This new logic does not enforce that the current call should end with a revert (but it stays the same for the old expectRevert only with data). The only thing that matters is that anywhere in the call stack `expected_revert_address` reverted. For example, if we have 2 contracts `A` and `B`, and `B` calls `A` which reverts, even if `B` catches the error but does not revert, if we are expecting `A` to revert then the assertion will be successful.

Ps: I'm super sorry for the super delayed pr 🙏🏼 

Closes: https://github.com/foundry-rs/foundry/issues/5299