### PR TITLE
fix(`ci`): exclude `rusoto` & `ethers-providers` from `cargo-deny`

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -3,10 +3,10 @@ name: deny
 on:
     push:
         branches: [master]
-        paths: [Cargo.lock]
+        paths: [Cargo.lock, deny.toml]
     pull_request:
         branches: [master]
-        paths: [Cargo.lock]
+        paths: [Cargo.lock, deny.toml]
 
 env:
     CARGO_TERM_COLOR: always

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,7 @@
+# Temporarily exclude rusoto and ethers-providers from bans since we've yet to transition to the 
+# Rust AWS SDK.
+exclude = ["rusoto_core", "rusoto_kms", "rusoto_credential", "ethers-providers"]
+
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html


### PR DESCRIPTION
Should stop CI erroring for now—we've yet to transition to using the maintained rust AWS SDK which would allow us to remove these denys.