### PR TITLE
chore: some alloy cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,7 +2796,6 @@ version = "0.2.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
- "const-hex",
  "dunce",
  "ethers-addressbook",
  "ethers-contract",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,8 +1054,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -5551,6 +5553,7 @@ dependencies = [
  "enumn",
  "hashbrown 0.14.0",
  "hex",
+ "once_cell",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,10 +1054,8 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,11 +135,10 @@ foundry-utils = { path = "crates/utils" }
 foundry-debugger = { path = "crates/debugger" }
 
 ## revm
-revm = { version = "3", default-features = false }
-revm-primitives = { version = "1", default-features = false }
+revm = "3"
+revm-primitives = "1"
 
 ## ethers
-
 ethers = { version = "2.0", default-features = false }
 ethers-addressbook = { version = "2.0", default-features = false }
 ethers-core = { version = "2.0", default-features = false }
@@ -152,17 +151,16 @@ ethers-etherscan = { version = "2.0", default-features = false }
 ethers-solc = { version = "2.0", default-features = false }
 
 ## alloy
-
-alloy-primitives = { version = "0.4", default-features = false }
-alloy-dyn-abi = { version = "0.4", default-features = false }
-alloy-json-abi = { version = "0.4", default-features = false }
+alloy-primitives = "0.4"
+alloy-dyn-abi = "0.4"
+alloy-json-abi = "0.4"
 
 solang-parser = "=0.3.2"
 
 ## misc
 toml = "0.8"
 itertools = "0.11"
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", features = ["clock"] }
 hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 
 #[patch."https://github.com/gakonst/ethers-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ solang-parser = "=0.3.2"
 ## misc
 toml = "0.8"
 itertools = "0.11"
-chrono = { version = "0.4", features = ["clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 
 #[patch."https://github.com/gakonst/ethers-rs"]

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -34,7 +34,7 @@ ethers = { workspace = true, features = ["rustls", "ws", "ipc"] }
 trie-db = { version = "0.23" }
 hash-db = { version = "0.15" }
 memory-db = { version = "0.29" }
-alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde"] }
+alloy-primitives = { workspace = true, features = ["serde"] }
 
 # axum related
 axum = { version = "0.5", features = ["ws"] }

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -12,11 +12,10 @@ repository.workspace = true
 [dependencies]
 # foundry internal
 foundry-evm = { path = "../../evm" }
-foundry-utils = { path = "../../utils"}
-revm = { workspace = true, default-features = false, features = ["std", "serde", "memory_limit"] }
+foundry-utils = { path = "../../utils" }
+revm = { workspace = true, features = ["serde", "memory_limit"] }
 
-
-alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde"] }
+alloy-primitives = { workspace = true, features = ["serde"] }
 ethers-core.workspace = true
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = "1"

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -53,7 +53,7 @@ use ethers::{
         DefaultFrame, Filter, FilteredParams, GethDebugTracingOptions, GethTrace, Log, OtherFields,
         Trace, Transaction, TransactionReceipt, H160,
     },
-    utils::{get_contract_address, hex, keccak256, rlp},
+    utils::{hex, keccak256, rlp},
 };
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use foundry_evm::{
@@ -1170,18 +1170,18 @@ impl Backend {
     where
         D: DatabaseRef<Error = DatabaseError>,
     {
-        let from = request.from.unwrap_or_default();
+        let from = request.from.unwrap_or_default().to_alloy();
         let to = if let Some(to) = request.to {
-            to
+            to.to_alloy()
         } else {
-            let nonce = state.basic(from.to_alloy())?.unwrap_or_default().nonce;
-            get_contract_address(from, nonce)
+            let nonce = state.basic(from)?.unwrap_or_default().nonce;
+            from.create(nonce)
         };
 
         let mut tracer = AccessListTracer::new(
             AccessList(request.access_list.clone().unwrap_or_default()),
-            from.to_alloy(),
-            to.to_alloy(),
+            from,
+            to,
             self.precompiles().into_iter().map(|p| p.to_alloy()).collect(),
         );
 

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
         }
         Subcommands::FromBin => {
             let hex = stdin::read_bytes(false)?;
-            println!("0x{}", hex::encode(hex));
+            println!("{}", hex::encode_prefixed(hex));
         }
         Subcommands::ToHexdata { input } => {
             let value = stdin::unwrap_line(input)?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1441,7 +1441,7 @@ impl SimpleCast {
     /// Encodes string into bytes32 value
     pub fn format_bytes32_string(s: &str) -> Result<String> {
         let formatted = format_bytes32_string(s)?;
-        Ok(format!("0x{}", hex::encode(formatted)))
+        Ok(hex::encode_prefixed(formatted))
     }
 
     /// Decodes string from bytes32 value
@@ -1933,7 +1933,7 @@ impl SimpleCast {
         }
         if optimize == 0 {
             let selector = HumanReadableParser::parse_function(signature)?.short_signature();
-            return Ok((format!("0x{}", hex::encode(selector)), String::from(signature)))
+            return Ok((hex::encode_prefixed(selector), String::from(signature)))
         }
         let Some((name, params)) = signature.split_once('(') else {
             eyre::bail!("Invalid signature");
@@ -1955,7 +1955,7 @@ impl SimpleCast {
 
                     if selector.iter().take_while(|&&byte| byte == 0).count() == optimize {
                         found.store(true, Ordering::Relaxed);
-                        return Some((nonce, format!("0x{}", hex::encode(selector)), input))
+                        return Some((nonce, hex::encode_prefixed(selector), input))
                     }
 
                     nonce += nonce_step;

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -258,7 +258,7 @@ async fn resolve_name_args<M: Middleware>(args: &[String], provider: &M) -> Vec<
         if arg.contains('.') {
             let addr = provider.resolve_name(arg).await;
             match addr {
-                Ok(addr) => format!("0x{}", hex::encode(addr.as_bytes())),
+                Ok(addr) => format!("{addr:?}"),
                 Err(_) => arg.to_string(),
             }
         } else {

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -31,9 +31,9 @@ ethers.workspace = true
 ethers-solc = { workspace = true, features = ["project-util", "full"] }
 
 # alloy
-alloy-dyn-abi = { workspace = true, default-features = false, features = ["std", "arbitrary"] }
-alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde", "getrandom", "arbitrary", "rlp"] }
-alloy-json-abi = { workspace = true, default-features = false, features = ["std"]}
+alloy-dyn-abi = { workspace = true, features = ["arbitrary"] }
+alloy-primitives = { workspace = true, features = ["serde", "getrandom", "arbitrary", "rlp"] }
+alloy-json-abi.workspace = true
 
 # async
 tokio = { version = "1", features = ["full"] }
@@ -49,7 +49,7 @@ serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 semver = "1"
 bytes = "1"
-revm = { workspace = true, default-features = false, features = ["std"] }
+revm.workspace = true
 eyre = "0.6"
 dirs = "5"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -421,9 +421,8 @@ impl ChiselDispatcher {
                                                 i,
                                                 i + 32
                                             )),
-                                            Paint::cyan(format!(
-                                                "0x{}",
-                                                hex::encode(&mem.data()[i..i + 32])
+                                            Paint::cyan(hex::encode_prefixed(
+                                                &mem.data()[i..i + 32]
                                             ))
                                         );
                                     });
@@ -839,7 +838,7 @@ impl ChiselDispatcher {
             // We can always safely unwrap here due to the regex matching.
             let addr: Address = match_str.parse().expect("Valid address regex");
             // Replace all occurrences of the address with a checksummed version
-            heap_input = heap_input.replace(match_str, &addr.to_checksum(None));
+            heap_input = heap_input.replace(match_str, &addr.to_string());
         });
         // Replace the old input with the formatted input.
         input = &heap_input;

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -319,13 +319,13 @@ impl SessionSource {
 fn format_token(token: DynSolValue) -> String {
     match token {
         DynSolValue::Address(a) => {
-            format!("Type: {}\n└ Data: {}", Paint::red("address"), Paint::cyan(format!("0x{a:x}")))
+            format!("Type: {}\n└ Data: {}", Paint::red("address"), Paint::cyan(a.to_string()))
         }
         DynSolValue::FixedBytes(b, _) => {
             format!(
                 "Type: {}\n└ Data: {}",
                 Paint::red(format!("bytes{}", b.len())),
-                Paint::cyan(format!("0x{}", hex::encode(b)))
+                Paint::cyan(hex::encode_prefixed(b))
             )
         }
         DynSolValue::Int(i, _) => {
@@ -349,7 +349,7 @@ fn format_token(token: DynSolValue) -> String {
         }
         DynSolValue::String(_) | DynSolValue::Bytes(_) => {
             let hex = hex::encode(token.abi_encode());
-            let s = token.as_str().map(|s| s.to_owned());
+            let s = token.as_str();
             format!(
                 "Type: {}\n{}├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
                 Paint::red(if s.is_some() { "string" } else { "dynamic bytes" }),

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -160,8 +160,8 @@ pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
 pub fn format_token(param: &Token) -> String {
     match param {
         Token::Address(addr) => to_checksum(addr, None),
-        Token::FixedBytes(bytes) => format!("0x{}", hex::encode(bytes)),
-        Token::Bytes(bytes) => format!("0x{}", hex::encode(bytes)),
+        Token::FixedBytes(bytes) => hex::encode_prefixed(bytes),
+        Token::Bytes(bytes) => hex::encode_prefixed(bytes),
         Token::Int(num) => format!("{}", I256::from_raw(*num)),
         Token::Uint(num) => format_uint_with_exponential_notation_hint(*num),
         Token::Bool(b) => format!("{b}"),

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 ethers-core.workspace = true
 ethers-solc = { workspace = true, features = ["async", "svm-solc"] }
 ethers-etherscan.workspace = true
-revm-primitives = { workspace = true, default-features = false, features = ["std"] }
+revm-primitives.workspace = true
 
 # formats
 Inflector = "0.11"

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -19,5 +19,5 @@ alloy-primitives.workspace = true
 crossterm = "0.26"
 eyre = "0.6"
 tracing = "0.1"
-revm = { workspace = true, default-features = false,features = ["std", "serde", "arbitrary"] }
+revm = { workspace = true, features = ["serde", "arbitrary"] }
 ratatui = { version = "0.22.0", default-features = false, features = ["crossterm"] }

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -677,10 +677,11 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
                     text_output.extend(Text::from("No sourcemap for contract"));
                 }
             } else {
-                text_output.extend(Text::from("No srcmap index for contract {contract_name}"));
+                text_output
+                    .extend(Text::from(format!("No srcmap index for contract {contract_name}")));
             }
         } else {
-            text_output.extend(Text::from(format!("Unknown contract at address {address:?}")));
+            text_output.extend(Text::from(format!("Unknown contract at address {address}")));
         }
 
         let paragraph =
@@ -700,7 +701,7 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
     ) {
         let block_source_code = Block::default()
             .title(format!(
-                "Address: {:?} | PC: {} | Gas used in call: {}",
+                "Address: {} | PC: {} | Gas used in call: {}",
                 address,
                 if let Some(step) = debug_steps.get(current_step) {
                     step.pc.to_string()

--- a/crates/doc/src/writer/buf_writer.rs
+++ b/crates/doc/src/writer/buf_writer.rs
@@ -1,4 +1,3 @@
-use ethers_core::utils::hex;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use solang_parser::pt::Parameter;
@@ -183,7 +182,7 @@ impl BufWriter {
 
             let row = [
                 Markdown::Bold(&network).as_doc()?,
-                Markdown::Code(&format!("0x{}", hex::encode(deployment.address))).as_doc()?,
+                Markdown::Code(&format!("{:?}", deployment.address)).as_doc()?,
             ];
             self.write_piped(&row.join("|"))?;
         }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -40,18 +40,16 @@ once_cell = "1"
 # EVM
 bytes = "1"
 hashbrown = { version = "0.13", features = ["serde"] }
-revm = { workspace = true, default-features = false, features = [
-  "std",
+revm = { workspace = true, features = [
   "serde",
   "memory_limit",
   "optional_eip3607",
   "optional_block_gas_limit",
   "optional_no_base_fee",
-  "arbitrary"
+  "arbitrary",
 ] }
-
-alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde", "getrandom", "arbitrary", "rlp"] }
-alloy-dyn-abi = { workspace = true, default-features = false, features = ["std", "arbitrary"] }
+alloy-primitives = { workspace = true, features = ["serde", "getrandom", "arbitrary", "rlp"] }
+alloy-dyn-abi = { workspace = true, features = ["arbitrary"] }
 
 # Fuzzer
 proptest = "1"

--- a/crates/evm/src/decode.rs
+++ b/crates/evm/src/decode.rs
@@ -3,6 +3,7 @@ use crate::{
     abi::ConsoleEvents::{self, *},
     executor::inspector::cheatcodes::util::MAGIC_SKIP_BYTES,
 };
+use alloy_primitives::B256;
 use ethers::{
     abi::{decode, AbiDecode, Contract as Abi, ParamType, RawLog, Token},
     contract::EthLogDecode,
@@ -33,7 +34,7 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
         LogBytesFilter(inner) => format!("{}", inner.0),
         LogNamedAddressFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
         LogNamedBytes32Filter(inner) => {
-            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
+            format!("{}: {}", inner.key, B256::new(inner.val))
         }
         LogNamedDecimalIntFilter(inner) => {
             let (sign, val) = inner.val.into_sign_and_abs();
@@ -54,7 +55,7 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
         LogNamedIntFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
         LogNamedUintFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
         LogNamedBytesFilter(inner) => {
-            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
+            format!("{}: {}", inner.key, inner.val)
         }
         LogNamedStringFilter(inner) => format!("{}: {}", inner.key, inner.val),
         LogNamedArray1Filter(inner) => format!("{}: {:?}", inner.key, inner.val),

--- a/crates/evm/src/executor/backend/error.rs
+++ b/crates/evm/src/executor/backend/error.rs
@@ -105,7 +105,7 @@ pub struct NoCheatcodeAccessError(pub Address);
 
 impl fmt::Display for NoCheatcodeAccessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "No cheatcode access granted for: {:?}, see `vm.allowCheatcodes()`", self.0)
+        write!(f, "No cheatcode access granted for: {}, see `vm.allowCheatcodes()`", self.0)
     }
 }
 

--- a/crates/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -94,7 +94,7 @@ pub fn handle_expect_revert(
             String::decode(data.0.as_ref())
                 .ok()
                 .or_else(|| std::str::from_utf8(data.as_ref()).ok().map(ToOwned::to_owned))
-                .unwrap_or_else(|| format!("0x{}", hex::encode(data)))
+                .unwrap_or_else(|| hex::encode_prefixed(data))
         };
         Err(fmt_err!(
             "Error != expected error: {} != {}",

--- a/crates/evm/src/executor/inspector/printer.rs
+++ b/crates/evm/src/executor/inspector/printer.rs
@@ -39,7 +39,7 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         inputs: &mut CallInputs,
     ) -> (InstructionResult, Gas, Bytes) {
         println!(
-            "SM CALL:   {:?},context:{:?}, is_static:{:?}, transfer:{:?}, input_size:{:?}",
+            "SM CALL:   {},context:{:?}, is_static:{:?}, transfer:{:?}, input_size:{:?}",
             inputs.contract,
             inputs.context,
             inputs.is_static,
@@ -55,7 +55,7 @@ impl<DB: Database> Inspector<DB> for TracePrinter {
         inputs: &mut CreateInputs,
     ) -> (InstructionResult, Option<Address>, Gas, Bytes) {
         println!(
-            "CREATE CALL: caller:{:?}, scheme:{:?}, value:{:?}, init_code:{:?}, gas:{:?}",
+            "CREATE CALL: caller:{}, scheme:{:?}, value:{:?}, init_code:{:?}, gas:{:?}",
             inputs.caller,
             inputs.scheme,
             inputs.value,

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -351,7 +351,7 @@ impl fmt::Display for BaseCounterExample {
         if let Some(sig) = &self.signature {
             write!(f, "calldata={}", &sig)?
         } else {
-            write!(f, "calldata=0x{}", hex::encode(&self.calldata))?
+            write!(f, "calldata=0x{}", self.calldata)?
         }
 
         write!(f, ", args=[{args}]")

--- a/crates/evm/src/trace/identifier/signatures.rs
+++ b/crates/evm/src/trace/identifier/signatures.rs
@@ -102,7 +102,7 @@ impl SignaturesIdentifier {
             SelectorType::Event => &mut self.cached.events,
         };
 
-        let hex_identifier = format!("0x{}", hex::encode(identifier));
+        let hex_identifier = hex::encode_prefixed(identifier);
 
         if !self.offline && !map.contains_key(&hex_identifier) {
             if let Ok(signatures) =

--- a/crates/evm/src/trace/mod.rs
+++ b/crates/evm/src/trace/mod.rs
@@ -280,15 +280,11 @@ impl fmt::Display for RawOrDecodedLog {
                         f,
                         "{:>13}: {}",
                         if i == 0 { "emit topic 0".to_string() } else { format!("topic {i}") },
-                        Paint::cyan(format!("0x{}", hex::encode(topic)))
+                        Paint::cyan(format!("{topic:?}"))
                     )?;
                 }
 
-                write!(
-                    f,
-                    "          data: {}",
-                    Paint::cyan(format!("0x{}", hex::encode(&log.data)))
-                )
+                write!(f, "          data: {}", Paint::cyan(hex::encode_prefixed(&log.data)))
             }
             RawOrDecodedLog::Decoded(name, params) => {
                 let params = params
@@ -378,10 +374,10 @@ impl fmt::Display for RawOrDecodedReturnData {
                 if bytes.is_empty() {
                     write!(f, "()")
                 } else {
-                    write!(f, "0x{}", hex::encode(bytes))
+                    bytes.fmt(f)
                 }
             }
-            RawOrDecodedReturnData::Decoded(decoded) => write!(f, "{}", decoded.clone()),
+            RawOrDecodedReturnData::Decoded(decoded) => f.write_str(decoded),
         }
     }
 }

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -2029,7 +2029,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
             Expression::HexNumberLiteral(loc, val, unit) => {
                 // ref: https://docs.soliditylang.org/en/latest/types.html?highlight=address%20literal#address-literals
                 let val = if val.len() == 42 {
-                    Address::from_str(val).expect("").to_checksum(None)
+                    Address::from_str(val).expect("").to_string()
                 } else {
                     val.to_owned()
                 };

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -39,7 +39,7 @@ forge-doc.workspace = true
 foundry-cli.workspace = true
 foundry-debugger.workspace = true
 
-alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde"] }
+alloy-primitives = { workspace = true, features = ["serde"] }
 
 async-trait = "0.1"
 bytes = "1.4"

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -271,14 +271,14 @@ impl CreateArgs {
         let address = deployed_contract.address().to_alloy();
         if self.json {
             let output = json!({
-                "deployer": deployer_address.to_alloy().to_checksum(None),
-                "deployedTo": address.to_checksum(None),
+                "deployer": deployer_address.to_alloy().to_string(),
+                "deployedTo": address.to_string(),
                 "transactionHash": receipt.transaction_hash
             });
             println!("{output}");
         } else {
-            println!("Deployer: {}", deployer_address.to_alloy().to_checksum(None));
-            println!("Deployed to: {}", address.to_checksum(None));
+            println!("Deployer: {}", deployer_address.to_alloy());
+            println!("Deployed to: {address}");
             println!("Transaction hash: {:?}", receipt.transaction_hash);
         };
 

--- a/crates/forge/bin/cmd/script/broadcast.rs
+++ b/crates/forge/bin/cmd/script/broadcast.rs
@@ -247,9 +247,10 @@ impl ScriptArgs {
                 .map_err(|_| eyre::eyre!("Not able to query the EOA nonce."))?;
 
             let tx_nonce = tx.nonce().expect("no nonce");
-
-            if nonce != (*tx_nonce).to_alloy() {
-                bail!("EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider.")
+            if let Ok(tx_nonce) = u64::try_from(tx_nonce.to_alloy()) {
+                if nonce != tx_nonce {
+                    bail!("EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider.")
+                }
             }
         }
 

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -1,5 +1,5 @@
 use super::*;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes};
 use ethers::{
     prelude::{
         artifacts::Libraries, cache::SolFilesCache, ArtifactId, Project, ProjectCompileOutput,
@@ -80,7 +80,7 @@ impl ScriptArgs {
         contracts: ArtifactContracts,
         libraries_addresses: Libraries,
         sender: Address,
-        nonce: U256,
+        nonce: u64,
     ) -> Result<BuildOutput> {
         let mut run_dependencies = vec![];
         let mut contract = CompactContractBytecode::default();

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -1,5 +1,5 @@
 use super::{multi::MultiChainSequence, sequence::ScriptSequence, verify::VerifyBundle, *};
-use alloy_primitives::{Bytes, U256};
+use alloy_primitives::Bytes;
 use ethers::{
     prelude::{Middleware, Signer},
     types::transaction::eip2718::TypedTransaction,
@@ -23,7 +23,7 @@ impl ScriptArgs {
         let (config, evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
         let mut script_config = ScriptConfig {
             // dapptools compatibility
-            sender_nonce: U256::from(1),
+            sender_nonce: 1,
             config,
             evm_opts,
             debug: self.debug,
@@ -277,7 +277,7 @@ impl ScriptArgs {
                 default_known_contracts,
                 Libraries::parse(&deployment_sequence.libraries)?,
                 script_config.config.sender.to_alloy(), // irrelevant, since we're not creating any
-                U256::ZERO,                             // irrelevant, since we're not creating any
+                0,                                      // irrelevant, since we're not creating any
             )?;
 
             verify.known_contracts = flatten_contracts(&highlevel_known_contracts, false);

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -426,7 +426,7 @@ impl ScriptArgs {
     fn create_deploy_transactions(
         &self,
         from: Address,
-        nonce: U256,
+        nonce: u64,
         data: &[Bytes],
         fork_url: &Option<RpcUrl>,
     ) -> BroadcastableTransactions {
@@ -437,7 +437,7 @@ impl ScriptArgs {
                 transaction: TypedTransaction::Legacy(TransactionRequest {
                     from: Some(from.to_ethers()),
                     data: Some(bytes.clone().0.into()),
-                    nonce: Some(nonce + U256::from(i)).map(|n| n.to_ethers()),
+                    nonce: Some(ethers::types::U256::from(nonce + i as u64)),
                     ..Default::default()
                 }),
             })
@@ -640,7 +640,7 @@ pub struct NestedValue {
 pub struct ScriptConfig {
     pub config: Config,
     pub evm_opts: EvmOpts,
-    pub sender_nonce: U256,
+    pub sender_nonce: u64,
     /// Maps a rpc url to a backend
     pub backends: HashMap<RpcUrl, Backend>,
     /// Script target contract

--- a/crates/forge/bin/cmd/script/runner.rs
+++ b/crates/forge/bin/cmd/script/runner.rs
@@ -35,7 +35,7 @@ impl ScriptRunner {
         libraries: &[Bytes],
         code: Bytes,
         setup: bool,
-        sender_nonce: U256,
+        sender_nonce: u64,
         is_broadcast: bool,
         need_create2_deployer: bool,
     ) -> Result<(Address, ScriptResult)> {
@@ -52,7 +52,7 @@ impl ScriptRunner {
             }
         }
 
-        self.executor.set_nonce(self.sender, sender_nonce.to())?;
+        self.executor.set_nonce(self.sender, sender_nonce)?;
 
         // We max out their balance so that they can deploy and make calls.
         self.executor.set_balance(CALLER, U256::MAX)?;
@@ -181,15 +181,13 @@ impl ScriptRunner {
     /// So we have to.
     fn maybe_correct_nonce(
         &mut self,
-        sender_initial_nonce: U256,
+        sender_initial_nonce: u64,
         libraries_len: usize,
     ) -> Result<()> {
         if let Some(cheatcodes) = &self.executor.inspector.cheatcodes {
             if !cheatcodes.corrected_nonce {
-                self.executor.set_nonce(
-                    self.sender,
-                    sender_initial_nonce.to::<u64>() + libraries_len as u64,
-                )?;
+                self.executor
+                    .set_nonce(self.sender, sender_initial_nonce + libraries_len as u64)?;
             }
             self.executor.inspector.cheatcodes.as_mut().unwrap().corrected_nonce = false;
         }

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -140,7 +140,7 @@ impl VerifyArgs {
         }
 
         let verifier_url = self.verifier.verifier_url.clone();
-        println!("Start verifying contract `{:?}` deployed on {chain}", self.address);
+        println!("Start verifying contract `{}` deployed on {chain}", self.address);
         self.verifier.verifier.client(&self.etherscan.key)?.verify(self).await.map_err(|err| {
             if let Some(verifier_url) = verifier_url {
                  match Url::parse(&verifier_url) {

--- a/crates/forge/bin/cmd/verify/sourcify.rs
+++ b/crates/forge/bin/cmd/verify/sourcify.rs
@@ -38,7 +38,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     println!(
                         "\nSubmitting verification for [{}] {:?}.",
                         args.contract.name,
-                        args.address.to_checksum(None)
+                        args.address.to_string()
                     );
                     let response = client
                         .post(args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL))
@@ -158,7 +158,7 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
         }
 
         let req = SourcifyVerifyRequest {
-            address: format!("{:?}", args.address),
+            address: args.address.to_string(),
             chain: args.etherscan.chain.unwrap_or_default().id().to_string(),
             files,
             chosen_contract: None,

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -287,7 +287,7 @@ impl MultiContractRunnerBuilder {
             &mut known_contracts,
             Default::default(),
             evm_opts.sender,
-            U256::from(1),
+            1,
             &mut deployable_contracts,
             |post_link_input| {
                 let PostLinkInput {

--- a/crates/macros/src/fmt/token.rs
+++ b/crates/macros/src/fmt/token.rs
@@ -19,8 +19,8 @@ fn fmt_token(f: &mut fmt::Formatter, item: &Token) -> fmt::Result {
             write!(f, "{}", utils::to_checksum(inner, None))
         }
         // add 0x
-        Token::Bytes(inner) => write!(f, "0x{}", hex::encode(inner)),
-        Token::FixedBytes(inner) => write!(f, "0x{}", hex::encode(inner)),
+        Token::Bytes(inner) => f.write_str(&hex::encode_prefixed(inner)),
+        Token::FixedBytes(inner) => f.write_str(&hex::encode_prefixed(inner)),
         // print as decimal
         Token::Uint(inner) => write!(f, "{inner}"),
         Token::Int(inner) => write!(f, "{}", I256::from_raw(*inner)),

--- a/crates/macros/src/fmt/ui.rs
+++ b/crates/macros/src/fmt/ui.rs
@@ -71,7 +71,7 @@ impl UIfmt for Bytes {
 
 impl<const N: usize> UIfmt for [u8; N] {
     fn pretty(&self) -> String {
-        format!("0x{}", hex::encode(&self[..]))
+        hex::encode_prefixed(&self[..])
     }
 }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -18,7 +18,7 @@ foundry-utils.workspace = true
 
 ethers.workspace = true
 ethers-solc = { workspace = true, features = ["project-util"] }
-alloy-primitives = { workspace = true, features = ["std"]}
+alloy-primitives.workspace = true
 
 eyre = "0.6"
 once_cell = "1"

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -1,5 +1,5 @@
 use crate::TestCommand;
-use alloy_primitives::{hex, Address, U256};
+use alloy_primitives::{Address, U256};
 use ethers::prelude::{Middleware, NameOrAddress};
 use eyre::Result;
 use foundry_common::{get_http_provider, RetryProvider};
@@ -136,16 +136,12 @@ impl ScriptTester {
     }
 
     pub fn add_deployer(&mut self, index: u32) -> &mut Self {
-        self.cmd.args([
-            "--sender",
-            &format!("0x{}", hex::encode(self.accounts_pub[index as usize].to_ethers())),
-        ]);
-        self
+        self.sender(self.accounts_pub[index as usize])
     }
 
     /// Adds given address as sender
     pub fn sender(&mut self, addr: Address) -> &mut Self {
-        self.cmd.args(["--sender", format!("{addr:?}").as_str()]);
+        self.cmd.args(["--sender", addr.to_string().as_str()]);
         self
     }
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -18,13 +18,12 @@ ethers-addressbook.workspace = true
 ethers-providers.workspace = true
 ethers-solc.workspace = true
 
-alloy-primitives = { workspace = true, features = ["std"]}
-alloy-dyn-abi = { workspace = true, features = ["std"]}
+alloy-primitives = { workspace = true, features = ["std"] }
+alloy-dyn-abi = { workspace = true, features = ["std"] }
 
 eyre = { version = "0.6", default-features = false }
 futures = "0.3"
 glob = "0.3"
-hex.workspace = true
 once_cell = "1"
 rand = "0.8"
 serde_json = { version = "1", default-features = false }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -18,8 +18,8 @@ ethers-addressbook.workspace = true
 ethers-providers.workspace = true
 ethers-solc.workspace = true
 
-alloy-primitives = { workspace = true, features = ["std"] }
-alloy-dyn-abi = { workspace = true, features = ["std"] }
+alloy-primitives.workspace = true
+alloy-dyn-abi.workspace = true
 
 eyre = { version = "0.6", default-features = false }
 futures = "0.3"

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -530,7 +530,7 @@ pub async fn next_nonce(
     let provider = Provider::try_from(provider_url)
         .wrap_err_with(|| format!("Bad fork_url provider: {provider_url}"))?;
     let res = provider.get_transaction_count(caller.to_ethers(), block).await?.to_alloy();
-    res.try_into().map_err(Into::into)
+    res.try_into().map_err(|e| eyre::eyre!("{e}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- Use `Display` for alloy address
- Use `Address::` methods instead of ethers utils
- hex::encode clean up
- make nonces u64 since we would panic anyway if above

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
