### PR TITLE
chore: re-export ethers-solc from foundry-config

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -3,7 +3,7 @@
 
 use crate::cache::StorageCachingConfig;
 use ethers_core::types::{Address, Chain::Mainnet, H160, H256, U256};
-pub use ethers_solc::artifacts::OptimizerDetails;
+pub use ethers_solc::{self, artifacts::OptimizerDetails};
 use ethers_solc::{
     artifacts::{
         output_selection::ContractOutputSelection, serde_helpers, BytecodeHash, DebuggingSettings,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Want to reuse config helper methods that return ethers_solc objects in https://github.com/parmanuxyz/solidity-analyzer/issues/12. Re-exporting will allow me to use it without having different crate version error.

I don't think this should be a problem to re-export? If it is let me know.