### PR TITLE
fix(cast): continue execution after preceding reverted transaction

### DIFF
--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1192,7 +1192,6 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            let filter = filter;
             return Ok(fork.logs(&filter).await?)
         }
 

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -402,7 +402,7 @@ impl Installer<'_> {
             let n = if s.is_empty() { Ok(1) } else { s.parse() };
             // match user input, 0 indicates skipping and use original tag
             match n {
-                Ok(i) if i == 0 => return Ok(tag.into()),
+                Ok(0) => return Ok(tag.into()),
                 Ok(i) if (1..=n_candidates).contains(&i) => {
                     let c = &candidates[i];
                     println!("[{i}] {c} selected");
@@ -470,7 +470,7 @@ impl Installer<'_> {
 
         // match user input, 0 indicates skipping and use original tag
         match input.parse::<usize>() {
-            Ok(i) if i == 0 => Ok(Some(tag.into())),
+            Ok(0) => Ok(Some(tag.into())),
             Ok(i) if (1..=n_candidates).contains(&i) => {
                 let c = &candidates[i];
                 println!("[{i}] {c} selected");

--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -263,7 +263,7 @@ impl ScriptArgs {
         &self,
         mut result: ScriptResult,
         libraries: Libraries,
-        decoder: &mut CallTraceDecoder,
+        decoder: &CallTraceDecoder,
         mut script_config: ScriptConfig,
         verify: VerifyBundle,
     ) -> Result<()> {
@@ -360,7 +360,7 @@ impl ScriptArgs {
         txs: BroadcastableTransactions,
         script_result: &ScriptResult,
         script_config: &mut ScriptConfig,
-        decoder: &mut CallTraceDecoder,
+        decoder: &CallTraceDecoder,
         known_contracts: &ContractsByArtifact,
     ) -> Result<Vec<ScriptSequence>> {
         if !txs.is_empty() {
@@ -391,8 +391,8 @@ impl ScriptArgs {
     async fn fills_transactions_with_gas(
         &self,
         txs: BroadcastableTransactions,
-        script_config: &mut ScriptConfig,
-        decoder: &mut CallTraceDecoder,
+        script_config: &ScriptConfig,
+        decoder: &CallTraceDecoder,
         known_contracts: &ContractsByArtifact,
     ) -> Result<VecDeque<TransactionWithMetadata>> {
         let gas_filled_txs = if self.skip_simulation {

--- a/cli/src/cmd/forge/script/cmd.rs
+++ b/cli/src/cmd/forge/script/cmd.rs
@@ -119,14 +119,8 @@ impl ScriptArgs {
         verify.known_contracts = flatten_contracts(&highlevel_known_contracts, false);
         self.check_contract_sizes(&result, &highlevel_known_contracts)?;
 
-        self.handle_broadcastable_transactions(
-            result,
-            libraries,
-            &mut decoder,
-            script_config,
-            verify,
-        )
-        .await
+        self.handle_broadcastable_transactions(result, libraries, &decoder, script_config, verify)
+            .await
     }
 
     // In case there are libraries to be deployed, it makes sure that these are added to the list of

--- a/cli/src/cmd/forge/script/executor.rs
+++ b/cli/src/cmd/forge/script/executor.rs
@@ -95,8 +95,8 @@ impl ScriptArgs {
     pub async fn onchain_simulation(
         &self,
         transactions: BroadcastableTransactions,
-        script_config: &mut ScriptConfig,
-        decoder: &mut CallTraceDecoder,
+        script_config: &ScriptConfig,
+        decoder: &CallTraceDecoder,
         contracts: &ContractsByArtifact,
     ) -> eyre::Result<VecDeque<TransactionWithMetadata>> {
         trace!(target: "script", "executing onchain simulation");
@@ -247,10 +247,7 @@ impl ScriptArgs {
     }
 
     /// Build the multiple runners from different forks.
-    async fn build_runners(
-        &self,
-        script_config: &mut ScriptConfig,
-    ) -> HashMap<RpcUrl, ScriptRunner> {
+    async fn build_runners(&self, script_config: &ScriptConfig) -> HashMap<RpcUrl, ScriptRunner> {
         let sender = script_config.evm_opts.sender;
 
         if !shell::verbosity().is_silent() {

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -206,7 +206,7 @@ impl CallTraceDecoder {
                         .errors
                         .errors
                         .entry(error.name.clone())
-                        .or_insert_with(Default::default);
+                        .or_default();
                     entry.push(error.clone());
                 });
 

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -202,11 +202,7 @@ impl CallTraceDecoder {
 
                 // Flatten errors from all ABIs
                 abi.errors().for_each(|error| {
-                    let entry = self
-                        .errors
-                        .errors
-                        .entry(error.name.clone())
-                        .or_default();
+                    let entry = self.errors.errors.entry(error.name.clone()).or_default();
                     entry.push(error.clone());
                 });
 

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -69,8 +69,7 @@ impl GasReport {
                 (!self.ignore.contains(&contract_name) && self.report_for.is_empty()) ||
                 (self.report_for.contains(&contract_name));
             if report_contract {
-                let contract_report =
-                    self.contracts.entry(name.to_string()).or_default();
+                let contract_report = self.contracts.entry(name.to_string()).or_default();
 
                 match &trace.data {
                     RawOrDecodedCall::Raw(bytes) if trace.created() => {

--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -70,7 +70,7 @@ impl GasReport {
                 (self.report_for.contains(&contract_name));
             if report_contract {
                 let contract_report =
-                    self.contracts.entry(name.to_string()).or_insert_with(Default::default);
+                    self.contracts.entry(name.to_string()).or_default();
 
                 match &trace.data {
                     RawOrDecodedCall::Raw(bytes) if trace.created() => {


### PR DESCRIPTION
## Motivation

When `cast run` targets the transaction that has a preceding reverted transaction within the same block, execution fails.  

The behavior can be reproduced by running:
```
cast run 0x2c00ce3c21741b75477258190a822d8c358c8584e3eef42426bf06f26e5840de --rpc-url $SEPOLIA_URL
```

<img width="758" alt="Screenshot 2023-08-02 at 13 28 26" src="https://github.com/foundry-rs/foundry/assets/25429261/a7ff237c-2e98-4b4b-974b-0aed95cfa0f4">

## Solution

Skip the reverted transactions without propagating the error.

