### PR TITLE
perf: optimize trace identifiers

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -958,13 +958,13 @@ impl ChiselDispatcher {
             session_config.evm_opts.get_remote_chain_id(),
         )?;
 
-        let mut decoder =
-            CallTraceDecoderBuilder::new().with_labels(result.labeled_addresses.clone()).build();
-
-        decoder.add_signature_identifier(SignaturesIdentifier::new(
-            Config::foundry_cache_dir(),
-            session_config.foundry_config.offline,
-        )?);
+        let mut decoder = CallTraceDecoderBuilder::new()
+            .with_labels(result.labeled_addresses.iter().map(|(a, s)| (*a, s.clone())))
+            .with_signature_identifier(SignaturesIdentifier::new(
+                Config::foundry_cache_dir(),
+                session_config.foundry_config.offline,
+            )?)
+            .build();
 
         for (_, trace) in &mut result.traces {
             // decoder.identify(trace, &mut local_identifier);

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -378,12 +378,13 @@ pub async fn handle_traces(
         None
     });
 
-    let mut decoder = CallTraceDecoderBuilder::new().with_labels(labeled_addresses).build();
-
-    decoder.add_signature_identifier(SignaturesIdentifier::new(
-        Config::foundry_cache_dir(),
-        config.offline,
-    )?);
+    let mut decoder = CallTraceDecoderBuilder::new()
+        .with_labels(labeled_addresses)
+        .with_signature_identifier(SignaturesIdentifier::new(
+            Config::foundry_cache_dir(),
+            config.offline,
+        )?)
+        .build();
 
     for (_, trace) in &mut result.traces {
         decoder.identify(trace, &mut etherscan_identifier);

--- a/crates/evm/src/trace/identifier/etherscan.rs
+++ b/crates/evm/src/trace/identifier/etherscan.rs
@@ -100,11 +100,11 @@ impl EtherscanIdentifier {
 }
 
 impl TraceIdentifier for EtherscanIdentifier {
-    fn identify_addresses(
-        &mut self,
-        addresses: Vec<(&Address, Option<&[u8]>)>,
-    ) -> Vec<AddressIdentity> {
-        trace!(target: "etherscanidentifier", "identify {} addresses", addresses.len());
+    fn identify_addresses<'a, A>(&mut self, addresses: A) -> Vec<AddressIdentity>
+    where
+        A: Iterator<Item = (&'a Address, Option<&'a [u8]>)>,
+    {
+        trace!(target: "etherscanidentifier", "identify {:?} addresses", addresses.size_hint().1);
 
         let Some(client) = self.client.clone() else {
             // no client was configured

--- a/crates/evm/src/trace/identifier/local.rs
+++ b/crates/evm/src/trace/identifier/local.rs
@@ -1,56 +1,45 @@
 use super::{AddressIdentity, TraceIdentifier};
-use ethers::{
-    abi::{Abi, Address, Event},
-    prelude::ArtifactId,
-};
+use ethers::abi::{Address, Event};
 use foundry_common::contracts::{diff_score, ContractsByArtifact};
-use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
 
 /// A trace identifier that tries to identify addresses using local contracts.
-pub struct LocalTraceIdentifier {
-    local_contracts: BTreeMap<Vec<u8>, (ArtifactId, Abi)>,
+pub struct LocalTraceIdentifier<'a> {
+    known_contracts: &'a ContractsByArtifact,
 }
 
-impl LocalTraceIdentifier {
-    pub fn new(known_contracts: &ContractsByArtifact) -> Self {
-        Self {
-            local_contracts: known_contracts
-                .iter()
-                .map(|(id, (abi, runtime_code))| (runtime_code.clone(), (id.clone(), abi.clone())))
-                .collect(),
-        }
+impl<'a> LocalTraceIdentifier<'a> {
+    pub fn new(known_contracts: &'a ContractsByArtifact) -> Self {
+        Self { known_contracts }
     }
 
     /// Get all the events of the local contracts.
     pub fn events(&self) -> impl Iterator<Item = &Event> {
-        self.local_contracts.iter().flat_map(|(_, (_, abi))| abi.events())
+        self.known_contracts.iter().flat_map(|(_, (abi, _))| abi.events())
     }
 }
 
-impl TraceIdentifier for LocalTraceIdentifier {
-    fn identify_addresses(
-        &mut self,
-        addresses: Vec<(&Address, Option<&[u8]>)>,
-    ) -> Vec<AddressIdentity> {
+impl TraceIdentifier for LocalTraceIdentifier<'_> {
+    fn identify_addresses<'a, A>(&mut self, addresses: A) -> Vec<AddressIdentity>
+    where
+        A: Iterator<Item = (&'a Address, Option<&'a [u8]>)>,
+    {
         addresses
-            .into_iter()
             .filter_map(|(address, code)| {
                 let code = code?;
-                let (_, (_, (id, abi))) = self
-                    .local_contracts
+                let (_, id, abi) = self
+                    .known_contracts
                     .iter()
-                    .filter_map(|entry| {
-                        let score = diff_score(entry.0, code);
+                    .filter_map(|(id, (abi, known_code))| {
+                        let score = diff_score(known_code, code);
                         if score < 0.1 {
-                            Some((OrderedFloat(score), entry))
+                            Some((OrderedFloat(score), id, abi))
                         } else {
                             None
                         }
                     })
-                    .sorted_by_key(|(score, _)| *score)
-                    .next()?;
+                    .min_by_key(|(score, _, _)| *score)?;
 
                 Some(AddressIdentity {
                     address: *address,

--- a/crates/evm/src/trace/identifier/mod.rs
+++ b/crates/evm/src/trace/identifier/mod.rs
@@ -33,9 +33,7 @@ pub struct AddressIdentity<'a> {
 pub trait TraceIdentifier {
     // TODO: Update docs
     /// Attempts to identify an address in one or more call traces.
-    #[allow(clippy::type_complexity)]
-    fn identify_addresses(
-        &mut self,
-        addresses: Vec<(&Address, Option<&[u8]>)>,
-    ) -> Vec<AddressIdentity>;
+    fn identify_addresses<'a, A>(&mut self, addresses: A) -> Vec<AddressIdentity>
+    where
+        A: Iterator<Item = (&'a Address, Option<&'a [u8]>)>;
 }

--- a/crates/evm/src/trace/utils.rs
+++ b/crates/evm/src/trace/utils.rs
@@ -79,7 +79,7 @@ pub(crate) fn decode_cheatcode_inputs(
         "serializeBytes32" |
         "serializeString" |
         "serializeBytes" => {
-            if verbosity == 5 {
+            if verbosity >= 5 {
                 None
             } else {
                 let mut decoded = func.decode_input(&data[SELECTOR_LEN..]).ok()?;
@@ -111,10 +111,10 @@ pub(crate) fn decode_cheatcode_outputs(
         // redacts derived private key
         return Some("<pk>".to_string())
     }
-    if func.name == "parseJson" && verbosity != 5 {
+    if func.name == "parseJson" && verbosity < 5 {
         return Some("<encoded JSON value>".to_string())
     }
-    if func.name == "readFile" && verbosity != 5 {
+    if func.name == "readFile" && verbosity < 5 {
         return Some("<file>".to_string())
     }
     None

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -237,14 +237,13 @@ impl ScriptArgs {
 
         let mut local_identifier = LocalTraceIdentifier::new(known_contracts);
         let mut decoder = CallTraceDecoderBuilder::new()
-            .with_labels(result.labeled_addresses.clone())
+            .with_labels(result.labeled_addresses.iter().map(|(a, s)| (*a, s.clone())))
             .with_verbosity(verbosity)
+            .with_signature_identifier(SignaturesIdentifier::new(
+                Config::foundry_cache_dir(),
+                script_config.config.offline,
+            )?)
             .build();
-
-        decoder.add_signature_identifier(SignaturesIdentifier::new(
-            Config::foundry_cache_dir(),
-            script_config.config.offline,
-        )?);
 
         // Decoding traces using etherscan is costly as we run into rate limits,
         // causing scripts to run for a very long time unnecesarily.

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -537,151 +537,146 @@ async fn test(
     if json {
         let results = runner.test(filter, None, test_options).await;
         println!("{}", serde_json::to_string(&results)?);
-        Ok(TestOutcome::new(results, allow_failure))
-    } else {
-        // Set up identifiers
-        let mut local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
-        let remote_chain_id = runner.evm_opts.get_remote_chain_id();
-        // Do not re-query etherscan for contracts that you've already queried today.
-        let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
-
-        // Set up test reporter channel
-        let (tx, rx) = channel::<(String, SuiteResult)>();
-
-        // Run tests
-        let handle =
-            tokio::task::spawn(async move { runner.test(filter, Some(tx), test_options).await });
-
-        let mut results: BTreeMap<String, SuiteResult> = BTreeMap::new();
-        let mut gas_report = GasReport::new(config.gas_reports, config.gas_reports_ignore);
-        let sig_identifier =
-            SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
-
-        let mut total_passed = 0;
-        let mut total_failed = 0;
-        let mut total_skipped = 0;
-
-        'outer: for (contract_name, suite_result) in rx {
-            results.insert(contract_name.clone(), suite_result.clone());
-
-            let mut tests = suite_result.test_results.clone();
-            println!();
-            for warning in suite_result.warnings.iter() {
-                eprintln!("{} {warning}", Paint::yellow("Warning:").bold());
-            }
-            if !tests.is_empty() {
-                let term = if tests.len() > 1 { "tests" } else { "test" };
-                println!("Running {} {term} for {contract_name}", tests.len());
-            }
-            for (name, result) in &mut tests {
-                short_test_result(name, result);
-
-                // If the test failed, we want to stop processing the rest of the tests
-                if fail_fast && result.status == TestStatus::Failure {
-                    break 'outer
-                }
-
-                // We only display logs at level 2 and above
-                if verbosity >= 2 {
-                    // We only decode logs from Hardhat and DS-style console events
-                    let console_logs = decode_console_logs(&result.logs);
-                    if !console_logs.is_empty() {
-                        println!("Logs:");
-                        for log in console_logs {
-                            println!("  {log}");
-                        }
-                        println!();
-                    }
-                }
-
-                if !result.traces.is_empty() {
-                    // Identify addresses in each trace
-                    let mut decoder = CallTraceDecoderBuilder::new()
-                        .with_labels(result.labeled_addresses.clone())
-                        .with_events(local_identifier.events().cloned())
-                        .with_verbosity(verbosity)
-                        .build();
-
-                    // Signatures are of no value for gas reports
-                    if !gas_reporting {
-                        decoder.add_signature_identifier(sig_identifier.clone());
-                    }
-
-                    // Decode the traces
-                    let mut decoded_traces = Vec::new();
-                    for (kind, trace) in &mut result.traces {
-                        decoder.identify(trace, &mut local_identifier);
-                        decoder.identify(trace, &mut etherscan_identifier);
-
-                        let should_include = match kind {
-                            // At verbosity level 3, we only display traces for failed tests
-                            // At verbosity level 4, we also display the setup trace for failed
-                            // tests At verbosity level 5, we display
-                            // all traces for all tests
-                            TraceKind::Setup => {
-                                (verbosity >= 5) ||
-                                    (verbosity == 4 && result.status == TestStatus::Failure)
-                            }
-                            TraceKind::Execution => {
-                                verbosity > 3 ||
-                                    (verbosity == 3 && result.status == TestStatus::Failure)
-                            }
-                            _ => false,
-                        };
-
-                        // We decode the trace if we either need to build a gas report or we need
-                        // to print it
-                        if should_include || gas_reporting {
-                            decoder.decode(trace).await;
-                        }
-
-                        if should_include {
-                            decoded_traces.push(trace.to_string());
-                        }
-                    }
-
-                    if !decoded_traces.is_empty() {
-                        println!("Traces:");
-                        decoded_traces.into_iter().for_each(|trace| println!("{trace}"));
-                    }
-
-                    if gas_reporting {
-                        gas_report.analyze(&result.traces);
-                    }
-                }
-            }
-            let block_outcome =
-                TestOutcome::new([(contract_name, suite_result)].into(), allow_failure);
-
-            total_passed += block_outcome.successes().count();
-            total_failed += block_outcome.failures().count();
-            total_skipped += block_outcome.skips().count();
-
-            println!("{}", block_outcome.summary());
-        }
-
-        if gas_reporting {
-            println!("{}", gas_report.finalize());
-        }
-
-        let num_test_suites = results.len();
-
-        if num_test_suites > 0 {
-            println!(
-                "{}",
-                format_aggregated_summary(
-                    num_test_suites,
-                    total_passed,
-                    total_failed,
-                    total_skipped
-                )
-            );
-        }
-
-        // reattach the thread
-        let _results = handle.await?;
-
-        trace!(target: "forge::test", "received {} results", results.len());
-        Ok(TestOutcome::new(results, allow_failure))
+        return Ok(TestOutcome::new(results, allow_failure))
     }
+
+    // Set up identifiers
+    let known_contracts = runner.known_contracts.clone();
+    let mut local_identifier = LocalTraceIdentifier::new(&known_contracts);
+    let remote_chain_id = runner.evm_opts.get_remote_chain_id();
+    // Do not re-query etherscan for contracts that you've already queried today.
+    let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
+
+    // Set up test reporter channel
+    let (tx, rx) = channel::<(String, SuiteResult)>();
+
+    // Run tests
+    let handle =
+        tokio::task::spawn(async move { runner.test(filter, Some(tx), test_options).await });
+
+    let mut results: BTreeMap<String, SuiteResult> = BTreeMap::new();
+    let mut gas_report = GasReport::new(config.gas_reports, config.gas_reports_ignore);
+    let sig_identifier = SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
+
+    let mut total_passed = 0;
+    let mut total_failed = 0;
+    let mut total_skipped = 0;
+
+    'outer: for (contract_name, suite_result) in rx {
+        results.insert(contract_name.clone(), suite_result.clone());
+
+        let mut tests = suite_result.test_results.clone();
+        println!();
+        for warning in suite_result.warnings.iter() {
+            eprintln!("{} {warning}", Paint::yellow("Warning:").bold());
+        }
+        if !tests.is_empty() {
+            let term = if tests.len() > 1 { "tests" } else { "test" };
+            println!("Running {} {term} for {contract_name}", tests.len());
+        }
+        for (name, result) in &mut tests {
+            short_test_result(name, result);
+
+            // If the test failed, we want to stop processing the rest of the tests
+            if fail_fast && result.status == TestStatus::Failure {
+                break 'outer
+            }
+
+            // We only display logs at level 2 and above
+            if verbosity >= 2 {
+                // We only decode logs from Hardhat and DS-style console events
+                let console_logs = decode_console_logs(&result.logs);
+                if !console_logs.is_empty() {
+                    println!("Logs:");
+                    for log in console_logs {
+                        println!("  {log}");
+                    }
+                    println!();
+                }
+            }
+
+            if result.traces.is_empty() {
+                continue
+            }
+
+            // Identify addresses in each trace
+            let mut builder = CallTraceDecoderBuilder::new()
+                .with_labels(result.labeled_addresses.iter().map(|(a, s)| (*a, s.clone())))
+                .with_events(local_identifier.events().cloned())
+                .with_verbosity(verbosity);
+
+            // Signatures are of no value for gas reports
+            if !gas_reporting {
+                builder = builder.with_signature_identifier(sig_identifier.clone());
+            }
+
+            let mut decoder = builder.build();
+
+            // Decode the traces
+            let mut decoded_traces = Vec::with_capacity(result.traces.len());
+            for (kind, trace) in &mut result.traces {
+                decoder.identify(trace, &mut local_identifier);
+                decoder.identify(trace, &mut etherscan_identifier);
+
+                // verbosity:
+                // - 0..3: nothing
+                // - 3: only display traces for failed tests
+                // - 4: also display the setup trace for failed tests
+                // - 5..: display all traces for all tests
+                let should_include = match kind {
+                    TraceKind::Execution => {
+                        (verbosity == 3 && result.status.is_failure()) || verbosity >= 4
+                    }
+                    TraceKind::Setup => {
+                        (verbosity == 4 && result.status.is_failure()) || verbosity >= 5
+                    }
+                    TraceKind::Deployment => false,
+                };
+
+                // Decode the trace if we either need to build a gas report or we need to print it
+                if should_include || gas_reporting {
+                    decoder.decode(trace).await;
+                }
+
+                if should_include {
+                    decoded_traces.push(trace.to_string());
+                }
+            }
+
+            if !decoded_traces.is_empty() {
+                println!("Traces:");
+                decoded_traces.into_iter().for_each(|trace| println!("{trace}"));
+            }
+
+            if gas_reporting {
+                gas_report.analyze(&result.traces);
+            }
+        }
+        let block_outcome = TestOutcome::new([(contract_name, suite_result)].into(), allow_failure);
+
+        total_passed += block_outcome.successes().count();
+        total_failed += block_outcome.failures().count();
+        total_skipped += block_outcome.skips().count();
+
+        println!("{}", block_outcome.summary());
+    }
+
+    if gas_reporting {
+        println!("{}", gas_report.finalize());
+    }
+
+    let num_test_suites = results.len();
+
+    if num_test_suites > 0 {
+        println!(
+            "{}",
+            format_aggregated_summary(num_test_suites, total_passed, total_failed, total_skipped)
+        );
+    }
+
+    // reattach the thread
+    let _results = handle.await?;
+
+    trace!(target: "forge::test", "received {} results", results.len());
+    Ok(TestOutcome::new(results, allow_failure))
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -58,12 +58,32 @@ impl SuiteResult {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TestStatus {
     Success,
     #[default]
     Failure,
     Skipped,
+}
+
+impl TestStatus {
+    /// Returns `true` if the test was successful.
+    #[inline]
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::Success)
+    }
+
+    /// Returns `true` if the test failed.
+    #[inline]
+    pub fn is_failure(self) -> bool {
+        matches!(self, Self::Failure)
+    }
+
+    /// Returns `true` if the test was skipped.
+    #[inline]
+    pub fn is_skipped(self) -> bool {
+        matches!(self, Self::Skipped)
+    }
 }
 
 /// The result of an executed solidity test


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

~~Identifying and decoding traces contributes the majority (usually >40%) of the time spent in running tests. We can avoid most of this by just using the existing check flags to skip identifying only when needed.~~

My assumptions were wrong. Generally, we decode traces on the main thread in parallel to the threads executing tests. This is a problem when there are a lot of them, and are sent batched (like for invariants). This causes the main thread to block for a while just decoding traces, which may also block after all tests are done.

This PR cleans up some tracing code, but the issue mentioned above will have to be fixed in another PR.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
