### PR TITLE
Expose `replace_account_storage` Method In Foundry EVM Backend

### DIFF
--- a/crates/evm/src/executor/backend/mod.rs
+++ b/crates/evm/src/executor/backend/mod.rs
@@ -492,6 +492,22 @@ impl Backend {
         ret
     }
 
+    /// Completely replace an account's storage without overriding account info.
+    ///
+    /// When forking, this causes the backend to assume a `0` value for all
+    /// unset storage slots instead of trying to fetch it.
+    pub fn replace_account_storage(
+        &mut self,
+        address: Address,
+        storage: Map<U256, U256>,
+    ) -> Result<(), DatabaseError> {
+        if let Some(db) = self.active_fork_db_mut() {
+            db.replace_account_storage(address, storage)
+        } else {
+            self.mem_db.replace_account_storage(address, storage)
+        }
+    }
+
     /// Returns all snapshots created in this backend
     pub fn snapshots(&self) -> &Snapshots<BackendSnapshot<BackendDatabaseSnapshot>> {
         &self.inner.snapshots


### PR DESCRIPTION
## Motivation

This PR is a follow up to https://github.com/foundry-rs/foundry/pull/5351 with a similar motivation. Namely, in the aforementioned PR, additional methods were added to `foundry_evm::Backend` in order to facilitate overriding storage slots in the database. However, a method to replace storage that exists on the `CacheDB` was not exposed, which is also useful (and has different semantics to `insert_account_storage` in that it assumes a `0` value for unset slots instead of trying to fetch it from the inner DB).

## Solution

Expose the `replace_account_storage` storage on the `foundry_evm::Backend` in the same vain as the aforementioned PR.

## Additional Notes

For the API, I chose to use `revm::HashMap` instead of the Rust standard library `HashMap`. I'm not 100% sure this is the correct choice here (as I don't really have much context as to why there are multiple hash map types being used).
