### PR TITLE
fix(`cheatcodes`): disallow using `vm.prank` after `vm.startPrank`

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -161,8 +161,11 @@ fn prank(
 ) -> Result {
     let prank = Prank::new(prank_caller, prank_origin, new_caller, new_origin, depth, single_call);
 
-    if let Some(Prank { used, .. }) = state.prank {
+    if let Some(Prank { used, single_call, .. }) = state.prank {
         ensure!(used, "You cannot overwrite `prank` until it is applied at least once");
+        // This case can only fail if the user calls `vm.startPrank` and then `vm.prank` later on.
+        // This should not be possible.
+        ensure!(single_call == single_call, "You cannot override an ongoing prank with a single vm.prank. Use vm.startPrank to override the current prank.");
     }
 
     ensure!(

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -161,11 +161,11 @@ fn prank(
 ) -> Result {
     let prank = Prank::new(prank_caller, prank_origin, new_caller, new_origin, depth, single_call);
 
-    if let Some(Prank { used, single_call, .. }) = state.prank {
+    if let Some(Prank { used, single_call: current_single_call, .. }) = state.prank {
         ensure!(used, "You cannot overwrite `prank` until it is applied at least once");
         // This case can only fail if the user calls `vm.startPrank` and then `vm.prank` later on.
         // This should not be possible.
-        ensure!(single_call == single_call, "You cannot override an ongoing prank with a single vm.prank. Use vm.startPrank to override the current prank.");
+        ensure!(single_call == current_single_call, "You cannot override an ongoing prank with a single vm.prank. Use vm.startPrank to override the current prank.");
     }
 
     ensure!(

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -164,7 +164,7 @@ fn prank(
     if let Some(Prank { used, single_call: current_single_call, .. }) = state.prank {
         ensure!(used, "You cannot overwrite `prank` until it is applied at least once");
         // This case can only fail if the user calls `vm.startPrank` and then `vm.prank` later on.
-        // This should not be possible.
+        // This should not be possible without first calling `stopPrank`
         ensure!(single_call == current_single_call, "You cannot override an ongoing prank with a single vm.prank. Use vm.startPrank to override the current prank.");
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5515 . This problem (`tx.origin` not being updated correctly after doing `vm.prank` after a `vm.startPrank`) is introduced in part due to https://github.com/foundry-rs/foundry/pull/4884 — we now have certain rules to override pranks that weren't explicit enough in the code. You should probably not be able to call `vm.prank` after a `vm.startPrank`, as `vm.startPrank` is "multi-use" and must be stopped, while `vm.prank` is "single use", and one should not overlap the other, as you can use `vm.startPrank` again after having used the first startPrank. This is made a little confusing as we don't have a `changePrank` cheatcode, but rather re-use `vm.startPrank` for this.

We could probably make a case for allowing this, but this feels like a hard-to-explain possible footgun and I'd rather disallow it entirely.

## Solution

Disallow calling `vm.prank` after a `vm.startPrank`.