### PR TITLE
refactor: move evm-spec-id to config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "reqwest",
+ "revm-primitives",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -5312,7 +5313,6 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1",
  "sha2 0.10.7",
  "sha3",
  "substrate-bn",
@@ -5806,24 +5806,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,10 @@ foundry-test-utils = { path = "crates/test-utils" }
 foundry-utils = { path = "crates/utils" }
 ui = { path = "crates/ui" }
 
+## revm
+revm = { version = "3", default-features = false }
+revm-primitives = { version = "1", default-features = false }
+
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-addressbook = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
@@ -156,3 +160,4 @@ tikv-jemallocator = "0.5.4"
 
 [patch.crates-io]
 revm = { git = "https://github.com/bluealloy/revm/", rev = "6b55b9c0ab264c000e087c2f54f2d8dc24b869aa" }
+revm-primitives = { git = "https://github.com/bluealloy/revm/", rev = "6b55b9c0ab264c000e087c2f54f2d8dc24b869aa" }

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../../evm" }
-revm = { version = "3", default-features = false, features = ["std", "serde", "memory_limit"] }
+revm = { workspace = true, default-features = false, features = ["std", "serde", "memory_limit"] }
 
 ethers-core.workspace = true
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -43,7 +43,7 @@ serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 semver = "1"
 bytes = "1"
-revm = "3"
+revm.workspace = true
 eyre = "0.6"
 dirs = "5"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -297,7 +297,7 @@ impl SessionSource {
                 )
             })
             .gas_limit(self.config.evm_opts.gas_limit())
-            .spec(foundry_evm::utils::evm_spec(self.config.foundry_config.evm_version))
+            .spec(self.config.foundry_config.evm_spec_id())
             .build(env, backend);
 
         // Create a [ChiselRunner] with a default balance of [U256::MAX] and

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 ethers-core.workspace = true
 ethers-solc = { workspace = true, features = ["async", "svm-solc"] }
 ethers-etherscan.workspace = true
+revm-primitives.workspace = true
 
 # formats
 Inflector = "0.11"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -76,6 +76,7 @@ pub mod fix;
 
 // reexport so cli types can implement `figment::Provider` to easily merge compiler arguments
 pub use figment;
+use revm_primitives::SpecId;
 use tracing::warn;
 
 /// config providers
@@ -683,6 +684,23 @@ impl Config {
         }
 
         Ok(None)
+    }
+
+    /// Returns the [SpecId] derived from the configured [EvmVersion]
+    pub fn evm_spec_id(&self) -> SpecId {
+        match self.evm_version {
+            EvmVersion::Homestead => SpecId::HOMESTEAD,
+            EvmVersion::TangerineWhistle => SpecId::TANGERINE,
+            EvmVersion::SpuriousDragon => SpecId::SPURIOUS_DRAGON,
+            EvmVersion::Byzantium => SpecId::BYZANTIUM,
+            EvmVersion::Constantinople => SpecId::CONSTANTINOPLE,
+            EvmVersion::Petersburg => SpecId::PETERSBURG,
+            EvmVersion::Istanbul => SpecId::ISTANBUL,
+            EvmVersion::Berlin => SpecId::BERLIN,
+            EvmVersion::London => SpecId::LONDON,
+            EvmVersion::Paris => SpecId::MERGE,
+            EvmVersion::Shanghai => SpecId::SHANGHAI,
+        }
     }
 
     /// Returns whether the compiler version should be auto-detected

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = "1"
 # EVM
 bytes = "1"
 hashbrown = { version = "0.13", features = ["serde"] }
-revm = { version = "3", default-features = false, features = [
+revm = { workspace = true, default-features = false, features = [
   "std",
   "serde",
   "memory_limit",

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -27,7 +27,6 @@ use foundry_cli::{
 };
 use foundry_common::{compile::ProjectCompiler, evm::EvmArgs, fs};
 use foundry_config::{Config, SolcReq};
-use foundry_evm::utils::evm_spec;
 use semver::Version;
 use std::{collections::HashMap, sync::mpsc::channel};
 use tracing::trace;
@@ -286,11 +285,10 @@ impl CoverageArgs {
         let root = project.paths.root;
 
         // Build the contract runner
-        let evm_spec = evm_spec(config.evm_version);
         let env = evm_opts.evm_env().await?;
         let mut runner = MultiContractRunnerBuilder::default()
             .initial_balance(evm_opts.initial_balance)
-            .evm_spec(evm_spec)
+            .evm_spec(config.evm_spec_id())
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, &evm_opts))

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -20,7 +20,6 @@ use forge::{
 };
 use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
 use foundry_common::{shell, RpcUrl};
-use foundry_evm::utils::evm_spec;
 use futures::future::join_all;
 use parking_lot::RwLock;
 use std::{collections::VecDeque, sync::Arc};
@@ -305,7 +304,7 @@ impl ScriptArgs {
         // We need to enable tracing to decode contract names: local or external.
         let mut builder = ExecutorBuilder::new()
             .inspectors(|stack| stack.trace(true))
-            .spec(evm_spec(script_config.config.evm_version))
+            .spec(script_config.config.evm_spec_id())
             .gas_limit(script_config.evm_opts.gas_limit());
 
         if let SimulationStage::Local = stage {

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -30,7 +30,7 @@ use foundry_config::{
     },
     get_available_profiles, Config,
 };
-use foundry_evm::{fuzz::CounterExample, utils::evm_spec};
+use foundry_evm::fuzz::CounterExample;
 use regex::Regex;
 use std::{collections::BTreeMap, path::PathBuf, sync::mpsc::channel, time::Duration};
 use tracing::trace;
@@ -177,11 +177,9 @@ impl TestArgs {
         let env = evm_opts.evm_env().await?;
 
         // Prepare the test builder
-        let evm_spec = evm_spec(config.evm_version);
-
         let mut runner = MultiContractRunnerBuilder::default()
             .initial_balance(evm_opts.initial_balance)
-            .evm_spec(evm_spec)
+            .evm_spec(config.evm_spec_id())
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, &evm_opts))

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -17,5 +17,5 @@ ethers.workspace = true
 
 crossterm = "0.26"
 eyre = "0.6"
-revm = { version = "3", features = ["std", "serde"] }
+revm = { workspace = true, features = ["std", "serde"] }
 ratatui = { version = "0.22.0", default-features = false, features = ["crossterm"]}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
prep for #5782

this makes it easier to access the spec id required for the evm from the config
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
