### PR TITLE
fix(`remappings`): properly filter only autodetected remappings, do not sort unnecesarily

### DIFF
--- a/cli/src/cmd/forge/build/core.rs
+++ b/cli/src/cmd/forge/build/core.rs
@@ -153,7 +153,7 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
         let mut remappings = Remappings::new_with_remappings(args.project_paths.get_remappings());
         remappings
             .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
-        figment.merge(("remappings", remappings.remappings)).merge(args)
+        figment.merge(("remappings", remappings.into_inner())).merge(args)
     }
 }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -574,9 +574,6 @@ impl Config {
                 r.path.path = r.path.path.to_slash_lossy().into_owned().into();
             });
         }
-        // remove any potential duplicates
-        self.remappings.sort_unstable();
-        self.remappings.dedup();
     }
 
     /// Returns the directory in which dependencies should be installed

--- a/config/src/providers/remappings.rs
+++ b/config/src/providers/remappings.rs
@@ -6,7 +6,7 @@ use figment::{
 };
 use std::{
     borrow::Cow,
-    collections::{btree_map::Entry, BTreeMap},
+    collections::{btree_map::Entry, BTreeMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -16,7 +16,7 @@ use tracing::trace;
 #[derive(Debug, Clone, Default)]
 pub struct Remappings {
     /// Remappings.
-    pub remappings: Vec<Remapping>,
+    remappings: Vec<Remapping>,
 }
 
 impl Remappings {
@@ -30,10 +30,30 @@ impl Remappings {
         Self { remappings }
     }
 
+    /// Consumes the wrapper and returns the inner remappings vector.
+    pub fn into_inner(self) -> Vec<Remapping> {
+        let mut tmp = HashSet::new();
+        let remappings = self
+            .remappings
+            .iter()
+            .filter_map(|r| {
+                let r = r.to_owned();
+                // only insert if it's not already present
+                if tmp.insert(r.name.clone()) {
+                    Some(r)
+                } else {
+                    // ignore duplicates
+                    None
+                }
+            })
+            .collect();
+        remappings
+    }
+
     /// Push an element ot the remappings vector, but only if it's not already present.
     pub fn push(&mut self, remapping: Remapping) {
         if !self.remappings.iter().any(|existing| {
-            existing.name.contains(&remapping.name) && existing.context == remapping.context
+            existing.name.starts_with(&remapping.name) && existing.context == remapping.context
         }) {
             self.remappings.push(remapping)
         }
@@ -102,13 +122,15 @@ impl<'a> RemappingsProvider<'a> {
             }
         }
 
-        let mut new_remappings = Remappings::new();
+        // Let's first just extend the remappings with the ones that were passed in,
+        // without any filtering.
+        let mut user_remappings = Vec::new();
 
-        // check env var
+        // check env vars
         if let Some(env_remappings) = remappings_from_env_var("DAPP_REMAPPINGS")
             .or_else(|| remappings_from_env_var("FOUNDRY_REMAPPINGS"))
         {
-            new_remappings
+            user_remappings
                 .extend(env_remappings.map_err::<Error, _>(|err| err.to_string().into())?);
         }
 
@@ -118,11 +140,14 @@ impl<'a> RemappingsProvider<'a> {
             let content = fs::read_to_string(remappings_file).map_err(|err| err.to_string())?;
             let remappings_from_file: Result<Vec<_>, _> =
                 remappings_from_newline(&content).collect();
-            new_remappings
+            user_remappings
                 .extend(remappings_from_file.map_err::<Error, _>(|err| err.to_string().into())?);
         }
 
-        new_remappings.extend(remappings);
+        user_remappings.extend(remappings);
+        // Let's now use the wrapper to conditionally extend the remappings with the autodetected
+        // ones. We want to avoid duplicates, and the wrapper will handle this for us.
+        let mut all_remappings = Remappings::new_with_remappings(user_remappings);
 
         // scan all library dirs and autodetect remappings
         // todo: if a lib specifies contexts for remappings manually, we need to figure out how to
@@ -151,7 +176,7 @@ impl<'a> RemappingsProvider<'a> {
                 insert_closest(&mut lib_remappings, r.context, r.name, r.path.into());
             }
 
-            new_remappings.extend(
+            all_remappings.extend(
                 lib_remappings
                     .into_iter()
                     .flat_map(|(context, remappings)| {
@@ -165,7 +190,7 @@ impl<'a> RemappingsProvider<'a> {
             );
         }
 
-        Ok(new_remappings.remappings)
+        Ok(all_remappings.into_inner())
     }
 
     /// Returns all remappings declared in foundry.toml files of libraries


### PR DESCRIPTION
## Motivation

Closes #5561.

The issue highlighted a few edge cases:
- we should filter with `starts_with`, rather than contains
- we should only filter autodetected remappings, instead of all remappings (as it might be intended for the user to have several keys pointing to the same location)
- we should filter without sorting, so filter instead of deduping.

## Solution

- Adds an `into_inner` method to the wrapper which produces a vector of remappings that are unique.
- removes unwanted sorting/filtering