### PR TITLE
fix(`forge`): properly clean git dir on path when installing thru template

### DIFF
--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -71,7 +71,7 @@ impl InitArgs {
             }
             // Modify the git history.
             let commit_hash = git.commit_hash(true)?;
-            std::fs::remove_dir_all(".git")?;
+            std::fs::remove_dir_all(root.join(".git"))?;
 
             git.init()?;
             git.add(Some("--all"))?;


### PR DESCRIPTION
## Motivation

Closes #5720 

## Solution

When installing thru templates, we were not using the proper path for cleaning the `.git` directory—we tried to clean the directory of the path we invoked the command from, not the actual project itself. blew my foundry `.git` folder a few times this way while debugging :D