### PR TITLE
ci: disable aarch64 mac tests

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -51,7 +51,9 @@ else:
         default_target,
         Target("ubuntu-latest", "aarch64-unknown-linux-gnu"),
         Target("macos-latest", "x86_64-apple-darwin"),
-        Target("macos-latest", "aarch64-apple-darwin"),
+        # Disabled since the test binary will be built for M1/M2, but there are no
+        # GitHub runners capable of executing those binaries.
+        # Target("macos-latest", "aarch64-apple-darwin"),
         Target("windows-latest", "x86_64-pc-windows-msvc"),
     ]
 


### PR DESCRIPTION
The aarch64 tests are failing because the test binaries are ARM, but GitHub can't execute them. I don't think there is a "reverse Rosetta", i.e. a way to run ARM binaries on x86 mac, so I think the best thing to do for now is to disable.

This should be fine since the operating systems are still the same; the APIs are the same, so if it builds and works for x86, it should also build and work for ARM, provided no external deps are missing. Obviously, running the tests would still be more robust.

This should bring CI back to green on main