### PR TITLE
chore: better create2 warning

### DIFF
--- a/crates/evm/src/executor/backend/error.rs
+++ b/crates/evm/src/executor/backend/error.rs
@@ -38,7 +38,7 @@ pub enum DatabaseError {
     #[error("Transaction {0:?} not found")]
     TransactionNotFound(H256),
     #[error(
-        "CREATE2 Deployer not present on this chain. [0x4e59b44847b379578588920ca78fbf26c0b4956c]"
+        "CREATE2 Deployer (0x4e59b44847b379578588920ca78fbf26c0b4956c) not present on this chain.\n\nFor a production environment, you can deploy it using the pre-signed transaction from https://github.com/Arachnid/deterministic-deployment-proxy.\n\nFor a test environment, you can use vm.etch to place the required bytecode at that address."
     )]
     MissingCreate2Deployer,
     #[error(transparent)]


### PR DESCRIPTION

## Motivation

Issues like https://github.com/foundry-rs/foundry/issues/5401 seem to come up frequently, so I figured a more detailed error message here would be useful.

## Solution

New error looks like the the below. I'm open to condensing this all into one line to clarify the trace if that's preferred
<img width="1001" alt="image" src="https://github.com/foundry-rs/foundry/assets/17163988/c1dfc156-e2ec-4a67-a644-fc939c9fd897">


