### PR TITLE
Add impersonated account while auto impersonating

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -304,7 +304,7 @@ impl Backend {
     ///
     /// Returns `true` if the account is already impersonated
     pub async fn impersonate(&self, addr: Address) -> DatabaseResult<bool> {
-        if self.cheats.is_impersonated(addr) {
+        if self.cheats.impersonated_accounts().contains(&addr) {
             return Ok(true)
         }
         // Ensure EIP-3607 is disabled

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -119,6 +119,7 @@ async fn can_auto_impersonate_account() {
     res.unwrap_err();
 
     api.anvil_auto_impersonate_account(true).await.unwrap();
+    assert!(api.accounts().unwrap().contains(&impersonate));
 
     let res = provider.send_transaction(tx.clone(), None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(res.from, impersonate);


### PR DESCRIPTION
## Motivation

(Basically https://github.com/foundry-rs/foundry/issues/5732 all over again but with `--auto-impersonate`)

When getting a `signer` from an RPC endpoint `ethers.js` expects any accounts owned by the node (impersonated or otherwise) to be returned when calling `eth_accounts`. https://github.com/foundry-rs/foundry/pull/5734 fixed that issue for the regular case. However, doing the same thing with `anvil --auto-impersonate` has the same issue.

## Solution

When calling `anvil_impersonate` the code checks under the hood whether the provided account is already being impersonated. If it is then no state gets modified (i.e. not added to `CheatsState::impersonated_accounts`) which means it can't be returned by `eth_accounts`.
To fix that instead of calling `is_impersonated()` (which returns true when `--auto-impersonate` is active) we check whether the address is already in the list of impersonated accounts.
To test that behavior I extended the `can_auto_impersonate_account` test to assert that the impersonated account gets returned by the `eth_account` handler.