### PR TITLE
fix: add input alias

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -67,6 +67,7 @@ pub struct EthTransactionRequest {
     /// value of th tx in wei
     pub value: Option<U256>,
     /// Any additional data sent
+    #[cfg_attr(feature = "serde", serde(alias = "input"))]
     pub data: Option<Bytes>,
     /// Transaction nonce
     pub nonce: Option<U256>,


### PR DESCRIPTION
closes #5917

Note this will also be mitigated once we unify rpc types with 

https://github.com/paradigmxyz/reth/blob/7024e9a8e91e9546ffd20b5aae65e85888f591a6/crates/rpc/rpc-types/src/eth/call.rs#L109-L111

which already supports both variants