### PR TITLE
chore: rename skip to skipTest

### DIFF
--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -82,7 +82,7 @@ expectRevert(bytes)
 expectRevert(bytes4)
 record()
 accesses(address)(bytes32[],bytes32[])
-skip(bool)
+skipTest(bool)
 
 recordLogs()
 getRecordedLogs()(Log[])

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -4750,10 +4750,10 @@ pub mod hevm {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("skip"),
+                    ::std::borrow::ToOwned::to_owned("skipTest"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("skip"),
+                            name: ::std::borrow::ToOwned::to_owned("skipTest"),
                             inputs: ::std::vec![
                                 ::ethers_core::abi::ethabi::Param {
                                     name: ::std::string::String::new(),
@@ -7252,13 +7252,13 @@ pub mod hevm {
                 .method_hash([178, 92, 90, 37], (p0, p1))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `skip` (0xdd82d13e) function
-        pub fn skip(
+        ///Calls the contract's `skipTest` (0x764e81ee) function
+        pub fn skip_test(
             &self,
             p0: bool,
         ) -> ::ethers_contract::builders::ContractCall<M, ()> {
             self.0
-                .method_hash([221, 130, 209, 62], p0)
+                .method_hash([118, 78, 129, 238], p0)
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `sleep` (0xfa9d8713) function
@@ -10175,7 +10175,7 @@ pub mod hevm {
     )]
     #[ethcall(name = "sign", abi = "sign((address,uint256,uint256,uint256),bytes32)")]
     pub struct Sign1Call(pub Wallet, pub [u8; 32]);
-    ///Container type for all input parameters for the `skip` function with signature `skip(bool)` and selector `0xdd82d13e`
+    ///Container type for all input parameters for the `skipTest` function with signature `skipTest(bool)` and selector `0x764e81ee`
     #[derive(
         Clone,
         ::ethers_contract::EthCall,
@@ -10186,8 +10186,8 @@ pub mod hevm {
         Eq,
         Hash
     )]
-    #[ethcall(name = "skip", abi = "skip(bool)")]
-    pub struct SkipCall(pub bool);
+    #[ethcall(name = "skipTest", abi = "skipTest(bool)")]
+    pub struct SkipTestCall(pub bool);
     ///Container type for all input parameters for the `sleep` function with signature `sleep(uint256)` and selector `0xfa9d8713`
     #[derive(
         Clone,
@@ -10748,7 +10748,7 @@ pub mod hevm {
         SetNonceUnsafe(SetNonceUnsafeCall),
         Sign0(Sign0Call),
         Sign1(Sign1Call),
-        Skip(SkipCall),
+        SkipTest(SkipTestCall),
         Sleep(SleepCall),
         Snapshot(SnapshotCall),
         StartBroadcast0(StartBroadcast0Call),
@@ -11698,10 +11698,10 @@ pub mod hevm {
             ) {
                 return Ok(Self::Sign1(decoded));
             }
-            if let Ok(decoded) = <SkipCall as ::ethers_core::abi::AbiDecode>::decode(
+            if let Ok(decoded) = <SkipTestCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
             ) {
-                return Ok(Self::Skip(decoded));
+                return Ok(Self::SkipTest(decoded));
             }
             if let Ok(decoded) = <SleepCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
@@ -12282,7 +12282,7 @@ pub mod hevm {
                 }
                 Self::Sign0(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Sign1(element) => ::ethers_core::abi::AbiEncode::encode(element),
-                Self::Skip(element) => ::ethers_core::abi::AbiEncode::encode(element),
+                Self::SkipTest(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Sleep(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Snapshot(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::StartBroadcast0(element) => {
@@ -12562,7 +12562,7 @@ pub mod hevm {
                 Self::SetNonceUnsafe(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Sign0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Sign1(element) => ::core::fmt::Display::fmt(element, f),
-                Self::Skip(element) => ::core::fmt::Display::fmt(element, f),
+                Self::SkipTest(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Sleep(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Snapshot(element) => ::core::fmt::Display::fmt(element, f),
                 Self::StartBroadcast0(element) => ::core::fmt::Display::fmt(element, f),
@@ -13513,9 +13513,9 @@ pub mod hevm {
             Self::Sign1(value)
         }
     }
-    impl ::core::convert::From<SkipCall> for HEVMCalls {
-        fn from(value: SkipCall) -> Self {
-            Self::Skip(value)
+    impl ::core::convert::From<SkipTestCall> for HEVMCalls {
+        fn from(value: SkipTestCall) -> Self {
+            Self::SkipTest(value)
         }
     }
     impl ::core::convert::From<SleepCall> for HEVMCalls {

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -508,7 +508,7 @@ fn sleep(milliseconds: &U256) -> Result {
 }
 
 /// Skip the current test, by returning a magic value that will be checked by the test runner.
-pub fn skip(state: &mut Cheatcodes, depth: u64, skip: bool) -> Result {
+pub fn skip_test(state: &mut Cheatcodes, depth: u64, skip: bool) -> Result {
     if !skip {
         return Ok(b"".into())
     }
@@ -714,7 +714,7 @@ pub fn apply<DB: Database>(
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
         HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),
-        HEVMCalls::Skip(inner) => skip(state, data.journaled_state.depth(), inner.0),
+        HEVMCalls::SkipTest(inner) => skip_test(state, data.journaled_state.depth(), inner.0),
         _ => return None,
     })
 }


### PR DESCRIPTION
## Motivation

Closes #5837 

## Solution

Renames `skip` to `skipTest`. This is targeting a `v1` branch, where we can host this and #5728 to avoid long-running changes.