### PR TITLE
chore: avoid cloning `CompileOutput` to parse inline config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1934,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.8"
-source = "git+https://github.com/gakonst/ethers-rs#179891d45cc7b50941f2b8c30b206355ab76d94c"
+source = "git+https://github.com/gakonst/ethers-rs#7603af021be920ca39b610f88c0012328b337cd6"
 dependencies = [
  "cfg-if",
  "const-hex",

--- a/crates/config/src/inline/conf_parser.rs
+++ b/crates/config/src/inline/conf_parser.rs
@@ -71,10 +71,8 @@ where
     fn validate_configs(natspec: &NatSpec) -> Result<(), InlineConfigError> {
         let config_key = Self::config_key();
 
-        let configs = natspec
-            .config_lines()
-            .filter(|l| l.contains(&config_key))
-            .collect::<Vec<String>>();
+        let configs =
+            natspec.config_lines().filter(|l| l.contains(&config_key)).collect::<Vec<String>>();
 
         Self::default().try_merge(&configs).map_err(|e| {
             let line = natspec.debug_context();

--- a/crates/config/src/inline/conf_parser.rs
+++ b/crates/config/src/inline/conf_parser.rs
@@ -73,7 +73,6 @@ where
 
         let configs = natspec
             .config_lines()
-            .into_iter()
             .filter(|l| l.contains(&config_key))
             .collect::<Vec<String>>();
 

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -57,7 +57,7 @@ impl NatSpec {
         &'a self,
         prefix: &'a str,
     ) -> impl Iterator<Item = String> + 'a {
-        self.config_lines().into_iter().filter(move |l| l.starts_with(prefix))
+        self.config_lines().filter(move |l| l.starts_with(prefix))
     }
 
     /// Returns a list of all the configuration lines available in the natspec

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -165,9 +165,8 @@ impl TestArgs {
         let test_options: TestOptions = TestOptionsBuilder::default()
             .fuzz(config.fuzz)
             .invariant(config.invariant)
-            .compile_output(&output)
             .profiles(profiles)
-            .build(project_root)?;
+            .build(&output, project_root)?;
 
         // Determine print verbosity and executor verbosity
         let verbosity = evm_opts.verbosity;

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -212,6 +212,6 @@ impl TestOptionsBuilder {
             self.profiles.unwrap_or_else(|| vec![Config::selected_profile().into()]);
         let base_fuzz = self.fuzz.unwrap_or_default();
         let base_invariant = self.invariant.unwrap_or_default();
-        TestOptions::new(output, &root, profiles, base_fuzz, base_invariant)
+        TestOptions::new(output, root, profiles, base_fuzz, base_invariant)
     }
 }

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -47,6 +47,47 @@ pub struct TestOptions {
 }
 
 impl TestOptions {
+    /// Tries to create a new instance by detecting inline configurations from the project compile
+    /// output.
+    pub fn new(
+        output: &ProjectCompileOutput,
+        root: &Path,
+        profiles: Vec<String>,
+        base_fuzz: FuzzConfig,
+        base_invariant: InvariantConfig,
+    ) -> Result<Self, InlineConfigError> {
+        let natspecs: Vec<NatSpec> = NatSpec::parse(output, root);
+        let mut inline_invariant = InlineConfig::<InvariantConfig>::default();
+        let mut inline_fuzz = InlineConfig::<FuzzConfig>::default();
+
+        for natspec in natspecs {
+            // Perform general validation
+            validate_profiles(&natspec, &profiles)?;
+            FuzzConfig::validate_configs(&natspec)?;
+            InvariantConfig::validate_configs(&natspec)?;
+
+            // Apply in-line configurations for the current profile
+            let configs: Vec<String> = natspec.current_profile_configs().collect();
+            let c: &str = &natspec.contract;
+            let f: &str = &natspec.function;
+            let line: String = natspec.debug_context();
+
+            match base_fuzz.try_merge(&configs) {
+                Ok(Some(conf)) => inline_fuzz.insert(c, f, conf),
+                Ok(None) => { /* No inline config found, do nothing */ }
+                Err(e) => Err(InlineConfigError { line: line.clone(), source: e })?,
+            }
+
+            match base_invariant.try_merge(&configs) {
+                Ok(Some(conf)) => inline_invariant.insert(c, f, conf),
+                Ok(None) => { /* No inline config found, do nothing */ }
+                Err(e) => Err(InlineConfigError { line: line.clone(), source: e })?,
+            }
+        }
+
+        Ok(Self { fuzz: base_fuzz, invariant: base_invariant, inline_fuzz, inline_invariant })
+    }
+
     /// Returns a "fuzz" test runner instance. Parameters are used to select tight scoped fuzz
     /// configs that apply for a contract-function pair. A fallback configuration is applied
     /// if no specific setup is found for a given input.
@@ -127,83 +168,23 @@ impl TestOptions {
     }
 }
 
-impl<'a, P> TryFrom<(&'a ProjectCompileOutput, &'a P, Vec<String>, FuzzConfig, InvariantConfig)>
-    for TestOptions
-where
-    P: AsRef<Path>,
-{
-    type Error = InlineConfigError;
-
-    /// Tries to create an instance of `Self`, detecting inline configurations from the project
-    /// compile output.
-    ///
-    /// Param is a tuple, whose elements are:
-    /// 1. Solidity compiler output, essential to extract natspec test configs.
-    /// 2. Root path to express contract base dirs. This is essential to match inline configs at
-    /// runtime. 3. List of available configuration profiles
-    /// 4. Reference to a fuzz base configuration.
-    /// 5. Reference to an invariant base configuration.
-    fn try_from(
-        value: (&'a ProjectCompileOutput, &'a P, Vec<String>, FuzzConfig, InvariantConfig),
-    ) -> Result<Self, Self::Error> {
-        let output = value.0;
-        let root = value.1;
-        let profiles = &value.2;
-        let base_fuzz: FuzzConfig = value.3;
-        let base_invariant: InvariantConfig = value.4;
-
-        let natspecs: Vec<NatSpec> = NatSpec::parse(output, root);
-        let mut inline_invariant = InlineConfig::<InvariantConfig>::default();
-        let mut inline_fuzz = InlineConfig::<FuzzConfig>::default();
-
-        for natspec in natspecs {
-            // Perform general validation
-            validate_profiles(&natspec, profiles)?;
-            FuzzConfig::validate_configs(&natspec)?;
-            InvariantConfig::validate_configs(&natspec)?;
-
-            // Apply in-line configurations for the current profile
-            let configs: Vec<String> = natspec.current_profile_configs();
-            let c: &str = &natspec.contract;
-            let f: &str = &natspec.function;
-            let line: String = natspec.debug_context();
-
-            match base_fuzz.try_merge(&configs) {
-                Ok(Some(conf)) => inline_fuzz.insert(c, f, conf),
-                Err(e) => Err(InlineConfigError { line: line.clone(), source: e })?,
-                _ => { /* No inline config found, do nothing */ }
-            }
-
-            match base_invariant.try_merge(&configs) {
-                Ok(Some(conf)) => inline_invariant.insert(c, f, conf),
-                Err(e) => Err(InlineConfigError { line: line.clone(), source: e })?,
-                _ => { /* No inline config found, do nothing */ }
-            }
-        }
-
-        Ok(Self { fuzz: base_fuzz, invariant: base_invariant, inline_fuzz, inline_invariant })
-    }
-}
-
 /// Builder utility to create a [`TestOptions`] instance.
 #[derive(Default)]
+#[must_use = "builders do nothing unless you call `build` on them"]
 pub struct TestOptionsBuilder {
     fuzz: Option<FuzzConfig>,
     invariant: Option<InvariantConfig>,
     profiles: Option<Vec<String>>,
-    output: Option<ProjectCompileOutput>,
 }
 
 impl TestOptionsBuilder {
     /// Sets a [`FuzzConfig`] to be used as base "fuzz" configuration.
-    #[must_use = "A base 'fuzz' config must be provided"]
     pub fn fuzz(mut self, conf: FuzzConfig) -> Self {
         self.fuzz = Some(conf);
         self
     }
 
     /// Sets a [`InvariantConfig`] to be used as base "invariant" configuration.
-    #[must_use = "A base 'invariant' config must be provided"]
     pub fn invariant(mut self, conf: InvariantConfig) -> Self {
         self.invariant = Some(conf);
         self
@@ -216,40 +197,21 @@ impl TestOptionsBuilder {
         self
     }
 
-    /// Sets a project compiler output instance. This is used to extract
-    /// inline test configurations that override `self.fuzz` and `self.invariant`
-    /// specs when necessary.
-    pub fn compile_output(mut self, output: &ProjectCompileOutput) -> Self {
-        self.output = Some(output.clone());
-        self
-    }
-
     /// Creates an instance of [`TestOptions`]. This takes care of creating "fuzz" and
     /// "invariant" fallbacks, and extracting all inline test configs, if available.
     ///
     /// `root` is a reference to the user's project root dir. This is essential
     /// to determine the base path of generated contract identifiers. This is to provide correct
     /// matchers for inline test configs.
-    pub fn build(self, root: impl AsRef<Path>) -> Result<TestOptions, InlineConfigError> {
-        let default_profiles = vec![Config::selected_profile().into()];
-        let profiles: Vec<String> = self.profiles.unwrap_or(default_profiles);
+    pub fn build(
+        self,
+        output: &ProjectCompileOutput,
+        root: &Path,
+    ) -> Result<TestOptions, InlineConfigError> {
+        let profiles: Vec<String> =
+            self.profiles.unwrap_or_else(|| vec![Config::selected_profile().into()]);
         let base_fuzz = self.fuzz.unwrap_or_default();
         let base_invariant = self.invariant.unwrap_or_default();
-
-        match self.output {
-            Some(compile_output) => Ok(TestOptions::try_from((
-                &compile_output,
-                &root,
-                profiles,
-                base_fuzz,
-                base_invariant,
-            ))?),
-            None => Ok(TestOptions {
-                fuzz: base_fuzz,
-                invariant: base_invariant,
-                inline_fuzz: InlineConfig::default(),
-                inline_invariant: InlineConfig::default(),
-            }),
-        }
+        TestOptions::new(output, &root, profiles, base_fuzz, base_invariant)
     }
 }

--- a/crates/forge/tests/it/inline.rs
+++ b/crates/forge/tests/it/inline.rs
@@ -76,9 +76,8 @@ fn build_test_options() {
     let build_result = TestOptionsBuilder::default()
         .fuzz(FuzzConfig::default())
         .invariant(InvariantConfig::default())
-        .compile_output(&COMPILED)
         .profiles(profiles)
-        .build(root);
+        .build(&COMPILED, root);
 
     assert!(build_result.is_ok());
 }
@@ -90,9 +89,8 @@ fn build_test_options_just_one_valid_profile() {
     let build_result = TestOptionsBuilder::default()
         .fuzz(FuzzConfig::default())
         .invariant(InvariantConfig::default())
-        .compile_output(&COMPILED)
         .profiles(valid_profiles)
-        .build(root);
+        .build(&COMPILED, root);
 
     // We expect an error, since COMPILED contains in-line
     // per-test configs for "default" and "ci" profiles
@@ -104,7 +102,6 @@ fn test_options() -> TestOptions {
     TestOptionsBuilder::default()
         .fuzz(FuzzConfig::default())
         .invariant(InvariantConfig::default())
-        .compile_output(&COMPILED)
-        .build(root)
+        .build(&COMPILED, root)
         .expect("Config loaded")
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Cloning = slow

Cloning compiler output (TWICE) = incredibly slow

Please do not do this :)
We're talking 150ms for a `forge init` project, going into the seconds PER CLONE for big projects.
Benchmarked with `AMD Ryzen 9 5900X (24) @ 3.700GHz`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Don't clone

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
