### PR TITLE
ci: fix deprecation warnings

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,13 +63,13 @@ jobs:
               run: |
                   if [[ "${{ github.event_name }}" == 'schedule' ]]; then
                     echo "cron trigger, assigning nightly tag"
-                    echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}"
+                    echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
                   elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ ${GITHUB_REF##*/} == "master" ]]; then
                     echo "manual trigger from master/main branch, assigning latest tag"
-                    echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+                    echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
                   else
                     echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
-                    echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}"
+                    echo "docker_tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
                   fi
 
             # Log docker metadata to explicitly know what is being pushed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
               id: release_info
               run: |
                   if [[ $IS_NIGHTLY ]]; then
-                    echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
-                    echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
+                    echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+                    echo "release_name=Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
                   else
-                    echo "::set-output name=tag_name::${GITHUB_REF_NAME}"
-                    echo "::set-output name=release_name::${GITHUB_REF_NAME}"
+                    echo "tag_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+                    echo "release_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
                   fi
 
             # Creates a `nightly-SHA` tag for this specific nightly
@@ -125,12 +125,9 @@ jobs:
                   echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
             - name: Build binaries
-              uses: actions-rs/cargo@v1
               env:
                   SVM_TARGET_PLATFORM: ${{ matrix.job.svm_target_platform }}
-              with:
-                  command: build
-                  args: --release --bins --target ${{ matrix.job.target }}
+              run: cargo build --release --bins --target ${{ matrix.job.target }}
 
             - name: Archive binaries
               id: artifacts
@@ -140,22 +137,22 @@ jobs:
                   ARCH: ${{ matrix.job.arch }}
                   VERSION_NAME: |
                       ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+              shell: bash
               run: |
                   if [ "$PLATFORM_NAME" == "linux" ]; then
                     tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast anvil chisel
-                    echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+                    echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
                   elif [ "$PLATFORM_NAME" == "darwin" ]; then
                     # We need to use gtar here otherwise the archive is corrupt.
                     # See: https://github.com/actions/virtual-environments/issues/2619
                     gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast anvil chisel
-                    echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+                    echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
                   else
                     cd ./target/${TARGET}/release
                     7z a -tzip "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe anvil.exe chisel.exe
                     mv "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
-                    echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
+                    echo "file_name=foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_OUTPUT
                   fi
-              shell: bash
 
             - name: Build man page
               id: man
@@ -165,6 +162,7 @@ jobs:
                   TARGET: ${{ matrix.job.target }}
                   VERSION_NAME: |
                       ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+              shell: bash
               run: |
                   sudo apt-get -y install help2man
                   help2man -N ./target/${TARGET}/release/forge > forge.1
@@ -176,8 +174,7 @@ jobs:
                   gzip anvil.1
                   gzip chisel.1
                   tar -czvf "foundry_man_${VERSION_NAME}.tar.gz" forge.1.gz cast.1.gz anvil.1.gz chisel.1.gz
-                  echo "::set-output name=foundry_man::foundry_man_${VERSION_NAME}.tar.gz"
-              shell: bash
+                  echo "foundry_man=foundry_man_${VERSION_NAME}.tar.gz" >> $GITHUB_OUTPUT
 
             # Creates the release for this specific version
             - name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
               run: |
                   output=$(python3 .github/scripts/matrices.py)
                   echo "::debug::build-matrix=$output"
-                  echo "build-matrix=$output" >> "$GITHUB_OUTPUT"
+                  echo "build-matrix=$output" >> $GITHUB_OUTPUT
 
                   export TEST=1
 
                   output=$(python3 .github/scripts/matrices.py)
                   echo "::debug::test-matrix=$output"
-                  echo "test-matrix=$output" >> "$GITHUB_OUTPUT"
+                  echo "test-matrix=$output" >> $GITHUB_OUTPUT
 
     build-tests:
         name: build tests


### PR DESCRIPTION
`echo "::set-output name=(\w+)::(.*)"` -> `echo "$1=$2" >> "$GITHUB_OUTPUT"`