### PR TITLE
chore(all): remove jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tikv-jemallocator",
  "tokio",
  "tracing",
  "vergen",
@@ -738,7 +737,6 @@ dependencies = [
  "serial_test",
  "solang-parser",
  "strum 0.25.0",
- "tikv-jemallocator",
  "time",
  "tokio",
  "vergen",
@@ -2176,7 +2174,6 @@ dependencies = [
  "strum 0.25.0",
  "svm-rs",
  "thiserror",
- "tikv-jemallocator",
  "tokio",
  "tracing",
  "vergen",
@@ -6311,26 +6308,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 itertools = "0.11"
 solang-parser = "=0.3.2"
-tikv-jemallocator = "0.5.4"
 
 #[patch."https://github.com/gakonst/ethers-rs"]
 #ethers = { path = "../ethers-rs/ethers" }

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -64,17 +64,13 @@ tokio = { version = "1", features = ["macros", "signal"] }
 tracing = "0.1"
 yansi = "0.5"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 [dev-dependencies]
 foundry-test-utils.workspace = true
 async-trait = "0.1"
 criterion = "0.5"
 
 [features]
-default = ["rustls", "jemalloc"]
-jemalloc = ["dep:tikv-jemallocator"]
+default = ["rustls"]
 rustls = ["foundry-cli/rustls"]
 openssl = ["foundry-cli/openssl"]
 

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -25,10 +25,6 @@ pub mod opts;
 
 use opts::{Opts, Subcommands, ToBaseArgs};
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 #[tokio::main]
 async fn main() -> Result<()> {
     utils::load_dotenv();

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -49,17 +49,13 @@ dirs = "5"
 time = { version = "0.3", features = ["formatting"] }
 regex = "1"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
 serial_test = "2"
 once_cell = "1"
 
 [features]
-default = ["rustls", "jemalloc"]
-jemalloc = ["dep:tikv-jemallocator"]
+default = ["rustls"]
 rustls = ["ethers/rustls", "reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
 openssl = ["ethers/openssl", "reqwest/default-tls"]
 

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -23,10 +23,6 @@ use foundry_config::{
 use rustyline::{config::Configurer, error::ReadlineError, Editor};
 use yansi::Paint;
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(ChiselParser, opts, evm_opts);
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -63,9 +63,6 @@ thiserror = "1"
 tokio = { version = "1", features = ["time"] }
 watchexec = "2"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 [dev-dependencies]
 anvil.workspace = true
 foundry-test-utils.workspace = true
@@ -78,8 +75,7 @@ serial_test = "2"
 svm = { package = "svm-rs", version = "0.3", default-features = false, features = ["rustls"] }
 
 [features]
-default = ["rustls", "jemalloc"]
-jemalloc = ["dep:tikv-jemallocator"]
+default = ["rustls"]
 rustls = ["foundry-cli/rustls", "reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
 openssl = ["foundry-cli/openssl", "reqwest/default-tls"]
 

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -9,10 +9,6 @@ mod opts;
 use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
 use opts::{Opts, Subcommands};
 
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 fn main() -> Result<()> {
     utils::load_dotenv();
     handler::install()?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5832 

jemalloc was brought in for performance increases on unix but we haven't had time to properly tune things so the allocator doesn't cause spurious issues on things specific to an OS, so we're removing it

we can totally reconsider having this later once we're done with bigger items

## Solution

remove jemalloc