### PR TITLE
fix: get_proof encoding bug

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2079,7 +2079,7 @@ impl Backend {
     pub async fn prove_account_at(
         &self,
         address: Address,
-        values: Vec<H256>,
+        keys: Vec<H256>,
         block_request: Option<BlockRequest>,
     ) -> Result<AccountProof, BlockchainError> {
         let account_key = H256::from(keccak256(address.as_bytes()));
@@ -2128,13 +2128,14 @@ impl Backend {
                 code_hash: account.code_hash,
                 storage_hash: account.storage_root,
                 account_proof: proof,
-                storage_proof: values
+                storage_proof: keys
                     .into_iter()
                     .map(|storage_key| {
+                        // the key that should be proofed is the keccak256 of the storage key
                         let key = H256::from(keccak256(storage_key));
                         prove_storage(&account, &account_db.0, key).map(
                             |(storage_proof, storage_value)| StorageProof {
-                                key,
+                                key: storage_key,
                                 value: storage_value.into_uint(),
                                 proof: storage_proof
                                     .into_iter()

--- a/crates/anvil/tests/it/proof/mod.rs
+++ b/crates/anvil/tests/it/proof/mod.rs
@@ -39,7 +39,11 @@ async fn can_get_proof() {
     let rlp_account = rlp::encode(&account);
 
     let root: H256 = api.state_root().await.unwrap();
-    let acc_proof: Vec<Vec<u8>> = proof.account_proof.into_iter().map(|b| b.to_vec()).collect();
+    let acc_proof: Vec<Vec<u8>> = proof
+        .account_proof
+        .into_iter()
+        .map(|node| rlp::decode::<Vec<u8>>(&node).unwrap())
+        .collect();
 
     verify_proof::<ExtensionLayout>(
         &root.0,
@@ -52,7 +56,8 @@ async fn can_get_proof() {
     assert_eq!(proof.storage_proof.len(), 1);
     let expected_value = rlp::encode(&value);
     let proof = proof.storage_proof[0].clone();
-    let storage_proof: Vec<Vec<u8>> = proof.proof.into_iter().map(|b| b.to_vec()).collect();
+    let storage_proof: Vec<Vec<u8>> =
+        proof.proof.into_iter().map(|node| rlp::decode::<Vec<u8>>(&node).unwrap()).collect();
     verify_proof::<ExtensionLayout>(
         &account.storage_root.0,
         &storage_proof,

--- a/crates/anvil/tests/it/proof/mod.rs
+++ b/crates/anvil/tests/it/proof/mod.rs
@@ -58,10 +58,11 @@ async fn can_get_proof() {
     let proof = proof.storage_proof[0].clone();
     let storage_proof: Vec<Vec<u8>> =
         proof.proof.into_iter().map(|node| rlp::decode::<Vec<u8>>(&node).unwrap()).collect();
+    let key = H256::from(keccak256(proof.key.as_bytes()));
     verify_proof::<ExtensionLayout>(
         &account.storage_root.0,
         &storage_proof,
-        proof.key.as_bytes(),
+        key.as_bytes(),
         Some(expected_value.as_ref()),
     )
     .unwrap();

--- a/testdata/cheats/Fork2.t.sol
+++ b/testdata/cheats/Fork2.t.sol
@@ -225,7 +225,7 @@ contract ForkTest is DSTest {
         string memory path = "fixtures/Rpc/balance_params.json";
         string memory file = vm.readFile(path);
         bytes memory result = vm.rpc("eth_getBalance", file);
-        assertEq(result, hex"34f4d7c595f11e");
+        assertEq(result, hex"3582f71d817d46");
     }
 }
 


### PR DESCRIPTION
this fixes at least the rlp encoding bugs for proof nodes

ref #5004

still no idea what the bug with the proof is.

maybe @rkrasiuk can figure this out, 

maybe something here 

https://github.com/foundry-rs/foundry/blob/master/crates/anvil/src/eth/backend/mem/state.rs#L44-L44

but idk, this entire thing is giga cursed