### PR TITLE
Make eth_accounts return impersonated accounts

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -528,12 +528,19 @@ impl EthApi {
     /// Handler for ETH RPC call: `eth_accounts`
     pub fn accounts(&self) -> Result<Vec<Address>> {
         node_info!("eth_accounts");
-        let mut accounts = HashSet::new();
+        let mut unique = HashSet::new();
+        let mut accounts = Vec::new();
         for signer in self.signers.iter() {
-            accounts.extend(signer.accounts());
+            accounts.extend(signer.accounts().into_iter().filter(|acc| unique.insert(*acc)));
         }
-        accounts.extend(self.backend.cheats().impersonated_accounts());
-        Ok(accounts.into_iter().collect())
+        accounts.extend(
+            self.backend
+                .cheats()
+                .impersonated_accounts()
+                .into_iter()
+                .filter(|acc| unique.insert(*acc)),
+        );
+        Ok(accounts)
     }
 
     /// Returns the number of most recent block.

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -60,6 +60,11 @@ impl CheatsManager {
         trace!(target: "cheats", "Auto impersonation set to {:?}", enabled);
         self.state.write().auto_impersonate_accounts = enabled
     }
+
+    /// Returns all accounts that are currently being impersonated.
+    pub fn impersonated_accounts(&self) -> HashSet<Address> {
+        self.state.read().impersonated_accounts.clone()
+    }
 }
 
 /// Container type for all the state variables

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -82,6 +82,7 @@ async fn can_impersonate_account() {
     res.unwrap_err();
 
     api.anvil_impersonate_account(impersonate).await.unwrap();
+    assert!(api.accounts().unwrap().contains(&impersonate));
 
     let res = provider.send_transaction(tx.clone(), None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(res.from, impersonate);


### PR DESCRIPTION
## Motivation

Fix for https://github.com/foundry-rs/foundry/issues/5732 (see that issue for detailed context).

## Solution

Added `CheatsManager::impersonated_accounts()` to allow fetching impersonated accounts from `EthApi`.
Collected relevant addresses in `EthApi::accounts()` into a `HashSet` to avoid returning duplicate accounts when a user tries to impersonate an account that is already owned by the node.
Extended the `can_impersonate_account` unit test to assert that the impersonated account gets returned by the `eth_accounts` handler.
