### PR TITLE
test: speed up some tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,19 @@ debug = 0
 
 # Speed up tests and dev build
 [profile.dev.package]
+# evm
 revm.opt-level = 3
 revm-primitives.opt-level = 3
 revm-interpreter.opt-level = 3
 revm-precompile.opt-level = 3
-
+tiny-keccak.opt-level = 3
 ruint.opt-level = 3
 primitive-types.opt-level = 3
 
+# keystores
+scrypt.opt-level = 3
+
+# forking
 axum.opt-level = 3
 
 [profile.release]

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -167,12 +167,12 @@ mod tests {
 
     #[test]
     fn basic_create2() {
-        let args = Create2Args::parse_from(["foundry-cli", "--starts-with", "babe"]);
+        let args = Create2Args::parse_from(["foundry-cli", "--starts-with", "aa"]);
         let create2_out = args.run().unwrap();
         let address = create2_out.address;
         let address = format!("{address:x}");
 
-        assert!(address.starts_with("babe"));
+        assert!(address.starts_with("aa"));
     }
 
     #[test]
@@ -180,13 +180,13 @@ mod tests {
         let args = Create2Args::parse_from([
             "foundry-cli",
             "--matching",
-            "0xbabeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "0xbbXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         ]);
         let create2_out = args.run().unwrap();
         let address = create2_out.address;
         let address = format!("{address:x}");
 
-        assert!(address.starts_with("babe"));
+        assert!(address.starts_with("bb"));
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
         let args = Create2Args::parse_from([
             "foundry-cli",
             "--starts-with",
-            "babe",
+            "cc",
             "--init-code",
             init_code,
         ]);
@@ -205,7 +205,7 @@ mod tests {
         let salt = create2_out.salt;
         let deployer = Address::from_str(DEPLOYER).unwrap();
 
-        assert!(address_str.starts_with("babe"));
+        assert!(address_str.starts_with("cc"));
         assert_eq!(address, verify_create2(deployer, salt, hex::decode(init_code).unwrap()));
     }
 
@@ -215,7 +215,7 @@ mod tests {
         let args = Create2Args::parse_from([
             "foundry-cli",
             "--starts-with",
-            "babe",
+            "dd",
             "--init-code-hash",
             init_code_hash,
         ]);
@@ -225,7 +225,7 @@ mod tests {
         let salt = create2_out.salt;
         let deployer = Address::from_str(DEPLOYER).unwrap();
 
-        assert!(address_str.starts_with("babe"));
+        assert!(address_str.starts_with("dd"));
         assert_eq!(
             address,
             verify_create2_hash(deployer, salt, hex::decode(init_code_hash).unwrap())

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -238,7 +238,7 @@ forgetest_init!(can_test_repeatedly, |_prj: TestProject, mut cmd: TestCommand| {
     cmd.arg("test");
     cmd.assert_non_empty_stdout();
 
-    for _ in 0..10 {
+    for _ in 0..5 {
         cmd.unchecked_output().stdout_matches_path(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("tests/fixtures/can_test_repeatedly.stdout"),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Unit tests are held hostage for 30s+ by a single keystore test because the key derivation crate is not optimized, and some create2 tests

Forge tests spend a lot of time cloning the compiler output, something to take note of (`(*COMPILED).clone()`) cc @Evalir 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
