### PR TITLE
fix(`evm`): revert all revm changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,12 +70,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "alloy-rlp"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,9 +637,6 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -3219,11 +3210,6 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-dependencies = [
- "ahash 0.8.3",
- "allocator-api2",
- "serde",
-]
 
 [[package]]
 name = "hashers"
@@ -5336,11 +5322,9 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/bluealloy/revm/?rev=bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab#bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "auto_impl",
- "once_cell",
- "rayon",
  "revm-interpreter",
  "revm-precompile",
  "serde",
@@ -5350,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm/?rev=bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab#bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "derive_more",
  "enumn",
@@ -5362,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/bluealloy/revm/?rev=bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab#bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "k256",
  "num",
@@ -5378,16 +5362,15 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm/?rev=bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab#bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab"
+source = "git+https://github.com/bluealloy/revm/?branch=release/v25#88337924f4d16ed1f5e4cde12a03d0cb755cd658"
 dependencies = [
  "auto_impl",
- "bitflags 2.3.3",
  "bitvec 1.0.1",
  "bytes",
  "derive_more",
  "enumn",
  "fixed-hash",
- "hashbrown 0.14.0",
+ "hashbrown 0.13.2",
  "hex",
  "hex-literal",
  "primitive-types",
@@ -5395,7 +5378,6 @@ dependencies = [
  "ruint",
  "serde",
  "sha3",
- "to-binary",
 ]
 
 [[package]]
@@ -6623,15 +6605,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "to-binary"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424552bc848fd1afbcd81f0e8a54b7401b90fd81bb418655ad6dc6d0823bbe3"
-dependencies = [
- "hex",
-]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,4 +135,4 @@ solang-parser = "=0.3.1"
 #ethers-solc = { path = "../ethers-rs/ethers-solc" }
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm/", rev = "bc4d203bf0b5f5c01868477c8e98d3abd6bb92ab" }
+revm = { git = "https://github.com/bluealloy/revm/", branch = "release/v25" }

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -61,21 +61,22 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        is_static: bool,
     ) -> InstructionResult {
         call_inspectors!(
             inspector,
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],
-            { inspector.initialize_interp(interp, data) }
+            { inspector.initialize_interp(interp, data, is_static) }
         );
         InstructionResult::Continue
     }
 
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>) -> InstructionResult {
+    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, is_static: bool) -> InstructionResult {
         call_inspectors!(
             inspector,
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],
             {
-                inspector.step(interp, data);
+                inspector.step(interp, data, is_static);
             }
         );
         InstructionResult::Continue
@@ -105,13 +106,14 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        is_static: bool,
         eval: InstructionResult,
     ) -> InstructionResult {
         call_inspectors!(
             inspector,
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],
             {
-                inspector.step_end(interp, data, eval);
+                inspector.step_end(interp, data, is_static, eval);
             }
         );
         eval
@@ -121,6 +123,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
+        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         call_inspectors!(
             inspector,
@@ -130,7 +133,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
                 Some(&mut self.log_collector)
             ],
             {
-                inspector.call(data, call);
+                inspector.call(data, call, is_static);
             }
         );
 
@@ -144,12 +147,13 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
+        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         call_inspectors!(
             inspector,
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],
             {
-                inspector.call_end(data, inputs, remaining_gas, ret, out.clone());
+                inspector.call_end(data, inputs, remaining_gas, ret, out.clone(), is_static);
             }
         );
         (ret, remaining_gas, out)

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -71,7 +71,12 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         InstructionResult::Continue
     }
 
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, is_static: bool) -> InstructionResult {
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> InstructionResult {
         call_inspectors!(
             inspector,
             [&mut self.gas.as_deref().map(|gas| gas.borrow_mut()), &mut self.tracer],

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -179,9 +179,6 @@ pub enum InvalidTransactionError {
     /// Thrown when a legacy tx was signed for a different chain
     #[error("Incompatible EIP-155 transaction, signed for another chain")]
     IncompatibleEIP155,
-    /// Thrown when an access list is used before the berlin hard fork.
-    #[error("Access lists are not supported before the Berlin hardfork")]
-    AccessListNotSupported,
 }
 
 impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
@@ -204,7 +201,7 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
                 })
             }
             InvalidTransaction::RejectCallerWithCode => InvalidTransactionError::SenderNoEOA,
-            InvalidTransaction::LackOfFundForMaxFee { .. } => {
+            InvalidTransaction::LackOfFundForGasLimit { .. } => {
                 InvalidTransactionError::InsufficientFunds
             }
             InvalidTransaction::OverflowPaymentInTransaction => {
@@ -218,9 +215,6 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
             }
             InvalidTransaction::NonceTooHigh { .. } => InvalidTransactionError::NonceTooHigh,
             InvalidTransaction::NonceTooLow { .. } => InvalidTransactionError::NonceTooLow,
-            InvalidTransaction::AccessListNotSupported => {
-                InvalidTransactionError::AccessListNotSupported
-            }
         }
     }
 }

