### PR TITLE
fix(`remappings`): Only append new lower-priority remappings if they do not exist

### DIFF
--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -153,7 +153,6 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         let mut remappings = Remappings::new_with_remappings(args.project_paths.get_remappings());
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
-        remappings.remappings.sort_by(|a, b| (&a.context, &a.name).cmp(&(&b.context, &b.name)));
         remappings.remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
         figment.merge(("remappings", remappings.remappings)).merge(args)
     }

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -153,7 +153,6 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         let mut remappings = Remappings::new_with_remappings(args.project_paths.get_remappings());
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
-        remappings.remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
         figment.merge(("remappings", remappings.remappings)).merge(args)
     }
 }

--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -13,6 +13,7 @@ use foundry_config::{
         value::{Dict, Map, Value},
         Figment, Metadata, Profile, Provider,
     },
+    providers::remappings::Remappings,
     Config,
 };
 use serde::Serialize;
@@ -149,12 +150,12 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         };
 
         // remappings should stack
-        let mut remappings = args.project_paths.get_remappings();
+        let mut remappings = Remappings::new_with_remappings(args.project_paths.get_remappings());
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
-        remappings.sort_by(|a, b| (&a.context, &a.name).cmp(&(&b.context, &b.name)));
-        remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
-        figment.merge(("remappings", remappings)).merge(args)
+        remappings.remappings.sort_by(|a, b| (&a.context, &a.name).cmp(&(&b.context, &b.name)));
+        remappings.remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
+        figment.merge(("remappings", remappings.remappings)).merge(args)
     }
 }
 

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -395,7 +395,7 @@ forgetest!(can_set_gas_price, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(config.gas_price, Some(300));
 });
 
-// test that optimizer runs works
+// test that we can detect remappings from foundry.toml
 forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCommand| {
     let config = cmd.config();
     let remappings = config.remappings.iter().cloned().map(Remapping::from).collect::<Vec<_>>();
@@ -407,6 +407,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
         ]
     );
+
     // create a new lib directly in the `lib` folder with a remapping
     let mut config = config;
     config.remappings = vec![Remapping::from_str("nested/=lib/nested").unwrap().into()];
@@ -420,11 +421,12 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj: TestProject, mut cmd: TestCom
     pretty_assertions::assert_eq!(
         remappings,
         vec![
-            // global
+            // default
             "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
-            "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remapping is local to the lib
+            "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
+            // global
             "nested/=lib/nested-lib/lib/nested/".parse().unwrap(),
         ]
     );

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -77,7 +77,9 @@ pub mod fix;
 pub use figment;
 use tracing::warn;
 
