### PR TITLE
feat(`debugger`): migrate `debugger` crate to alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,11 +2411,12 @@ dependencies = [
 name = "foundry-debugger"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "crossterm",
- "ethers",
  "eyre",
  "foundry-common",
  "foundry-evm",
+ "foundry-utils",
  "ratatui",
  "revm",
  "tracing",

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -12,8 +12,9 @@ repository.workspace = true
 [dependencies]
 foundry-evm.workspace = true
 foundry-common.workspace = true
+foundry-utils.workspace = true
 
-ethers.workspace = true
+alloy-primitives.workspace = true
 
 crossterm = "0.26"
 eyre = "0.6"

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -1,6 +1,7 @@
 use crate::Ui;
 use foundry_common::{compile::ContractSources, evm::Breakpoints, get_contract_name};
-use foundry_evm::{debug::DebugArena, trace::CallTraceDecoder, utils::b160_to_h160};
+use foundry_evm::{debug::DebugArena, trace::CallTraceDecoder};
+use foundry_utils::types::ToAlloy;
 use tracing::trace;
 
 use crate::{TUIExitReason, Tui};
@@ -31,11 +32,13 @@ impl DebuggerArgs<'_> {
             .decoder
             .contracts
             .iter()
-            .map(|(addr, identifier)| (*addr, get_contract_name(identifier).to_string()))
+            .map(|(addr, identifier)| {
+                ((*addr).to_alloy(), get_contract_name(identifier).to_string())
+            })
             .collect();
 
         let tui = Tui::new(
-            flattened.into_iter().map(|i| (b160_to_h160(i.0), i.1, i.2)).collect(),
+            flattened.into_iter().map(|i| (i.0, i.1, i.2)).collect(),
             0,
             identified_contracts,
             self.sources.clone(),

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(unused_crate_dependencies)]
 
+use alloy_primitives::Address;
 use crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
@@ -8,7 +9,6 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ethers::types::Address;
 use eyre::Result;
 use foundry_common::{compile::ContractSources, evm::Breakpoints};
 use foundry_evm::{
@@ -16,6 +16,7 @@ use foundry_evm::{
     utils::{build_pc_ic_map, PCICMap},
     CallKind,
 };
+use foundry_utils::types::ToAlloy;
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -1048,7 +1049,7 @@ impl Ui for Tui {
                     // address with this pc)
                     if let Some((caller, pc)) = self.breakpoints.get(&c) {
                         for (i, (_caller, debug_steps, _)) in debug_call.iter().enumerate() {
-                            if _caller == caller {
+                            if _caller == &caller.to_alloy() {
                                 if let Some(step) =
                                     debug_steps.iter().position(|step| step.pc == *pc)
                                 {


### PR DESCRIPTION
Removes ethers from the debugger crate and replaces it with alloy.