### PR TITLE
fix: correct check for scientific notation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "vergen",
  "watchexec",
  "yansi 0.5.1",

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -239,11 +239,11 @@ pub fn value_to_token(value: &Value) -> Result<DynSolValue> {
                     // Example: 18446744073709551615 becomes 18446744073709552000 after parsing it
                     // to f64.
                     let s = number.to_string();
-
                     // Coerced to scientific notation, so short-ciruit to using fallback.
                     // This will not have a problem with hex numbers, as for parsing these
                     // We'd need to prefix this with 0x.
-                    if s.starts_with("1e") {
+                    // See also <https://docs.soliditylang.org/en/latest/types.html#rational-and-integer-literals>
+                    if s.contains('e') {
                         // Calling Number::to_string with powers of ten formats the number using
                         // scientific notation and causes from_dec_str to fail. Using format! with
                         // f64 keeps the full number representation.
@@ -312,6 +312,7 @@ fn encode_abi_values(values: Vec<DynSolValue>) -> Vec<u8> {
 
 /// Parses a vector of [`Value`]s into a vector of [`DynSolValue`]s.
 fn parse_json_values(values: Vec<&Value>, key: &str) -> Result<Vec<DynSolValue>> {
+    trace!(?values, %key, "parseing json values");
     values
         .iter()
         .map(|inner| {
@@ -325,6 +326,7 @@ fn parse_json_values(values: Vec<&Value>, key: &str) -> Result<Vec<DynSolValue>>
 /// deserialized in the same order. That means that the solidity `struct` should order it's fields
 /// alphabetically and not by efficient packing or some other taxonomy.
 fn parse_json(json_str: &str, key: &str, coerce: Option<DynSolType>) -> Result {
+    trace!(%json_str, %key, ?coerce, "parsing json");
     let json =
         serde_json::from_str(json_str).map_err(|err| fmt_err!("Failed to parse JSON: {err}"))?;
     match key {
@@ -340,6 +342,8 @@ fn parse_json(json_str: &str, key: &str, coerce: Option<DynSolType>) -> Result {
         }
         _ => {
             let values = jsonpath_lib::select(&json, &canonicalize_json_key(key))?;
+            trace!(?values, "selected json values");
+
             // values is an array of items. Depending on the JsonPath key, they
             // can be many or a single item. An item can be a single value or
             // an entire JSON object.

--- a/crates/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -206,7 +206,7 @@ impl Cheatcodes {
         Self { config, fs_commit: true, ..Default::default() }
     }
 
-    #[instrument(level = "error", name = "apply", target = "evm::cheatcodes", skip_all)]
+    #[instrument(level = "error", name = "apply", skip_all)]
     fn apply_cheatcode<DB: DatabaseExt>(
         &mut self,
         data: &mut EVMData<'_, DB>,

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -75,6 +75,7 @@ path-slash = "0.2"
 pretty_assertions = "1"
 serial_test = "2"
 svm = { package = "svm-rs", version = "0.3", default-features = false, features = ["rustls"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [features]
 default = ["rustls"]

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -132,6 +132,13 @@ pub fn test_opts() -> TestOptions {
     }
 }
 
+#[allow(unused)]
+pub(crate) fn init_tracing() {
+    let _ = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
 pub fn manifest_root() -> PathBuf {
     let mut root = Path::new(env!("CARGO_MANIFEST_DIR"));
     // need to check here where we're executing the test from, if in `forge` we need to also allow

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -290,6 +290,12 @@ async fn test_issue_3792() {
     test_repro!("Issue3792");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/6006>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_6006() {
+    test_repro!("Issue6006");
+}
+
 // <https://github.com/foundry-rs/foundry/issues/5808>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_issue_5808() {

--- a/testdata/repros/Issue6006.t.sol
+++ b/testdata/repros/Issue6006.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6006
+contract Issue6066Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function test_parse_11e20_sci() public {
+        string memory json = '{"value": 1.1e20}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 1.1e20);
+    }
+
+    function test_parse_22e20_sci() public {
+        string memory json = '{"value": 2.2e20}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 2.2e20);
+    }
+
+    function test_parse_2e_sci() public {
+        string memory json = '{"value": 2e10}';
+        bytes memory parsed = vm.parseJson(json);
+        Value memory data = abi.decode(parsed, (Value));
+        assertEq(data.value, 2e10);
+    }
+}
+
+struct Value {
+    uint256 value;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #6006

only checking for "e" is valid because this is a json::number
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
incorrect scientific notation check
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
