### PR TITLE
⚡ Improve test summary formatting

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -397,13 +397,6 @@ impl TestOutcome {
             }
             println!();
         }
-
-        let successes = self.successes().count();
-        println!(
-            "Encountered a total of {} failing tests, {} tests succeeded",
-            Paint::red(failures.to_string()),
-            Paint::green(successes.to_string())
-        );
         std::process::exit(1);
     }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -397,6 +397,13 @@ impl TestOutcome {
             }
             println!();
         }
+        let successes = self.successes().count();
+        println!(
+            "Encountered a total of {} failing tests, {} tests succeeded",
+            Paint::red(failures.to_string()),
+            Paint::green(successes.to_string())
+        );
+
         std::process::exit(1);
     }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -414,7 +414,7 @@ impl TestOutcome {
             result,
             Paint::green(self.successes().count()),
             Paint::red(failed),
-            Paint::blue(self.skips().count()),
+            Paint::yellow(self.skips().count()),
             self.duration()
         )
     }
@@ -469,7 +469,7 @@ fn format_aggregated_summary(
         num_test_suites,
         Paint::green(total_passed),
         Paint::red(total_failed),
-        Paint::blue(total_skipped),
+        Paint::yellow(total_skipped),
         total_tests
     )
 }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -474,7 +474,7 @@ fn format_aggregated_summary(
     )
 }
 
-/// Lists all matching tests    
+/// Lists all matching tests
 fn list(
     runner: MultiContractRunner,
     filter: ProjectPathsAwareFilter,

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -419,9 +419,9 @@ impl TestOutcome {
         format!(
             "Test result: {}. {} passed; {} failed; {} skipped; finished in {:.2?}",
             result,
-            self.successes().count(),
-            failed,
-            self.skips().count(),
+            Paint::green(self.successes().count()),
+            Paint::red(failed),
+            Paint::blue(self.skips().count()),
             self.duration()
         )
     }
@@ -472,12 +472,16 @@ fn format_aggregated_summary(
 ) -> String {
     let total_tests = total_passed + total_failed + total_skipped;
     format!(
-        "Ran {} test suites: {} tests passed, {} failed, {} skipped ({} total tests)",
-        num_test_suites, total_passed, total_failed, total_skipped, total_tests
+        " \nRan {} test suites: {} tests passed, {} failed, {} skipped ({} total tests)",
+        num_test_suites,
+        Paint::green(total_passed),
+        Paint::red(total_failed),
+        Paint::blue(total_skipped),
+        total_tests
     )
 }
 
-/// Lists all matching tests
+/// Lists all matching tests    
 fn list(
     runner: MultiContractRunner,
     filter: ProjectPathsAwareFilter,

--- a/crates/forge/tests/fixtures/can_check_snapshot.stdout
+++ b/crates/forge/tests/fixtures/can_check_snapshot.stdout
@@ -5,5 +5,5 @@ Compiler run successful!
 Running 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
-
+ 
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_check_snapshot.stdout
+++ b/crates/forge/tests/fixtures/can_check_snapshot.stdout
@@ -5,4 +5,5 @@ Compiler run successful!
 Running 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
+
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_run_test_in_custom_test_folder.stdout
+++ b/crates/forge/tests/fixtures/can_run_test_in_custom_test_folder.stdout
@@ -5,4 +5,5 @@ Compiler run successful!
 Running 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() (gas: 168)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
+ 
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_test_repeatedly.stdout
+++ b/crates/forge/tests/fixtures/can_test_repeatedly.stdout
@@ -4,5 +4,5 @@ Running 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 [PASS] test_Increment() (gas: 28357)
 Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
-
+ 
 Ran 1 test suites: 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/crates/forge/tests/fixtures/can_test_repeatedly.stdout
+++ b/crates/forge/tests/fixtures/can_test_repeatedly.stdout
@@ -4,4 +4,5 @@ Running 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 [PASS] test_Increment() (gas: 28357)
 Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
+
 Ran 1 test suites: 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -5,5 +5,5 @@ Compiler run successful!
 Running 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70373)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
-
+ 
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -5,4 +5,5 @@ Compiler run successful!
 Running 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70373)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
+
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -5,4 +5,5 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.10.stdout
@@ -5,5 +5,5 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-
+ 
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -5,4 +5,5 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.0.8.13.stdout
@@ -5,5 +5,5 @@ Compiler run successful!
 Running 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
 Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
-
+ 
 Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, the test result summary doesn't differentiate between the failed, passed and skipped tests visually. So it would be nice to have colored test summary similar to Hardhat. 

Also redundant summary is printed if any of the tests fail. It is no longer required as we already print aggregated test summary by default (Issue #5195).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Used red, green and blue colors in test summary for the no.of failed, passed and skipped tests respectively. 
Also removed the redundant test summary output.  

### Before: 
<img width="576" alt="Screenshot 2023-08-27 at 12 24 08 AM" src="https://github.com/foundry-rs/foundry/assets/42379522/034efd5e-c209-43a8-984a-ce5f2445ab8b">

### After: 
<img width="573" alt="Screenshot 2023-08-27 at 12 25 48 AM" src="https://github.com/foundry-rs/foundry/assets/42379522/80d07fbf-fd61-43f1-8765-0deae3f2b830">
