### PR TITLE
fix: incorrect fuzz filter check

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -146,7 +146,6 @@ impl EthApi {
 
         let mut res: Vec<_> = vec![];
 
-        dbg!(to, from);
         for n in (to..=from).rev() {
             if n == to {
                 last_page = true;
@@ -271,7 +270,7 @@ impl EthApi {
 
         // loop in reverse, since we want the latest deploy to the address
         for n in (from..=to).rev() {
-            if let Some(traces) = dbg!(self.backend.mined_parity_trace_block(n)) {
+            if let Some(traces) = self.backend.mined_parity_trace_block(n) {
                 for trace in traces.into_iter().rev() {
                     match (trace.action, trace.result) {
                         (

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -238,9 +238,7 @@ contract Contract {
     let call = contract.method::<_, ()>("trigger_revert", ()).unwrap().gas(150_000u64);
     let receipt = call.send().await.unwrap().await.unwrap().unwrap();
 
-    let block = api.block_by_number_full(BlockNumber::Latest).await.unwrap().unwrap();
-    dbg!(block);
-    // let tx = block.transactions[0].hashVg
+    let _block = api.block_by_number_full(BlockNumber::Latest).await.unwrap().unwrap();
 
     let res = api.ots_get_transaction_error(receipt.transaction_hash).await.unwrap().unwrap();
     assert_eq!(res, Bytes::from_str("0x8d6ea8be00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000012526576657274537472696e67466f6f4261720000000000000000000000000000").unwrap());
@@ -299,13 +297,11 @@ async fn can_call_ots_get_block_transactions() {
         hashes.push_back(receipt.tx_hash());
     }
 
-    dbg!(&hashes);
     api.mine_one().await;
 
     let page_size = 3;
     for page in 0..4 {
         let result = api.ots_get_block_transactions(1, page, page_size).await.unwrap();
-        dbg!(&result);
 
         assert!(result.receipts.len() <= page_size);
         assert!(result.fullblock.block.transactions.len() <= page_size);

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -2,7 +2,7 @@ use crate::Ui;
 use foundry_common::{compile::ContractSources, evm::Breakpoints, get_contract_name};
 use foundry_evm::{debug::DebugArena, trace::CallTraceDecoder};
 use foundry_utils::types::ToAlloy;
-use tracing::trace;
+use tracing::{error, trace};
 
 use crate::{TUIExitReason, Tui};
 
@@ -19,14 +19,17 @@ pub struct DebuggerArgs<'a> {
 }
 
 impl DebuggerArgs<'_> {
+    /// Starts the debugger
     pub fn run(&self) -> eyre::Result<TUIExitReason> {
         trace!(target: "debugger", "running debugger");
-
         let flattened = self
             .debug
             .last()
             .map(|arena| arena.flatten(0))
-            .expect("We should have collected debug information");
+            .ok_or_else(|| {
+                error!(target: "debugger", debug_entries=?self.debug.len(), "Failed to get debug information for arena");
+                eyre::eyre!("Unable to collected debug information")
+            })?;
 
         let identified_contracts = self
             .decoder

--- a/crates/evm/src/executor/mod.rs
+++ b/crates/evm/src/executor/mod.rs
@@ -326,7 +326,6 @@ impl Executor {
         // Persist the snapshot failure recorded on the fuzz backend wrapper.
         self.backend
             .set_snapshot_failure(self.backend.has_snapshot_failure() || db.has_snapshot_failure());
-
         convert_executed_result(env, inspector, result)
     }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -199,16 +199,16 @@ impl TestArgs {
 
         if should_debug {
             filter.args_mut().test_pattern = self.debug.clone();
-            let n = runner.count_filtered_tests(&filter);
-            if n != 1 {
+            let num_filtered = runner.matching_test_function_count(&filter);
+            if num_filtered != 1 {
                 return Err(
-                        eyre::eyre!("{n} tests matched your criteria, but exactly 1 test must match in order to run the debugger.\n
+                        eyre::eyre!("{num_filtered} tests matched your criteria, but exactly 1 test must match in order to run the debugger.\n
                         \n
                         Use --match-contract and --match-path to further limit the search."));
             }
-            let test_funcs = runner.get_typed_tests(&filter);
+            let test_funcs = runner.get_matching_test_functions(&filter);
             // if we debug a fuzz test, we should not collect data on the first run
-            if !test_funcs.get(0).unwrap().inputs.is_empty() {
+            if !test_funcs.get(0).expect("matching function exists").inputs.is_empty() {
                 runner_builder = runner_builder.set_debug(false);
                 runner = runner_builder.clone().build(
                     project_root,
@@ -229,7 +229,6 @@ impl TestArgs {
 
         if should_debug {
             let tests = outcome.clone().into_tests();
-
             let mut decoders = Vec::new();
             for test in tests {
                 let mut result = test.result;
@@ -308,7 +307,6 @@ impl TestArgs {
 
             let test = outcome.clone().into_tests().next().unwrap();
             let result = test.result;
-
             // Run the debugger
             let debugger = DebuggerArgs {
                 debug: result.debug.map_or(vec![], |debug| vec![debug]),
@@ -618,7 +616,7 @@ async fn test(
     fail_fast: bool,
 ) -> Result<TestOutcome> {
     trace!(target: "forge::test", "running all tests");
-    if runner.count_filtered_tests(&filter) == 0 {
+    if runner.matching_test_function_count(&filter) == 0 {
         let filter_str = filter.to_string();
         if filter_str.is_empty() {
             println!(

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -60,7 +60,23 @@ pub struct MultiContractRunner {
 
 impl MultiContractRunner {
     /// Returns the number of matching tests
-    pub fn count_filtered_tests(&self, filter: &impl TestFilter) -> usize {
+    pub fn matching_test_function_count(&self, filter: &impl TestFilter) -> usize {
+        self.matching_test_functions(filter).count()
+    }
+
+    /// Returns all test functions matching the filter
+    pub fn get_matching_test_functions<'a>(
+        &'a self,
+        filter: &'a impl TestFilter,
+    ) -> Vec<&Function> {
+        self.matching_test_functions(filter).collect()
+    }
+
+    /// Returns all test functions matching the filter
+    pub fn matching_test_functions<'a>(
+        &'a self,
+        filter: &'a impl TestFilter,
+    ) -> impl Iterator<Item = &Function> {
         self.contracts
             .iter()
             .filter(|(id, _)| {
@@ -70,10 +86,10 @@ impl MultiContractRunner {
             .flat_map(|(_, (abi, _, _))| {
                 abi.functions().filter(|func| filter.matches_test(func.signature()))
             })
-            .count()
     }
 
-    /// Get an iterator over all test functions that matches the filter path and contract name
+    /// Get an iterator over all test contract functions that matches the filter path and contract
+    /// name
     fn filtered_tests<'a>(
         &'a self,
         filter: &'a impl TestFilter,
@@ -93,11 +109,6 @@ impl MultiContractRunner {
             .map(|func| func.name.clone())
             .filter(|name| name.is_test())
             .collect()
-    }
-
-    /// Returns all test functions matching the filter
-    pub fn get_typed_tests<'a>(&'a self, filter: &'a impl TestFilter) -> Vec<&Function> {
-        self.filtered_tests(filter).filter(|func| func.name.is_test()).collect()
     }
 
     /// Returns all matching tests grouped by contract grouped by file (file -> (contract -> tests))

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -327,7 +327,7 @@ impl<'a> ContractRunner<'a> {
         // Run unit test
         let mut executor = self.executor.clone();
         let start = Instant::now();
-        let mut debug_arena = None;
+        let debug_arena;
         let (reverted, reason, gas, stipend, coverage, state_changeset, breakpoints) =
             match executor.execute_test::<(), _, _>(
                 self.sender.to_alloy(),
@@ -362,6 +362,7 @@ impl<'a> ContractRunner<'a> {
                     labeled_addresses
                         .extend(err.labels.into_iter().map(|l| (l.0.to_ethers(), l.1)));
                     logs.extend(err.logs);
+                    debug_arena = err.debug;
                     (
                         err.reverted,
                         Some(err.reason),


### PR DESCRIPTION
Closes #5883

this fixes a bad fuzz filter check when debugger is enabled resulting in misconfiguration of the testrunner.

the filter function we're using to check if the target function is a fuzz function was only checking contracts not functions

tested against repro of #5883