### PR TITLE
Debugger Refactor #1: fuzz single

### DIFF
--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -27,6 +27,8 @@ pub mod error;
 pub mod invariant;
 pub mod strategies;
 
+/// Returned by a single fuzz in the case of a successful run
+#[derive(Debug)]
 pub struct CaseOutcome {
     pub case: FuzzCase,
     pub gas_used: u64,
@@ -37,6 +39,8 @@ pub struct CaseOutcome {
     pub breakpoints: Breakpoints,
 }
 
+/// Returned by a single fuzz when a counterexample has been discovered
+#[derive(Debug)]
 pub struct CounterExampleOutcome {
     pub counterexample: (ethers::types::Bytes, RawCallResult),
     pub exit_reason: InstructionResult,
@@ -44,6 +48,8 @@ pub struct CounterExampleOutcome {
     pub breakpoints: Breakpoints,
 }
 
+/// Outcome of a single fuzz
+#[derive(Debug)]
 pub enum FuzzOutcome {
     Case(CaseOutcome),
     CounterExample(CounterExampleOutcome),

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -250,7 +250,7 @@ impl<'a> FuzzedExecutor<'a> {
         }
 
         let breakpoints =
-            call.cheatcodes.clone().map_or(Default::default(), |cheats| cheats.breakpoints);
+            call.cheatcodes.as_ref().map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
         let success =
             self.executor.is_success(address, call.reverted, state_changeset.clone(), should_fail);

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -234,7 +234,6 @@ impl<'a> FuzzedExecutor<'a> {
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {
                 case: FuzzCase { calldata, gas: call.gas_used, stipend: call.stipend },
-                gas_used: call.gas_used,
                 stipend: call.stipend,
                 traces: call.traces,
                 coverage: call.coverage,

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -108,10 +108,10 @@ impl<'a> FuzzedExecutor<'a> {
             match fuzz_res {
                 FuzzOutcome::Case(case) => {
                     let mut first_case = first_case.borrow_mut();
+                    gas_by_case.borrow_mut().push((case.case.gas, case.case.stipend));
                     if first_case.is_none() {
                         first_case.replace(case.case);
                     }
-                    gas_by_case.borrow_mut().push((case.gas_used, case.stipend));
 
                     traces.replace(case.traces);
 
@@ -234,7 +234,6 @@ impl<'a> FuzzedExecutor<'a> {
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {
                 case: FuzzCase { calldata, gas: call.gas_used, stipend: call.stipend },
-                stipend: call.stipend,
                 traces: call.traces,
                 coverage: call.coverage,
                 debug: call.debug,

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -223,8 +223,10 @@ impl<'a> FuzzedExecutor<'a> {
             return Err(TestCaseError::reject(FuzzError::AssumeReject))
         }
 
-        let breakpoints =
-            call.cheatcodes.as_ref().map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
+        let breakpoints = call
+            .cheatcodes
+            .as_ref()
+            .map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
         let success =
             self.executor.is_success(address, call.reverted, state_changeset.clone(), should_fail);

--- a/crates/evm/src/fuzz/types.rs
+++ b/crates/evm/src/fuzz/types.rs
@@ -18,21 +18,28 @@ pub struct FuzzCase {
 /// Returned by a single fuzz in the case of a successful run
 #[derive(Debug)]
 pub struct CaseOutcome {
+    /// Data of a single fuzz test case
     pub case: FuzzCase,
-    pub gas_used: u64,
-    pub stipend: u64,
+    /// The traces of the call
     pub traces: Option<CallTraceArena>,
+    /// The coverage info collected during the call
     pub coverage: Option<HitMaps>,
+    /// The debug nodes of the call
     pub debug: Option<DebugArena>,
+    /// Breakpoints char pc map
     pub breakpoints: Breakpoints,
 }
 
 /// Returned by a single fuzz when a counterexample has been discovered
 #[derive(Debug)]
 pub struct CounterExampleOutcome {
+    /// Minimal reproduction test case for failing test
     pub counterexample: (ethers::types::Bytes, RawCallResult),
+    /// The status of the call
     pub exit_reason: InstructionResult,
+    /// The debug nodes of the call
     pub debug: Option<DebugArena>,
+    /// Breakpoints char pc map
     pub breakpoints: Breakpoints,
 }
 

--- a/crates/evm/src/fuzz/types.rs
+++ b/crates/evm/src/fuzz/types.rs
@@ -1,0 +1,44 @@
+use crate::{coverage::HitMaps, debug::DebugArena, executor::RawCallResult, trace::CallTraceArena};
+use ethers::types::Bytes;
+use foundry_common::evm::Breakpoints;
+use revm::interpreter::InstructionResult;
+use serde::{Deserialize, Serialize};
+
+/// Data of a single fuzz test case
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct FuzzCase {
+    /// The calldata used for this fuzz test
+    pub calldata: Bytes,
+    /// Consumed gas
+    pub gas: u64,
+    /// The initial gas stipend for the transaction
+    pub stipend: u64,
+}
+
+/// Returned by a single fuzz in the case of a successful run
+#[derive(Debug)]
+pub struct CaseOutcome {
+    pub case: FuzzCase,
+    pub gas_used: u64,
+    pub stipend: u64,
+    pub traces: Option<CallTraceArena>,
+    pub coverage: Option<HitMaps>,
+    pub debug: Option<DebugArena>,
+    pub breakpoints: Breakpoints,
+}
+
+/// Returned by a single fuzz when a counterexample has been discovered
+#[derive(Debug)]
+pub struct CounterExampleOutcome {
+    pub counterexample: (ethers::types::Bytes, RawCallResult),
+    pub exit_reason: InstructionResult,
+    pub debug: Option<DebugArena>,
+    pub breakpoints: Breakpoints,
+}
+
+/// Outcome of a single fuzz
+#[derive(Debug)]
+pub enum FuzzOutcome {
+    Case(CaseOutcome),
+    CounterExample(CounterExampleOutcome),
+}

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -6,7 +6,7 @@ use foundry_common::evm::Breakpoints;
 use foundry_evm::{
     coverage::HitMaps,
     executor::EvmError,
-    fuzz::{CounterExample, FuzzCase},
+    fuzz::{types::FuzzCase, CounterExample},
     trace::{TraceKind, Traces},
 };
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
First part of https://github.com/foundry-rs/foundry/pull/5547 breaking into smaller chunks.
This PR refactors the `fuzz` function in order to have access to a more granular, single-step, function called `single_fuzz`.
It will let us in the context of the debugger to be able to run again the fuzzer on the last relevant (either a counter-example, or the first case, see the current imeplemtnation of the debugger launching https://github.com/foundry-rs/foundry/blob/master/crates/forge/bin/cmd/test/mod.rs#L209-L213 with this time debug traces (they are expensive, especially when fuzzed).