### PR TITLE
fix(cast): skip optimism system tx

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -16,6 +16,11 @@ use foundry_evm::{
 use foundry_utils::types::ToAlloy;
 use tracing::trace;
 
+const OPTIMISM_SENDER: H160 = H160([
+    0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad,
+    0xde, 0xad, 0x00, 0x01,
+]);
+
 const ARBITRUM_SENDER: H160 = H160([
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x0a, 0x4b, 0x05,
@@ -135,8 +140,9 @@ impl RunArgs {
 
                 for (index, tx) in block.transactions.into_iter().enumerate() {
                     // arbitrum L1 transaction at the start of every block that has gas price 0
-                    // and gas limit 0 which causes reverts, so we skip it
-                    if tx.from == ARBITRUM_SENDER {
+                    // and gas limit 0, and optimism's also has gas price 0
+                    // both txs causes reverts on validating tx, so we skip it
+                    if tx.from == ARBITRUM_SENDER || tx.from == OPTIMISM_SENDER {
                         update_progress!(pb, index);
                         continue
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Fixes #5987 

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


Like base and optimism, chains built on the OP Stack have the first transaction in the block created by the fixed system address (`0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead0001`), which fails tx validation in revm.


[reference](https://github.com/ethereum-optimism/optimism/blob/d5ccf81966bc2fc650c802fd4b80a30e98843a0b/op-node/rollup/derive/l1_block_info.go#L26)


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Like https://github.com/foundry-rs/foundry/pull/5226, for `cast run`, transactions have already been confirmed by the network. Hardcoded a transaction skip from `0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead0001`.
