### PR TITLE
feat: set chain id endpoint

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -421,6 +421,10 @@ pub enum EthRequest {
     )]
     SetCoinbase(Address),
 
+    /// Sets the chain id
+    #[cfg_attr(feature = "serde", serde(rename = "anvil_setChainId", with = "sequence"))]
+    SetChainId(u64),
+
     /// Enable or disable logging
     #[cfg_attr(
         feature = "serde",

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -303,6 +303,7 @@ impl EthApi {
                 self.anvil_set_storage_at(addr, slot, val).await.to_rpc_result()
             }
             EthRequest::SetCoinbase(addr) => self.anvil_set_coinbase(addr).await.to_rpc_result(),
+            EthRequest::SetChainId(id) => self.anvil_set_chain_id(id).await.to_rpc_result(),
             EthRequest::SetLogging(log) => self.anvil_set_logging(log).await.to_rpc_result(),
             EthRequest::SetMinGasPrice(gas) => {
                 self.anvil_set_min_gas_price(gas).await.to_rpc_result()
@@ -1534,6 +1535,12 @@ impl EthApi {
         } else {
             Err(BlockchainError::RpcUnimplemented)
         }
+    }
+
+    pub async fn anvil_set_chain_id(&self, chain_id: u64) -> Result<()> {
+        node_info!("anvil_setChainId");
+        self.backend.set_chain_id(chain_id);
+        Ok(())
     }
 
     /// Modifies the balance of an account.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -492,6 +492,10 @@ impl Backend {
         self.env.read().cfg.chain_id.into()
     }
 
+    pub fn set_chain_id(&self, chain_id: u64) {
+        self.env.write().cfg.chain_id = chain_id;
+    }
+
     /// Returns balance of the given account.
     pub async fn current_balance(&self, address: Address) -> DatabaseResult<U256> {
         Ok(self.get_account(address).await?.balance.to_ethers())

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -483,3 +483,18 @@ async fn test_get_transaction_receipt() {
         new_receipt.unwrap().effective_gas_price.unwrap().as_u64()
     );
 }
+
+// test can set chain id
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_chain_id() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let chain_id = provider.get_chainid().await.unwrap();
+    assert_eq!(chain_id, U256::from(31337));
+
+    let chain_id = 1234;
+    api.anvil_set_chain_id(chain_id).await.unwrap();
+
+    let chain_id = provider.get_chainid().await.unwrap();
+    assert_eq!(chain_id, U256::from(1234));
+}


### PR DESCRIPTION

## Motivation
It would be useful to have the ability to change the chain ID in anvil using an RPC method, further outlined in https://github.com/foundry-rs/foundry/issues/6046

## Solution
Add an `anvil_setChainId` method, and an associated test.
