### PR TITLE
chore(`cast`): re-add --from-utf8 as alias from book

### DIFF
--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -74,6 +74,7 @@ pub enum Subcommands {
     #[clap(
         visible_aliases = &[
         "--from-ascii",
+        "--from-utf8",
         "from-ascii",
         "fu",
         "fa"]


### PR DESCRIPTION
## Motivation

Quite a few commits ago it seems we removed support from `--from-utf8` as alias, and this was in the book. While the book has been updated, don't see why this shouldn't be supported

## Solution

add back