### PR TITLE
perf: replace `rustc-hex` and `hex` with `const-hex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "const-hex",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -827,11 +828,9 @@ dependencies = [
  "foundry-evm",
  "foundry-utils",
  "futures",
- "hex",
  "rayon",
  "rusoto_core",
  "rusoto_kms",
- "rustc-hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -1203,6 +1202,18 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268f52aae268980d03dd9544c1ea591965b2735b038d6998d6e4ab37c8c24445"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -2325,6 +2336,7 @@ name = "forge"
 version = "0.2.0"
 dependencies = [
  "comfy-table",
+ "const-hex",
  "ethers",
  "eyre",
  "foundry-common",
@@ -2332,7 +2344,6 @@ dependencies = [
  "foundry-evm",
  "foundry-utils",
  "glob",
- "hex",
  "once_cell",
  "parking_lot",
  "proptest",
@@ -2444,6 +2455,7 @@ dependencies = [
  "clap_complete_fig",
  "color-eyre",
  "comfy-table",
+ "const-hex",
  "criterion",
  "dialoguer",
  "dotenvy",
@@ -2461,7 +2473,6 @@ dependencies = [
  "foundry-utils",
  "futures",
  "globset",
- "hex",
  "indicatif",
  "itertools",
  "once_cell",
@@ -2473,7 +2484,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rpassword",
- "rustc-hex",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -2583,6 +2593,7 @@ version = "0.2.0"
 dependencies = [
  "auto_impl",
  "bytes",
+ "const-hex",
  "ethers",
  "eyre",
  "foundry-abi",
@@ -2592,7 +2603,6 @@ dependencies = [
  "foundry-utils",
  "futures",
  "hashbrown 0.13.2",
- "hex",
  "itertools",
  "jsonpath_lib",
  "once_cell",
@@ -2635,6 +2645,7 @@ dependencies = [
 name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
+ "const-hex",
  "dunce",
  "ethers-addressbook",
  "ethers-contract",
@@ -2647,13 +2658,11 @@ dependencies = [
  "foundry-common",
  "futures",
  "glob",
- "hex",
  "once_cell",
  "pretty_assertions",
  "rand 0.8.5",
  "reqwest",
  "rlp",
- "rustc-hex",
  "serde",
  "serde_json",
  "tokio",
@@ -7092,12 +7101,12 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 name = "ui"
 version = "0.2.0"
 dependencies = [
+ "const-hex",
  "crossterm 0.26.1",
  "ethers",
  "eyre",
  "forge",
  "foundry-common",
- "hex",
  "revm",
  "tui",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-featu
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 solang-parser = "=0.3.1"
 
 #[patch."https://github.com/gakonst/ethers-rs"]

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -20,11 +20,10 @@ ethers-providers = { workspace = true }
 ethers-signers = { workspace = true }
 futures = "0.3"
 eyre = "0.6"
-rustc-hex = "2"
 serde = "1"
 serde_json = "1"
 chrono.workspace = true
-hex = "0.4"
+hex.workspace = true
 rayon = "1"
 
 # aws

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -60,12 +60,11 @@ tempfile = "3"
 # misc
 eyre = "0.6"
 color-eyre = "0.6"
-rustc-hex = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = { version = "1", default-features = false }
 rpassword = "7"
-hex = "0.4"
+hex = { workspace = true, features = ["serde"] }
 itertools = "0.10"
 proptest = "1"
 semver = "1"

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -22,7 +22,6 @@ use foundry_common::{
     },
 };
 use foundry_config::Config;
-use rustc_hex::ToHex;
 use std::time::Instant;
 
 #[tokio::main]
@@ -83,21 +82,9 @@ async fn main() -> eyre::Result<()> {
         Subcommands::ToHexdata { input } => {
             let value = stdin::unwrap_line(input)?;
             let output = match value {
-                s if s.starts_with('@') => {
-                    let var = std::env::var(&s[1..])?;
-                    var.as_bytes().to_hex()
-                }
-                s if s.starts_with('/') => {
-                    let input = fs::read(s)?;
-                    input.to_hex()
-                }
-                s => {
-                    let mut output = String::new();
-                    for s in s.split(':') {
-                        output.push_str(&s.trim_start_matches("0x").to_lowercase())
-                    }
-                    output
-                }
+                s if s.starts_with('@') => hex::encode(std::env::var(&s[1..])?),
+                s if s.starts_with('/') => hex::encode(fs::read(s)?),
+                s => s.split(':').map(|s| s.trim_start_matches("0x").to_lowercase()).collect(),
             };
             println!("0x{output}");
         }

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -18,7 +18,6 @@ use ethers::{
 };
 use eyre::Context;
 use foundry_common::{abi::parse_tokens, compile, estimate_eip1559_fees};
-use rustc_hex::ToHex;
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
 
@@ -263,10 +262,9 @@ impl CreateArgs {
                 let code = Vec::new();
                 let encoded_args = abi
                     .constructor()
-                    .ok_or(eyre::eyre!("could not find constructor"))?
-                    .encode_input(code, &args)?
-                    .to_hex::<String>();
-                constructor_args = Some(encoded_args);
+                    .ok_or_else(|| eyre::eyre!("could not find constructor"))?
+                    .encode_input(code, &args)?;
+                constructor_args = Some(hex::encode(encoded_args));
             }
 
             self.verify_preflight_check(constructor_args.clone(), chain).await?;

--- a/cli/src/cmd/forge/verify/etherscan/mod.rs
+++ b/cli/src/cmd/forge/verify/etherscan/mod.rs
@@ -24,7 +24,6 @@ use foundry_utils::Retry;
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rustc_hex::ToHex;
 use semver::{BuildMetadata, Version};
 use std::{
     fmt::Debug,
@@ -432,8 +431,8 @@ impl EtherscanVerificationProvider {
             let encoded_args = encode_args(
                 &func,
                 &read_constructor_args_file(constructor_args_path.to_path_buf())?,
-            )?
-            .to_hex::<String>();
+            )?;
+            let encoded_args = hex::encode(encoded_args);
             return Ok(Some(encoded_args[8..].into()))
         }
 

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -19,7 +19,7 @@ ethers = { workspace = true, features = ["ethers-solc"] }
 # Encoding/decoding
 serde_json = "1"
 serde = "1"
-hex = "0.4"
+hex.workspace = true
 jsonpath_lib = "0.3"
 
 # Error handling

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -16,7 +16,7 @@ ethers = { workspace = true, features = ["solc-full"] }
 comfy-table = "6"
 eyre = "0.6"
 glob = "0.3"
-hex = "0.4"
+hex.workspace = true
 once_cell = "1"
 parking_lot = "0.12"
 proptest = "1"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -15,6 +15,6 @@ ethers = { workspace = true }
 
 crossterm = "0.26"
 eyre = "0.6"
-hex = "0.4"
+hex.workspace = true
 revm = { version = "3", features = ["std", "serde"] }
 tui = { version = "0.19", default-features = false, features = ["crossterm"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,12 +19,11 @@ ethers-solc = { workspace = true }
 eyre = { version = "0.6", default-features = false }
 futures = "0.3"
 glob = "0.3"
-hex = "0.4"
+hex.workspace = true
 once_cell = "1"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls"] }
 rlp = "0.5"
-rustc-hex = { version = "2", default-features = false }
 serde = "1"
 serde_json = { version = "1", default-features = false }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

[`const-hex`](https://github.com/DaniPopes/const-hex)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