-mod providers;
+/// config providers
+pub mod providers;
+
 use crate::{
     error::ExtractConfigError,
     etherscan::{EtherscanConfigError, EtherscanConfigs, ResolvedEtherscanConfig},

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2725,9 +2725,8 @@ mod tests {
                 vec![
                     // From environment
                     Remapping::from_str("ds-test=lib/ds-test/").unwrap().into(),
-                    // From remapping.txt
-                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
-                    Remapping::from_str("file-other/=lib/other/").unwrap().into(),
+                    // We won't get the remapping.txt remappings as they're essentially duplicates
+                    // of the environment ones, just with a different name.
                     // From environment
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2725,8 +2725,9 @@ mod tests {
                 vec![
                     // From environment
                     Remapping::from_str("ds-test=lib/ds-test/").unwrap().into(),
-                    // We won't get the remapping.txt remappings as they're essentially duplicates
-                    // of the environment ones, just with a different name.
+                    // From remapping.txt
+                    Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
+                    Remapping::from_str("file-other/=lib/other/").unwrap().into(),
                     // From environment
                     Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2723,13 +2723,12 @@ mod tests {
             assert_eq!(
                 config.remappings,
                 vec![
-                    // From environment
+                    // From environment (should have precedence over remapping.txt)
                     Remapping::from_str("ds-test=lib/ds-test/").unwrap().into(),
-                    // From remapping.txt
+                    Remapping::from_str("other/=lib/other/").unwrap().into(),
+                    // From remapping.txt (should have less precedence than remapping.txt)
                     Remapping::from_str("file-ds-test/=lib/ds-test/").unwrap().into(),
                     Remapping::from_str("file-other/=lib/other/").unwrap().into(),
-                    // From environment
-                    Remapping::from_str("other/=lib/other/").unwrap().into(),
                 ],
             );
 

--- a/config/src/providers/mod.rs
+++ b/config/src/providers/mod.rs
@@ -4,6 +4,7 @@ use figment::{
     Error, Figment, Metadata, Profile, Provider,
 };
 
+/// Remappings provider
 pub mod remappings;
 
 /// Generate warnings for unknown sections and deprecated keys
@@ -16,6 +17,7 @@ pub struct WarningsProvider<P> {
 impl<P> WarningsProvider<P> {
     const WARNINGS_KEY: &'static str = "__warnings";
 
+    /// Creates a new warnings provider.
     pub fn new(
         provider: P,
         profile: impl Into<Profile>,
@@ -24,6 +26,7 @@ impl<P> WarningsProvider<P> {
         Self { provider, profile: profile.into(), old_warnings }
     }
 
+    /// Creates a new figment warnings provider.
     pub fn for_figment(provider: P, figment: &Figment) -> Self {
         let old_warnings = {
             let warnings_res = figment.extract_inner(Self::WARNINGS_KEY);
@@ -38,6 +41,7 @@ impl<P> WarningsProvider<P> {
 }
 
 impl<P: Provider> WarningsProvider<P> {
+    /// Collects all warnings.
     pub fn collect_warnings(&self) -> Result<Vec<Warning>, Error> {
         let mut out = self.old_warnings.clone()?;
         // add warning for unknown sections
@@ -103,6 +107,7 @@ pub struct FallbackProfileProvider<P> {
 }
 
 impl<P> FallbackProfileProvider<P> {
+    /// Creates a new fallback profile provider.
     pub fn new(provider: P, profile: impl Into<Profile>, fallback: impl Into<Profile>) -> Self {
         FallbackProfileProvider { provider, profile: profile.into(), fallback: fallback.into() }
     }

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -6,7 +6,7 @@ use figment::{
 };
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
+    collections::{btree_map::Entry, BTreeMap},
     fs,
     path::{Path, PathBuf},
 };
@@ -83,7 +83,7 @@ impl<'a> RemappingsProvider<'a> {
         ///   - ("a", "1/2") over ("a", "1/2/3")
         /// grouped by remapping context
         fn insert_closest(
-            mappings: &mut HashMap<Option<String>, HashMap<String, PathBuf>>,
+            mappings: &mut BTreeMap<Option<String>, BTreeMap<String, PathBuf>>,
             context: Option<String>,
             key: String,
             path: PathBuf,
@@ -127,7 +127,7 @@ impl<'a> RemappingsProvider<'a> {
         // todo: if a lib specifies contexts for remappings manually, we need to figure out how to
         // resolve that
         if self.auto_detect_remappings {
-            let mut lib_remappings = HashMap::new();
+            let mut lib_remappings = BTreeMap::new();
             // find all remappings of from libs that use a foundry.toml
             for r in self.lib_foundry_toml_remappings() {
                 insert_closest(&mut lib_remappings, r.context, r.name, r.path.into());

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -33,7 +33,7 @@ impl Remappings {
     /// Push an element ot the remappings vector, but only if it's not already present.
     pub fn push(&mut self, remapping: Remapping) {
         if self.remappings.iter().any(|existing| {
-            existing.name.contains(&remapping.name) || remapping.name.contains(&existing.name)
+            existing.name.contains(&remapping.name)
         }) {
         } else {
             self.remappings.push(remapping)

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -20,8 +20,14 @@ pub struct Remappings {
 }
 
 impl Remappings {
-    fn new() -> Self {
+    /// Create a new `Remappings` wrapper with an empty vector.
+    pub fn new() -> Self {
         Self { remappings: Vec::new() }
+    }
+
+    /// Create a new `Remappings` wrapper with a vector of remappings.
+    pub fn new_with_remappings(remappings: Vec<Remapping>) -> Self {
+        Self { remappings }
     }
 
     /// Push an element ot the remappings vector, but only if it's not already present.

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -32,9 +32,7 @@ impl Remappings {
 
     /// Push an element ot the remappings vector, but only if it's not already present.
     pub fn push(&mut self, remapping: Remapping) {
-        if self.remappings.iter().any(|existing| {
-            existing.name.contains(&remapping.name)
-        }) {
+        if self.remappings.iter().any(|existing| existing.name.contains(&remapping.name)) {
         } else {
             self.remappings.push(remapping)
         }

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -32,8 +32,9 @@ impl Remappings {
 
     /// Push an element ot the remappings vector, but only if it's not already present.
     pub fn push(&mut self, remapping: Remapping) {
-        if self.remappings.iter().any(|existing| existing.name.contains(&remapping.name)) {
-        } else {
+        if !self.remappings.iter().any(|existing| {
+            existing.name.contains(&remapping.name) && existing.context == remapping.context
+        }) {
             self.remappings.push(remapping)
         }
     }
@@ -163,9 +164,6 @@ impl<'a> RemappingsProvider<'a> {
                     .collect(),
             );
         }
-
-        // remove duplicates at this point
-        new_remappings.remappings.dedup_by(|a, b| (&a.context, &a.name).eq(&(&b.context, &b.name)));
 
         Ok(new_remappings.remappings)
     }

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -35,7 +35,6 @@ impl Remappings {
         if self.remappings.iter().any(|existing| {
             existing.name.contains(&remapping.name) || remapping.name.contains(&existing.name)
         }) {
-            return
         } else {
             self.remappings.push(remapping)
         }


### PR DESCRIPTION
## Motivation

Closes #5540 

As discussed in the issue, we were doing two things wrong:
- Sorting (therefore losing all priority)
- Inserting remappings that might conflict with other remappings that might not be "closer" but are higher priority.

## Solution

We now do not sort, and only insert if the remapping name has not been seen before.