### PR TITLE
chore(forge): do not re-build decoded traces for all tests

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -230,7 +230,6 @@ impl TestArgs {
         if should_debug {
             let tests = outcome.clone().into_tests();
 
-            let mut decoded_traces = Vec::new();
             let mut decoders = Vec::new();
             for test in tests {
                 let mut result = test.result;
@@ -280,10 +279,6 @@ impl TestArgs {
                         // to print it
                         if should_include || self.gas_report {
                             decoder.decode(trace).await;
-                        }
-
-                        if should_include {
-                            decoded_traces.push(trace.to_string());
                         }
                     }
                 }


### PR DESCRIPTION
## Motivation

Smol followup for #5879. There was duplicated work happening here, were decoded_traces was being built in `execute_tests`, when this already happens for each individual test. This vec was unused.

## Solution

Remove it.