### PR TITLE
refactor(find_project_root_path): optional arg to provide path instead of cwd default

### DIFF
--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -73,7 +73,8 @@ impl RunArgs {
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
     pub async fn run(self) -> eyre::Result<()> {
-        let figment = Config::figment_with_root(find_project_root_path().unwrap()).merge(self.rpc);
+        let figment =
+            Config::figment_with_root(find_project_root_path(None).unwrap()).merge(self.rpc);
         let mut evm_opts = figment.extract::<EvmOpts>()?;
         let config = Config::from_provider(figment).sanitized();
         let provider = utils::get_provider(&config)?;

--- a/cli/src/cmd/forge/build/paths.rs
+++ b/cli/src/cmd/forge/build/paths.rs
@@ -67,7 +67,7 @@ impl ProjectPathsArgs {
     ///
     /// This will be the `--root` argument if provided, otherwise see [find_project_root_path()]
     pub fn project_root(&self) -> PathBuf {
-        self.root.clone().unwrap_or_else(|| find_project_root_path().unwrap())
+        self.root.clone().unwrap_or_else(|| find_project_root_path(None).unwrap())
     }
 
     /// Returns the remappings to add to the config

--- a/cli/src/cmd/forge/doc.rs
+++ b/cli/src/cmd/forge/doc.rs
@@ -50,7 +50,7 @@ impl Cmd for DocArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let root = self.root.clone().unwrap_or(find_project_root_path()?);
+        let root = self.root.clone().unwrap_or(find_project_root_path(None)?);
         let config = load_config_with_root(Some(root.clone()));
 
         let mut doc_config = config.doc.clone();

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -179,7 +179,7 @@ pub fn load_dotenv() {
     // we only want the .env file of the cwd and project root
     // `find_project_root_path` calls `current_dir` internally so both paths are either both `Ok` or
     // both `Err`
-    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), find_project_root_path()) {
+    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), find_project_root_path(None)) {
         load(&prj_root);
         if cwd != prj_root {
             // prj root and cwd can be identical

--- a/cli/tests/it/create.rs
+++ b/cli/tests/it/create.rs
@@ -111,12 +111,8 @@ library ChainlinkTWAP {
 }
 
 /// configures the `TestProject` with the given closure and calls the `forge create` command
-fn create_on_chain<F>(
-    info: Option<EnvExternalities>,
-    prj: TestProject,
-    mut cmd: TestCommand,
-    f: F,
-) where
+fn create_on_chain<F>(info: Option<EnvExternalities>, prj: TestProject, mut cmd: TestCommand, f: F)
+where
     F: FnOnce(&TestProject) -> String,
 {
     if let Some(info) = info {

--- a/cli/tests/it/create.rs
+++ b/cli/tests/it/create.rs
@@ -24,7 +24,7 @@ use std::{path::PathBuf, str::FromStr};
 /// This will create a library `remapping/MyLib.sol:MyLib`
 ///
 /// returns the contract argument for the create command
-fn setup_with_simple_remapping(prj: &mut TestProject) -> String {
+fn setup_with_simple_remapping(prj: &TestProject) -> String {
     // explicitly set remapping and libraries
     let config = Config {
         remappings: vec![Remapping::from_str("remapping/=lib/remapping/").unwrap().into()],
@@ -65,7 +65,7 @@ library MyLib {
     "src/LinkTest.sol:LinkTest".to_string()
 }
 
-fn setup_oracle(prj: &mut TestProject) -> String {
+fn setup_oracle(prj: &TestProject) -> String {
     let config = Config {
         libraries: vec![format!(
             "./src/libraries/ChainlinkTWAP.sol:ChainlinkTWAP:{:?}",
@@ -113,14 +113,14 @@ library ChainlinkTWAP {
 /// configures the `TestProject` with the given closure and calls the `forge create` command
 fn create_on_chain<F>(
     info: Option<EnvExternalities>,
-    mut prj: TestProject,
+    prj: TestProject,
     mut cmd: TestCommand,
     f: F,
 ) where
-    F: FnOnce(&mut TestProject) -> String,
+    F: FnOnce(&TestProject) -> String,
 {
     if let Some(info) = info {
-        let contract_path = f(&mut prj);
+        let contract_path = f(&prj);
         cmd.arg("create");
         cmd.args(info.create_args()).arg(contract_path);
 

--- a/config/src/macros.rs
+++ b/config/src/macros.rs
@@ -62,7 +62,7 @@ macro_rules! impl_figment_convert {
                 if let Some(root) = args.root.clone() {
                     $crate::Config::figment_with_root(root)
                 } else {
-                    $crate::Config::figment_with_root($crate::find_project_root_path().unwrap())
+                    $crate::Config::figment_with_root($crate::find_project_root_path(None).unwrap())
                 }
                 .merge(args)
             }
@@ -190,7 +190,7 @@ macro_rules! impl_figment_convert_cast {
     ($name:ty) => {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
             fn from(args: &'a $name) -> Self {
-                $crate::Config::figment_with_root($crate::find_project_root_path().unwrap())
+                $crate::Config::figment_with_root($crate::find_project_root_path(None).unwrap())
                     .merge(args)
             }
         }

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -40,8 +40,8 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 
 /// Returns the root path to set for the project root
 ///
-/// traverse the dir tree up and look for a `foundry.toml` file starting at the cwd, but only until
-/// the root dir of the current repo so that
+/// traverse the dir tree up and look for a `foundry.toml` file starting at the given path or cwd,
+/// but only until the root dir of the current repo so that
 ///
 /// ```text
 /// -- foundry.toml
@@ -49,7 +49,7 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 /// -- repo
 ///   |__ .git
 ///   |__sub
-///      |__ cwd
+///      |__ [given_path | cwd]
 /// ```
 /// will still detect `repo` as root
 pub fn find_project_root_path(path: Option<PathBuf>) -> std::io::Result<PathBuf> {

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -21,7 +21,7 @@ pub fn load_config_with_root(root: Option<PathBuf>) -> Config {
     if let Some(root) = root {
         Config::load_with_root(root)
     } else {
-        Config::load_with_root(find_project_root_path().unwrap())
+        Config::load_with_root(find_project_root_path(None).unwrap())
     }
     .sanitized()
 }
@@ -52,8 +52,8 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 ///      |__ cwd
 /// ```
 /// will still detect `repo` as root
-pub fn find_project_root_path() -> std::io::Result<PathBuf> {
-    let cwd = std::env::current_dir()?;
+pub fn find_project_root_path(path: Option<PathBuf>) -> std::io::Result<PathBuf> {
+    let cwd = path.unwrap_or(std::env::current_dir()?);
     let boundary = find_git_root_path(&cwd)
         .ok()
         .filter(|p| !p.as_os_str().is_empty())

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -55,7 +55,7 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 pub fn find_project_root_path(path: Option<&PathBuf>) -> std::io::Result<PathBuf> {
     let cwd = &std::env::current_dir()?;
     let cwd = path.unwrap_or(cwd);
-    let boundary = find_git_root_path(&cwd)
+    let boundary = find_git_root_path(cwd)
         .ok()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| cwd.clone());

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -52,8 +52,9 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 ///      |__ [given_path | cwd]
 /// ```
 /// will still detect `repo` as root
-pub fn find_project_root_path(path: Option<PathBuf>) -> std::io::Result<PathBuf> {
-    let cwd = path.unwrap_or(std::env::current_dir()?);
+pub fn find_project_root_path(path: Option<&PathBuf>) -> std::io::Result<PathBuf> {
+    let cwd = &std::env::current_dir()?;
+    let cwd = path.unwrap_or(cwd);
     let boundary = find_git_root_path(&cwd)
         .ok()
         .filter(|p| !p.as_os_str().is_empty())


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I want to use this utility in an external project

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

