### PR TITLE
feat: `cool` cheatcode

### DIFF
--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -22,6 +22,7 @@ fee(uint256)
 coinbase(address)
 store(address,bytes32,bytes32)
 load(address,bytes32)(bytes32)
+cool(address)
 
 setEnv(string,string)
 envBool(string)(bool)

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -271,6 +271,24 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("cool"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("cool"),
+                            inputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Address,
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("copyFile"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -5429,6 +5447,15 @@ pub mod hevm {
                 .method_hash([255, 72, 60, 84], p0)
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `cool` (0x40ff9f21) function
+        pub fn cool(
+            &self,
+            p0: ::ethers_core::types::Address,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([64, 255, 159, 33], p0)
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `copyFile` (0xa54a87d8) function
         pub fn copy_file(
             &self,
@@ -7680,6 +7707,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "coinbase", abi = "coinbase(address)")]
     pub struct CoinbaseCall(pub ::ethers_core::types::Address);
+    ///Container type for all input parameters for the `cool` function with signature `cool(address)` and selector `0x40ff9f21`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "cool", abi = "cool(address)")]
+    pub struct CoolCall(pub ::ethers_core::types::Address);
     ///Container type for all input parameters for the `copyFile` function with signature `copyFile(string,string)` and selector `0xa54a87d8`
     #[derive(
         Clone,
@@ -10539,6 +10579,7 @@ pub mod hevm {
         ClearMockedCalls(ClearMockedCallsCall),
         CloseFile(CloseFileCall),
         Coinbase(CoinbaseCall),
+        Cool(CoolCall),
         CopyFile(CopyFileCall),
         CreateDir(CreateDirCall),
         CreateFork1(CreateFork1Call),
@@ -10811,6 +10852,11 @@ pub mod hevm {
                 data,
             ) {
                 return Ok(Self::Coinbase(decoded));
+            }
+            if let Ok(decoded) = <CoolCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::Cool(decoded));
             }
             if let Ok(decoded) = <CopyFileCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
@@ -11835,6 +11881,7 @@ pub mod hevm {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
                 Self::Coinbase(element) => ::ethers_core::abi::AbiEncode::encode(element),
+                Self::Cool(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::CopyFile(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::CreateDir(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
@@ -12330,6 +12377,7 @@ pub mod hevm {
                 Self::ClearMockedCalls(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CloseFile(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Coinbase(element) => ::core::fmt::Display::fmt(element, f),
+                Self::Cool(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CopyFile(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CreateDir(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CreateFork1(element) => ::core::fmt::Display::fmt(element, f),
@@ -12618,6 +12666,11 @@ pub mod hevm {
     impl ::core::convert::From<CoinbaseCall> for HEVMCalls {
         fn from(value: CoinbaseCall) -> Self {
             Self::Coinbase(value)
+        }
+    }
+    impl ::core::convert::From<CoolCall> for HEVMCalls {
+        fn from(value: CoolCall) -> Self {
+            Self::Cool(value)
         }
     }
     impl ::core::convert::From<CopyFileCall> for HEVMCalls {

--- a/crates/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/env.rs
@@ -387,6 +387,17 @@ pub fn apply<DB: DatabaseExt>(
             )?;
             ru256_to_u256(val).encode().into()
         }
+        HEVMCalls::Cool(inner) => {
+            ensure!(!is_potential_precompile(inner.0), "Load cannot be used on precompile addresses (N < 10). Please use an address bigger than 10 instead");
+            let address = &h160_to_b160(inner.0);
+            if let Some(account) = data.journaled_state.state.get_mut(address) {
+                if account.is_touched() {
+                    account.unmark_touch();
+                }
+                account.storage.clear();
+            }
+            Bytes::new()
+        }
         HEVMCalls::Breakpoint0(inner) => add_breakpoint(state, caller, &inner.0, true)?,
         HEVMCalls::Breakpoint1(inner) => add_breakpoint(state, caller, &inner.0, inner.1)?,
         HEVMCalls::Etch(inner) => {

--- a/testdata/cheats/Cool.t.sol
+++ b/testdata/cheats/Cool.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "../lib/ds-test/src/test.sol";
+import "./Vm.sol";
+
+contract CoolTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 public slot0 = 1;
+
+    function testCool_SLOAD_normal() public {
+        uint256 startGas;
+        uint256 endGas;
+        uint256 val;
+        uint256 beforeCoolGas;
+        uint256 noCoolGas;
+
+        startGas = gasleft();
+        val = slot0;
+        endGas = gasleft();
+        beforeCoolGas = startGas - endGas;
+
+        startGas = gasleft();
+        val = slot0;
+        endGas = gasleft();
+        noCoolGas = startGas - endGas;
+
+        assertGt(beforeCoolGas, noCoolGas);
+    }
+
+    function testCool_SLOAD() public {
+        uint256 startGas;
+        uint256 endGas;
+        uint256 val;
+        uint256 beforeCoolGas;
+        uint256 afterCoolGas;
+        uint256 noCoolGas;
+
+        startGas = gasleft();
+        val = slot0;
+        endGas = gasleft();
+        beforeCoolGas = startGas - endGas;
+
+        vm.cool(address(this));
+
+        startGas = gasleft();
+        val = slot0;
+        endGas = gasleft();
+        afterCoolGas = startGas - endGas;
+
+        assertEq(beforeCoolGas, afterCoolGas);
+
+        startGas = gasleft();
+        val = slot0;
+        endGas = gasleft();
+        noCoolGas = startGas - endGas;
+
+        assertGt(beforeCoolGas, noCoolGas);
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -96,6 +96,9 @@ interface Vm {
     // Stores a value to an address' storage slot, (who, slot, value)
     function store(address, bytes32, bytes32) external;
 
+    // Cools off a warm address and it's storage slots
+    function cool(address) external;
+
     // Signs data, (privateKey, digest) => (v, r, s)
     function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -96,7 +96,7 @@ interface Vm {
     // Stores a value to an address' storage slot, (who, slot, value)
     function store(address, bytes32, bytes32) external;
 
-    // Cools off a warm address and it's storage slots
+    // Cools off a warm address and its storage slots
     function cool(address) external;
 
     // Signs data, (privateKey, digest) => (v, r, s)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #1340.

Motivation is wanting to have more accurate and easier gas tests in foundry without needing to do hacks around functions/setUp. Adds a cheatcode to reset a warm account to cold and it's storage to be untouched/cold via `vm.cool(address)`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

> not familiar with the language/code so maybe some things are pretty wrong, would love some guidance on what to change or if something is missing!

it untouches the `Account.status` and clears all storage cache in the `Account` via `Account.storage`

also had some code relating to removing the `JournalEntry` for `JournalEntry::StorageChange` but it wasn't necessary for this to work in the tests i wrote - so i don't know if it's supposed to be cleared or not but it's not effecting how the gas is calculated at least in this basic test?

i'm not sure the best way to test other than via `gasleft` - instead of hardcoding gas values that may change it just asserts that the same calls have the same gas values and the warm call is less gas. i wrote a few more tests using sstore (20k for zero to non zero and 5k for nonzero to nonzero) but wasn't sure it was necessary

(didn't account for refunds if that is related, since gasleft doesn't do it)

see also: twitter [context](https://x.com/rakitadragan/status/1702047574075535562?s=20)