### PR TITLE
feat(anvil/cast): mnemonic generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "memory-db",
  "parking_lot",
  "pretty_assertions",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_repr",

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -61,6 +61,7 @@ thiserror = "1"
 yansi = "0.5"
 tempfile = "3"
 itertools.workspace = true
+rand = "0.8"
 
 # cli
 clap = { version = "4", features = ["derive", "env", "wrap_help"], optional = true }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -61,9 +61,11 @@ pub struct NodeArgs {
     pub mnemonic_random: Option<usize>,
 
     /// Generates a BIP39 mnemonic phrase from a given seed
-    /// CAREFUL: this is obviously NOT SAFE and should only be used for testing
     /// Cannot be used with other `mnemonic` options
-    #[clap(long, conflicts_with_all = &["mnemonic", "mnemonic_random"])]
+    ///
+    /// CAREFUL: this is NOT SAFE and should only be used for testing.
+    /// Never use the private keys generated in production.
+    #[clap(long = "mnemonic-seed-unsafe", conflicts_with_all = &["mnemonic", "mnemonic_random"])]
     pub mnemonic_seed: Option<u64>,
 
     /// Sets the derivation path of the child key to be derived.

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -170,7 +170,8 @@ impl WalletSubcommands {
 
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";
-                let wallets = (0..accounts).map(|i| {
+                let wallets = (0..accounts)
+                    .map(|i| {
                         builder
                             .clone()
                             .derivation_path(&format!("{derivation_path}{i}"))

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -172,15 +172,10 @@ impl WalletSubcommands {
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";
                 let wallets = (0..accounts)
-                    .map(|i| {
-                        builder
-                            .clone()
-                            .derivation_path(&format!("{derivation_path}{i}"))
-                            .unwrap()
-                            .build()
-                            .unwrap()
-                    })
-                    .collect::<Vec<_>>();
+                    .map(|i| builder.clone().derivation_path(&format!("{derivation_path}{i}")))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let wallets =
+                    wallets.into_iter().map(|b| b.build()).collect::<Result<Vec<_>, _>>()?;
 
                 println!("{}", Paint::green("Successfully generated a new mnemonic."));
                 println!("Phrase:\n{phrase}");

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -6,8 +6,9 @@ use ethers::{
         coins_bip39::{English, Mnemonic},
         LocalWallet, MnemonicBuilder, Signer,
     },
-    types::{transaction::eip712::TypedData, Address, Signature},
+    types::{transaction::eip712::TypedData, Signature},
 };
+use ethers_core::utils::to_checksum;
 use eyre::{Context, Result};
 use foundry_cli::opts::{RawWallet, Wallet};
 use foundry_common::fs;
@@ -181,12 +182,12 @@ impl WalletSubcommands {
                     })
                     .collect::<Vec<_>>();
 
-                println!("Successfully generated a new mnemonic.");
+                println!("{}", Paint::green("Successfully generated a new mnemonic."));
                 println!("Phrase:\n{phrase}");
                 println!("\nAccounts:");
                 for (i, wallet) in wallets.iter().enumerate() {
                     println!("- Account {i}:");
-                    println!("Address:     {}", SimpleCast::to_checksum_address(&wallet.address()));
+                    println!("Address:     {}", to_checksum(&wallet.address(), None));
                     println!("Private key: 0x{}\n", hex::encode(wallet.signer().to_bytes()));
                 }
             }

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -170,9 +170,7 @@ impl WalletSubcommands {
 
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";
-                let wallets = (0..accounts)
-                    .into_iter()
-                    .map(|i| {
+                let wallets = (0..accounts).map(|i| {
                         builder
                             .clone()
                             .derivation_path(&format!("{derivation_path}{i}"))


### PR DESCRIPTION
Added some new options in Anvil and Cast to ease mnemonic generation.
# Cast
Added a "new-mnemonic" (or `nm`) option to generate a new mnemonic and generate a requested number of accounts from the mnemonic.
Example: `cast wallet nm --words 12 --accounts 6`
Generates a 12 words mnemonic and displays the first 6 accounts derived from that mnemonic.

# Anvil
Added 2 options:
- `mnemonic-random` to start Anvil with a randomly generated mnemonic 
- `mnemonic-seed` to provide a seed that generates a mnemonic. Useful for testing so that the base accounts are always the same
Examples:
```
anvil --mnemonic-seed 42
anvil --mnemonic-random
```