### PR TITLE
refactor: parallelize invariants

### DIFF
--- a/crates/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -217,7 +217,6 @@ impl Cheatcodes {
         // but only if the backend is in forking mode
         data.db.ensure_cheatcode_access_forking_mode(caller)?;
 
-        // TODO: Log the opcode for the debugger
         let opt = env::apply(self, data, caller, &decoded)
             .transpose()
             .or_else(|| util::apply(self, data, &decoded))

--- a/crates/evm/src/fuzz/invariant/executor.rs
+++ b/crates/evm/src/fuzz/invariant/executor.rs
@@ -20,10 +20,10 @@ use crate::{
     CALLER,
 };
 use ethers::{
-    abi::{Abi, Address, Detokenize, FixedBytes, Function, Tokenizable, TokenizableItem},
+    abi::{Abi, Address, Detokenize, FixedBytes, Tokenizable, TokenizableItem},
     prelude::U256,
 };
-use eyre::ContextCompat;
+use eyre::{ContextCompat, Result};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::{FuzzDictionaryConfig, InvariantConfig};
 use parking_lot::{Mutex, RwLock};
@@ -46,12 +46,12 @@ type InvariantPreparation =
 /// Contains the success condition and call results of the last run
 struct RichInvariantResults {
     success: bool,
-    call_results: Option<BTreeMap<String, RawCallResult>>,
+    call_result: Option<RawCallResult>,
 }
 
 impl RichInvariantResults {
-    fn new(success: bool, call_results: Option<BTreeMap<String, RawCallResult>>) -> Self {
-        Self { success, call_results }
+    fn new(success: bool, call_result: Option<RawCallResult>) -> Self {
+        Self { success, call_result }
     }
 }
 
@@ -61,7 +61,7 @@ impl RichInvariantResults {
 /// inputs, until it finds a counterexample sequence. The provided [`TestRunner`] contains all the
 /// configuration which can be overridden via [environment variables](https://docs.rs/proptest/1.0.0/proptest/test_runner/struct.Config.html)
 pub struct InvariantExecutor<'a> {
-    pub executor: &'a mut Executor,
+    pub executor: Executor,
     /// Proptest runner.
     runner: TestRunner,
     /// The invariant configuration
@@ -78,7 +78,7 @@ pub struct InvariantExecutor<'a> {
 impl<'a> InvariantExecutor<'a> {
     /// Instantiates a fuzzed executor EVM given a testrunner
     pub fn new(
-        executor: &'a mut Executor,
+        executor: Executor,
         runner: TestRunner,
         config: InvariantConfig,
         setup_contracts: &'a ContractsByAddress,
@@ -94,27 +94,23 @@ impl<'a> InvariantExecutor<'a> {
         }
     }
 
-    /// Fuzzes any deployed contract and checks any broken invariant at `invariant_address`
-    /// Returns a list of all the consumed gas and calldata of every invariant fuzz case
+    /// Fuzzes any deployed contract and checks any broken invariant at `invariant_address`.
     pub fn invariant_fuzz(
         &mut self,
-        invariant_contract: &InvariantContract,
-    ) -> eyre::Result<InvariantFuzzTestResult> {
-        let (fuzz_state, targeted_contracts, strat) = self.prepare_fuzzing(invariant_contract)?;
+        invariant_contract: InvariantContract,
+    ) -> Result<InvariantFuzzTestResult> {
+        let (fuzz_state, targeted_contracts, strat) = self.prepare_fuzzing(&invariant_contract)?;
 
         // Stores the consumed gas and calldata of every successful fuzz call.
         let fuzz_cases: RefCell<Vec<FuzzedCases>> = RefCell::new(Default::default());
 
         // Stores data related to reverts or failed assertions of the test.
-        let failures =
-            RefCell::new(InvariantFailures::new(&invariant_contract.invariant_functions));
-
-        let blank_executor = RefCell::new(&mut *self.executor);
+        let failures = RefCell::new(InvariantFailures::new());
 
         let last_call_results = RefCell::new(
             assert_invariants(
-                invariant_contract,
-                &blank_executor.borrow(),
+                &invariant_contract,
+                &self.executor,
                 &[],
                 &mut failures.borrow_mut(),
                 self.config.shrink_sequence,
@@ -127,79 +123,70 @@ impl<'a> InvariantExecutor<'a> {
             fuzz_cases.borrow_mut().push(FuzzedCases::new(vec![]));
         }
 
-        if failures.borrow().broken_invariants_count < invariant_contract.invariant_functions.len()
-        {
-            // The strategy only comes with the first `input`. We fill the rest of the `inputs`
-            // until the desired `depth` so we can use the evolving fuzz dictionary
-            // during the run. We need another proptest runner to query for random
-            // values.
-            let branch_runner = RefCell::new(self.runner.clone());
-            let _ = self.runner.run(&strat, |mut inputs| {
-                // Scenarios where we want to fail as soon as possible.
-                {
-                    if self.config.fail_on_revert && failures.borrow().reverts == 1 {
-                        return Err(TestCaseError::fail("Revert occurred."))
-                    }
+        // The strategy only comes with the first `input`. We fill the rest of the `inputs`
+        // until the desired `depth` so we can use the evolving fuzz dictionary
+        // during the run. We need another proptest runner to query for random
+        // values.
+        let branch_runner = RefCell::new(self.runner.clone());
+        let _ = self.runner.run(&strat, |mut inputs| {
+            // Scenarios where we want to fail as soon as possible.
+            if self.config.fail_on_revert && failures.borrow().reverts == 1 {
+                return Err(TestCaseError::fail("Revert occurred."))
+            }
 
-                    if failures.borrow().broken_invariants_count ==
-                        invariant_contract.invariant_functions.len()
-                    {
-                        return Err(TestCaseError::fail("All invariants have been broken."))
-                    }
+            // Before each run, we must reset the backend state.
+            let mut executor = self.executor.clone();
+
+            // Used for stat reports (eg. gas usage).
+            let mut fuzz_runs = Vec::with_capacity(self.config.depth as usize);
+
+            // Created contracts during a run.
+            let mut created_contracts = vec![];
+
+            for current_run in 0..self.config.depth {
+                let (sender, (address, calldata)) =
+                    inputs.last().expect("to have the next randomly generated input.");
+
+                // Executes the call from the randomly generated sequence.
+                let call_result = executor
+                    .call_raw(*sender, *address, calldata.0.clone(), U256::zero())
+                    .expect("could not make raw evm call");
+
+                // Collect data for fuzzing from the state changeset.
+                let mut state_changeset =
+                    call_result.state_changeset.to_owned().expect("no changesets");
+
+                collect_data(
+                    &mut state_changeset,
+                    sender,
+                    &call_result,
+                    fuzz_state.clone(),
+                    &self.config.dictionary,
+                );
+
+                if let Err(error) = collect_created_contracts(
+                    &state_changeset,
+                    self.project_contracts,
+                    self.setup_contracts,
+                    &self.artifact_filters,
+                    targeted_contracts.clone(),
+                    &mut created_contracts,
+                ) {
+                    warn!(target: "forge::test", "{error}");
                 }
 
-                // Before each run, we must reset the backend state.
-                let mut executor = blank_executor.borrow().clone();
+                // Commit changes to the database.
+                executor.backend.commit(state_changeset.clone());
 
-                // Used for stat reports (eg. gas usage).
-                let mut fuzz_runs = Vec::with_capacity(self.config.depth as usize);
+                fuzz_runs.push(FuzzCase {
+                    calldata: calldata.clone(),
+                    gas: call_result.gas_used,
+                    stipend: call_result.stipend,
+                });
 
-                // Created contracts during a run.
-                let mut created_contracts = vec![];
-
-                'fuzz_run: for current_run in 0..self.config.depth {
-                    let (sender, (address, calldata)) =
-                        inputs.last().expect("to have the next randomly generated input.");
-
-                    // Executes the call from the randomly generated sequence.
-                    let call_result = executor
-                        .call_raw(*sender, *address, calldata.0.clone(), U256::zero())
-                        .expect("could not make raw evm call");
-
-                    // Collect data for fuzzing from the state changeset.
-                    let mut state_changeset =
-                        call_result.state_changeset.to_owned().expect("no changesets");
-
-                    collect_data(
-                        &mut state_changeset,
-                        sender,
-                        &call_result,
-                        fuzz_state.clone(),
-                        &self.config.dictionary,
-                    );
-
-                    if let Err(error) = collect_created_contracts(
-                        &state_changeset,
-                        self.project_contracts,
-                        self.setup_contracts,
-                        &self.artifact_filters,
-                        targeted_contracts.clone(),
-                        &mut created_contracts,
-                    ) {
-                        warn!(target: "forge::test", "{error}");
-                    }
-
-                    // Commit changes to the database.
-                    executor.backend.commit(state_changeset.clone());
-
-                    fuzz_runs.push(FuzzCase {
-                        calldata: calldata.clone(),
-                        gas: call_result.gas_used,
-                        stipend: call_result.stipend,
-                    });
-
-                    let RichInvariantResults { success: can_continue, call_results } = can_continue(
-                        invariant_contract,
+                let RichInvariantResults { success: can_continue, call_result: call_results } =
+                    can_continue(
+                        &invariant_contract,
                         call_result,
                         &executor,
                         &inputs,
@@ -210,46 +197,45 @@ impl<'a> InvariantExecutor<'a> {
                         self.config.shrink_sequence,
                     );
 
-                    if !can_continue || current_run == self.config.depth - 1 {
-                        *last_run_calldata.borrow_mut() = inputs.clone();
-                    }
-
-                    if !can_continue {
-                        break 'fuzz_run
-                    }
-
-                    *last_call_results.borrow_mut() = call_results;
-
-                    // Generates the next call from the run using the recently updated
-                    // dictionary.
-                    inputs.extend(
-                        strat
-                            .new_tree(&mut branch_runner.borrow_mut())
-                            .map_err(|_| TestCaseError::Fail("Could not generate case".into()))?
-                            .current(),
-                    );
+                if !can_continue || current_run == self.config.depth - 1 {
+                    *last_run_calldata.borrow_mut() = inputs.clone();
                 }
 
-                // We clear all the targeted contracts created during this run.
-                if !created_contracts.is_empty() {
-                    let mut writable_targeted = targeted_contracts.lock();
-                    for addr in created_contracts.iter() {
-                        writable_targeted.remove(addr);
-                    }
+                if !can_continue {
+                    break
                 }
 
-                fuzz_cases.borrow_mut().push(FuzzedCases::new(fuzz_runs));
+                *last_call_results.borrow_mut() = call_results;
 
-                Ok(())
-            });
-        }
+                // Generates the next call from the run using the recently updated
+                // dictionary.
+                inputs.extend(
+                    strat
+                        .new_tree(&mut branch_runner.borrow_mut())
+                        .map_err(|_| TestCaseError::Fail("Could not generate case".into()))?
+                        .current(),
+                );
+            }
+
+            // We clear all the targeted contracts created during this run.
+            if !created_contracts.is_empty() {
+                let mut writable_targeted = targeted_contracts.lock();
+                for addr in created_contracts.iter() {
+                    writable_targeted.remove(addr);
+                }
+            }
+
+            fuzz_cases.borrow_mut().push(FuzzedCases::new(fuzz_runs));
+
+            Ok(())
+        });
 
         trace!(target: "forge::test::invariant::dictionary", "{:?}", fuzz_state.read().values().iter().map(hex::encode).collect::<Vec<_>>());
 
-        let (reverts, invariants) = failures.into_inner().into_inner();
+        let (reverts, error) = failures.into_inner().into_inner();
 
         Ok(InvariantFuzzTestResult {
-            invariants,
+            error,
             cases: fuzz_cases.into_inner(),
             reverts,
             last_run_inputs: last_run_calldata.take(),
@@ -501,9 +487,11 @@ impl<'a> InvariantExecutor<'a> {
                 address_selectors.push(get_function(name, &selector, abi)?);
             }
         } else {
-            let (name, abi) = self.setup_contracts.get(&address).wrap_err(format!(
-                "[targetSelectors] address does not have an associated contract: {address}"
-            ))?;
+            let (name, abi) = self.setup_contracts.get(&address).ok_or_else(|| {
+                eyre::eyre!(
+                    "[targetSelectors] address does not have an associated contract: {address}"
+                )
+            })?;
 
             let functions = bytes4_array
                 .into_iter()
@@ -622,48 +610,31 @@ fn can_continue(
 
             failures.revert_reason = Some(error.revert_reason.clone());
 
-            // Hacky to provide the full error to the user.
-            for invariant in invariant_contract.invariant_functions.iter() {
-                failures.failed_invariants.insert(
-                    invariant.name.clone(),
-                    (Some(error.clone()), invariant.to_owned().clone()),
-                );
-            }
-
             return RichInvariantResults::new(false, None)
         }
     }
     RichInvariantResults::new(true, call_results)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 /// Stores information about failures and reverts of the invariant tests.
 pub struct InvariantFailures {
-    /// The latest revert reason of a run.
-    pub revert_reason: Option<String>,
     /// Total number of reverts.
     pub reverts: usize,
     /// How many different invariants have been broken.
     pub broken_invariants_count: usize,
+    /// The latest revert reason of a run.
+    pub revert_reason: Option<String>,
     /// Maps a broken invariant to its specific error.
-    pub failed_invariants: BTreeMap<String, (Option<InvariantFuzzError>, Function)>,
+    pub error: Option<InvariantFuzzError>,
 }
 
 impl InvariantFailures {
-    fn new(invariants: &[&Function]) -> Self {
-        InvariantFailures {
-            reverts: 0,
-            broken_invariants_count: 0,
-            failed_invariants: invariants
-                .iter()
-                .map(|f| (f.name.to_string(), (None, f.to_owned().clone())))
-                .collect(),
-            revert_reason: None,
-        }
+    fn new() -> Self {
+        Self::default()
     }
 
-    /// Moves `reverts` and `failed_invariants` out of the struct.
-    fn into_inner(self) -> (usize, BTreeMap<String, (Option<InvariantFuzzError>, Function)>) {
-        (self.reverts, self.failed_invariants)
+    fn into_inner(self) -> (usize, Option<InvariantFuzzError>) {
+        (self.reverts, self.error)
     }
 }

--- a/crates/evm/src/fuzz/invariant/executor.rs
+++ b/crates/evm/src/fuzz/invariant/executor.rs
@@ -107,16 +107,13 @@ impl<'a> InvariantExecutor<'a> {
         // Stores data related to reverts or failed assertions of the test.
         let failures = RefCell::new(InvariantFailures::new());
 
-        let last_call_results = RefCell::new(
-            assert_invariants(
-                &invariant_contract,
-                &self.executor,
-                &[],
-                &mut failures.borrow_mut(),
-                self.config.shrink_sequence,
-            )
-            .ok(),
-        );
+        let last_call_results = RefCell::new(assert_invariants(
+            &invariant_contract,
+            &self.executor,
+            &[],
+            &mut failures.borrow_mut(),
+            self.config.shrink_sequence,
+        ));
         let last_run_calldata: RefCell<Vec<BasicTxDetails>> = RefCell::new(vec![]);
         // Make sure invariants are sound even before starting to fuzz
         if last_call_results.borrow().is_none() {
@@ -588,8 +585,7 @@ fn can_continue(
     // Assert invariants IFF the call did not revert and the handlers did not fail.
     if !call_result.reverted && !handlers_failed {
         call_results =
-            assert_invariants(invariant_contract, executor, calldata, failures, shrink_sequence)
-                .ok();
+            assert_invariants(invariant_contract, executor, calldata, failures, shrink_sequence);
         if call_results.is_none() {
             return RichInvariantResults::new(false, None)
         }

--- a/crates/evm/src/fuzz/invariant/mod.rs
+++ b/crates/evm/src/fuzz/invariant/mod.rs
@@ -1,26 +1,32 @@
 //! Fuzzing support abstracted over the [`Evm`](crate::Evm) used
+
 use crate::{
+    executor::Executor,
     fuzz::*,
     trace::{load_contracts, TraceKind, Traces},
     CALLER,
 };
-mod error;
-pub use error::InvariantFuzzError;
-mod filters;
-pub use filters::{ArtifactFilters, SenderFilters};
-mod call_override;
-pub use call_override::{set_up_inner_replay, RandomCallGenerator};
-use foundry_common::ContractsByArtifact;
-mod executor;
-use crate::executor::Executor;
 use ethers::{
     abi::{Abi, Function},
     types::{Address, Bytes, U256},
 };
-pub use executor::{InvariantExecutor, InvariantFailures};
+use foundry_common::ContractsByArtifact;
 use parking_lot::Mutex;
-pub use proptest::test_runner::Config as FuzzConfig;
 use std::{collections::BTreeMap, sync::Arc};
+
+pub use proptest::test_runner::Config as FuzzConfig;
+
+mod error;
+pub use error::InvariantFuzzError;
+
+mod call_override;
+pub use call_override::{set_up_inner_replay, RandomCallGenerator};
+
+mod executor;
+pub use executor::{InvariantExecutor, InvariantFailures};
+
+mod filters;
+pub use filters::{ArtifactFilters, SenderFilters};
 
 pub type TargetedContracts = BTreeMap<Address, (String, Abi, Vec<Function>)>;
 pub type FuzzRunIdentifiedContracts = Arc<Mutex<TargetedContracts>>;
@@ -34,7 +40,7 @@ pub struct InvariantContract<'a> {
     /// Address of the test contract.
     pub address: Address,
     /// Invariant functions present in the test contract.
-    pub invariant_functions: Vec<&'a Function>,
+    pub invariant_functions: &'a Function,
     /// Abi of the test contract.
     pub abi: &'a Abi,
 }
@@ -48,8 +54,7 @@ pub fn assert_invariants(
     calldata: &[BasicTxDetails],
     invariant_failures: &mut InvariantFailures,
     shrink_sequence: bool,
-) -> eyre::Result<BTreeMap<String, RawCallResult>> {
-    let mut found_case = false;
+) -> Result<RawCallResult> {
     let mut inner_sequence = vec![];
 
     if let Some(fuzzer) = &executor.inspector.fuzzer {
@@ -58,80 +63,40 @@ pub fn assert_invariants(
         }
     }
 
-    let mut call_results = BTreeMap::new();
-    for func in &invariant_contract.invariant_functions {
-        let mut call_result = executor
-            .call_raw(
-                CALLER,
-                invariant_contract.address,
-                func.encode_input(&[]).expect("invariant should have no inputs").into(),
-                U256::zero(),
-            )
-            .expect("EVM error");
+    let func = invariant_contract.invariant_functions;
+    let mut call_result = executor
+        .call_raw(
+            CALLER,
+            invariant_contract.address,
+            func.encode_input(&[]).expect("invariant should have no inputs").into(),
+            U256::zero(),
+        )
+        .expect("EVM error");
 
-        let err = if call_result.reverted {
-            Some(*func)
-        } else {
-            // This will panic and get caught by the executor
-            if !executor.is_success(
-                invariant_contract.address,
-                call_result.reverted,
-                call_result.state_changeset.take().expect("we should have a state changeset"),
-                false,
-            ) {
-                Some(*func)
-            } else {
-                None
-            }
-        };
-
-        if let Some(broken_invariant) = err {
-            let invariant_error = invariant_failures
-                .failed_invariants
-                .get(&broken_invariant.name)
-                .expect("to have been initialized.");
-
-            // We only care about invariants which we haven't broken yet.
-            if invariant_error.0.is_none() {
-                invariant_failures.failed_invariants.insert(
-                    broken_invariant.name.clone(),
-                    (
-                        Some(InvariantFuzzError::new(
-                            invariant_contract,
-                            Some(broken_invariant),
-                            calldata,
-                            call_result,
-                            &inner_sequence,
-                            shrink_sequence,
-                        )),
-                        broken_invariant.clone().to_owned(),
-                    ),
-                );
-                found_case = true;
-            } else {
-                call_results.insert(func.name.clone(), call_result);
-            }
-        } else {
-            call_results.insert(func.name.clone(), call_result);
+    // This will panic and get caught by the executor
+    let is_err = call_result.reverted ||
+        !executor.is_success(
+            invariant_contract.address,
+            call_result.reverted,
+            call_result.state_changeset.take().expect("we should have a state changeset"),
+            false,
+        );
+    if is_err {
+        // We only care about invariants which we haven't broken yet.
+        if invariant_failures.error.is_none() {
+            invariant_failures.error = Some(InvariantFuzzError::new(
+                invariant_contract,
+                Some(func),
+                calldata,
+                call_result,
+                &inner_sequence,
+                shrink_sequence,
+            ));
+            eyre::bail!("Failed");
         }
     }
 
-    if found_case {
-        let before = invariant_failures.broken_invariants_count;
-
-        invariant_failures.broken_invariants_count = invariant_failures
-            .failed_invariants
-            .iter()
-            .filter(|(_function, error)| error.0.is_some())
-            .count();
-
-        eyre::bail!(
-            "{} new invariants have been broken.",
-            invariant_failures.broken_invariants_count - before
-        );
-    }
-
-    Ok(call_results)
+    Ok(call_result)
 }
 
 /// Replays the provided invariant run for collecting the logs and traces from all depths.
@@ -185,7 +150,7 @@ pub fn replay_run(
 /// The outcome of an invariant fuzz test
 #[derive(Debug)]
 pub struct InvariantFuzzTestResult {
-    pub invariants: BTreeMap<String, (Option<InvariantFuzzError>, Function)>,
+    pub error: Option<InvariantFuzzError>,
     /// Every successful fuzz test case
     pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls

--- a/crates/evm/src/fuzz/invariant/mod.rs
+++ b/crates/evm/src/fuzz/invariant/mod.rs
@@ -40,7 +40,7 @@ pub struct InvariantContract<'a> {
     /// Address of the test contract.
     pub address: Address,
     /// Invariant functions present in the test contract.
-    pub invariant_functions: &'a Function,
+    pub invariant_function: &'a Function,
     /// Abi of the test contract.
     pub abi: &'a Abi,
 }
@@ -54,7 +54,7 @@ pub fn assert_invariants(
     calldata: &[BasicTxDetails],
     invariant_failures: &mut InvariantFailures,
     shrink_sequence: bool,
-) -> Result<RawCallResult> {
+) -> Option<RawCallResult> {
     let mut inner_sequence = vec![];
 
     if let Some(fuzzer) = &executor.inspector.fuzzer {
@@ -63,7 +63,7 @@ pub fn assert_invariants(
         }
     }
 
-    let func = invariant_contract.invariant_functions;
+    let func = invariant_contract.invariant_function;
     let mut call_result = executor
         .call_raw(
             CALLER,
@@ -92,11 +92,11 @@ pub fn assert_invariants(
                 &inner_sequence,
                 shrink_sequence,
             ));
-            eyre::bail!("Failed");
+            return None
         }
     }
 
-    Ok(call_result)
+    Some(call_result)
 }
 
 /// Replays the provided invariant run for collecting the logs and traces from all depths.

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -372,25 +372,30 @@ pub struct FuzzedCases {
 }
 
 impl FuzzedCases {
+    #[inline]
     pub fn new(mut cases: Vec<FuzzCase>) -> Self {
         cases.sort_by_key(|c| c.gas);
         Self { cases }
     }
 
+    #[inline]
     pub fn cases(&self) -> &[FuzzCase] {
         &self.cases
     }
 
+    #[inline]
     pub fn into_cases(self) -> Vec<FuzzCase> {
         self.cases
     }
 
     /// Get the last [FuzzCase]
+    #[inline]
     pub fn last(&self) -> Option<&FuzzCase> {
         self.cases.last()
     }
 
     /// Returns the median gas of all test cases
+    #[inline]
     pub fn median_gas(&self, with_stipend: bool) -> u64 {
         let mut values = self.gas_values(with_stipend);
         values.sort_unstable();
@@ -398,12 +403,14 @@ impl FuzzedCases {
     }
 
     /// Returns the average gas use of all test cases
+    #[inline]
     pub fn mean_gas(&self, with_stipend: bool) -> u64 {
         let mut values = self.gas_values(with_stipend);
         values.sort_unstable();
         calc::mean(&values).as_u64()
     }
 
+    #[inline]
     fn gas_values(&self, with_stipend: bool) -> Vec<u64> {
         self.cases
             .iter()
@@ -412,16 +419,19 @@ impl FuzzedCases {
     }
 
     /// Returns the case with the highest gas usage
+    #[inline]
     pub fn highest(&self) -> Option<&FuzzCase> {
         self.cases.last()
     }
 
     /// Returns the case with the lowest gas usage
+    #[inline]
     pub fn lowest(&self) -> Option<&FuzzCase> {
         self.cases.first()
     }
 
     /// Returns the highest amount of gas spent on a fuzz case
+    #[inline]
     pub fn highest_gas(&self, with_stipend: bool) -> u64 {
         self.highest()
             .map(|c| if with_stipend { c.gas } else { c.gas - c.stipend })
@@ -429,6 +439,7 @@ impl FuzzedCases {
     }
 
     /// Returns the lowest amount of gas spent on a fuzz case
+    #[inline]
     pub fn lowest_gas(&self) -> u64 {
         self.lowest().map(|c| c.gas).unwrap_or_default()
     }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, fmt, time::Duration};
 pub struct SuiteResult {
     /// Total duration of the test run for this block of tests
     pub duration: Duration,
-    /// Individual test results. `test method name -> TestResult`
+    /// Individual test results. `test fn signature -> TestResult`
     pub test_results: BTreeMap<String, TestResult>,
     /// Warnings
     pub warnings: Vec<String>,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -264,28 +264,30 @@ impl<'a> ContractRunner<'a> {
             .collect::<BTreeMap<_, _>>();
 
         if has_invariants {
-            let identified_contracts = load_contracts(setup.traces.clone(), known_contracts);
-
-            // TODO: par_iter ?
-            let functions = self
+            let invariants: Vec<_> = self
                 .contract
                 .functions()
-                .filter(|&func| func.is_invariant_test() && filter.matches_test(func.signature()));
-            for func in functions {
-                let runner = test_options.invariant_runner(self.name, &func.name);
-                let invariant_config = test_options.invariant_config(self.name, &func.name);
-                let results = self.run_invariant_test(
-                    runner,
-                    setup.clone(),
-                    *invariant_config,
-                    vec![func],
-                    known_contracts,
-                    identified_contracts.clone(),
-                );
-                for result in results {
-                    test_results.insert(func.signature(), result);
-                }
-            }
+                .filter(|&func| func.is_invariant_test() && filter.matches_test(func.signature()))
+                .collect();
+
+            let identified_contracts = load_contracts(setup.traces.clone(), known_contracts);
+            let results: Vec<_> = invariants
+                .par_iter()
+                .map(|func| {
+                    let runner = test_options.invariant_runner(self.name, &func.name);
+                    let invariant_config = test_options.invariant_config(self.name, &func.name);
+                    let res = self.run_invariant_test(
+                        runner,
+                        setup.clone(),
+                        *invariant_config,
+                        func,
+                        known_contracts,
+                        &identified_contracts,
+                    );
+                    (func.signature(), res)
+                })
+                .collect();
+            test_results.extend(results);
         }
 
         let duration = start.elapsed();
@@ -407,41 +409,41 @@ impl<'a> ContractRunner<'a> {
 
     #[instrument(name = "invariant-test", skip_all)]
     pub fn run_invariant_test(
-        &mut self,
+        &self,
         runner: TestRunner,
         setup: TestSetup,
         invariant_config: InvariantConfig,
-        functions: Vec<&Function>,
+        func: &Function,
         known_contracts: Option<&ContractsByArtifact>,
-        identified_contracts: ContractsByAddress,
-    ) -> Vec<TestResult> {
-        trace!(target: "forge::test::fuzz", "executing invariant test with invariant functions {:?}",  functions.iter().map(|f|&f.name).collect::<Vec<_>>());
+        identified_contracts: &ContractsByAddress,
+    ) -> TestResult {
+        trace!(target: "forge::test::fuzz", "executing invariant test for {:?}", func.name);
         let empty = ContractsByArtifact::default();
         let project_contracts = known_contracts.unwrap_or(&empty);
         let TestSetup { address, logs, traces, labeled_addresses, .. } = setup;
 
         // First, run the test normally to see if it needs to be skipped.
-        if let Err(EvmError::SkipError) = self.executor.execute_test::<(), _, _>(
+        if let Err(EvmError::SkipError) = self.executor.clone().execute_test::<(), _, _>(
             self.sender,
             address,
-            functions[0].clone(),
+            func.clone(),
             (),
             0.into(),
             self.errors,
         ) {
-            return vec![TestResult {
+            return TestResult {
                 status: TestStatus::Skipped,
                 reason: None,
                 decoded_logs: decode_console_logs(&logs),
                 traces,
                 labeled_addresses,
-                kind: TestKind::Standard(0),
+                kind: TestKind::Invariant { runs: 1, calls: 1, reverts: 1 },
                 ..Default::default()
-            }]
+            }
         };
 
         let mut evm = InvariantExecutor::new(
-            &mut self.executor,
+            self.executor.clone(),
             runner,
             invariant_config,
             &identified_contracts,
@@ -449,87 +451,92 @@ impl<'a> ContractRunner<'a> {
         );
 
         let invariant_contract =
-            InvariantContract { address, invariant_functions: functions, abi: self.contract };
+            InvariantContract { address, invariant_functions: func, abi: self.contract };
 
-        let Ok(InvariantFuzzTestResult { invariants, cases, reverts, last_run_inputs }) =
-            evm.invariant_fuzz(&invariant_contract)
-        else {
-            return vec![]
+        let InvariantFuzzTestResult { error, cases, reverts, last_run_inputs } = match evm
+            .invariant_fuzz(invariant_contract.clone())
+        {
+            Ok(x) => x,
+            Err(e) => {
+                return TestResult {
+                    status: TestStatus::Failure,
+                    reason: Some(format!("Failed to set up invariant testing environment: {e}")),
+                    decoded_logs: decode_console_logs(&logs),
+                    traces,
+                    labeled_addresses,
+                    kind: TestKind::Invariant { runs: 0, calls: 0, reverts: 0 },
+                    ..Default::default()
+                }
+            }
         };
 
-        invariants
-            .into_values()
-            .map(|(test_error, invariant)| {
-                let mut counterexample = None;
-                let mut logs = logs.clone();
-                let mut traces = traces.clone();
-
-                let success = test_error.is_none();
-                let reason = test_error.as_ref().and_then(|err| {
-                    (!err.revert_reason.is_empty()).then(|| err.revert_reason.clone())
-                });
-
-                match test_error {
-                    // If invariants were broken, replay the error to collect logs and traces
-                    Some(error @ InvariantFuzzError { test_error: TestError::Fail(_, _), .. }) => {
-                        match error.replay(
-                            self.executor.clone(),
-                            known_contracts,
-                            identified_contracts.clone(),
-                            &mut logs,
-                            &mut traces,
-                        ) {
-                            Ok(c) => counterexample = c,
-                            Err(err) => {
-                                error!(?err, "Failed to replay invariant error")
-                            }
-                        };
-
-                        logs.extend(error.logs);
-
-                        if let Some(error_traces) = error.traces {
-                            traces.push((TraceKind::Execution, error_traces));
-                        }
+        let mut counterexample = None;
+        let mut logs = logs.clone();
+        let mut traces = traces.clone();
+        let success = error.is_none();
+        let reason = error
+            .as_ref()
+            .and_then(|err| (!err.revert_reason.is_empty()).then(|| err.revert_reason.clone()));
+        match error {
+            // If invariants were broken, replay the error to collect logs and traces
+            Some(error @ InvariantFuzzError { test_error: TestError::Fail(_, _), .. }) => {
+                match error.replay(
+                    self.executor.clone(),
+                    known_contracts,
+                    identified_contracts.clone(),
+                    &mut logs,
+                    &mut traces,
+                ) {
+                    Ok(c) => counterexample = c,
+                    Err(err) => {
+                        error!(?err, "Failed to replay invariant error")
                     }
-                    _ => {
-                        // If invariants ran successfully, replay the last run to collect logs and
-                        // traces.
-                        replay_run(
-                            &invariant_contract,
-                            self.executor.clone(),
-                            known_contracts,
-                            identified_contracts.clone(),
-                            &mut logs,
-                            &mut traces,
-                            invariant,
-                            last_run_inputs.clone(),
-                        );
-                    }
-                }
-
-                let kind = TestKind::Invariant {
-                    runs: cases.len(),
-                    calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
-                    reverts,
                 };
 
-                TestResult {
-                    status: match success {
-                        true => TestStatus::Success,
-                        false => TestStatus::Failure,
-                    },
-                    reason,
-                    counterexample,
-                    decoded_logs: decode_console_logs(&logs),
-                    logs,
-                    kind,
-                    coverage: None, // TODO ?
-                    traces,
-                    labeled_addresses: labeled_addresses.clone(),
-                    breakpoints: Default::default(),
+                logs.extend(error.logs);
+
+                if let Some(error_traces) = error.traces {
+                    traces.push((TraceKind::Execution, error_traces));
                 }
-            })
-            .collect()
+            }
+
+            // If invariants ran successfully, replay the last run to collect logs and
+            // traces.
+            _ => {
+                replay_run(
+                    &invariant_contract,
+                    self.executor.clone(),
+                    known_contracts,
+                    identified_contracts.clone(),
+                    &mut logs,
+                    &mut traces,
+                    func.clone(),
+                    last_run_inputs.clone(),
+                );
+            }
+        }
+
+        let kind = TestKind::Invariant {
+            runs: cases.len(),
+            calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
+            reverts,
+        };
+
+        TestResult {
+            status: match success {
+                true => TestStatus::Success,
+                false => TestStatus::Failure,
+            },
+            reason,
+            counterexample,
+            decoded_logs: decode_console_logs(&logs),
+            logs,
+            kind,
+            coverage: None, // TODO ?
+            traces,
+            labeled_addresses: labeled_addresses.clone(),
+            breakpoints: Default::default(),
+        }
     }
 
     #[instrument(name = "fuzz-test", skip_all, fields(name = %func.signature(), %should_fail))]

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -446,12 +446,12 @@ impl<'a> ContractRunner<'a> {
             self.executor.clone(),
             runner,
             invariant_config,
-            &identified_contracts,
+            identified_contracts,
             project_contracts,
         );
 
         let invariant_contract =
-            InvariantContract { address, invariant_functions: func, abi: self.contract };
+            InvariantContract { address, invariant_function: func, abi: self.contract };
 
         let InvariantFuzzTestResult { error, cases, reverts, last_run_inputs } = match evm
             .invariant_fuzz(invariant_contract.clone())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Most of the invariant code is written as if it handles multiple functions per call (e.g. argument is `&[Function]` instead of `&Function` etc.).

This is fine, except we call these functions with `vec![function]` in a loop over the functions...

Recommended to review with "Hide whitespace" since this gets rid of a lot of indentation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Rewrite invariants to run one function at a time, and parallelize the top level loop

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
