### PR TITLE
added report-file option and new coverage test

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -356,11 +356,11 @@ impl CoverageArgs {
                 CoverageReportKind::Lcov => {
                     if let Some(report_file) = self.report_file {
                         return LcovReporter::new(&mut fs::create_file(root.join(report_file))?)
-                            .report(&report);
+                            .report(&report)
                     } else {
                         return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?)
-                            .report(&report);
-                    } 
+                            .report(&report)
+                    }
                 }
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -355,14 +355,11 @@ impl CoverageArgs {
         for report_kind in self.report {
             match report_kind {
                 CoverageReportKind::Summary => SummaryReporter::default().report(&report),
-                // TODO: Sensible place to put the LCOV file
                 CoverageReportKind::Lcov => {
                         match self.report_file {
                             Some(_) => return LcovReporter::new(&mut fs::create_file(root.join(self.report_file.as_ref().unwrap()))?).report(&report),
                             None =>  return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
-                        };
-                        
-                    //  LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
+                        };                        
                 }
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -354,18 +354,13 @@ impl CoverageArgs {
             match report_kind {
                 CoverageReportKind::Summary => SummaryReporter::default().report(&report),
                 CoverageReportKind::Lcov => {
-                    match self.report_file {
-                        Some(_) => {
-                            return LcovReporter::new(&mut fs::create_file(
-                                root.join(self.report_file.as_ref().unwrap()),
-                            )?)
-                            .report(&report)
-                        }
-                        None => {
-                            return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?)
-                                .report(&report)
-                        }
-                    };
+                    if let Some(report_file) = self.report_file {
+                        return LcovReporter::new(&mut fs::create_file(root.join(report_file))?)
+                            .report(&report);
+                    } else {
+                        return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?)
+                            .report(&report);
+                    } 
                 }
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -1,6 +1,6 @@
 use super::{install, test::FilterArgs};
 use alloy_primitives::{Address, Bytes, U256};
-use clap::{Parser, ValueEnum};
+use clap::{Parser, ValueEnum, ValueHint};
 use ethers::{
     prelude::{
         artifacts::{Ast, CompactBytecode, CompactDeployedBytecode},
@@ -32,6 +32,7 @@ use semver::Version;
 use std::{collections::HashMap, sync::mpsc::channel};
 use tracing::trace;
 use yansi::Paint;
+use std::path::PathBuf;
 
 /// A map, keyed by contract ID, to a tuple of the deployment source map and the runtime source map.
 type SourceMaps = HashMap<ContractId, (SourceMap, SourceMap)>;
@@ -55,6 +56,17 @@ pub struct CoverageArgs {
     #[clap(long)]
     ir_minimum: bool,
 
+    /// The path to output the report.
+    /// 
+    /// If not specified, the report will be stored in the root of the project.
+    #[clap(
+        long,
+        short,
+        value_hint = ValueHint::FilePath,
+        value_name = "PATH"
+    )]
+    report_file: Option<PathBuf>,
+
     #[clap(flatten)]
     filter: FilterArgs,
 
@@ -63,6 +75,7 @@ pub struct CoverageArgs {
 
     #[clap(flatten)]
     opts: CoreBuildArgs,
+    
 }
 
 impl CoverageArgs {
@@ -344,7 +357,12 @@ impl CoverageArgs {
                 CoverageReportKind::Summary => SummaryReporter::default().report(&report),
                 // TODO: Sensible place to put the LCOV file
                 CoverageReportKind::Lcov => {
-                    LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
+                        match self.report_file {
+                            Some(_) => return LcovReporter::new(&mut fs::create_file(root.join(self.report_file.as_ref().unwrap()))?).report(&report),
+                            None =>  return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
+                        };
+                        
+                    //  LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
                 }
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -5,12 +5,12 @@ forgetest!(basic_coverage, |_prj: TestProject, mut cmd: TestCommand| {
     cmd.assert_success();
 });
 
-forgetest!(report_file_coverage, |_prj: TestProject, mut cmd: TestCommand| {
+forgetest!(report_file_coverage, |prj: TestProject, mut cmd: TestCommand| {
     cmd.arg("coverage").args([
         "--report".to_string(),
         "lcov".to_string(),
         "--report-file".to_string(),
-        "/path/to/lcov.info".to_string(),
+        prj.root().join("lcov.info").to_str().unwrap().to_string(),
     ]);
     cmd.assert_success();
 });

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -4,3 +4,8 @@ forgetest!(basic_coverage, |_prj: TestProject, mut cmd: TestCommand| {
     cmd.args(["coverage"]);
     cmd.assert_success();
 });
+
+forgetest!(report_file_coverage, |_prj: TestProject, mut cmd: TestCommand| {
+    cmd.arg("coverage").args(["--report".to_string(), "lcov".to_string(), "--report-file".to_string(), "/path/to/lcov.info".to_string()]);
+    cmd.assert_success();
+});

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -6,6 +6,11 @@ forgetest!(basic_coverage, |_prj: TestProject, mut cmd: TestCommand| {
 });
 
 forgetest!(report_file_coverage, |_prj: TestProject, mut cmd: TestCommand| {
-    cmd.arg("coverage").args(["--report".to_string(), "lcov".to_string(), "--report-file".to_string(), "/path/to/lcov.info".to_string()]);
+    cmd.arg("coverage").args([
+        "--report".to_string(),
+        "lcov".to_string(),
+        "--report-file".to_string(),
+        "/path/to/lcov.info".to_string(),
+    ]);
     cmd.assert_success();
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The change was made to close #5886 which would allow users to include a `--report-file` option on the `forge coverage --report lcov` command, that would let them choose the path for generating `lcov.info`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
All I did was add the `report-file` field to the `CoverageArgs` struct and also the required imports like `use::clap::ValueHint` and `use std::path::PathBuf` to the `coverage.rs` file, then I added a `match` in the part of the code that previously generated the `lcov.info` file that would use path provided by the user to generate the file or just generate it in root if a path is not provided:
```rust
match self.report_file {
     Some(_) => return LcovReporter::new(&mut fs::create_file(root.join(self.report_file.as_ref().unwrap()))?).report(&report),
     None =>  return LcovReporter::new(&mut fs::create_file(root.join("lcov.info"))?).report(&report)
 };
```

I also added a new test case for a case when the user provided a path with the `report-file` option in `crates/forge/tests/cli/coverage`:
```rust
forgetest!(report_file_coverage, |_prj: TestProject, mut cmd: TestCommand| {
    cmd.arg("coverage").args(["--report".to_string(), "lcov".to_string(), "--report-file".to_string(), "/path/to/lcov.info".to_string()]);
    cmd.assert_success();
});
```

The tests pass but I'm not completely sure I got it right. Please review and give feedback on what I can Improve :)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
