### PR TITLE
Pass details on GasTooHigh

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -2053,7 +2053,7 @@ impl EthApi {
 
         // Exceptional case: init used too much gas, we need to increase the gas limit and try
         // again
-        if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh)) =
+        if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh(_))) =
             ethres
         {
             // if price or limit was included in the request then we can execute the request
@@ -2125,7 +2125,7 @@ impl EthApi {
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
             // again
-            if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh)) =
+            if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh(_))) =
                 ethres
             {
                 // increase the lowest gas limit

--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -2125,8 +2125,9 @@ impl EthApi {
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
             // again
-            if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh(_))) =
-                ethres
+            if let Err(BlockchainError::InvalidTransaction(InvalidTransactionError::GasTooHigh(
+                _,
+            ))) = ethres
             {
                 // increase the lowest gas limit
                 lowest_gas_limit = mid_gas_limit;

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -2181,7 +2181,7 @@ impl TransactionValidator for Backend {
         if !env.cfg.disable_block_gas_limit && tx.gas_limit() > env.block.gas_limit.into() {
             warn!(target: "backend", "[{:?}] gas too high", tx.hash());
             return Err(InvalidTransactionError::GasTooHigh(ErrDetail {
-                detail: String::from("tx.gas_limit>env.block.gas_limit"),
+                detail: String::from("tx.gas_limit > env.block.gas_limit"),
             }))
         }
 

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -13,7 +13,7 @@ use crate::{
             time::{utc_from_secs, TimeManager},
             validate::TransactionValidator,
         },
-        error::{BlockchainError, InvalidTransactionError},
+        error::{BlockchainError, ErrDetail, InvalidTransactionError},
         fees::{FeeDetails, FeeManager},
         macros::node_info,
         pool::transactions::PoolTransaction,
@@ -2180,7 +2180,9 @@ impl TransactionValidator for Backend {
         // Check gas limit, iff block gas limit is set.
         if !env.cfg.disable_block_gas_limit && tx.gas_limit() > env.block.gas_limit.into() {
             warn!(target: "backend", "[{:?}] gas too high", tx.hash());
-            return Err(InvalidTransactionError::GasTooHigh)
+            return Err(InvalidTransactionError::GasTooHigh(ErrDetail {
+                detail: String::from("tx.gas_limit>env.block.gas_limit"),
+            }))
         }
 
         // check nonce

--- a/anvil/src/eth/error.rs
+++ b/anvil/src/eth/error.rs
@@ -119,6 +119,11 @@ pub enum FeeHistoryError {
     InvalidBlockRange,
 }
 
+#[derive(Debug)]
+pub struct ErrDetail {
+    pub detail: String,
+}
+
 /// An error due to invalid transaction
 #[derive(thiserror::Error, Debug)]
 pub enum InvalidTransactionError {
@@ -150,8 +155,8 @@ pub enum InvalidTransactionError {
     #[error("intrinsic gas too low")]
     GasTooLow,
     /// returned if the transaction gas exceeds the limit
-    #[error("intrinsic gas too high")]
-    GasTooHigh,
+    #[error("intrinsic gas too high -- {}",.0.detail)]
+    GasTooHigh(ErrDetail),
     /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
     /// fee cap.
     #[error("max priority fee per gas higher than max fee per gas")]
@@ -185,8 +190,16 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
                 InvalidTransactionError::TipAboveFeeCap
             }
             InvalidTransaction::GasPriceLessThanBasefee => InvalidTransactionError::FeeCapTooLow,
-            InvalidTransaction::CallerGasLimitMoreThanBlock => InvalidTransactionError::GasTooHigh,
-            InvalidTransaction::CallGasCostMoreThanGasLimit => InvalidTransactionError::GasTooHigh,
+            InvalidTransaction::CallerGasLimitMoreThanBlock => {
+                InvalidTransactionError::GasTooHigh(ErrDetail {
+                    detail: String::from("CallerGasLimitMoreThanBlock"),
+                })
+            }
+            InvalidTransaction::CallGasCostMoreThanGasLimit => {
+                InvalidTransactionError::GasTooHigh(ErrDetail {
+                    detail: String::from("CallGasCostMoreThanGasLimit"),
+                })
+            }
             InvalidTransaction::RejectCallerWithCode => InvalidTransactionError::SenderNoEOA,
             InvalidTransaction::LackOfFundForGasLimit { .. } => {
                 InvalidTransactionError::InsufficientFunds
@@ -272,7 +285,15 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                             data: serde_json::to_value(data).ok(),
                         }
                     }
-                    InvalidTransactionError::GasTooLow | InvalidTransactionError::GasTooHigh => {
+                    InvalidTransactionError::GasTooLow => {
+                        // <https://eips.ethereum.org/EIPS/eip-1898>
+                        RpcError {
+                            code: ErrorCode::ServerError(-32000),
+                            message: err.to_string().into(),
+                            data: None,
+                        }
+                    }
+                    InvalidTransactionError::GasTooHigh(_) => {
                         // <https://eips.ethereum.org/EIPS/eip-1898>
                         RpcError {
                             code: ErrorCode::ServerError(-32000),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

GasTooHigh errors were too opaque and I could not tell what was generating the GasTooHigh error.

## Solution

Made the GasTooHigh variant a struct with a string that could carry details.
