### PR TITLE
feat(forge): Implement vm.Sleep

### DIFF
--- a/abi/abi/HEVM.sol
+++ b/abi/abi/HEVM.sol
@@ -217,3 +217,5 @@ stopMappingRecording()
 getMappingLength(address,bytes32)
 getMappingSlotAt(address,bytes32,uint256)
 getMappingKeyAndParentOf(address,bytes32)
+
+sleep(uint256)

--- a/abi/src/bindings/hevm.rs
+++ b/abi/src/bindings/hevm.rs
@@ -4340,6 +4340,24 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("sleep"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("sleep"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Uint(256usize),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("snapshot"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -6602,6 +6620,15 @@ pub mod hevm {
         ) -> ::ethers_contract::builders::ContractCall<M, ()> {
             self.0
                 .method_hash([221, 130, 209, 62], p0)
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `sleep` (0xfa9d8713) function
+        pub fn sleep(
+            &self,
+            p0: ::ethers_core::types::U256,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([250, 157, 135, 19], p0)
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `snapshot` (0x9711715a) function
@@ -9317,6 +9344,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "skip", abi = "skip(bool)")]
     pub struct SkipCall(pub bool);
+    ///Container type for all input parameters for the `sleep` function with signature `sleep(uint256)` and selector `0xfa9d8713`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "sleep", abi = "sleep(uint256)")]
+    pub struct SleepCall(pub ::ethers_core::types::U256);
     ///Container type for all input parameters for the `snapshot` function with signature `snapshot()` and selector `0x9711715a`
     #[derive(
         Clone,
@@ -9838,6 +9878,7 @@ pub mod hevm {
         SetNonceUnsafe(SetNonceUnsafeCall),
         Sign(SignCall),
         Skip(SkipCall),
+        Sleep(SleepCall),
         Snapshot(SnapshotCall),
         StartBroadcast0(StartBroadcast0Call),
         StartBroadcast1(StartBroadcast1Call),
@@ -10593,6 +10634,10 @@ pub mod hevm {
                 return Ok(Self::Skip(decoded));
             }
             if let Ok(decoded)
+                = <SleepCall as ::ethers_core::abi::AbiDecode>::decode(data) {
+                return Ok(Self::Sleep(decoded));
+            }
+            if let Ok(decoded)
                 = <SnapshotCall as ::ethers_core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::Snapshot(decoded));
             }
@@ -11110,6 +11155,7 @@ pub mod hevm {
                 }
                 Self::Sign(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Skip(element) => ::ethers_core::abi::AbiEncode::encode(element),
+                Self::Sleep(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Snapshot(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::StartBroadcast0(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
@@ -11374,6 +11420,7 @@ pub mod hevm {
                 Self::SetNonceUnsafe(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Sign(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Skip(element) => ::core::fmt::Display::fmt(element, f),
+                Self::Sleep(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Snapshot(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StartBroadcast0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StartBroadcast1(element) => ::core::fmt::Display::fmt(element, f),
@@ -12255,6 +12302,11 @@ pub mod hevm {
     impl ::core::convert::From<SkipCall> for HEVMCalls {
         fn from(value: SkipCall) -> Self {
             Self::Skip(value)
+        }
+    }
+    impl ::core::convert::From<SleepCall> for HEVMCalls {
+        fn from(value: SleepCall) -> Self {
+            Self::Sleep(value)
         }
     }
     impl ::core::convert::From<SnapshotCall> for HEVMCalls {

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -418,6 +418,15 @@ fn key_exists(json_str: &str, key: &str) -> Result {
     Ok(exists)
 }
 
+/// Sleeps for a given amount of milliseconds.
+fn sleep(milliseconds: &U256) -> Result {
+    let sleep_duration = std::time::Duration::from_millis(milliseconds.as_u64());
+    println!("Sleeping for {:?} milliseconds", sleep_duration);
+    std::thread::sleep(sleep_duration);
+
+    Ok(Default::default())
+}
+
 #[instrument(level = "error", name = "ext", target = "evm::cheatcodes", skip_all)]
 pub fn apply(state: &mut Cheatcodes, call: &HEVMCalls) -> Option<Result> {
     Some(match call {
@@ -592,6 +601,7 @@ pub fn apply(state: &mut Cheatcodes, call: &HEVMCalls) -> Option<Result> {
         HEVMCalls::SerializeBytes1(inner) => {
             serialize_json(state, &inner.0, &inner.1, &array_str_to_str(&inner.2))
         }
+        HEVMCalls::Sleep(inner) => sleep(&inner.0),
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
         HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),

--- a/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -421,7 +421,6 @@ fn key_exists(json_str: &str, key: &str) -> Result {
 /// Sleeps for a given amount of milliseconds.
 fn sleep(milliseconds: &U256) -> Result {
     let sleep_duration = std::time::Duration::from_millis(milliseconds.as_u64());
-    println!("Sleeping for {:?} milliseconds", sleep_duration);
     std::thread::sleep(sleep_duration);
 
     Ok(Default::default())

--- a/testdata/cheats/Sleep.t.sol
+++ b/testdata/cheats/Sleep.t.sol
@@ -16,12 +16,12 @@ contract SleepTest is DSTest {
         inputs[1] = "+%s000";
 
         bytes memory res = vm.ffi(inputs);
-        uint256 start = vm.parseUint(string(res)); 
+        uint256 start = vm.parseUint(string(res));
 
         vm.sleep(milliseconds);
 
         res = vm.ffi(inputs);
-        uint256 end = vm.parseUint(string(res)); 
+        uint256 end = vm.parseUint(string(res));
 
         // Limit precision to 1000 ms
         assertGe(end - start, milliseconds / 1000 * 1000, "sleep failed");
@@ -38,12 +38,12 @@ contract SleepTest is DSTest {
         inputs[1] = "+%s000";
 
         bytes memory res = vm.ffi(inputs);
-        uint256 start = vm.parseUint(string(res)); 
+        uint256 start = vm.parseUint(string(res));
 
         vm.sleep(milliseconds);
 
         res = vm.ffi(inputs);
-        uint256 end = vm.parseUint(string(res)); 
+        uint256 end = vm.parseUint(string(res));
 
         // Limit precision to 1000 ms
         assertGe(end - start, milliseconds / 1000 * 1000, "sleep failed");

--- a/testdata/cheats/Sleep.t.sol
+++ b/testdata/cheats/Sleep.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "./Vm.sol";
+
+contract SleepTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testSleep() public {
+        uint256 milliseconds = 1234;
+
+        string[] memory inputs = new string[](2);
+        inputs[0] = "date";
+        // OS X does not support precision more than 1 second
+        inputs[1] = "+%s000";
+
+        bytes memory res = vm.ffi(inputs);
+        uint256 start = vm.parseUint(string(res)); 
+
+        vm.sleep(milliseconds);
+
+        res = vm.ffi(inputs);
+        uint256 end = vm.parseUint(string(res)); 
+
+        // Limit precision to 1000 ms
+        assertGe(end - start, milliseconds / 1000 * 1000, "sleep failed");
+    }
+
+    /// forge-config: default.fuzz.runs = 10
+    function testSleepFuzzed(uint256 _milliseconds) public {
+        // Limit sleep time to 2 seconds to decrease test time
+        uint256 milliseconds = _milliseconds % 2000;
+
+        string[] memory inputs = new string[](2);
+        inputs[0] = "date";
+        // OS X does not support precision more than 1 second
+        inputs[1] = "+%s000";
+
+        bytes memory res = vm.ffi(inputs);
+        uint256 start = vm.parseUint(string(res)); 
+
+        vm.sleep(milliseconds);
+
+        res = vm.ffi(inputs);
+        uint256 end = vm.parseUint(string(res)); 
+
+        // Limit precision to 1000 ms
+        assertGe(end - start, milliseconds / 1000 * 1000, "sleep failed");
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -183,6 +183,9 @@ interface Vm {
     // Skips a test.
     function skip(bool) external;
 
+    // Sleeps for a given number of milliseconds.
+    function sleep(uint256) external;
+
     // Expects an error on next call
     function expectRevert() external;
 


### PR DESCRIPTION
Closes #4848

Uses `std::thread::sleep(sleep_duration);` to suspend execution of the thread for the specified duration.

It was not straightforward to test this feature. I used vm.ffi() to get time before and after to calculate duration, but OS X `date` command does not support nanosecond precision, so the testing is somehow limited. Not sure at all about behaviour on windows. However this only affects the tests and the implementation should be sound across platforms.