### PR TITLE
fix(`cast`): properly bail if no api key is set when fetching storage remotely

### DIFF
--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -120,6 +120,10 @@ impl StorageArgs {
         // Get code from Etherscan
         eprintln!("No matching artifacts found, fetching source code from Etherscan...");
 
+        if self.etherscan.key.is_none() {
+            eyre::bail!("You must provide an Etherscan API key if you're fetching a remote contract's storage.");
+        }
+
         let chain = utils::get_chain(config.chain_id, &provider).await?;
         let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
         let client = Client::new(chain.named()?, api_key)?;


### PR DESCRIPTION
Closes #5750 

we're letting etherscan give a bad message to the user if no api key is set. This properly bails out if we can't fetch from etherscan because there's no api key.
