### PR TITLE
fix(forge): correctly suppress compiler output

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -162,14 +162,12 @@ impl TestArgs {
         }
 
         let compiler = ProjectCompiler::default();
-        let output = if config.sparse_mode {
-            compiler.compile_sparse(&project, filter.clone())
-        } else if self.opts.silent {
-            compile::suppress_compile(&project)
-        } else {
-            compiler.compile(&project)
+        let output = match (config.sparse_mode, self.opts.silent | self.json) {
+            (false, false) => compiler.compile(&project),
+            (true, false) => compiler.compile_sparse(&project, filter.clone()),
+            (false, true) => compile::suppress_compile(&project),
+            (true, true) => compile::suppress_compile_sparse(&project, filter.clone()),
         }?;
-
         // Create test options from general project settings
         // and compiler output
         let project_root = &project.paths.root;


### PR DESCRIPTION
## Motivation

When compiling with `sparse_mode = true` and `--silent` the compiler output is still not suppressed.

Similarly, it is expected that `--json` will result in only JSON output that can be piped to `jq` or saved as a file. Currently it has to be used as `--json --silent`. 

## Solution

Expand the logic to cover all permutations of `--json, `sparse_mode` and `--silent`.
