### PR TITLE
chore: removed `is_eip1559` boolean flag

### DIFF
--- a/anvil/src/eth/api.rs
+++ b/anvil/src/eth/api.rs
@@ -958,7 +958,6 @@ impl EthApi {
                 pending.transaction,
                 None,
                 None,
-                true,
                 Some(self.backend.base_fee()),
             );
             // we set the from field here explicitly to the set sender of the pending transaction,
@@ -1883,7 +1882,6 @@ impl EthApi {
                 tx.pending_transaction.transaction.clone(),
                 None,
                 None,
-                true,
                 None,
             );
 
@@ -2231,7 +2229,6 @@ impl EthApi {
                 tx,
                 Some(&block),
                 Some(info),
-                true,
                 Some(base_fee),
             );
             block_transactions.push(tx);

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -1360,7 +1360,7 @@ impl Backend {
             let info = storage.transactions.get(&hash)?.info.clone();
             let tx = block.transactions.get(info.transaction_index as usize)?.clone();
 
-            let tx = transaction_build(Some(hash), tx, Some(block), Some(info), true, base_fee);
+            let tx = transaction_build(Some(hash), tx, Some(block), Some(info), base_fee);
             transactions.push(tx);
         }
         Some(transactions)
@@ -1978,7 +1978,6 @@ impl Backend {
             tx,
             Some(&block),
             Some(info),
-            true,
             block.header.base_fee_per_gas,
         ))
     }
@@ -2014,7 +2013,6 @@ impl Backend {
             tx,
             Some(&block),
             Some(info),
-            true,
             block.header.base_fee_per_gas,
         ))
     }
@@ -2238,7 +2236,6 @@ pub fn transaction_build(
     eth_transaction: MaybeImpersonatedTransaction,
     block: Option<&Block>,
     info: Option<TransactionInfo>,
-    is_eip1559: bool,
     base_fee: Option<U256>,
 ) -> Transaction {
     let mut transaction: Transaction = eth_transaction.clone().into();
@@ -2257,10 +2254,6 @@ pub fn transaction_build(
                 base_fee.checked_add(max_priority_fee_per_gas).unwrap_or_else(U256::max_value),
             );
         }
-    } else if !is_eip1559 {
-        transaction.max_fee_per_gas = None;
-        transaction.max_priority_fee_per_gas = None;
-        transaction.transaction_type = None;
     }
 
     transaction.block_hash =

--- a/anvil/src/eth/backend/mem/mod.rs
+++ b/anvil/src/eth/backend/mem/mod.rs
@@ -2254,6 +2254,10 @@ pub fn transaction_build(
                 base_fee.checked_add(max_priority_fee_per_gas).unwrap_or_else(U256::max_value),
             );
         }
+    } else {
+        transaction.max_fee_per_gas = None;
+        transaction.max_priority_fee_per_gas = None;
+        transaction.transaction_type = None;
     }
 
     transaction.block_hash =


### PR DESCRIPTION
## Motivation

Fixes https://github.com/foundry-rs/foundry/issues/5485

## Solution

Removed `is_eip1559` flag from `transaction_build` fn
