### PR TITLE
Add correct processing for non-existent json-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ To use the latest pinned nightly on your CI, modify your Foundry installation st
 - [precompiles will not be compatible with all cheatcodes](https://github.com/foundry-rs/foundry/pull/4905).
 - The difficulty and prevrandao cheatcodes now [fail if not used with the correct EVM version](https://github.com/foundry-rs/foundry/pull/4904).
 - The default EVM version will be Shanghai. If you're using an EVM chain which is not compatible with [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) you need to change your EVM version. See [Matt Solomon's thread](https://twitter.com/msolomon44/status/1656411871635972096) for more information.
+- Non-existent JSON keys are now processed correctly, and `parseJson` returns non-decodable empty bytes if they do not exist. https://github.com/foundry-rs/foundry/pull/5511

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -246,7 +246,7 @@ fn canonicalize_json_key(key: &str) -> String {
 
 /// Encodes a vector of [`Token`] into a vector of bytes.
 fn encode_abi_values(values: Vec<Token>) -> Vec<u8> {
-    if values.len() == 0 {
+    if values.is_empty() {
         abi::encode(&[Token::Bytes(Vec::new())])
     } else if values.len() == 1 {
         abi::encode(&[Token::Bytes(abi::encode(&values))])

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -246,7 +246,9 @@ fn canonicalize_json_key(key: &str) -> String {
 
 /// Encodes a vector of [`Token`] into a vector of bytes.
 fn encode_abi_values(values: Vec<Token>) -> Vec<u8> {
-    if values.len() == 1 {
+    if values.len() == 0 {
+        abi::encode(&[Token::Bytes(Vec::new())])
+    } else if values.len() == 1 {
         abi::encode(&[Token::Bytes(abi::encode(&values))])
     } else {
         abi::encode(&[Token::Bytes(abi::encode(&[Token::Array(values)]))])

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -148,6 +148,17 @@ contract ParseJsonTest is DSTest {
         string memory decodedData = abi.decode(data, (string));
         assertEq("hai", decodedData);
     }
+
+    function test_nonExistentKey() public {
+        bytes memory data = vm.parseJson(json, ".thisKeyDoesNotExist");
+        assertEq(0, data.length);
+
+        data = vm.parseJson(json, ".this.path.does.n.0.t.exist");
+        assertEq(0, data.length);
+
+        data = vm.parseJson("", ".");
+        assertEq(0, data.length);
+    }
 }
 
 contract WriteJsonTest is DSTest {


### PR DESCRIPTION
## Motivation

Right now following code will return `uint256(32)`: `abi.decode(vm.parseJson('{"a": 1}', '.b'), (uint256))` while expected behavior would be for it to revert because `vm.parseJson('{"a": 1}', '.b')` should result in `bytes("")`

But, in fact, it results in `0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000 == abi.encode(bytes(""))`

## Solution

Add processing of edge case when there are no json tokens corresponding to given path
