### PR TITLE
fix: clean watch command from concatenated short flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2361,7 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix 0.38.13",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3788,17 +3788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,7 +3800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.13",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -4046,12 +4035,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5844,20 +5827,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
@@ -5865,7 +5834,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -6686,7 +6655,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.38.13",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -6723,11 +6692,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.37.23",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -7706,7 +7675,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.13",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -788,3 +788,48 @@ async fn test(
     trace!(target: "forge::test", "received {} results", results.len());
     Ok(TestOutcome::new(results, allow_failure))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Sanity test that unknown args are rejected
+    #[test]
+    fn test_verbosity() {
+        #[derive(Debug, Parser)]
+        pub struct VerbosityArgs {
+            #[clap(long, short, action = clap::ArgAction::Count)]
+            verbosity: u8,
+        }
+        let res = VerbosityArgs::try_parse_from(["foundry-cli", "-vw"]);
+        assert!(res.is_err());
+
+        let res = VerbosityArgs::try_parse_from(["foundry-cli", "-vv"]);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_verbosity_multi_short() {
+        #[derive(Debug, Parser)]
+        pub struct VerbosityArgs {
+            #[clap(long, short)]
+            verbosity: bool,
+            #[clap(
+                long,
+                short,
+                num_args(0..),
+                value_name = "PATH",
+            )]
+            watch: Option<Vec<String>>,
+        }
+        // this is supported by clap
+        let res = VerbosityArgs::try_parse_from(["foundry-cli", "-vw"]);
+        assert!(res.is_ok())
+    }
+
+    #[test]
+    fn test_watch_parse() {
+        let args: TestArgs = TestArgs::parse_from(["foundry-cli", "-vw"]);
+        assert!(args.watch.watch.is_some());
+    }
+}

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -263,10 +263,35 @@ fn watch_command(mut args: Vec<String>) -> Command {
 
 /// Returns the env args without the `--watch` flag from the args for the Watchexec command
 fn cmd_args(num: usize) -> Vec<String> {
-    // all the forge arguments including path to forge bin
-    let mut cmd_args: Vec<_> = std::env::args().collect();
+    clean_cmd_args(num, std::env::args().collect())
+}
+fn clean_cmd_args(num: usize, mut cmd_args: Vec<String>) -> Vec<String> {
     if let Some(pos) = cmd_args.iter().position(|arg| arg == "--watch" || arg == "-w") {
         cmd_args.drain(pos..=(pos + num));
+    }
+
+    // There's another edge case where short flags are combined into one which is supported by clap,
+    // like `-vw` for verbosity and watch
+    // this removes any `w` from concatenated short flags
+    if let Some(pos) = cmd_args.iter().position(|arg| {
+        fn contains_w_in_short(arg: &str) -> Option<bool> {
+            let mut iter = arg.chars();
+            if iter.next()? != '-' {
+                return None
+            }
+            if iter.next()? == '-' {
+                return None
+            }
+            Some(iter.any(|c| c == 'w'))
+        }
+        contains_w_in_short(arg).unwrap_or(false)
+    }) {
+        let clean_arg = cmd_args[pos].replace('w', "");
+        if clean_arg == "-" {
+            cmd_args.remove(pos);
+        } else {
+            cmd_args[pos] = clean_arg;
+        }
     }
 
     cmd_args
@@ -412,4 +437,16 @@ pub fn runtime(args: &WatchArgs) -> Result<RuntimeConfig> {
     });
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cmd_args() {
+        let args = vec!["-vw".to_string()];
+        let cleaned = clean_cmd_args(0, args);
+        assert_eq!(cleaned, vec!["-v".to_string()]);
+    }
 }


### PR DESCRIPTION
closes #5684

clap supports concatenated short flags which can lead to recursive watch spawm via `-vw`

this adds another cleanup check to remove any w from these flags