### PR TITLE
feat(`evm`): migrate executor to alloy & add glue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ name = "foundry-evm"
 version = "0.2.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "bytes",
  "const-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,8 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "forge"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
  "anvil",
  "async-trait",
  "bytes",

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,7 +38,9 @@ use foundry_evm::{
     },
     revm,
     revm::primitives::{BlockEnv, CfgEnv, SpecId, TxEnv, U256 as rU256},
-    utils::{apply_chain_and_block_specific_env_changes, h256_to_b256, u256_to_ru256, b160_to_h160},
+    utils::{
+        apply_chain_and_block_specific_env_changes, b160_to_h160, h256_to_b256, u256_to_ru256,
+    },
 };
 use parking_lot::RwLock;
 use serde_json::{json, to_writer, Value};

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,9 +38,7 @@ use foundry_evm::{
     },
     revm,
     revm::primitives::{BlockEnv, CfgEnv, SpecId, TxEnv, U256 as rU256},
-    utils::{
-        apply_chain_and_block_specific_env_changes, h256_to_b256, u256_to_ru256,
-    },
+    utils::{apply_chain_and_block_specific_env_changes, h256_to_b256, u256_to_ru256},
 };
 use parking_lot::RwLock;
 use serde_json::{json, to_writer, Value};

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,7 +38,7 @@ use foundry_evm::{
     },
     revm,
     revm::primitives::{BlockEnv, CfgEnv, SpecId, TxEnv, U256 as rU256},
-    utils::{apply_chain_and_block_specific_env_changes, h256_to_b256, u256_to_ru256},
+    utils::{apply_chain_and_block_specific_env_changes, h256_to_b256, u256_to_ru256, b160_to_h160},
 };
 use parking_lot::RwLock;
 use serde_json::{json, to_writer, Value};
