### PR TITLE
chore(deps): bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/bluealloy/revm/?rev=7eacc3a728b8a9cf3c15db609753e5d9f69e08ce#7eacc3a728b8a9cf3c15db609753e5d9f69e08ce"
+source = "git+https://github.com/bluealloy/revm/?rev=429da731cd8efdc0939ed912240b2667b9155834#429da731cd8efdc0939ed912240b2667b9155834"
 dependencies = [
  "auto_impl",
  "rayon",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm/?rev=7eacc3a728b8a9cf3c15db609753e5d9f69e08ce#7eacc3a728b8a9cf3c15db609753e5d9f69e08ce"
+source = "git+https://github.com/bluealloy/revm/?rev=429da731cd8efdc0939ed912240b2667b9155834#429da731cd8efdc0939ed912240b2667b9155834"
 dependencies = [
  "derive_more",
  "enumn",
@@ -5184,7 +5184,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/bluealloy/revm/?rev=7eacc3a728b8a9cf3c15db609753e5d9f69e08ce#7eacc3a728b8a9cf3c15db609753e5d9f69e08ce"
+source = "git+https://github.com/bluealloy/revm/?rev=429da731cd8efdc0939ed912240b2667b9155834#429da731cd8efdc0939ed912240b2667b9155834"
 dependencies = [
  "k256",
  "num",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/bluealloy/revm/?rev=7eacc3a728b8a9cf3c15db609753e5d9f69e08ce#7eacc3a728b8a9cf3c15db609753e5d9f69e08ce"
+source = "git+https://github.com/bluealloy/revm/?rev=429da731cd8efdc0939ed912240b2667b9155834#429da731cd8efdc0939ed912240b2667b9155834"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ tikv-jemallocator = "0.5.4"
 #ethers-solc = { path = "../ethers-rs/ethers-solc" }
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm/", rev = "7eacc3a728b8a9cf3c15db609753e5d9f69e08ce" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm/", rev = "7eacc3a728b8a9cf3c15db609753e5d9f69e08ce" }
-revm-precompile = { git = "https://github.com/bluealloy/revm/", rev = "7eacc3a728b8a9cf3c15db609753e5d9f69e08ce" }
-revm-primitives = { git = "https://github.com/bluealloy/revm/", rev = "7eacc3a728b8a9cf3c15db609753e5d9f69e08ce" }
+revm = { git = "https://github.com/bluealloy/revm/", rev = "429da731cd8efdc0939ed912240b2667b9155834" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm/", rev = "429da731cd8efdc0939ed912240b2667b9155834" }
+revm-precompile = { git = "https://github.com/bluealloy/revm/", rev = "429da731cd8efdc0939ed912240b2667b9155834" }
+revm-primitives = { git = "https://github.com/bluealloy/revm/", rev = "429da731cd8efdc0939ed912240b2667b9155834" }


### PR DESCRIPTION
## Motivation

Bumps revm up to latest rev.

The included changes do not affect anything we currently use—the reason for the bump is to include https://github.com/bluealloy/revm/pull/716 which should hopefully increase performance by reducing `hash_slow` usage.

## Solution

bump revm