### PR TITLE
docs: correct `README.md` link path

### DIFF
--- a/crates/anvil/README.md
+++ b/crates/anvil/README.md
@@ -13,7 +13,7 @@
 
 ## Installation
 
-`anvil` binary is available via [`foundryup`](../README.md#installation).
+`anvil` binary is available via [`foundryup`](../../README.md#installation).
 
 ### Installing from source
 

--- a/crates/chisel/README.md
+++ b/crates/chisel/README.md
@@ -43,7 +43,7 @@ simple as installing Chisel via `foundryup`. For information on features, usage,
 
 To install `chisel`, simply run `foundryup`!
 
-If you do not have `foundryup` installed, reference the Foundry [installation guide](../README.md#installation).
+If you do not have `foundryup` installed, reference the Foundry [installation guide](../../README.md#installation).
 
 ## Usage
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -4,7 +4,7 @@ The CLIs are written using [clap's](https://docs.rs/clap) [derive feature](https
 
 ## Installation
 
-See [Installation](../README.md#Installation).
+See [Installation](../../README.md#Installation).
 
 ## Usage
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When looking https://github.com/foundry-rs/foundry/blob/5f2262736feaeabadeef2ae989a78e9b43da8eee/crates/anvil/README.md#installation, the `foundryup` link didn't work. Because the link was broken since https://github.com/foundry-rs/foundry/pull/5597.

## Solution

I just fixed those links 🔨 
