### PR TITLE
chore: misc cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,6 @@ name = "cast"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "bytes",
  "chrono",
  "clap",
  "clap_complete",
@@ -1026,7 +1025,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "bytes",
  "clap",
  "criterion",
  "dirs 5.0.1",
@@ -2467,7 +2465,6 @@ dependencies = [
  "alloy-primitives",
  "anvil",
  "async-trait",
- "bytes",
  "clap",
  "clap_complete",
  "clap_complete_fig",

--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 
 [build-dependencies]
 ethers-contract-abigen.workspace = true
-eyre = "0.6"
+eyre.workspace = true
 syn = "2.0"
 
 [dependencies]

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -43,7 +43,7 @@ tower = "0.4"
 tower-http = { version = "0.4", features = ["trace"] }
 
 # tracing
-tracing = "0.1"
+tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 # async
@@ -54,8 +54,8 @@ async-trait = "0.1"
 
 # misc
 flate2 = "1.0"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
+serde_json.workspace = true
+serde.workspace = true
 thiserror = "1"
 yansi = "0.5"
 tempfile = "3"

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -13,12 +13,12 @@ repository.workspace = true
 # foundry internal
 foundry-evm = { path = "../../evm" }
 foundry-utils = { path = "../../utils" }
-revm = { workspace = true,  default-features = false, features = ["std", "serde", "memory_limit"] }
+revm = { workspace = true, default-features = false, features = ["std", "serde", "memory_limit"] }
 
 alloy-primitives = { workspace = true, features = ["serde"] }
 ethers-core.workspace = true
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = "1"
+serde = { workspace = true, optional = true }
+serde_json.workspace = true
 bytes = { version = "1.4" }
 open-fastrlp = { version = "0.1.4", optional = true }
 
@@ -30,7 +30,7 @@ reference-trie = { version = "0.25" }
 keccak-hasher = { version = "0.15" }
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 
 [features]
 default = []

--- a/crates/anvil/core/src/eth/utils.rs
+++ b/crates/anvil/core/src/eth/utils.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address as rAddress, U256 as rU256};
+use alloy_primitives::{Address as aAddress, U256 as rU256};
 use ethers_core::{
     types::{transaction::eip2930::AccessListItem, Address, U256},
     utils::{
@@ -23,7 +23,7 @@ pub fn to_access_list(list: Vec<AccessListItem>) -> Vec<(Address, Vec<U256>)> {
         .collect()
 }
 
-pub fn to_revm_access_list(list: Vec<AccessListItem>) -> Vec<(rAddress, Vec<rU256>)> {
+pub fn to_revm_access_list(list: Vec<AccessListItem>) -> Vec<(aAddress, Vec<rU256>)> {
     list.into_iter()
         .map(|item| {
             (

--- a/crates/anvil/rpc/Cargo.toml
+++ b/crates/anvil/rpc/Cargo.toml
@@ -10,8 +10,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/anvil/server/Cargo.toml
+++ b/crates/anvil/server/Cargo.toml
@@ -19,7 +19,7 @@ hyper = "0.14"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 
 # tracing
-tracing = "0.1"
+tracing.workspace = true
 
 # async
 parking_lot = "0.12"
@@ -31,8 +31,8 @@ bytes = { version = "1.4", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 
 # misc
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
+serde_json.workspace = true
+serde.workspace = true
 async-trait = "0.1"
 thiserror = "1"
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -173,7 +173,7 @@ pub struct NodeConfig {
 
 impl NodeConfig {
     fn as_string(&self, fork: Option<&ClientFork>) -> String {
-        let mut config_string: String = "".to_owned();
+        let mut config_string: String = String::new();
         let _ = write!(config_string, "\n{}", Paint::green(BANNER));
         let _ = write!(config_string, "\n    {VERSION_MESSAGE}");
         let _ = write!(

--- a/crates/anvil/src/eth/backend/genesis.rs
+++ b/crates/anvil/src/eth/backend/genesis.rs
@@ -4,7 +4,7 @@ use crate::{
     eth::backend::db::{Db, MaybeHashDatabase},
     genesis::Genesis,
 };
-use alloy_primitives::{Address as B160, B256, U256};
+use alloy_primitives::{Address as aAddress, B256, U256};
 use ethers::{
     abi::ethereum_types::BigEndianHash,
     types::{Address, H256},
@@ -103,7 +103,7 @@ pub(crate) struct AtGenesisStateDb<'a> {
 
 impl<'a> DatabaseRef for AtGenesisStateDb<'a> {
     type Error = DatabaseError;
-    fn basic(&self, address: B160) -> DatabaseResult<Option<AccountInfo>> {
+    fn basic(&self, address: aAddress) -> DatabaseResult<Option<AccountInfo>> {
         if let Some(acc) = self.accounts.get(&(address.to_ethers())).cloned() {
             return Ok(Some(acc))
         }
@@ -117,7 +117,7 @@ impl<'a> DatabaseRef for AtGenesisStateDb<'a> {
         self.db.code_by_hash(code_hash)
     }
 
-    fn storage(&self, address: B160, index: U256) -> DatabaseResult<U256> {
+    fn storage(&self, address: aAddress, index: U256) -> DatabaseResult<U256> {
         if let Some(acc) = self
             .genesis
             .as_ref()

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -140,8 +140,7 @@ mod tests {
         revm::primitives::AccountInfo,
         Address,
     };
-    use alloy_primitives::U256 as rU256;
-    use bytes::Bytes;
+    use alloy_primitives::{Bytes, U256 as rU256};
     use ethers::types::U256;
     use foundry_evm::{
         executor::{backend::MemDb, DatabaseRef},
@@ -159,9 +158,7 @@ mod tests {
 
         let mut dump_db = MemDb::default();
 
-        let contract_code: Bytecode =
-            Bytecode::new_raw(alloy_primitives::Bytes(Bytes::from("fake contract code")))
-                .to_checked();
+        let contract_code = Bytecode::new_raw(Bytes::from("fake contract code")).to_checked();
 
         dump_db.insert_account(
             test_addr,
@@ -201,9 +198,7 @@ mod tests {
         let test_addr2: Address =
             Address::from_str("0x70997970c51812dc3a010c7d01b50e0d17dc79c8").unwrap();
 
-        let contract_code: Bytecode =
-            Bytecode::new_raw(alloy_primitives::Bytes(Bytes::from("fake contract code")))
-                .to_checked();
+        let contract_code = Bytecode::new_raw(Bytes::from("fake contract code")).to_checked();
 
         let mut db = MemDb::default();
 

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -9,7 +9,7 @@ use foundry_evm::{
     revm,
     revm::{
         interpreter::{CallInputs, CreateInputs, Gas, InstructionResult, Interpreter},
-        primitives::{Address as rAddress, Bytes, B256},
+        primitives::{Address, Bytes, B256},
         EVMData,
     },
 };
@@ -71,7 +71,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
     fn log(
         &mut self,
         evm_data: &mut EVMData<'_, DB>,
-        address: &rAddress,
+        address: &Address,
         topics: &[B256],
         data: &Bytes,
     ) {
@@ -126,7 +126,7 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         &mut self,
         data: &mut EVMData<'_, DB>,
         call: &mut CreateInputs,
-    ) -> (InstructionResult, Option<rAddress>, Gas, Bytes) {
+    ) -> (InstructionResult, Option<Address>, Gas, Bytes) {
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.create(data, call);
         });
@@ -140,10 +140,10 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         data: &mut EVMData<'_, DB>,
         inputs: &CreateInputs,
         status: InstructionResult,
-        address: Option<rAddress>,
+        address: Option<Address>,
         gas: Gas,
         retdata: Bytes,
-    ) -> (InstructionResult, Option<rAddress>, Gas, Bytes) {
+    ) -> (InstructionResult, Option<Address>, Gas, Bytes) {
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.create_end(data, inputs, status, address, gas, retdata.clone());
         });

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -1,9 +1,8 @@
 //! Support for generating the state root for memdb storage
 
 use crate::eth::{backend::db::AsHashDB, error::BlockchainError};
-use alloy_primitives::{Address as rAddress, U256 as rU256};
+use alloy_primitives::{Address, Bytes, U256 as rU256};
 use anvil_core::eth::{state::StateOverride, trie::RefSecTrieDBMut};
-use bytes::Bytes;
 use ethers::{
     types::H256,
     utils::{rlp, rlp::RlpStream},
@@ -63,7 +62,7 @@ pub fn storage_trie_db(storage: &Map<rU256, rU256>) -> (AsHashDB, H256) {
 }
 
 /// Returns the account data as `HashDB`
-pub fn trie_hash_db(accounts: &Map<rAddress, DbAccount>) -> (AsHashDB, H256) {
+pub fn trie_hash_db(accounts: &Map<Address, DbAccount>) -> (AsHashDB, H256) {
     let accounts = trie_accounts(accounts);
 
     // Populate DB with full trie from entries.
@@ -83,7 +82,7 @@ pub fn trie_hash_db(accounts: &Map<rAddress, DbAccount>) -> (AsHashDB, H256) {
 }
 
 /// Returns all RLP-encoded Accounts
-pub fn trie_accounts(accounts: &Map<rAddress, DbAccount>) -> Vec<(rAddress, Bytes)> {
+pub fn trie_accounts(accounts: &Map<Address, DbAccount>) -> Vec<(Address, Bytes)> {
     accounts
         .iter()
         .map(|(address, account)| {
@@ -93,7 +92,7 @@ pub fn trie_accounts(accounts: &Map<rAddress, DbAccount>) -> Vec<(rAddress, Byte
         .collect()
 }
 
-pub fn state_merkle_trie_root(accounts: &Map<rAddress, DbAccount>) -> H256 {
+pub fn state_merkle_trie_root(accounts: &Map<Address, DbAccount>) -> H256 {
     trie_hash_db(accounts).1
 }
 
@@ -104,7 +103,7 @@ pub fn trie_account_rlp(info: &AccountInfo, storage: &Map<rU256, rU256>) -> Byte
     stream.append(&info.balance.to_ethers());
     stream.append(&storage_trie_db(storage).1);
     stream.append(&info.code_hash.as_slice());
-    stream.out().freeze()
+    stream.out().freeze().into()
 }
 
 /// Applies the given state overrides to the state, returning a new CacheDB state

--- a/crates/binder/Cargo.toml
+++ b/crates/binder/Cargo.toml
@@ -13,8 +13,8 @@ repository.workspace = true
 [dependencies]
 foundry-config.workspace = true
 ethers-contract = { workspace = true, features = ["abigen"] }
-eyre = "0.6"
+eyre.workspace = true
 git2 = { version = "0.18", default-features = false }
 url = "2"
-tracing = "0.1"
+tracing.workspace = true
 tempfile = "3"

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -29,12 +29,12 @@ ethers-core.workspace = true
 ethers-providers.workspace = true
 chrono.workspace = true
 evm-disassembler = "0.2"
-eyre = "0.6"
+eyre.workspace = true
 futures = "0.3"
 hex.workspace = true
 rayon = "1"
-serde = "1"
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 # aws
 rusoto_core = { version = "0.48", default-features = false }
@@ -48,7 +48,6 @@ foundry-cli.workspace = true
 ethers = { workspace = true, features = ["rustls"] }
 eth-keystore = "0.5"
 
-bytes = "1.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4"
 clap_complete_fig = "4"
@@ -61,7 +60,7 @@ rpassword = "7"
 semver = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "signal"] }
-tracing = "0.1"
+tracing.workspace = true
 yansi = "0.5"
 
 [dev-dependencies]

--- a/crates/cast/bin/cmd/logs.rs
+++ b/crates/cast/bin/cmd/logs.rs
@@ -305,7 +305,7 @@ mod tests {
             None,
             None,
             Some(TRANSFER_SIG.to_string()),
-            vec!["".to_string(), ADDRESS.to_string()],
+            vec![String::new(), ADDRESS.to_string()],
         )
         .unwrap();
         assert_eq!(filter, expected)
@@ -352,7 +352,7 @@ mod tests {
             None,
             None,
             Some(TRANSFER_TOPIC.to_string()),
-            vec!["".to_string(), TRANSFER_TOPIC.to_string()],
+            vec![String::new(), TRANSFER_TOPIC.to_string()],
         )
         .unwrap();
 

--- a/crates/cast/bin/cmd/wallet/vanity.rs
+++ b/crates/cast/bin/cmd/wallet/vanity.rs
@@ -122,7 +122,7 @@ impl VanityArgs {
                     nonce.unwrap(),
                 ))
             } else {
-                "".to_string()
+                String::new()
             },
             SimpleCast::to_checksum_address(&wallet.address()),
             hex::encode(wallet.signer().to_bytes()),

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -45,12 +45,11 @@ rustyline = "12"
 solang-parser.workspace = true
 yansi = "0.5"
 strum = { version = "0.25", features = ["derive"] }
-serde = "1"
-serde_json = { version = "1", features = ["raw_value"] }
+serde.workspace = true
+serde_json.workspace = true
 semver = "1"
-bytes = "1"
 revm.workspace = true
-eyre = "0.6"
+eyre.workspace = true
 dirs = "5"
 time = { version = "0.3", features = ["formatting"] }
 regex = "1"

--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -46,7 +46,7 @@ pub struct ChiselResult {
     /// Map of addresses to their labels
     pub labeled_addresses: BTreeMap<Address, String>,
     /// Return data
-    pub returned: bytes::Bytes,
+    pub returned: Bytes,
     /// Called address
     pub address: Option<Address>,
     /// EVM State at the final instruction of the `run()` function
@@ -200,7 +200,7 @@ impl ChiselRunner {
         let RawCallResult { result, reverted, logs, traces, labels, chisel_state, .. } = res;
 
         Ok(ChiselResult {
-            returned: result.0,
+            returned: result,
             success: !reverted,
             gas_used,
             logs,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,21 +29,21 @@ alloy-primitives.workspace = true
 
 async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
-color-eyre = "0.6"
+color-eyre.workspace = true
 dotenvy = "0.15"
-eyre = "0.6"
+eyre.workspace = true
 hex = { workspace = true, features = ["serde"] }
 indicatif = "0.17"
 itertools.workspace = true
 once_cell = "1"
 regex = { version = "1", default-features = false }
 rpassword = "7"
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 strsim = "0.10"
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros"] }
-tracing = "0.1"
+tracing.workspace = true
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
 yansi = "0.5"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,17 +27,17 @@ reqwest = { version = "0.11", default-features = false }
 # cli
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 comfy-table = "7"
-tracing = "0.1"
+tracing.workspace = true
 yansi = "0.5"
 tempfile = "3"
 
 #  misc
 auto_impl = "1.1.0"
 async-trait = "0.1"
-serde = "1"
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 thiserror = "1"
-eyre = "0.6"
+eyre.workspace = true
 walkdir = "2"
 semver = "1"
 once_cell = "1"

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -136,7 +136,7 @@ pub fn sanitize_token(token: Token) -> Token {
                     Token::String(val) => {
                         let val = match val.as_str() {
                             // this is supposed to be an empty string
-                            "\"\"" | "''" => "".to_string(),
+                            "\"\"" | "''" => String::new(),
                             _ => val,
                         };
                         Token::String(val)
@@ -369,12 +369,12 @@ mod tests {
         let token =
             Token::Array(LenientTokenizer::tokenize_array("[\"\"]", &ParamType::String).unwrap());
         let sanitized = sanitize_token(token);
-        assert_eq!(sanitized, Token::Array(vec![Token::String("".to_string())]));
+        assert_eq!(sanitized, Token::Array(vec![Token::String(String::new())]));
 
         let token =
             Token::Array(LenientTokenizer::tokenize_array("['']", &ParamType::String).unwrap());
         let sanitized = sanitize_token(token);
-        assert_eq!(sanitized, Token::Array(vec![Token::String("".to_string())]));
+        assert_eq!(sanitized, Token::Array(vec![Token::String(String::new())]));
 
         let token = Token::Array(
             LenientTokenizer::tokenize_array("[\"\",\"\"]", &ParamType::String).unwrap(),
@@ -382,7 +382,7 @@ mod tests {
         let sanitized = sanitize_token(token);
         assert_eq!(
             sanitized,
-            Token::Array(vec![Token::String("".to_string()), Token::String("".to_string())])
+            Token::Array(vec![Token::String(String::new()), Token::String(String::new())])
         );
 
         let token =
@@ -390,7 +390,7 @@ mod tests {
         let sanitized = sanitize_token(token);
         assert_eq!(
             sanitized,
-            Token::Array(vec![Token::String("".to_string()), Token::String("".to_string())])
+            Token::Array(vec![Token::String(String::new()), Token::String(String::new())])
         );
     }
 

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -19,7 +19,7 @@ pub const CONTRACT_MAX_SIZE: usize = 24576;
 /// responses. This timeout should be a reasonable amount of time to wait for a request.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(45);
 
-/// Alchemy free tier cups <https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups>
+/// Alchemy free tier cups: <https://docs.alchemy.com/reference/pricing-plans>
 pub const ALCHEMY_FREE_TIER_CUPS: u64 = 330;
 
 /// Logged when an error is indicative that the user is trying to fork from a non-archive node.

--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -1,9 +1,10 @@
 //! Commonly used traits
 
+use auto_impl::auto_impl;
 use ethers_core::abi::Function;
 
 /// Extension trait for matching tests
-#[auto_impl::auto_impl(&)]
+#[auto_impl(&)]
 pub trait TestFilter: Send + Sync {
     /// Returns whether the test should be included
     fn matches_test(&self, test_name: impl AsRef<str>) -> bool;
@@ -14,7 +15,7 @@ pub trait TestFilter: Send + Sync {
 }
 
 /// Extension trait for `Function`
-#[auto_impl::auto_impl(&)]
+#[auto_impl(&)]
 pub trait TestFunctionExt {
     /// Whether this function should be executed as invariant test
     fn is_invariant_test(&self) -> bool;
@@ -51,28 +52,6 @@ impl TestFunctionExt for Function {
     }
 }
 
-impl<'a> TestFunctionExt for &'a str {
-    fn is_invariant_test(&self) -> bool {
-        self.starts_with("invariant") || self.starts_with("statefulFuzz")
-    }
-
-    fn is_fuzz_test(&self) -> bool {
-        unimplemented!("no naming convention for fuzz tests.")
-    }
-
-    fn is_test(&self) -> bool {
-        self.starts_with("test")
-    }
-
-    fn is_test_fail(&self) -> bool {
-        self.starts_with("testFail")
-    }
-
-    fn is_setup(&self) -> bool {
-        self.eq_ignore_ascii_case("setup")
-    }
-}
-
 impl TestFunctionExt for String {
     fn is_invariant_test(&self) -> bool {
         self.as_str().is_invariant_test()
@@ -92,5 +71,27 @@ impl TestFunctionExt for String {
 
     fn is_setup(&self) -> bool {
         self.as_str().is_setup()
+    }
+}
+
+impl TestFunctionExt for str {
+    fn is_invariant_test(&self) -> bool {
+        self.starts_with("invariant") || self.starts_with("statefulFuzz")
+    }
+
+    fn is_fuzz_test(&self) -> bool {
+        unimplemented!("no naming convention for fuzz tests.")
+    }
+
+    fn is_test(&self) -> bool {
+        self.starts_with("test")
+    }
+
+    fn is_test_fail(&self) -> bool {
+        self.starts_with("testFail")
+    }
+
+    fn is_setup(&self) -> bool {
+        self.eq_ignore_ascii_case("setup")
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,9 +21,9 @@ revm-primitives = { workspace = true, default-features = false, features = ["std
 Inflector = "0.11"
 figment = { version = "0.10", features = ["toml", "env"] }
 number_prefix = "0.4"
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 serde_regex = "1"
-serde_json = "1"
+serde_json.workspace = true
 toml = { version = "0.8", features = ["preserve_order"] }
 toml_edit = "0.20"
 
@@ -36,10 +36,10 @@ walkdir = "2"
 open-fastrlp = "0.1"
 
 # misc
-eyre = "0.6"
+eyre.workspace = true
 regex = "1"
 semver = { version = "1", features = ["serde"] }
-tracing = "0.1"
+tracing.workspace = true
 once_cell = "1"
 thiserror = "1"
 reqwest = { version = "0.11", default-features = false }

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -17,7 +17,7 @@ foundry-utils.workspace = true
 alloy-primitives.workspace = true
 
 crossterm = "0.27"
-eyre = "0.6"
-tracing = "0.1"
+eyre.workspace = true
+tracing.workspace = true
 revm = { workspace = true, default-features = false, features = ["std", "serde", "arbitrary"] }
 ratatui = { version = "0.23.0", default-features = false, features = ["crossterm"] }

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -1,10 +1,8 @@
-use crate::Ui;
+use crate::{TUIExitReason, Tui, Ui};
 use foundry_common::{compile::ContractSources, evm::Breakpoints, get_contract_name};
 use foundry_evm::{debug::DebugArena, trace::CallTraceDecoder};
 use foundry_utils::types::ToAlloy;
 use tracing::{error, trace};
-
-use crate::{TUIExitReason, Tui};
 
 /// Standardized way of firing up the debugger
 pub struct DebuggerArgs<'a> {

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -21,7 +21,7 @@ ethers-solc = { workspace = true, features = ["async"] }
 ethers-core.workspace = true
 
 # tracing
-tracing = "0.1"
+tracing.workspace = true
 
 # mdbook
 mdbook = { version = "0.4", default-features = false, features = ["search"] }
@@ -31,7 +31,7 @@ futures-util = "0.3"
 
 # misc
 solang-parser.workspace = true
-eyre = "0.6"
+eyre.workspace = true
 thiserror = "1"
 rayon = "1"
 itertools.workspace = true
@@ -39,5 +39,5 @@ toml.workspace = true
 auto_impl = "1"
 derive_more = "0.99"
 once_cell = "1"
-serde = "1.0.163"
-serde_json = "1.0.96"
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/doc/src/parser/comment.rs
+++ b/crates/doc/src/parser/comment.rs
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(CommentTag::from_str("param"), Some(CommentTag::Param));
         assert_eq!(CommentTag::from_str("return"), Some(CommentTag::Return));
         assert_eq!(CommentTag::from_str("inheritdoc"), Some(CommentTag::Inheritdoc));
-        assert_eq!(CommentTag::from_str("custom:"), Some(CommentTag::Custom("".to_owned())));
+        assert_eq!(CommentTag::from_str("custom:"), Some(CommentTag::Custom(String::new())));
         assert_eq!(
             CommentTag::from_str("custom:some"),
             Some(CommentTag::Custom("some".to_owned()))

--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -23,7 +23,7 @@ solang-parser.workspace = true
 itertools.workspace = true
 thiserror = "1"
 ariadne = "0.3"
-tracing = "0.1"
+tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1254,7 +1254,7 @@ impl<'a, W: Write> Formatter<'a, W> {
         ident: &mut Option<Identifier>,
     ) -> Result<()> {
         let ident =
-            if let Some(ident) = ident { format!(":{}", ident.name) } else { "".to_owned() };
+            if let Some(ident) = ident { format!(":{}", ident.name) } else { String::new() };
         write_chunk!(self, loc.start(), loc.end(), "{val}{ident}")?;
         Ok(())
     }

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -26,11 +26,11 @@ foundry-evm.workspace = true
 
 comfy-table = "7"
 ethers = { workspace = true, features = ["solc-full"] }
-eyre = "0.6"
+eyre.workspace = true
 proptest = "1"
 rayon = "1"
-serde = "1"
-tracing = "0.1"
+serde.workspace = true
+tracing.workspace = true
 yansi = "0.5"
 
 # bin
@@ -42,7 +42,6 @@ foundry-debugger.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 
 async-trait = "0.1"
-bytes = "1.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete = "4"
 clap_complete_fig = "4"
@@ -57,7 +56,7 @@ parking_lot = "0.12"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 semver = "1"
-serde_json = "1"
+serde_json.workspace = true
 similar = { version = "2", features = ["inline"] }
 solang-parser.workspace = true
 strum = { version = "0.25", features = ["derive"] }

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -257,7 +257,7 @@ impl ScriptArgs {
     pub fn get_returns(
         &self,
         script_config: &ScriptConfig,
-        returned: &bytes::Bytes,
+        returned: &Bytes,
     ) -> Result<HashMap<String, NestedValue>> {
         let func = script_config.called_function.as_ref().expect("There should be a function.");
         let mut returns = HashMap::new();
@@ -283,7 +283,7 @@ impl ScriptArgs {
                 }
             }
             Err(_) => {
-                shell::println(format!("{:x?}", (&returned)))?;
+                shell::println(format!("{returned:?}"))?;
             }
         }
 
@@ -617,7 +617,7 @@ pub struct ScriptResult {
     pub gas_used: u64,
     pub labeled_addresses: BTreeMap<Address, String>,
     pub transactions: Option<BroadcastableTransactions>,
-    pub returned: bytes::Bytes,
+    pub returned: Bytes,
     pub address: Option<Address>,
     pub script_wallets: Vec<LocalWallet>,
     pub breakpoints: Breakpoints,

--- a/crates/forge/bin/cmd/script/runner.rs
+++ b/crates/forge/bin/cmd/script/runner.rs
@@ -158,7 +158,7 @@ impl ScriptRunner {
         Ok((
             address,
             ScriptResult {
-                returned: bytes::Bytes::new(),
+                returned: Bytes::new(),
                 success,
                 gas_used,
                 labeled_addresses: labeled_addresses
@@ -235,7 +235,7 @@ impl ScriptRunner {
             };
 
             Ok(ScriptResult {
-                returned: bytes::Bytes::new(),
+                returned: Bytes::new(),
                 success: address != Address::ZERO,
                 gas_used,
                 logs,
@@ -296,7 +296,7 @@ impl ScriptRunner {
         let breakpoints = res.cheatcodes.map(|cheats| cheats.breakpoints).unwrap_or_default();
 
         Ok(ScriptResult {
-            returned: result.0,
+            returned: result,
             success: !reverted,
             gas_used,
             logs,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -63,7 +63,7 @@ pub static COMPILED_WITH_LIBS: Lazy<ProjectCompileOutput> = Lazy::new(|| {
 
 pub static EVM_OPTS: Lazy<EvmOpts> = Lazy::new(|| EvmOpts {
     env: Env {
-        gas_limit: 18446744073709551615,
+        gas_limit: u64::MAX,
         chain_id: None,
         tx_origin: Config::DEFAULT_SENDER.to_alloy(),
         block_number: 1,

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -20,12 +20,12 @@ ethers.workspace = true
 ethers-solc = { workspace = true, features = ["project-util"] }
 alloy-primitives.workspace = true
 
-eyre = "0.6"
+eyre.workspace = true
 once_cell = "1"
 parking_lot = "0.12"
 pretty_assertions = "1"
 regex = "1"
-serde_json = "1"
+serde_json.workspace = true
 tempfile = "3"
 walkdir = "2"
 

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -740,7 +740,7 @@ impl TestCommand {
             let suggest = if out.stderr.is_empty() {
                 "\n\nDid your forge command end up with no output?".to_string()
             } else {
-                "".to_string()
+                String::new()
             };
             eyre::bail!(
                 "\n\n==========\n\

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -26,8 +26,8 @@ futures = "0.3"
 glob = "0.3"
 once_cell = "1"
 rand = "0.8"
-serde_json = { version = "1", default-features = false }
-tracing = "0.1"
+serde_json.workspace = true
+tracing.workspace = true
 dunce = "1"
 
 [dev-dependencies]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -427,7 +427,7 @@ pub fn to_table(value: serde_json::Value) -> String {
             }
             s
         }
-        _ => "".to_owned(),
+        _ => String::new(),
     }
 }
 

--- a/crates/utils/src/types.rs
+++ b/crates/utils/src/types.rs
@@ -14,14 +14,16 @@ pub trait ToAlloy {
 impl ToAlloy for H160 {
     type To = Address;
 
+    #[inline(always)]
     fn to_alloy(self) -> Self::To {
-        Address::from_slice(self.as_bytes())
+        Address::new(self.0)
     }
 }
 
 impl ToAlloy for H256 {
     type To = B256;
 
+    #[inline(always)]
     fn to_alloy(self) -> Self::To {
         B256::new(self.0)
     }
@@ -30,6 +32,7 @@ impl ToAlloy for H256 {
 impl ToAlloy for U256 {
     type To = AlloyU256;
 
+    #[inline(always)]
     fn to_alloy(self) -> Self::To {
         AlloyU256::from_limbs(self.0)
     }
@@ -38,6 +41,7 @@ impl ToAlloy for U256 {
 impl ToAlloy for U64 {
     type To = AlloyU64;
 
+    #[inline(always)]
     fn to_alloy(self) -> Self::To {
         AlloyU64::from_limbs(self.0)
     }
@@ -46,6 +50,7 @@ impl ToAlloy for U64 {
 impl ToAlloy for u64 {
     type To = AlloyU256;
 
+    #[inline(always)]
     fn to_alloy(self) -> Self::To {
         AlloyU256::from(self)
     }
@@ -62,14 +67,16 @@ pub trait ToEthers {
 impl ToEthers for Address {
     type To = H160;
 
+    #[inline(always)]
     fn to_ethers(self) -> Self::To {
-        H160::from_slice(self.as_slice())
+        H160(self.0 .0)
     }
 }
 
 impl ToEthers for B256 {
     type To = H256;
 
+    #[inline(always)]
     fn to_ethers(self) -> Self::To {
         H256(self.0)
     }
@@ -78,7 +85,8 @@ impl ToEthers for B256 {
 impl ToEthers for AlloyU256 {
     type To = U256;
 
+    #[inline(always)]
     fn to_ethers(self) -> Self::To {
-        U256::from_little_endian(&self.as_le_bytes())
+        U256(self.into_limbs())
     }
 }


### PR DESCRIPTION
Misc changes that I had built up (no `evm` changes)

- `String::new` instead of `"".to_owned` or similar
- more workspace deps
- drop usage of `bytes::Bytes` for alloy everywhere
- some remaining `rAddress` where there is no other `Address`, keep rename consistent with `aAddress`