### PR TITLE
feat(`forge`) - Test scaffolding

### DIFF
--- a/cli/assets/generated/TestTemplate.t.sol
+++ b/cli/assets/generated/TestTemplate.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "../src/{contract_name}.sol"; 
+import {Test, console2} from "forge-std/Test.sol";
+import {{contract_name}} from "../src/{contract_name}.sol"; 
 
 contract {contract_name}Test is Test {
     {contract_name} public {instance_name};

--- a/cli/assets/generated/TestTemplate.t.sol
+++ b/cli/assets/generated/TestTemplate.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../src/{contract_name}.sol"; 
+
+contract {contract_name}Test is Test {
+    {contract_name} public {instance_name};
+
+    function setUp() public {
+        {instance_name} = new {contract_name}();
+    }
+}

--- a/cli/src/cmd/forge/generate/mod.rs
+++ b/cli/src/cmd/forge/generate/mod.rs
@@ -1,8 +1,7 @@
 //! generate command
 
 use clap::{Parser, Subcommand};
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
 
 /// CLI arguments for `forge generate`.
 #[derive(Debug, Parser)]

--- a/cli/src/cmd/forge/generate/mod.rs
+++ b/cli/src/cmd/forge/generate/mod.rs
@@ -45,7 +45,7 @@ impl GenerateTestArgs {
         fs::write(&test_file_path, test_content).unwrap();
 
         println!("Test file generated: {}", test_file_path.to_str().unwrap());
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/cli/src/cmd/forge/generate/mod.rs
+++ b/cli/src/cmd/forge/generate/mod.rs
@@ -1,7 +1,9 @@
 //! generate command
 
 use clap::{Parser, Subcommand};
-use std::{fs, path::Path};
+use foundry_common::fs;
+use std::path::Path;
+use yansi::Paint;
 
 /// CLI arguments for `forge generate`.
 #[derive(Debug, Parser)]
@@ -35,15 +37,15 @@ impl GenerateTestArgs {
             .replace("{instance_name}", &instance_name);
 
         // Create the test directory if it doesn't exist.
-        fs::create_dir_all("test").unwrap();
+        fs::create_dir_all("test")?;
 
         // Define the test file path
         let test_file_path = Path::new("test").join(format!("{}.t.sol", contract_name));
 
         // Write the test content to the test file.
-        fs::write(&test_file_path, test_content).unwrap();
+        fs::write(&test_file_path, test_content)?;
 
-        println!("Test file generated: {}", test_file_path.to_str().unwrap());
+        println!("{} test file: {}", Paint::green("Generated"), test_file_path.to_str().unwrap());
         Ok(())
     }
 }

--- a/cli/src/cmd/forge/generate/mod.rs
+++ b/cli/src/cmd/forge/generate/mod.rs
@@ -1,0 +1,70 @@
+//! generate command
+
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::Path;
+
+/// CLI arguments for `forge generate`.
+#[derive(Debug, Parser)]
+pub struct GenerateArgs {
+    #[clap(subcommand)]
+    pub sub: GenerateSubcommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GenerateSubcommands {
+    /// Scaffolds test file for given contract.
+    Test(GenerateTestArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct GenerateTestArgs {
+    /// Contract name for test generation.
+    #[clap(long, short, value_name = "CONTRACT_NAME")]
+    pub contract_name: String,
+}
+
+impl GenerateTestArgs {
+    pub fn run(self) -> eyre::Result<()> {
+        let contract_name = format_identifier(&self.contract_name, true);
+        let instance_name = format_identifier(&self.contract_name, false);
+
+        // Create the test file content.
+        let test_content = include_str!("../../../../assets/generated/TestTemplate.t.sol");
+        let test_content = test_content
+            .replace("{contract_name}", &contract_name)
+            .replace("{instance_name}", &instance_name);
+
+        // Create the test directory if it doesn't exist.
+        fs::create_dir_all("test").unwrap();
+
+        // Define the test file path
+        let test_file_path = Path::new("test").join(format!("{}.t.sol", contract_name));
+
+        // Write the test content to the test file.
+        fs::write(&test_file_path, test_content).unwrap();
+
+        println!("Test file generated: {}", test_file_path.to_str().unwrap());
+        return Ok(());
+    }
+}
+
+/// Utility function to convert an identifier to pascal or camel case.
+fn format_identifier(input: &str, is_pascal_case: bool) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = is_pascal_case;
+
+    for word in input.split_whitespace() {
+        if !word.is_empty() {
+            let (first, rest) = word.split_at(1);
+            let formatted_word = if capitalize_next {
+                format!("{}{}", first.to_uppercase(), rest)
+            } else {
+                format!("{}{}", first.to_lowercase(), rest)
+            };
+            capitalize_next = true;
+            result.push_str(&formatted_word);
+        }
+    }
+    result
+}

--- a/cli/src/cmd/forge/mod.rs
+++ b/cli/src/cmd/forge/mod.rs
@@ -51,6 +51,7 @@ pub mod flatten;
 pub mod fmt;
 pub mod fourbyte;
 pub mod geiger;
+pub mod generate;
 pub mod init;
 pub mod inspect;
 pub mod install;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -2,7 +2,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use foundry_cli::{
     cmd::{
-        forge::{cache::CacheSubcommands, watch},
+        forge::{cache::CacheSubcommands, generate::GenerateSubcommands, watch},
         Cmd,
     },
     handler,
@@ -97,5 +97,8 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::Doc(cmd) => cmd.run(),
         Subcommands::Selectors { command } => utils::block_on(command.run()),
+        Subcommands::Generate(cmd) => match cmd.sub {
+            GenerateSubcommands::Test(cmd) => cmd.run(),
+        },
     }
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -9,7 +9,7 @@ use crate::cmd::forge::{
     flatten,
     fmt::FmtArgs,
     fourbyte::UploadSelectorsArgs,
-    geiger,
+    geiger, generate,
     init::InitArgs,
     inspect,
     install::InstallArgs,
@@ -163,6 +163,9 @@ pub enum Subcommands {
         #[clap(subcommand)]
         command: SelectorsSubcommands,
     },
+
+    /// Generate scaffold files.
+    Generate(generate::GenerateArgs),
 }
 
 // A set of solc compiler settings that can be set via command line arguments, which are intended


### PR DESCRIPTION
> [!NOTE]  
> I have exactly 3 days of Rust experience. So I had to wing this PR. Please excuse if I have missed any obvious expectations. BTW rust blown away by the rust compiler :exploding_head: 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Creating test file typically involves repeated, verbose steps. This PR introduces a new forge sub command to help scaffold generation of test file - one of many features discussed in detail in this issue: #5466 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A new forge sub command has been introduced `forge generate test --contract-name <CONTRACT_NAME>`. For a given contract it does the following:
- Creates the test file in `tests` directory.
- Adds the necessary imports.
- Adds setup code for the test contract.

A sub command called generate has intentionally been added to accommodate  more potential scaffolds in the future - like generating Interface for a given contract which also is a cumbersome exercise. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

cc: @mattsse @Evalir @0x-r4bbit 
