### PR TITLE
feat(`cheatcodes`): add `keyExists` cheatcode

### DIFF
--- a/abi/abi/HEVM.sol
+++ b/abi/abi/HEVM.sol
@@ -208,6 +208,7 @@ serializeString(string,string,string)(string)
 serializeString(string,string,string[])(string)
 serializeBytes(string,string,bytes)(string)
 serializeBytes(string,string,bytes[])(string)
+keyExists(string,string)(bool)
 
 pauseGasMetering()
 resumeGasMetering()

--- a/abi/src/bindings/hevm.rs
+++ b/abi/src/bindings/hevm.rs
@@ -2040,6 +2040,35 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("keyExists"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("keyExists"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::String,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::String,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Bool,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("label"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -5559,6 +5588,16 @@ pub mod hevm {
                 .method_hash([217, 45, 142, 253], p0)
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `keyExists` (0x528a683c) function
+        pub fn key_exists(
+            &self,
+            p0: ::std::string::String,
+            p1: ::std::string::String,
+        ) -> ::ethers_contract::builders::ContractCall<M, bool> {
+            self.0
+                .method_hash([82, 138, 104, 60], (p0, p1))
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `label` (0xc657c718) function
         pub fn label(
             &self,
@@ -7826,6 +7865,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "isPersistent", abi = "isPersistent(address)")]
     pub struct IsPersistentCall(pub ::ethers_core::types::Address);
+    ///Container type for all input parameters for the `keyExists` function with signature `keyExists(string,string)` and selector `0x528a683c`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "keyExists", abi = "keyExists(string,string)")]
+    pub struct KeyExistsCall(pub ::std::string::String, pub ::std::string::String);
     ///Container type for all input parameters for the `label` function with signature `label(address,string)` and selector `0xc657c718`
     #[derive(
         Clone,
@@ -9463,6 +9515,7 @@ pub mod hevm {
         GetNonce(GetNonceCall),
         GetRecordedLogs(GetRecordedLogsCall),
         IsPersistent(IsPersistentCall),
+        KeyExists(KeyExistsCall),
         Label(LabelCall),
         Load(LoadCall),
         MakePersistent0(MakePersistent0Call),
@@ -9916,6 +9969,10 @@ pub mod hevm {
             if let Ok(decoded)
                 = <IsPersistentCall as ::ethers_core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::IsPersistent(decoded));
+            }
+            if let Ok(decoded)
+                = <KeyExistsCall as ::ethers_core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::KeyExists(decoded));
             }
             if let Ok(decoded)
                 = <LabelCall as ::ethers_core::abi::AbiDecode>::decode(data) {
@@ -10565,6 +10622,9 @@ pub mod hevm {
                 Self::IsPersistent(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
+                Self::KeyExists(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
                 Self::Label(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Load(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::MakePersistent0(element) => {
@@ -10931,6 +10991,7 @@ pub mod hevm {
                 Self::GetNonce(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetRecordedLogs(element) => ::core::fmt::Display::fmt(element, f),
                 Self::IsPersistent(element) => ::core::fmt::Display::fmt(element, f),
+                Self::KeyExists(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Label(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Load(element) => ::core::fmt::Display::fmt(element, f),
                 Self::MakePersistent0(element) => ::core::fmt::Display::fmt(element, f),
@@ -11462,6 +11523,11 @@ pub mod hevm {
     impl ::core::convert::From<IsPersistentCall> for HEVMCalls {
         fn from(value: IsPersistentCall) -> Self {
             Self::IsPersistent(value)
+        }
+    }
+    impl ::core::convert::From<KeyExistsCall> for HEVMCalls {
+        fn from(value: KeyExistsCall) -> Self {
+            Self::KeyExists(value)
         }
     }
     impl ::core::convert::From<LabelCall> for HEVMCalls {
@@ -12571,6 +12637,18 @@ pub mod hevm {
         Hash
     )]
     pub struct IsPersistentReturn(pub bool);
+    ///Container type for all return fields from the `keyExists` function with signature `keyExists(string,string)` and selector `0x528a683c`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct KeyExistsReturn(pub bool);
     ///Container type for all return fields from the `load` function with signature `load(address,bytes32)` and selector `0x667f9d70`
     #[derive(
         Clone,

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -274,7 +274,6 @@ fn parse_json(json_str: &str, key: &str, coerce: Option<ParamType>) -> Result {
         // in this case.
         "." => {
             let values = jsonpath_lib::select(&json, "$")?;
-            println!("values: {:?} {:?}", values, values.len());
             let res = parse_json_values(values, key)?;
 
             // encode the bytes as the 'bytes' solidity type

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -274,6 +274,7 @@ fn parse_json(json_str: &str, key: &str, coerce: Option<ParamType>) -> Result {
         // in this case.
         "." => {
             let values = jsonpath_lib::select(&json, "$")?;
+            println!("values: {:?} {:?}", values, values.len());
             let res = parse_json_values(values, key)?;
 
             // encode the bytes as the 'bytes' solidity type
@@ -404,6 +405,15 @@ fn write_json(
     })?;
     super::fs::write_file(state, path, json_string)?;
     Ok(Bytes::new())
+}
+
+/// Checks if a key exists in a JSON object.
+fn key_exists(json_str: &str, key: &str) -> Result {
+    let json: Value =
+        serde_json::from_str(json_str).map_err(|e| format!("Could not convert to JSON: {e}"))?;
+    let values = jsonpath_lib::select(&json, &canonicalize_json_key(key))?;
+    let exists = util::parse(&(!values.is_empty()).to_string(), &ParamType::Bool)?;
+    Ok(exists)
 }
 
 #[instrument(level = "error", name = "ext", target = "evm::cheatcodes", skip_all)]
@@ -582,6 +592,7 @@ pub fn apply(state: &mut Cheatcodes, call: &HEVMCalls) -> Option<Result> {
         }
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
+        HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),
         _ => return None,
     })
 }

--- a/evm/src/trace/utils.rs
+++ b/evm/src/trace/utils.rs
@@ -55,16 +55,17 @@ pub(crate) fn decode_cheatcode_inputs(
             Some(decoded.iter().map(format_token).collect())
         }
         "deriveKey" => Some(vec!["<pk>".to_string()]),
-        "parseJson" | "writeJson" => {
+        "parseJson" | "writeJson" | "keyExists" => {
             if verbosity == 5 {
                 None
             } else {
                 let mut decoded = func.decode_input(&data[SELECTOR_LEN..]).ok()?;
-                let token = if func.name.as_str() == "parseJson" {
-                    "<JSON file>"
-                } else {
-                    "<stringified JSON>"
-                };
+                let token =
+                    if func.name.as_str() == "parseJson" || func.name.as_str() == "keyExists" {
+                        "<JSON file>"
+                    } else {
+                        "<stringified JSON>"
+                    };
                 decoded[0] = Token::String(token.to_string());
                 Some(decoded.iter().map(format_token).collect())
             }

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -5,7 +5,7 @@ import "ds-test/test.sol";
 import "./Vm.sol";
 import "../logs/console.sol";
 
-contract ParseJson is DSTest {
+contract ParseJsonTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
     string json;
 
@@ -150,7 +150,7 @@ contract ParseJson is DSTest {
     }
 }
 
-contract WriteJson is DSTest {
+contract WriteJsonTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     string json1;

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -244,14 +244,21 @@ contract WriteJson is DSTest {
         bytes memory data = vm.parseJson(json, ".");
         notSimpleJson memory decodedData = abi.decode(data, (notSimpleJson));
         console.log(decodedData.a);
-        assertEq(decodedData.a, 12345);
+        assertEq(decodedData.a, 123);
     }
 
     function test_checkKeyExists() public {
         string memory path = "../testdata/fixtures/Json/write_complex_test.json";
         string memory json = vm.readFile(path);
         bool exists = vm.keyExists(json, "a");
-        assert(exists);
+        assertTrue(exists);
+    }
+
+    function test_checkKeyDoesNotExist() public {
+        string memory path = "../testdata/fixtures/Json/write_complex_test.json";
+        string memory json = vm.readFile(path);
+        bool exists = vm.keyExists(json, "d");
+        assertTrue(!exists);
     }
 
     function test_writeJson() public {

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -245,7 +245,13 @@ contract WriteJson is DSTest {
         notSimpleJson memory decodedData = abi.decode(data, (notSimpleJson));
         console.log(decodedData.a);
         assertEq(decodedData.a, 12345);
-        assertEq(true, false);
+    }
+
+    function test_checkKeyExists() public {
+        string memory path = "../testdata/fixtures/Json/write_complex_test.json";
+        string memory json = vm.readFile(path);
+        bool exists = vm.keyExists(json, "a");
+        assert(exists);
     }
 
     function test_writeJson() public {

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -582,6 +582,9 @@ interface Vm {
 
     function writeJson(string calldata, string calldata, string calldata) external;
 
+    // Checks if a key exists in the given json string
+    function keyExists(string calldata, string calldata) external returns (bool);
+
     // Pauses gas metering (gas usage will not be counted)
     function pauseGasMetering() external;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5369 , supersedes https://github.com/foundry-rs/forge-std/pull/226 as a native impl of the cheatcode.

Instead of reverting if a key does not exist, a more correct behavior should be exposing a helper to validate if a key exists or not.

## Solution

Implements a `keyExists(string calldata json, string calldata key) external view returns (bool)` cheatcode, which can validate if a certain key exists or not.

cc @mds1 