### PR TITLE
chore(dockerfile): upgrade alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM alpine:3.16 as build-environment
+FROM alpine:3.18 as build-environment
 
 ARG TARGETARCH
 WORKDIR /opt


### PR DESCRIPTION
Upgrades the alpine image we're using to 3.18. 3.16 is around a year old already and seems to be causing issues with c-kzg.
