### PR TITLE
chore(cast): update `from-bin` command description

### DIFF
--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -91,7 +91,7 @@ pub enum Subcommands {
         data: Vec<String>,
     },
 
-    /// "Convert binary data into hex data."
+    /// Convert binary data into hex data.
     #[clap(visible_aliases = &["--from-bin", "from-binx", "fb"])]
     FromBin,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`from-bin` command description is displayed with quotes.

```sh
$ cast --help | grep from-bin
  from-bin               "Convert binary data into hex data." [aliases: --from-bin, from-binx, fb]
```

## Solution

```sh
$ cast --help | grep from-bin
  from-bin               Convert binary data into hex data. [aliases: --from-bin, from-binx, fb]
```
