### PR TITLE
Add vm.unixTime() cheatcode

### DIFF
--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -239,4 +239,4 @@ getMappingSlotAt(address,bytes32,uint256)
 getMappingKeyAndParentOf(address,bytes32)
 
 sleep(uint256)
-time()(uint256)
+unixTime()(uint256)

--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -239,3 +239,4 @@ getMappingSlotAt(address,bytes32,uint256)
 getMappingKeyAndParentOf(address,bytes32)
 
 sleep(uint256)
+time()(uint256)

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -4962,24 +4962,6 @@ pub mod hevm {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("time"),
-                    ::std::vec![
-                        ::ethers_core::abi::ethabi::Function {
-                            name: ::std::borrow::ToOwned::to_owned("time"),
-                            inputs: ::std::vec![],
-                            outputs: ::std::vec![
-                                ::ethers_core::abi::ethabi::Param {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers_core::abi::ethabi::ParamType::Uint(256usize),
-                                    internal_type: ::core::option::Option::None,
-                                },
-                            ],
-                            constant: ::core::option::Option::None,
-                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("toString"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -5151,6 +5133,24 @@ pub mod hevm {
                                 },
                             ],
                             outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("unixTime"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("unixTime"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Uint(256usize),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
                             constant: ::core::option::Option::None,
                             state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
                         },
@@ -7382,14 +7382,6 @@ pub mod hevm {
                 .method_hash([112, 202, 16, 187], (p0, p1, p2))
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `time` (0x16ada547) function
-        pub fn time(
-            &self,
-        ) -> ::ethers_contract::builders::ContractCall<M, ::ethers_core::types::U256> {
-            self.0
-                .method_hash([22, 173, 165, 71], ())
-                .expect("method not found (this should never happen)")
-        }
         ///Calls the contract's `toString` (0x71aad10d) function
         pub fn to_string_0(
             &self,
@@ -7482,6 +7474,14 @@ pub mod hevm {
         ) -> ::ethers_contract::builders::ContractCall<M, ()> {
             self.0
                 .method_hash([72, 245, 12, 15], p0)
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `unixTime` (0x625387dc) function
+        pub fn unix_time(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<M, ::ethers_core::types::U256> {
+            self.0
+                .method_hash([98, 83, 135, 220], ())
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `warp` (0xe5d6bf02) function
@@ -10373,19 +10373,6 @@ pub mod hevm {
     )]
     #[ethcall(name = "store", abi = "store(address,bytes32,bytes32)")]
     pub struct StoreCall(pub ::ethers_core::types::Address, pub [u8; 32], pub [u8; 32]);
-    ///Container type for all input parameters for the `time` function with signature `time()` and selector `0x16ada547`
-    #[derive(
-        Clone,
-        ::ethers_contract::EthCall,
-        ::ethers_contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
-    #[ethcall(name = "time", abi = "time()")]
-    pub struct TimeCall;
     ///Container type for all input parameters for the `toString` function with signature `toString(bytes)` and selector `0x71aad10d`
     #[derive(
         Clone,
@@ -10516,6 +10503,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "txGasPrice", abi = "txGasPrice(uint256)")]
     pub struct TxGasPriceCall(pub ::ethers_core::types::U256);
+    ///Container type for all input parameters for the `unixTime` function with signature `unixTime()` and selector `0x625387dc`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "unixTime", abi = "unixTime()")]
+    pub struct UnixTimeCall;
     ///Container type for all input parameters for the `warp` function with signature `warp(uint256)` and selector `0xe5d6bf02`
     #[derive(
         Clone,
@@ -10800,7 +10800,6 @@ pub mod hevm {
         StopMappingRecording(StopMappingRecordingCall),
         StopPrank(StopPrankCall),
         Store(StoreCall),
-        Time(TimeCall),
         ToString0(ToString0Call),
         ToString1(ToString1Call),
         ToString2(ToString2Call),
@@ -10811,6 +10810,7 @@ pub mod hevm {
         Transact1(Transact1Call),
         TryFfi(TryFfiCall),
         TxGasPrice(TxGasPriceCall),
+        UnixTime(UnixTimeCall),
         Warp(WarpCall),
         WriteFile(WriteFileCall),
         WriteFileBinary(WriteFileBinaryCall),
@@ -11803,11 +11803,6 @@ pub mod hevm {
             ) {
                 return Ok(Self::Store(decoded));
             }
-            if let Ok(decoded) = <TimeCall as ::ethers_core::abi::AbiDecode>::decode(
-                data,
-            ) {
-                return Ok(Self::Time(decoded));
-            }
             if let Ok(decoded) = <ToString0Call as ::ethers_core::abi::AbiDecode>::decode(
                 data,
             ) {
@@ -11857,6 +11852,11 @@ pub mod hevm {
                 data,
             ) {
                 return Ok(Self::TxGasPrice(decoded));
+            }
+            if let Ok(decoded) = <UnixTimeCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::UnixTime(decoded));
             }
             if let Ok(decoded) = <WarpCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
@@ -12358,7 +12358,6 @@ pub mod hevm {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
                 Self::Store(element) => ::ethers_core::abi::AbiEncode::encode(element),
-                Self::Time(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::ToString0(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
@@ -12387,6 +12386,7 @@ pub mod hevm {
                 Self::TxGasPrice(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
+                Self::UnixTime(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Warp(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::WriteFile(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
@@ -12625,7 +12625,6 @@ pub mod hevm {
                 }
                 Self::StopPrank(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Store(element) => ::core::fmt::Display::fmt(element, f),
-                Self::Time(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString1(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString2(element) => ::core::fmt::Display::fmt(element, f),
@@ -12636,6 +12635,7 @@ pub mod hevm {
                 Self::Transact1(element) => ::core::fmt::Display::fmt(element, f),
                 Self::TryFfi(element) => ::core::fmt::Display::fmt(element, f),
                 Self::TxGasPrice(element) => ::core::fmt::Display::fmt(element, f),
+                Self::UnixTime(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Warp(element) => ::core::fmt::Display::fmt(element, f),
                 Self::WriteFile(element) => ::core::fmt::Display::fmt(element, f),
                 Self::WriteFileBinary(element) => ::core::fmt::Display::fmt(element, f),
@@ -13625,11 +13625,6 @@ pub mod hevm {
             Self::Store(value)
         }
     }
-    impl ::core::convert::From<TimeCall> for HEVMCalls {
-        fn from(value: TimeCall) -> Self {
-            Self::Time(value)
-        }
-    }
     impl ::core::convert::From<ToString0Call> for HEVMCalls {
         fn from(value: ToString0Call) -> Self {
             Self::ToString0(value)
@@ -13678,6 +13673,11 @@ pub mod hevm {
     impl ::core::convert::From<TxGasPriceCall> for HEVMCalls {
         fn from(value: TxGasPriceCall) -> Self {
             Self::TxGasPrice(value)
+        }
+    }
+    impl ::core::convert::From<UnixTimeCall> for HEVMCalls {
+        fn from(value: UnixTimeCall) -> Self {
+            Self::UnixTime(value)
         }
     }
     impl ::core::convert::From<WarpCall> for HEVMCalls {
@@ -15126,18 +15126,6 @@ pub mod hevm {
         Hash
     )]
     pub struct SnapshotReturn(pub ::ethers_core::types::U256);
-    ///Container type for all return fields from the `time` function with signature `time()` and selector `0x16ada547`
-    #[derive(
-        Clone,
-        ::ethers_contract::EthAbiType,
-        ::ethers_contract::EthAbiCodec,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
-    pub struct TimeReturn(pub ::ethers_core::types::U256);
     ///Container type for all return fields from the `tryFfi` function with signature `tryFfi(string[])` and selector `0xf45c1ce7`
     #[derive(
         Clone,
@@ -15152,6 +15140,18 @@ pub mod hevm {
     pub struct TryFfiReturn(
         pub (i32, ::ethers_core::types::Bytes, ::ethers_core::types::Bytes),
     );
+    ///Container type for all return fields from the `unixTime` function with signature `unixTime()` and selector `0x625387dc`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct UnixTimeReturn(pub ::ethers_core::types::U256);
     ///`DirEntry(string,string,uint64,bool,bool)`
     #[derive(
         Clone,

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -4962,6 +4962,24 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("time"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned("time"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Uint(256usize),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("toString"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -7362,6 +7380,14 @@ pub mod hevm {
         ) -> ::ethers_contract::builders::ContractCall<M, ()> {
             self.0
                 .method_hash([112, 202, 16, 187], (p0, p1, p2))
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `time` (0x16ada547) function
+        pub fn time(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<M, ::ethers_core::types::U256> {
+            self.0
+                .method_hash([22, 173, 165, 71], ())
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `toString` (0x71aad10d) function
@@ -10347,6 +10373,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "store", abi = "store(address,bytes32,bytes32)")]
     pub struct StoreCall(pub ::ethers_core::types::Address, pub [u8; 32], pub [u8; 32]);
+    ///Container type for all input parameters for the `time` function with signature `time()` and selector `0x16ada547`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "time", abi = "time()")]
+    pub struct TimeCall;
     ///Container type for all input parameters for the `toString` function with signature `toString(bytes)` and selector `0x71aad10d`
     #[derive(
         Clone,
@@ -10761,6 +10800,7 @@ pub mod hevm {
         StopMappingRecording(StopMappingRecordingCall),
         StopPrank(StopPrankCall),
         Store(StoreCall),
+        Time(TimeCall),
         ToString0(ToString0Call),
         ToString1(ToString1Call),
         ToString2(ToString2Call),
@@ -11763,6 +11803,11 @@ pub mod hevm {
             ) {
                 return Ok(Self::Store(decoded));
             }
+            if let Ok(decoded) = <TimeCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::Time(decoded));
+            }
             if let Ok(decoded) = <ToString0Call as ::ethers_core::abi::AbiDecode>::decode(
                 data,
             ) {
@@ -12313,6 +12358,7 @@ pub mod hevm {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
                 Self::Store(element) => ::ethers_core::abi::AbiEncode::encode(element),
+                Self::Time(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::ToString0(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
@@ -12579,6 +12625,7 @@ pub mod hevm {
                 }
                 Self::StopPrank(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Store(element) => ::core::fmt::Display::fmt(element, f),
+                Self::Time(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString1(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ToString2(element) => ::core::fmt::Display::fmt(element, f),
@@ -13576,6 +13623,11 @@ pub mod hevm {
     impl ::core::convert::From<StoreCall> for HEVMCalls {
         fn from(value: StoreCall) -> Self {
             Self::Store(value)
+        }
+    }
+    impl ::core::convert::From<TimeCall> for HEVMCalls {
+        fn from(value: TimeCall) -> Self {
+            Self::Time(value)
         }
     }
     impl ::core::convert::From<ToString0Call> for HEVMCalls {
@@ -15074,6 +15126,18 @@ pub mod hevm {
         Hash
     )]
     pub struct SnapshotReturn(pub ::ethers_core::types::U256);
+    ///Container type for all return fields from the `time` function with signature `time()` and selector `0x16ada547`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct TimeReturn(pub ::ethers_core::types::U256);
     ///Container type for all return fields from the `tryFfi` function with signature `tryFfi(string[])` and selector `0xf45c1ce7`
     #[derive(
         Clone,

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -731,7 +731,7 @@ pub fn apply<DB: Database>(
             serialize_json(state, &inner.0, Some(&inner.1), &array_str_to_str(&inner.2))
         }
         HEVMCalls::Sleep(inner) => sleep(&inner.0),
-        HEVMCalls::Time(_) => duration_since_epoch(),
+        HEVMCalls::UnixTime(_) => duration_since_epoch(),
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
         HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -521,8 +521,9 @@ fn sleep(milliseconds: &U256) -> Result {
 /// Returns the time since unix epoch in milliseconds
 fn duration_since_epoch() -> Result {
     let sys_time = SystemTime::now();
-    let difference =
-        sys_time.duration_since(UNIX_EPOCH).expect("Failed getting timestamp in unixTime cheatcode");
+    let difference = sys_time
+        .duration_since(UNIX_EPOCH)
+        .expect("Failed getting timestamp in unixTime cheatcode");
     let millis = difference.as_millis();
     Ok(rU256::from(millis).to_ethers().encode().into())
 }

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -522,7 +522,7 @@ fn sleep(milliseconds: &U256) -> Result {
 fn duration_since_epoch() -> Result {
     let sys_time = SystemTime::now();
     let difference =
-        sys_time.duration_since(UNIX_EPOCH).expect("Failed getting timestamp in time cheatcode");
+        sys_time.duration_since(UNIX_EPOCH).expect("Failed getting timestamp in unixTime cheatcode");
     let millis = difference.as_millis();
     Ok(rU256::from(millis).to_ethers().encode().into())
 }

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -8,6 +8,7 @@ use ethers::{
 };
 use foundry_common::{fmt::*, fs, get_artifact_path};
 use foundry_config::fs_permissions::FsAccessKind;
+use foundry_utils::types::ToEthers;
 use revm::{Database, EVMData};
 use serde::Deserialize;
 use serde_json::Value;
@@ -518,13 +519,12 @@ fn sleep(milliseconds: &U256) -> Result {
 }
 
 /// Returns the time since unix epoch in milliseconds
-fn time() -> Result {
+fn duration_since_epoch() -> Result {
     let sys_time = SystemTime::now();
     let difference =
         sys_time.duration_since(UNIX_EPOCH).expect("Failed getting timestamp in time cheatcode");
     let millis = difference.as_millis();
-    let as_u8_arr: [u8; 32] = rU256::from(millis).to_be_bytes();
-    Ok(Bytes::from(as_u8_arr))
+    Ok(rU256::from(millis).to_ethers().encode().into())
 }
 
 /// Skip the current test, by returning a magic value that will be checked by the test runner.
@@ -731,7 +731,7 @@ pub fn apply<DB: Database>(
             serialize_json(state, &inner.0, Some(&inner.1), &array_str_to_str(&inner.2))
         }
         HEVMCalls::Sleep(inner) => sleep(&inner.0),
-        HEVMCalls::Time(_) => time(),
+        HEVMCalls::Time(_) => duration_since_epoch(),
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
         HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -1,6 +1,6 @@
 use super::{bail, ensure, fmt_err, util::MAGIC_SKIP_BYTES, Cheatcodes, Error, Result};
 use crate::{abi::HEVMCalls, executor::inspector::cheatcodes::parse};
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, U256 as rU256};
 use ethers::{
     abi::{self, AbiEncode, JsonAbi, ParamType, Token},
     prelude::artifacts::CompactContractBytecode,
@@ -11,7 +11,13 @@ use foundry_config::fs_permissions::FsAccessKind;
 use revm::{Database, EVMData};
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::BTreeMap, env, path::Path, process::Command};
+use std::{
+    collections::BTreeMap,
+    env,
+    path::Path,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 /// Invokes a `Command` with the given args and returns the exit code, stdout, and stderr.
 ///
@@ -511,6 +517,16 @@ fn sleep(milliseconds: &U256) -> Result {
     Ok(Default::default())
 }
 
+/// Returns the time since unix epoch in milliseconds
+fn time() -> Result {
+    let sys_time = SystemTime::now();
+    let difference =
+        sys_time.duration_since(UNIX_EPOCH).expect("Failed getting timestamp in time cheatcode");
+    let millis = difference.as_millis();
+    let as_u8_arr: [u8; 32] = rU256::from(millis).to_be_bytes();
+    Ok(Bytes::from(as_u8_arr))
+}
+
 /// Skip the current test, by returning a magic value that will be checked by the test runner.
 pub fn skip(state: &mut Cheatcodes, depth: u64, skip: bool) -> Result {
     if !skip {
@@ -715,6 +731,7 @@ pub fn apply<DB: Database>(
             serialize_json(state, &inner.0, Some(&inner.1), &array_str_to_str(&inner.2))
         }
         HEVMCalls::Sleep(inner) => sleep(&inner.0),
+        HEVMCalls::Time(_) => time(),
         HEVMCalls::WriteJson0(inner) => write_json(state, &inner.0, &inner.1, None),
         HEVMCalls::WriteJson1(inner) => write_json(state, &inner.0, &inner.1, Some(&inner.2)),
         HEVMCalls::KeyExists(inner) => key_exists(&inner.0, &inner.1),

--- a/testdata/cheats/Time.t.sol
+++ b/testdata/cheats/Time.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "./Vm.sol";
+
+contract TimeTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 errMargin = 100; // allow errors of up to errMargin milliseconds
+
+    function testTimeAgainstDate() public {
+        string[] memory inputs = new string[](2);
+        inputs[0] = "date";
+        // OS X does not support precision more than 1 second
+        inputs[1] = "+%s000";
+
+        bytes memory res = vm.ffi(inputs);
+        uint256 date = vm.parseUint(string(res));
+
+        // Limit precision to 1000 ms
+        uint256 time = vm.time() / 1000 * 1000;
+
+        assertEq(date, time, ".time() is inaccurate");
+    }
+
+    function testTime() public {
+        uint256 sleepTime = 2000;
+
+        uint256 start = vm.time();
+        vm.sleep(sleepTime);
+        uint256 end = vm.time();
+        uint256 interval = end - start;
+
+        assertGe(interval, sleepTime - errMargin, ".time() is inaccurate");
+        assertLe(interval, sleepTime + errMargin, ".time() is inaccurate");
+    }
+}

--- a/testdata/cheats/UnixTime.t.sol
+++ b/testdata/cheats/UnixTime.t.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.18;
 import "ds-test/test.sol";
 import "./Vm.sol";
 
-contract TimeTest is DSTest {
+contract UnixTimeTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
     uint256 errMargin = 100; // allow errors of up to errMargin milliseconds
 
-    function testTimeAgainstDate() public {
+    function testUnixTimeAgainstDate() public {
         string[] memory inputs = new string[](2);
         inputs[0] = "date";
         // OS X does not support precision more than 1 second
@@ -18,20 +18,20 @@ contract TimeTest is DSTest {
         uint256 date = vm.parseUint(string(res));
 
         // Limit precision to 1000 ms
-        uint256 time = vm.time() / 1000 * 1000;
+        uint256 time = vm.unixTime() / 1000 * 1000;
 
-        assertEq(date, time, ".time() is inaccurate");
+        assertEq(date, time, ".unixTime() is inaccurate");
     }
 
-    function testTime() public {
+    function testUnixTime() public {
         uint256 sleepTime = 2000;
 
-        uint256 start = vm.time();
+        uint256 start = vm.unixTime();
         vm.sleep(sleepTime);
-        uint256 end = vm.time();
+        uint256 end = vm.unixTime();
         uint256 interval = end - start;
 
-        assertGe(interval, sleepTime - errMargin, ".time() is inaccurate");
-        assertLe(interval, sleepTime + errMargin, ".time() is inaccurate");
+        assertGe(interval, sleepTime - errMargin, ".unixTime() is inaccurate");
+        assertLe(interval, sleepTime + errMargin, ".unixTime() is inaccurate");
     }
 }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -234,6 +234,9 @@ interface Vm {
     // Sleeps for a given number of milliseconds.
     function sleep(uint256) external;
 
+    /// Returns the time since unix epoch in milliseconds
+    function time() external returns (uint256);
+
     // Expects an error on next call
     function expectRevert() external;
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -235,7 +235,7 @@ interface Vm {
     function sleep(uint256) external;
 
     /// Returns the time since unix epoch in milliseconds
-    function time() external returns (uint256);
+    function unixTime() external returns (uint256);
 
     // Expects an error on next call
     function expectRevert() external;


### PR DESCRIPTION
## Motivation
Fixes #5937.
For long-running scripts it is sometimes useful to measure certain parts and analyze their performance in order to optimize running time. `block.timestamp` does not provide a real-time system timestamp, and using `date` via `ffi` is not granular enough due to Mac OS lack of milliseconds support.

This feature will return an accurate timestamp, in milliseconds since unix epoch, as `uint`.

## Solution
I've added the usual cheatcode components:
- Added function to `HEVM.sol`
- Generated abi bindings
- Added implementation to `foundry-evm` (specifically, `ext.rs`)
- Added Solidity tests in `testdata`

Implementation details:
- Using `SystemTime::now().duration_since(UNIX_EPOCH)`, following the [example from the docs](https://doc.rust-lang.org/std/time/struct.SystemTime.html#impl-SystemTime)
- Converting `u128` to `Bytes` via `rU256` 

## Open questions
- The following test fails both on my branch and on master: `'otterscan::can_call_ots_has_code'`.
Is this ok?
- Using`rU256` to convert the `u128` from `.as_millis()` to bytes — is there a nicer way to achieve this?
- Should this be renamed to something else, such as `.unixTime()`, `.systemTime()` or `.timestamp()`? Personally I would have preferred `vm.now()` but `now` is a reserved word in Solidity
