### PR TITLE
feat: cast decode can decode raw eip2718 txns

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -493,11 +493,14 @@ async fn main() -> Result<()> {
             let tx = stdin::unwrap_line(tx)?;
             let (tx, sig) = SimpleCast::decode_raw_transaction(&tx)?;
 
-            // Serialise tx and sig as json strings and reformat to print as a single json object
-            let mut tx = serde_json::to_string_pretty(&tx)?;
-            tx.truncate(tx.len() - 2);
-            let sig = serde_json::to_string_pretty(&sig)?[2..].to_string();
-            println!("{},\n{}", tx, sig);
+            // Serialize tx, sig and constructed a merged json string
+            let mut tx = serde_json::to_value(&tx)?;
+            let tx_map = tx.as_object_mut().unwrap();
+            serde_json::to_value(sig)?.as_object().unwrap().iter().for_each(|(k, v)| {
+                tx_map.entry(k).or_insert(v.clone());
+            });
+
+            println!("{}", serde_json::to_string_pretty(&tx)?);
         }
     };
     Ok(())

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -489,6 +489,12 @@ async fn main() -> Result<()> {
             &mut std::io::stdout(),
         ),
         Subcommands::Logs(cmd) => cmd.run().await?,
+        Subcommands::Decode { tx } => {
+            let tx = stdin::unwrap_line(tx)?;
+            let (tx, sig) = SimpleCast::decode_tx(tx)?;
+            println!("Transaction: {}", tx);
+            println!("Signature: {}", sig);
+        }
     };
     Ok(())
 }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -489,11 +489,15 @@ async fn main() -> Result<()> {
             &mut std::io::stdout(),
         ),
         Subcommands::Logs(cmd) => cmd.run().await?,
-        Subcommands::Decode { tx } => {
+        Subcommands::DecodeTransaction { tx } => {
             let tx = stdin::unwrap_line(tx)?;
-            let (tx, sig) = SimpleCast::decode_tx(tx)?;
-            println!("Transaction: {}", tx);
-            println!("Signature: {}", sig);
+            let (tx, sig) = SimpleCast::decode_raw_transaction(&tx)?;
+
+            // Serialise tx and sig as json strings and reformat to print as a single json object
+            let mut tx = serde_json::to_string_pretty(&tx)?;
+            tx.truncate(tx.len() - 2);
+            let sig = serde_json::to_string_pretty(&sig)?[2..].to_string();
+            println!("{},\n{}", tx, sig);
         }
     };
     Ok(())

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -861,8 +861,8 @@ pub enum Subcommands {
     },
 
     /// Decodes a raw signed EIP 2718 typed transaction
-    #[clap(visible_alias = "d")]
-    Decode { tx: Option<String> },
+    #[clap(visible_alias = "dt")]
+    DecodeTransaction { tx: Option<String> },
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -859,6 +859,10 @@ pub enum Subcommands {
         #[clap(value_name = "BYTES")]
         bytes: Option<String>,
     },
