### PR TITLE
chore(`test`): ensure decoder building occurs only when `--debug` is present

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -227,69 +227,71 @@ impl TestArgs {
         let outcome = self
             .run_tests(runner, config.clone(), verbosity, filter.clone(), test_options.clone())
             .await?;
-        let tests = outcome.clone().into_tests();
-
-        let mut decoded_traces = Vec::new();
-        let mut decoders = Vec::new();
-        for test in tests {
-            let mut result = test.result;
-            // Identify addresses in each trace
-            let mut builder = CallTraceDecoderBuilder::new()
-                .with_labels(result.labeled_addresses.clone())
-                .with_events(local_identifier.events().cloned())
-                .with_verbosity(verbosity);
-
-            // Signatures are of no value for gas reports
-            if !self.gas_report {
-                let sig_identifier =
-                    SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
-                builder = builder.with_signature_identifier(sig_identifier.clone());
-            }
-
-            let mut decoder = builder.build();
-
-            if !result.traces.is_empty() {
-                // Set up identifiers
-                // Do not re-query etherscan for contracts that you've already queried today.
-                let mut etherscan_identifier = EtherscanIdentifier::new(&config, remote_chain_id)?;
-
-                // Decode the traces
-                for (kind, trace) in &mut result.traces {
-                    decoder.identify(trace, &mut local_identifier);
-                    decoder.identify(trace, &mut etherscan_identifier);
-
-                    let should_include = match kind {
-                        // At verbosity level 3, we only display traces for failed tests
-                        // At verbosity level 4, we also display the setup trace for failed
-                        // tests At verbosity level 5, we display
-                        // all traces for all tests
-                        TraceKind::Setup => {
-                            (verbosity >= 5) ||
-                                (verbosity == 4 && result.status == TestStatus::Failure)
-                        }
-                        TraceKind::Execution => {
-                            verbosity > 3 ||
-                                (verbosity == 3 && result.status == TestStatus::Failure)
-                        }
-                        _ => false,
-                    };
-
-                    // We decode the trace if we either need to build a gas report or we need
-                    // to print it
-                    if should_include || self.gas_report {
-                        decoder.decode(trace).await;
-                    }
-
-                    if should_include {
-                        decoded_traces.push(trace.to_string());
-                    }
-                }
-            }
-
-            decoders.push(decoder);
-        }
 
         if should_debug {
+            let tests = outcome.clone().into_tests();
+
+            let mut decoded_traces = Vec::new();
+            let mut decoders = Vec::new();
+            for test in tests {
+                let mut result = test.result;
+                // Identify addresses in each trace
+                let mut builder = CallTraceDecoderBuilder::new()
+                    .with_labels(result.labeled_addresses.clone())
+                    .with_events(local_identifier.events().cloned())
+                    .with_verbosity(verbosity);
+
+                // Signatures are of no value for gas reports
+                if !self.gas_report {
+                    let sig_identifier =
+                        SignaturesIdentifier::new(Config::foundry_cache_dir(), config.offline)?;
+                    builder = builder.with_signature_identifier(sig_identifier.clone());
+                }
+
+                let mut decoder = builder.build();
+
+                if !result.traces.is_empty() {
+                    // Set up identifiers
+                    // Do not re-query etherscan for contracts that you've already queried today.
+                    let mut etherscan_identifier =
+                        EtherscanIdentifier::new(&config, remote_chain_id)?;
+
+                    // Decode the traces
+                    for (kind, trace) in &mut result.traces {
+                        decoder.identify(trace, &mut local_identifier);
+                        decoder.identify(trace, &mut etherscan_identifier);
+
+                        let should_include = match kind {
+                            // At verbosity level 3, we only display traces for failed tests
+                            // At verbosity level 4, we also display the setup trace for failed
+                            // tests At verbosity level 5, we display
+                            // all traces for all tests
+                            TraceKind::Setup => {
+                                (verbosity >= 5) ||
+                                    (verbosity == 4 && result.status == TestStatus::Failure)
+                            }
+                            TraceKind::Execution => {
+                                verbosity > 3 ||
+                                    (verbosity == 3 && result.status == TestStatus::Failure)
+                            }
+                            _ => false,
+                        };
+
+                        // We decode the trace if we either need to build a gas report or we need
+                        // to print it
+                        if should_include || self.gas_report {
+                            decoder.decode(trace).await;
+                        }
+
+                        if should_include {
+                            decoded_traces.push(trace.to_string());
+                        }
+                    }
+                }
+
+                decoders.push(decoder);
+            }
+
             let mut sources: ContractSources = Default::default();
             for (id, artifact) in output.into_artifacts() {
                 // Sources are only required for the debugger, but it *might* mean that there's


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #5845

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
After running `forge test`, the command would "halt" after printing "Ran X test suites: X tests passed, X failed, X skipped (X total tests)". This is because of the `test of tests` loop running immediately after which was introduced in #5753. This loop is only responsible for building and pushing decoders for every test which is only used if the `--debug` flag is present. Moving this `if should_debug` to only push those decoders removes that halting after the tests are finished running

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
