### PR TITLE
feat(`evm`): migrate `fuzz` `evm` folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,7 @@ name = "foundry-evm"
 version = "0.2.0"
 dependencies = [
  "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
  "auto_impl",
  "bytes",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -52,7 +52,7 @@ revm = { workspace = true, default-features = false, features = [
 
 alloy-primitives = { workspace = true, default-features = false, features = ["std", "serde", "getrandom", "arbitrary", "rlp"] }
 alloy-dyn-abi = { workspace = true, default-features = false, features = ["std", "arbitrary", "eip712"] }
-
+alloy-json-abi ={ workspace = true, default-features = false, features = ["std"]}
 # Fuzzer
 proptest = "1"
 

--- a/crates/evm/src/executor/inspector/fuzzer.rs
+++ b/crates/evm/src/executor/inspector/fuzzer.rs
@@ -105,12 +105,12 @@ impl Fuzzer {
                     call_generator.next(call.context.caller.to_ethers(), call.contract.to_ethers())
                 {
                     *call.input = input.0;
-                    call.context.caller = sender.to_alloy();
-                    call.contract = contract.to_alloy();
+                    call.context.caller = sender;
+                    call.contract = contract;
 
                     // TODO: in what scenarios can the following be problematic
-                    call.context.code_address = contract.to_alloy();
-                    call.context.address = contract.to_alloy();
+                    call.context.code_address = contract;
+                    call.context.address = contract;
 
                     call_generator.used = true;
                 }

--- a/crates/evm/src/fuzz/invariant/call_override.rs
+++ b/crates/evm/src/fuzz/invariant/call_override.rs
@@ -1,6 +1,6 @@
 use super::BasicTxDetails;
 use crate::executor::Executor;
-use ethers::types::{Address, Bytes};
+use alloy_primitives::{Address, Bytes};
 use foundry_utils::types::ToAlloy;
 use parking_lot::{Mutex, RwLock};
 use proptest::{
@@ -73,7 +73,7 @@ impl RandomCallGenerator {
             )
         } else {
             // TODO: Do we want it to be 80% chance only too ?
-            let new_caller = original_target.to_alloy();
+            let new_caller = original_target;
 
             // Set which contract we mostly (80% chance) want to generate calldata from.
             *self.target_reference.write() = original_caller;
@@ -84,7 +84,7 @@ impl RandomCallGenerator {
                 .new_tree(&mut self.runner.lock())
                 .unwrap()
                 .current()
-                .map(|(new_target, calldata)| (new_caller, (new_target.to_alloy(), calldata.0.into())));
+                .map(|(new_target, calldata)| (new_caller, (new_target, calldata.0.into())));
 
             self.last_sequence.write().push(choice.clone());
             choice

--- a/crates/evm/src/fuzz/invariant/call_override.rs
+++ b/crates/evm/src/fuzz/invariant/call_override.rs
@@ -1,6 +1,7 @@
 use super::BasicTxDetails;
 use crate::executor::Executor;
 use ethers::types::{Address, Bytes};
+use foundry_utils::types::ToAlloy;
 use parking_lot::{Mutex, RwLock};
 use proptest::{
     option::weighted,
@@ -72,7 +73,7 @@ impl RandomCallGenerator {
             )
         } else {
             // TODO: Do we want it to be 80% chance only too ?
-            let new_caller = original_target;
+            let new_caller = original_target.to_alloy();
 
             // Set which contract we mostly (80% chance) want to generate calldata from.
             *self.target_reference.write() = original_caller;
@@ -83,7 +84,7 @@ impl RandomCallGenerator {
                 .new_tree(&mut self.runner.lock())
                 .unwrap()
                 .current()
-                .map(|(new_target, calldata)| (new_caller, (new_target, calldata)));
+                .map(|(new_target, calldata)| (new_caller, (new_target.to_alloy(), calldata.0.into())));
 
             self.last_sequence.write().push(choice.clone());
             choice

--- a/crates/evm/src/fuzz/invariant/error.rs
+++ b/crates/evm/src/fuzz/invariant/error.rs
@@ -6,7 +6,7 @@ use crate::{
     trace::{load_contracts, TraceKind, Traces},
     CALLER,
 };
-use ethers::abi::Function;
+use alloy_json_abi::Function;
 use eyre::{Result, WrapErr};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use proptest::test_runner::TestError;
@@ -42,7 +42,7 @@ impl InvariantFuzzError {
         shrink: bool,
     ) -> Self {
         let (func, origin) = if let Some(f) = error_func {
-            (Some(f.short_signature().into()), f.name.as_str())
+            (Some(f.selector()), f.name.as_str())
         } else {
             (None, "Revert")
         };
@@ -70,7 +70,7 @@ impl InvariantFuzzError {
             return_reason: "".into(),
             revert_reason: revert_reason.unwrap_or_default(),
             addr: invariant_contract.address,
-            func,
+            func: func.map(|f| f.0.clone().into()),
             inner_sequence: inner_sequence.to_vec(),
             shrink,
         }
@@ -107,8 +107,8 @@ impl InvariantFuzzError {
         for (sender, (addr, bytes)) in calls.iter() {
             let call_result = executor
                 .call_raw_committing(
-                    sender.to_alloy(),
-                    addr.to_alloy(),
+                    *sender,
+                    *addr,
                     bytes.0.clone().into(),
                     U256::ZERO,
                 )
@@ -137,7 +137,7 @@ impl InvariantFuzzError {
             // Checks the invariant.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(CALLER, self.addr.to_alloy(), func.0.clone().into(), U256::ZERO)
+                    .call_raw(CALLER, self.addr, func.0.clone().into(), U256::ZERO)
                     .expect("bad call to evm");
 
                 traces.push((TraceKind::Execution, error_call_result.traces.clone().unwrap()));
@@ -173,8 +173,8 @@ impl InvariantFuzzError {
 
             executor
                 .call_raw_committing(
-                    sender.to_alloy(),
-                    addr.to_alloy(),
+                    *sender,
+                    *addr,
                     bytes.0.clone().into(),
                     U256::ZERO,
                 )
@@ -183,7 +183,7 @@ impl InvariantFuzzError {
             // Checks the invariant. If we exit before the last call, all the better.
             if let Some(func) = &self.func {
                 let error_call_result = executor
-                    .call_raw(CALLER, self.addr.to_alloy(), func.0.clone().into(), U256::ZERO)
+                    .call_raw(CALLER, self.addr, func.0.clone().into(), U256::ZERO)
                     .expect("bad call to evm");
 
                 if error_call_result.reverted {

--- a/crates/evm/src/fuzz/invariant/executor.rs
+++ b/crates/evm/src/fuzz/invariant/executor.rs
@@ -19,7 +19,8 @@ use crate::{
     utils::get_function,
     CALLER,
 };
-use ethers::abi::{Abi, Address, Detokenize, FixedBytes, Tokenizable, TokenizableItem};
+use alloy_primitives::{Address, U256, FixedBytes};
+use alloy_json_abi::JsonAbi as Abi;
 use eyre::{eyre, ContextCompat, Result};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::{FuzzDictionaryConfig, InvariantConfig};
@@ -30,7 +31,7 @@ use proptest::{
     test_runner::{TestCaseError, TestRunner},
 };
 use revm::{
-    primitives::{Address as rAddress, HashMap, U256 as rU256},
+    primitives::HashMap,
     DatabaseCommit,
 };
 use std::{cell::RefCell, collections::BTreeMap, sync::Arc};
@@ -153,7 +154,7 @@ impl<'a> InvariantExecutor<'a> {
                         sender.to_alloy(),
                         address.to_alloy(),
                         calldata.0.clone().into(),
-                        rU256::ZERO,
+                        U256::ZERO,
                     )
                     .expect("could not make raw evm call");
 
@@ -391,7 +392,7 @@ impl<'a> InvariantExecutor<'a> {
     fn validate_selected_contract(
         &mut self,
         contract: String,
-        selectors: &[FixedBytes],
+        selectors: &[FixedBytes<4>],
     ) -> eyre::Result<String> {
         if let Some((artifact, (abi, _))) =
             self.project_contracts.find_by_name_or_identifier(&contract)?
@@ -571,7 +572,7 @@ impl<'a> InvariantExecutor<'a> {
                 address.to_alloy(),
                 func.clone(),
                 (),
-                rU256::ZERO,
+                U256::ZERO,
                 Some(abi),
             ) {
                 return call_result.result
@@ -591,7 +592,7 @@ impl<'a> InvariantExecutor<'a> {
 /// before inserting it into the dictionary. Otherwise, we flood the dictionary with
 /// randomly generated addresses.
 fn collect_data(
-    state_changeset: &mut HashMap<rAddress, revm::primitives::Account>,
+    state_changeset: &mut HashMap<Address, revm::primitives::Account>,
     sender: &Address,
     call_result: &RawCallResult,
     fuzz_state: EvmFuzzState,

--- a/crates/evm/src/fuzz/invariant/filters.rs
+++ b/crates/evm/src/fuzz/invariant/filters.rs
@@ -1,17 +1,16 @@
 use crate::utils::get_function;
-use ethers::{
-    abi::{Abi, Address, FixedBytes, Function},
-    solc::ArtifactId,
-};
+use ethers::solc::ArtifactId;
+use alloy_primitives::{Address, FixedBytes};
+use alloy_json_abi::{JsonAbi as Abi, Function};
 use std::collections::BTreeMap;
 
 /// Contains which contracts are to be targeted or excluded on an invariant test through their
 /// artifact identifiers.
 #[derive(Default)]
 pub struct ArtifactFilters {
-    /// List of `contract_path:contract_name` which are to be targeted. If list of functions is not
+    /// List of `contract_path:contract_name` along with selectors, which are to be targeted. If list of functions is not
     /// empty, target only those.
-    pub targeted: BTreeMap<String, Vec<FixedBytes>>,
+    pub targeted: BTreeMap<String, Vec<FixedBytes<4>>>,
     /// List of `contract_path:contract_name` which are to be excluded.
     pub excluded: Vec<String>,
 }

--- a/crates/evm/src/fuzz/invariant/filters.rs
+++ b/crates/evm/src/fuzz/invariant/filters.rs
@@ -62,7 +62,7 @@ pub struct SenderFilters {
 
 impl SenderFilters {
     pub fn new(mut targeted: Vec<Address>, mut excluded: Vec<Address>) -> Self {
-        let addr_0 = Address::zero();
+        let addr_0 = Address::ZERO;
         if !excluded.contains(&addr_0) {
             excluded.push(addr_0);
         }

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -5,12 +5,11 @@ use crate::{
     executor::{Executor, RawCallResult},
     trace::CallTraceArena,
 };
-use alloy_primitives::U256;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_json_abi::{JsonAbi as Abi, Function};
+use alloy_dyn_abi::DynSolValue;
 use error::{FuzzError, ASSUME_MAGIC_RETURN_CODE};
-use ethers::{
-    abi::{Abi, Function, Token},
-    types::{Address, Bytes, Log},
-};
+use ethers::types::Log;
 use eyre::Result;
 use foundry_common::{calc, contracts::ContractsByAddress};
 use foundry_config::FuzzConfig;
@@ -135,7 +134,7 @@ impl<'a> FuzzedExecutor<'a> {
                     // to run at least one more case to find a minimal failure
                     // case.
                     let call_res = _counterexample.1.result.clone();
-                    *counterexample.borrow_mut() = _counterexample;
+                    *counterexample.borrow_mut() = _counterexample.0.into();
                     Err(TestCaseError::fail(
                         decode::decode_revert(&call_res, errors, Some(status)).unwrap_or_default(),
                     ))
@@ -288,9 +287,9 @@ pub struct BaseCounterExample {
     pub contract_name: Option<String>,
     /// Traces
     pub traces: Option<CallTraceArena>,
-    // Token does not implement Serde (lol), so we just serialize the calldata
+    // 
     #[serde(skip)]
-    pub args: Vec<Token>,
+    pub args: Vec<DynSolValue>,
 }
 
 impl BaseCounterExample {

--- a/crates/evm/src/fuzz/mod.rs
+++ b/crates/evm/src/fuzz/mod.rs
@@ -13,7 +13,7 @@ use ethers::types::Log;
 use eyre::Result;
 use foundry_common::{calc, contracts::ContractsByAddress};
 use foundry_config::FuzzConfig;
-use foundry_utils::types::{ToAlloy, ToEthers};
+use foundry_utils::types::ToEthers;
 pub use proptest::test_runner::Reason;
 use proptest::test_runner::{TestCaseError, TestError, TestRunner};
 use serde::{Deserialize, Serialize};

--- a/crates/evm/src/fuzz/strategies/calldata.rs
+++ b/crates/evm/src/fuzz/strategies/calldata.rs
@@ -1,5 +1,9 @@
+use std::str::FromStr;
+
 use super::fuzz_param;
-use ethers::{abi::Function, types::Bytes};
+use alloy_dyn_abi::{JsonAbiExt, DynSolType};
+use alloy_json_abi::Function;
+use alloy_primitives::Bytes;
 use proptest::prelude::{BoxedStrategy, Strategy};
 
 /// Given a function, it returns a strategy which generates valid calldata
@@ -7,7 +11,7 @@ use proptest::prelude::{BoxedStrategy, Strategy};
 pub fn fuzz_calldata(func: Function) -> BoxedStrategy<Bytes> {
     // We need to compose all the strategies generated for each parameter in all
     // possible combinations
-    let strats = func.inputs.iter().map(|input| fuzz_param(&input.kind)).collect::<Vec<_>>();
+    let strats = func.inputs.iter().map(|input| fuzz_param(&DynSolType::from_str(&input.ty).unwrap())).collect::<Vec<_>>();
 
     strats
         .prop_map(move |tokens| {

--- a/crates/evm/src/fuzz/strategies/int.rs
+++ b/crates/evm/src/fuzz/strategies/int.rs
@@ -25,12 +25,12 @@ impl IntValueTree {
     /// * `start` - Starting value for the tree
     /// * `fixed` - If `true` the tree would only contain one element and won't be simplified.
     fn new(start: I256, fixed: bool) -> Self {
-        Self { lo: I256::zero(), curr: start, hi: start, fixed }
+        Self { lo: I256::ZERO, curr: start, hi: start, fixed }
     }
 
     fn reposition(&mut self) -> bool {
         let interval = self.hi - self.lo;
-        let new_mid = self.lo + interval / I256::from(2);
+        let new_mid = self.lo + interval / I256::from_raw(U256::from(2));
 
         if new_mid == self.curr {
             false
@@ -69,7 +69,7 @@ impl ValueTree for IntValueTree {
             return false
         }
 
-        self.lo = self.curr + if self.hi.is_negative() { I256::minus_one() } else { I256::one() };
+        self.lo = self.curr + if self.hi.is_negative() { I256::MINUS_ONE } else { I256::ONE };
 
         self.reposition()
     }
@@ -113,7 +113,7 @@ impl IntStrategy {
     fn generate_edge_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
         let rng = runner.rng();
 
-        let offset = I256::from(rng.gen_range(0..4));
+        let offset = I256::from_raw(U256::from(rng.gen_range(0..4)));
         let umax: U256 = (U256::from(1u8) << U256::from(self.bits - 1)) - 1;
         // Choose if we want values around min, -0, +0, or max
         let kind = rng.gen_range(0..4);
@@ -143,7 +143,7 @@ impl IntStrategy {
         let bits = rng.gen_range(0..=self.bits);
 
         if bits == 0 {
-            return Ok(IntValueTree::new(I256::zero(), false))
+            return Ok(IntValueTree::new(I256::ZERO, false))
         }
 
         // init 2 128-bit randoms

--- a/crates/evm/src/fuzz/strategies/int.rs
+++ b/crates/evm/src/fuzz/strategies/int.rs
@@ -1,10 +1,10 @@
-use ethers::{core::rand::Rng, prelude::Sign};
+use ethers::core::rand::Rng;
 use proptest::{
     strategy::{NewTree, Strategy, ValueTree},
     test_runner::TestRunner,
 };
 
-use ethers::types::{I256, U256};
+use alloy_primitives::{I256, U256, Sign};
 
 /// Value tree for signed ints (up to int256).
 /// This is very similar to [proptest::BinarySearch]
@@ -170,7 +170,7 @@ impl IntStrategy {
         let sign = if rng.gen_bool(0.5) { Sign::Positive } else { Sign::Negative };
         // we have a small bias here, i.e. intN::min will never be generated
         // but it's ok since it's generated in `fn generate_edge_tree(...)`
-        let (start, _) = I256::overflowing_from_sign_and_abs(sign, U256(inner));
+        let (start, _) = I256::overflowing_from_sign_and_abs(sign, U256::from(inner));
 
         Ok(IntValueTree::new(start, false))
     }

--- a/crates/evm/src/fuzz/strategies/invariants.rs
+++ b/crates/evm/src/fuzz/strategies/invariants.rs
@@ -4,10 +4,8 @@ use crate::fuzz::{
     strategies::fuzz_param,
     EvmFuzzState,
 };
-use alloy_dyn_abi::DynSolType;
 use alloy_primitives::{Address, Bytes};
 use alloy_json_abi::{JsonAbi as Abi, Function};
-use foundry_utils::types::{ToAlloy, ToEthers};
 use parking_lot::RwLock;
 use proptest::prelude::*;
 pub use proptest::test_runner::Config as FuzzConfig;
@@ -112,13 +110,13 @@ fn select_random_sender(
         ),
     ])
     // Too many exclusions can slow down testing.
-    .prop_filter("senders not allowed", move |addr| !senders_ref.excluded.contains(&addr.to_ethers()))
+    .prop_filter("senders not allowed", move |addr| !senders_ref.excluded.contains(addr))
     .boxed();
 
     if !senders.targeted.is_empty() {
         any::<prop::sample::Selector>()
             .prop_map(move |selector| *selector.select(&*senders.targeted))
-            .prop_map(|s| s.to_alloy())
+            .prop_map(|s| s)
             .boxed()
     } else {
         fuzz_strategy

--- a/crates/evm/src/fuzz/strategies/param.rs
+++ b/crates/evm/src/fuzz/strategies/param.rs
@@ -1,7 +1,6 @@
 use super::state::EvmFuzzState;
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{Address, I256, U256, FixedBytes};
-use foundry_utils::types::ToAlloy;
 use proptest::prelude::*;
 
 /// The max length of arrays we fuzz for is 256.
@@ -19,10 +18,10 @@ pub fn fuzz_param(param: &DynSolType) -> BoxedStrategy<DynSolValue> {
         }
         DynSolType::Bytes => any::<Vec<u8>>().prop_map(|x| DynSolValue::Bytes(x)).boxed(),
         DynSolType::Int(n) => {
-            super::IntStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Int(x.to_alloy(), 256)).boxed()
+            super::IntStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Int(x, 256)).boxed()
         }
         DynSolType::Uint(n) => {
-            super::UintStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Uint(x.to_alloy(), 256)).boxed()
+            super::UintStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Uint(x, 256)).boxed()
         }
         DynSolType::Bool => any::<bool>().prop_map(|x| DynSolValue::Bool(x)).boxed(),
         DynSolType::String => any::<Vec<u8>>()

--- a/crates/evm/src/fuzz/strategies/param.rs
+++ b/crates/evm/src/fuzz/strategies/param.rs
@@ -1,8 +1,7 @@
 use super::state::EvmFuzzState;
-use ethers::{
-    abi::{ParamType, Token, Tokenizable},
-    types::{Address, Bytes, H160, I256, U256},
-};
+use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_primitives::{Address, I256, U256, FixedBytes};
+use foundry_utils::types::ToAlloy;
 use proptest::prelude::*;
 
 /// The max length of arrays we fuzz for is 256.
@@ -11,36 +10,37 @@ pub const MAX_ARRAY_LEN: usize = 256;
 /// Given a parameter type, returns a strategy for generating values for that type.
 ///
 /// Works with ABI Encoder v2 tuples.
-pub fn fuzz_param(param: &ParamType) -> BoxedStrategy<Token> {
+pub fn fuzz_param(param: &DynSolType) -> BoxedStrategy<DynSolValue> {
     match param {
-        ParamType::Address => {
+        DynSolType::Address => {
             // The key to making this work is the `boxed()` call which type erases everything
             // https://altsysrq.github.io/proptest-book/proptest/tutorial/transforming-strategies.html
-            any::<[u8; 20]>().prop_map(|x| H160(x).into_token()).boxed()
+            any::<[u8; 20]>().prop_map(|x| DynSolValue::Address(x.into())).boxed()
         }
-        ParamType::Bytes => any::<Vec<u8>>().prop_map(|x| Bytes::from(x).into_token()).boxed(),
-        ParamType::Int(n) => {
-            super::IntStrategy::new(*n, vec![]).prop_map(|x| x.into_token()).boxed()
+        DynSolType::Bytes => any::<Vec<u8>>().prop_map(|x| DynSolValue::Bytes(x)).boxed(),
+        DynSolType::Int(n) => {
+            super::IntStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Int(x.to_alloy(), 256)).boxed()
         }
-        ParamType::Uint(n) => {
-            super::UintStrategy::new(*n, vec![]).prop_map(|x| x.into_token()).boxed()
+        DynSolType::Uint(n) => {
+            super::UintStrategy::new(*n, vec![]).prop_map(|x| DynSolValue::Uint(x.to_alloy(), 256)).boxed()
         }
-        ParamType::Bool => any::<bool>().prop_map(|x| x.into_token()).boxed(),
-        ParamType::String => any::<Vec<u8>>()
-            .prop_map(|x| Token::String(unsafe { String::from_utf8_unchecked(x) }))
+        DynSolType::Bool => any::<bool>().prop_map(|x| DynSolValue::Bool(x)).boxed(),
+        DynSolType::String => any::<Vec<u8>>()
+            .prop_map(|x| DynSolValue::String(unsafe { String::from_utf8_unchecked(x) }))
             .boxed(),
-        ParamType::Array(param) => proptest::collection::vec(fuzz_param(param), 0..MAX_ARRAY_LEN)
-            .prop_map(Token::Array)
+        DynSolType::Array(param) => proptest::collection::vec(fuzz_param(param), 0..MAX_ARRAY_LEN)
+            .prop_map(DynSolValue::Array)
             .boxed(),
-        ParamType::FixedBytes(size) => {
-            prop::collection::vec(any::<u8>(), *size).prop_map(Token::FixedBytes).boxed()
+        DynSolType::FixedBytes(size) => {
+            prop::collection::vec(any::<u8>(), *size).prop_map(|e| DynSolValue::FixedBytes(FixedBytes::from_slice(&e), *size)).boxed()
         }
-        ParamType::FixedArray(param, size) => {
-            prop::collection::vec(fuzz_param(param), *size).prop_map(Token::FixedArray).boxed()
+        DynSolType::FixedArray(param, size) => {
+            prop::collection::vec(fuzz_param(param), *size).prop_map(DynSolValue::FixedArray).boxed()
         }
-        ParamType::Tuple(params) => {
-            params.iter().map(fuzz_param).collect::<Vec<_>>().prop_map(Token::Tuple).boxed()
+        DynSolType::Tuple(params) => {
+            params.iter().map(fuzz_param).collect::<Vec<_>>().prop_map(DynSolValue::Tuple).boxed()
         }
+        _ => panic!("Unimplemented")
     }
 }
 
@@ -48,7 +48,7 @@ pub fn fuzz_param(param: &ParamType) -> BoxedStrategy<Token> {
 /// fuzz state.
 ///
 /// Works with ABI Encoder v2 tuples.
-pub fn fuzz_param_from_state(param: &ParamType, arc_state: EvmFuzzState) -> BoxedStrategy<Token> {
+pub fn fuzz_param_from_state(param: &DynSolType, arc_state: EvmFuzzState) -> BoxedStrategy<DynSolValue> {
     // These are to comply with lifetime requirements
     let state_len = arc_state.read().values().len();
 
@@ -60,64 +60,65 @@ pub fn fuzz_param_from_state(param: &ParamType, arc_state: EvmFuzzState) -> Boxe
 
     // Convert the value based on the parameter type
     match param {
-        ParamType::Address => {
-            value.prop_map(move |value| Address::from_slice(&value[12..]).into_token()).boxed()
+        DynSolType::Address => {
+            value.prop_map(move |value| DynSolValue::Address(Address::from_slice(&value[12..]))).boxed()
         }
-        ParamType::Bytes => value.prop_map(move |value| Bytes::from(value).into_token()).boxed(),
-        ParamType::Int(n) => match n / 8 {
+        DynSolType::Bytes => value.prop_map(move |value| DynSolValue::Bytes(value.into())).boxed(),
+        DynSolType::Int(n) => match n / 8 {
             32 => {
-                value.prop_map(move |value| I256::from_raw(U256::from(value)).into_token()).boxed()
+                value.prop_map(move |value| DynSolValue::Int(I256::from_raw(U256::from_be_bytes(value)), 256)).boxed()
             }
             y @ 1..=31 => value
                 .prop_map(move |value| {
                     // Generate a uintN in the correct range, then shift it to the range of intN
                     // by subtracting 2^(N-1)
-                    let uint = U256::from(value) % U256::from(2usize).pow(U256::from(y * 8));
+                    let uint = U256::from_be_bytes(value) % U256::from(2usize).pow(U256::from(y * 8));
                     let max_int_plus1 = U256::from(2usize).pow(U256::from(y * 8 - 1));
                     let num = I256::from_raw(uint.overflowing_sub(max_int_plus1).0);
-                    num.into_token()
+                    DynSolValue::Int(num, 256)
                 })
                 .boxed(),
             _ => panic!("unsupported solidity type int{n}"),
         },
-        ParamType::Uint(n) => match n / 8 {
-            32 => value.prop_map(move |value| U256::from(value).into_token()).boxed(),
+        DynSolType::Uint(n) => match n / 8 {
+            32 => value.prop_map(move |value| DynSolValue::Uint(U256::from_be_bytes(value), 256)).boxed(),
             y @ 1..=31 => value
                 .prop_map(move |value| {
-                    (U256::from(value) % (U256::from(2usize).pow(U256::from(y * 8)))).into_token()
+                    DynSolValue::Uint(U256::from_be_bytes(value) % (U256::from(2usize).pow(U256::from(y * 8))), y * 8)
                 })
                 .boxed(),
             _ => panic!("unsupported solidity type uint{n}"),
         },
-        ParamType::Bool => value.prop_map(move |value| Token::Bool(value[31] == 1)).boxed(),
-        ParamType::String => value
+        DynSolType::Bool => value.prop_map(move |value| DynSolValue::Bool(value[31] == 1)).boxed(),
+        DynSolType::String => value
             .prop_map(move |value| {
-                Token::String(
+                DynSolValue::String(
                     String::from_utf8_lossy(&value[..]).trim().trim_end_matches('\0').to_string(),
                 )
             })
             .boxed(),
-        ParamType::Array(param) => {
+        DynSolType::Array(param) => {
             proptest::collection::vec(fuzz_param_from_state(param, arc_state), 0..MAX_ARRAY_LEN)
-                .prop_map(Token::Array)
+                .prop_map(DynSolValue::Array)
                 .boxed()
         }
-        ParamType::FixedBytes(size) => {
+        DynSolType::FixedBytes(size) => {
             let size = *size;
-            value.prop_map(move |value| Token::FixedBytes(value[32 - size..].to_vec())).boxed()
+            value.prop_map(move |value| DynSolValue::FixedBytes(FixedBytes::from_slice(&value[32 - size..]), size)).boxed()
         }
-        ParamType::FixedArray(param, size) => {
+        DynSolType::FixedArray(param, size) => {
             let fixed_size = *size;
             proptest::collection::vec(fuzz_param_from_state(param, arc_state), fixed_size)
-                .prop_map(Token::FixedArray)
+                .prop_map(DynSolValue::FixedArray)
                 .boxed()
         }
-        ParamType::Tuple(params) => params
+        DynSolType::Tuple(params) => params
             .iter()
             .map(|p| fuzz_param_from_state(p, arc_state.clone()))
             .collect::<Vec<_>>()
-            .prop_map(Token::Tuple)
+            .prop_map(DynSolValue::Tuple)
             .boxed(),
+        _ => panic!("Unimplemented")
     }
 }
 
@@ -127,6 +128,7 @@ mod tests {
     use ethers::abi::HumanReadableParser;
     use foundry_config::FuzzDictionaryConfig;
     use revm::db::{CacheDB, EmptyDB};
+    use alloy_json_abi::Function;
 
     #[test]
     fn can_fuzz_array() {

--- a/crates/evm/src/fuzz/strategies/state.rs
+++ b/crates/evm/src/fuzz/strategies/state.rs
@@ -278,7 +278,7 @@ pub fn collect_created_contracts(
                         {
                             created_contracts.push(*address);
                             writable_targeted.insert(
-                                address.to_ethers(),
+                                *address,
                                 (artifact.name.clone(), abi.clone(), functions),
                             );
                         }

--- a/crates/evm/src/fuzz/strategies/uint.rs
+++ b/crates/evm/src/fuzz/strategies/uint.rs
@@ -4,7 +4,7 @@ use proptest::{
     test_runner::TestRunner,
 };
 
-use ethers::types::U256;
+use alloy_primitives::U256;
 
 /// Value tree for unsigned ints (up to uint256).
 /// This is very similar to [proptest::BinarySearch]
@@ -154,7 +154,7 @@ impl UintStrategy {
         inner[1] = (lower >> 64) as u64;
         inner[2] = (higher & mask64) as u64;
         inner[3] = (higher >> 64) as u64;
-        let start: U256 = U256(inner);
+        let start: U256 = U256::from(inner);
 
         Ok(UintValueTree::new(start, false))
     }

--- a/crates/evm/src/fuzz/strategies/uint.rs
+++ b/crates/evm/src/fuzz/strategies/uint.rs
@@ -25,12 +25,12 @@ impl UintValueTree {
     /// * `start` - Starting value for the tree
     /// * `fixed` - If `true` the tree would only contain one element and won't be simplified.
     fn new(start: U256, fixed: bool) -> Self {
-        Self { lo: 0.into(), curr: start, hi: start, fixed }
+        Self { lo: U256::ZERO, curr: start, hi: start, fixed }
     }
 
     fn reposition(&mut self) -> bool {
         let interval = self.hi - self.lo;
-        let new_mid = self.lo + interval / 2;
+        let new_mid = self.lo + interval / U256::from(2);
 
         if new_mid == self.curr {
             false
@@ -62,7 +62,7 @@ impl ValueTree for UintValueTree {
             return false
         }
 
-        self.lo = self.curr + 1;
+        self.lo = self.curr + U256::from(1);
         self.reposition()
     }
 }
@@ -109,7 +109,7 @@ impl UintStrategy {
         let is_min = rng.gen_bool(0.5);
         let offset = U256::from(rng.gen_range(0..4));
         let max = if self.bits < 256 {
-            (U256::from(1u8) << U256::from(self.bits)) - 1
+            (U256::from(1u8).rotate_left(self.bits)) - U256::from(1)
         } else {
             U256::MAX
         };
@@ -154,7 +154,7 @@ impl UintStrategy {
         inner[1] = (lower >> 64) as u64;
         inner[2] = (higher & mask64) as u64;
         inner[3] = (higher >> 64) as u64;
-        let start: U256 = U256::from(inner);
+        let start: U256 = U256::from_limbs(inner);
 
         Ok(UintValueTree::new(start, false))
     }

--- a/crates/evm/src/fuzz/types.rs
+++ b/crates/evm/src/fuzz/types.rs
@@ -1,5 +1,5 @@
 use crate::{coverage::HitMaps, debug::DebugArena, executor::RawCallResult, trace::CallTraceArena};
-use ethers::types::Bytes;
+use alloy_primitives::Bytes;
 use foundry_common::evm::Breakpoints;
 use revm::interpreter::InstructionResult;
 use serde::{Deserialize, Serialize};

--- a/crates/utils/src/types.rs
+++ b/crates/utils/src/types.rs
@@ -1,7 +1,7 @@
 //! Temporary utility conversion traits between ethers-rs and alloy types.
 
-use alloy_primitives::{Address, B256, U256 as AlloyU256, U64 as AlloyU64};
-use ethers_core::types::{H160, H256, U256, U64};
+use alloy_primitives::{Address, B256, U256 as AlloyU256, U64 as AlloyU64, I256 as AlloyI256};
+use ethers_core::types::{H160, H256, U256, U64, I256};
 
 /// Conversion trait to easily convert from ethers-rs types to alloy primitive types.
 pub trait ToAlloy {
@@ -40,6 +40,16 @@ impl ToAlloy for U64 {
 
     fn to_alloy(self) -> Self::To {
         AlloyU64::from_limbs(self.0)
+    }
+}
+
+impl ToAlloy for I256 {
+    type To = AlloyI256;
+    
+    fn to_alloy(self) -> Self::To {
+        let mut buffer: [u8; 32] = [0u8; 32];
+        self.to_big_endian(&mut buffer);
+        AlloyI256::from_be_bytes(buffer)
     }
 }
 


### PR DESCRIPTION
Continuation over #5928, which migrates the `fuzz` part of the `evm` crate to alloy. There are a few things to resolve here which I've highlighted in the comments.
