### PR TITLE
feat(`deps`): use main revm branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,8 +5502,8 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "3.3.0"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#f7d211e27dc6e56abcaa09e3097158bf063f5190"
+version = "3.4.0"
+source = "git+https://github.com/bluealloy/revm/?branch=main#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5514,8 +5514,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#f7d211e27dc6e56abcaa09e3097158bf063f5190"
+version = "1.2.0"
+source = "git+https://github.com/bluealloy/revm/?branch=main#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -5523,8 +5523,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "2.0.3"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#f7d211e27dc6e56abcaa09e3097158bf063f5190"
+version = "2.1.0"
+source = "git+https://github.com/bluealloy/revm/?branch=main#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "c-kzg",
  "k256",
@@ -5539,8 +5539,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "1.1.2"
-source = "git+https://github.com/Evalir/revm/?branch=reintroduce-alloy-rebased#f7d211e27dc6e56abcaa09e3097158bf063f5190"
+version = "1.2.0"
+source = "git+https://github.com/bluealloy/revm/?branch=main#4e78fbe86ef4d030968d00f461926abbcb813943"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ ethers-middleware = { git = "https://github.com/gakonst/ethers-rs" }
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs" }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs" }
 
-revm = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
-revm-interpreter = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
-revm-precompile = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
-revm-primitives = { git = "https://github.com/Evalir/revm/", branch = "reintroduce-alloy-rebased" }
+revm = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+revm-precompile = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "main" }


### PR DESCRIPTION
We can come back to using the main revm branch instead of using my fork, as https://github.com/bluealloy/revm/pull/724 was merged.