### PR TITLE
chore(cli): remove `Cmd` trait

### DIFF
--- a/crates/cli/src/cast/cmd/access_list.rs
+++ b/crates/cli/src/cast/cmd/access_list.rs
@@ -4,7 +4,7 @@ use ethers::{
     providers::Middleware,
     types::{BlockId, NameOrAddress},
 };
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
     utils,
@@ -57,7 +57,7 @@ pub struct AccessListArgs {
 }
 
 impl AccessListArgs {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let AccessListArgs { to, sig, args, data, tx, eth, block, json: to_json } = self;
 
         let config = Config::from(&eth);
@@ -82,7 +82,7 @@ async fn access_list<M: Middleware, F: Into<NameOrAddress>, T: Into<NameOrAddres
     chain: Chain,
     block: Option<BlockId>,
     to_json: bool,
-) -> eyre::Result<()>
+) -> Result<()>
 where
     M::Error: 'static,
 {

--- a/crates/cli/src/cast/cmd/call.rs
+++ b/crates/cli/src/cast/cmd/call.rs
@@ -4,7 +4,7 @@ use ethers::{
     solc::EvmVersion,
     types::{BlockId, NameOrAddress, U256},
 };
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use forge::executor::opts::EvmOpts;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
@@ -108,7 +108,7 @@ pub enum CallSubcommands {
 }
 
 impl CallArgs {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let CallArgs {
             to,
             sig,
@@ -224,7 +224,7 @@ async fn fill_create(
     code: String,
     sig: Option<String>,
     args: Vec<String>,
-) -> eyre::Result<()> {
+) -> Result<()> {
     builder.value(value);
 
     let mut data = hex::decode(code.strip_prefix("0x").unwrap_or(&code))?;
@@ -246,7 +246,7 @@ async fn fill_tx(
     sig: Option<String>,
     args: Vec<String>,
     data: Option<String>,
-) -> eyre::Result<()> {
+) -> Result<()> {
     builder.value(value);
 
     if let Some(sig) = sig {

--- a/crates/cli/src/cast/cmd/create2.rs
+++ b/crates/cli/src/cast/cmd/create2.rs
@@ -6,7 +6,6 @@ use ethers::{
     utils::{get_create2_address_from_hash, keccak256},
 };
 use eyre::{Result, WrapErr};
-use foundry_cli::utils::Cmd;
 use rayon::prelude::*;
 use regex::RegexSetBuilder;
 use std::{str::FromStr, time::Instant};
@@ -59,16 +58,8 @@ pub struct Create2Output {
     pub salt: U256,
 }
 
-impl Cmd for Create2Args {
-    type Output = Create2Output;
-
-    fn run(self) -> eyre::Result<Self::Output> {
-        Create2Args::generate_address(self)
-    }
-}
-
 impl Create2Args {
-    fn generate_address(self) -> Result<Create2Output> {
+    pub fn run(self) -> Result<Create2Output> {
         let Create2Args {
             starts_with,
             ends_with,

--- a/crates/cli/src/cast/cmd/interface.rs
+++ b/crates/cli/src/cast/cmd/interface.rs
@@ -1,5 +1,6 @@
 use cast::{AbiPath, SimpleCast};
 use clap::Parser;
+use eyre::Result;
 use foundry_cli::opts::EtherscanOpts;
 use foundry_common::fs;
 use foundry_config::Config;
@@ -37,7 +38,7 @@ pub struct InterfaceArgs {
 }
 
 impl InterfaceArgs {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let InterfaceArgs { path_or_address, name, pragma, output: output_location, etherscan } =
             self;
         let config = Config::from(&etherscan);

--- a/crates/cli/src/cast/cmd/logs.rs
+++ b/crates/cli/src/cast/cmd/logs.rs
@@ -5,13 +5,11 @@ use ethers::{
     providers::Middleware,
     types::{BlockId, BlockNumber, Filter, FilterBlockOption, NameOrAddress, ValueOrArray, H256},
 };
+use eyre::Result;
 use foundry_cli::{opts::EthereumOpts, utils};
-
 use foundry_common::abi::{get_event, parse_tokens};
 use foundry_config::Config;
-
 use itertools::Itertools;
-
 use std::str::FromStr;
 
 /// CLI arguments for `cast logs`.
@@ -55,7 +53,7 @@ pub struct LogsArgs {
 }
 
 impl LogsArgs {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let LogsArgs {
             from_block, to_block, address, topics_or_args, sig_or_topic, json, eth, ..
         } = self;

--- a/crates/cli/src/cast/cmd/run.rs
+++ b/crates/cli/src/cast/cmd/run.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use ethers::{prelude::Middleware, solc::EvmVersion, types::H160};
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use forge::{
     executor::{inspector::cheatcodes::util::configure_tx_env, opts::EvmOpts},
     revm::primitives::U256 as rU256,
@@ -82,7 +82,7 @@ impl RunArgs {
     /// This replays the entire block the transaction was mined in unless `quick` is set to true
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let figment =
             Config::figment_with_root(find_project_root_path(None).unwrap()).merge(self.rpc);
         let evm_opts = figment.extract::<EvmOpts>()?;

--- a/crates/cli/src/cast/cmd/send.rs
+++ b/crates/cli/src/cast/cmd/send.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use ethers::{
     prelude::MiddlewareBuilder, providers::Middleware, signers::Signer, types::NameOrAddress,
 };
+use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
     utils,
@@ -73,7 +74,7 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         let SendTxArgs {
             eth,
             to,
@@ -208,7 +209,7 @@ async fn cast_send<M: Middleware, F: Into<NameOrAddress>, T: Into<NameOrAddress>
     cast_async: bool,
     confs: usize,
     to_json: bool,
-) -> eyre::Result<()>
+) -> Result<()>
 where
     M::Error: 'static,
 {

--- a/crates/cli/src/cast/cmd/wallet/mod.rs
+++ b/crates/cli/src/cast/cmd/wallet/mod.rs
@@ -5,11 +5,8 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{transaction::eip712::TypedData, Address, Signature},
 };
-use eyre::Context;
-use foundry_cli::{
-    opts::{RawWallet, Wallet},
-    utils::Cmd,
-};
+use eyre::{Context, Result};
+use foundry_cli::opts::{RawWallet, Wallet};
 use foundry_common::fs;
 use foundry_config::Config;
 use std::path::Path;
@@ -120,7 +117,7 @@ pub enum WalletSubcommands {
 }
 
 impl WalletSubcommands {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         match self {
             WalletSubcommands::New { path, unsafe_password, .. } => {
                 let mut rng = thread_rng();
@@ -281,7 +278,7 @@ flag to set your key via:
         Ok(())
     }
 
-    fn hex_str_to_bytes(s: &str) -> eyre::Result<Vec<u8>> {
+    fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>> {
         Ok(match s.strip_prefix("0x") {
             Some(data) => hex::decode(data).wrap_err("Could not decode 0x-prefixed string.")?,
             None => s.as_bytes().to_vec(),

--- a/crates/cli/src/cast/cmd/wallet/vanity.rs
+++ b/crates/cli/src/cast/cmd/wallet/vanity.rs
@@ -6,7 +6,8 @@ use ethers::{
     types::{H160, U256},
     utils::{get_contract_address, secret_key_to_address},
 };
-use foundry_cli::utils::Cmd;
+use eyre::Result;
+
 use rayon::iter::{self, ParallelIterator};
 use regex::Regex;
 use std::time::Instant;
@@ -37,10 +38,8 @@ pub struct VanityArgs {
     pub nonce: Option<u64>,
 }
 
-impl Cmd for VanityArgs {
-    type Output = LocalWallet;
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl VanityArgs {
+    pub fn run(self) -> Result<LocalWallet> {
         let Self { starts_with, ends_with, nonce } = self;
         let mut left_exact_hex = None;
         let mut left_regex = None;

--- a/crates/cli/src/cast/main.rs
+++ b/crates/cli/src/cast/main.rs
@@ -7,7 +7,8 @@ use ethers::{
     types::Address,
     utils::keccak256,
 };
-use foundry_cli::{handler, prompt, stdin, utils, utils::Cmd};
+use eyre::Result;
+use foundry_cli::{handler, prompt, stdin, utils};
 use foundry_common::{
     abi::{format_tokens, get_event},
     fs,
@@ -25,7 +26,7 @@ pub mod opts;
 use opts::{Opts, Subcommands, ToBaseArgs};
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> Result<()> {
     utils::load_dotenv();
     handler::install()?;
     utils::subscriber();

--- a/crates/cli/src/cast/opts.rs
+++ b/crates/cli/src/cast/opts.rs
@@ -8,6 +8,7 @@ use ethers::{
     abi::ethabi::ethereum_types::BigEndianHash,
     types::{serde_helpers::Numeric, Address, BlockId, NameOrAddress, H256, U256},
 };
+use eyre::Result;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::parse_u256,
@@ -862,7 +863,7 @@ pub struct ToBaseArgs {
     pub base_in: Option<String>,
 }
 
-pub fn parse_slot(s: &str) -> eyre::Result<H256> {
+pub fn parse_slot(s: &str) -> Result<H256> {
     Numeric::from_str(s)
         .map_err(|e| eyre::eyre!("Could not parse slot number: {e}"))
         .map(|n| H256::from_uint(&n.into()))

--- a/crates/cli/src/forge/cmd/bind.rs
+++ b/crates/cli/src/forge/cmd/bind.rs
@@ -1,9 +1,7 @@
 use clap::{Parser, ValueHint};
 use ethers::contract::{Abigen, ContractFilter, ExcludeContracts, MultiAbigen, SelectContracts};
-use foundry_cli::{
-    opts::CoreBuildArgs,
-    utils::{Cmd, LoadConfig},
-};
+use eyre::Result;
+use foundry_cli::{opts::CoreBuildArgs, utils::LoadConfig};
 use foundry_common::{compile, fs::json_files};
 use foundry_config::impl_figment_convert;
 use std::{
@@ -121,7 +119,7 @@ impl BindArgs {
     }
 
     /// Instantiate the multi-abigen
-    fn get_multi(&self, artifacts: impl AsRef<Path>) -> eyre::Result<MultiAbigen> {
+    fn get_multi(&self, artifacts: impl AsRef<Path>) -> Result<MultiAbigen> {
         let abigens = json_files(artifacts.as_ref())
             .into_iter()
             .filter_map(|path| {
@@ -147,7 +145,7 @@ No contract artifacts found. Hint: Have you built your contracts yet? `forge bin
     }
 
     /// Check that the existing bindings match the expected abigen output
-    fn check_existing_bindings(&self, artifacts: impl AsRef<Path>) -> eyre::Result<()> {
+    fn check_existing_bindings(&self, artifacts: impl AsRef<Path>) -> Result<()> {
         let bindings = self.get_multi(&artifacts)?.build()?;
         println!("Checking bindings for {} contracts.", bindings.len());
         if !self.module {
@@ -166,7 +164,7 @@ No contract artifacts found. Hint: Have you built your contracts yet? `forge bin
     }
 
     /// Generate the bindings
-    fn generate_bindings(&self, artifacts: impl AsRef<Path>) -> eyre::Result<()> {
+    fn generate_bindings(&self, artifacts: impl AsRef<Path>) -> Result<()> {
         let bindings = self.get_multi(&artifacts)?.build()?;
         println!("Generating bindings for {} contracts", bindings.len());
         if !self.module {
@@ -181,12 +179,8 @@ No contract artifacts found. Hint: Have you built your contracts yet? `forge bin
         }
         Ok(())
     }
-}
 
-impl Cmd for BindArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+    pub fn run(self) -> Result<()> {
         if !self.skip_build {
             // run `forge build`
             let project = self.build_args.project()?;

--- a/crates/cli/src/forge/cmd/build.rs
+++ b/crates/cli/src/forge/cmd/build.rs
@@ -1,10 +1,8 @@
 use super::{install, watch::WatchArgs};
 use clap::Parser;
 use ethers::solc::{Project, ProjectCompileOutput};
-use foundry_cli::{
-    opts::CoreBuildArgs,
-    utils::{Cmd, LoadConfig},
-};
+use eyre::Result;
+use foundry_cli::{opts::CoreBuildArgs, utils::LoadConfig};
 use foundry_common::{
     compile,
     compile::{ProjectCompiler, SkipBuildFilter},
@@ -73,10 +71,8 @@ pub struct BuildArgs {
     pub watch: WatchArgs,
 }
 
-impl Cmd for BuildArgs {
-    type Output = ProjectCompileOutput;
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl BuildArgs {
+    pub fn run(self) -> Result<ProjectCompileOutput> {
         let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;
 
@@ -97,15 +93,13 @@ impl Cmd for BuildArgs {
             compiler.compile(&project)
         }
     }
-}
 
-impl BuildArgs {
     /// Returns the `Project` for the current workspace
     ///
     /// This loads the `foundry_config::Config` for the current workspace (see
     /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]
-    pub fn project(&self) -> eyre::Result<Project> {
+    pub fn project(&self) -> Result<Project> {
         self.args.project()
     }
 
@@ -116,7 +110,7 @@ impl BuildArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
         // use the path arguments or if none where provided the `src` dir
         self.watch.watchexec_config(|| {
             let config = Config::from(self);

--- a/crates/cli/src/forge/cmd/cache.rs
+++ b/crates/cli/src/forge/cmd/cache.rs
@@ -5,7 +5,6 @@ use clap::{
 };
 use ethers::prelude::Chain;
 use eyre::Result;
-use foundry_cli::utils::Cmd;
 use foundry_config::{cache, Chain as FoundryConfigChain, Config};
 use std::{ffi::OsStr, str::FromStr};
 use strum::VariantNames;
@@ -56,10 +55,8 @@ pub struct CleanArgs {
     etherscan: bool,
 }
 
-impl Cmd for CleanArgs {
-    type Output = ();
-
-    fn run(self) -> Result<Self::Output> {
+impl CleanArgs {
+    pub fn run(self) -> Result<()> {
         let CleanArgs { chains, blocks, etherscan } = self;
 
         for chain_or_all in chains {
@@ -92,10 +89,8 @@ pub struct LsArgs {
     chains: Vec<ChainOrAll>,
 }
 
-impl Cmd for LsArgs {
-    type Output = ();
-
-    fn run(self) -> Result<Self::Output> {
+impl LsArgs {
+    pub fn run(self) -> Result<()> {
         let LsArgs { chains } = self;
         let mut cache = Cache::default();
         for chain_or_all in chains {

--- a/crates/cli/src/forge/cmd/config.rs
+++ b/crates/cli/src/forge/cmd/config.rs
@@ -1,6 +1,7 @@
 use super::build::BuildArgs;
 use clap::Parser;
-use foundry_cli::utils::{Cmd, LoadConfig};
+use eyre::Result;
+use foundry_cli::utils::LoadConfig;
 use foundry_common::{evm::EvmArgs, term::cli_warn};
 use foundry_config::fix::fix_tomls;
 
@@ -29,10 +30,8 @@ pub struct ConfigArgs {
     evm_opts: EvmArgs,
 }
 
-impl Cmd for ConfigArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl ConfigArgs {
+    pub fn run(self) -> Result<()> {
         if self.fix {
             for warning in fix_tomls() {
                 cli_warn!("{warning}");

--- a/crates/cli/src/forge/cmd/create.rs
+++ b/crates/cli/src/forge/cmd/create.rs
@@ -7,7 +7,7 @@ use ethers::{
     solc::{info::ContractInfo, utils::canonicalized},
     types::{transaction::eip2718::TypedTransaction, Chain},
 };
-use eyre::Context;
+use eyre::{Context, Result};
 use foundry_cli::{
     opts::{CoreBuildArgs, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
@@ -69,7 +69,7 @@ pub struct CreateArgs {
 
 impl CreateArgs {
     /// Executes the command to create a contract
-    pub async fn run(mut self) -> eyre::Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         // Find Project & Compile
         let project = self.opts.project()?;
         let mut output = if self.json || self.opts.silent {
@@ -141,7 +141,7 @@ impl CreateArgs {
         &self,
         constructor_args: Option<String>,
         chain: u64,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         // NOTE: this does not represent the same `VerifyArgs` that would be sent after deployment,
         // since we don't know the address yet.
         let verify = verify::VerifyArgs {
@@ -176,7 +176,7 @@ impl CreateArgs {
         args: Vec<Token>,
         provider: M,
         chain: u64,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         let deployer_address =
             provider.default_sender().expect("no sender address set for provider");
         let bin = bin.into_bytes().unwrap_or_else(|| {
@@ -315,7 +315,7 @@ impl CreateArgs {
         &self,
         constructor: &Constructor,
         constructor_args: &[String],
-    ) -> eyre::Result<Vec<Token>> {
+    ) -> Result<Vec<Token>> {
         let params = constructor
             .inputs
             .iter()

--- a/crates/cli/src/forge/cmd/debug.rs
+++ b/crates/cli/src/forge/cmd/debug.rs
@@ -1,5 +1,6 @@
 use super::{build::BuildArgs, retry::RETRY_VERIFY_ON_CREATE, script::ScriptArgs};
 use clap::{Parser, ValueHint};
+use eyre::Result;
 use foundry_cli::opts::CoreBuildArgs;
 use foundry_common::evm::{Breakpoints, EvmArgs};
 use std::path::PathBuf;
@@ -40,7 +41,7 @@ pub struct DebugArgs {
 }
 
 impl DebugArgs {
-    pub async fn debug(self, breakpoints: Breakpoints) -> eyre::Result<()> {
+    pub async fn debug(self, breakpoints: Breakpoints) -> Result<()> {
         let script = ScriptArgs {
             path: self.path.to_str().expect("Invalid path string.").to_string(),
             args: self.args,

--- a/crates/cli/src/forge/cmd/doc.rs
+++ b/crates/cli/src/forge/cmd/doc.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueHint};
+use eyre::Result;
 use forge_doc::{ContractInheritance, Deployments, DocBuilder, GitSource, Inheritdoc, Server};
-use foundry_cli::{opts::GH_REPO_PREFIX_REGEX, utils::Cmd};
+use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
 use foundry_config::{find_project_root_path, load_config_with_root};
 use std::{path::PathBuf, process::Command};
 
@@ -46,10 +47,8 @@ pub struct DocArgs {
     deployments: Option<Option<PathBuf>>,
 }
 
-impl Cmd for DocArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl DocArgs {
+    pub fn run(self) -> Result<()> {
         let root = self.root.clone().unwrap_or(find_project_root_path(None)?);
         let config = load_config_with_root(Some(root.clone()));
 

--- a/crates/cli/src/forge/cmd/flatten.rs
+++ b/crates/cli/src/forge/cmd/flatten.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, ValueHint};
+use eyre::Result;
 use foundry_cli::{
     opts::{CoreBuildArgs, ProjectPathsArgs},
-    utils::{Cmd, LoadConfig},
+    utils::LoadConfig,
 };
 use foundry_common::fs;
 use std::path::PathBuf;
@@ -28,9 +29,8 @@ pub struct FlattenArgs {
     project_paths: ProjectPathsArgs,
 }
 
-impl Cmd for FlattenArgs {
-    type Output = ();
-    fn run(self) -> eyre::Result<Self::Output> {
+impl FlattenArgs {
+    pub fn run(self) -> Result<()> {
         let FlattenArgs { target_path, output, project_paths } = self;
 
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config

--- a/crates/cli/src/forge/cmd/fmt.rs
+++ b/crates/cli/src/forge/cmd/fmt.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueHint};
+use eyre::Result;
 use forge_fmt::{format, parse, print_diagnostics_report};
-use foundry_cli::utils::{Cmd, FoundryPathExt, LoadConfig};
+use foundry_cli::utils::{FoundryPathExt, LoadConfig};
 use foundry_common::{fs, term::cli_warn};
 use foundry_config::impl_figment_convert_basic;
 use foundry_utils::glob::expand_globs;
@@ -45,10 +46,8 @@ impl_figment_convert_basic!(FmtArgs);
 
 // === impl FmtArgs ===
 
-impl Cmd for FmtArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl FmtArgs {
+    pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
 
         // Expand ignore globs and canonicalize from the get go
@@ -95,7 +94,7 @@ impl Cmd for FmtArgs {
             }
         };
 
-        let format = |source: String, path: Option<&Path>| -> eyre::Result<_> {
+        let format = |source: String, path: Option<&Path>| -> Result<_> {
             let name = match path {
                 Some(path) => {
                     path.strip_prefix(&config.__root.0).unwrap_or(path).display().to_string()

--- a/crates/cli/src/forge/cmd/fourbyte.rs
+++ b/crates/cli/src/forge/cmd/fourbyte.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use ethers::prelude::artifacts::output_selection::ContractOutputSelection;
+use eyre::Result;
 use foundry_cli::{
     opts::{CompilerArgs, CoreBuildArgs, ProjectPathsArgs},
     utils::FoundryPathExt,
@@ -28,7 +29,7 @@ pub struct UploadSelectorsArgs {
 
 impl UploadSelectorsArgs {
     /// Builds a contract and uploads the ABI to selector database
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         shell::println(Paint::yellow("Warning! This command is deprecated and will be removed in v1, use `forge selectors upload` instead"))?;
 
         let UploadSelectorsArgs { contract, all, project_paths } = self;

--- a/crates/cli/src/forge/cmd/geiger/find.rs
+++ b/crates/cli/src/forge/cmd/geiger/find.rs
@@ -1,4 +1,5 @@
 use super::{error::ScanFileError, visitor::CheatcodeVisitor};
+use eyre::Result;
 use forge_fmt::{offset_to_line_column, parse, Visitable};
 use foundry_common::fs;
 use solang_parser::{diagnostics::Diagnostic, pt::Loc};

--- a/crates/cli/src/forge/cmd/geiger/mod.rs
+++ b/crates/cli/src/forge/cmd/geiger/mod.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueHint};
 use ethers::solc::Graph;
-use eyre::WrapErr;
-use foundry_cli::utils::{Cmd, LoadConfig};
+use eyre::{Result, WrapErr};
+use foundry_cli::utils::LoadConfig;
 use foundry_config::{impl_figment_convert_basic, Config};
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -57,7 +57,7 @@ pub struct GeigerArgs {
 impl_figment_convert_basic!(GeigerArgs);
 
 impl GeigerArgs {
-    pub fn sources(&self, config: &Config) -> eyre::Result<Vec<PathBuf>> {
+    pub fn sources(&self, config: &Config) -> Result<Vec<PathBuf>> {
         let cwd = std::env::current_dir()?;
 
         let mut sources: Vec<PathBuf> = {
@@ -85,12 +85,8 @@ impl GeigerArgs {
 
         Ok(sources)
     }
-}
 
-impl Cmd for GeigerArgs {
-    type Output = usize;
-
-    fn run(self) -> eyre::Result<Self::Output> {
+    pub fn run(self) -> Result<usize> {
         let config = self.try_load_config_emit_warnings()?;
         let sources = self.sources(&config).wrap_err("Failed to resolve files")?;
 

--- a/crates/cli/src/forge/cmd/geiger/visitor.rs
+++ b/crates/cli/src/forge/cmd/geiger/visitor.rs
@@ -1,4 +1,5 @@
 use super::find::UnsafeCheatcodes;
+use eyre::Result;
 use forge_fmt::{Visitable, Visitor};
 use solang_parser::pt::{
     ContractDefinition, Expression, FunctionDefinition, IdentifierPath, Loc, Parameter, SourceUnit,

--- a/crates/cli/src/forge/cmd/generate/mod.rs
+++ b/crates/cli/src/forge/cmd/generate/mod.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use eyre::Result;
 use foundry_common::fs;
 use std::path::Path;
 use yansi::Paint;
@@ -24,7 +25,7 @@ pub struct GenerateTestArgs {
 }
 
 impl GenerateTestArgs {
-    pub fn run(self) -> eyre::Result<()> {
+    pub fn run(self) -> Result<()> {
         let contract_name = format_identifier(&self.contract_name, true);
         let instance_name = format_identifier(&self.contract_name, false);
 

--- a/crates/cli/src/forge/cmd/init.rs
+++ b/crates/cli/src/forge/cmd/init.rs
@@ -1,10 +1,8 @@
 use super::install::DependencyInstallOpts;
 use clap::{Parser, ValueHint};
 use ethers::solc::remappings::Remapping;
-use foundry_cli::{
-    p_println,
-    utils::{Cmd, Git},
-};
+use eyre::Result;
+use foundry_cli::{p_println, utils::Git};
 use foundry_common::fs;
 use foundry_config::Config;
 use std::path::{Path, PathBuf};
@@ -38,10 +36,8 @@ pub struct InitArgs {
     opts: DependencyInstallOpts,
 }
 
-impl Cmd for InitArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl InitArgs {
+    pub fn run(self) -> Result<()> {
         let InitArgs { root, template, opts, offline, force, vscode } = self;
         let DependencyInstallOpts { shallow, no_git, no_commit, quiet } = opts;
 
@@ -161,7 +157,7 @@ pub fn get_commit_hash(root: &Path) -> Option<String> {
 /// Creates `.gitignore` and `.github/workflows/test.yml`, if they don't exist already.
 ///
 /// Commits everything in `root` if `no_commit` is false.
-fn init_git_repo(git: Git<'_>, no_commit: bool) -> eyre::Result<()> {
+fn init_git_repo(git: Git<'_>, no_commit: bool) -> Result<()> {
     // git init
     if !git.is_in_repo()? {
         git.init()?;
@@ -190,7 +186,7 @@ fn init_git_repo(git: Git<'_>, no_commit: bool) -> eyre::Result<()> {
 }
 
 /// initializes the `.vscode/settings.json` file
-fn init_vscode(root: &Path) -> eyre::Result<()> {
+fn init_vscode(root: &Path) -> Result<()> {
     let remappings_file = root.join("remappings.txt");
     if !remappings_file.exists() {
         let mut remappings = Remapping::find_many(root.join("lib"))

--- a/crates/cli/src/forge/cmd/inspect.rs
+++ b/crates/cli/src/forge/cmd/inspect.rs
@@ -14,10 +14,8 @@ use ethers::{
         utils::canonicalize,
     },
 };
-use foundry_cli::{
-    opts::{CompilerArgs, CoreBuildArgs},
-    utils::Cmd,
-};
+use eyre::Result;
+use foundry_cli::opts::{CompilerArgs, CoreBuildArgs};
 use foundry_common::compile;
 use serde_json::{to_value, Value};
 use std::fmt;
@@ -42,10 +40,8 @@ pub struct InspectArgs {
     build: CoreBuildArgs,
 }
 
-impl Cmd for InspectArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl InspectArgs {
+    pub fn run(self) -> Result<()> {
         let InspectArgs { mut contract, field, build, pretty } = self;
 
         trace!(target: "forge", ?field, ?contract, "running forge inspect");
@@ -207,7 +203,7 @@ impl Cmd for InspectArgs {
     }
 }
 
-pub fn print_abi(abi: &LosslessAbi, pretty: bool) -> eyre::Result<()> {
+pub fn print_abi(abi: &LosslessAbi, pretty: bool) -> Result<()> {
     let abi_json = to_value(abi)?;
     if !pretty {
         println!("{}", serde_json::to_string_pretty(&abi_json)?);
@@ -221,10 +217,7 @@ pub fn print_abi(abi: &LosslessAbi, pretty: bool) -> eyre::Result<()> {
     Ok(())
 }
 
-pub fn print_storage_layout(
-    storage_layout: &Option<StorageLayout>,
-    pretty: bool,
-) -> eyre::Result<()> {
+pub fn print_storage_layout(storage_layout: &Option<StorageLayout>, pretty: bool) -> Result<()> {
     if storage_layout.is_none() {
         eyre::bail!("Could not get storage layout")
     }

--- a/crates/cli/src/forge/cmd/install.rs
+++ b/crates/cli/src/forge/cmd/install.rs
@@ -3,7 +3,7 @@ use eyre::{Context, Result};
 use foundry_cli::{
     opts::Dependency,
     p_println, prompt,
-    utils::{Cmd, CommandUtils, Git, LoadConfig},
+    utils::{CommandUtils, Git, LoadConfig},
 };
 use foundry_common::fs;
 use foundry_config::{impl_figment_convert_basic, Config};
@@ -56,10 +56,8 @@ pub struct InstallArgs {
 
 impl_figment_convert_basic!(InstallArgs);
 
-impl Cmd for InstallArgs {
-    type Output = ();
-
-    fn run(self) -> Result<Self::Output> {
+impl InstallArgs {
+    pub fn run(self) -> Result<()> {
         let mut config = self.try_load_config_emit_warnings()?;
         self.opts.install(&mut config, self.dependencies)
     }

--- a/crates/cli/src/forge/cmd/remappings.rs
+++ b/crates/cli/src/forge/cmd/remappings.rs
@@ -1,7 +1,8 @@
 use cast::HashMap;
 use clap::{Parser, ValueHint};
 use ethers::solc::remappings::RelativeRemapping;
-use foundry_cli::utils::{Cmd, LoadConfig};
+use eyre::Result;
+use foundry_cli::utils::LoadConfig;
 use foundry_config::impl_figment_convert_basic;
 use std::path::PathBuf;
 
@@ -20,11 +21,9 @@ pub struct RemappingArgs {
 }
 impl_figment_convert_basic!(RemappingArgs);
 
-impl Cmd for RemappingArgs {
-    type Output = ();
-
+impl RemappingArgs {
     // TODO: Do people use `forge remappings >> file`?
-    fn run(self) -> eyre::Result<Self::Output> {
+    pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
 
         if self.pretty {

--- a/crates/cli/src/forge/cmd/remove.rs
+++ b/crates/cli/src/forge/cmd/remove.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, ValueHint};
+use eyre::Result;
 use foundry_cli::{
     opts::Dependency,
-    utils::{Cmd, Git, LoadConfig},
+    utils::{Git, LoadConfig},
 };
 use foundry_config::impl_figment_convert_basic;
 use std::path::PathBuf;
@@ -25,10 +26,8 @@ pub struct RemoveArgs {
 }
 impl_figment_convert_basic!(RemoveArgs);
 
-impl Cmd for RemoveArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl RemoveArgs {
+    pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
         let (root, paths) = super::update::dependencies_paths(&self.dependencies, &config)?;
         let git_modules = root.join(".git/modules");

--- a/crates/cli/src/forge/cmd/script/cmd.rs
+++ b/crates/cli/src/forge/cmd/script/cmd.rs
@@ -3,6 +3,7 @@ use ethers::{
     prelude::{Middleware, Signer},
     types::{transaction::eip2718::TypedTransaction, U256},
 };
+use eyre::Result;
 use foundry_cli::utils::LoadConfig;
 use foundry_common::{contracts::flatten_contracts, try_get_http_provider};
 use std::sync::Arc;
@@ -13,7 +14,7 @@ type NewSenderChanges = (CallTraceDecoder, Libraries, ArtifactContracts<Contract
 
 impl ScriptArgs {
     /// Executes the script
-    pub async fn run_script(mut self, breakpoints: Breakpoints) -> eyre::Result<()> {
+    pub async fn run_script(mut self, breakpoints: Breakpoints) -> Result<()> {
         trace!(target: "script", "executing script command");
 
         let (config, evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
@@ -129,7 +130,7 @@ impl ScriptArgs {
         default_known_contracts: ArtifactContracts,
         predeploy_libraries: Vec<Bytes>,
         result: &mut ScriptResult,
-    ) -> eyre::Result<Option<NewSenderChanges>> {
+    ) -> Result<Option<NewSenderChanges>> {
         if let Some(new_sender) = self.maybe_new_sender(
             &script_config.evm_opts,
             result.transactions.as_ref(),
@@ -186,7 +187,7 @@ impl ScriptArgs {
         libraries: Libraries,
         result: ScriptResult,
         verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         if self.multi {
             return self
                 .multi_chain_deployment(
@@ -223,7 +224,7 @@ impl ScriptArgs {
         default_known_contracts: ArtifactContracts,
         result: ScriptResult,
         mut verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         trace!(target: "script", "resuming single deployment");
 
         let fork_url = script_config
@@ -292,7 +293,7 @@ impl ScriptArgs {
         new_sender: Address,
         first_run_result: &mut ScriptResult,
         default_known_contracts: ArtifactContracts,
-    ) -> eyre::Result<(Libraries, ArtifactContracts<ContractBytecodeSome>)> {
+    ) -> Result<(Libraries, ArtifactContracts<ContractBytecodeSome>)> {
         // if we had a new sender that requires relinking, we need to
         // get the nonce mainnet for accurate addresses for predeploy libs
         let nonce = foundry_utils::next_nonce(
@@ -342,7 +343,7 @@ impl ScriptArgs {
 
     /// In case the user has loaded *only* one private-key, we can assume that he's using it as the
     /// `--sender`
-    fn maybe_load_private_key(&mut self, script_config: &mut ScriptConfig) -> eyre::Result<()> {
+    fn maybe_load_private_key(&mut self, script_config: &mut ScriptConfig) -> Result<()> {
         if let Some(ref private_key) = self.wallets.private_key {
             self.wallets.private_keys = Some(vec![private_key.clone()]);
         }

--- a/crates/cli/src/forge/cmd/script/executor.rs
+++ b/crates/cli/src/forge/cmd/script/executor.rs
@@ -8,6 +8,7 @@ use ethers::{
     solc::artifacts::CompactContractBytecode,
     types::{transaction::eip2718::TypedTransaction, Address, U256},
 };
+use eyre::Result;
 use forge::{
     executor::{
         inspector::{cheatcodes::util::BroadcastableTransactions, CheatsConfig},
@@ -37,7 +38,7 @@ impl ScriptArgs {
         contract: CompactContractBytecode,
         sender: Address,
         predeploy_libraries: &[ethers::types::Bytes],
-    ) -> eyre::Result<ScriptResult> {
+    ) -> Result<ScriptResult> {
         trace!(target: "script", "start executing script");
 
         let CompactContractBytecode { abi, bytecode, .. } = contract;
@@ -95,7 +96,7 @@ impl ScriptArgs {
         script_config: &ScriptConfig,
         decoder: &CallTraceDecoder,
         contracts: &ContractsByArtifact,
-    ) -> eyre::Result<VecDeque<TransactionWithMetadata>> {
+    ) -> Result<VecDeque<TransactionWithMetadata>> {
         trace!(target: "script", "executing onchain simulation");
 
         let runners = Arc::new(
@@ -210,7 +211,7 @@ impl ScriptArgs {
         let mut abort = false;
         for res in join_all(futs).await {
             // type hint
-            let res: eyre::Result<RunnerResult> = res;
+            let res: Result<RunnerResult> = res;
 
             let (tx, mut traces) = res?;
 

--- a/crates/cli/src/forge/cmd/script/multi.rs
+++ b/crates/cli/src/forge/cmd/script/multi.rs
@@ -8,7 +8,7 @@ use ethers::{
     prelude::{artifacts::Libraries, ArtifactId},
     signers::LocalWallet,
 };
-use eyre::{ContextCompat, WrapErr};
+use eyre::{ContextCompat, Result, WrapErr};
 use foundry_cli::utils::now;
 use foundry_common::{fs, get_http_provider};
 use foundry_config::Config;
@@ -43,7 +43,7 @@ impl MultiChainSequence {
         target: &ArtifactId,
         log_folder: &Path,
         broadcasted: bool,
-    ) -> eyre::Result<Self> {
+    ) -> Result<Self> {
         let path =
             MultiChainSequence::get_path(&log_folder.join("multi"), sig, target, broadcasted)?;
 
@@ -56,7 +56,7 @@ impl MultiChainSequence {
         sig: &str,
         target: &ArtifactId,
         broadcasted: bool,
-    ) -> eyre::Result<PathBuf> {
+    ) -> Result<PathBuf> {
         let mut out = out.to_path_buf();
 
         if !broadcasted {
@@ -82,13 +82,13 @@ impl MultiChainSequence {
     }
 
     /// Loads the sequences for the multi chain deployment.
-    pub fn load(log_folder: &Path, sig: &str, target: &ArtifactId) -> eyre::Result<Self> {
+    pub fn load(log_folder: &Path, sig: &str, target: &ArtifactId) -> Result<Self> {
         let path = MultiChainSequence::get_path(&log_folder.join("multi"), sig, target, true)?;
         ethers::solc::utils::read_json_file(path).wrap_err("Multi-chain deployment not found.")
     }
 
     /// Saves the transactions as file if it's a standalone deployment.
-    pub fn save(&mut self) -> eyre::Result<()> {
+    pub fn save(&mut self) -> Result<()> {
         self.timestamp = now().as_secs();
 
         //../Contract-latest/run.json
@@ -118,7 +118,7 @@ impl ScriptArgs {
         config: &Config,
         script_wallets: Vec<LocalWallet>,
         verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         if !libraries.is_empty() {
             eyre::bail!("Libraries are currently not supported on multi deployment setups.");
         }

--- a/crates/cli/src/forge/cmd/script/providers.rs
+++ b/crates/cli/src/forge/cmd/script/providers.rs
@@ -1,5 +1,5 @@
 use ethers::prelude::{Http, Middleware, Provider, RetryClient, U256};
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use foundry_common::{get_http_provider, RpcUrl};
 use foundry_config::Chain;
 use std::{
@@ -20,7 +20,7 @@ impl ProvidersManager {
         &mut self,
         rpc: &str,
         is_legacy: bool,
-    ) -> eyre::Result<&ProviderInfo> {
+    ) -> Result<&ProviderInfo> {
         Ok(match self.inner.entry(rpc.to_string()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
@@ -51,12 +51,12 @@ pub struct ProviderInfo {
 /// Represents the outcome of a gas price request
 #[derive(Debug)]
 pub enum GasPrice {
-    Legacy(eyre::Result<U256>),
-    EIP1559(eyre::Result<(U256, U256)>),
+    Legacy(Result<U256>),
+    EIP1559(Result<(U256, U256)>),
 }
 
 impl ProviderInfo {
-    pub async fn new(rpc: &str, mut is_legacy: bool) -> eyre::Result<ProviderInfo> {
+    pub async fn new(rpc: &str, mut is_legacy: bool) -> Result<ProviderInfo> {
         let provider = Arc::new(get_http_provider(rpc));
         let chain = provider.get_chainid().await?.as_u64();
 
@@ -78,7 +78,7 @@ impl ProviderInfo {
     }
 
     /// Returns the gas price to use
-    pub fn gas_price(&self) -> eyre::Result<U256> {
+    pub fn gas_price(&self) -> Result<U256> {
         let res = match &self.gas_price {
             GasPrice::Legacy(res) => res.as_ref(),
             GasPrice::EIP1559(res) => res.as_ref().map(|res| &res.0),

--- a/crates/cli/src/forge/cmd/script/receipts.rs
+++ b/crates/cli/src/forge/cmd/script/receipts.rs
@@ -4,6 +4,7 @@ use ethers::{
     providers::Middleware,
     types::TransactionReceipt,
 };
+use eyre::Result;
 use foundry_cli::{init_progress, update_progress, utils::print_receipt};
 use foundry_common::RetryProvider;
 use futures::StreamExt;
@@ -33,7 +34,7 @@ impl From<TransactionReceipt> for TxStatus {
 pub async fn wait_for_pending(
     provider: Arc<RetryProvider>,
     deployment_sequence: &mut ScriptSequence,
-) -> eyre::Result<()> {
+) -> Result<()> {
     if deployment_sequence.pending.is_empty() {
         return Ok(())
     }
@@ -56,7 +57,7 @@ pub async fn clear_pendings(
     provider: Arc<RetryProvider>,
     deployment_sequence: &mut ScriptSequence,
     tx_hashes: Option<Vec<TxHash>>,
-) -> eyre::Result<()> {
+) -> Result<()> {
     let to_query = tx_hashes.unwrap_or_else(|| deployment_sequence.pending.clone());
 
     let count = deployment_sequence.pending.len();

--- a/crates/cli/src/forge/cmd/script/runner.rs
+++ b/crates/cli/src/forge/cmd/script/runner.rs
@@ -1,5 +1,6 @@
 use super::*;
 use ethers::types::{Address, Bytes, NameOrAddress, U256};
+use eyre::Result;
 use forge::{
     executor::{CallResult, DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
     revm::interpreter::{return_ok, InstructionResult},
@@ -36,7 +37,7 @@ impl ScriptRunner {
         sender_nonce: U256,
         is_broadcast: bool,
         need_create2_deployer: bool,
-    ) -> eyre::Result<(Address, ScriptResult)> {
+    ) -> Result<(Address, ScriptResult)> {
         trace!(target: "script", "executing setUP()");
 
         if !is_broadcast {
@@ -177,7 +178,7 @@ impl ScriptRunner {
         &mut self,
         sender_initial_nonce: U256,
         libraries_len: usize,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         if let Some(ref cheatcodes) = self.executor.inspector_config().cheatcodes {
             if !cheatcodes.corrected_nonce {
                 self.executor
@@ -194,7 +195,7 @@ impl ScriptRunner {
     }
 
     /// Executes the method that will collect all broadcastable transactions.
-    pub fn script(&mut self, address: Address, calldata: Bytes) -> eyre::Result<ScriptResult> {
+    pub fn script(&mut self, address: Address, calldata: Bytes) -> Result<ScriptResult> {
         self.call(self.sender, address, calldata, U256::zero(), false)
     }
 
@@ -205,7 +206,7 @@ impl ScriptRunner {
         to: Option<NameOrAddress>,
         calldata: Option<Bytes>,
         value: Option<U256>,
-    ) -> eyre::Result<ScriptResult> {
+    ) -> Result<ScriptResult> {
         if let Some(NameOrAddress::Address(to)) = to {
             self.call(from, to, calldata.unwrap_or_default(), value.unwrap_or(U256::zero()), true)
         } else if to.is_none() {
@@ -263,7 +264,7 @@ impl ScriptRunner {
         calldata: Bytes,
         value: U256,
         commit: bool,
-    ) -> eyre::Result<ScriptResult> {
+    ) -> Result<ScriptResult> {
         let mut res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
         let mut gas_used = res.gas_used;
 
@@ -322,7 +323,7 @@ impl ScriptRunner {
         to: Address,
         calldata: &Bytes,
         value: U256,
-    ) -> eyre::Result<u64> {
+    ) -> Result<u64> {
         let mut gas_used = res.gas_used;
         if matches!(res.exit_reason, return_ok!()) {
             // store the current gas limit and reset it later

--- a/crates/cli/src/forge/cmd/script/sequence.rs
+++ b/crates/cli/src/forge/cmd/script/sequence.rs
@@ -12,7 +12,7 @@ use ethers::{
     prelude::{artifacts::Libraries, ArtifactId, TransactionReceipt, TxHash},
     types::transaction::eip2718::TypedTransaction,
 };
-use eyre::{ContextCompat, WrapErr};
+use eyre::{ContextCompat, Result, WrapErr};
 use foundry_cli::utils::now;
 use foundry_common::{fs, shell, SELECTOR_LEN};
 use foundry_config::Config;
@@ -81,7 +81,7 @@ impl ScriptSequence {
         config: &Config,
         broadcasted: bool,
         is_multi: bool,
-    ) -> eyre::Result<Self> {
+    ) -> Result<Self> {
         let chain = config.chain_id.unwrap_or_default().id();
 
         let (path, sensitive_path) = ScriptSequence::get_paths(
@@ -117,7 +117,7 @@ impl ScriptSequence {
         target: &ArtifactId,
         chain_id: u64,
         broadcasted: bool,
-    ) -> eyre::Result<Self> {
+    ) -> Result<Self> {
         let (path, sensitive_path) = ScriptSequence::get_paths(
             &config.broadcast,
             &config.cache_path,
@@ -148,7 +148,7 @@ impl ScriptSequence {
     }
 
     /// Saves the transactions as file if it's a standalone deployment.
-    pub fn save(&mut self) -> eyre::Result<()> {
+    pub fn save(&mut self) -> Result<()> {
         if self.multi || self.transactions.is_empty() {
             return Ok(())
         }
@@ -221,7 +221,7 @@ impl ScriptSequence {
         target: &ArtifactId,
         chain_id: u64,
         broadcasted: bool,
-    ) -> eyre::Result<(PathBuf, PathBuf)> {
+    ) -> Result<(PathBuf, PathBuf)> {
         let mut broadcast = broadcast.to_path_buf();
         let mut cache = cache.to_path_buf();
         let mut common = PathBuf::new();
@@ -254,7 +254,7 @@ impl ScriptSequence {
         &mut self,
         config: &Config,
         mut verify: VerifyBundle,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         trace!(target: "script", "verifying {} contracts [{}]", verify.known_contracts.len(), self.chain);
 
         verify.set_chain(config, self.chain.into());

--- a/crates/cli/src/forge/cmd/script/transaction.rs
+++ b/crates/cli/src/forge/cmd/script/transaction.rs
@@ -6,7 +6,7 @@ use ethers::{
     prelude::{NameOrAddress, H256 as TxHash},
     types::transaction::eip2718::TypedTransaction,
 };
-use eyre::{ContextCompat, WrapErr};
+use eyre::{ContextCompat, Result, WrapErr};
 use foundry_common::{abi::format_token_raw, RpcUrl, SELECTOR_LEN};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -69,7 +69,7 @@ impl TransactionWithMetadata {
         decoder: &CallTraceDecoder,
         additional_contracts: Vec<AdditionalContract>,
         is_fixed_gas_limit: bool,
-    ) -> eyre::Result<Self> {
+    ) -> Result<Self> {
         let mut metadata = Self { transaction, rpc, is_fixed_gas_limit, ..Default::default() };
 
         // Specify if any contract was directly created with this transaction
@@ -123,7 +123,7 @@ impl TransactionWithMetadata {
         address: Address,
         contracts: &BTreeMap<Address, ArtifactInfo>,
         decoder: &CallTraceDecoder,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         if is_create2 {
             self.opcode = CallKind::Create2;
         } else {
@@ -201,7 +201,7 @@ impl TransactionWithMetadata {
         target: Address,
         local_contracts: &BTreeMap<Address, ArtifactInfo>,
         decoder: &CallTraceDecoder,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         self.opcode = CallKind::Call;
 
         if let Some(data) = self.transaction.data() {

--- a/crates/cli/src/forge/cmd/selectors.rs
+++ b/crates/cli/src/forge/cmd/selectors.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use comfy_table::Table;
 use ethers::prelude::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
+use eyre::Result;
 use foundry_cli::{
     opts::{CompilerArgs, CoreBuildArgs, ProjectPathsArgs},
     utils::FoundryPathExt,
@@ -53,7 +54,7 @@ pub enum SelectorsSubcommands {
 }
 
 impl SelectorsSubcommands {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         match self {
             SelectorsSubcommands::Upload { contract, all, project_paths } => {
                 let build_args = CoreBuildArgs {

--- a/crates/cli/src/forge/cmd/snapshot.rs
+++ b/crates/cli/src/forge/cmd/snapshot.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use clap::{builder::RangedU64ValueParser, Parser, ValueHint};
 use ethers::types::U256;
-use eyre::Context;
+use eyre::{Context, Result};
 use forge::result::TestKindReport;
 use foundry_cli::utils::STATIC_FUZZ_SEED;
 use once_cell::sync::Lazy;
@@ -92,11 +92,11 @@ impl SnapshotArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
         self.test.watchexec_config()
     }
 
-    pub async fn run(mut self) -> eyre::Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         // Set fuzz seed so gas snapshots are deterministic
         self.test.fuzz_seed = Some(U256::from_big_endian(&STATIC_FUZZ_SEED));
 
@@ -258,7 +258,7 @@ impl FromStr for SnapshotEntry {
 }
 
 /// Reads a list of snapshot entries from a snapshot file
-fn read_snapshot(path: impl AsRef<Path>) -> eyre::Result<Vec<SnapshotEntry>> {
+fn read_snapshot(path: impl AsRef<Path>) -> Result<Vec<SnapshotEntry>> {
     let path = path.as_ref();
     let mut entries = Vec::new();
     for line in io::BufReader::new(
@@ -277,7 +277,7 @@ fn write_to_snapshot_file(
     tests: &[Test],
     path: impl AsRef<Path>,
     _format: Option<Format>,
-) -> eyre::Result<()> {
+) -> Result<()> {
     let mut reports = tests
         .iter()
         .map(|test| {
@@ -352,7 +352,7 @@ fn check(tests: Vec<Test>, snaps: Vec<SnapshotEntry>, tolerance: Option<u32>) ->
 }
 
 /// Compare the set of tests with an existing snapshot
-fn diff(tests: Vec<Test>, snaps: Vec<SnapshotEntry>) -> eyre::Result<()> {
+fn diff(tests: Vec<Test>, snaps: Vec<SnapshotEntry>) -> Result<()> {
     let snaps = snaps
         .into_iter()
         .map(|s| ((s.contract_name, s.signature), s.gas_used))

--- a/crates/cli/src/forge/cmd/test/mod.rs
+++ b/crates/cli/src/forge/cmd/test/mod.rs
@@ -2,6 +2,7 @@ use super::{debug::DebugArgs, install, test::filter::ProjectPathsAwareFilter, wa
 use cast::fuzz::CounterExample;
 use clap::Parser;
 use ethers::types::U256;
+use eyre::Result;
 use forge::{
     decode::decode_console_logs,
     executor::inspector::CheatsConfig,
@@ -115,7 +116,7 @@ impl TestArgs {
         &self.opts
     }
 
-    pub async fn run(self) -> eyre::Result<TestOutcome> {
+    pub async fn run(self) -> Result<TestOutcome> {
         trace!(target: "forge::test", "executing test command");
         shell::set_shell(shell::Shell::from_args(self.opts.silent, self.json))?;
         self.execute_tests().await
@@ -127,7 +128,7 @@ impl TestArgs {
     /// configured filter will be executed
     ///
     /// Returns the test results for all matching tests.
-    pub async fn execute_tests(self) -> eyre::Result<TestOutcome> {
+    pub async fn execute_tests(self) -> Result<TestOutcome> {
         // Merge all configs
         let (mut config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
 
@@ -268,7 +269,7 @@ impl TestArgs {
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
-    pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+    pub(crate) fn watchexec_config(&self) -> Result<(InitConfig, RuntimeConfig)> {
         self.watch.watchexec_config(|| {
             let config = Config::from(self);
             vec![config.src, config.test]
@@ -372,7 +373,7 @@ impl TestOutcome {
     }
 
     /// Checks if there are any failures and failures are disallowed
-    pub fn ensure_ok(&self) -> eyre::Result<()> {
+    pub fn ensure_ok(&self) -> Result<()> {
         let failures = self.failures().count();
         if self.allow_failure || failures == 0 {
             return Ok(())
@@ -483,7 +484,7 @@ fn list(
     runner: MultiContractRunner,
     filter: ProjectPathsAwareFilter,
     json: bool,
-) -> eyre::Result<TestOutcome> {
+) -> Result<TestOutcome> {
     let results = runner.list(&filter);
 
     if json {
@@ -512,7 +513,7 @@ async fn test(
     test_options: TestOptions,
     gas_reporting: bool,
     fail_fast: bool,
-) -> eyre::Result<TestOutcome> {
+) -> Result<TestOutcome> {
     trace!(target: "forge::test", "running all tests");
     if runner.count_filtered_tests(&filter) == 0 {
         let filter_str = filter.to_string();

--- a/crates/cli/src/forge/cmd/tree.rs
+++ b/crates/cli/src/forge/cmd/tree.rs
@@ -3,10 +3,8 @@ use ethers::solc::{
     resolver::{Charset, TreeOptions},
     Graph,
 };
-use foundry_cli::{
-    opts::ProjectPathsArgs,
-    utils::{Cmd, LoadConfig},
-};
+use eyre::Result;
+use foundry_cli::{opts::ProjectPathsArgs, utils::LoadConfig};
 
 /// CLI arguments for `forge tree`.
 #[derive(Debug, Clone, Parser)]
@@ -27,10 +25,8 @@ pub struct TreeArgs {
 
 foundry_config::impl_figment_convert!(TreeArgs, opts);
 
-impl Cmd for TreeArgs {
-    type Output = ();
-
-    fn run(self) -> eyre::Result<Self::Output> {
+impl TreeArgs {
+    pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
         let graph = Graph::resolve(&config.project_paths())?;
         let opts = TreeOptions { charset: self.charset, no_dedupe: self.no_dedupe };

--- a/crates/cli/src/forge/cmd/update.rs
+++ b/crates/cli/src/forge/cmd/update.rs
@@ -2,7 +2,7 @@ use clap::{Parser, ValueHint};
 use eyre::{Context, Result};
 use foundry_cli::{
     opts::Dependency,
-    utils::{Cmd, Git, LoadConfig},
+    utils::{Git, LoadConfig},
 };
 use foundry_config::{impl_figment_convert_basic, Config};
 use std::path::PathBuf;
@@ -26,10 +26,8 @@ pub struct UpdateArgs {
 }
 impl_figment_convert_basic!(UpdateArgs);
 
-impl Cmd for UpdateArgs {
-    type Output = ();
-
-    fn run(self) -> Result<Self::Output> {
+impl UpdateArgs {
+    pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
         let (root, paths) = dependencies_paths(&self.dependencies, &config)?;
         Git::new(&root).submodule_update(self.force, true, paths)

--- a/crates/cli/src/forge/cmd/verify/etherscan/flatten.rs
+++ b/crates/cli/src/forge/cmd/verify/etherscan/flatten.rs
@@ -6,7 +6,7 @@ use ethers::{
         AggregatedCompilerOutput, CompilerInput, Project, Solc,
     },
 };
-use eyre::Context;
+use eyre::{Context, Result};
 use semver::{BuildMetadata, Version};
 use std::{collections::BTreeMap, path::Path};
 
@@ -19,7 +19,7 @@ impl EtherscanSourceProvider for EtherscanFlattenedSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> eyre::Result<(String, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let metadata = project.solc_config.settings.metadata.as_ref();
         let bch = metadata.and_then(|m| m.bytecode_hash).unwrap_or_default();
 
@@ -67,7 +67,7 @@ impl EtherscanFlattenedSource {
         content: impl Into<String>,
         version: &Version,
         contract_path: &Path,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         let version = strip_build_meta(version.clone());
         let solc = Solc::find_svm_installed_version(version.to_string())?
             .unwrap_or(Solc::blocking_install(&version)?);

--- a/crates/cli/src/forge/cmd/verify/etherscan/standard_json.rs
+++ b/crates/cli/src/forge/cmd/verify/etherscan/standard_json.rs
@@ -2,7 +2,7 @@ use super::{EtherscanSourceProvider, VerifyArgs};
 use ethers::{
     etherscan::verify::CodeFormat, prelude::artifacts::StandardJsonCompilerInput, solc::Project,
 };
-use eyre::Context;
+use eyre::{Context, Result};
 use semver::Version;
 use std::path::Path;
 use tracing::trace;
@@ -16,7 +16,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
         project: &Project,
         target: &Path,
         version: &Version,
-    ) -> eyre::Result<(String, String, CodeFormat)> {
+    ) -> Result<(String, String, CodeFormat)> {
         let mut input: StandardJsonCompilerInput = project
             .standard_json_input(target)
             .wrap_err("Failed to get standard json input")?

--- a/crates/cli/src/forge/cmd/verify/mod.rs
+++ b/crates/cli/src/forge/cmd/verify/mod.rs
@@ -1,6 +1,7 @@
 use super::retry::RetryArgs;
 use clap::{Parser, ValueHint};
 use ethers::{abi::Address, solc::info::ContractInfo};
+use eyre::Result;
 use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config};
 use provider::VerificationProviderType;
@@ -124,7 +125,7 @@ impl figment::Provider for VerifyArgs {
 
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
-    pub async fn run(mut self) -> eyre::Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         let config = self.load_config_emit_warnings();
         let chain = config.chain_id.unwrap_or_default();
         self.etherscan.chain = Some(chain);
@@ -162,7 +163,7 @@ impl VerifyArgs {
     }
 
     /// Returns the configured verification provider
-    pub fn verification_provider(&self) -> eyre::Result<Box<dyn VerificationProvider>> {
+    pub fn verification_provider(&self) -> Result<Box<dyn VerificationProvider>> {
         self.verifier.verifier.client(&self.etherscan.key)
     }
 }
@@ -191,7 +192,7 @@ impl_figment_convert_cast!(VerifyCheckArgs);
 
 impl VerifyCheckArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
-    pub async fn run(self) -> eyre::Result<()> {
+    pub async fn run(self) -> Result<()> {
         println!("Checking verification status on {}", self.etherscan.chain.unwrap_or_default());
         self.verifier.verifier.client(&self.etherscan.key)?.check(self).await
     }

--- a/crates/cli/src/forge/cmd/verify/provider.rs
+++ b/crates/cli/src/forge/cmd/verify/provider.rs
@@ -3,6 +3,7 @@ use super::{
     VerifyCheckArgs,
 };
 use async_trait::async_trait;
+use eyre::Result;
 use std::{fmt, str::FromStr};
 
 /// An abstraction for various verification providers such as etherscan, sourcify, blockscout
@@ -15,13 +16,13 @@ pub trait VerificationProvider {
     /// [`VerifyArgs`] are valid to begin with. This should prevent situations where there's a
     /// contract deployment that's executed before the verify request and the subsequent verify task
     /// fails due to misconfiguration.
-    async fn preflight_check(&mut self, args: VerifyArgs) -> eyre::Result<()>;
+    async fn preflight_check(&mut self, args: VerifyArgs) -> Result<()>;
 
     /// Sends the actual verify request for the targeted contract.
-    async fn verify(&mut self, args: VerifyArgs) -> eyre::Result<()>;
+    async fn verify(&mut self, args: VerifyArgs) -> Result<()>;
 
     /// Checks whether the contract is verified.
-    async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()>;
+    async fn check(&self, args: VerifyCheckArgs) -> Result<()>;
 }
 
 impl FromStr for VerificationProviderType {
@@ -64,7 +65,7 @@ pub enum VerificationProviderType {
 
 impl VerificationProviderType {
     /// Returns the corresponding `VerificationProvider` for the key
-    pub fn client(&self, key: &Option<String>) -> eyre::Result<Box<dyn VerificationProvider>> {
+    pub fn client(&self, key: &Option<String>) -> Result<Box<dyn VerificationProvider>> {
         match self {
             VerificationProviderType::Etherscan => {
                 if key.as_ref().map_or(true, |key| key.is_empty()) {

--- a/crates/cli/src/forge/cmd/verify/sourcify.rs
+++ b/crates/cli/src/forge/cmd/verify/sourcify.rs
@@ -2,6 +2,7 @@ use super::{provider::VerificationProvider, VerifyArgs, VerifyCheckArgs};
 use async_trait::async_trait;
 use cast::SimpleCast;
 use ethers::solc::ConfigurableContractArtifact;
+use eyre::Result;
 use foundry_cli::utils::{get_cached_entry_by_name, LoadConfig};
 use foundry_common::fs;
 use foundry_utils::Retry;
@@ -19,12 +20,12 @@ pub struct SourcifyVerificationProvider;
 
 #[async_trait]
 impl VerificationProvider for SourcifyVerificationProvider {
-    async fn preflight_check(&mut self, args: VerifyArgs) -> eyre::Result<()> {
+    async fn preflight_check(&mut self, args: VerifyArgs) -> Result<()> {
         let _ = self.prepare_request(&args)?;
         Ok(())
     }
 
-    async fn verify(&mut self, args: VerifyArgs) -> eyre::Result<()> {
+    async fn verify(&mut self, args: VerifyArgs) -> Result<()> {
         let body = self.prepare_request(&args)?;
 
         trace!("submitting verification request {:?}", body);
@@ -71,7 +72,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
         Ok(())
     }
 
-    async fn check(&self, args: VerifyCheckArgs) -> eyre::Result<()> {
+    async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
         let retry: Retry = args.retry.into();
         let resp = retry
             .run_async(|| {
@@ -105,7 +106,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
 
 impl SourcifyVerificationProvider {
     /// Configures the API request to the sourcify API using the given [`VerifyArgs`].
-    fn prepare_request(&self, args: &VerifyArgs) -> eyre::Result<SourcifyVerifyRequest> {
+    fn prepare_request(&self, args: &VerifyArgs) -> Result<SourcifyVerifyRequest> {
         let mut config = args.try_load_config_emit_warnings()?;
         config.libraries.extend(args.libraries.clone());
 

--- a/crates/cli/src/forge/cmd/watch.rs
+++ b/crates/cli/src/forge/cmd/watch.rs
@@ -1,5 +1,6 @@
 use super::{build::BuildArgs, snapshot::SnapshotArgs, test::TestArgs};
 use clap::Parser;
+use eyre::Result;
 use foundry_cli::utils::{self, FoundryPathExt};
 use foundry_config::Config;
 use std::{collections::HashSet, convert::Infallible, path::PathBuf, sync::Arc};
@@ -64,7 +65,7 @@ impl WatchArgs {
     pub fn watchexec_config(
         &self,
         f: impl FnOnce() -> Vec<PathBuf>,
-    ) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+    ) -> Result<(InitConfig, RuntimeConfig)> {
         let init = init()?;
         let mut runtime = runtime(self)?;
 
@@ -81,7 +82,7 @@ impl WatchArgs {
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// build`
-pub async fn watch_build(args: BuildArgs) -> eyre::Result<()> {
+pub async fn watch_build(args: BuildArgs) -> Result<()> {
     let (init, mut runtime) = args.watchexec_config()?;
     let cmd = cmd_args(args.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
 
@@ -100,7 +101,7 @@ pub async fn watch_build(args: BuildArgs) -> eyre::Result<()> {
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// snapshot`
-pub async fn watch_snapshot(args: SnapshotArgs) -> eyre::Result<()> {
+pub async fn watch_snapshot(args: SnapshotArgs) -> Result<()> {
     let (init, mut runtime) = args.watchexec_config()?;
     let cmd = cmd_args(args.test.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
 
@@ -119,7 +120,7 @@ pub async fn watch_snapshot(args: SnapshotArgs) -> eyre::Result<()> {
 
 /// Executes a [`Watchexec`] that listens for changes in the project's src dir and reruns `forge
 /// test`
-pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
+pub async fn watch_test(args: TestArgs) -> Result<()> {
     let (init, mut runtime) = args.watchexec_config()?;
     let cmd = cmd_args(args.watch.watch.as_ref().map(|paths| paths.len()).unwrap_or_default());
     trace!("watch test cmd={:?}", cmd);
@@ -272,7 +273,7 @@ fn cmd_args(num: usize) -> Vec<String> {
 }
 
 /// Returns the Initialisation configuration for [`Watchexec`].
-pub fn init() -> eyre::Result<InitConfig> {
+pub fn init() -> Result<InitConfig> {
     let mut config = InitConfig::default();
     config.on_error(SyncFnHandler::from(|data| -> std::result::Result<(), Infallible> {
         trace!("[[{:?}]]", data);
@@ -390,7 +391,7 @@ fn on_action<F, T>(
 }
 
 /// Returns the Runtime configuration for [`Watchexec`].
-pub fn runtime(args: &WatchArgs) -> eyre::Result<RuntimeConfig> {
+pub fn runtime(args: &WatchArgs) -> Result<RuntimeConfig> {
     let mut config = RuntimeConfig::default();
 
     config.pathset(args.watch.clone().unwrap_or_default());

--- a/crates/cli/src/forge/main.rs
+++ b/crates/cli/src/forge/main.rs
@@ -1,6 +1,7 @@
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use foundry_cli::{handler, utils, utils::Cmd};
+use eyre::Result;
+use foundry_cli::{handler, utils};
 
 mod cmd;
 mod opts;
@@ -8,7 +9,7 @@ mod opts;
 use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
 use opts::{Opts, Subcommands};
 
-fn main() -> eyre::Result<()> {
+fn main() -> Result<()> {
     utils::load_dotenv();
     handler::install()?;
     utils::subscriber();

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -1,4 +1,4 @@
-use eyre::EyreHandler;
+use eyre::{EyreHandler, Result};
 use std::error::Error;
 use tracing::error;
 use yansi::Paint;
@@ -49,7 +49,7 @@ impl EyreHandler for Handler {
 ///
 /// Panics are always caught by the more debug-centric handler.
 #[cfg_attr(windows, inline(never))]
-pub fn install() -> eyre::Result<()> {
+pub fn install() -> Result<()> {
     let debug_enabled = std::env::var("FOUNDRY_DEBUG").is_ok();
 
     if debug_enabled {

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -4,6 +4,7 @@ use clap::{Parser, ValueHint};
 use ethers::solc::{
     artifacts::RevertStrings, remappings::Remapping, utils::canonicalized, Project,
 };
+use eyre::Result;
 use foundry_config::{
     figment,
     figment::{
@@ -119,7 +120,7 @@ impl CoreBuildArgs {
     /// This loads the `foundry_config::Config` for the current workspace (see
     /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]
-    pub fn project(&self) -> eyre::Result<Project> {
+    pub fn project(&self) -> Result<Project> {
         let config = self.try_load_config_emit_warnings()?;
         Ok(config.project()?)
     }

--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueHint};
 use ethers::solc::remappings::Remapping;
+use eyre::Result;
 use foundry_config::{
     figment,
     figment::{

--- a/crates/cli/src/opts/chain.rs
+++ b/crates/cli/src/opts/chain.rs
@@ -1,5 +1,6 @@
 use clap::builder::{PossibleValuesParser, TypedValueParser};
 use ethers::types::Chain as NamedChain;
+use eyre::Result;
 use foundry_config::Chain;
 use std::ffi::OsStr;
 use strum::VariantNames;

--- a/crates/cli/src/opts/dependency.rs
+++ b/crates/cli/src/opts/dependency.rs
@@ -1,5 +1,6 @@
 //! CLI dependency parsing
 
+use eyre::Result;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::str::FromStr;
@@ -129,7 +130,7 @@ impl Dependency {
     }
 
     /// Returns the URL of the dependency if it exists, or an error if not.
-    pub fn require_url(&self) -> eyre::Result<&str> {
+    pub fn require_url(&self) -> Result<&str> {
         self.url.as_deref().ok_or_else(|| eyre::eyre!("dependency {} has no url", self.name()))
     }
 }

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -2,6 +2,7 @@ use crate::utils::{parse_ether_value, parse_u256};
 use clap::Parser;
 use ethers::types::U256;
 use serde::Serialize;
+
 #[derive(Parser, Debug, Clone, Serialize)]
 #[clap(next_help_heading = "Transaction options")]
 pub struct TransactionOpts {

--- a/crates/cli/src/opts/wallet/mod.rs
+++ b/crates/cli/src/opts/wallet/mod.rs
@@ -216,7 +216,7 @@ impl Wallet {
     }
     /// Returns a [Signer] corresponding to the provided private key, mnemonic or hardware signer.
     #[instrument(skip(self), level = "trace")]
-    pub async fn signer(&self, chain_id: u64) -> eyre::Result<WalletSigner> {
+    pub async fn signer(&self, chain_id: u64) -> Result<WalletSigner> {
         trace!("start finding signer");
 
         if self.ledger {

--- a/crates/cli/src/stdin.rs
+++ b/crates/cli/src/stdin.rs
@@ -9,7 +9,7 @@ use std::{
 
 /// Prints a message to [`stdout`][io::stdout] and [reads a line from stdin into a String](read).
 ///
-/// Returns `eyre::Result<T>`, so sometimes `T` must be explicitly specified, like in `str::parse`.
+/// Returns `Result<T>`, so sometimes `T` must be explicitly specified, like in `str::parse`.
 ///
 /// # Examples
 ///
@@ -39,7 +39,7 @@ macro_rules! prompt {
 }
 
 /// Unwraps the given `Option<T>` or [reads stdin into a String](read) and parses it as `T`.
-pub fn unwrap<T>(value: Option<T>, read_line: bool) -> eyre::Result<T>
+pub fn unwrap<T>(value: Option<T>, read_line: bool) -> Result<T>
 where
     T: FromStr,
     T::Err: StdError + Send + Sync + 'static,
@@ -66,7 +66,7 @@ where
 
 /// [Reads stdin into a String](read) and parses it as `Vec<T>` using whitespaces as delimiters if
 /// the given `Vec<T>` is empty.
-pub fn unwrap_vec<T>(mut value: Vec<T>) -> eyre::Result<Vec<T>>
+pub fn unwrap_vec<T>(mut value: Vec<T>) -> Result<Vec<T>>
 where
     T: FromStr,
     T::Err: StdError + Send + Sync + 'static,
@@ -81,7 +81,7 @@ where
 
 /// Short-hand for `unwrap(value, true)`.
 #[inline]
-pub fn unwrap_line<T>(value: Option<T>) -> eyre::Result<T>
+pub fn unwrap_line<T>(value: Option<T>) -> Result<T>
 where
     T: FromStr,
     T::Err: StdError + Send + Sync + 'static,

--- a/crates/cli/test-utils/src/script.rs
+++ b/crates/cli/test-utils/src/script.rs
@@ -4,6 +4,7 @@ use ethers::{
     prelude::{Middleware, NameOrAddress, U256},
     utils::hex,
 };
+use eyre::Result;
 use foundry_common::{get_http_provider, RetryProvider};
 use std::{collections::BTreeMap, path::Path, str::FromStr};
 
@@ -96,7 +97,7 @@ impl ScriptTester {
     }
 
     /// Initialises the test contracts by copying them into the workspace
-    fn copy_testdata(current_dir: &Path) -> eyre::Result<()> {
+    fn copy_testdata(current_dir: &Path) -> Result<()> {
         let testdata = Self::testdata_path();
         std::fs::copy(testdata.clone() + "/cheats/Vm.sol", current_dir.join("src/Vm.sol"))?;
         std::fs::copy(testdata + "/lib/ds-test/src/test.sol", current_dir.join("lib/test.sol"))?;

--- a/crates/cli/test-utils/src/util.rs
+++ b/crates/cli/test-utils/src/util.rs
@@ -3,7 +3,7 @@ use ethers_solc::{
     project_util::{copy_dir, TempProject},
     ArtifactOutput, ConfigurableArtifacts, PathStyle, ProjectPathsConfig, Solc,
 };
-use eyre::WrapErr;
+use eyre::{Result, WrapErr};
 use foundry_config::Config;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -148,7 +148,7 @@ pub fn setup_forge_remote(prj: impl Into<RemoteProject>) -> (TestProject, TestCo
 /// Same as `setup_forge_remote` but not panicing
 pub fn try_setup_forge_remote(
     config: impl Into<RemoteProject>,
-) -> eyre::Result<(TestProject, TestCommand)> {
+) -> Result<(TestProject, TestCommand)> {
     let config = config.into();
     let mut tmp = TempProject::checkout(&config.id).wrap_err("failed to checkout project")?;
     tmp.project_mut().paths = config.path_style.paths(tmp.root())?;
@@ -620,7 +620,7 @@ impl TestCommand {
 
     /// Executes command and expects an successful result
     #[track_caller]
-    pub fn ensure_execute_success(&mut self) -> eyre::Result<process::Output> {
+    pub fn ensure_execute_success(&mut self) -> Result<process::Output> {
         let out = self.try_execute()?;
         self.ensure_success(out)
     }
@@ -735,7 +735,7 @@ impl TestCommand {
     }
 
     #[track_caller]
-    pub fn ensure_success(&self, out: process::Output) -> eyre::Result<process::Output> {
+    pub fn ensure_success(&self, out: process::Output) -> Result<process::Output> {
         if !out.status.success() {
             let suggest = if out.stderr.is_empty() {
                 "\n\nDid your forge command end up with no output?".to_string()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This is an unnecessary abstraction, and also all async commands do not implement it anyway.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Remove it and just have public `run` functions

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
