### PR TITLE
feat(`forge`): support for `console.log` on Invariant handlers

### DIFF
--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -147,10 +147,9 @@ impl InvariantFuzzError {
 
                 traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
 
+                logs.extend(error_call_result.logs);
                 if error_call_result.reverted {
                     break
-                } else {
-                    logs.extend(error_call_result.logs);
                 }
             }
         }

--- a/evm/src/fuzz/invariant/error.rs
+++ b/evm/src/fuzz/invariant/error.rs
@@ -145,8 +145,12 @@ impl InvariantFuzzError {
                     .call_raw(CALLER, self.addr, func.0.clone(), U256::zero())
                     .expect("bad call to evm");
 
+                traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
+
                 if error_call_result.reverted {
                     break
+                } else {
+                    logs.extend(error_call_result.logs);
                 }
             }
         }

--- a/evm/src/fuzz/invariant/executor.rs
+++ b/evm/src/fuzz/invariant/executor.rs
@@ -564,8 +564,12 @@ fn collect_data(
     }
 }
 
+type RichInvariantResults =
+    (bool, Option<BTreeMap<String, RawCallResult>>, Vec<Log>, Option<CallTraceArena>);
+
 /// Verifies that the invariant run execution can continue.
-/// Returns the mapping of (Invariant Function Name -> Call Result) if invariants were asserted.
+/// Returns the mapping of (Invariant Function Name -> Call Result, Logs, Traces) if invariants were
+/// asserted.
 #[allow(clippy::too_many_arguments)]
 fn can_continue(
     invariant_contract: &InvariantContract,
@@ -577,7 +581,7 @@ fn can_continue(
     state_changeset: StateChangeset,
     fail_on_revert: bool,
     shrink_sequence: bool,
-) -> (bool, Option<BTreeMap<String, RawCallResult>>, Vec<Log>, Option<CallTraceArena>) {
+) -> RichInvariantResults {
     let mut call_results = None;
 
     // Detect handler assertion failures first.

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -135,4 +135,8 @@ pub struct InvariantFuzzTestResult {
     pub reverts: usize,
 
     pub last_call_results: Option<BTreeMap<String, RawCallResult>>,
+
+    pub last_call_logs: Vec<Log>,
+
+    pub last_run_traces: Option<CallTraceArena>,
 }

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -1,11 +1,16 @@
 //! Fuzzing support abstracted over the [`Evm`](crate::Evm) used
-use crate::{fuzz::*, CALLER};
+use crate::{
+    fuzz::*,
+    trace::{load_contracts, TraceKind, Traces},
+    CALLER,
+};
 mod error;
 pub use error::InvariantFuzzError;
 mod filters;
 pub use filters::{ArtifactFilters, SenderFilters};
 mod call_override;
 pub use call_override::{set_up_inner_replay, RandomCallGenerator};
+use foundry_common::ContractsByArtifact;
 mod executor;
 use crate::executor::Executor;
 use ethers::{
@@ -87,17 +92,20 @@ pub fn assert_invariants(
                 .expect("to have been initialized.");
 
             // We only care about invariants which we haven't broken yet.
-            if invariant_error.is_none() {
+            if invariant_error.0.is_none() {
                 invariant_failures.failed_invariants.insert(
                     broken_invariant.name.clone(),
-                    Some(InvariantFuzzError::new(
-                        invariant_contract,
-                        Some(broken_invariant),
-                        calldata,
-                        call_result,
-                        &inner_sequence,
-                        shrink_sequence,
-                    )),
+                    (
+                        Some(InvariantFuzzError::new(
+                            invariant_contract,
+                            Some(broken_invariant),
+                            calldata,
+                            call_result,
+                            &inner_sequence,
+                            shrink_sequence,
+                        )),
+                        broken_invariant.clone().to_owned(),
+                    ),
                 );
                 found_case = true;
             } else {
@@ -114,7 +122,7 @@ pub fn assert_invariants(
         invariant_failures.broken_invariants_count = invariant_failures
             .failed_invariants
             .iter()
-            .filter(|(_function, error)| error.is_some())
+            .filter(|(_function, error)| error.0.is_some())
             .count();
 
         eyre::bail!(
@@ -126,18 +134,63 @@ pub fn assert_invariants(
     Ok(call_results)
 }
 
+/// Replays the provided invariant run for collecting the logs and traces from all depths.
+pub fn replay_run(
+    invariant_contract: &InvariantContract,
+    mut executor: Executor,
+    known_contracts: Option<&ContractsByArtifact>,
+    mut ided_contracts: ContractsByAddress,
+    logs: &mut Vec<Log>,
+    traces: &mut Traces,
+    func: Function,
+    inputs: Vec<BasicTxDetails>,
+) {
+    // We want traces for a failed case.
+    executor.set_tracing(true);
+
+    // set_up_inner_replay(&mut executor, &inputs);
+
+    // Replay each call from the sequence until we break the invariant.
+    for (sender, (addr, bytes)) in inputs.iter() {
+        let call_result = executor
+            .call_raw_committing(*sender, *addr, bytes.0.clone(), U256::zero())
+            .expect("bad call to evm");
+
+        logs.extend(call_result.logs);
+        traces.push((TraceKind::Execution, call_result.traces.clone().unwrap()));
+
+        // Identify newly generated contracts, if they exist.
+        ided_contracts.extend(load_contracts(
+            vec![(TraceKind::Execution, call_result.traces.clone().unwrap())],
+            known_contracts,
+        ));
+
+        // Checks the invariant.
+        let error_call_result = executor
+            .call_raw(
+                CALLER,
+                invariant_contract.address,
+                func.encode_input(&[]).expect("invariant should have no inputs").into(),
+                U256::zero(),
+            )
+            .expect("bad call to evm");
+
+        traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
+
+        logs.extend(error_call_result.logs);
+    }
+}
+
 /// The outcome of an invariant fuzz test
 #[derive(Debug)]
 pub struct InvariantFuzzTestResult {
-    pub invariants: BTreeMap<String, Option<InvariantFuzzError>>,
+    pub invariants: BTreeMap<String, (Option<InvariantFuzzError>, Function)>,
     /// Every successful fuzz test case
     pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls
     pub reverts: usize,
 
-    pub last_call_results: Option<BTreeMap<String, RawCallResult>>,
-
-    pub last_call_logs: Vec<Log>,
-
-    pub last_run_traces: Option<CallTraceArena>,
+    /// The entire inputs of the last run of the invariant campaign, used for
+    /// replaying the run for collecting traces.
+    pub last_run_inputs: Vec<BasicTxDetails>,
 }

--- a/evm/src/fuzz/invariant/mod.rs
+++ b/evm/src/fuzz/invariant/mod.rs
@@ -135,6 +135,7 @@ pub fn assert_invariants(
 }
 
 /// Replays the provided invariant run for collecting the logs and traces from all depths.
+#[allow(clippy::too_many_arguments)]
 pub fn replay_run(
     invariant_contract: &InvariantContract,
     mut executor: Executor,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -456,7 +456,9 @@ impl<'a> ContractRunner<'a> {
             return vec![]
         };
 
-        invariants.into_values().map(|test_error| {
+        invariants
+            .into_values()
+            .map(|test_error| {
                 let (test_error, invariant) = test_error;
                 let mut counterexample = None;
                 let mut logs = logs.clone();

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -490,7 +490,6 @@ impl<'a> ContractRunner<'a> {
                         };
 
                         logs.extend(error.logs);
-                        logs.extend(last_call_logs.clone());
 
                         if let Some(error_traces) = error.traces {
                             traces.push((TraceKind::Execution, error_traces));

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -456,9 +456,7 @@ impl<'a> ContractRunner<'a> {
             return vec![]
         };
 
-        invariants
-            .into_iter()
-            .map(|(_, test_error)| {
+        invariants.into_values().map(|test_error| {
                 let (test_error, invariant) = test_error;
                 let mut counterexample = None;
                 let mut logs = logs.clone();


### PR DESCRIPTION
## Motivation

Closes #4951 

## Solution

Adds support for console logs on invariant handlers, by persisting the logs and traces for the last call.

To avoid any performance regressions we only move values and only copy where absolutely necessary (filling each invariant with the corresponding logs at the end), and only persist the call values at the end of each run campaign, as they would just be overwriting values persisted at the stack otherwise.