### PR TITLE
fix(forge): fix `verify-contract` etherscan cloudflare bug

### DIFF
--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -263,9 +263,13 @@ impl EtherscanVerificationProvider {
         config: &Config,
     ) -> Result<Client> {
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
-        let etherscan_api_url = etherscan_config.as_ref().map(|c| c.api_url.clone() + "?");
 
-        let api_url = verifier_url.or_else(|| etherscan_api_url.as_deref());
+        let etherscan_api_url = verifier_url
+            .or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()))
+            .map(str::to_owned)
+            .map(|url| if url.ends_with('?') { url } else { url + "?" });
+
+        let api_url = etherscan_api_url.as_deref();
         let base_url = etherscan_config
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -263,9 +263,9 @@ impl EtherscanVerificationProvider {
         config: &Config,
     ) -> Result<Client> {
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
+        let etherscan_api_url = etherscan_config.as_ref().map(|c| (c.api_url.clone()+"?"));
 
-        let api_url =
-            verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
+        let api_url = verifier_url.or_else(|| etherscan_api_url.as_deref());
         let base_url = etherscan_config
             .as_ref()
             .and_then(|c| c.browser_url.as_deref())

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -263,7 +263,7 @@ impl EtherscanVerificationProvider {
         config: &Config,
     ) -> Result<Client> {
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
-        let etherscan_api_url = etherscan_config.as_ref().map(|c| (c.api_url.clone()+"?"));
+        let etherscan_api_url = etherscan_config.as_ref().map(|c| c.api_url.clone() + "?");
 
         let api_url = verifier_url.or_else(|| etherscan_api_url.as_deref());
         let base_url = etherscan_config


### PR DESCRIPTION
Etherscan verification for non-mainnet chains requires a question mark at the end of the verifier url in order to prevent a forward slash from being added to the url which trips a cloudflare rule on requests from ec2 boxes.

Verification on both Goerli and Sepolia fails without this character present.

Hardhat-verify does not add the extra forward slash to the verifier url and has no issues verifying contracts on etherscan.

Fixes #4865, #5251, #5741

## Motivation

Fix etherscan contract verification on non-mainnet chains.

## Solution

Add a question mark to the end of the verifier url.