### PR TITLE
fix(`fmt`): properly ignore paths when `forge fmt` is called without any paths

### DIFF
--- a/cli/src/cmd/forge/fmt.rs
+++ b/cli/src/cmd/forge/fmt.rs
@@ -57,8 +57,7 @@ impl Cmd for FmtArgs {
         // Expand ignore globs and canonicalize from the get go
         let ignored = expand_globs(&config.__root.0, config.fmt.ignore.iter())?
             .iter()
-            .map(|p| foundry_utils::path::canonicalize_path(p))
-            .flatten()
+            .flat_map(foundry_utils::path::canonicalize_path)
             .collect::<Vec<_>>();
 
         let cwd = std::env::current_dir()?;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -23,6 +23,7 @@ use tracing::trace;
 pub mod abi;
 pub mod error;
 pub mod glob;
+pub mod path;
 pub mod rpc;
 
 /// Data passed to the post link handler of the linker for each linked artifact.

--- a/utils/src/path.rs
+++ b/utils/src/path.rs
@@ -1,0 +1,10 @@
+//! General Foundry path utils
+
+use std::path::PathBuf;
+
+/// Canonicalize a path, returning an error if the path does not exist.
+/// Mainly useful to apply canonicalization to paths obtained from project files
+/// but still error properly instead of flattening the errors.
+pub fn canonicalize_path(path: &PathBuf) -> eyre::Result<PathBuf> {
+    Ok(dunce::canonicalize(path)?)
+}


### PR DESCRIPTION
## Motivation

We weren't filtering out the ignored paths correctly in the case we ran `forge fmt --check` on a project root without any more input on the contract locations.

## Solution

canonicalize the ignored paths, and filter them out
