### PR TITLE
feat(forge): rename master branch to main

### DIFF
--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -74,6 +74,7 @@ impl Cmd for InitArgs {
             git.add(Some("--all"))?;
             let commit_msg = format!("chore: init from {template} at {commit_hash}");
             git.commit(&commit_msg)?;
+            git.rename_branch()?;
         } else {
             // if target is not empty
             if root.read_dir().map_or(false, |mut i| i.next().is_some()) {
@@ -185,6 +186,7 @@ fn init_git_repo(git: Git<'_>, no_commit: bool) -> eyre::Result<()> {
     if !no_commit {
         git.add(Some("--all"))?;
         git.commit("chore: forge init")?;
+        git.rename_branch()?;
     }
 
     Ok(())

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -480,6 +480,10 @@ https://github.com/foundry-rs/foundry/issues/new/choose"
             .map(drop)
     }
 
+    pub fn rename_branch(self) -> Result<()> {
+        self.cmd().args(["branch", "-M", "main"]).exec().map(drop)
+    }
+
     pub fn submodule_update<I, S>(self, force: bool, remote: bool, paths: I) -> Result<()>
     where
         I: IntoIterator<Item = S>,


### PR DESCRIPTION
## Motivation

The motivation comes from the Issue #4344. 

Forge inits git repo with a "master" branch, however "main" name is used in GitHub name convention. 
It creates inconsistency, and in the end people need to rename the branch themselves.

## Solution

In the #4344 I left a comment how I can implement this, however new abstraction `Git` was added; 
I added function `rename_branch()`  in `utils.rs` module:
```rust
pub fn rename_branch(self) -> Result<()> {
    self.cmd().args(["branch", "-M", "main"]).exec().map(drop)
}
```
and inserted this rename after creating commits in the `init.rs` module.

Tested this feature locally by running forge.

---

Thanks for attention!