### PR TITLE
Append extra 0 to prefix/suffix in cast create2 to avoid getting wrong hex strings

### DIFF
--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -158,7 +158,7 @@ impl Create2Args {
 fn get_regex_hex_string(s: String) -> Result<String> {
     let s = s.strip_prefix("0x").unwrap_or(&s);
     let pad_width = s.len() + s.len() % 2;
-    hex::decode(format!("{s:0>pad_width$}"))?;
+    hex::decode(format!("{s:0<pad_width$}"))?;
     Ok(s.to_string())
 }
 
@@ -204,10 +204,15 @@ mod tests {
 
         assert!(address.starts_with("aaa"));
 
-        // TODO: add check fails on wrong chars
-        // let args = Create2Args::parse_from(["foundry-cli", "--starts-with", "0xtest"]);
-        // let create2_out = args.run();
-        // assert_eq!(create2_out, Err("invalid prefix hex provided"));
+        // check fails on wrong chars
+        let args = Create2Args::parse_from(["foundry-cli", "--starts-with", "0xerr"]);
+        let create2_out = args.run();
+        assert!(create2_out.is_err());
+
+        // check fails on wrong x prefixed string provided
+        let args = Create2Args::parse_from(["foundry-cli", "--starts-with", "x00"]);
+        let create2_out = args.run();
+        assert!(create2_out.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Follow up to my previous PR https://github.com/foundry-rs/foundry/pull/5713. While testing I also got another error case with `cast create2 -s x00` which would hangs infinitely as well.
We pass `hex::decode` check because extra 0 is prepended and hex string becomes valid (`0x00`) though it would never be possible to find address starting with `x00`

## Solution

Instead of prepending extra `0` to the searchable string to check with `hex::decode`, append `0` to the end of the searchable string

```diff
-hex::decode(format!("{s:0>pad_width$}"))?;
+hex::decode(format!("{s:0<pad_width$}"))?;
```

Added relevant tests