--- a/crates/anvil/src/genesis.rs
+++ b/crates/anvil/src/genesis.rs
@@ -146,7 +146,7 @@ impl From<GenesisAccount> for AccountInfo {
         AccountInfo {
             balance: balance.into(),
             nonce: nonce.unwrap_or_default(),
-            code_hash: code.as_ref().map(|code| code.hash_slow()).unwrap_or(KECCAK_EMPTY),
+            code_hash: code.as_ref().map(|code| code.hash).unwrap_or(KECCAK_EMPTY),
             code,
         }
     }

--- a/crates/evm/src/executor/backend/mod.rs
+++ b/crates/evm/src/executor/backend/mod.rs
@@ -1099,7 +1099,7 @@ impl DatabaseExt for Backend {
                 // prevent issues in the new journalstate, e.g. assumptions that accounts are loaded
                 // if the account is not touched, we reload it, if it's touched we clone it
                 for (addr, acc) in journaled_state.state.iter() {
-                    if acc.is_touched() {
+                    if acc.is_touched {
                         merge_journaled_state_data(
                             b160_to_h160(*addr),
                             journaled_state,

--- a/crates/evm/src/executor/fork/cache.rs
+++ b/crates/evm/src/executor/fork/cache.rs
@@ -1,13 +1,11 @@
 //! Cache related abstraction
 use crate::executor::backend::snapshot::StateSnapshot;
+use hashbrown::HashMap as Map;
 use parking_lot::RwLock;
 use revm::{
-    primitives::{
-        Account, AccountInfo, B160, B256, KECCAK_EMPTY, U256,
-    },
+    primitives::{Account, AccountInfo, B160, B256, KECCAK_EMPTY, U256},
     DatabaseCommit,
 };
-use hashbrown::HashMap as Map;
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeSet, fs, io::BufWriter, path::PathBuf, sync::Arc};
 
@@ -257,12 +255,8 @@ impl MemDb {
                 storage.remove(&add);
             } else {
                 // insert account
-                if let Some(code_hash) = acc
-                    .info
-                    .code
-                    .as_ref()
-                    .filter(|code| !code.is_empty())
-                    .map(|code| code.hash)
+                if let Some(code_hash) =
+                    acc.info.code.as_ref().filter(|code| !code.is_empty()).map(|code| code.hash)
                 {
                     acc.info.code_hash = code_hash;
                 } else if acc.info.code_hash.is_zero() {

--- a/crates/evm/src/executor/inspector/access_list.rs
+++ b/crates/evm/src/executor/inspector/access_list.rs
@@ -58,6 +58,7 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         _data: &mut EVMData<'_, DB>,
+        _is_static: bool,
     ) -> InstructionResult {
         let pc = interpreter.program_counter();
         let op = interpreter.contract.bytecode.bytecode()[pc];

--- a/crates/evm/src/executor/inspector/cheatcodes/mapping.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/mapping.rs
@@ -91,7 +91,7 @@ pub fn on_evm_step<DB: Database>(
     _data: &mut EVMData<'_, DB>,
 ) {
     match interpreter.contract.bytecode.bytecode()[interpreter.program_counter()] {
-        opcode::KECCAK256 => {
+        opcode::SHA3 => {
             if interpreter.stack.peek(1) == Ok(revm::primitives::U256::from(0x40)) {
                 let address = interpreter.contract.address;
                 let offset = interpreter.stack.peek(0).expect("stack size > 1").to::<usize>();

--- a/crates/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -303,6 +303,7 @@ where
         &mut self,
         _: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
         // When the first interpreter is initialized we've circumvented the balance and gas checks,
         // so we apply our actual block data with the correct fees and all.
@@ -320,6 +321,7 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
         self.pc = interpreter.program_counter();
 
@@ -520,7 +522,7 @@ where
                 (CALLCODE, 5, 6, true),
                 (STATICCALL, 4, 5, true),
                 (DELEGATECALL, 4, 5, true),
-                (KECCAK256, 0, 1, false),
+                (SHA3, 0, 1, false),
                 (LOG0, 0, 1, false),
                 (LOG1, 0, 1, false),
                 (LOG2, 0, 1, false),
@@ -575,6 +577,7 @@ where
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
+        is_static: bool,
     ) -> (InstructionResult, Gas, bytes::Bytes) {
         if call.contract == h160_to_b160(CHEATCODE_ADDRESS) {
             let gas = Gas::new(call.gas_limit);
@@ -683,7 +686,7 @@ where
                     // because we only need the from, to, value, and data. We can later change this
                     // into 1559, in the cli package, relatively easily once we
                     // know the target chain supports EIP-1559.
-                    if !call.is_static {
+                    if !is_static {
                         if let Err(err) = data
                             .journaled_state
                             .load_account(h160_to_b160(broadcast.new_origin), data.db)
@@ -748,6 +751,7 @@ where
         remaining_gas: Gas,
         status: InstructionResult,
         retdata: bytes::Bytes,
+        _: bool,
     ) -> (InstructionResult, Gas, bytes::Bytes) {
         if call.contract == h160_to_b160(CHEATCODE_ADDRESS) ||
             call.contract == h160_to_b160(HARDHAT_CONSOLE_ADDRESS)

--- a/crates/evm/src/executor/inspector/chisel_state.rs
+++ b/crates/evm/src/executor/inspector/chisel_state.rs
@@ -26,6 +26,7 @@ where
         &mut self,
         interp: &mut Interpreter,
         _: &mut revm::EVMData<'_, DB>,
+        _: bool,
         eval: InstructionResult,
     ) -> InstructionResult {
         // If we are at the final pc of the REPL contract execution, set the state.

--- a/crates/evm/src/executor/inspector/coverage.rs
+++ b/crates/evm/src/executor/inspector/coverage.rs
@@ -22,8 +22,9 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
-        let hash = b256_to_h256(interpreter.contract.bytecode.clone().unlock().hash_slow());
+        let hash = b256_to_h256(interpreter.contract.bytecode.hash());
         self.maps.entry(hash).or_insert_with(|| {
             HitMap::new(Bytes::copy_from_slice(
                 interpreter.contract.bytecode.original_bytecode_slice(),
@@ -37,8 +38,9 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
-        let hash = b256_to_h256(interpreter.contract.bytecode.clone().unlock().hash_slow());
+        let hash = b256_to_h256(interpreter.contract.bytecode.hash());
         self.maps.entry(hash).and_modify(|map| map.hit(interpreter.program_counter()));
 
         InstructionResult::Continue

--- a/crates/evm/src/executor/inspector/debugger.rs
+++ b/crates/evm/src/executor/inspector/debugger.rs
@@ -70,6 +70,7 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
         let pc = interpreter.program_counter();
         let op = interpreter.contract.bytecode.bytecode()[pc];
@@ -111,6 +112,7 @@ where
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.enter(
             data.journaled_state.depth() as usize,
@@ -137,6 +139,7 @@ where
         gas: Gas,
         status: InstructionResult,
         retdata: Bytes,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.exit();
 

--- a/crates/evm/src/executor/inspector/fuzzer.rs
+++ b/crates/evm/src/executor/inspector/fuzzer.rs
@@ -27,6 +27,7 @@ where
         &mut self,
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
+        _: bool,
     ) -> InstructionResult {
         // We only collect `stack` and `memory` data before and after calls.
         if self.collect {
@@ -40,6 +41,7 @@ where
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         // We don't want to override the very first call made to the test contract.
         if self.call_generator.is_some() && data.env.tx.caller != call.context.caller {
@@ -60,6 +62,7 @@ where
         remaining_gas: Gas,
         status: InstructionResult,
         retdata: Bytes,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         if let Some(ref mut call_generator) = self.call_generator {
             call_generator.used = false;

--- a/crates/evm/src/executor/inspector/logs.rs
+++ b/crates/evm/src/executor/inspector/logs.rs
@@ -60,6 +60,7 @@ where
         &mut self,
         _: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         if call.contract == h160_to_b160(HARDHAT_CONSOLE_ADDRESS) {
             let (status, reason) = self.hardhat_log(call.input.to_vec());

--- a/crates/evm/src/executor/inspector/printer.rs
+++ b/crates/evm/src/executor/inspector/printer.rs
@@ -24,7 +24,12 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
 
     // get opcode by calling `interp.contract.opcode(interp.program_counter())`.
     // all other information can be obtained from interp.
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, is_static: bool) -> InstructionResult {
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> InstructionResult {
         let opcode = interp.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 

--- a/crates/evm/src/executor/inspector/printer.rs
+++ b/crates/evm/src/executor/inspector/printer.rs
@@ -16,14 +16,15 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        is_static: bool,
     ) -> InstructionResult {
-        self.gas_inspector.initialize_interp(interp, data);
+        self.gas_inspector.initialize_interp(interp, data, is_static);
         InstructionResult::Continue
     }
 
     // get opcode by calling `interp.contract.opcode(interp.program_counter())`.
     // all other information can be obtained from interp.
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>) -> InstructionResult {
+    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, is_static: bool) -> InstructionResult {
         let opcode = interp.current_opcode();
         let opcode_str = opcode::OPCODE_JUMPMAP[opcode as usize];
 
@@ -44,7 +45,7 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
             hex::encode(interp.memory.data()),
         );
 
-        self.gas_inspector.step(interp, data);
+        self.gas_inspector.step(interp, data, is_static);
 
         InstructionResult::Continue
     }
@@ -53,9 +54,10 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        is_static: bool,
         eval: InstructionResult,
     ) -> InstructionResult {
-        self.gas_inspector.step_end(interp, data, eval);
+        self.gas_inspector.step_end(interp, data, is_static, eval);
         InstructionResult::Continue
     }
 
@@ -63,12 +65,13 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         &mut self,
         _data: &mut EVMData<'_, DB>,
         inputs: &mut CallInputs,
+        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         println!(
             "SM CALL:   {:?},context:{:?}, is_static:{:?}, transfer:{:?}, input_size:{:?}",
             inputs.contract,
             inputs.context,
-            inputs.is_static,
+            is_static,
             inputs.transfer,
             inputs.input.len(),
         );
@@ -82,8 +85,9 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         remaining_gas: Gas,
         ret: InstructionResult,
         out: Bytes,
+        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
-        self.gas_inspector.call_end(data, inputs, remaining_gas, ret, out.clone());
+        self.gas_inspector.call_end(data, inputs, remaining_gas, ret, out.clone(), is_static);
         (ret, remaining_gas, out)
     }
 

--- a/crates/evm/src/executor/inspector/stack.rs
+++ b/crates/evm/src/executor/inspector/stack.rs
@@ -107,8 +107,14 @@ impl InspectorStack {
                 &mut self.printer
             ],
             {
-                let (new_status, new_gas, new_retdata) =
-                    inspector.call_end(data, call, remaining_gas, status, retdata.clone(), is_static);
+                let (new_status, new_gas, new_retdata) = inspector.call_end(
+                    data,
+                    call,
+                    remaining_gas,
+                    status,
+                    retdata.clone(),
+                    is_static,
+                );
 
                 // If the inspector returns a different status or a revert with a non-empty message,
                 // we assume it wants to tell us something
@@ -240,7 +246,7 @@ where
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
-        is_static: bool
+        is_static: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         call_inspectors!(
             inspector,

--- a/crates/evm/src/executor/inspector/tracer.rs
+++ b/crates/evm/src/executor/inspector/tracer.rs
@@ -162,7 +162,7 @@ impl<DB> Inspector<DB> for Tracer
 where
     DB: Database,
 {
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>) -> InstructionResult {
+    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, _is_static: bool) -> InstructionResult {
         if !self.record_steps {
             return InstructionResult::Continue
         }
@@ -183,6 +183,7 @@ where
         &mut self,
         interp: &mut Interpreter,
         data: &mut EVMData<'_, DB>,
+        _: bool,
         status: InstructionResult,
     ) -> InstructionResult {
         if !self.record_steps {
@@ -198,6 +199,7 @@ where
         &mut self,
         data: &mut EVMData<'_, DB>,
         inputs: &mut CallInputs,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         let (from, to) = match inputs.context.scheme {
             CallScheme::DelegateCall | CallScheme::CallCode => {
@@ -225,6 +227,7 @@ where
         gas: Gas,
         status: InstructionResult,
         retdata: Bytes,
+        _: bool,
     ) -> (InstructionResult, Gas, Bytes) {
         self.fill_trace(
             status,

--- a/crates/evm/src/executor/inspector/tracer.rs
+++ b/crates/evm/src/executor/inspector/tracer.rs
@@ -162,7 +162,12 @@ impl<DB> Inspector<DB> for Tracer
 where
     DB: Database,
 {
-    fn step(&mut self, interp: &mut Interpreter, data: &mut EVMData<'_, DB>, _is_static: bool) -> InstructionResult {
+    fn step(
+        &mut self,
+        interp: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> InstructionResult {
         if !self.record_steps {
             return InstructionResult::Continue
         }

--- a/crates/evm/src/fuzz/strategies/state.rs
+++ b/crates/evm/src/fuzz/strategies/state.rs
@@ -260,7 +260,7 @@ pub fn collect_created_contracts(
 
     for (address, account) in state_changeset {
         if !setup_contracts.contains_key(&b160_to_h160(*address)) {
-            if let (true, Some(code)) = (&account.is_touched(), &account.info.code) {
+            if let (true, Some(code)) = (&account.is_touched, &account.info.code) {
                 if !code.is_empty() {
                     if let Some((artifact, (abi, _))) = project_contracts.find_by_code(code.bytes())
                     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

For some reason the revm upgrade broke a lot of stuff that shouldn't have been broken considering the migration was mostly transparent, and we've yet to triage the entirety of the issue.

## Solution

Revert back to `release/25` as a stable revm version. The current branch with latest revm changes is now `latest-revm`.