### PR TITLE
chore(`deps`): use latest revm release instead of patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,7 +5477,8 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/bluealloy/revm/?branch=main#23cbac479f616eba5ab11ddfe6d5814b9c492202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f4ca8ae0345104523b4af1a8a7ea97cfa1865cdb7a7c25d23c1a18d9b48598"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5489,7 +5490,8 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm/?branch=main#23cbac479f616eba5ab11ddfe6d5814b9c492202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959cafdf64a7f89b014fa73dc2325001cf654b3d9400260b212d19a2ebe3da0"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -5498,7 +5500,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/bluealloy/revm/?branch=main#23cbac479f616eba5ab11ddfe6d5814b9c492202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
 dependencies = [
  "c-kzg",
  "k256",
@@ -5514,7 +5517,8 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm/?branch=main#23cbac479f616eba5ab11ddfe6d5814b9c492202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,10 +191,10 @@ ethers-middleware = { git = "https://github.com/gakonst/ethers-rs" }
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs" }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs" }
 
-revm = { git = "https://github.com/bluealloy/revm/", branch = "main" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm/", branch = "main" }
-revm-precompile = { git = "https://github.com/bluealloy/revm/", branch = "main" }
-revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+# revm = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+# revm-interpreter = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+# revm-precompile = { git = "https://github.com/bluealloy/revm/", branch = "main" }
+# revm-primitives = { git = "https://github.com/bluealloy/revm/", branch = "main" }
 
 alloy-dyn-abi = { git = "https://github.com/alloy-rs/core/", branch = "main"}
 alloy-primitives = { git = "https://github.com/alloy-rs/core/", branch = "main"}


### PR DESCRIPTION
`revm` has recently received a bunch of changes that we've had to incorporate with using patches to keep track of master. Now this is all merged in, including alloy, so there's no point to use a patch now, meaning we can switch to the latest release.