### PR TITLE
Updated link to all config options example file

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2439,7 +2439,7 @@ impl BasicConfig {
             "\
 [profile.{}]
 {s}
-# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config\n",
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options\n",
             self.profile
         ))
     }
@@ -4139,7 +4139,7 @@ mod tests {
             out = 'out'
             libs = ['lib']
 
-            # See more config options https://github.com/foundry-rs/foundry/tree/master/config
+            # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
         "#;
         assert_eq!(
             parse_with_profile::<BasicConfig>(foundry_str).unwrap().unwrap(),


### PR DESCRIPTION
Updated the link displayed in the default `foundry.toml` file, as the existing one seems to be outdated (`https://github.com/foundry-rs/foundry/tree/master/config`)
