### PR TITLE
chore(`forge`): handle fork instantiating failures more gracefully

### DIFF
--- a/chisel/src/executor.rs
+++ b/chisel/src/executor.rs
@@ -236,7 +236,8 @@ impl SessionSource {
     ///
     /// A configured [ChiselRunner]
     async fn prepare_runner(&mut self, final_pc: usize) -> ChiselRunner {
-        let env = self.config.evm_opts.evm_env().await;
+        let env =
+            self.config.evm_opts.evm_env().await.expect("Could not instantiate fork environment");
 
         // Create an in-memory backend
         let backend = match self.config.backend.take() {

--- a/cli/src/cmd/cast/run.rs
+++ b/cli/src/cmd/cast/run.rs
@@ -102,7 +102,7 @@ impl RunArgs {
         evm_opts.fork_block_number = Some(tx_block_number - 1);
 
         // Set up the execution environment
-        let mut env = evm_opts.evm_env().await;
+        let mut env = evm_opts.evm_env().await?;
         // can safely disable base fee checks on replaying txs because can
         // assume those checks already passed on confirmed txs
         env.cfg.disable_base_fee = true;

--- a/cli/src/cmd/forge/coverage.rs
+++ b/cli/src/cmd/forge/coverage.rs
@@ -301,7 +301,7 @@ impl CoverageArgs {
 
         // Build the contract runner
         let evm_spec = evm_spec(&config.evm_version);
-        let env = evm_opts.evm_env().await;
+        let env = evm_opts.evm_env().await?;
         let mut runner = MultiContractRunnerBuilder::default()
             .initial_balance(evm_opts.initial_balance)
             .evm_spec(evm_spec)

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -282,7 +282,8 @@ impl ScriptArgs {
         stage: SimulationStage,
     ) -> ScriptRunner {
         trace!("preparing script runner");
-        let env = script_config.evm_opts.evm_env().await;
+        let env =
+            script_config.evm_opts.evm_env().await.expect("Could not instantiate fork environment");
 
         // The db backend that serves all the data.
         let db = match &script_config.evm_opts.fork_url {

--- a/cli/src/cmd/forge/test/mod.rs
+++ b/cli/src/cmd/forge/test/mod.rs
@@ -176,7 +176,7 @@ impl TestArgs {
             evm_opts.verbosity = 3;
         }
 
-        let env = evm_opts.evm_env().await;
+        let env = evm_opts.evm_env().await?;
 
         // Prepare the test builder
         let evm_spec = evm_spec(&config.evm_version);

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -59,11 +59,11 @@ impl EvmOpts {
     ///
     /// If a `fork_url` is set, it gets configured with settings fetched from the endpoint (chain
     /// id, )
-    pub async fn evm_env(&self) -> revm::primitives::Env {
+    pub async fn evm_env(&self) -> eyre::Result<revm::primitives::Env> {
         if let Some(ref fork_url) = self.fork_url {
-            self.fork_evm_env(fork_url).await.expect("Could not instantiate forked environment").0
+            Ok(self.fork_evm_env(fork_url).await?.0)
         } else {
-            self.local_evm_env()
+            Ok(self.local_evm_env())
         }
     }
 

--- a/forge/tests/it/config.rs
+++ b/forge/tests/it/config.rs
@@ -161,7 +161,12 @@ pub async fn runner_with_config(mut config: Config) -> MultiContractRunner {
     base_runner()
         .with_cheats_config(CheatsConfig::new(&config, &EVM_OPTS))
         .sender(config.sender)
-        .build(&PROJECT.paths.root, (*COMPILED).clone(), EVM_OPTS.evm_env().await, EVM_OPTS.clone())
+        .build(
+            &PROJECT.paths.root,
+            (*COMPILED).clone(),
+            EVM_OPTS.evm_env().await.expect("Could not instantiate fork environment"),
+            EVM_OPTS.clone(),
+        )
         .unwrap()
 }
 
@@ -170,7 +175,12 @@ pub async fn tracing_runner() -> MultiContractRunner {
     let mut opts = EVM_OPTS.clone();
     opts.verbosity = 5;
     base_runner()
-        .build(&PROJECT.paths.root, (*COMPILED).clone(), EVM_OPTS.evm_env().await, opts)
+        .build(
+            &PROJECT.paths.root,
+            (*COMPILED).clone(),
+            EVM_OPTS.evm_env().await.expect("Could not instantiate fork environment"),
+            opts,
+        )
         .unwrap()
 }
 
@@ -181,7 +191,7 @@ pub async fn forked_runner(rpc: &str) -> MultiContractRunner {
     opts.env.chain_id = None; // clear chain id so the correct one gets fetched from the RPC
     opts.fork_url = Some(rpc.to_string());
 
-    let env = opts.evm_env().await;
+    let env = opts.evm_env().await.expect("Could not instantiate fork environment");
     let fork = opts.get_fork(&Default::default(), env.clone());
 
     base_runner()


### PR DESCRIPTION
## Motivation

A smol leftover from #5503, we could handle these failures more gracefully depending on where they happened.

## Solution

Deal with a `Result` instead of outright panicking