### PR TITLE
chore: bump ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.10"
-source = "git+https://github.com/gakonst/ethers-rs#4ac0058f50571954596cabbe13a3d57351d9adac"
+source = "git+https://github.com/gakonst/ethers-rs#4b5e08ce73047ac49af1f1197a980374839d950c"
 dependencies = [
  "cfg-if",
  "const-hex",


### PR DESCRIPTION
Includes https://github.com/gakonst/ethers-rs/pull/2607 which fixes a bug related to semver.
