### PR TITLE
docs(`contributing`): add note about using a debugger with foundry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,8 @@ If you are working on a larger feature, we encourage you to open up a draft pull
 
 If you would like to test the binaries built from your change, see [foundryup](https://github.com/foundry-rs/foundry/tree/master/foundryup).
 
+If you would like to use a debugger with breakpoints to debug a patch you might be working on, keep in mind we currently strip debug info for faster builds, which is *not* the default. Therefore, to use a debugger, you need to enable it on the workspace `Cargo.toml`'s `dev` profile.
+
 #### Adding tests
 
 If the change being proposed alters code, it is either adding new functionality to Foundry, or fixing existing, broken functionality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ If you are working on a larger feature, we encourage you to open up a draft pull
 
 If you would like to test the binaries built from your change, see [foundryup](https://github.com/foundry-rs/foundry/tree/master/foundryup).
 
-If you would like to use a debugger with breakpoints to debug a patch you might be working on, keep in mind we currently strip debug info for faster builds, which is *not* the default. Therefore, to use a debugger, you need to enable it on the workspace `Cargo.toml`'s `dev` profile.
+If you would like to use a debugger with breakpoints to debug a patch you might be working on, keep in mind we currently strip debug info for faster builds, which is *not* the default. Therefore, to use a debugger, you need to enable it on the workspace [`Cargo.toml`'s `dev` profile](https://github.com/foundry-rs/foundry/tree/master/Cargo.toml#L15-L18).
 
 #### Adding tests
 


### PR DESCRIPTION
Adds a small note to `CONTRIBUTING.md` illustrating that we currently strip debug info on the default debug build, and should be re-enabled if a contributor wanted to use a debugger.