### PR TITLE
feat(`forge`): partial forge migration

### DIFF
--- a/crates/evm/src/coverage/anchors.rs
+++ b/crates/evm/src/coverage/anchors.rs
@@ -1,9 +1,7 @@
 use super::{CoverageItem, CoverageItemKind, ItemAnchor, SourceLocation};
 use crate::utils::ICPCMap;
-use ethers::prelude::{
-    sourcemap::{SourceElement, SourceMap},
-    Bytes,
-};
+use alloy_primitives::Bytes;
+use ethers::prelude::sourcemap::{SourceElement, SourceMap};
 use revm::{
     interpreter::opcode::{self, spec_opcode_gas},
     primitives::SpecId,

--- a/crates/evm/src/coverage/mod.rs
+++ b/crates/evm/src/coverage/mod.rs
@@ -1,8 +1,8 @@
 pub mod analysis;
 pub mod anchors;
 
+use alloy_primitives::B256;
 use bytes::Bytes;
-use ethers::types::H256;
 use semver::Version;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -115,7 +115,7 @@ impl CoverageReport {
 
 /// A collection of [HitMap]s
 #[derive(Default, Clone, Debug)]
-pub struct HitMaps(pub HashMap<H256, HitMap>);
+pub struct HitMaps(pub HashMap<B256, HitMap>);
 
 impl HitMaps {
     pub fn merge(mut self, other: HitMaps) -> Self {
@@ -132,7 +132,7 @@ impl HitMaps {
 }
 
 impl Deref for HitMaps {
-    type Target = HashMap<H256, HitMap>;
+    type Target = HashMap<B256, HitMap>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/evm/src/executor/inspector/coverage.rs
+++ b/crates/evm/src/executor/inspector/coverage.rs
@@ -1,6 +1,5 @@
 use crate::coverage::{HitMap, HitMaps};
 use bytes::Bytes;
-use foundry_utils::types::ToEthers;
 use revm::{
     interpreter::{InstructionResult, Interpreter},
     Database, EVMData, Inspector,
@@ -19,7 +18,7 @@ impl<DB: Database> Inspector<DB> for CoverageCollector {
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
     ) -> InstructionResult {
-        let hash = interpreter.contract.hash.to_ethers();
+        let hash = interpreter.contract.hash;
         self.maps.entry(hash).or_insert_with(|| {
             HitMap::new(Bytes::copy_from_slice(
                 interpreter.contract.bytecode.original_bytecode_slice(),
@@ -35,7 +34,7 @@ impl<DB: Database> Inspector<DB> for CoverageCollector {
         interpreter: &mut Interpreter,
         _: &mut EVMData<'_, DB>,
     ) -> InstructionResult {
-        let hash = interpreter.contract.hash.to_ethers();
+        let hash = interpreter.contract.hash;
         self.maps.entry(hash).and_modify(|map| map.hit(interpreter.program_counter()));
 
         InstructionResult::Continue

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -5,7 +5,6 @@ use ethers::{
     prelude::{artifacts::BytecodeObject, ContractFactory, Middleware, MiddlewareBuilder},
     solc::{info::ContractInfo, utils::canonicalized},
     types::{transaction::eip2718::TypedTransaction, Chain},
-    utils::to_checksum,
 };
 use eyre::{Context, Result};
 use foundry_cli::{
@@ -13,6 +12,7 @@ use foundry_cli::{
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
 use foundry_common::{abi::parse_tokens, compile, estimate_eip1559_fees};
+use foundry_utils::types::ToAlloy;
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc};
 
@@ -268,17 +268,17 @@ impl CreateArgs {
         // Deploy the actual contract
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
 
-        let address = deployed_contract.address();
+        let address = deployed_contract.address().to_alloy();
         if self.json {
             let output = json!({
-                "deployer": to_checksum(&deployer_address, None),
-                "deployedTo": to_checksum(&address, None),
+                "deployer": deployer_address.to_alloy().to_checksum(None),
+                "deployedTo": address.to_checksum(None),
                 "transactionHash": receipt.transaction_hash
             });
             println!("{output}");
         } else {
-            println!("Deployer: {}", to_checksum(&deployer_address, None));
-            println!("Deployed to: {}", to_checksum(&address, None));
+            println!("Deployer: {}", deployer_address.to_alloy().to_checksum(None));
+            println!("Deployed to: {}", address.to_checksum(None));
             println!("Transaction hash: {:?}", receipt.transaction_hash);
         };
 

--- a/crates/forge/bin/cmd/script/broadcast.rs
+++ b/crates/forge/bin/cmd/script/broadcast.rs
@@ -31,11 +31,11 @@ impl ScriptArgs {
         let already_broadcasted = deployment_sequence.receipts.len();
 
         if already_broadcasted < deployment_sequence.transactions.len() {
-            let required_addresses = deployment_sequence
+            let required_addresses: HashSet<Address> = deployment_sequence
                 .typed_transactions()
                 .into_iter()
                 .skip(already_broadcasted)
-                .map(|(_, tx)| *tx.from().expect("No sender for onchain transaction!"))
+                .map(|(_, tx)| (*tx.from().expect("No sender for onchain transaction!")).to_alloy())
                 .collect();
 
             let (send_kind, chain) = if self.unlocked {
@@ -43,22 +43,32 @@ impl ScriptArgs {
                 let mut senders = HashSet::from([self
                     .evm_opts
                     .sender
+                    .map(|sender| sender.to_alloy())
                     .wrap_err("--sender must be set with --unlocked")?]);
                 // also take all additional senders that where set manually via broadcast
                 senders.extend(
                     deployment_sequence
                         .typed_transactions()
                         .iter()
-                        .filter_map(|(_, tx)| tx.from().copied()),
+                        .filter_map(|(_, tx)| tx.from().copied().map(|addr| addr.to_alloy())),
                 );
                 (SendTransactionsKind::Unlocked(senders), chain.as_u64())
             } else {
                 let local_wallets = self
                     .wallets
-                    .find_all(provider.clone(), required_addresses, script_wallets)
+                    .find_all(
+                        provider.clone(),
+                        required_addresses.into_iter().map(|addr| addr.to_ethers()).collect(),
+                        script_wallets,
+                    )
                     .await?;
                 let chain = local_wallets.values().last().wrap_err("Error accessing local wallet when trying to send onchain transaction, did you set a private key, mnemonic or keystore?")?.chain_id();
-                (SendTransactionsKind::Raw(local_wallets), chain)
+                (
+                    SendTransactionsKind::Raw(
+                        local_wallets.into_iter().map(|m| (m.0.to_alloy(), m.1)).collect(),
+                    ),
+                    chain,
+                )
             };
 
             // We only wait for a transaction receipt before sending the next transaction, if there
@@ -91,7 +101,7 @@ impl ScriptArgs {
                 .skip(already_broadcasted)
                 .map(|tx_with_metadata| {
                     let tx = tx_with_metadata.typed_tx();
-                    let from = *tx.from().expect("No sender for onchain transaction!");
+                    let from = (*tx.from().expect("No sender for onchain transaction!")).to_alloy();
 
                     let kind = send_kind.for_sender(&from)?;
                     let is_fixed_gas_limit = tx_with_metadata.is_fixed_gas_limit;
@@ -101,7 +111,7 @@ impl ScriptArgs {
                     tx.set_chain_id(chain);
 
                     if let Some(gas_price) = self.with_gas_price {
-                        tx.set_gas_price(gas_price);
+                        tx.set_gas_price(gas_price.to_ethers());
                     } else {
                         // fill gas price
                         match tx {
@@ -112,7 +122,8 @@ impl ScriptArgs {
                                 let eip1559_fees =
                                     eip1559_fees.expect("Could not get eip1559 fee estimation.");
                                 if let Some(priority_gas_price) = self.priority_gas_price {
-                                    inner.max_priority_fee_per_gas = Some(priority_gas_price);
+                                    inner.max_priority_fee_per_gas =
+                                        Some(priority_gas_price.to_ethers());
                                 } else {
                                     inner.max_priority_fee_per_gas = Some(eip1559_fees.1);
                                 }
@@ -153,13 +164,17 @@ impl ScriptArgs {
 
                     if sequential_broadcast {
                         let tx_hash = tx_hash.await?;
-                        deployment_sequence.add_pending(index, tx_hash);
+                        deployment_sequence.add_pending(index, tx_hash.to_alloy());
 
                         update_progress!(pb, (index + already_broadcasted));
                         index += 1;
 
-                        clear_pendings(provider.clone(), deployment_sequence, Some(vec![tx_hash]))
-                            .await?;
+                        clear_pendings(
+                            provider.clone(),
+                            deployment_sequence,
+                            Some(vec![tx_hash.to_alloy()]),
+                        )
+                        .await?;
                     } else {
                         pending_transactions.push(tx_hash);
                     }
@@ -170,7 +185,7 @@ impl ScriptArgs {
 
                     while let Some(tx_hash) = buffer.next().await {
                         let tx_hash = tx_hash?;
-                        deployment_sequence.add_pending(index, tx_hash);
+                        deployment_sequence.add_pending(index, tx_hash.to_alloy());
 
                         update_progress!(pb, (index + already_broadcasted));
                         index += 1;
@@ -194,16 +209,17 @@ impl ScriptArgs {
         shell::println("\nONCHAIN EXECUTION COMPLETE & SUCCESSFUL.")?;
 
         let (total_gas, total_gas_price, total_paid) = deployment_sequence.receipts.iter().fold(
-            (U256::zero(), U256::zero(), U256::zero()),
+            (U256::ZERO, U256::ZERO, U256::ZERO),
             |acc, receipt| {
-                let gas_used = receipt.gas_used.unwrap_or_default();
-                let gas_price = receipt.effective_gas_price.unwrap_or_default();
+                let gas_used = receipt.gas_used.unwrap_or_default().to_alloy();
+                let gas_price = receipt.effective_gas_price.unwrap_or_default().to_alloy();
                 (acc.0 + gas_used, acc.1 + gas_price, acc.2 + gas_used.mul(gas_price))
             },
         );
-        let paid = format_units(total_paid, 18).unwrap_or_else(|_| "N/A".to_string());
-        let avg_gas_price = format_units(total_gas_price / deployment_sequence.receipts.len(), 9)
-            .unwrap_or_else(|_| "N/A".to_string());
+        let paid = format_units(total_paid.to_ethers(), 18).unwrap_or_else(|_| "N/A".to_string());
+        let avg_gas_price =
+            format_units(total_gas_price.to_ethers() / deployment_sequence.receipts.len(), 9)
+                .unwrap_or_else(|_| "N/A".to_string());
         shell::println(format!(
             "Total Paid: {} ETH ({} gas * avg {} gwei)",
             paid.trim_end_matches('0'),
@@ -226,13 +242,13 @@ impl ScriptArgs {
         let from = tx.from().expect("no sender");
 
         if sequential_broadcast {
-            let nonce = foundry_utils::next_nonce(*from, fork_url, None)
+            let nonce = foundry_utils::next_nonce((*from).to_alloy(), fork_url, None)
                 .await
                 .map_err(|_| eyre::eyre!("Not able to query the EOA nonce."))?;
 
             let tx_nonce = tx.nonce().expect("no nonce");
 
-            if nonce != *tx_nonce {
+            if nonce != (*tx_nonce).to_alloy() {
                 bail!("EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider.")
             }
         }
@@ -493,8 +509,8 @@ impl ScriptArgs {
                     }
                 }
 
-                let total_gas = total_gas_per_rpc.entry(tx_rpc.clone()).or_insert(U256::zero());
-                *total_gas += *typed_tx.gas().expect("gas is set");
+                let total_gas = total_gas_per_rpc.entry(tx_rpc.clone()).or_insert(U256::ZERO);
+                *total_gas += (*typed_tx.gas().expect("gas is set")).to_alloy();
             }
 
             new_sequence.push_back(tx);
@@ -543,7 +559,7 @@ impl ScriptArgs {
 
                 shell::println(format!(
                     "\nEstimated gas price: {} gwei",
-                    format_units(per_gas, 9)
+                    format_units(per_gas.to_ethers(), 9)
                         .unwrap_or_else(|_| "[Could not calculate]".to_string())
                         .trim_end_matches('0')
                         .trim_end_matches('.')
@@ -551,7 +567,7 @@ impl ScriptArgs {
                 shell::println(format!("\nEstimated total gas used for script: {total_gas}"))?;
                 shell::println(format!(
                     "\nEstimated amount required: {} ETH",
-                    format_units(total_gas.saturating_mul(per_gas), 18)
+                    format_units(total_gas.saturating_mul(per_gas).to_ethers(), 18)
                         .unwrap_or_else(|_| "[Could not calculate]".to_string())
                         .trim_end_matches('0')
                 ))?;

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloy_primitives::{Address, Bytes, U256};
 use ethers::{
     prelude::{
         artifacts::Libraries, cache::SolFilesCache, ArtifactId, Project, ProjectCompileOutput,
@@ -8,7 +9,6 @@ use ethers::{
         contracts::ArtifactContracts,
         info::ContractInfo,
     },
-    types::{Address, U256},
 };
 use eyre::{Context, ContextCompat, Result};
 use foundry_cli::utils::get_cached_entry_by_name;
@@ -16,7 +16,7 @@ use foundry_common::{
     compact_to_contract,
     compile::{self, ContractSources},
 };
-use foundry_utils::{types::ToEthers, PostLinkInput, ResolvedDependency};
+use foundry_utils::{PostLinkInput, ResolvedDependency};
 use std::{collections::BTreeMap, fs, str::FromStr};
 use tracing::{trace, warn};
 
@@ -64,7 +64,7 @@ impl ScriptArgs {
             project,
             contracts,
             script_config.config.parsed_libraries()?,
-            script_config.evm_opts.sender.to_ethers(),
+            script_config.evm_opts.sender,
             script_config.sender_nonce,
         )?;
 
@@ -272,7 +272,7 @@ struct ExtraLinkingInfo<'a> {
     no_target_name: bool,
     target_fname: String,
     contract: &'a mut CompactContractBytecode,
-    dependencies: &'a mut Vec<(String, ethers::types::Bytes)>,
+    dependencies: &'a mut Vec<(String, Bytes)>,
     matched: bool,
     target_id: Option<ArtifactId>,
 }
@@ -284,6 +284,6 @@ pub struct BuildOutput {
     pub known_contracts: ArtifactContracts,
     pub highlevel_known_contracts: ArtifactContracts<ContractBytecodeSome>,
     pub libraries: Libraries,
-    pub predeploy_libraries: Vec<ethers::types::Bytes>,
+    pub predeploy_libraries: Vec<Bytes>,
     pub sources: ContractSources,
 }

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -4,9 +4,9 @@ use super::{
     transaction::{AdditionalContract, TransactionWithMetadata},
     *,
 };
+use alloy_primitives::{Address, Bytes, U256};
 use ethers::{
-    solc::artifacts::CompactContractBytecode,
-    types::{transaction::eip2718::TypedTransaction, Address, U256},
+    solc::artifacts::CompactContractBytecode, types::transaction::eip2718::TypedTransaction,
 };
 use eyre::Result;
 use forge::{
@@ -37,7 +37,7 @@ impl ScriptArgs {
         script_config: &mut ScriptConfig,
         contract: CompactContractBytecode,
         sender: Address,
-        predeploy_libraries: &[ethers::types::Bytes],
+        predeploy_libraries: &[Bytes],
     ) -> Result<ScriptResult> {
         trace!(target: "script", "start executing script");
 
@@ -48,10 +48,12 @@ impl ScriptArgs {
 
         ensure_clean_constructor(&abi)?;
 
+        let predeploy_libraries =
+            predeploy_libraries.iter().map(|b| b.0.clone().into()).collect::<Vec<_>>();
         let mut runner = self.prepare_runner(script_config, sender, SimulationStage::Local).await;
         let (address, mut result) = runner.setup(
-            predeploy_libraries,
-            bytecode,
+            &predeploy_libraries,
+            bytecode.0.into(),
             needs_setup(&abi),
             script_config.sender_nonce,
             self.broadcast,
@@ -63,7 +65,7 @@ impl ScriptArgs {
 
         // Only call the method if `setUp()` succeeded.
         if result.success {
-            let script_result = runner.script(address, calldata)?;
+            let script_result = runner.script(address, calldata.0.into())?;
 
             result.success &= script_result.success;
             result.gas_used = script_result.gas_used;
@@ -127,7 +129,7 @@ impl ScriptArgs {
                         abi,
                         code,
                     };
-                    return Some((*addr, info))
+                    return Some(((*addr).to_alloy(), info))
                 }
                 None
             })
@@ -136,78 +138,81 @@ impl ScriptArgs {
         let mut final_txs = VecDeque::new();
 
         // Executes all transactions from the different forks concurrently.
-        let futs = transactions
-            .into_iter()
-            .map(|transaction| async {
-                let mut runner = runners
-                    .get(transaction.rpc.as_ref().expect("to have been filled already."))
-                    .expect("to have been built.")
-                    .write();
+        let futs =
+            transactions
+                .into_iter()
+                .map(|transaction| async {
+                    let mut runner = runners
+                        .get(transaction.rpc.as_ref().expect("to have been filled already."))
+                        .expect("to have been built.")
+                        .write();
 
-                if let TypedTransaction::Legacy(mut tx) = transaction.transaction {
-                    let result = runner
+                    if let TypedTransaction::Legacy(mut tx) = transaction.transaction {
+                        let result = runner
                         .simulate(
                             tx.from.expect(
                                 "Transaction doesn't have a `from` address at execution time",
-                            ),
+                            ).to_alloy(),
                             tx.to.clone(),
-                            tx.data.clone(),
-                            tx.value,
+                            tx.data.clone().map(|b| b.0.into()),
+                            tx.value.map(|v| v.to_alloy()),
                         )
                         .expect("Internal EVM error");
 
-                    if !result.success || result.traces.is_empty() {
-                        return Ok((None, result.traces))
-                    }
+                        if !result.success || result.traces.is_empty() {
+                            return Ok((None, result.traces))
+                        }
 
-                    let created_contracts = result
-                        .traces
-                        .iter()
-                        .flat_map(|(_, traces)| {
-                            traces.arena.iter().filter_map(|node| {
-                                if matches!(node.kind(), CallKind::Create | CallKind::Create2) {
-                                    return Some(AdditionalContract {
-                                        opcode: node.kind(),
-                                        address: node.trace.address,
-                                        init_code: node.trace.data.to_raw(),
-                                    })
-                                }
-                                None
+                        let created_contracts = result
+                            .traces
+                            .iter()
+                            .flat_map(|(_, traces)| {
+                                traces.arena.iter().filter_map(|node| {
+                                    if matches!(node.kind(), CallKind::Create | CallKind::Create2) {
+                                        return Some(AdditionalContract {
+                                            opcode: node.kind(),
+                                            address: node.trace.address.to_alloy(),
+                                            init_code: node.trace.data.to_raw(),
+                                        })
+                                    }
+                                    None
+                                })
                             })
-                        })
-                        .collect();
+                            .collect();
 
-                    // Simulate mining the transaction if the user passes `--slow`.
-                    if self.slow {
-                        runner.executor.env.block.number += rU256::from(1);
-                    }
+                        // Simulate mining the transaction if the user passes `--slow`.
+                        if self.slow {
+                            runner.executor.env.block.number += rU256::from(1);
+                        }
 
-                    let is_fixed_gas_limit = tx.gas.is_some();
-                    // If tx.gas is already set that means it was specified in script
-                    if !is_fixed_gas_limit {
-                        // We inflate the gas used by the user specified percentage
-                        tx.gas =
-                            Some(U256::from(result.gas_used * self.gas_estimate_multiplier / 100));
+                        let is_fixed_gas_limit = tx.gas.is_some();
+                        // If tx.gas is already set that means it was specified in script
+                        if !is_fixed_gas_limit {
+                            // We inflate the gas used by the user specified percentage
+                            tx.gas = Some(
+                                U256::from(result.gas_used * self.gas_estimate_multiplier / 100)
+                                    .to_ethers(),
+                            );
+                        } else {
+                            println!("Gas limit was set in script to {:}", tx.gas.unwrap());
+                        }
+
+                        let tx = TransactionWithMetadata::new(
+                            tx.into(),
+                            transaction.rpc,
+                            &result,
+                            &address_to_abi,
+                            decoder,
+                            created_contracts,
+                            is_fixed_gas_limit,
+                        )?;
+
+                        Ok((Some(tx), result.traces))
                     } else {
-                        println!("Gas limit was set in script to {:}", tx.gas.unwrap());
+                        unreachable!()
                     }
-
-                    let tx = TransactionWithMetadata::new(
-                        tx.into(),
-                        transaction.rpc,
-                        &result,
-                        &address_to_abi,
-                        decoder,
-                        created_contracts,
-                        is_fixed_gas_limit,
-                    )?;
-
-                    Ok((Some(tx), result.traces))
-                } else {
-                    unreachable!()
-                }
-            })
-            .collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
 
         let mut abort = false;
         for res in join_all(futs).await {
@@ -262,12 +267,7 @@ impl ScriptArgs {
 
                 (
                     rpc.clone(),
-                    self.prepare_runner(
-                        &mut script_config,
-                        sender.to_ethers(),
-                        SimulationStage::OnChain,
-                    )
-                    .await,
+                    self.prepare_runner(&mut script_config, sender, SimulationStage::OnChain).await,
                 )
             })
             .collect::<Vec<_>>();
@@ -322,10 +322,6 @@ impl ScriptArgs {
             });
         }
 
-        ScriptRunner::new(
-            builder.build(env, db),
-            script_config.evm_opts.initial_balance.to_ethers(),
-            sender,
-        )
+        ScriptRunner::new(builder.build(env, db), script_config.evm_opts.initial_balance, sender)
     }
 }

--- a/crates/forge/bin/cmd/script/providers.rs
+++ b/crates/forge/bin/cmd/script/providers.rs
@@ -1,7 +1,9 @@
-use ethers::prelude::{Middleware, Provider, U256};
+use alloy_primitives::U256;
+use ethers::prelude::{Middleware, Provider};
 use eyre::{Result, WrapErr};
 use foundry_common::{get_http_provider, runtime_client::RuntimeClient, RpcUrl};
 use foundry_config::Chain;
+use foundry_utils::types::ToAlloy;
 use std::{
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
@@ -66,11 +68,19 @@ impl ProviderInfo {
 
         let gas_price = if is_legacy {
             GasPrice::Legacy(
-                provider.get_gas_price().await.wrap_err("Failed to get legacy gas price"),
+                provider
+                    .get_gas_price()
+                    .await
+                    .wrap_err("Failed to get legacy gas price")
+                    .map(|p| p.to_alloy()),
             )
         } else {
             GasPrice::EIP1559(
-                provider.estimate_eip1559_fees(None).await.wrap_err("Failed to get EIP-1559 fees"),
+                provider
+                    .estimate_eip1559_fees(None)
+                    .await
+                    .wrap_err("Failed to get EIP-1559 fees")
+                    .map(|p| (p.0.to_alloy(), p.1.to_alloy())),
             )
         };
 

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -1,16 +1,12 @@
 use super::{artifacts::ArtifactInfo, ScriptResult};
-use ethers::{
-    abi,
-    abi::Address,
-    prelude::{NameOrAddress, H256 as TxHash},
-    types::transaction::eip2718::TypedTransaction,
-};
+use alloy_primitives::{Address, B256};
+use ethers::{abi, prelude::NameOrAddress, types::transaction::eip2718::TypedTransaction};
 use eyre::{ContextCompat, Result, WrapErr};
 use foundry_common::{abi::format_token_raw, RpcUrl, SELECTOR_LEN};
 use foundry_evm::{
     executor::inspector::DEFAULT_CREATE2_DEPLOYER, trace::CallTraceDecoder, CallKind,
 };
-use foundry_utils::types::ToAlloy;
+use foundry_utils::types::{ToAlloy, ToEthers};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tracing::error;
@@ -29,7 +25,7 @@ pub struct AdditionalContract {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionWithMetadata {
-    pub hash: Option<TxHash>,
+    pub hash: Option<B256>,
     #[serde(rename = "transactionType")]
     pub opcode: CallKind,
     #[serde(default = "default_string")]
@@ -52,7 +48,7 @@ fn default_string() -> Option<String> {
 }
 
 fn default_address() -> Option<Address> {
-    Some(Address::zero())
+    Some(Address::ZERO)
 }
 
 fn default_vec_of_strings() -> Option<Vec<String>> {
@@ -86,7 +82,7 @@ impl TransactionWithMetadata {
                 )?;
             } else {
                 metadata
-                    .set_call(to, local_contracts, decoder)
+                    .set_call(to.to_alloy(), local_contracts, decoder)
                     .wrap_err("Could not decode transaction type.")?;
             }
         } else if metadata.transaction.to().is_none() {
@@ -234,7 +230,7 @@ impl TransactionWithMetadata {
                         .get(&data.0[..SELECTOR_LEN])
                         .map(|functions| functions.first())
                     {
-                        self.contract_name = decoder.contracts.get(&target).cloned();
+                        self.contract_name = decoder.contracts.get(&target.to_ethers()).cloned();
 
                         self.function = Some(function.signature());
                         self.arguments = Some(
@@ -288,7 +284,7 @@ pub mod wrapper {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&to_checksum(addr, None))
+        serializer.serialize_str(&to_checksum(&addr.to_ethers(), None))
     }
 
     pub fn serialize_opt_addr<S>(opt: &Option<Address>, serializer: S) -> Result<S::Ok, S::Error>
@@ -373,7 +369,7 @@ pub mod wrapper {
     impl From<Log> for WrappedLog {
         fn from(log: Log) -> Self {
             Self {
-                address: log.address,
+                address: log.address.to_alloy(),
                 topics: log.topics,
                 data: log.data,
                 block_hash: log.block_hash,
@@ -455,11 +451,11 @@ pub mod wrapper {
                 transaction_index: receipt.transaction_index,
                 block_hash: receipt.block_hash,
                 block_number: receipt.block_number,
-                from: receipt.from,
-                to: receipt.to,
+                from: receipt.from.to_alloy(),
+                to: receipt.to.map(|addr| addr.to_alloy()),
                 cumulative_gas_used: receipt.cumulative_gas_used,
                 gas_used: receipt.gas_used,
-                contract_address: receipt.contract_address,
+                contract_address: receipt.contract_address.map(|addr| addr.to_alloy()),
                 logs: receipt.logs,
                 status: receipt.status,
                 root: receipt.root,

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -2,10 +2,8 @@ use crate::cmd::{
     retry::RetryArgs,
     verify::{VerifierArgs, VerifyArgs},
 };
-use ethers::{
-    abi::Address,
-    solc::{info::ContractInfo, Project},
-};
+use alloy_primitives::Address;
+use ethers::solc::{info::ContractInfo, Project};
 use foundry_cli::opts::{EtherscanOpts, ProjectPathsArgs};
 use foundry_common::ContractsByArtifact;
 use foundry_config::{Chain, Config};

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -2,8 +2,8 @@ use super::{
     test,
     test::{Test, TestOutcome},
 };
+use alloy_primitives::U256;
 use clap::{builder::RangedU64ValueParser, Parser, ValueHint};
-use ethers::types::U256;
 use eyre::{Context, Result};
 use forge::result::TestKindReport;
 use foundry_cli::utils::STATIC_FUZZ_SEED;
@@ -98,7 +98,7 @@ impl SnapshotArgs {
 
     pub async fn run(mut self) -> Result<()> {
         // Set fuzz seed so gas snapshots are deterministic
-        self.test.fuzz_seed = Some(U256::from_big_endian(&STATIC_FUZZ_SEED));
+        self.test.fuzz_seed = Some(U256::from_be_bytes(STATIC_FUZZ_SEED));
 
         let outcome = self.test.execute_tests().await?;
         outcome.ensure_ok()?;

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -1,6 +1,6 @@
 use super::{install, test::filter::ProjectPathsAwareFilter, watch::WatchArgs};
+use alloy_primitives::U256;
 use clap::Parser;
-use ethers::types::U256;
 use eyre::Result;
 use forge::{
     decode::decode_console_logs,
@@ -33,7 +33,6 @@ use foundry_config::{
 };
 use foundry_debugger::DebuggerArgs;
 use foundry_evm::fuzz::CounterExample;
-use foundry_utils::types::ToEthers;
 use regex::Regex;
 use std::{collections::BTreeMap, fs, sync::mpsc::channel, time::Duration};
 use tracing::trace;
@@ -184,9 +183,9 @@ impl TestArgs {
 
         let mut runner_builder = MultiContractRunnerBuilder::default()
             .set_debug(should_debug)
-            .initial_balance(evm_opts.initial_balance.to_ethers())
+            .initial_balance(evm_opts.initial_balance)
             .evm_spec(config.evm_spec_id())
-            .sender(evm_opts.sender.to_ethers())
+            .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, &evm_opts))
             .with_test_options(test_options.clone());

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -15,7 +15,7 @@ use eyre::{eyre, Context, Result};
 use foundry_cli::utils::{get_cached_entry_by_name, read_constructor_args_file, LoadConfig};
 use foundry_common::abi::encode_args;
 use foundry_config::{Chain, Config, SolcReq};
-use foundry_utils::Retry;
+use foundry_utils::{types::ToEthers, Retry};
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -119,7 +119,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
         {}",
                 resp.message,
                 resp.result,
-                etherscan.address_url(args.address)
+                etherscan.address_url(args.address.to_ethers())
             );
 
             if args.watch {
@@ -312,7 +312,7 @@ impl EtherscanVerificationProvider {
         let compiler_version = format!("v{}", ensure_solc_build_metadata(compiler_version).await?);
         let constructor_args = self.constructor_args(args, &project)?;
         let mut verify_args =
-            VerifyContract::new(args.address, contract_name, source, compiler_version)
+            VerifyContract::new(args.address.to_ethers(), contract_name, source, compiler_version)
                 .constructor_arguments(constructor_args)
                 .code_format(code_format);
 

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -1,6 +1,7 @@
 use super::retry::RetryArgs;
+use alloy_primitives::Address;
 use clap::{Parser, ValueHint};
-use ethers::{abi::Address, solc::info::ContractInfo};
+use ethers::solc::info::ContractInfo;
 use eyre::Result;
 use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_config::{figment, impl_figment_convert, impl_figment_convert_cast, Config};

--- a/crates/forge/bin/cmd/verify/sourcify.rs
+++ b/crates/forge/bin/cmd/verify/sourcify.rs
@@ -1,6 +1,6 @@
 use super::{provider::VerificationProvider, VerifyArgs, VerifyCheckArgs};
 use async_trait::async_trait;
-use ethers::{solc::ConfigurableContractArtifact, utils::to_checksum};
+use ethers::solc::ConfigurableContractArtifact;
 use eyre::Result;
 use foundry_cli::utils::{get_cached_entry_by_name, LoadConfig};
 use foundry_common::fs;
@@ -38,7 +38,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     println!(
                         "\nSubmitting verification for [{}] {:?}.",
                         args.contract.name,
-                        to_checksum(&args.address, None)
+                        args.address.to_checksum(None)
                     );
                     let response = client
                         .post(args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL))

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -1,9 +1,9 @@
 use crate::{result::SuiteResult, ContractRunner, TestFilter, TestOptions};
+use alloy_primitives::{Address, Bytes, U256};
 use ethers::{
     abi::{Abi, Function},
     prelude::{artifacts::CompactContractBytecode, ArtifactId, ArtifactOutput},
     solc::{contracts::ArtifactContracts, Artifact, ProjectCompileOutput},
-    types::{Address, Bytes, U256},
 };
 use eyre::Result;
 use foundry_common::{ContractsByArtifact, TestFunctionExt};
@@ -202,15 +202,16 @@ impl MultiContractRunner {
         filter: impl TestFilter,
         test_options: TestOptions,
     ) -> SuiteResult {
+        let libs = libs.iter().map(|l| l.0.clone().into()).collect::<Vec<_>>();
         let runner = ContractRunner::new(
             name,
             executor,
             contract,
-            deploy_code,
+            deploy_code.0.into(),
             self.evm_opts.initial_balance.to_ethers(),
-            self.sender,
+            self.sender.map(|a| a.to_ethers()),
             self.errors.as_ref(),
-            libs,
+            &libs,
             self.debug,
         );
         runner.run_tests(filter, test_options, Some(&self.known_contracts))
@@ -285,8 +286,8 @@ impl MultiContractRunnerBuilder {
             ArtifactContracts::from_iter(contracts),
             &mut known_contracts,
             Default::default(),
-            evm_opts.sender.to_ethers(),
-            U256::one(),
+            evm_opts.sender,
+            U256::from(1),
             &mut deployable_contracts,
             |post_link_input| {
                 let PostLinkInput {
@@ -318,8 +319,11 @@ impl MultiContractRunnerBuilder {
                         id.clone(),
                         (
                             abi.clone(),
-                            bytecode,
-                            dependencies.into_iter().map(|dep| dep.bytecode).collect::<Vec<_>>(),
+                            bytecode.0.into(),
+                            dependencies
+                                .into_iter()
+                                .map(|dep| dep.bytecode.0.into())
+                                .collect::<Vec<_>>(),
                         ),
                     );
                 }

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -14,7 +14,7 @@ use foundry_config::{
 use foundry_evm::{
     decode::decode_console_logs, executor::inspector::CheatsConfig, revm::primitives::SpecId,
 };
-use foundry_utils::types::ToEthers;
+use foundry_utils::types::ToAlloy;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -144,7 +144,7 @@ pub fn manifest_root() -> PathBuf {
 
 /// Builds a base runner
 pub fn base_runner() -> MultiContractRunnerBuilder {
-    MultiContractRunnerBuilder::default().sender(EVM_OPTS.sender.to_ethers())
+    MultiContractRunnerBuilder::default().sender(EVM_OPTS.sender)
 }
 
 /// Builds a non-tracing runner
@@ -161,7 +161,7 @@ pub async fn runner_with_config(mut config: Config) -> MultiContractRunner {
 
     base_runner()
         .with_cheats_config(CheatsConfig::new(&config, &EVM_OPTS))
-        .sender(config.sender)
+        .sender(config.sender.to_alloy())
         .build(
             &PROJECT.paths.root,
             (*COMPILED).clone(),


### PR DESCRIPTION
Migrates forge's primitive types to alloy. Types remaining from `ethers` are `solc`, `etherscan` and `rpc` related unless highlighted for discussion.