### PR TITLE
fix(anvil): Fix ots_blockDetails

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -86,7 +86,7 @@ impl EthApi {
     pub async fn ots_get_block_details(&self, number: BlockNumber) -> Result<OtsBlockDetails> {
         node_info!("ots_getBlockDetails");
 
-        if let Some(block) = self.backend.block_by_number_full(number).await? {
+        if let Some(block) = self.backend.block_by_number(number).await? {
             let ots_block = OtsBlockDetails::build(block, &self.backend).await?;
 
             Ok(ots_block)
@@ -101,7 +101,7 @@ impl EthApi {
     pub async fn ots_get_block_details_by_hash(&self, hash: H256) -> Result<OtsBlockDetails> {
         node_info!("ots_getBlockDetailsByHash");
 
-        if let Some(block) = self.backend.block_by_hash_full(hash).await? {
+        if let Some(block) = self.backend.block_by_hash(hash).await? {
             let ots_block = OtsBlockDetails::build(block, &self.backend).await?;
 
             Ok(ots_block)

--- a/crates/anvil/src/eth/otterscan/types.rs
+++ b/crates/anvil/src/eth/otterscan/types.rs
@@ -23,7 +23,7 @@ pub struct OtsBlock<TX> {
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OtsBlockDetails {
-    pub block: OtsBlock<Transaction>,
+    pub block: OtsBlock<H256>,
     pub total_fees: U256,
     pub issuance: Issuance,
 }
@@ -121,11 +121,9 @@ impl OtsBlockDetails {
     ///   - It breaks the abstraction built in `OtsBlock<TX>` which computes `transaction_count`
     ///   based on the existing list.
     /// Therefore we keep it simple by keeping the data in the response
-    pub async fn build(block: Block<Transaction>, backend: &Backend) -> Result<Self> {
-        let receipts_futs = block
-            .transactions
-            .iter()
-            .map(|tx| async { backend.transaction_receipt(tx.hash).await });
+    pub async fn build(block: Block<H256>, backend: &Backend) -> Result<Self> {
+        let receipts_futs =
+            block.transactions.iter().map(|tx| async { backend.transaction_receipt(*tx).await });
 
         // fetch all receipts
         let receipts: Vec<TransactionReceipt> = join_all(receipts_futs)

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -260,7 +260,7 @@ async fn can_call_ots_get_block_details() {
     let result = api.ots_get_block_details(1.into()).await.unwrap();
 
     assert_eq!(result.block.transaction_count, 1);
-    assert_eq!(result.block.block.transactions[0].hash, receipt.transaction_hash);
+    assert_eq!(result.block.block.transactions[0], receipt.transaction_hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -278,7 +278,7 @@ async fn can_call_ots_get_block_details_by_hash() {
     let result = api.ots_get_block_details_by_hash(block_hash).await.unwrap();
 
     assert_eq!(result.block.transaction_count, 1);
-    assert_eq!(result.block.block.transactions[0].hash, receipt.transaction_hash);
+    assert_eq!(result.block.block.transactions[0], receipt.transaction_hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

Otterscan expects the `ots_blockDetails` function to return either a list of transaction hashes, an empty list, or for the field to not exist internally. This is defined by the formatter `transactions: Formatter.allowNull(Formatter.arrayOf(Formatter.hash), [])` in the typescript code.

## Solution

Currently, we are returning the full transactions, which is causing the `block/{id}` page in Otterscan to crash. These changes will modify the response to only include the list of transaction hashes, allowing the Otterscan page to function normally.