### PR TITLE
fix(forge): BaseCounterExample for targetInterface

### DIFF
--- a/crates/evm/src/fuzz/error.rs
+++ b/crates/evm/src/fuzz/error.rs
@@ -9,10 +9,6 @@ pub const ASSUME_MAGIC_RETURN_CODE: &[u8] = b"FOUNDRY::ASSUME";
 pub enum FuzzError {
     #[error("Couldn't call unknown contract")]
     UnknownContract,
-    #[error("Couldn't find function")]
-    UnknownFunction,
-    #[error("Failed to decode fuzzer inputs")]
-    FailedDecodeInput,
     #[error("Failed contract call")]
     FailedContractCall,
     #[error("Empty state changeset")]

--- a/crates/evm/src/fuzz/invariant/error.rs
+++ b/crates/evm/src/fuzz/invariant/error.rs
@@ -7,7 +7,7 @@ use crate::{
     CALLER,
 };
 use ethers::abi::Function;
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use proptest::test_runner::TestError;
 use revm::primitives::U256;
@@ -123,16 +123,13 @@ impl InvariantFuzzError {
                 known_contracts,
             ));
 
-            counterexample_sequence.push(
-                BaseCounterExample::create(
-                    *sender,
-                    *addr,
-                    bytes,
-                    &ided_contracts,
-                    call_result.traces,
-                )
-                .wrap_err("Failed to create counter example")?,
-            );
+            counterexample_sequence.push(BaseCounterExample::create(
+                *sender,
+                *addr,
+                bytes,
+                &ided_contracts,
+                call_result.traces,
+            ));
 
             // Checks the invariant.
             if let Some(func) = &self.func {

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -300,14 +300,14 @@ impl BaseCounterExample {
         bytes: &Bytes,
         contracts: &ContractsByAddress,
         traces: Option<CallTraceArena>,
-    ) -> Result<Self> {
+    ) -> Self {
         if let Some((name, abi)) = &contracts.get(&addr) {
             if let Some(func) =
                 abi.functions().find(|f| f.short_signature() == bytes.0.as_ref()[0..4])
             {
                 // skip the function selector when decoding
                 if let Ok(args) = func.decode_input(&bytes.0.as_ref()[4..]) {
-                    return Ok(BaseCounterExample {
+                    return BaseCounterExample {
                         sender: Some(sender),
                         addr: Some(addr),
                         calldata: bytes.clone(),
@@ -315,12 +315,12 @@ impl BaseCounterExample {
                         contract_name: Some(name.clone()),
                         traces,
                         args,
-                    })
+                    }
                 }
             }
         }
 
-        Ok(BaseCounterExample {
+        BaseCounterExample {
             sender: Some(sender),
             addr: Some(addr),
             calldata: bytes.clone(),
@@ -328,7 +328,7 @@ impl BaseCounterExample {
             contract_name: None,
             traces,
             args: vec![],
-        })
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/foundry-rs/foundry/issues/5891

## Solution

Do not bomb on failing to create a counter example, rather just return raw trace. This seems like the a more suitable behaviour, regardless of the issues introduced with `targetInterface`. 

This is still not perfect, as we would want to decode the input when using `targetInterface`, but that would require a lot more changes to propagate the associated interfaces to the tracer.