### PR TITLE
fix(`cast`) Remove `block.json` file write for `cast run`

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -132,8 +132,6 @@ impl RunArgs {
             env.block.gas_limit = block.gas_limit.to_alloy();
         }
 
-        std::fs::write("block.json", serde_json::to_string_pretty(&block).unwrap()).unwrap();
-
         // Set the state to the moment right before the transaction
         if !self.quick {
             println!("Executing previous transactions from the block.");


### PR DESCRIPTION
Every time `cast run` was called, it would create an unnecessary `block.json` file.