### PR TITLE
Fixing the installation command in Anvil README

### DIFF
--- a/crates/anvil/README.md
+++ b/crates/anvil/README.md
@@ -20,7 +20,7 @@ A local Ethereum node, akin to Ganache, designed for development with [**Forge**
 ```sh
 git clone https://github.com/foundry-rs/foundry
 cd foundry
-cargo install --path ./anvil --bins --locked --force
+cargo install --path ./crates/anvil --profile local --force
 ```
 
 ## Getting started


### PR DESCRIPTION
The cargo installation command in the Anvil README was fixed according to the [Installation guide in the Foundry Book](https://book.getfoundry.sh/getting-started/installation#building).

## Motivation

The Lighthouse Book links the Anvil README in the list of their requirements, but I had issues installing Anvil the described way. The command in the Foundry Book worked for me, therefore I am fixing this command according to this documentation.

## Solution

The broken set of commands was fixed according to the documentation.
