### PR TITLE
fix(`cast`) fix `prevrando` config for `cast run`

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -127,7 +127,7 @@ impl RunArgs {
             env.block.timestamp = block.timestamp.to_alloy();
             env.block.coinbase = block.author.unwrap_or_default().to_alloy();
             env.block.difficulty = block.difficulty.to_alloy();
-            env.block.prevrandao = block.mix_hash.map(|h| h.to_alloy());
+            env.block.prevrandao = Some(block.mix_hash.map(|h| h.to_alloy()).unwrap_or_default());
             env.block.basefee = block.base_fee_per_gas.unwrap_or_default().to_alloy();
             env.block.gas_limit = block.gas_limit.to_alloy();
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was trying to get traces from a transaction on moonbeam by running the following command

```
 cast run --rpc-url https://1rpc.io/glmr  0xc8ab251113930754a43389dcae3750469fe2deb38ee6ab5c4869e5ea50615c1f  
```

I was hit with the error

<img width="808" alt="image" src="https://github.com/foundry-rs/foundry/assets/114708157/917fb545-046d-42d3-b20c-f142fbf2aa75">


## Solution

Similar to https://github.com/foundry-rs/foundry/issues/4232 (fixed in #4238) I had to change the `prevrandao` config variable for `cast run`


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

With the following branch, i ran `foundryup` with my branch and was able to successfully run the command
<img width="296" alt="image" src="https://github.com/foundry-rs/foundry/assets/114708157/b6db4822-20c7-4f12-953f-fd6a7edda482">
