### PR TITLE
fix(`ci`): ignore tungstenite in deps for anvil

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 # Temporarily exclude rusoto and ethers-providers from bans since we've yet to transition to the 
 # Rust AWS SDK.
-exclude = ["rusoto_core", "rusoto_kms", "rusoto_credential", "ethers-providers"]
+exclude = ["rusoto_core", "rusoto_kms", "rusoto_credential", "ethers-providers", "tungstenite"]
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:


### PR DESCRIPTION
## Motivation

We've got a new security advisory for `tungstenite`, which is used on the current version of `axum` we run on anvil. We should eventually update axum to solve this, but the advisory is, for the most part, not too concerning to us. I think it's acceptable to just bypass it until we update `axum` which will entirely solve the problem

## Solution

Update `deny.toml` to ignore tungstenite.