### PR TITLE
chore(`ci`): fix some flaky tests

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -1616,7 +1616,7 @@ mod tests {
 
         // on some CI targets installing results in weird malformed solc files, we try installing it
         // multiple times
-        let version = "0.8.19";
+        let version = "0.8.20";
         for _ in 0..3 {
             let mut is_preinstalled = PRE_INSTALL_SOLC_LOCK.lock().unwrap();
             if !*is_preinstalled {

--- a/testdata/cheats/Fs.t.sol
+++ b/testdata/cheats/Fs.t.sol
@@ -303,7 +303,10 @@ contract FsTest is DSTest {
         metadata = vm.fsMetadata("fixtures/File/read.txt");
         assertEq(metadata.isDir, false);
         assertEq(metadata.isSymlink, false);
-        assertEq(metadata.length, 45);
+        // This test will fail on windows if we compared to 45, as windows
+        // ends files with both line feed and carriage return, unlike
+        // unix which only uses the first one.
+        assertTrue(metadata.length == 45 || metadata.length == 46);
 
         metadata = vm.fsMetadata("fixtures/File/symlink");
         assertEq(metadata.isDir, false);


### PR DESCRIPTION
## Motivation

Let's get main CI back to green—this fixes some tests.

## Solution

Fixes the failing tests:
- `testFsMetadata`: failing due to silly file endings on windows
- `chisel` cache tests: still investigating, but probably `create_dir_all` failures. Trying with installing a different solc version first.