### PR TITLE
feat: add tmp cancun config value

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -356,6 +356,13 @@ pub struct Config {
     ///
     /// This includes what operations can be executed (read, write)
     pub fs_permissions: FsPermissions,
+
+    /// Temporary config to enable [SpecId::CANCUN]
+    ///
+    /// <https://github.com/foundry-rs/foundry/issues/5782>
+    /// Should be removed once EvmVersion Cancun is supported by solc
+    pub cancun: bool,
+
     /// The root path where the config detection started from, `Config::with_root`
     #[doc(hidden)]
     //  We're skipping serialization here, so it won't be included in the [`Config::to_string()`]
@@ -689,6 +696,9 @@ impl Config {
     /// Returns the [SpecId] derived from the configured [EvmVersion]
     #[inline]
     pub fn evm_spec_id(&self) -> SpecId {
+        if self.cancun {
+            return SpecId::CANCUN
+        }
         evm_spec_id(&self.evm_version)
     }
 
@@ -1750,6 +1760,7 @@ impl Default for Config {
         Self {
             profile: Self::DEFAULT_PROFILE,
             fs_permissions: FsPermissions::new([PathPermission::read("out")]),
+            cancun: false,
             __root: Default::default(),
             src: "src".into(),
             test: "test".into(),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -114,6 +114,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         fmt: Default::default(),
         doc: Default::default(),
         fs_permissions: Default::default(),
+        cancun: true,
         __non_exhaustive: (),
         __warnings: vec![],
     };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref #5782
This adds a `cancun = true` option to foundry.toml which enables Cancun SpecId.

This is a temp measure that will get phased out once solc recognizes the cancun version, until then the solc target and evm can be configured independently 

ref https://github.com/gakonst/ethers-rs/issues/2585

@snreynolds
This can be enabled by adding `cancun = true` to foundry.toml, 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
