### PR TITLE
chore: use standard `available_parallelism`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,6 @@ dependencies = [
  "foundry-utils",
  "futures",
  "hex",
- "num_cpus",
  "rayon",
  "rusoto_core",
  "rusoto_kms",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -25,7 +25,6 @@ serde = "1"
 serde_json = "1"
 chrono = "0.4"
 hex = "0.4"
-num_cpus = "1"
 rayon = "1"
 
 # aws

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1801,7 +1801,7 @@ impl SimpleCast {
             eyre::bail!("Invalid signature");
         };
 
-        let num_threads = num_cpus::get();
+        let num_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
         let found = AtomicBool::new(false);
 
         let result: Option<(u32, String, String)> =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Stabilized in 1.59.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace `num_cpus` with [`std::thread::available_parallelism`](https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
