### PR TITLE
fix(forge):`forge init --template` correctly handles submodules

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -378,7 +378,7 @@ impl<'a> Git<'a> {
             .args(shallow.then_some("--no-tags"))
             .args(shallow.then_some("--depth=1"))
             .arg(remote)
-            .args(branch.map(|b| b))
+            .args(branch)
             .exec()
             .map(drop)
     }
@@ -433,8 +433,8 @@ impl<'a> Git<'a> {
         self.cmd()
             .arg("commit-tree")
             .arg(tree)
-            .args(msg.as_ref().map(|_| "-m"))
-            .args(msg.map(|msg| msg))
+            .args(msg.as_ref().is_some().then_some("-m"))
+            .args(msg)
             .get_stdout_lossy()
     }
 

--- a/crates/forge/bin/cmd/doc.rs
+++ b/crates/forge/bin/cmd/doc.rs
@@ -74,7 +74,7 @@ impl DocArgs {
             }
         }
 
-        let commit = foundry_cli::utils::Git::new(&root).commit_hash(false).ok();
+        let commit = foundry_cli::utils::Git::new(&root).commit_hash(false, "HEAD").ok();
 
         let mut builder = DocBuilder::new(root.clone(), config.project_paths().sources)
             .with_should_build(self.build)

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -126,7 +126,7 @@ impl DependencyInstallOpts {
 
         if dependencies.is_empty() && !self.no_git {
             p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
-            git.submodule_update(false, false, Some(&libs))?;
+            git.submodule_update(false, false, false, Some(&libs))?;
         }
         fs::create_dir_all(&libs)?;
 
@@ -304,7 +304,7 @@ impl Installer<'_> {
         self.git.submodule_add(true, url, path)?;
 
         trace!("updating submodule recursively");
-        self.git.submodule_update(false, false, Some(path))
+        self.git.submodule_update(false, false, false, Some(path))
     }
 
     fn git_checkout(self, dep: &Dependency, path: &Path, recurse: bool) -> Result<String> {

--- a/crates/forge/bin/cmd/update.rs
+++ b/crates/forge/bin/cmd/update.rs
@@ -30,7 +30,7 @@ impl UpdateArgs {
     pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
         let (root, paths) = dependencies_paths(&self.dependencies, &config)?;
-        Git::new(&root).submodule_update(self.force, true, paths)
+        Git::new(&root).submodule_update(self.force, true, false, paths)
     }
 }
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -391,6 +391,8 @@ forgetest!(can_init_template_with_branch, |prj: TestProject, mut cmd: TestComman
     assert!(prj.root().join(".git").exists());
     assert!(prj.root().join(".dapprc").exists());
     assert!(prj.root().join("lib/ds-test").exists());
+    // assert that gitmodules were correctly initialized
+    assert!(prj.root().join("lib/ds-test/.git/modules").exists());
     assert!(prj.root().join("src").exists());
     assert!(prj.root().join("scripts").exists());
 });

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -392,7 +392,7 @@ forgetest!(can_init_template_with_branch, |prj: TestProject, mut cmd: TestComman
     assert!(prj.root().join(".dapprc").exists());
     assert!(prj.root().join("lib/ds-test").exists());
     // assert that gitmodules were correctly initialized
-    assert!(prj.root().join("lib/ds-test/.git/modules").exists());
+    assert!(prj.root().join(".git/modules").exists());
     assert!(prj.root().join("src").exists());
     assert!(prj.root().join("scripts").exists());
 });

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -378,6 +378,8 @@ forgetest!(can_init_template, |prj: TestProject, mut cmd: TestCommand| {
     assert!(prj.root().join(".git").exists());
     assert!(prj.root().join("foundry.toml").exists());
     assert!(prj.root().join("lib/forge-std").exists());
+    // assert that gitmodules were correctly initialized
+    assert!(prj.root().join(".git/modules").exists());
     assert!(prj.root().join("src").exists());
     assert!(prj.root().join("test").exists());
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`forge init --template` would clone a repo, then delete the entire `.git` directory so that it could re-initialize the repository with a single commit in its history.

This clobbers submodule tracking and commits entire recursed submodules directly to the git tree.


Closes #5925

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Instead of cloning the template repository:
- initialize the git repository
- fetch just the head of the specified template repository branch
- prepare a new commit using the commit at `FETCH_HEAD`
- `git reset` the branch to the prepared commit, leaving only a single commit in the history


The template test now checks that the `.git/modules` directory is intact when initializing from a template.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
