### PR TITLE
Support all ether units in to-unit #5962

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1076,7 +1076,7 @@ impl SimpleCast {
     pub fn to_ascii(hex: &str) -> Result<String> {
         let bytes = hex::decode(hex)?;
         if !bytes.iter().all(u8::is_ascii) {
-            return Err(eyre::eyre!("Invalid ASCII bytes"));
+            return Err(eyre::eyre!("Invalid ASCII bytes"))
         }
         Ok(String::from_utf8(bytes).unwrap())
     }
@@ -1410,7 +1410,7 @@ impl SimpleCast {
         let base_in = Base::unwrap_or_detect(base_in, value)?;
         let base_out: Base = base_out.parse()?;
         if base_in == base_out {
-            return Ok(value.to_string());
+            return Ok(value.to_string())
         }
 
         let mut n = NumberWithBase::parse_int(value, Some(base_in.to_string()))?;
@@ -1479,7 +1479,7 @@ impl SimpleCast {
         let s = if let Some(stripped) = s.strip_prefix("000000000000000000000000") {
             stripped
         } else {
-            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"));
+            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"))
         };
 
         let lowercase_address_string = format!("0x{s}");
@@ -1945,7 +1945,7 @@ impl SimpleCast {
         }
         if optimize == 0 {
             let selector = HumanReadableParser::parse_function(signature)?.short_signature();
-            return Ok((hex::encode_prefixed(selector), String::from(signature)));
+            return Ok((hex::encode_prefixed(selector), String::from(signature)))
         }
         let Some((name, params)) = signature.split_once('(') else {
             eyre::bail!("Invalid signature");
@@ -1967,7 +1967,7 @@ impl SimpleCast {
 
                     if selector.iter().take_while(|&&byte| byte == 0).count() == optimize {
                         found.store(true, Ordering::Relaxed);
-                        return Some((nonce, hex::encode_prefixed(selector), input));
+                        return Some((nonce, hex::encode_prefixed(selector), input))
                     }
 
                     nonce += nonce_step;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1076,7 +1076,7 @@ impl SimpleCast {
     pub fn to_ascii(hex: &str) -> Result<String> {
         let bytes = hex::decode(hex)?;
         if !bytes.iter().all(u8::is_ascii) {
-            return Err(eyre::eyre!("Invalid ASCII bytes"))
+            return Err(eyre::eyre!("Invalid ASCII bytes"));
         }
         Ok(String::from_utf8(bytes).unwrap())
     }
@@ -1271,9 +1271,21 @@ impl SimpleCast {
             "eth" | "ether" => ethers_core::utils::format_units(value, 18)?
                 .trim_end_matches(".000000000000000000")
                 .to_string(),
+            "milli" | "milliether" => ethers_core::utils::format_units(value, 15)?
+                .trim_end_matchers(".000000000000000")
+                .to_string(),
+            "micro" | "microether" => ethers_core::utils::format_units(value, 12)?
+                .trim_end_matches(".000000000000")
+                .to_string(),
             "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?
                 .trim_end_matches(".000000000")
                 .to_string(),
+            "mwei" | "mega" | "megaether" => {
+                ethers_core::utils::format_units(value, 6)?.trim_end_matches(".000000").to_string()
+            }
+            "kwei" | "kilo" | "kiloether" => {
+                ethers_core::utils::format_units(value, 3)?.trim_end_matches(".000").to_string()
+            }
             "wei" => ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string(),
             _ => eyre::bail!("invalid unit: \"{}\"", unit),
         })
@@ -1398,7 +1410,7 @@ impl SimpleCast {
         let base_in = Base::unwrap_or_detect(base_in, value)?;
         let base_out: Base = base_out.parse()?;
         if base_in == base_out {
-            return Ok(value.to_string())
+            return Ok(value.to_string());
         }
 
         let mut n = NumberWithBase::parse_int(value, Some(base_in.to_string()))?;
@@ -1467,7 +1479,7 @@ impl SimpleCast {
         let s = if let Some(stripped) = s.strip_prefix("000000000000000000000000") {
             stripped
         } else {
-            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"))
+            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"));
         };
 
         let lowercase_address_string = format!("0x{s}");
@@ -1933,7 +1945,7 @@ impl SimpleCast {
         }
         if optimize == 0 {
             let selector = HumanReadableParser::parse_function(signature)?.short_signature();
-            return Ok((hex::encode_prefixed(selector), String::from(signature)))
+            return Ok((hex::encode_prefixed(selector), String::from(signature)));
         }
         let Some((name, params)) = signature.split_once('(') else {
             eyre::bail!("Invalid signature");
@@ -1955,7 +1967,7 @@ impl SimpleCast {
 
                     if selector.iter().take_while(|&&byte| byte == 0).count() == optimize {
                         found.store(true, Ordering::Relaxed);
-                        return Some((nonce, hex::encode_prefixed(selector), input))
+                        return Some((nonce, hex::encode_prefixed(selector), input));
                     }
 
                     nonce += nonce_step;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1272,7 +1272,7 @@ impl SimpleCast {
                 .trim_end_matches(".000000000000000000")
                 .to_string(),
             "milli" | "milliether" => ethers_core::utils::format_units(value, 15)?
-                .trim_end_matchers(".000000000000000")
+                .trim_end_matches(".000000000000000")
                 .to_string(),
             "micro" | "microether" => ethers_core::utils::format_units(value, 12)?
                 .trim_end_matches(".000000000000")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
it would be great to be able to use cast to-unit with the rest of the ether units kwei, mwei, microether and milliether. The reason being for easy command-line decimal conversion of certain smart contract calls, e.g. USDC's balanceOf, which has a decimals of 6 rather than the standard 18

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
I have added the kwei , mwei , microether and miliether to the unit conversion. These are the conversion units that i have used. 
1. kwei - 3
2. mwei - 6
3. microether - 12
4. milliether - 15

If there are more things to add to the changes , please let me know. I would very much happy to help.