### PR TITLE
feat(`cheatcodes`): v1 `expect*` changes

### DIFF
--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -118,6 +118,16 @@ pub struct ExpectedEmit {
     pub found: bool,
 }
 
+fn expect_emit(
+    state: &mut Cheatcodes,
+    address: Option<H160>,
+    depth: u64,
+    checks: [bool; 4],
+) -> Result {
+    state.expected_emits.push_back(ExpectedEmit { depth, address, checks, ..Default::default() });
+    Ok(Bytes::new())
+}
+
 pub fn handle_expect_emit(state: &mut Cheatcodes, log: RawLog, address: &Address) {
     // Fill or check the expected emits.
     // We expect for emit checks to be filled as they're declared (from oldest to newest),
@@ -210,6 +220,8 @@ pub struct ExpectedCallData {
     pub count: u64,
     /// The type of call
     pub call_type: ExpectedCallType,
+    /// The depth at which this call must be checked
+    pub depth: u64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -287,6 +299,7 @@ fn expect_call(
     min_gas: Option<u64>,
     count: u64,
     call_type: ExpectedCallType,
+    depth: u64,
 ) -> Result {
     match call_type {
         ExpectedCallType::Count => {
@@ -298,8 +311,10 @@ fn expect_call(
                 !expecteds.contains_key(&calldata),
                 "Counted expected calls can only bet set once."
             );
-            expecteds
-                .insert(calldata, (ExpectedCallData { value, gas, min_gas, count, call_type }, 0));
+            expecteds.insert(
+                calldata,
+                (ExpectedCallData { value, gas, min_gas, count, call_type, depth }, 0),
+            );
             Ok(Bytes::new())
         }
         ExpectedCallType::NonCount => {
@@ -317,7 +332,7 @@ fn expect_call(
                 // If it does not exist, then create it.
                 expecteds.insert(
                     calldata,
-                    (ExpectedCallData { value, gas, min_gas, count, call_type }, 0),
+                    (ExpectedCallData { value, gas, min_gas, count, call_type, depth }, 0),
                 );
             }
             Ok(Bytes::new())
@@ -340,39 +355,26 @@ pub fn apply<DB: DatabaseExt>(
             expect_revert(state, Some(inner.0.into()), data.journaled_state.depth())
         }
         HEVMCalls::ExpectEmit0(_) => {
-            state.expected_emits.push_back(ExpectedEmit {
-                depth: data.journaled_state.depth(),
-                checks: [true, true, true, true],
-                ..Default::default()
-            });
-            Ok(Bytes::new())
+            expect_emit(state, None, data.journaled_state.depth(), [true, true, true, true])
         }
-        HEVMCalls::ExpectEmit1(inner) => {
-            state.expected_emits.push_back(ExpectedEmit {
-                depth: data.journaled_state.depth(),
-                checks: [true, true, true, true],
-                address: Some(inner.0),
-                ..Default::default()
-            });
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectEmit2(inner) => {
-            state.expected_emits.push_back(ExpectedEmit {
-                depth: data.journaled_state.depth(),
-                checks: [inner.0, inner.1, inner.2, inner.3],
-                ..Default::default()
-            });
-            Ok(Bytes::new())
-        }
-        HEVMCalls::ExpectEmit3(inner) => {
-            state.expected_emits.push_back(ExpectedEmit {
-                depth: data.journaled_state.depth(),
-                checks: [inner.0, inner.1, inner.2, inner.3],
-                address: Some(inner.4),
-                ..Default::default()
-            });
-            Ok(Bytes::new())
-        }
+        HEVMCalls::ExpectEmit1(inner) => expect_emit(
+            state,
+            Some(inner.0),
+            data.journaled_state.depth(),
+            [true, true, true, true],
+        ),
+        HEVMCalls::ExpectEmit2(inner) => expect_emit(
+            state,
+            None,
+            data.journaled_state.depth(),
+            [inner.0, inner.1, inner.2, inner.3],
+        ),
+        HEVMCalls::ExpectEmit3(inner) => expect_emit(
+            state,
+            Some(inner.4),
+            data.journaled_state.depth(),
+            [inner.0, inner.1, inner.2, inner.3],
+        ),
         HEVMCalls::ExpectCall0(inner) => expect_call(
             state,
             inner.0,
@@ -382,6 +384,7 @@ pub fn apply<DB: DatabaseExt>(
             None,
             1,
             ExpectedCallType::NonCount,
+            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall1(inner) => expect_call(
             state,
@@ -392,6 +395,7 @@ pub fn apply<DB: DatabaseExt>(
             None,
             inner.2,
             ExpectedCallType::Count,
+            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall2(inner) => expect_call(
             state,
@@ -402,6 +406,7 @@ pub fn apply<DB: DatabaseExt>(
             None,
             1,
             ExpectedCallType::NonCount,
+            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall3(inner) => expect_call(
             state,
@@ -412,13 +417,13 @@ pub fn apply<DB: DatabaseExt>(
             None,
             inner.3,
             ExpectedCallType::Count,
+            data.journaled_state.depth(),
         ),
         HEVMCalls::ExpectCall4(inner) => {
             let value = inner.1;
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-
             expect_call(
                 state,
                 inner.0,
@@ -428,6 +433,7 @@ pub fn apply<DB: DatabaseExt>(
                 None,
                 1,
                 ExpectedCallType::NonCount,
+                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCall5(inner) => {
@@ -435,7 +441,6 @@ pub fn apply<DB: DatabaseExt>(
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-
             expect_call(
                 state,
                 inner.0,
@@ -445,6 +450,7 @@ pub fn apply<DB: DatabaseExt>(
                 None,
                 inner.4,
                 ExpectedCallType::Count,
+                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCallMinGas0(inner) => {
@@ -452,7 +458,6 @@ pub fn apply<DB: DatabaseExt>(
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-
             expect_call(
                 state,
                 inner.0,
@@ -462,6 +467,7 @@ pub fn apply<DB: DatabaseExt>(
                 Some(inner.2 + positive_value_cost_stipend),
                 1,
                 ExpectedCallType::NonCount,
+                data.journaled_state.depth(),
             )
         }
         HEVMCalls::ExpectCallMinGas1(inner) => {
@@ -469,7 +475,6 @@ pub fn apply<DB: DatabaseExt>(
             // If the value of the transaction is non-zero, the EVM adds a call stipend of 2300 gas
             // to ensure that the basic fallback function can be called.
             let positive_value_cost_stipend = if value > U256::zero() { 2300 } else { 0 };
-
             expect_call(
                 state,
                 inner.0,
@@ -479,6 +484,7 @@ pub fn apply<DB: DatabaseExt>(
                 Some(inner.2 + positive_value_cost_stipend),
                 inner.4,
                 ExpectedCallType::Count,
+                data.journaled_state.depth(),
             )
         }
         HEVMCalls::MockCall0(inner) => {


### PR DESCRIPTION
## `expect*` cheatcode changes

This is the working feature branch for the 1.0 expect* cheatcodes-related changes.
### `expectCall`
It will now only work for the *next* call's subcalls. See detailed description:
<details><summary>Details</summary>

## Motivation

Right now, `expectCall` works at the "test" level—as long as there are enough calls to the target contract at any depth level in the test, it will pass. This will make it so that the calls are only counted if they happen in an external call, meaning calls performed at the "test" ("root") level will not count.

## New behavior

The current behavior allows using expectCall this way:

```solidity
// PASS
function testThings() {
  Contract inner = new Contract();
  NestedContract target = new NestedContract(inner);
  vm.expectCall(address(inner), abi.encodeWithSelector(inner.bar.selector), 2);
  inner.bar(); // call bar directly. Counts as 1 of two calls expected.
  target.baz(); // will call bar internally. This counts as 2 of two calls expected. expectCall is fulfilled.
}
```

This is not the intended behavior, due to this reason:
- `expect*` cheatcodes should only work for the next call. 
 
This means that `expectCall` should actually expect to match calls that are "subcalls" of the next call.

This PR introduces the following behavior

```solidity
// FAIL
function testOne() {
  Contract inner = new Contract();
  NestedContract target = new NestedContract(inner);
  vm.expectCall(address(inner), abi.encodeWithSelector(inner.bar.selector), 1);
  inner.bar(); // call bar directly. This does not get counted, as this is a test-level call. It should be abstracted into another call.
}

// PASS
function testOne() {
  Contract inner = new Contract();
  NestedContract target = new NestedContract(inner);
  vm.expectCall(address(inner), abi.encodeWithSelector(inner.bar.selector), 1);
  target.baz(); // will call bar internally, therefore works.
}

contract NestedContract {
  Contract public inner;

  constructor(Contract _inner) {
    inner = _inner;
  }
  function baz() public {
    inner.bar(); // call bar 
  }
} 
```
<p>



</p>
</details> 

###  `expectRevert`
Will now only catch reverts coming from the _next_ call, instead of at any level in the test function, including at the "test level" itself. Detailed description:

<details><summary>Details</summary>
<p>

** This is a big breaking change**

## Motivation

Closes #3723 , Closes #3437 , Closes #4832 .

`expectRevert` currently has incorrect behavior: it matches reverts at the _test_ level, not at the _next call_ level. This means that reverting cheatcodes were being incorrectly catched by `expectRevert` (we're supposed to bypass checks for cheatcode calls) and also let users use the cheatcode incorrectly as illustrated in #3723.

## Solution and Behavior

`expectRevert` now only works on the next `CALL`. Cheatcode calls are now ignored properly, _even if those cheatcode calls revert_. To illustrate, these are examples of now legal/illegal behavior:

```solidity
// OK
function testExpectRevertString() public {
    Reverter reverter = new Reverter();
    cheats.expectRevert("revert");
    reverter.revertWithMessage("revert");
}

// FAIL
function testFailRevertNotOnImmediateNextCall() public {
    Reverter reverter = new Reverter();
    // expectRevert should only work for the next call. However,
    // we do not inmediately revert, so,
    // we fail.
    cheats.expectRevert("revert");
    reverter.doNotRevert();
    reverter.revertWithMessage("revert");
}

// FAIL
function testFailCheatcodeRevert() public {
  // This expectRevert is hanging, as the next cheatcode call is ignored.
  vm.expectRevert();
  vm.fsMetadata(fakePath) // try to go to some non-existent path to cause a revert
}
```

</p>
</details> 

Please note that CI is expected to fail due to solady and other repos not being upgraded to V1's expect behavior.