@@ -1016,7 +1016,7 @@ latest block number: {latest_block}"
         // if the option is not disabled and we are not forking.
         if !self.disable_default_create2_deployer && self.eth_rpc_url.is_none() {
             backend
-                .set_create2_deployer(DEFAULT_CREATE2_DEPLOYER)
+                .set_create2_deployer(b160_to_h160(DEFAULT_CREATE2_DEPLOYER))
                 .await
                 .expect("Failed to create default create2 deployer");
         }

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -65,11 +65,11 @@ impl Db for ForkedDatabase {
     }
 
     fn snapshot(&mut self) -> U256 {
-        self.insert_snapshot()
+        ru256_to_u256(self.insert_snapshot())
     }
 
     fn revert(&mut self, id: U256) -> bool {
-        self.revert_snapshot(id)
+        self.revert_snapshot(u256_to_ru256(id))
     }
 
     fn current_state(&self) -> StateDb {

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -70,11 +70,11 @@ impl Db for MemDb {
     fn snapshot(&mut self) -> U256 {
         let id = self.snapshots.insert(self.inner.clone());
         trace!(target: "backend::memdb", "Created new snapshot {}", id);
-        id
+        ru256_to_u256(id)
     }
 
     fn revert(&mut self, id: U256) -> bool {
-        if let Some(snapshot) = self.snapshots.remove(id) {
+        if let Some(snapshot) = self.snapshots.remove(u256_to_ru256(id)) {
             self.inner = snapshot;
             trace!(target: "backend::memdb", "Reverted snapshot {}", id);
             true

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -173,10 +173,7 @@ mod tests {
         assert_eq!(loaded_account.nonce, 1234);
         assert_eq!(
             load_db
-                .storage(
-                    h160_to_b160(test_addr),
-                    u256_to_ru256(Into::<U256>::into("0x1234567"))
-                )
+                .storage(h160_to_b160(test_addr), u256_to_ru256(Into::<U256>::into("0x1234567")))
                 .unwrap(),
             u256_to_ru256(Into::<U256>::into("0x1"))
         );

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -10,7 +10,11 @@ use foundry_cli::{
     utils::{self, handle_traces, parse_ether_value, TraceResult},
 };
 use foundry_config::{find_project_root_path, Config};
-use foundry_evm::{executor::opts::EvmOpts, trace::TracingExecutor};
+use foundry_evm::{
+    executor::opts::EvmOpts,
+    trace::TracingExecutor,
+    utils::{h160_to_b160, u256_to_ru256},
+};
 use std::str::FromStr;
 
 type Provider =
@@ -155,9 +159,9 @@ impl CallArgs {
                             .await;
 
                     let trace = match executor.deploy(
-                        sender,
+                        h160_to_b160(sender),
                         code.into(),
-                        value.unwrap_or(U256::zero()),
+                        u256_to_ru256(value.unwrap_or(U256::zero())),
                         None,
                     ) {
                         Ok(deploy_result) => TraceResult::from(deploy_result),
@@ -192,10 +196,10 @@ impl CallArgs {
                     let (tx, _) = builder.build();
 
                     let trace = TraceResult::from(executor.call_raw_committing(
-                        sender,
-                        tx.to_addr().copied().expect("an address to be here"),
+                        h160_to_b160(sender),
+                        h160_to_b160(tx.to_addr().copied().expect("an address to be here")),
                         tx.data().cloned().unwrap_or_default().to_vec().into(),
-                        tx.value().copied().unwrap_or_default(),
+                        u256_to_ru256(tx.value().copied().unwrap_or_default()),
                     )?);
 
                     handle_traces(trace, &config, chain, labels, verbose, debug).await?;

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -50,6 +50,7 @@ revm = { version = "3", default-features = false, features = [
 ] }
 
 alloy-primitives = { version = "0.3", default-features = false, features = ["std", "serde"] }
+alloy-rlp = { version = "0.3", default-features = false, features = ["std", "derive"] }
 
 # Fuzzer
 proptest = "1"

--- a/crates/evm/src/executor/abi/mod.rs
+++ b/crates/evm/src/executor/abi/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 ///
 /// This is the same address as the one used in DappTools's HEVM.
 /// `address(bytes20(uint160(uint256(keccak256('hevm cheat code')))))`
-pub const CHEATCODE_ADDRESS: Address = Address::from_slice(&[
+pub const CHEATCODE_ADDRESS: Address = Address::new([
     0x71, 0x09, 0x70, 0x9E, 0xcf, 0xa9, 0x1a, 0x80, 0x62, 0x6f, 0xf3, 0x98, 0x9d, 0x68, 0xf6, 0x7f,
     0x5b, 0x1d, 0xd1, 0x2d,
 ]);
@@ -21,7 +21,7 @@ pub const CHEATCODE_ADDRESS: Address = Address::from_slice(&[
 /// The Hardhat console address (0x000000000000000000636F6e736F6c652e6c6f67).
 ///
 /// See: https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/console.sol
-pub const HARDHAT_CONSOLE_ADDRESS: Address = Address::from_slice(&[
+pub const HARDHAT_CONSOLE_ADDRESS: Address = Address::new([
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x63, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x65,
     0x2e, 0x6c, 0x6f, 0x67,
 ]);

--- a/crates/evm/src/executor/abi/mod.rs
+++ b/crates/evm/src/executor/abi/mod.rs
@@ -1,4 +1,6 @@
-use ethers::types::{Address, Selector, H160};
+//! Several ABI-related utilities for executors.
+
+use alloy_primitives::{Address, Selector};
 pub use foundry_abi::{
     console::{self, ConsoleEvents, CONSOLE_ABI},
     hardhat_console::{self, HardhatConsoleCalls, HARDHATCONSOLE_ABI as HARDHAT_CONSOLE_ABI},
@@ -11,7 +13,7 @@ use std::collections::HashMap;
 ///
 /// This is the same address as the one used in DappTools's HEVM.
 /// `address(bytes20(uint160(uint256(keccak256('hevm cheat code')))))`
-pub const CHEATCODE_ADDRESS: Address = H160([
+pub const CHEATCODE_ADDRESS: Address = Address::from_slice(&[
     0x71, 0x09, 0x70, 0x9E, 0xcf, 0xa9, 0x1a, 0x80, 0x62, 0x6f, 0xf3, 0x98, 0x9d, 0x68, 0xf6, 0x7f,
     0x5b, 0x1d, 0xd1, 0x2d,
 ]);
@@ -19,7 +21,7 @@ pub const CHEATCODE_ADDRESS: Address = H160([
 /// The Hardhat console address (0x000000000000000000636F6e736F6c652e6c6f67).
 ///
 /// See: https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/console.sol
-pub const HARDHAT_CONSOLE_ADDRESS: Address = H160([
+pub const HARDHAT_CONSOLE_ADDRESS: Address = Address::from_slice(&[
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x63, 0x6f, 0x6e, 0x73, 0x6f, 0x6c, 0x65,
     0x2e, 0x6c, 0x6f, 0x67,
 ]);

--- a/crates/evm/src/executor/backend/diagnostic.rs
+++ b/crates/evm/src/executor/backend/diagnostic.rs
@@ -1,4 +1,7 @@
-use crate::executor::{backend::LocalForkId, inspector::Cheatcodes};
+use crate::{
+    executor::{backend::LocalForkId, inspector::Cheatcodes},
+    utils::b160_to_h160,
+};
 use alloy_primitives::Address;
 use foundry_common::fmt::UIfmt;
 
@@ -27,7 +30,7 @@ impl RevertDiagnostic {
 
         match self {
             RevertDiagnostic::ContractExistsOnOtherForks { contract, active, available_on } => {
-                let contract_label = get_label(contract);
+                let contract_label = get_label(&b160_to_h160(*contract));
 
                 format!(
                     r#"Contract {contract_label} does not exist on active fork with id `{active}`
@@ -35,7 +38,7 @@ impl RevertDiagnostic {
                 )
             }
             RevertDiagnostic::ContractDoesNotExist { contract, persistent, .. } => {
-                let contract_label = get_label(contract);
+                let contract_label = get_label(&b160_to_h160(*contract));
                 if *persistent {
                     format!("Contract {contract_label} does not exist")
                 } else {

--- a/crates/evm/src/executor/backend/diagnostic.rs
+++ b/crates/evm/src/executor/backend/diagnostic.rs
@@ -1,7 +1,5 @@
-use crate::{
-    executor::{backend::LocalForkId, inspector::Cheatcodes},
-    Address,
-};
+use crate::executor::{backend::LocalForkId, inspector::Cheatcodes};
+use alloy_primitives::Address;
 use foundry_common::fmt::UIfmt;
 
 /// Represents possible diagnostic cases on revert

--- a/crates/evm/src/executor/backend/error.rs
+++ b/crates/evm/src/executor/backend/error.rs
@@ -1,5 +1,5 @@
-use ethers::types::BlockId;
 use alloy_primitives::{Address, B256, U256};
+use ethers::types::BlockId;
 use foundry_utils::error::SolError;
 use futures::channel::mpsc::{SendError, TrySendError};
 use std::{

--- a/crates/evm/src/executor/backend/error.rs
+++ b/crates/evm/src/executor/backend/error.rs
@@ -1,4 +1,5 @@
-use ethers::types::{Address, BlockId, H256, U256};
+use ethers::types::BlockId;
+use alloy_primitives::{Address, B256, U256};
 use foundry_utils::error::SolError;
 use futures::channel::mpsc::{SendError, TrySendError};
 use std::{
@@ -16,7 +17,7 @@ pub enum DatabaseError {
     #[error("Failed to fetch AccountInfo {0:?}")]
     MissingAccount(Address),
     #[error("Could should already be loaded: {0:?}")]
-    MissingCode(H256),
+    MissingCode(B256),
     #[error(transparent)]
     Recv(#[from] RecvError),
     #[error(transparent)]
@@ -34,9 +35,9 @@ pub enum DatabaseError {
     #[error("Block {0:?} does not exist")]
     BlockNotFound(BlockId),
     #[error("Failed to get transaction {0:?}: {1:?}")]
-    GetTransaction(H256, Arc<eyre::Error>),
+    GetTransaction(B256, Arc<eyre::Error>),
     #[error("Transaction {0:?} not found")]
-    TransactionNotFound(H256),
+    TransactionNotFound(B256),
     #[error(
         "CREATE2 Deployer not present on this chain. [0x4e59b44847b379578588920ca78fbf26c0b4956c]"
     )]

--- a/crates/evm/src/executor/backend/fuzz.rs
+++ b/crates/evm/src/executor/backend/fuzz.rs
@@ -1,19 +1,16 @@
-use crate::{
-    executor::{
+//! A wrapper around `Backend` that is clone-on-write used for fuzzing.
+
+use crate::executor::{
         backend::{
             diagnostic::RevertDiagnostic, error::DatabaseError, Backend, DatabaseExt, LocalForkId,
         },
         fork::{CreateFork, ForkId},
         inspector::cheatcodes::Cheatcodes,
-    },
-    Address,
-};
-use ethers::prelude::{H256, U256};
-
+    };
 use revm::{
     db::DatabaseRef,
     primitives::{
-        AccountInfo, Address as aB160, Bytecode, Env, ResultAndState, B256, U256 as rU256,
+        AccountInfo, Address, Bytecode, Env, ResultAndState, B256, U256,
     },
     Database, Inspector, JournaledState,
 };
@@ -131,7 +128,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn create_fork_at_transaction(
         &mut self,
         fork: CreateFork,
-        transaction: H256,
+        transaction: B256,
     ) -> eyre::Result<LocalForkId> {
         trace!(?transaction, "fuzz: create fork at");
         self.backend.to_mut().create_fork_at_transaction(fork, transaction)
@@ -161,7 +158,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn roll_fork_to_transaction(
         &mut self,
         id: Option<LocalForkId>,
-        transaction: H256,
+        transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
@@ -172,7 +169,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     fn transact(
         &mut self,
         id: Option<LocalForkId>,
-        transaction: H256,
+        transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
         cheatcodes_inspector: Option<&mut Cheatcodes>,
@@ -233,7 +230,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
 impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {
     type Error = DatabaseError;
 
-    fn basic(&self, address: aB160) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         DatabaseRef::basic(self.backend.as_ref(), address)
     }
 
@@ -241,11 +238,11 @@ impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {
         DatabaseRef::code_by_hash(self.backend.as_ref(), code_hash)
     }
 
-    fn storage(&self, address: aB160, index: rU256) -> Result<rU256, Self::Error> {
+    fn storage(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         DatabaseRef::storage(self.backend.as_ref(), address, index)
     }
 
-    fn block_hash(&self, number: rU256) -> Result<B256, Self::Error> {
+    fn block_hash(&self, number: U256) -> Result<B256, Self::Error> {
         DatabaseRef::block_hash(self.backend.as_ref(), number)
     }
 }
@@ -253,7 +250,7 @@ impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {
 impl<'a> Database for FuzzBackendWrapper<'a> {
     type Error = DatabaseError;
 
-    fn basic(&mut self, address: aB160) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         DatabaseRef::basic(self, address)
     }
 
@@ -261,11 +258,11 @@ impl<'a> Database for FuzzBackendWrapper<'a> {
         DatabaseRef::code_by_hash(self, code_hash)
     }
 
-    fn storage(&mut self, address: aB160, index: rU256) -> Result<rU256, Self::Error> {
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         DatabaseRef::storage(self, address, index)
     }
 
-    fn block_hash(&mut self, number: rU256) -> Result<B256, Self::Error> {
+    fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
         DatabaseRef::block_hash(self, number)
     }
 }

--- a/crates/evm/src/executor/backend/fuzz.rs
+++ b/crates/evm/src/executor/backend/fuzz.rs
@@ -1,17 +1,15 @@
 //! A wrapper around `Backend` that is clone-on-write used for fuzzing.
 
 use crate::executor::{
-        backend::{
-            diagnostic::RevertDiagnostic, error::DatabaseError, Backend, DatabaseExt, LocalForkId,
-        },
-        fork::{CreateFork, ForkId},
-        inspector::cheatcodes::Cheatcodes,
-    };
+    backend::{
+        diagnostic::RevertDiagnostic, error::DatabaseError, Backend, DatabaseExt, LocalForkId,
+    },
+    fork::{CreateFork, ForkId},
+    inspector::cheatcodes::Cheatcodes,
+};
 use revm::{
     db::DatabaseRef,
-    primitives::{
-        AccountInfo, Address, Bytecode, Env, ResultAndState, B256, U256,
-    },
+    primitives::{AccountInfo, Address, Bytecode, Env, ResultAndState, B256, U256},
     Database, Inspector, JournaledState,
 };
 use std::borrow::Cow;

--- a/crates/evm/src/executor/backend/mod.rs
+++ b/crates/evm/src/executor/backend/mod.rs
@@ -8,10 +8,10 @@ use crate::{
         inspector::{cheatcodes::Cheatcodes, DEFAULT_CREATE2_DEPLOYER},
         snapshot::Snapshots,
     },
-    utils::{h160_to_b160, h256_to_b256, ru256_to_u256, u256_to_ru256, b256_to_h256, u64_to_ru64},
+    utils::{b256_to_h256, h160_to_b160, h256_to_b256, ru256_to_u256, u256_to_ru256, u64_to_ru64},
     CALLER, TEST_CONTRACT_ADDRESS,
 };
-use alloy_primitives::{U64, U256};
+use alloy_primitives::{U256, U64};
 use ethers::{
     prelude::Block,
     types::{BlockNumber, Transaction},
@@ -481,23 +481,12 @@ impl Backend {
         value: U256,
     ) -> Result<(), DatabaseError> {
         let ret = if let Some(db) = self.active_fork_db_mut() {
-            db.insert_account_storage(
-                address,
-                slot,
-                value,
-            )
+            db.insert_account_storage(address, slot, value)
         } else {
-            self.mem_db.insert_account_storage(
-                address,
-                slot,
-                value,
-            )
+            self.mem_db.insert_account_storage(address, slot, value)
         };
 
-        debug_assert!(
-            self.storage(address, slot).unwrap() ==
-                value
-        );
+        debug_assert!(self.storage(address, slot).unwrap() == value);
 
         ret
     }
@@ -620,8 +609,7 @@ impl Backend {
     /// in "failed"
     /// See <https://github.com/dapphub/ds-test/blob/9310e879db8ba3ea6d5c6489a579118fd264a3f5/src/test.sol#L66-L72>
     pub fn is_global_failure(&self, current_state: &JournaledState) -> bool {
-        let index: U256 =
-            U256::from_str_radix(GLOBAL_FAILURE_SLOT, 16).expect("This is a bug.");
+        let index: U256 = U256::from_str_radix(GLOBAL_FAILURE_SLOT, 16).expect("This is a bug.");
         if let Some(account) = current_state.state.get(&CHEATCODE_ADDRESS) {
             let value = account.storage.get(&index).cloned().unwrap_or_default().present_value();
             return value == revm::primitives::U256::from(1)
@@ -788,9 +776,7 @@ impl Backend {
             .fork_init_journaled_state
             .state
             .iter()
-            .filter(|(addr, _)| {
-                !self.is_existing_precompile(addr) && !self.is_persistent(addr)
-            })
+            .filter(|(addr, _)| !self.is_existing_precompile(addr) && !self.is_persistent(addr))
             .map(|(addr, _)| addr)
             .copied()
             .collect::<Vec<_>>();

--- a/crates/evm/src/executor/builder.rs
+++ b/crates/evm/src/executor/builder.rs
@@ -1,5 +1,8 @@
 use super::{inspector::InspectorStackBuilder, Executor};
-use crate::{executor::backend::Backend, utils::ru256_to_u256};
+use crate::{
+    executor::backend::Backend,
+    utils::{ru256_to_u256, u256_to_ru256},
+};
 use ethers::types::U256;
 use revm::primitives::{Env, SpecId};
 
@@ -69,6 +72,6 @@ impl ExecutorBuilder {
         stack.block = Some(env.block.clone());
         stack.gas_price = Some(ru256_to_u256(env.tx.gas_price));
         let gas_limit = gas_limit.unwrap_or(ru256_to_u256(env.block.gas_limit));
-        Executor::new(db, env, stack.build(), gas_limit)
+        Executor::new(db, env, stack.build(), u256_to_ru256(gas_limit))
     }
 }

--- a/crates/evm/src/executor/fork/database.rs
+++ b/crates/evm/src/executor/fork/database.rs
@@ -8,11 +8,11 @@ use crate::{
     },
     revm::db::CacheDB,
 };
-use ethers::{prelude::U256, types::BlockId};
+use ethers::types::BlockId;
 use parking_lot::Mutex;
 use revm::{
     db::DatabaseRef,
-    primitives::{Account, AccountInfo, Address, Bytecode, HashMap as Map, B256, U256 as rU256},
+    primitives::{Account, AccountInfo, Address, Bytecode, HashMap as Map, B256, U256},
     Database, DatabaseCommit,
 };
 use std::sync::Arc;
@@ -162,11 +162,11 @@ impl Database for ForkedDatabase {
         Database::code_by_hash(&mut self.cache_db, code_hash)
     }
 
-    fn storage(&mut self, address: Address, index: rU256) -> Result<rU256, Self::Error> {
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         Database::storage(&mut self.cache_db, address, index)
     }
 
-    fn block_hash(&mut self, number: rU256) -> Result<B256, Self::Error> {
+    fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
         Database::block_hash(&mut self.cache_db, number)
     }
 }
@@ -182,11 +182,11 @@ impl DatabaseRef for ForkedDatabase {
         self.cache_db.code_by_hash(code_hash)
     }
 
-    fn storage(&self, address: Address, index: rU256) -> Result<rU256, Self::Error> {
+    fn storage(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         DatabaseRef::storage(&self.cache_db, address, index)
     }
 
-    fn block_hash(&self, number: rU256) -> Result<B256, Self::Error> {
+    fn block_hash(&self, number: U256) -> Result<B256, Self::Error> {
         self.cache_db.block_hash(number)
     }
 }
@@ -209,7 +209,7 @@ pub struct ForkDbSnapshot {
 // === impl DbSnapshot ===
 
 impl ForkDbSnapshot {
-    fn get_storage(&self, address: Address, index: rU256) -> Option<rU256> {
+    fn get_storage(&self, address: Address, index: U256) -> Option<U256> {
         self.local.accounts.get(&address).and_then(|account| account.storage.get(&index)).copied()
     }
 }
@@ -238,7 +238,7 @@ impl DatabaseRef for ForkDbSnapshot {
         self.local.code_by_hash(code_hash)
     }
 
-    fn storage(&self, address: Address, index: rU256) -> Result<rU256, Self::Error> {
+    fn storage(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         match self.local.accounts.get(&address) {
             Some(account) => match account.storage.get(&index) {
                 Some(entry) => Ok(*entry),
@@ -254,7 +254,7 @@ impl DatabaseRef for ForkDbSnapshot {
         }
     }
 
-    fn block_hash(&self, number: rU256) -> Result<B256, Self::Error> {
+    fn block_hash(&self, number: U256) -> Result<B256, Self::Error> {
         match self.snapshot.block_hashes.get(&number).copied() {
             None => self.local.block_hash(number),
             Some(block_hash) => Ok(block_hash),
@@ -293,7 +293,7 @@ mod tests {
         let info = Database::basic(&mut db, address).unwrap();
         assert!(info.is_some());
         let mut info = info.unwrap();
-        info.balance = rU256::from(500u64);
+        info.balance = U256::from(500u64);
 
         // insert the modified account info
         db.database_mut().insert_account_info(address, info.clone());

--- a/crates/evm/src/executor/inspector/cheatcodes/fork.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/fork.rs
@@ -52,7 +52,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::MakePersistent1(acc) => {
             data.db.extend_persistent_accounts(
-                (acc.0.into_iter().map(h160_to_b160)).collect::<Vec<_>>(),
+                (acc.0.clone().into_iter().map(h160_to_b160)).collect::<Vec<_>>(),
             );
             Ok(Bytes::new())
         }
@@ -76,7 +76,7 @@ pub fn apply<DB: DatabaseExt>(
         }
         HEVMCalls::RevokePersistent1(acc) => {
             data.db.remove_persistent_accounts(
-                acc.0.into_iter().map(h160_to_b160).collect::<Vec<_>>(),
+                acc.0.clone().into_iter().map(h160_to_b160).collect::<Vec<_>>(),
             );
             Ok(Bytes::new())
         }

--- a/crates/evm/src/executor/inspector/cheatcodes/snapshot.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/snapshot.rs
@@ -1,5 +1,9 @@
 use super::Result;
-use crate::{abi::HEVMCalls, executor::backend::DatabaseExt, utils::{ru256_to_u256, u256_to_ru256}};
+use crate::{
+    abi::HEVMCalls,
+    executor::backend::DatabaseExt,
+    utils::{ru256_to_u256, u256_to_ru256},
+};
 use ethers::abi::AbiEncode;
 use revm::EVMData;
 

--- a/crates/evm/src/executor/inspector/cheatcodes/snapshot.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/snapshot.rs
@@ -1,5 +1,5 @@
 use super::Result;
-use crate::{abi::HEVMCalls, executor::backend::DatabaseExt};
+use crate::{abi::HEVMCalls, executor::backend::DatabaseExt, utils::{ru256_to_u256, u256_to_ru256}};
 use ethers::abi::AbiEncode;
 use revm::EVMData;
 
@@ -8,11 +8,11 @@ use revm::EVMData;
 pub fn apply<DB: DatabaseExt>(data: &mut EVMData<'_, DB>, call: &HEVMCalls) -> Option<Result> {
     Some(match call {
         HEVMCalls::Snapshot(_) => {
-            Ok(data.db.snapshot(&data.journaled_state, data.env).encode().into())
+            Ok(ru256_to_u256(data.db.snapshot(&data.journaled_state, data.env)).encode().into())
         }
         HEVMCalls::RevertTo(snapshot) => {
             let res = if let Some(journaled_state) =
-                data.db.revert(snapshot.0, &data.journaled_state, data.env)
+                data.db.revert(u256_to_ru256(snapshot.0), &data.journaled_state, data.env)
             {
                 // we reset the evm's journaled_state to the state of the snapshot previous state
                 data.journaled_state = journaled_state;

--- a/crates/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/util.rs
@@ -4,7 +4,7 @@ use crate::{
         error::{DatabaseError, DatabaseResult},
         DatabaseExt,
     },
-    utils::{h160_to_b160, h256_to_u256_be, ru256_to_u256, u256_to_ru256, b160_to_h160},
+    utils::{b160_to_h160, h160_to_b160, h256_to_u256_be, ru256_to_u256, u256_to_ru256},
 };
 use bytes::{BufMut, Bytes, BytesMut};
 use ethers::{
@@ -19,7 +19,7 @@ use ethers::{
 use foundry_common::RpcUrl;
 use revm::{
     interpreter::CreateInputs,
-    primitives::{Account, TransactTo, Address as aB160},
+    primitives::{Account, Address as aB160, TransactTo},
     Database, EVMData, JournaledState,
 };
 use std::collections::VecDeque;
@@ -138,7 +138,11 @@ where
             calldata.put_slice(&salt_bytes);
             calldata.put(bytecode);
 
-            Ok((calldata.freeze(), Some(NameOrAddress::Address(b160_to_h160(DEFAULT_CREATE2_DEPLOYER))), nonce))
+            Ok((
+                calldata.freeze(),
+                Some(NameOrAddress::Address(b160_to_h160(DEFAULT_CREATE2_DEPLOYER))),
+                nonce,
+            ))
         }
     }
 }

--- a/crates/evm/src/executor/inspector/cheatcodes/util.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/util.rs
@@ -27,7 +27,7 @@ use std::collections::VecDeque;
 pub const MAGIC_SKIP_BYTES: &[u8] = b"FOUNDRY::SKIP";
 
 /// Address of the default CREATE2 deployer 0x4e59b44847b379578588920ca78fbf26c0b4956c
-pub const DEFAULT_CREATE2_DEPLOYER: aB160 = aB160::from_slice(&[
+pub const DEFAULT_CREATE2_DEPLOYER: aB160 = aB160::new([
     78, 89, 180, 72, 71, 179, 121, 87, 133, 136, 146, 12, 167, 143, 191, 38, 192, 180, 149, 108,
 ]);
 

--- a/crates/evm/src/executor/inspector/cheatcodes/wallet.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/wallet.rs
@@ -167,7 +167,9 @@ pub fn apply<DB: Database>(
     Some(match call {
         HEVMCalls::Addr(inner) => addr(inner.0),
         // [function sign(uint256,bytes32)] Used to sign bytes32 digests using the given private key
-        HEVMCalls::Sign0(inner) => sign(inner.0, inner.1.into(), ru256_to_u256(data.env.cfg.chain_id.into())),
+        HEVMCalls::Sign0(inner) => {
+            sign(inner.0, inner.1.into(), ru256_to_u256(data.env.cfg.chain_id.into()))
+        }
         // [function createWallet(string)] Used to derive private key and label the wallet with the
         // same string
         HEVMCalls::CreateWallet0(inner) => {
@@ -193,7 +195,9 @@ pub fn apply<DB: Database>(
         HEVMCalls::DeriveKey3(inner) => {
             derive_key_with_wordlist(&inner.0, &inner.1, inner.2, &inner.3)
         }
-        HEVMCalls::RememberKey(inner) => remember_key(state, inner.0, ru256_to_u256(data.env.cfg.chain_id)),
+        HEVMCalls::RememberKey(inner) => {
+            remember_key(state, inner.0, ru256_to_u256(data.env.cfg.chain_id))
+        }
         HEVMCalls::Label(inner) => {
             state.labels.insert(inner.0, inner.1.clone());
             Ok(Default::default())

--- a/crates/evm/src/executor/inspector/cheatcodes/wallet.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/wallet.rs
@@ -168,7 +168,7 @@ pub fn apply<DB: Database>(
         HEVMCalls::Addr(inner) => addr(inner.0),
         // [function sign(uint256,bytes32)] Used to sign bytes32 digests using the given private key
         HEVMCalls::Sign0(inner) => {
-            sign(inner.0, inner.1.into(), ru256_to_u256(data.env.cfg.chain_id.into()))
+            sign(inner.0, inner.1.into(), ru256_to_u256(data.env.cfg.chain_id))
         }
         // [function createWallet(string)] Used to derive private key and label the wallet with the
         // same string

--- a/crates/evm/src/executor/inspector/debugger.rs
+++ b/crates/evm/src/executor/inspector/debugger.rs
@@ -102,7 +102,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             b160_to_h160(call.context.code_address),
             call.context.scheme.into(),
         );
-        if CHEATCODE_ADDRESS == b160_to_h160(call.contract) {
+        if CHEATCODE_ADDRESS == call.contract {
             self.arena.arena[self.head].steps.push(DebugStep {
                 memory: Memory::new(),
                 instruction: Instruction::Cheatcode(

--- a/crates/evm/src/executor/inspector/logs.rs
+++ b/crates/evm/src/executor/inspector/logs.rs
@@ -1,6 +1,6 @@
 use crate::{
     executor::{patch_hardhat_console_selector, HardhatConsoleCalls, HARDHAT_CONSOLE_ADDRESS},
-    utils::{b160_to_h160, b256_to_h256, h160_to_b160},
+    utils::{b160_to_h160, b256_to_h256},
 };
 use ethers::{
     abi::{AbiDecode, Token},

--- a/crates/evm/src/executor/inspector/logs.rs
+++ b/crates/evm/src/executor/inspector/logs.rs
@@ -57,7 +57,7 @@ impl<DB: Database> Inspector<DB> for LogCollector {
         _: &mut EVMData<'_, DB>,
         call: &mut CallInputs,
     ) -> (InstructionResult, Gas, Bytes) {
-        if call.contract == h160_to_b160(HARDHAT_CONSOLE_ADDRESS) {
+        if call.contract == HARDHAT_CONSOLE_ADDRESS {
             let (status, reason) = self.hardhat_log(call.input.to_vec());
             (status, Gas::new(call.gas_limit), reason)
         } else {

--- a/crates/evm/src/executor/mod.rs
+++ b/crates/evm/src/executor/mod.rs
@@ -6,10 +6,7 @@ use crate::{
     debug::DebugArena,
     decode,
     trace::CallTraceArena,
-    utils::{
-        b160_to_h160, eval_to_instruction_result, h160_to_b160, halt_to_instruction_result,
-        ru256_to_u256, u256_to_ru256,
-    },
+    utils::{eval_to_instruction_result, h160_to_b160, halt_to_instruction_result},
     CALLER,
 };
 pub use abi::{
@@ -32,8 +29,8 @@ pub use revm::{
     db::{DatabaseCommit, DatabaseRef},
     interpreter::{return_ok, CreateScheme, InstructionResult, Memory, Stack},
     primitives::{
-        Account, Address, BlockEnv, Bytecode, ExecutionResult, HashMap, Output,
-        ResultAndState, TransactTo, TxEnv, U256,
+        Account, Address, BlockEnv, Bytecode, ExecutionResult, HashMap, Output, ResultAndState,
+        TransactTo, TxEnv, U256,
     },
 };
 use std::collections::BTreeMap;
@@ -157,11 +154,7 @@ impl Executor {
 
     /// Gets the balance of an account
     pub fn get_balance(&self, address: Address) -> DatabaseResult<U256> {
-        Ok(self
-            .backend
-            .basic(address)?
-            .map(|acc| acc.balance)
-            .unwrap_or_default())
+        Ok(self.backend.basic(address)?.map(|acc| acc.balance).unwrap_or_default())
     }
 
     /// Set the nonce of an account.
@@ -295,12 +288,7 @@ impl Executor {
         let calldata = Bytes::from(encode_function_data(&func, args)?.to_vec());
 
         // execute the call
-        let env = self.build_test_env(
-            from,
-            TransactTo::Call(test_contract),
-            calldata,
-            value,
-        );
+        let env = self.build_test_env(from, TransactTo::Call(test_contract), calldata, value);
         let call_result = self.call_raw_with_env(env)?;
         convert_call_result(abi, &func, call_result)
     }
@@ -335,8 +323,7 @@ impl Executor {
     ) -> eyre::Result<RawCallResult> {
         let mut inspector = self.inspector.clone();
         // Build VM
-        let mut env =
-            self.build_test_env(from, TransactTo::Call(to), calldata, value);
+        let mut env = self.build_test_env(from, TransactTo::Call(to), calldata, value);
         let mut db = FuzzBackendWrapper::new(&self.backend);
         let result = db.inspect_ref(&mut env, &mut inspector)?;
 
@@ -467,15 +454,7 @@ impl Executor {
 
         trace!(address=?address, "deployed contract");
 
-        Ok(DeployResult {
-            address: address,
-            gas_used,
-            gas_refunded,
-            logs,
-            traces,
-            debug,
-            env,
-        })
+        Ok(DeployResult { address, gas_used, gas_refunded, logs, traces, debug, env })
     }
 
     /// Deploys a contract and commits the new state to the underlying database.
@@ -589,10 +568,10 @@ impl Executor {
                 ..self.env.block.clone()
             },
             tx: TxEnv {
-                caller: caller,
+                caller,
                 transact_to,
                 data: alloy_primitives::Bytes(data),
-                value: value,
+                value,
                 // As above, we set the gas price to 0.
                 gas_price: U256::from(0),
                 gas_priority_fee: None,

--- a/crates/evm/src/executor/snapshot.rs
+++ b/crates/evm/src/executor/snapshot.rs
@@ -1,7 +1,7 @@
 //! support for snapshotting different states
 
-use ethers::types::U256;
-use std::collections::HashMap;
+use alloy_primitives::U256;
+use std::{collections::HashMap, ops::Add};
 
 /// Represents all snapshots
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub struct Snapshots<T> {
 impl<T> Snapshots<T> {
     fn next_id(&mut self) -> U256 {
         let id = self.id;
-        self.id = id.saturating_add(U256::one());
+        self.id = id.saturating_add(U256::from(1));
         id
     }
 
@@ -32,10 +32,10 @@ impl<T> Snapshots<T> {
         let snapshot = self.snapshots.remove(&id);
 
         // revert all snapshots taken after the snapshot
-        let mut to_revert = id + 1;
+        let mut to_revert = id.add(U256::from(1));
         while to_revert < self.id {
             self.snapshots.remove(&to_revert);
-            to_revert = to_revert + 1;
+            to_revert = to_revert.add(U256::from(1));
         }
 
         snapshot
@@ -66,6 +66,6 @@ impl<T> Snapshots<T> {
 
 impl<T> Default for Snapshots<T> {
     fn default() -> Self {
-        Self { id: U256::zero(), snapshots: HashMap::new() }
+        Self { id: U256::ZERO, snapshots: HashMap::new() }
     }
 }

--- a/crates/evm/src/fuzz/invariant/error.rs
+++ b/crates/evm/src/fuzz/invariant/error.rs
@@ -4,15 +4,14 @@ use crate::{
     executor::{Executor, RawCallResult},
     fuzz::{invariant::set_up_inner_replay, *},
     trace::{load_contracts, TraceKind, Traces},
-    CALLER, utils::b160_to_h160,
+    utils::h160_to_b160,
+    CALLER,
 };
-use ethers::{
-    abi::Function,
-    types::{Address, U256},
-};
+use ethers::abi::Function;
 use eyre::{Result, WrapErr};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use proptest::test_runner::TestError;
+use revm::primitives::U256;
 
 #[derive(Debug, Clone)]
 pub struct InvariantFuzzError {
@@ -108,7 +107,12 @@ impl InvariantFuzzError {
         // Replay each call from the sequence until we break the invariant.
         for (sender, (addr, bytes)) in calls.iter() {
             let call_result = executor
-                .call_raw_committing(*sender, *addr, bytes.0.clone(), U256::zero())
+                .call_raw_committing(
+                    h160_to_b160(*sender),
+                    h160_to_b160(*addr),
+                    bytes.0.clone(),
+                    U256::ZERO,
+                )
                 .expect("bad call to evm");
 
             logs.extend(call_result.logs);
@@ -134,7 +138,7 @@ impl InvariantFuzzError {
             // Checks the invariant.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(b160_to_h160(CALLER), self.addr, func.0.clone(), U256::zero())
+                    .call_raw(CALLER, h160_to_b160(self.addr), func.0.clone(), U256::ZERO)
                     .expect("bad call to evm");
 
                 traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
@@ -169,13 +173,18 @@ impl InvariantFuzzError {
             let (sender, (addr, bytes)) = details;
 
             executor
-                .call_raw_committing(*sender, *addr, bytes.0.clone(), 0.into())
+                .call_raw_committing(
+                    h160_to_b160(*sender),
+                    h160_to_b160(*addr),
+                    bytes.0.clone(),
+                    U256::ZERO,
+                )
                 .expect("bad call to evm");
 
             // Checks the invariant. If we exit before the last call, all the better.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(b160_to_h160(CALLER), self.addr, func.0.clone(), 0.into())
+                    .call_raw(CALLER, h160_to_b160(self.addr), func.0.clone(), U256::ZERO)
                     .expect("bad call to evm");
 
                 if error_call_result.reverted {

--- a/crates/evm/src/fuzz/invariant/error.rs
+++ b/crates/evm/src/fuzz/invariant/error.rs
@@ -4,7 +4,7 @@ use crate::{
     executor::{Executor, RawCallResult},
     fuzz::{invariant::set_up_inner_replay, *},
     trace::{load_contracts, TraceKind, Traces},
-    CALLER,
+    CALLER, utils::b160_to_h160,
 };
 use ethers::{
     abi::Function,
@@ -134,7 +134,7 @@ impl InvariantFuzzError {
             // Checks the invariant.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(CALLER, self.addr, func.0.clone(), U256::zero())
+                    .call_raw(b160_to_h160(CALLER), self.addr, func.0.clone(), U256::zero())
                     .expect("bad call to evm");
 
                 traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
@@ -175,7 +175,7 @@ impl InvariantFuzzError {
             // Checks the invariant. If we exit before the last call, all the better.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(CALLER, self.addr, func.0.clone(), 0.into())
+                    .call_raw(b160_to_h160(CALLER), self.addr, func.0.clone(), 0.into())
                     .expect("bad call to evm");
 
                 if error_call_result.reverted {

--- a/crates/evm/src/fuzz/invariant/executor.rs
+++ b/crates/evm/src/fuzz/invariant/executor.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         FuzzCase, FuzzedCases,
     },
-    utils::{get_function, h160_to_b160},
+    utils::{get_function, h160_to_b160, b160_to_h160},
     CALLER,
 };
 use ethers::{
@@ -417,8 +417,8 @@ impl<'a> InvariantExecutor<'a> {
             .into_iter()
             .filter(|(addr, (identifier, _))| {
                 *addr != invariant_address &&
-                    *addr != CHEATCODE_ADDRESS &&
-                    *addr != HARDHAT_CONSOLE_ADDRESS &&
+                    *addr != b160_to_h160(CHEATCODE_ADDRESS) &&
+                    *addr != b160_to_h160(HARDHAT_CONSOLE_ADDRESS) &&
                     (selected.is_empty() || selected.contains(addr)) &&
                     (self.artifact_filters.targeted.is_empty() ||
                         self.artifact_filters.targeted.contains_key(identifier)) &&
@@ -559,7 +559,7 @@ impl<'a> InvariantExecutor<'a> {
     {
         if let Some(func) = abi.functions().find(|func| func.name == method_name) {
             if let Ok(call_result) = self.executor.call::<Vec<T>, _, _>(
-                CALLER,
+                b160_to_h160(CALLER),
                 address,
                 func.clone(),
                 (),

--- a/crates/evm/src/fuzz/invariant/mod.rs
+++ b/crates/evm/src/fuzz/invariant/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     executor::Executor,
     fuzz::*,
     trace::{load_contracts, TraceKind, Traces},
-    CALLER,
+    CALLER, utils::b160_to_h160,
 };
 use ethers::{
     abi::{Abi, Function},
@@ -66,7 +66,7 @@ pub fn assert_invariants(
     let func = invariant_contract.invariant_function;
     let mut call_result = executor
         .call_raw(
-            CALLER,
+            b160_to_h160(CALLER),
             invariant_contract.address,
             func.encode_input(&[]).expect("invariant should have no inputs").into(),
             U256::zero(),
@@ -134,7 +134,7 @@ pub fn replay_run(
         // Checks the invariant.
         let error_call_result = executor
             .call_raw(
-                CALLER,
+                b160_to_h160(CALLER),
                 invariant_contract.address,
                 func.encode_input(&[]).expect("invariant should have no inputs").into(),
                 U256::zero(),

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -1,9 +1,12 @@
+//! Executor wrapper which can be used for fuzzing, using [`proptest`](https://docs.rs/proptest/1.0.0/proptest/)
 use crate::{
     coverage::HitMaps,
     decode::{self, decode_console_logs},
     executor::{Executor, RawCallResult},
     trace::CallTraceArena,
+    utils::{b160_to_h160, h160_to_b160},
 };
+use alloy_primitives::U256;
 use error::{FuzzError, ASSUME_MAGIC_RETURN_CODE};
 use ethers::{
     abi::{Abi, Function, Token},
@@ -154,7 +157,7 @@ impl<'a> FuzzedExecutor<'a> {
             counterexample: None,
             decoded_logs: decode_console_logs(&call.logs),
             logs: call.logs,
-            labeled_addresses: call.labels,
+            labeled_addresses: call.labels.into_iter().map(|l| (b160_to_h160(l.0), l.1)).collect(),
             traces: if run_result.is_ok() { traces.into_inner() } else { call.traces.clone() },
             coverage: coverage.into_inner(),
         };
@@ -203,7 +206,12 @@ impl<'a> FuzzedExecutor<'a> {
     ) -> Result<FuzzOutcome, TestCaseError> {
         let call = self
             .executor
-            .call_raw(self.sender, address, calldata.0.clone(), 0.into())
+            .call_raw(
+                h160_to_b160(self.sender),
+                h160_to_b160(address),
+                calldata.0.clone(),
+                U256::ZERO,
+            )
             .map_err(|_| TestCaseError::fail(FuzzError::FailedContractCall))?;
         let state_changeset = call
             .state_changeset
@@ -228,8 +236,12 @@ impl<'a> FuzzedExecutor<'a> {
             .as_ref()
             .map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
-        let success =
-            self.executor.is_success(address, call.reverted, state_changeset.clone(), should_fail);
+        let success = self.executor.is_success(
+            h160_to_b160(address),
+            call.reverted,
+            state_changeset.clone(),
+            should_fail,
+        );
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -19,7 +19,7 @@ pub mod coverage;
 /// Forge test execution backends
 pub mod executor;
 
-use ethers::types::{ActionType, CallType, H160};
+use ethers::types::{ActionType, CallType};
 pub use executor::abi;
 
 /// Fuzzing wrapper for executors

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -32,7 +32,10 @@ pub mod utils;
 pub use ethers::types::Address;
 pub use hashbrown;
 use revm::interpreter::{CallScheme, CreateScheme};
-pub use revm::{self, primitives::{HashMap, Address as aB160}};
+pub use revm::{
+    self,
+    primitives::{Address as aB160, HashMap},
+};
 use serde::{Deserialize, Serialize};
 
 /// Stores the caller address to be used as _sender_ account for:

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -44,13 +44,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// The address was derived from `address(uint160(uint256(keccak256("foundry default caller"))))`
 /// and is equal to 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38.
-pub const CALLER: aB160 = aB160::from_slice(&[
+pub const CALLER: aB160 = aB160::new([
     0x18, 0x04, 0xc8, 0xAB, 0x1F, 0x12, 0xE6, 0xbb, 0xF3, 0x89, 0x4D, 0x40, 0x83, 0xF3, 0x3E, 0x07,
     0x30, 0x9D, 0x1F, 0x38,
 ]);
 
 /// Stores the default test contract address: 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84
-pub const TEST_CONTRACT_ADDRESS: aB160 = aB160::from_slice(&[
+pub const TEST_CONTRACT_ADDRESS: aB160 = aB160::new([
     180, 199, 157, 171, 143, 37, 156, 122, 238, 110, 91, 42, 167, 41, 130, 24, 100, 34, 126, 132,
 ]);
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -32,7 +32,7 @@ pub mod utils;
 pub use ethers::types::Address;
 pub use hashbrown;
 use revm::interpreter::{CallScheme, CreateScheme};
-pub use revm::{self, primitives::HashMap};
+pub use revm::{self, primitives::{HashMap, Address as aB160}};
 use serde::{Deserialize, Serialize};
 
 /// Stores the caller address to be used as _sender_ account for:
@@ -41,13 +41,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// The address was derived from `address(uint160(uint256(keccak256("foundry default caller"))))`
 /// and is equal to 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38.
-pub const CALLER: Address = H160([
+pub const CALLER: aB160 = aB160::from_slice(&[
     0x18, 0x04, 0xc8, 0xAB, 0x1F, 0x12, 0xE6, 0xbb, 0xF3, 0x89, 0x4D, 0x40, 0x83, 0xF3, 0x3E, 0x07,
     0x30, 0x9D, 0x1F, 0x38,
 ]);
 
 /// Stores the default test contract address: 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84
-pub const TEST_CONTRACT_ADDRESS: Address = H160([
+pub const TEST_CONTRACT_ADDRESS: aB160 = aB160::from_slice(&[
     180, 199, 157, 171, 143, 37, 156, 122, 238, 110, 91, 42, 167, 41, 130, 24, 100, 34, 126, 132,
 ]);
 

--- a/crates/evm/src/trace/decoder.rs
+++ b/crates/evm/src/trace/decoder.rs
@@ -7,7 +7,8 @@ use crate::{
     decode,
     executor::inspector::DEFAULT_CREATE2_DEPLOYER,
     trace::{node::CallTraceNode, utils},
-    CALLER, TEST_CONTRACT_ADDRESS, utils::b160_to_h160,
+    utils::b160_to_h160,
+    CALLER, TEST_CONTRACT_ADDRESS,
 };
 use ethers::{
     abi::{Abi, Address, Event, Function, Param, ParamType, Token},

--- a/crates/evm/src/trace/decoder.rs
+++ b/crates/evm/src/trace/decoder.rs
@@ -7,7 +7,7 @@ use crate::{
     decode,
     executor::inspector::DEFAULT_CREATE2_DEPLOYER,
     trace::{node::CallTraceNode, utils},
-    CALLER, TEST_CONTRACT_ADDRESS,
+    CALLER, TEST_CONTRACT_ADDRESS, utils::b160_to_h160,
 };
 use ethers::{
     abi::{Abi, Address, Event, Function, Param, ParamType, Token},
@@ -156,11 +156,11 @@ impl CallTraceDecoder {
             contracts: Default::default(),
 
             labels: [
-                (CHEATCODE_ADDRESS, "VM".to_string()),
-                (HARDHAT_CONSOLE_ADDRESS, "console".to_string()),
-                (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
-                (CALLER, "DefaultSender".to_string()),
-                (TEST_CONTRACT_ADDRESS, "DefaultTestContract".to_string()),
+                (b160_to_h160(CHEATCODE_ADDRESS), "VM".to_string()),
+                (b160_to_h160(HARDHAT_CONSOLE_ADDRESS), "console".to_string()),
+                (b160_to_h160(DEFAULT_CREATE2_DEPLOYER), "Create2Deployer".to_string()),
+                (b160_to_h160(CALLER), "DefaultSender".to_string()),
+                (b160_to_h160(TEST_CONTRACT_ADDRESS), "DefaultTestContract".to_string()),
             ]
             .into(),
 
@@ -256,7 +256,7 @@ impl CallTraceDecoder {
                 if bytes.len() >= 4 {
                     if let Some(funcs) = self.functions.get(&bytes[..SELECTOR_LEN]) {
                         node.decode_function(funcs, &self.labels, &self.errors, self.verbosity);
-                    } else if node.trace.address == DEFAULT_CREATE2_DEPLOYER {
+                    } else if node.trace.address == b160_to_h160(DEFAULT_CREATE2_DEPLOYER) {
                         node.trace.data =
                             RawOrDecodedCall::Decoded("create2".to_string(), String::new(), vec![]);
                     } else if let Some(identifier) = &self.signature_identifier {

--- a/crates/evm/src/trace/mod.rs
+++ b/crates/evm/src/trace/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     abi::CHEATCODE_ADDRESS, debug::Instruction, trace::identifier::LocalTraceIdentifier,
-    utils::ru256_to_u256, CallKind,
+    utils::{ru256_to_u256, b160_to_h160}, CallKind,
 };
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use ethers::{
@@ -597,7 +597,7 @@ impl TraceKind {
 
 /// Chooses the color of the trace depending on the destination address and status of the call.
 fn trace_color(trace: &CallTrace) -> Color {
-    if trace.address == CHEATCODE_ADDRESS {
+    if trace.address == b160_to_h160(CHEATCODE_ADDRESS) {
         Color::Blue
     } else if trace.success {
         Color::Green

--- a/crates/evm/src/trace/mod.rs
+++ b/crates/evm/src/trace/mod.rs
@@ -430,9 +430,7 @@ impl From<&CallTraceStep> for StructLog {
             } else {
                 None
             },
-            stack: Some(
-                step.stack.data().iter().copied().map(ru256_to_u256).collect(),
-            ),
+            stack: Some(step.stack.data().iter().copied().map(ru256_to_u256).collect()),
             // Filled in `CallTraceArena::geth_trace` as a result of compounding all slot changes
             storage: None,
         }

--- a/crates/evm/src/trace/mod.rs
+++ b/crates/evm/src/trace/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
-    abi::CHEATCODE_ADDRESS, debug::Instruction, trace::identifier::LocalTraceIdentifier,
-    utils::{ru256_to_u256, b160_to_h160}, CallKind,
+    abi::CHEATCODE_ADDRESS,
+    debug::Instruction,
+    trace::identifier::LocalTraceIdentifier,
+    utils::{b160_to_h160, ru256_to_u256},
+    CallKind,
 };
 pub use decoder::{CallTraceDecoder, CallTraceDecoderBuilder};
 use ethers::{

--- a/crates/evm/src/trace/node.rs
+++ b/crates/evm/src/trace/node.rs
@@ -5,7 +5,8 @@ use crate::{
         utils, utils::decode_cheatcode_outputs, CallTrace, LogCallOrder, RawOrDecodedCall,
         RawOrDecodedLog, RawOrDecodedReturnData,
     },
-    CallKind, utils::b160_to_h160,
+    utils::b160_to_h160,
+    CallKind,
 };
 use ethers::{
     abi::{Abi, Function},
@@ -136,7 +137,7 @@ impl CallTraceNode {
 
             if let RawOrDecodedReturnData::Raw(bytes) = &self.trace.output {
                 if !bytes.is_empty() && self.trace.success {
-                    if self.trace.address ==  b160_to_h160(CHEATCODE_ADDRESS) {
+                    if self.trace.address == b160_to_h160(CHEATCODE_ADDRESS) {
                         if let Some(decoded) = funcs
                             .iter()
                             .find_map(|func| decode_cheatcode_outputs(func, bytes, verbosity))

--- a/crates/evm/src/trace/node.rs
+++ b/crates/evm/src/trace/node.rs
@@ -5,7 +5,7 @@ use crate::{
         utils, utils::decode_cheatcode_outputs, CallTrace, LogCallOrder, RawOrDecodedCall,
         RawOrDecodedLog, RawOrDecodedReturnData,
     },
-    CallKind,
+    CallKind, utils::b160_to_h160,
 };
 use ethers::{
     abi::{Abi, Function},
@@ -109,7 +109,7 @@ impl CallTraceNode {
 
         if let RawOrDecodedCall::Raw(ref bytes) = self.trace.data {
             let inputs = if bytes.len() >= SELECTOR_LEN {
-                if self.trace.address == CHEATCODE_ADDRESS {
+                if self.trace.address == b160_to_h160(CHEATCODE_ADDRESS) {
                     // Try to decode cheatcode inputs in a more custom way
                     utils::decode_cheatcode_inputs(func, bytes, errors, verbosity).unwrap_or_else(
                         || {
@@ -136,7 +136,7 @@ impl CallTraceNode {
 
             if let RawOrDecodedReturnData::Raw(bytes) = &self.trace.output {
                 if !bytes.is_empty() && self.trace.success {
-                    if self.trace.address == CHEATCODE_ADDRESS {
+                    if self.trace.address ==  b160_to_h160(CHEATCODE_ADDRESS) {
                         if let Some(decoded) = funcs
                             .iter()
                             .find_map(|func| decode_cheatcode_outputs(func, bytes, verbosity))

--- a/crates/evm/src/utils.rs
+++ b/crates/evm/src/utils.rs
@@ -70,6 +70,12 @@ pub fn u256_to_ru256(u: ethers::types::U256) -> revm::primitives::U256 {
     revm::primitives::U256::from_le_bytes(buffer)
 }
 
+// Small helper function to convert ethers's [U64] into alloy's [U64].
+#[inline]
+pub fn u64_to_ru64(u: ethers::types::U64) -> alloy_primitives::U64 {
+    alloy_primitives::U64::from(u.as_u64())
+}
+
 /// Small helper function to convert revm's [U256] into ethers's [U256].
 #[inline]
 pub fn ru256_to_u256(u: alloy_primitives::U256) -> ethers::types::U256 {

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -39,6 +39,9 @@ forge-doc.workspace = true
 foundry-cli.workspace = true
 ui.workspace = true
 
+alloy-primitives = { version = "0.3", default-features = false, features = ["std", "serde"] }
+alloy-rlp = { version = "0.3", default-features = false, features = ["std", "derive"] }
+
 async-trait = "0.1"
 bytes = "1.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -53,6 +53,7 @@ use foundry_evm::{
         cheatcodes::{util::BroadcastableTransactions, BroadcastableTransaction},
         DEFAULT_CREATE2_DEPLOYER,
     },
+    utils::h160_to_b160,
 };
 use futures::future;
 use serde::{Deserialize, Serialize};
@@ -601,7 +602,7 @@ impl ScriptArgs {
 
             // Find if it's a CREATE or CREATE2. Otherwise, skip transaction.
             if let Some(NameOrAddress::Address(to)) = to {
-                if *to == DEFAULT_CREATE2_DEPLOYER {
+                if h160_to_b160(*to) == DEFAULT_CREATE2_DEPLOYER {
                     // Size of the salt prefix.
                     offset = 32;
                 }

--- a/crates/forge/bin/cmd/script/runner.rs
+++ b/crates/forge/bin/cmd/script/runner.rs
@@ -3,10 +3,14 @@ use ethers::types::{Address, Bytes, NameOrAddress, U256};
 use eyre::Result;
 use forge::{
     executor::{CallResult, DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
-    revm::interpreter::{return_ok, InstructionResult},
+    revm::{
+        interpreter::{return_ok, InstructionResult},
+        primitives::U256 as rU256,
+    },
     trace::{TraceKind, Traces},
     CALLER,
 };
+use foundry_evm::utils::{b160_to_h160, u256_to_ru256};
 use tracing::log::trace;
 
 /// Represents which simulation stage is the script execution at.
@@ -43,7 +47,7 @@ impl ScriptRunner {
         if !is_broadcast {
             if self.sender == Config::DEFAULT_SENDER {
                 // We max out their balance so that they can deploy and make calls.
-                self.executor.set_balance(self.sender, U256::MAX)?;
+                self.executor.set_balance(h160_to_b160(self.sender), rU256::MAX)?;
             }
 
             if need_create2_deployer {
@@ -51,10 +55,10 @@ impl ScriptRunner {
             }
         }
 
-        self.executor.set_nonce(self.sender, sender_nonce.as_u64())?;
+        self.executor.set_nonce(h160_to_b160(self.sender), sender_nonce.as_u64())?;
 
         // We max out their balance so that they can deploy and make calls.
-        self.executor.set_balance(CALLER, U256::MAX)?;
+        self.executor.set_balance(CALLER, rU256::MAX)?;
 
         // Deploy libraries
         let mut traces: Traces = libraries
@@ -62,7 +66,7 @@ impl ScriptRunner {
             .filter_map(|code| {
                 let DeployResult { traces, .. } = self
                     .executor
-                    .deploy(self.sender, code.0.clone(), 0u32.into(), None)
+                    .deploy(h160_to_b160(self.sender), code.0.clone(), rU256::ZERO, None)
                     .expect("couldn't deploy library");
 
                 traces
@@ -79,11 +83,11 @@ impl ScriptRunner {
             ..
         } = self
             .executor
-            .deploy(CALLER, code.0, 0u32.into(), None)
+            .deploy(CALLER, code.0, rU256::ZERO, None)
             .map_err(|err| eyre::eyre!("Failed to deploy script:\n{}", err))?;
 
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
-        self.executor.set_balance(address, self.initial_balance)?;
+        self.executor.set_balance(address, u256_to_ru256(self.initial_balance))?;
 
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions, debug, script_wallets) = if !setup
@@ -98,7 +102,7 @@ impl ScriptRunner {
                 vec![],
             )
         } else {
-            match self.executor.setup(Some(self.sender), address) {
+            match self.executor.setup(Some(h160_to_b160(self.sender)), address) {
                 Ok(CallResult {
                     reverted,
                     traces: setup_traces,
@@ -155,12 +159,15 @@ impl ScriptRunner {
         };
 
         Ok((
-            address,
+            b160_to_h160(address),
             ScriptResult {
                 returned: bytes::Bytes::new(),
                 success,
                 gas_used,
-                labeled_addresses,
+                labeled_addresses: labeled_addresses
+                    .into_iter()
+                    .map(|l| (b160_to_h160(l.0), l.1))
+                    .collect::<BTreeMap<_, _>>(),
                 transactions,
                 logs,
                 traces,
@@ -181,8 +188,10 @@ impl ScriptRunner {
     ) -> Result<()> {
         if let Some(cheatcodes) = &self.executor.inspector.cheatcodes {
             if !cheatcodes.corrected_nonce {
-                self.executor
-                    .set_nonce(self.sender, sender_initial_nonce.as_u64() + libraries_len as u64)?;
+                self.executor.set_nonce(
+                    h160_to_b160(self.sender),
+                    sender_initial_nonce.as_u64() + libraries_len as u64,
+                )?;
             }
             self.executor.inspector.cheatcodes.as_mut().unwrap().corrected_nonce = false;
         }
@@ -206,13 +215,13 @@ impl ScriptRunner {
             self.call(from, to, calldata.unwrap_or_default(), value.unwrap_or(U256::zero()), true)
         } else if to.is_none() {
             let (address, gas_used, logs, traces, debug) = match self.executor.deploy(
-                from,
+                h160_to_b160(from),
                 calldata.expect("No data for create transaction").0,
-                value.unwrap_or(U256::zero()),
+                u256_to_ru256(value.unwrap_or(U256::zero())),
                 None,
             ) {
                 Ok(DeployResult { address, gas_used, logs, traces, debug, .. }) => {
-                    (address, gas_used, logs, traces, debug)
+                    (b160_to_h160(address), gas_used, logs, traces, debug)
                 }
                 Err(EvmError::Execution(err)) => {
                     let ExecutionErr { reason, traces, gas_used, logs, debug, .. } = *err;
@@ -260,7 +269,12 @@ impl ScriptRunner {
         value: U256,
         commit: bool,
     ) -> Result<ScriptResult> {
-        let mut res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
+        let mut res = self.executor.call_raw(
+            h160_to_b160(from),
+            h160_to_b160(to),
+            calldata.0.clone(),
+            u256_to_ru256(value),
+        )?;
         let mut gas_used = res.gas_used;
 
         // We should only need to calculate realistic gas costs when preparing to broadcast
@@ -270,7 +284,12 @@ impl ScriptRunner {
         // Otherwise don't re-execute, or some usecases might be broken: https://github.com/foundry-rs/foundry/issues/3921
         if commit {
             gas_used = self.search_optimal_gas_usage(&res, from, to, &calldata, value)?;
-            res = self.executor.call_raw_committing(from, to, calldata.0, value)?;
+            res = self.executor.call_raw_committing(
+                h160_to_b160(from),
+                h160_to_b160(to),
+                calldata.0,
+                u256_to_ru256(value),
+            )?;
         }
 
         let RawCallResult {
@@ -298,7 +317,7 @@ impl ScriptRunner {
                 })
                 .unwrap_or_default(),
             debug: vec![debug].into_iter().collect(),
-            labeled_addresses: labels,
+            labeled_addresses: labels.into_iter().map(|l| (b160_to_h160(l.0), l.1)).collect(),
             transactions,
             address: None,
             script_wallets,
@@ -330,7 +349,12 @@ impl ScriptRunner {
             while (highest_gas_limit - lowest_gas_limit) > 1 {
                 let mid_gas_limit = (highest_gas_limit + lowest_gas_limit) / 2;
                 self.executor.env.tx.gas_limit = mid_gas_limit;
-                let res = self.executor.call_raw(from, to, calldata.0.clone(), value)?;
+                let res = self.executor.call_raw(
+                    h160_to_b160(from),
+                    h160_to_b160(to),
+                    calldata.0.clone(),
+                    u256_to_ru256(value),
+                )?;
                 match res.exit_reason {
                     InstructionResult::Revert |
                     InstructionResult::OutOfGas |

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -8,7 +8,8 @@ use ethers::{
 use eyre::{ContextCompat, Result, WrapErr};
 use foundry_common::{abi::format_token_raw, RpcUrl, SELECTOR_LEN};
 use foundry_evm::{
-    executor::inspector::DEFAULT_CREATE2_DEPLOYER, trace::CallTraceDecoder, CallKind,
+    executor::inspector::DEFAULT_CREATE2_DEPLOYER, trace::CallTraceDecoder, utils::h160_to_b160,
+    CallKind,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -76,7 +77,7 @@ impl TransactionWithMetadata {
 
         // Specify if any contract was directly created with this transaction
         if let Some(NameOrAddress::Address(to)) = metadata.transaction.to().cloned() {
-            if to == DEFAULT_CREATE2_DEPLOYER {
+            if h160_to_b160(to) == DEFAULT_CREATE2_DEPLOYER {
                 metadata.set_create(
                     true,
                     Address::from_slice(&result.returned),

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -47,7 +47,9 @@ impl GasReport {
         let node = &arena.arena[node_index];
         let trace = &node.trace;
 
-        if trace.address == b160_to_h160(CHEATCODE_ADDRESS) || trace.address == b160_to_h160(HARDHAT_CONSOLE_ADDRESS) {
+        if trace.address == b160_to_h160(CHEATCODE_ADDRESS) ||
+            trace.address == b160_to_h160(HARDHAT_CONSOLE_ADDRESS)
+        {
             return
         }
 

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -5,6 +5,7 @@ use crate::{
 use comfy_table::{presets::ASCII_MARKDOWN, *};
 use ethers::types::U256;
 use foundry_common::{calc, TestFunctionExt};
+use foundry_evm::utils::b160_to_h160;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Display};
 
@@ -46,7 +47,7 @@ impl GasReport {
         let node = &arena.arena[node_index];
         let trace = &node.trace;
 
-        if trace.address == CHEATCODE_ADDRESS || trace.address == HARDHAT_CONSOLE_ADDRESS {
+        if trace.address == b160_to_h160(CHEATCODE_ADDRESS) || trace.address == b160_to_h160(HARDHAT_CONSOLE_ADDRESS) {
             return
         }
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -8,6 +8,7 @@ use foundry_evm::{
     executor::EvmError,
     fuzz::{types::FuzzCase, CounterExample},
     trace::{TraceKind, Traces},
+    utils::b160_to_h160,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, time::Duration};
@@ -240,7 +241,9 @@ impl TestSetup {
                 // force the tracekind to be setup so a trace is shown.
                 traces.extend(err.traces.map(|traces| (TraceKind::Setup, traces)));
                 logs.extend(err.logs);
-                labeled_addresses.extend(err.labels);
+                labeled_addresses.extend(
+                    err.labels.into_iter().map(|l| (b160_to_h160(l.0), l.1)).collect::<Vec<_>>(),
+                );
                 Self::failed_with(logs, traces, labeled_addresses, err.reason)
             }
             e => Self::failed_with(

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -23,7 +23,7 @@ use foundry_evm::{
         FuzzedExecutor,
     },
     trace::{load_contracts, TraceKind},
-    CALLER,
+    CALLER, utils::b160_to_h160,
 };
 use proptest::test_runner::{TestError, TestRunner};
 use rayon::prelude::*;
@@ -93,7 +93,7 @@ impl<'a> ContractRunner<'a> {
 
         // We max out their balance so that they can deploy and make calls.
         self.executor.set_balance(self.sender, U256::MAX)?;
-        self.executor.set_balance(CALLER, U256::MAX)?;
+        self.executor.set_balance(b160_to_h160(CALLER), U256::MAX)?;
 
         // We set the nonce of the deployer accounts to 1 to get the same addresses as DappTools
         self.executor.set_nonce(self.sender, 1)?;
@@ -134,7 +134,7 @@ impl<'a> ContractRunner<'a> {
         // balance to the initial balance we want
         self.executor.set_balance(address, self.initial_balance)?;
         self.executor.set_balance(self.sender, self.initial_balance)?;
-        self.executor.set_balance(CALLER, self.initial_balance)?;
+        self.executor.set_balance(b160_to_h160(CALLER), self.initial_balance)?;
 
         self.executor.deploy_create2_deployer()?;
 

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -14,7 +14,8 @@ use foundry_evm::{
         DatabaseRef, Executor, ExecutorBuilder,
     },
     fuzz::FuzzedExecutor,
-    CALLER, utils::b160_to_h160,
+    utils::b160_to_h160,
+    CALLER,
 };
 use std::{path::PathBuf, str::FromStr};
 

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -14,7 +14,7 @@ use foundry_evm::{
         DatabaseRef, Executor, ExecutorBuilder,
     },
     fuzz::FuzzedExecutor,
-    CALLER,
+    CALLER, utils::b160_to_h160,
 };
 use std::{path::PathBuf, str::FromStr};
 
@@ -82,7 +82,7 @@ pub fn fuzz_executor<DB: DatabaseRef>(executor: &Executor) -> FuzzedExecutor {
     FuzzedExecutor::new(
         executor,
         proptest::test_runner::TestRunner::new(cfg),
-        CALLER,
+        b160_to_h160(CALLER),
         config::test_opts().fuzz,
     )
 }


### PR DESCRIPTION
## Motivation

This migrates the main `Executor` and `Backend` structs to use alloy types. None of the wrappers around the executor/backend or related builders were migrated, and instead, glue was added between them for this PR to serve as a checkpoint in the migration.

Beyond this point, preventing more type-spill is probably not possible as many `evm` constructs are used directly from the runners and anvil, and a total EVM crate migration, bar the forked backend which will still contain ethers types, is probably needed.
