### PR TITLE
test: add fuzz-seed tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
 name = "foundry-cli"
 version = "0.2.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "clap",
  "color-eyre",
@@ -2609,6 +2610,7 @@ dependencies = [
  "foundry-config",
  "foundry-debugger",
  "foundry-evm",
+ "foundry-utils",
  "indicatif",
  "itertools 0.11.0",
  "once_cell",

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -113,3 +113,14 @@ impl EstimateArgs {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_estimate_value() {
+        let args: EstimateArgs = EstimateArgs::parse_from(["foundry-cli", "--value", "100"]);
+        assert!(args.value.is_some());
+    }
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ foundry-config.workspace = true
 foundry-common.workspace = true
 foundry-evm.workspace = true
 foundry-debugger.workspace = true
+foundry-utils.workspace = true
 
 # aws
 rusoto_core = { version = "0.48", default-features = false }
@@ -22,6 +23,9 @@ rusoto_kms = { version = "0.48", default-features = false }
 
 # eth
 ethers = { workspace = true, features = ["aws", "ledger", "trezor"] }
+
+# alloy
+alloy-primitives.workspace = true
 
 async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -46,3 +46,15 @@ pub struct TransactionOpts {
     #[clap(long)]
     pub legacy: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_priority_gas_tx_opts() {
+        let args: TransactionOpts =
+            TransactionOpts::parse_from(["foundry-cli", "--priority-gas-price", "100"]);
+        assert!(args.priority_gas_price.is_some());
+    }
+}

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -83,6 +83,13 @@ pub fn parse_u256(s: &str) -> Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
 }
 
+/// parse a hex str or decimal str as U256
+// TODO: rm after alloy transition
+pub fn alloy_parse_u256(s: &str) -> Result<alloy_primitives::U256> {
+    use foundry_utils::types::ToAlloy;
+    Ok(parse_u256(s)?.to_alloy())
+}
+
 /// Returns a [RetryProvider](foundry_common::RetryProvider) instantiated using [Config]'s RPC URL
 /// and chain.
 ///
@@ -131,6 +138,12 @@ pub fn parse_ether_value(value: &str) -> Result<U256> {
     } else {
         U256::from(LenientTokenizer::tokenize_uint(value)?)
     })
+}
+
+// TODO: rm after alloy transition
+pub fn alloy_parse_ether_value(value: &str) -> Result<alloy_primitives::U256> {
+    use foundry_utils::types::ToAlloy;
+    Ok(parse_ether_value(value)?.to_alloy())
 }
 
 /// Parses a `Duration` from a &str

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -28,7 +28,7 @@ use forge::{
     },
     CallKind,
 };
-use foundry_cli::{opts::MultiWallet, utils::parse_ether_value};
+use foundry_cli::opts::MultiWallet;
 use foundry_common::{
     abi::{encode_args, format_token},
     contracts::get_contract_name,
@@ -115,7 +115,7 @@ pub struct ScriptArgs {
     #[clap(
         long,
         env = "ETH_PRIORITY_GAS_PRICE",
-        value_parser = parse_ether_value,
+        value_parser = foundry_cli::utils::alloy_parse_ether_value,
         value_name = "PRICE"
     )]
     pub priority_gas_price: Option<U256>,
@@ -192,7 +192,7 @@ pub struct ScriptArgs {
     #[clap(
         long,
         env = "ETH_GAS_PRICE",
-        value_parser = parse_ether_value,
+        value_parser = foundry_cli::utils::alloy_parse_ether_value,
         value_name = "PRICE",
     )]
     pub with_gas_price: Option<U256>,
@@ -981,5 +981,13 @@ mod tests {
         assert_eq!(etherscan, Some("polygonkey".to_string()));
         let etherscan = config.get_etherscan_api_key(Option::<u64>::None);
         assert_eq!(etherscan, Some("polygonkey".to_string()));
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/5923>
+    #[test]
+    fn test_5923() {
+        let args: ScriptArgs =
+            ScriptArgs::parse_from(["foundry-cli", "DeployV1", "--priority-gas-price", "100"]);
+        assert!(args.priority_gas_price.is_some());
     }
 }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -92,7 +92,7 @@ pub struct TestArgs {
     list: bool,
 
     /// Set seed used to generate randomness during your fuzz runs.
-    #[clap(long, value_parser = utils::parse_u256)]
+    #[clap(long, value_parser = utils::alloy_parse_u256)]
     pub fuzz_seed: Option<U256>,
 
     #[clap(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -828,4 +828,18 @@ mod tests {
         let args: TestArgs = TestArgs::parse_from(["foundry-cli", "-vw"]);
         assert!(args.watch.watch.is_some());
     }
+
+    #[test]
+    fn test_fuzz_seed() {
+        let args: TestArgs = TestArgs::parse_from(["foundry-cli", "--fuzz-seed", "0x10"]);
+        assert!(args.fuzz_seed.is_some());
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/5913>
+    #[test]
+    fn test_5913() {
+        let args: TestArgs =
+            TestArgs::parse_from(["foundry-cli", "-vvv", "--gas-report", "--fuzz-seed", "0x10"]);
+        assert!(args.fuzz_seed.is_some());
+    }
 }


### PR DESCRIPTION
Closes #5913
Closes #5923

@Evalir this is a cast bug because clap here goes via typeid not types and since this

https://github.com/foundry-rs/foundry/blob/master/crates/cli/src/utils/mod.rs#L81-L84

is still on ethers U256 this currently bugs out


fixed by updating the value parser for forge

added test for other crates that will catch these issues