### PR TITLE
logs member name changed to logger when referring to LogCollector inspector

### DIFF
--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -23,7 +23,7 @@ pub struct Inspector {
     pub gas: Option<Rc<RefCell<GasInspector>>>,
     pub tracer: Option<Tracer>,
     /// collects all `console.sol` logs
-    pub logger: LogCollector,
+    pub log_collector: LogCollector,
 }
 
 // === impl Inspector ===
@@ -33,7 +33,7 @@ impl Inspector {
     ///
     /// This will log all `console.sol` logs
     pub fn print_logs(&self) {
-        print_logs(&self.logger.logs)
+        print_logs(&self.log_collector.logs)
     }
 
     /// Configures the `Tracer` [`revm::Inspector`]
@@ -99,7 +99,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             [
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.tracer,
-                Some(&mut self.logger)
+                Some(&mut self.log_collector)
             ],
             {
                 inspector.log(evm_data, address, topics, data);
@@ -135,7 +135,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             [
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.tracer,
-                Some(&mut self.logger)
+                Some(&mut self.log_collector)
             ],
             {
                 inspector.call(data, call, is_static);

--- a/anvil/src/eth/backend/mem/inspector.rs
+++ b/anvil/src/eth/backend/mem/inspector.rs
@@ -23,7 +23,7 @@ pub struct Inspector {
     pub gas: Option<Rc<RefCell<GasInspector>>>,
     pub tracer: Option<Tracer>,
     /// collects all `console.sol` logs
-    pub logs: LogCollector,
+    pub logger: LogCollector,
 }
 
 // === impl Inspector ===
@@ -33,7 +33,7 @@ impl Inspector {
     ///
     /// This will log all `console.sol` logs
     pub fn print_logs(&self) {
-        print_logs(&self.logs.logs)
+        print_logs(&self.logger.logs)
     }
 
     /// Configures the `Tracer` [`revm::Inspector`]
@@ -99,7 +99,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             [
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.tracer,
-                Some(&mut self.logs)
+                Some(&mut self.logger)
             ],
             {
                 inspector.log(evm_data, address, topics, data);
@@ -135,7 +135,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
             [
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.tracer,
-                Some(&mut self.logs)
+                Some(&mut self.logger)
             ],
             {
                 inspector.call(data, call, is_static);

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -75,7 +75,7 @@ impl InspectorStackConfig {
     /// See also [`revm::Evm::inspect_ref`] and  [`revm::Evm::commit_ref`]
     pub fn stack(&self) -> InspectorStack {
         let mut stack =
-            InspectorStack { logs: Some(LogCollector::default()), ..Default::default() };
+            InspectorStack { logger: Some(LogCollector::default()), ..Default::default() };
 
         stack.cheatcodes = self.create_cheatcodes();
         if let Some(ref mut cheatcodes) = stack.cheatcodes {

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -75,7 +75,7 @@ impl InspectorStackConfig {
     /// See also [`revm::Evm::inspect_ref`] and  [`revm::Evm::commit_ref`]
     pub fn stack(&self) -> InspectorStack {
         let mut stack =
-            InspectorStack { logger: Some(LogCollector::default()), ..Default::default() };
+            InspectorStack { log_collector: Some(LogCollector::default()), ..Default::default() };
 
         stack.cheatcodes = self.create_cheatcodes();
         if let Some(ref mut cheatcodes) = stack.cheatcodes {

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -52,7 +52,7 @@ pub struct InspectorData {
 #[derive(Default)]
 pub struct InspectorStack {
     pub tracer: Option<Tracer>,
-    pub logger: Option<LogCollector>,
+    pub log_collector: Option<LogCollector>,
     pub cheatcodes: Option<Cheatcodes>,
     pub gas: Option<Rc<RefCell<GasInspector>>>,
     pub debugger: Option<Debugger>,
@@ -65,7 +65,7 @@ pub struct InspectorStack {
 impl InspectorStack {
     pub fn collect_inspector_states(self) -> InspectorData {
         InspectorData {
-            logs: self.logger.map(|logs| logs.logs).unwrap_or_default(),
+            logs: self.log_collector.map(|logs| logs.logs).unwrap_or_default(),
             labels: self
                 .cheatcodes
                 .as_ref()
@@ -102,7 +102,7 @@ impl InspectorStack {
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -147,7 +147,7 @@ where
                 &mut self.debugger,
                 &mut self.coverage,
                 &mut self.tracer,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -178,7 +178,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -204,7 +204,7 @@ where
     ) {
         call_inspectors!(
             inspector,
-            [&mut self.tracer, &mut self.logger, &mut self.cheatcodes, &mut self.printer],
+            [&mut self.tracer, &mut self.log_collector, &mut self.cheatcodes, &mut self.printer],
             {
                 inspector.log(evm_data, address, topics, data);
             }
@@ -224,7 +224,7 @@ where
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.debugger,
                 &mut self.tracer,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer,
                 &mut self.chisel_state
@@ -256,7 +256,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -308,7 +308,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -341,7 +341,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -370,7 +370,7 @@ where
             [
                 &mut self.debugger,
                 &mut self.tracer,
-                &mut self.logger,
+                &mut self.log_collector,
                 &mut self.cheatcodes,
                 &mut self.printer,
                 &mut self.chisel_state

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -52,7 +52,7 @@ pub struct InspectorData {
 #[derive(Default)]
 pub struct InspectorStack {
     pub tracer: Option<Tracer>,
-    pub logs: Option<LogCollector>,
+    pub logger: Option<LogCollector>,
     pub cheatcodes: Option<Cheatcodes>,
     pub gas: Option<Rc<RefCell<GasInspector>>>,
     pub debugger: Option<Debugger>,
@@ -65,7 +65,7 @@ pub struct InspectorStack {
 impl InspectorStack {
     pub fn collect_inspector_states(self) -> InspectorData {
         InspectorData {
-            logs: self.logs.map(|logs| logs.logs).unwrap_or_default(),
+            logs: self.logger.map(|logs| logs.logs).unwrap_or_default(),
             labels: self
                 .cheatcodes
                 .as_ref()
@@ -102,7 +102,7 @@ impl InspectorStack {
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -147,7 +147,7 @@ where
                 &mut self.debugger,
                 &mut self.coverage,
                 &mut self.tracer,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -178,7 +178,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -204,7 +204,7 @@ where
     ) {
         call_inspectors!(
             inspector,
-            [&mut self.tracer, &mut self.logs, &mut self.cheatcodes, &mut self.printer],
+            [&mut self.tracer, &mut self.logger, &mut self.cheatcodes, &mut self.printer],
             {
                 inspector.log(evm_data, address, topics, data);
             }
@@ -224,7 +224,7 @@ where
                 &mut self.gas.as_deref().map(|gas| gas.borrow_mut()),
                 &mut self.debugger,
                 &mut self.tracer,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer,
                 &mut self.chisel_state
@@ -256,7 +256,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -308,7 +308,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -341,7 +341,7 @@ where
                 &mut self.debugger,
                 &mut self.tracer,
                 &mut self.coverage,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer
             ],
@@ -370,7 +370,7 @@ where
             [
                 &mut self.debugger,
                 &mut self.tracer,
-                &mut self.logs,
+                &mut self.logger,
                 &mut self.cheatcodes,
                 &mut self.printer,
                 &mut self.chisel_state


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

To make the source code clearer, and searching for places where the code is touching the log inspector vs the collected logs, and to make the naming more consistent with its brethren (like "tracer"), I've renamed the struct members in InspectorStack and Inspector from logs to logger.

## Solution

Symbol name change.