### PR TITLE
feat(anvil): resume work on anvil reset starting a fork

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -288,7 +288,7 @@ impl NodeArgs {
             // this will make sure that the fork RPC cache is flushed if caching is configured
             if let Some(fork) = fork.take() {
                 trace!("flushing cache on shutdown");
-                fork.database.read().await.flush_cache();
+                fork.database.read().await.maybe_flush_cache().expect("Could not flush cache on fork DB");
                 // cleaning up and shutting down
                 // this will make sure that the fork RPC cache is flushed if caching is configured
             }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -288,7 +288,11 @@ impl NodeArgs {
             // this will make sure that the fork RPC cache is flushed if caching is configured
             if let Some(fork) = fork.take() {
                 trace!("flushing cache on shutdown");
-                fork.database.read().await.maybe_flush_cache().expect("Could not flush cache on fork DB");
+                fork.database
+                    .read()
+                    .await
+                    .maybe_flush_cache()
+                    .expect("Could not flush cache on fork DB");
                 // cleaning up and shutting down
                 // this will make sure that the fork RPC cache is flushed if caching is configured
             }

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -12,6 +12,7 @@ use foundry_common::errors::FsPathError;
 use foundry_evm::{
     executor::{
         backend::{snapshot::StateSnapshot, DatabaseError, DatabaseResult, MemDb},
+        fork::BlockchainDb,
         DatabaseRef,
     },
     revm::{
@@ -77,6 +78,8 @@ pub trait MaybeForkedDatabase {
     fn maybe_reset(&mut self, _url: Option<String>, block_number: BlockId) -> Result<(), String>;
 
     fn maybe_flush_cache(&self) -> Result<(), String>;
+
+    fn maybe_inner(&self) -> Result<&BlockchainDb, String>;
 }
 
 /// This bundles all required revm traits
@@ -267,6 +270,10 @@ impl<T: DatabaseRef<Error = DatabaseError>> MaybeForkedDatabase for CacheDB<T> {
     }
 
     fn maybe_flush_cache(&self) -> Result<(), String> {
+        Err("not supported".to_string())
+    }
+
+    fn maybe_inner(&self) -> Result<&BlockchainDb, String> {
         Err("not supported".to_string())
     }
 }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -1,6 +1,6 @@
 //! Support for forking off another client
 
-use crate::eth::{backend::mem::fork_db::ForkedDatabase, error::BlockchainError};
+use crate::eth::{backend::db::Db, error::BlockchainError};
 use anvil_core::eth::{proof::AccountProof, transaction::EthTransactionRequest};
 use ethers::{
     prelude::BlockNumber,
@@ -34,14 +34,14 @@ pub struct ClientFork {
     // endpoints
     pub config: Arc<RwLock<ClientForkConfig>>,
     /// This also holds a handle to the underlying database
-    pub database: Arc<AsyncRwLock<ForkedDatabase>>,
+    pub database: Arc<AsyncRwLock<Box<dyn Db>>>,
 }
 
 // === impl ClientFork ===
 
 impl ClientFork {
     /// Creates a new instance of the fork
-    pub fn new(config: ClientForkConfig, database: Arc<AsyncRwLock<ForkedDatabase>>) -> Self {
+    pub fn new(config: ClientForkConfig, database: Arc<AsyncRwLock<Box<dyn Db>>>) -> Self {
         Self { storage: Default::default(), config: Arc::new(RwLock::new(config)), database }
     }
 
@@ -56,7 +56,7 @@ impl ClientFork {
             self.database
                 .write()
                 .await
-                .reset(url.clone(), block_number)
+                .maybe_reset(url.clone(), block_number)
                 .map_err(BlockchainError::Internal)?;
         }
 

--- a/crates/anvil/src/eth/backend/genesis.rs
+++ b/crates/anvil/src/eth/backend/genesis.rs
@@ -59,7 +59,7 @@ impl GenesisConfig {
     /// If an initial `genesis.json` was provided, this applies the account alloc to the db
     pub fn apply_genesis_json_alloc(
         &self,
-        mut db: RwLockWriteGuard<'_, dyn Db>,
+        mut db: RwLockWriteGuard<'_, Box<dyn Db>>,
     ) -> DatabaseResult<()> {
         if let Some(ref genesis) = self.genesis_init {
             for (addr, mut acc) in genesis.alloc.accounts.clone() {

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -1,11 +1,12 @@
 use crate::{
     eth::backend::db::{
-        Db, MaybeHashDatabase, SerializableAccountRecord, SerializableState, StateDb,
+        Db, MaybeForkedDatabase, MaybeHashDatabase, SerializableAccountRecord, SerializableState,
+        StateDb,
     },
     revm::primitives::AccountInfo,
     Address, U256,
 };
-use ethers::prelude::H256;
+use ethers::{prelude::H256, types::BlockId};
 pub use foundry_evm::executor::fork::database::ForkedDatabase;
 use foundry_evm::{
     executor::{
@@ -99,6 +100,7 @@ impl MaybeHashDatabase for ForkedDatabase {
         *db.block_hashes.write() = block_hashes;
     }
 }
+
 impl MaybeHashDatabase for ForkDbSnapshot {
     fn clear_into_snapshot(&mut self) -> StateSnapshot {
         std::mem::take(&mut self.snapshot)
@@ -111,5 +113,15 @@ impl MaybeHashDatabase for ForkDbSnapshot {
 
     fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
         self.snapshot = snapshot;
+    }
+}
+
+impl MaybeForkedDatabase for ForkedDatabase {
+    fn maybe_reset(&mut self, url: Option<String>, block_number: BlockId) -> Result<(), String> {
+        self.reset(url, block_number)
+    }
+
+    fn maybe_flush_cache(&self) -> Result<(), String> {
+        Ok(self.flush_cache())
     }
 }

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -11,7 +11,7 @@ pub use foundry_evm::executor::fork::database::ForkedDatabase;
 use foundry_evm::{
     executor::{
         backend::{snapshot::StateSnapshot, DatabaseResult},
-        fork::database::ForkDbSnapshot,
+        fork::{database::ForkDbSnapshot, BlockchainDb},
     },
     revm::Database,
 };
@@ -122,6 +122,11 @@ impl MaybeForkedDatabase for ForkedDatabase {
     }
 
     fn maybe_flush_cache(&self) -> Result<(), String> {
-        Ok(self.flush_cache())
+        self.flush_cache();
+        Ok(())
+    }
+
+    fn maybe_inner(&self) -> Result<&BlockchainDb, String> {
+        Ok(self.inner())
     }
 }

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -15,8 +15,11 @@ use tracing::{trace, warn};
 
 // reexport for convenience
 use crate::mem::state::storage_trie_db;
-use foundry_evm::executor::backend::{snapshot::StateSnapshot, DatabaseResult};
 pub use foundry_evm::executor::{backend::MemDb, DatabaseRef};
+use foundry_evm::executor::{
+    backend::{snapshot::StateSnapshot, DatabaseResult},
+    fork::BlockchainDb,
+};
 
 impl Db for MemDb {
     fn insert_account(&mut self, address: Address, account: AccountInfo) {
@@ -122,6 +125,10 @@ impl MaybeForkedDatabase for MemDb {
     }
 
     fn maybe_flush_cache(&self) -> Result<(), String> {
+        Err("not supported".to_string())
+    }
+
+    fn maybe_inner(&self) -> Result<&BlockchainDb, String> {
         Err("not supported".to_string())
     }
 }

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -2,13 +2,14 @@
 
 use crate::{
     eth::backend::db::{
-        AsHashDB, Db, MaybeHashDatabase, SerializableAccountRecord, SerializableState, StateDb,
+        AsHashDB, Db, MaybeForkedDatabase, MaybeHashDatabase, SerializableAccountRecord,
+        SerializableState, StateDb,
     },
     mem::state::{state_merkle_trie_root, trie_hash_db},
     revm::primitives::AccountInfo,
     Address, U256,
 };
-use ethers::prelude::H256;
+use ethers::{prelude::H256, types::BlockId};
 use foundry_utils::types::{ToAlloy, ToEthers};
 use tracing::{trace, warn};
 
@@ -112,6 +113,16 @@ impl MaybeHashDatabase for MemDb {
 
     fn init_from_snapshot(&mut self, snapshot: StateSnapshot) {
         self.inner.init_from_snapshot(snapshot)
+    }
+}
+
+impl MaybeForkedDatabase for MemDb {
+    fn maybe_reset(&mut self, _url: Option<String>, _block_number: BlockId) -> Result<(), String> {
+        Err("not supported".to_string())
+    }
+
+    fn maybe_flush_cache(&self) -> Result<(), String> {
+        Err("not supported".to_string())
     }
 }
 

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -20,6 +20,7 @@ use futures::StreamExt;
 use std::{sync::Arc, time::Duration};
 
 const BLOCK_NUMBER: u64 = 14_608_400u64;
+const DEAD_BALANCE_AT_BLOCK_NUMBER: u128 = 12_556_069_338_441_120_059_867u128;
 
 const BLOCK_TIMESTAMP: u64 = 1_650_274_250u64;
 
@@ -227,8 +228,13 @@ async fn test_fork_reset_setup() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
+    let dead_addr: Address = "000000000000000000000000000000000000dEaD".parse().unwrap();
+
     let block_number = provider.get_block_number().await.unwrap();
     assert_eq!(block_number, 0.into());
+
+    let local_balance = provider.get_balance(dead_addr, None).await.unwrap();
+    assert_eq!(local_balance, 0.into());
 
     api.anvil_reset(Some(Forking {
         json_rpc_url: Some(rpc::next_http_archive_rpc_endpoint()),
@@ -240,11 +246,8 @@ async fn test_fork_reset_setup() {
     let block_number = provider.get_block_number().await.unwrap();
     assert_eq!(block_number, BLOCK_NUMBER.into());
 
-    // TODO: This won't work because we don't replace the DB with a ForkedDatabase yet
-    // let addr: Address = "000000000000000000000000000000000000dEaD".parse().unwrap();
-
-    // let remote_balance = provider.get_balance(addr, None).await.unwrap();
-    // assert_eq!(remote_balance, 12556069338441120059867u128.into());
+    let remote_balance = provider.get_balance(dead_addr, None).await.unwrap();
+    assert_eq!(remote_balance, DEAD_BALANCE_AT_BLOCK_NUMBER.into());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -302,7 +305,15 @@ async fn test_separate_states() {
 
     let fork = api.get_fork().unwrap();
     let fork_db = fork.database.read().await;
-    let acc = fork_db.inner().db().accounts.read().get(&addr.to_alloy()).cloned().unwrap();
+    let acc = fork_db
+        .maybe_inner()
+        .expect("could not get fork db inner")
+        .db()
+        .accounts
+        .read()
+        .get(&addr.to_alloy())
+        .cloned()
+        .unwrap();
 
     assert_eq!(acc.balance, remote_balance.to_alloy())
 }


### PR DESCRIPTION
## Motivation

As per https://github.com/foundry-rs/foundry/issues/5805, picking up work back from https://github.com/foundry-rs/foundry/pull/5834.

## Solution

`Box` the `dyn Db` so that the size is known at compile time. However, I'm stumped on how to actually swap one Boxed Db with another and would appreciate help with this.
