### PR TITLE
feat(`test-utils`: partially migrate test-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,11 +2771,13 @@ dependencies = [
 name = "foundry-test-utils"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "ethers",
  "ethers-solc",
  "eyre",
  "foundry-common",
  "foundry-config",
+ "foundry-utils",
  "once_cell",
  "parking_lot",
  "pretty_assertions",

--- a/crates/forge/tests/cli/multi_script.rs
+++ b/crates/forge/tests/cli/multi_script.rs
@@ -5,6 +5,7 @@ use foundry_test_utils::{
     util::{TestCommand, TestProject},
     ScriptOutcome, ScriptTester,
 };
+use foundry_utils::types::ToEthers;
 
 forgetest_async!(
     can_deploy_multi_chain_script_without_lib,
@@ -20,11 +21,35 @@ forgetest_async!(
             .args(vec![handle1.http_endpoint(), handle2.http_endpoint()])
             .broadcast(ScriptOutcome::OkBroadcast);
 
-        assert!(1 == api1.transaction_count(tester.accounts_pub[0], None).await.unwrap().as_u32());
-        assert!(1 == api1.transaction_count(tester.accounts_pub[1], None).await.unwrap().as_u32());
+        assert!(
+            1 == api1
+                .transaction_count(tester.accounts_pub[0].to_ethers(), None)
+                .await
+                .unwrap()
+                .as_u32()
+        );
+        assert!(
+            1 == api1
+                .transaction_count(tester.accounts_pub[1].to_ethers(), None)
+                .await
+                .unwrap()
+                .as_u32()
+        );
 
-        assert!(2 == api2.transaction_count(tester.accounts_pub[0], None).await.unwrap().as_u32());
-        assert!(3 == api2.transaction_count(tester.accounts_pub[1], None).await.unwrap().as_u32());
+        assert!(
+            2 == api2
+                .transaction_count(tester.accounts_pub[0].to_ethers(), None)
+                .await
+                .unwrap()
+                .as_u32()
+        );
+        assert!(
+            3 == api2
+                .transaction_count(tester.accounts_pub[1].to_ethers(), None)
+                .await
+                .unwrap()
+                .as_u32()
+        );
     }
 );
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -8,7 +8,7 @@ use foundry_test_utils::{
     util::{OutputExt, TestCommand, TestProject},
     ScriptOutcome, ScriptTester,
 };
-use foundry_utils::rpc;
+use foundry_utils::{rpc, types::ToAlloy};
 use regex::Regex;
 use serde_json::Value;
 use std::{env, path::PathBuf, str::FromStr};
@@ -456,15 +456,15 @@ forgetest_async!(
         let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
 
         tester
-            .load_addresses(vec![
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()
-            ])
+            .load_addresses(vec![Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906")
+                .unwrap()
+                .to_alloy()])
             .await
             .add_sig("BroadcastTest", "deployPrivateKey()")
             .simulate(ScriptOutcome::OkSimulation)
             .broadcast(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment_addresses(vec![(
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap(),
+                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap().to_alloy(),
                 3,
             )])
             .await;
@@ -495,15 +495,15 @@ forgetest_async!(
         let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
 
         tester
-            .load_addresses(vec![
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()
-            ])
+            .load_addresses(vec![Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906")
+                .unwrap()
+                .to_alloy()])
             .await
             .add_sig("BroadcastTest", "deployRememberKey()")
             .simulate(ScriptOutcome::OkSimulation)
             .broadcast(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment_addresses(vec![(
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap(),
+                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap().to_alloy(),
                 2,
             )])
             .await;
@@ -519,9 +519,9 @@ forgetest_async!(
 
         tester
             .add_deployer(0)
-            .load_addresses(vec![
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap()
-            ])
+            .load_addresses(vec![Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906")
+                .unwrap()
+                .to_alloy()])
             .await
             .add_sig("BroadcastTest", "deployRememberKeyResume()")
             .simulate(ScriptOutcome::OkSimulation)
@@ -531,7 +531,7 @@ forgetest_async!(
             .await
             .run(ScriptOutcome::OkBroadcast)
             .assert_nonce_increment_addresses(vec![(
-                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap(),
+                Address::from_str("0x90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap().to_alloy(),
                 1,
             )])
             .await

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -14,9 +14,11 @@ repository.workspace = true
 [dependencies]
 foundry-config.workspace = true
 foundry-common.workspace = true
+foundry-utils.workspace = true
 
 ethers.workspace = true
 ethers-solc = { workspace = true, features = ["project-util"] }
+alloy-primitives = { workspace = true, features = ["std"]}
 
 eyre = "0.6"
 once_cell = "1"

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -1,11 +1,9 @@
 use crate::TestCommand;
-use ethers::{
-    abi::Address,
-    prelude::{Middleware, NameOrAddress, U256},
-    utils::hex,
-};
+use alloy_primitives::{hex, Address, U256};
+use ethers::prelude::{Middleware, NameOrAddress};
 use eyre::Result;
 use foundry_common::{get_http_provider, RetryProvider};
+use foundry_utils::types::{ToAlloy, ToEthers};
 use std::{collections::BTreeMap, path::Path, str::FromStr};
 
 pub const BROADCAST_TEST_PATH: &str = "src/Broadcast.t.sol";
@@ -112,12 +110,12 @@ impl ScriptTester {
             if let Some(provider) = &self.provider {
                 let nonce = provider
                     .get_transaction_count(
-                        NameOrAddress::Address(self.accounts_pub[index as usize]),
+                        NameOrAddress::Address(self.accounts_pub[index as usize].to_ethers()),
                         None,
                     )
                     .await
                     .unwrap();
-                self.nonces.insert(index, nonce);
+                self.nonces.insert(index, nonce.to_alloy());
             }
         }
         self
@@ -129,10 +127,10 @@ impl ScriptTester {
                 .provider
                 .as_ref()
                 .unwrap()
-                .get_transaction_count(NameOrAddress::Address(address), None)
+                .get_transaction_count(NameOrAddress::Address(address.to_ethers()), None)
                 .await
                 .unwrap();
-            self.address_nonces.insert(address, nonce);
+            self.address_nonces.insert(address, nonce.to_alloy());
         }
         self
     }
@@ -140,7 +138,7 @@ impl ScriptTester {
     pub fn add_deployer(&mut self, index: u32) -> &mut Self {
         self.cmd.args([
             "--sender",
-            &format!("0x{}", hex::encode(self.accounts_pub[index as usize].as_bytes())),
+            &format!("0x{}", hex::encode(self.accounts_pub[index as usize].to_ethers())),
         ]);
         self
     }
@@ -184,14 +182,16 @@ impl ScriptTester {
                 .as_ref()
                 .unwrap()
                 .get_transaction_count(
-                    NameOrAddress::Address(self.accounts_pub[private_key_slot as usize]),
+                    NameOrAddress::Address(
+                        self.accounts_pub[private_key_slot as usize].to_ethers(),
+                    ),
                     None,
                 )
                 .await
                 .unwrap();
             let prev_nonce = self.nonces.get(&private_key_slot).unwrap();
 
-            assert_eq!(nonce, prev_nonce + U256::from(expected_increment));
+            assert_eq!(nonce, (prev_nonce + U256::from(expected_increment)).to_ethers());
         }
         self
     }
@@ -206,12 +206,12 @@ impl ScriptTester {
                 .provider
                 .as_ref()
                 .unwrap()
-                .get_transaction_count(NameOrAddress::Address(address), None)
+                .get_transaction_count(NameOrAddress::Address(address.to_ethers()), None)
                 .await
                 .unwrap();
             let prev_nonce = self.address_nonces.get(&address).unwrap();
 
-            assert_eq!(nonce, prev_nonce + U256::from(expected_increment));
+            assert_eq!(nonce, (prev_nonce + U256::from(expected_increment)).to_ethers());
         }
         self
     }


### PR DESCRIPTION
Migrates the test-utils crate. As with most crates, there are a few `ethers_solc`/`rpc` types left.