### PR TITLE
fix(`remappings`): do not output debug skip remapping info

### DIFF
--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -163,7 +163,7 @@ impl<'a> RemappingsProvider<'a> {
             {
                 // this is an additional safety check for weird auto-detected remappings
                 if ["lib/", "src/", "contracts/"].contains(&r.name.as_str()) {
-                    println!("- skipping the remapping");
+                    trace!(target: "forge", "- skipping the remapping");
                     continue
                 }
                 insert_closest(&mut lib_remappings, r.context, r.name, r.path.into());


### PR DESCRIPTION
## Motivation

This is debug info, should be traced.

## Solution

Trace and not println

Closes #5751 