+
+    /// Decodes a raw signed EIP 2718 typed transaction
+    #[clap(visible_alias = "d")]
+    Decode { tx: Option<String> },
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1835,9 +1835,9 @@ impl SimpleCast {
     ///
     /// fn main() -> eyre::Result<()> {
     ///     let tx = "0x02f8f582a86a82058d8459682f008508351050808303fd84948e42f2f4101563bf679975178e880fd87d3efd4e80b884659ac74b00000000000000000000000080f0c1c49891dcfdd40b6e0f960f84e6042bcb6f000000000000000000000000b97ef9ef8734c71904d8002f8b6bc66dd9c48a6e00000000000000000000000000000000000000000000000000000000007ff4e20000000000000000000000000000000000000000000000000000000000000064c001a05d429597befe2835396206781b199122f2e8297327ed4a05483339e7a8b2022aa04c23a7f70fb29dda1b4ee342fb10a625e9b8ddc6a603fb4e170d4f6f37700cb8";
-    ///     let (tx, sig) = Cast::decode_raw_transaction(&tx);
-    ///     println!("{:?}", tx);
-    ///     println!("{:?}", sig);
+    ///     let (tx, sig) = Cast::decode_raw_transaction(&tx)?;
+    ///
+    ///     Ok(())
     /// }
     pub fn decode_raw_transaction(tx: &str) -> Result<(TypedTransaction, Signature)> {
         let tx_hex = hex::decode(strip_0x(tx))?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1825,15 +1825,24 @@ impl SimpleCast {
         }
     }
 
-    pub fn decode_tx(tx: String) -> Result<(String, String)> {
-        let tx_hex = hex::decode(strip_0x(&tx))?;
+    /// Decodes a raw EIP2718 transaction payload
+    /// Returns details about the typed transaction and ECSDA signature components
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     let tx = "0x02f8f582a86a82058d8459682f008508351050808303fd84948e42f2f4101563bf679975178e880fd87d3efd4e80b884659ac74b00000000000000000000000080f0c1c49891dcfdd40b6e0f960f84e6042bcb6f000000000000000000000000b97ef9ef8734c71904d8002f8b6bc66dd9c48a6e00000000000000000000000000000000000000000000000000000000007ff4e20000000000000000000000000000000000000000000000000000000000000064c001a05d429597befe2835396206781b199122f2e8297327ed4a05483339e7a8b2022aa04c23a7f70fb29dda1b4ee342fb10a625e9b8ddc6a603fb4e170d4f6f37700cb8";
+    ///     let (tx, sig) = Cast::decode_raw_transaction(&tx);
+    ///     println!("{:?}", tx);
+    ///     println!("{:?}", sig);
+    /// }
+    pub fn decode_raw_transaction(tx: &str) -> Result<(TypedTransaction, Signature)> {
+        let tx_hex = hex::decode(strip_0x(tx))?;
         let tx_rlp = rlp::Rlp::new(tx_hex.as_slice());
-        let (tx, sig) = TypedTransaction::decode_signed(&tx_rlp)?;
-
-        let tx = serde_json::to_string_pretty(&tx)?;
-        let sig = serde_json::to_string_pretty(&sig)?;
-
-        Ok((tx, sig))
+        Ok(TypedTransaction::decode_signed(&tx_rlp)?)
     }
 }
 

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -6,7 +6,7 @@ use ethers_core::{
         token::{LenientTokenizer, Tokenizer},
         Function, HumanReadableParser, ParamType, RawAbi, Token,
     },
-    types::{Chain, *},
+    types::{transaction::eip2718::TypedTransaction, Chain, *},
     utils::{
         format_bytes32_string, format_units, get_contract_address, keccak256, parse_bytes32_string,
         parse_units, rlp, Units,
@@ -1823,6 +1823,17 @@ impl SimpleCast {
             Some((_nonce, selector, signature)) => Ok((selector, signature)),
             None => eyre::bail!("No selector found"),
         }
+    }
+
+    pub fn decode_tx(tx: String) -> Result<(String, String)> {
+        let tx_hex = hex::decode(strip_0x(&tx))?;
+        let tx_rlp = rlp::Rlp::new(tx_hex.as_slice());
+        let (tx, sig) = TypedTransaction::decode_signed(&tx_rlp)?;
+
+        let tx = serde_json::to_string_pretty(&tx)?;
+        let sig = serde_json::to_string_pretty(&sig)?;
+
+        Ok((tx, sig))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Resolve #4752 and implement `cast decode` to decode raw EIP2718 transaction payloads

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- [x] Implement new clap subcommand `Decode`
- [x] Implement `SimpleCast::decode_tx` that uses `ethers_core::utils::rlp` to decode raw eip2718 signed txns to `ethers_core::types::transaction::eip2718::TypedTransaction` and `Signature`
- [x] Pretty print decoded txn details

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
