### PR TITLE
feat(cargo): add fast debug profile for perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,20 @@ scrypt.opt-level = 3
 # forking
 axum.opt-level = 3
 
+# Optimized release profile
 [profile.release]
 opt-level = "s"
 lto = "fat"
 strip = true
 panic = "abort"
 codegen-units = 1
+
+# Like release, but with full debug symbols and with stack unwinds. Useful for e.g. `perf`.
+[profile.debug-fast]
+inherits = "release"
+debug = true
+strip = "none"
+panic = "unwind"
 
 [profile.release.package]
 # Optimize all non-workspace packages for speed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,10 @@ codegen-units = 1
 # Like release, but with full debug symbols and with stack unwinds. Useful for e.g. `perf`.
 [profile.debug-fast]
 inherits = "release"
-debug = true
+debug = "full"
 strip = "none"
 panic = "unwind"
+incremental = false
 
 [profile.release.package]
 # Optimize all non-workspace packages for speed


### PR DESCRIPTION
## Motivation

Mainly an improvement taken from reth which has this profile. Dani and I usually have this locally but I thought I'd make this available here for anyone who wants to use this.

## Solution

Adds a `debug-fast` profile which retains full debug symbols and does not strip any code info.
