### PR TITLE
Fix deadlock scenario in Anvil's backend/mem

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1187,7 +1187,7 @@ impl Backend {
         filter: Filter,
         hash: H256,
     ) -> Result<Vec<Log>, BlockchainError> {
-        if let Some(block) = self.blockchain.storage.read().blocks.get(&hash).cloned() {
+        if let Some(block) = self.blockchain.get_block_by_hash(&hash) {
             return Ok(self.mined_logs_for_block(filter, block))
         }
 
@@ -1352,7 +1352,7 @@ impl Backend {
     }
 
     fn mined_block_by_hash(&self, hash: H256) -> Option<EthersBlock<TxHash>> {
-        let block = self.blockchain.storage.read().blocks.get(&hash)?.clone();
+        let block = self.blockchain.get_block_by_hash(&hash)?;
         Some(self.convert_block(block))
     }
 
@@ -1441,7 +1441,7 @@ impl Backend {
     }
 
     pub fn get_block_by_hash(&self, hash: H256) -> Option<Block> {
-        self.blockchain.storage.read().blocks.get(&hash).cloned()
+        self.blockchain.get_block_by_hash(&hash)
     }
 
     fn mined_block_by_number(&self, number: BlockNumber) -> Option<EthersBlock<TxHash>> {
@@ -1846,13 +1846,13 @@ impl Backend {
     /// Returns the transaction receipt for the given hash
     pub(crate) fn mined_transaction_receipt(&self, hash: H256) -> Option<MinedTransactionReceipt> {
         let MinedTransaction { info, receipt, block_hash, .. } =
-            self.blockchain.storage.read().transactions.get(&hash)?.clone();
+            self.blockchain.get_transaction_by_hash(&hash)?;
 
         let EIP658Receipt { status_code, gas_used, logs_bloom, logs } = receipt.into();
 
         let index = info.transaction_index as usize;
 
-        let block = self.blockchain.storage.read().blocks.get(&block_hash).cloned()?;
+        let block = self.blockchain.get_block_by_hash(&block_hash)?;
 
         // TODO store cumulative gas used in receipt instead
         let receipts = self.get_receipts(block.transactions.iter().map(|tx| tx.hash()));

--- a/anvil/src/eth/backend/mem/storage.rs
+++ b/anvil/src/eth/backend/mem/storage.rs
@@ -335,6 +335,14 @@ impl Blockchain {
         }
     }
 
+    pub fn get_block_by_hash(&self, hash: &H256) -> Option<Block> {
+        self.storage.read().blocks.get(hash).cloned()
+    }
+
+    pub fn get_transaction_by_hash(&self, hash: &H256) -> Option<MinedTransaction> {
+        self.storage.read().transactions.get(hash).cloned()
+    }
+
     /// Returns the total number of blocks
     pub fn blocks_count(&self) -> usize {
         self.storage.read().blocks.len()


### PR DESCRIPTION
## Motivation

There is an observed deadlock scenario in the anvil backend code. 

In short, this is caused by incorrectly trying to take 2 read locks on the same thread with the potential of a waiting write lock on a different thread.

On line 1190 of `anvil/src/eth/backend/mem/mod.rs`:
- The read lock taken by the `if let...` is still in scope when it calls into `mined_logs_for_block` on the next line. See https://doc.rust-lang.org/stable/reference/destructors.html#temporary-scopes.
- Then on line 1355, another read lock is attempted.
- If a write lock has been attempted on another thread, you will have a deadlock. Write Lock A will be waiting for Read Lock A to release, but Read Lock A can't release until Read Lock B is taken, which can't happen with the pending Write Lock A.

This was confirmed by:
1. Logging the status of Read Lock A at the time Read Lock B is attempted.
2. Changing `anvil/src/eth/backend/mem/mod.rs:1210` to call `read_recursive()` — fixed it.

## Solution

Potential solutions:
1. Keep the above mentioned `read_recursive()` fix.
2. Pull all simple read locking into separate methods, which guarantees locks go out of scope on return.

Solution 2 is better practice when dealing with locks and is implemented below.

## Reproduce

This heisenbug was challenging to reproduce and diagnose. It requires many attempts and a sufficiently slow machine. Observing the bug with logging also "fixed" it. 

## Abbreviated Stack Trace From `parking_lot`
```
1 deadlocks detected
Deadlock #0
Thread Id 139618065679936
   0:     0x563efd052f9f - backtrace::backtrace::trace_unsynchronized::h35be2c2ca520d3a1
   1:     0x563efd052f50 - backtrace::backtrace::trace::hbcf836d72fa93a02
   2:     0x563efd057ef3 - backtrace::capture::Backtrace::create::hff52a56c9d356e68
   3:     0x563efd057e6d - backtrace::capture::Backtrace::new::hc7c6b55b4243f4fb
   4:     0x563efd0484b0 - parking_lot_core::parking_lot::deadlock_impl::on_unpark::hdb8816f6aef131ed
   5:     0x563efd03c40f - parking_lot::raw_rwlock::RawRwLock::lock_shared_slow::h7cf3df83b758efed
   6:     0x563efc22264e - <parking_lot::raw_rwlock::RawRwLock as lock_api::rwlock::RawRwLock>::lock_shared::h41529e7feea2a8aa
   7:     0x563efc2417ef - anvil::eth::backend::mem::Backend::mined_logs_for_block::h17caa3c1e708bd8e
   8:     0x563efc417a37 - anvil::eth::backend::mem::Backend::logs::{{closure}}::hc1656a74aaa51872
   9:     0x563efc3d69a4 - anvil::eth::api::EthApi::execute::{{closure}}::h3b0f8e2b655e36f9
  10:     0x563efc42cdcb - <anvil::server::handler::HttpEthRpcHandler as anvil_server::RpcHandler>::on_request::{{closure}}::h86f7f950be930c54
  11:     0x563efc362d38 - anvil_server::RpcHandler::on_call::{{closure}}::h71315da13b003eb7
  12:     0x563efc2d3857 - <F as axum::handler::Handler<(T1,T2),B>>::call::{{closure}}::h66d98aaa66463092
```