### PR TITLE
fix(script): decode create2 constructor args

### DIFF
--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -163,7 +163,6 @@ impl TransactionWithMetadata {
 
                         if let Ok(arguments) = abi::decode(&params, constructor_args) {
                             self.arguments = Some(arguments.iter().map(format_token_raw).collect());
-                            println!("{:?}", self.arguments);
                         } else {
                             let (signature, bytecode) = on_err();
                             error!(constructor=?signature, contract=?self.contract_name, bytecode, "Failed to decode constructor arguments")

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -141,7 +141,7 @@ impl TransactionWithMetadata {
 
                 if contains_constructor_args {
                     if let Some(constructor) = info.abi.constructor() {
-                        let creation_code = if is_create2 { &data[32..] } else { &data };
+                        let creation_code = if is_create2 { &data[32..] } else { data };
 
                         let on_err = || {
                             let inputs = constructor
@@ -151,7 +151,7 @@ impl TransactionWithMetadata {
                                 .collect::<Vec<_>>()
                                 .join(",");
                             let signature = format!("constructor({inputs})");
-                            let bytecode = hex::encode(&creation_code);
+                            let bytecode = hex::encode(creation_code);
                             (signature, bytecode)
                         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

While working on metropolis, I found that create2 constructor arguments were not being deserialized and put in the `tx.arguments` array of the broadcast artifacts

## Solution

Simply include a 32 byte offset (to remove the salt) and re-use the logic from CREATE transaction decoding