### PR TITLE
fix: enforce 0x prefix for numeric hex strings

### DIFF
--- a/crates/evm/src/executor/inspector/cheatcodes/parse.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/parse.rs
@@ -1,7 +1,7 @@
 use super::{fmt_err, Cheatcodes, Result};
 use crate::abi::HEVMCalls;
 use ethers::{
-    abi::{ParamType, Token},
+    abi::{ethereum_types::FromDecStrErr, ParamType, Token},
     prelude::*,
 };
 use foundry_macros::UIfmt;
@@ -52,6 +52,9 @@ fn parse_int(s: &str) -> Result<U256, String> {
     // `I256::from_hex_str`
     if s.starts_with("0x") || s.starts_with("+0x") || s.starts_with("-0x") {
         s.replacen("0x", "", 1).parse::<I256>().map_err(|err| err.to_string())
+    } else if s.chars().any(|c| !c.is_numeric()) {
+        // Throw if numeric string contains non-numeric characters
+        Err(ParseI256Error::InvalidDigit.to_string())
     } else {
         match I256::from_dec_str(s) {
             Ok(val) => Ok(val),
@@ -66,6 +69,9 @@ fn parse_int(s: &str) -> Result<U256, String> {
 fn parse_uint(s: &str) -> Result<U256, String> {
     if s.starts_with("0x") {
         s.parse::<U256>().map_err(|err| err.to_string())
+    } else if s.chars().any(|c| !c.is_numeric()) {
+        // Throw if numeric string contains non-numeric characters
+        Err(FromDecStrErr::InvalidCharacter.to_string())
     } else {
         match U256::from_dec_str(s) {
             Ok(val) => Ok(val),

--- a/testdata/repros/Issue5808.t.sol
+++ b/testdata/repros/Issue5808.t.sol
@@ -9,9 +9,13 @@ contract Issue5808Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testReadInt() public {
-        string memory json = '["ffffffff","00000010"]';
-        int256[] memory ints = vm.parseJsonIntArray(json, "");
-        assertEq(ints[0], 4294967295);
-        assertEq(ints[1], 10);
+        string memory str1 = '["ffffffff","00000010"]';
+        vm.expectRevert();
+        int256[] memory ints1 = vm.parseJsonIntArray(str1, "");
+
+        string memory str2 = '["0xffffffff","0x00000010"]';
+        int256[] memory ints2 = vm.parseJsonIntArray(str2, "");
+        assertEq(ints2[0], 4294967295);
+        assertEq(ints2[1], 10);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Resolve #5808 to enable disambiguous numeric hex string parsing

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* Explicitly check that numeric strings being parsed via `*parseInt` or `*parseUint` cheats don't contain any non-numeric characters
* Throw if the above does not hold
* Modify test added in #5809 to verify new behavior
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
