### PR TITLE
fix: invariant tests with input args don't panic

### DIFF
--- a/crates/evm/src/fuzz/invariant/executor.rs
+++ b/crates/evm/src/fuzz/invariant/executor.rs
@@ -23,7 +23,7 @@ use ethers::{
     abi::{Abi, Address, Detokenize, FixedBytes, Tokenizable, TokenizableItem},
     prelude::U256,
 };
-use eyre::{ContextCompat, Result};
+use eyre::{eyre, ContextCompat, Result};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::{FuzzDictionaryConfig, InvariantConfig};
 use parking_lot::{Mutex, RwLock};
@@ -99,6 +99,11 @@ impl<'a> InvariantExecutor<'a> {
         &mut self,
         invariant_contract: InvariantContract,
     ) -> Result<InvariantFuzzTestResult> {
+        // Throw an error to abort test run if the invariant function accepts input params
+        if !invariant_contract.invariant_function.inputs.is_empty() {
+            return Err(eyre!("Invariant test function should have no inputs"))
+        }
+
         let (fuzz_state, targeted_contracts, strat) = self.prepare_fuzzing(&invariant_contract)?;
 
         // Stores the consumed gas and calldata of every successful fuzz call.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Resolve #5084 and prevent invariant tests with input args from panicking and crashing the program.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Ensure the invariant function does not have any input args before asserting the invariant. This allows any invalid tests to fail gracefully with a clear error message without affecting any other tests being run.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
