### PR TITLE
fix(`config`): init foundry.toml url

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2439,7 +2439,7 @@ impl BasicConfig {
             "\
 [profile.{}]
 {s}
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config\n",
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config\n",
             self.profile
         ))
     }


### PR DESCRIPTION
## Motivation

Apparently the structure of the repo changed a bit but this link hasn't been updated.

## Solution

Update the link :-)
