### PR TITLE
chore(deps): bump `revm`, accomodate new cancun struct changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.37",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +784,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -845,6 +880,19 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "c-kzg"
+version = "0.1.0"
+source = "git+https://github.com/ethereum/c-kzg-4844#fbef59a3f9e8fa998bdb5069d212daf83d586aa5"
+dependencies = [
+ "bindgen",
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
 ]
 
 [[package]]
@@ -947,6 +995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1090,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3904,6 +3972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,6 +3993,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -4730,6 +4814,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5455,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.3.0"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#5845079baf8df56f624a1ecae579a05f8423a2df"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#04395590d58de5351057f51cb84b6172f83f0e7f"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5467,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#5845079baf8df56f624a1ecae579a05f8423a2df"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#04395590d58de5351057f51cb84b6172f83f0e7f"
 dependencies = [
  "derive_more",
  "enumn",
@@ -5478,21 +5568,24 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.0.3"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#5845079baf8df56f624a1ecae579a05f8423a2df"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#04395590d58de5351057f51cb84b6172f83f0e7f"
 dependencies = [
+ "c-kzg",
+ "hex",
  "k256",
  "num",
  "once_cell",
  "revm-primitives",
  "ripemd",
  "sha2 0.10.7",
+ "sha3",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
 version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#5845079baf8df56f624a1ecae579a05f8423a2df"
+source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#04395590d58de5351057f51cb84b6172f83f0e7f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5500,11 +5593,13 @@ dependencies = [
  "bitflags 2.4.0",
  "bitvec",
  "bytes",
+ "c-kzg",
  "derive_more",
  "enumn",
  "hashbrown 0.14.0",
  "hex",
  "hex-literal",
+ "once_cell",
  "primitive-types",
  "serde",
 ]
@@ -5714,6 +5809,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"
@@ -6669,6 +6770,15 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1209,6 +1209,7 @@ impl PendingTransaction {
                     gas_priority_fee: None,
                     gas_limit: gas_limit.as_u64(),
                     access_list: vec![],
+                    ..Default::default()
                 }
             }
             TypedTransaction::EIP2930(tx) => {
@@ -1234,6 +1235,7 @@ impl PendingTransaction {
                     gas_priority_fee: None,
                     gas_limit: gas_limit.as_u64(),
                     access_list: to_revm_access_list(access_list.0.clone()),
+                    ..Default::default()
                 }
             }
             TypedTransaction::EIP1559(tx) => {
@@ -1260,6 +1262,7 @@ impl PendingTransaction {
                     gas_priority_fee: Some(u256_to_ru256(*max_priority_fee_per_gas)),
                     gas_limit: gas_limit.as_u64(),
                     access_list: to_revm_access_list(access_list.0.clone()),
+                    ..Default::default()
                 }
             }
         }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -894,6 +894,7 @@ latest block number: {latest_block}"
                     // Keep previous `coinbase` and `basefee` value
                     coinbase: env.block.coinbase,
                     basefee: env.block.basefee,
+                    ..Default::default()
                 };
 
                 // apply changes such as difficulty -> prevrandao

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -376,6 +376,7 @@ impl Backend {
                     // Keep previous `coinbase` and `basefee` value
                     coinbase: env.block.coinbase,
                     basefee: env.block.basefee,
+                    ..Default::default()
                 };
 
                 self.time.reset(ru256_to_u256(env.block.timestamp).as_u64());
@@ -1035,6 +1036,7 @@ impl Backend {
             chain_id: None,
             nonce: nonce.map(|n| n.as_u64()),
             access_list: to_revm_access_list(access_list.unwrap_or_default()),
+            ..Default::default()
         };
 
         if env.block.basefee == revm::primitives::U256::ZERO {
@@ -1068,6 +1070,7 @@ impl Backend {
                 }
                 EVMError::PrevrandaoNotSet => return Err(BlockchainError::PrevrandaoNotSet),
                 EVMError::Database(e) => return Err(BlockchainError::DatabaseError(e)),
+                EVMError::ExcessBlobGasNotSet => return Err(BlockchainError::ExcessBlobGasNotSet),
             },
         };
         let state = result_and_state.state;
@@ -1594,6 +1597,7 @@ impl Backend {
                                 block.header.base_fee_per_gas.unwrap_or_default(),
                             ),
                             gas_limit: u256_to_ru256(block.header.gas_limit),
+                            ..Default::default()
                         };
                         f(state, block)
                     })
@@ -1621,6 +1625,7 @@ impl Backend {
                         prevrandao: Some(block.header.mix_hash).map(h256_to_b256),
                         basefee: u256_to_ru256(block.header.base_fee_per_gas.unwrap_or_default()),
                         gas_limit: u256_to_ru256(block.header.gas_limit),
+                        ..Default::default()
                     };
                     return Ok(f(Box::new(state), block))
                 }

--- a/crates/evm/src/executor/fork/init.rs
+++ b/crates/evm/src/executor/fork/init.rs
@@ -78,6 +78,7 @@ where
             prevrandao: Some(block.mix_hash.map(h256_to_b256).unwrap_or_default()),
             basefee: u256_to_ru256(block.base_fee_per_gas.unwrap_or_default()),
             gas_limit: u256_to_ru256(block.gas_limit),
+            ..Default::default()
         },
         tx: TxEnv {
             caller: origin,

--- a/crates/evm/src/executor/opts.rs
+++ b/crates/evm/src/executor/opts.rs
@@ -110,6 +110,7 @@ impl EvmOpts {
                 prevrandao: Some(self.env.block_prevrandao),
                 basefee: U256::from(self.env.block_base_fee_per_gas),
                 gas_limit: self.gas_limit(),
+                ..Default::default()
             },
             cfg,
             tx: TxEnv {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Right now cargo deny, clippy and other ci tests might fail because https://github.com/bluealloy/revm/pull/724 was squashed and rebased against revm's master, which implements 4844, and the sha used doesn't exist anymore.

## Solution

- Updates `revm` to use the latest commit on the branch we're using
- Accomodates the new `TxEnv`/`BlockEnv` fields by setting them to default. This should be non-consequential since we're not activating the cancun flag yet.
- Accomodates the new `EVMError`s fields by creating the corresponding tx/blockchain errors on anvil/evm. Should be non-consequential since we're not activating cancun yet.

Albeit both should be fine for current users, it might be the case that things might be misconfigured if ppl e.g solc team / uniswap team wants to test new opcodes @mattsse — so need to confirm if Defaults are okay (i'm referring to `BlockEnv`'s `excess_blob_gas`, and `TxEnv`'s `max_fee_per_blob_gas` specifically)