### PR TITLE
feat(forge): Add `--priority-gas-price` argument for `forge script`

### DIFF
--- a/cli/src/cmd/forge/script/broadcast.rs
+++ b/cli/src/cmd/forge/script/broadcast.rs
@@ -113,8 +113,12 @@ impl ScriptArgs {
                             TypedTransaction::Eip1559(ref mut inner) => {
                                 let eip1559_fees =
                                     eip1559_fees.expect("Could not get eip1559 fee estimation.");
+                                if let Some(priority_gas_price) = self.priority_gas_price {
+                                    inner.max_priority_fee_per_gas = Some(priority_gas_price);
+                                } else {
+                                    inner.max_priority_fee_per_gas = Some(eip1559_fees.1);
+                                }
                                 inner.max_fee_per_gas = Some(eip1559_fees.0);
-                                inner.max_priority_fee_per_gas = Some(eip1559_fees.1);
                             }
                         }
                     }

--- a/cli/src/cmd/forge/script/mod.rs
+++ b/cli/src/cmd/forge/script/mod.rs
@@ -116,6 +116,15 @@ pub struct ScriptArgs {
     )]
     pub sig: String,
 
+    /// Max priority fee per gas for EIP1559 transactions.
+    #[clap(
+        long,
+        env = "ETH_PRIORITY_GAS_PRICE",
+        value_parser = parse_ether_value,
+        value_name = "PRICE"
+    )]
+    pub priority_gas_price: Option<U256>,
+
     /// Use legacy transactions instead of EIP1559 ones.
     ///
     /// This is auto-enabled for common networks without EIP1559.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, the estimated `ETH_PRIORITY_GAS_PRICE` used by `forge script` is unnecessarily large on L2's such as Optimism and Arbitrum. Resolves #5281
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR adds an argument to manually set the priority gas price for forge script and uses that price if it is provided. 

[Additional context](https://github.com/foundry-rs/foundry/issues/5281#issuecomment-1673019379)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
