### PR TITLE
feat(`evm`): make `vm.snapshot`s persistent

### DIFF
--- a/evm/src/executor/backend/mod.rs
+++ b/evm/src/executor/backend/mod.rs
@@ -880,7 +880,9 @@ impl DatabaseExt for Backend {
         current: &mut Env,
     ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
-        if let Some(mut snapshot) = self.inner.snapshots.remove(id) {
+        if let Some(mut snapshot) = self.inner.snapshots.remove_at(id) {
+            // Re-insert snapshot to persist it
+            self.inner.snapshots.insert_at(snapshot.clone(), id);
             // need to check whether there's a global failure which means an error occurred either
             // during the snapshot or even before
             if self.is_global_failure(current_state) {

--- a/evm/src/executor/backend/snapshot.rs
+++ b/evm/src/executor/backend/snapshot.rs
@@ -6,7 +6,7 @@ use revm::{
 use serde::{Deserialize, Serialize};
 
 /// A minimal abstraction of a state at a certain point in time
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct StateSnapshot {
     pub accounts: Map<B160, AccountInfo>,
     pub storage: Map<B160, Map<U256, U256>>,

--- a/evm/src/executor/fork/database.rs
+++ b/evm/src/executor/fork/database.rs
@@ -114,8 +114,9 @@ impl ForkedDatabase {
     }
 
     pub fn revert_snapshot(&mut self, id: U256) -> bool {
-        let snapshot = { self.snapshots().lock().remove(id) };
+        let snapshot = { self.snapshots().lock().remove_at(id) };
         if let Some(snapshot) = snapshot {
+            self.snapshots().lock().insert_at(snapshot.clone(), id);
             let ForkDbSnapshot {
                 local,
                 snapshot: StateSnapshot { accounts, storage, block_hashes },
@@ -200,7 +201,7 @@ impl DatabaseCommit for ForkedDatabase {
 /// Represents a snapshot of the database
 ///
 /// This mimics `revm::CacheDB`
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ForkDbSnapshot {
     pub local: CacheDB<SharedBackend>,
     pub snapshot: StateSnapshot,

--- a/evm/src/executor/snapshot.rs
+++ b/evm/src/executor/snapshot.rs
@@ -55,10 +55,12 @@ impl<T> Snapshots<T> {
         id
     }
 
-    /// Inserts the new snapshot at the given `id`, without auto-incrementing the next `id`.
-    pub fn insert_at(&mut self, snapshot: T, id: U256) -> bool {
+    /// Inserts the new snapshot at the given `id`.
+    ///
+    ///  Does not auto-increment the next `id`.
+    pub fn insert_at(&mut self, snapshot: T, id: U256) -> U256 {
         self.snapshots.insert(id, snapshot);
-        true
+        id
     }
 }
 

--- a/evm/src/executor/snapshot.rs
+++ b/evm/src/executor/snapshot.rs
@@ -41,11 +41,24 @@ impl<T> Snapshots<T> {
         snapshot
     }
 
+    /// Removes the snapshot with the given `id`.
+    ///
+    /// Does not remove snapshots after it.
+    pub fn remove_at(&mut self, id: U256) -> Option<T> {
+        self.snapshots.remove(&id)
+    }
+
     /// Inserts the new snapshot and returns the id
     pub fn insert(&mut self, snapshot: T) -> U256 {
         let id = self.next_id();
         self.snapshots.insert(id, snapshot);
         id
+    }
+
+    /// Inserts the new snapshot at the given `id`, without auto-incrementing the next `id`.
+    pub fn insert_at(&mut self, snapshot: T, id: U256) -> bool {
+        self.snapshots.insert(id, snapshot);
+        true
     }
 }
 


### PR DESCRIPTION
## Motivation

Closes #5118 

Right now snapshots are not persisted, and snapshots created after the snapshot to be deleted are also deleted.

## Solution

Remove this legacy behavior by just persisting snapshots.

We now have a few more clones as a result of this, but it should be OK—this is an infrequent operation.