### PR TITLE
fix(common): include ws and ipc features

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -17,7 +17,7 @@ foundry-macros.workspace = true
 # eth
 ethers-core.workspace = true
 ethers-solc.workspace = true
-ethers-providers.workspace = true
+ethers-providers = { workspace = true, features = ["ws", "ipc"] }
 ethers-middleware.workspace = true
 ethers-etherscan = { workspace = true, features = ["ethers-solc"] }
 


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/5783

https://github.com/foundry-rs/foundry/pull/5571 broke installing binaries using `cargo` due to workspace features being missing.

## Solution

Ensure the correct features are included in the `cargo.toml`.

## Test

```
cargo install --git https://github.com/bernard-wagner/foundry --branch fix-ws-ipc --profile local forge cast chisel anvil
```
