### PR TITLE
feat(`utils`): Add primitive types conversion traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
 name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "const-hex",
  "dunce",
  "ethers-addressbook",

--- a/crates/evm/src/executor/backend/diagnostic.rs
+++ b/crates/evm/src/executor/backend/diagnostic.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use alloy_primitives::Address;
 use foundry_common::fmt::UIfmt;
+use foundry_utils::types::ToEthers;
 use itertools::Itertools;
 
 /// Represents possible diagnostic cases on revert
@@ -31,7 +32,7 @@ impl RevertDiagnostic {
 
         match self {
             RevertDiagnostic::ContractExistsOnOtherForks { contract, active, available_on } => {
-                let contract_label = get_label(&b160_to_h160(*contract));
+                let contract_label = get_label(&(*contract).to_ethers());
 
                 format!(
                     r#"Contract {} does not exist on active fork with id `{}`

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -18,6 +18,8 @@ ethers-addressbook.workspace = true
 ethers-providers.workspace = true
 ethers-solc.workspace = true
 
+alloy-primitives = { workspace = true, features = ["std"]}
+
 eyre = { version = "0.6", default-features = false }
 futures = "0.3"
 glob = "0.3"

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -26,6 +26,7 @@ pub mod error;
 pub mod glob;
 pub mod path;
 pub mod rpc;
+pub mod types;
 
 /// Data passed to the post link handler of the linker for each linked artifact.
 #[derive(Debug)]

--- a/crates/utils/src/types.rs
+++ b/crates/utils/src/types.rs
@@ -20,20 +20,18 @@ impl ToAlloy for H160 {
 }
 
 impl ToAlloy for H256 {
-    type To = alloy_primitives::B256;
+    type To = B256;
 
     fn to_alloy(self) -> Self::To {
-        B256::from_slice(self.as_bytes())
+        B256::new(self.0)
     }
 }
 
 impl ToAlloy for U256 {
-    type To = alloy_primitives::U256;
+    type To = AlloyU256;
 
     fn to_alloy(self) -> Self::To {
-        let mut buffer = [0u8; 32];
-        self.to_little_endian(buffer.as_mut_slice());
-        AlloyU256::from_le_bytes(buffer)
+        AlloyU256::from_limbs(self.0)
     }
 }
 

--- a/crates/utils/src/types.rs
+++ b/crates/utils/src/types.rs
@@ -1,0 +1,70 @@
+//! Temporary utility conversion traits between ethers-rs and alloy types.
+
+use alloy_primitives::{Address, B256, U256 as AlloyU256};
+use ethers_core::types::{H160, H256, U256};
+
+/// Conversion trait to easily convert from ethers-rs types to alloy primitive types.
+pub trait ToAlloy {
+    type To;
+
+    /// Converts the alloy type to the corresponding ethers-rs type.
+    fn to_alloy(self) -> Self::To;
+}
+
+impl ToAlloy for H160 {
+    type To = Address;
+
+    fn to_alloy(self) -> Self::To {
+        Address::from_slice(self.as_bytes())
+    }
+}
+
+impl ToAlloy for H256 {
+    type To = alloy_primitives::B256;
+
+    fn to_alloy(self) -> Self::To {
+        B256::from_slice(self.as_bytes())
+    }
+}
+
+impl ToAlloy for U256 {
+    type To = alloy_primitives::U256;
+
+    fn to_alloy(self) -> Self::To {
+        let mut buffer = [0u8; 32];
+        self.to_little_endian(buffer.as_mut_slice());
+        AlloyU256::from_le_bytes(buffer)
+    }
+}
+
+/// Conversion trait to easily convert from alloy primitive types to ethers-rs types.
+pub trait ToEthers {
+    type To;
+
+    /// Converts the alloy type to the corresponding ethers-rs type.
+    fn to_ethers(self) -> Self::To;
+}
+
+impl ToEthers for Address {
+    type To = H160;
+
+    fn to_ethers(self) -> Self::To {
+        H160::from_slice(self.as_slice())
+    }
+}
+
+impl ToEthers for B256 {
+    type To = H256;
+
+    fn to_ethers(self) -> Self::To {
+        H256(self.0)
+    }
+}
+
+impl ToEthers for AlloyU256 {
+    type To = U256;
+
+    fn to_ethers(self) -> Self::To {
+        U256::from_little_endian(&self.as_le_bytes())
+    }
+}


### PR DESCRIPTION
## Motivation

It's extremely painful to have to write `u256_to_ru256(stuff)` when we could have a trait for this.

## Solution

Add conversion traits for:
- Alloy -> Ethers
- Ethers -> Alloy
