### PR TITLE
fix(`tests`): only run heavy integration tests on workflow by tightening filters

### DIFF
--- a/.github/workflows/heavy-integration.yml
+++ b/.github/workflows/heavy-integration.yml
@@ -58,7 +58,7 @@ jobs:
             matrix:
                 job:
                     - name: Long-running integration tests
-                      filter: "!test(~live)"
+                      filter: "!test(~live) & test(heavy)"
         env:
             ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
         steps:

--- a/crates/forge/tests/cli/heavy_integration.rs
+++ b/crates/forge/tests/cli/heavy_integration.rs
@@ -1,5 +1,6 @@
 //! Heavy integration tests that can take an hour to run or more.
+//! All tests are prefixed with heavy so they can be filtered by nextest.
 
 use foundry_test_utils::forgetest_external;
 
-forgetest_external!(maple, "maple-labs/maple-core-v2");
+forgetest_external!(heavy_maple, "maple-labs/maple-core-v2");


### PR DESCRIPTION
## Motivation

The current heavy integration tests workflow fails because the maple repo is just damn huge, and takes almost an hour to run. Combined with other tests that are matching the current filter that also clog the CI, it makes the whole job fail because it takes longer than an hour and github automatically disconnects it, not even allowing an issue to be created.

## Solution

prefix all heavy integration tests (only maple atm) with `heavy`, and filter this with nextest.
