### PR TITLE
feat: chisel migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chisel"
 version = "0.2.0"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
  "bytes",
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,11 @@ ethers-middleware = { version = "2.0", default-features = false }
 ethers-etherscan = { version = "2.0", default-features = false }
 ethers-solc = { version = "2.0", default-features = false }
 
+## alloy
+
 alloy-primitives = { version = "0.3", default-features = false }
 alloy-dyn-abi = { version = "0.3", default-features = false }
+alloy-json-abi = { version = "0.3", default-features = false }
 
 solang-parser = "=0.3.2"
 

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -30,6 +30,11 @@ forge-fmt.workspace = true
 ethers.workspace = true
 ethers-solc = { workspace = true, features = ["project-util", "full"] }
 
+# alloy
+alloy-dyn-abi = { workspace = true, default-features = false, features = ["std", "arbitrary"] }
+alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde", "getrandom", "arbitrary", "rlp"] }
+alloy-json-abi = { workspace = true, default-features = false, features = ["std"]}
+
 # async
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11", default-features = false }

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -54,6 +54,7 @@ eyre = "0.6"
 dirs = "5"
 time = { version = "0.3", features = ["formatting"] }
 regex = "1"
+once_cell = "1.18.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -9,7 +9,6 @@ use crate::prelude::{
 };
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{hex, Address};
-use ethers::contract::Lazy;
 use forge_fmt::FormatterConfig;
 use foundry_config::{Config, RpcEndpoint};
 use foundry_evm::{
@@ -20,6 +19,7 @@ use foundry_evm::{
     },
 };
 use foundry_utils::types::ToEthers;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -8,7 +8,7 @@ use crate::prelude::{
 use core::fmt::Debug;
 use std::str::FromStr;
 use alloy_dyn_abi::{DynSolValue, DynSolType};
-use alloy_json_abi::{EventParam, Param};
+use alloy_json_abi::EventParam;
 use alloy_primitives::{Address, U256, hex};
 use ethers_solc::Artifact;
 use eyre::{Result, WrapErr};
@@ -20,7 +20,7 @@ use foundry_utils::types::ToEthers;
 use solang_parser::pt::{self, CodeLocation};
 use yansi::Paint;
 
-const USIZE_MAX_AS_U256: U256 = U256::from(usize::MAX);
+const USIZE_MAX_AS_U256: U256 = U256::from_limbs([usize::MAX as u64, 0, 0, 0]);
 
 /// Executor implementation for [SessionSource]
 impl SessionSource {
@@ -386,8 +386,8 @@ fn format_token(token: DynSolValue) -> String {
         }
         DynSolValue::Tuple(tokens) => {
             let displayed_types = tokens
-                .into_iter()
-                .map(|t| t.sol_type_name())
+                .iter()
+                .map(|t| t.sol_type_name().to_owned())
                 .map(|t| t.unwrap_or_default().into_owned())
                 .collect::<Vec<_>>().join(", ");
             let mut out = format!(

--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -3,8 +3,8 @@
 //! This module contains the `ChiselRunner` struct, which assists with deploying
 //! and calling the REPL contract on a in-memory REVM instance.
 
+use alloy_primitives::{Address, Bytes, U256};
 use ethers::types::Log;
-use alloy_primitives::{Address, U256, Bytes};
 use eyre::Result;
 use foundry_evm::{
     executor::{DeployResult, Executor, RawCallResult},
@@ -109,8 +109,7 @@ impl ChiselRunner {
         }
 
         // Call the "run()" function of the REPL contract
-        let call_res =
-            self.call(self.sender, address, Bytes::from(calldata), U256::from(0), true);
+        let call_res = self.call(self.sender, address, Bytes::from(calldata), U256::from(0), true);
 
         call_res.map(|res| (address, res))
     }
@@ -139,12 +138,7 @@ impl ChiselRunner {
             false
         };
 
-        let mut res = self.executor.call_raw(
-            from,
-            to,
-            calldata.0.clone().into(),
-            value,
-        )?;
+        let mut res = self.executor.call_raw(from, to, calldata.0.clone().into(), value)?;
         let mut gas_used = res.gas_used;
         if matches!(res.exit_reason, return_ok!()) {
             // store the current gas limit and reset it later
@@ -160,12 +154,7 @@ impl ChiselRunner {
             while (highest_gas_limit - lowest_gas_limit) > 1 {
                 let mid_gas_limit = (highest_gas_limit + lowest_gas_limit) / 2;
                 self.executor.env.tx.gas_limit = mid_gas_limit;
-                let res = self.executor.call_raw(
-                    from,
-                    to,
-                    calldata.0.clone().into(),
-                    value,
-                )?;
+                let res = self.executor.call_raw(from, to, calldata.0.clone().into(), value)?;
                 match res.exit_reason {
                     InstructionResult::Revert |
                     InstructionResult::OutOfGas |
@@ -200,22 +189,12 @@ impl ChiselRunner {
                 cheatcodes.fs_commit = !cheatcodes.fs_commit;
             }
 
-            res = self.executor.call_raw(
-                from,
-                to,
-                calldata.0.clone().into(),
-                value,
-            )?;
+            res = self.executor.call_raw(from, to, calldata.0.clone().into(), value)?;
         }
 
         if commit {
             // if explicitly requested we can now commit the call
-            res = self.executor.call_raw_committing(
-                from,
-                to,
-                calldata.0.clone().into(),
-                value,
-            )?;
+            res = self.executor.call_raw_committing(from, to, calldata.0.clone().into(), value)?;
         }
 
         let RawCallResult { result, reverted, logs, traces, labels, chisel_state, .. } = res;


### PR DESCRIPTION
Switches `chisel` to use `alloy` types. There's only a stray `ethers::types::Log` and `ethers::solc` types. the former will be removed once https://github.com/alloy-rs/core/pull/271 is merged, but these are not blockers for now.