### PR TITLE
fix(`forge`): Dedup remappings on build correctly & do not set context by default

### DIFF
--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -153,7 +153,7 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
         remappings.sort_by(|a, b| a.name.cmp(&b.name));
-        remappings.dedup_by(|a, b| a.name.eq(&b.name));
+        remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
         figment.merge(("remappings", remappings)).merge(args)
     }
 }

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -152,7 +152,7 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         let mut remappings = args.project_paths.get_remappings();
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
-        remappings.sort_by(|a, b| a.name.cmp(&b.name));
+        remappings.sort_by(|a, b| (&a.context, &a.name).cmp(&(&b.context, &b.name)));
         remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
         figment.merge(("remappings", remappings)).merge(args)
     }

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -293,7 +293,7 @@ pub fn filter_sources_and_artifacts(
         .filter_map(|(id, path)| {
             let mut resolved = project
                 .paths
-                .resolve_library_import(project.root(), &PathBuf::from(&path))
+                .resolve_library_import(&PathBuf::from(&path))
                 .unwrap_or_else(|| PathBuf::from(&path));
 
             if !resolved.is_absolute() {

--- a/cli/src/cmd/forge/script/build.rs
+++ b/cli/src/cmd/forge/script/build.rs
@@ -293,7 +293,7 @@ pub fn filter_sources_and_artifacts(
         .filter_map(|(id, path)| {
             let mut resolved = project
                 .paths
-                .resolve_library_import(&PathBuf::from(&path))
+                .resolve_library_import(project.root(), &PathBuf::from(&path))
                 .unwrap_or_else(|| PathBuf::from(&path));
 
             if !resolved.is_absolute() {

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -412,6 +412,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         vec![
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
+            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
         ]
     );
@@ -430,6 +431,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         vec![
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
+            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remapping is local to the lib
@@ -455,6 +457,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
             "lib/nested-lib:another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
+            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib
@@ -478,6 +481,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
                 .unwrap(),
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
+            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -412,7 +412,6 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         vec![
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
         ]
     );
@@ -431,11 +430,10 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         vec![
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remapping is local to the lib
-            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 
@@ -454,17 +452,14 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         remappings,
         vec![
             // local to the lib
-            "lib/nested-lib:another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
+            "another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib
-            "lib/nested-lib:nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/"
-                .parse()
-                .unwrap(),
-            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            "nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/".parse().unwrap(),
+            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 
@@ -476,19 +471,14 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
         remappings,
         vec![
             // local to the lib
-            "lib/nested-lib:another-lib/=lib/nested-lib/lib/another-lib/custom-source-dir/"
-                .parse()
-                .unwrap(),
+            "another-lib/=lib/nested-lib/lib/another-lib/custom-source-dir/".parse().unwrap(),
             // global
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
-            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib
-            "lib/nested-lib:nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/"
-                .parse()
-                .unwrap(),
-            "lib/nested-lib:nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
+            "nested-twice/=lib/nested-lib/lib/another-lib/lib/nested-twice/".parse().unwrap(),
+            "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );
 });

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -144,18 +144,10 @@ forgetest_init!(
         let foundry_toml = prj.root().join(Config::FILE_NAME);
         assert!(foundry_toml.exists());
 
-        let mut profile = Config::load_with_root(prj.root());
+        let profile = Config::load_with_root(prj.root());
         // ensure that the auto-generated internal remapping for forge-std's ds-test exists
         assert_eq!(profile.remappings.len(), 2);
-        pretty_eq!(
-            "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/",
-            profile.remappings[2].to_string()
-        );
-
-        // remove the auto-generated remapping to compare with `forge config` since `forge config`
-        // does not include the auto-generated remappings
-        profile.remappings.remove(2);
-        assert_eq!(profile.remappings.len(), 2);
+        pretty_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());
 
         // ensure remappings contain test
         pretty_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -146,7 +146,7 @@ forgetest_init!(
 
         let mut profile = Config::load_with_root(prj.root());
         // ensure that the auto-generated internal remapping for forge-std's ds-test exists
-        assert_eq!(profile.remappings.len(), 3);
+        assert_eq!(profile.remappings.len(), 2);
         pretty_eq!(
             "lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/",
             profile.remappings[2].to_string()

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -169,11 +169,6 @@ impl<'a> RemappingsProvider<'a> {
                     .remappings
                     .into_iter()
                     .map(Remapping::from)
-                    .map(|mut r| {
-                        // todo: windows/mac/linux
-                        r.context = Some(lib.to_string_lossy().to_string());
-                        r
-                    })
                     .collect::<Vec<Remapping>>();
 
                 if let Some(r) = src_remapping {

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -166,8 +166,8 @@ impl<'a> RemappingsProvider<'a> {
                 }
 
                 // Eventually, we could set context for remappings at this location,
-                // taking into account the OS platform. We'll need to be able to handle nested contexts
-                // depending on dependencies for this to work.
+                // taking into account the OS platform. We'll need to be able to handle nested
+                // contexts depending on dependencies for this to work.
                 // For now, we just leave the default context (none).
                 let mut remappings =
                     config.remappings.into_iter().map(Remapping::from).collect::<Vec<Remapping>>();

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -165,6 +165,10 @@ impl<'a> RemappingsProvider<'a> {
                     }
                 }
 
+                // Eventually, we could set context for remappings at this location,
+                // taking into account the OS platform. We'll need to be able to handle nested contexts
+                // depending on dependencies for this to work.
+                // For now, we just leave the default context (none).
                 let mut remappings =
                     config.remappings.into_iter().map(Remapping::from).collect::<Vec<Remapping>>();
 

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -165,11 +165,8 @@ impl<'a> RemappingsProvider<'a> {
                     }
                 }
 
-                let mut remappings = config
-                    .remappings
-                    .into_iter()
-                    .map(Remapping::from)
-                    .collect::<Vec<Remapping>>();
+                let mut remappings =
+                    config.remappings.into_iter().map(Remapping::from).collect::<Vec<Remapping>>();
 
                 if let Some(r) = src_remapping {
                     remappings.push(r);


### PR DESCRIPTION
## Motivation

Right now we have an issue where remappings are being set even if they're optional—which blows up the whole input, and creates problems for _nested_ contexts, which we yet can't really handle. There's also bad deduping happening as we're not taking contexts into account.

## Solution

Do not set contexts by default which resolves #5475.

Also dedupe and sort remappings correctly, which resolves #5447.