### PR TITLE
fix: remove println in get_env function

### DIFF
--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -200,7 +200,6 @@ fn get_env(key: &str, ty: DynSolType, delim: Option<&str>, default: Option<Strin
             fmt_err!("Failed to get environment variable `{key}` as type `{ty}`: {e}")
         })
     })?;
-    println!("got val: {}", val);
     if let Some(d) = delim {
         parse::parse_array(val.split(d).map(str::trim), &ty)
     } else {


### PR DESCRIPTION
## Motivation

Spotted this in my terminal after running `foundryup`. I assume it got left in accidentally. 

## Solution

Remove leftover println.
