### PR TITLE
Add named imports in default solidity templates

### DIFF
--- a/cli/assets/CounterTemplate.s.sol
+++ b/cli/assets/CounterTemplate.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Script} "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 contract CounterScript is Script {
     function setUp() public {}

--- a/cli/assets/CounterTemplate.s.sol
+++ b/cli/assets/CounterTemplate.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Script.sol";
+import {Script} "forge-std/Script.sol";
 
 contract CounterScript is Script {
     function setUp() public {}

--- a/cli/assets/CounterTemplate.s.sol
+++ b/cli/assets/CounterTemplate.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Script} from "forge-std/Script.sol";
+import {Script, console2} from "forge-std/Script.sol";
 
 contract CounterScript is Script {
     function setUp() public {}

--- a/cli/assets/CounterTemplate.t.sol
+++ b/cli/assets/CounterTemplate.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console2} from "forge-std/Test.sol";
 import {Counter} from "../src/Counter.sol";
 
 contract CounterTest is Test {

--- a/cli/assets/CounterTemplate.t.sol
+++ b/cli/assets/CounterTemplate.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "../src/Counter.sol";
+import {Test} from "forge-std/Test.sol";
+import {Counter} from "../src/Counter.sol";
 
 contract CounterTest is Test {
     Counter public counter;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

To Add named imports which can increase readability.

## Solution

In `CounterTemplate.t.sol` and `CounterTemplate.s.sol` 
`named` imports have been added.

fixes #5455 