### PR TITLE
fix: function returns formatting

### DIFF
--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1497,12 +1497,27 @@ impl<'a, W: Write> Formatter<'a, W> {
                 if fmt.inline_config.is_disabled(returns_loc) {
                     fmt.indented(1, |fmt| fmt.visit_source(returns_loc))?;
                 } else {
-                    let returns = fmt.items_to_chunks(
+                    let mut returns = fmt.items_to_chunks(
                         returns_end,
                         func.returns
                             .iter_mut()
                             .filter_map(|(loc, param)| param.as_mut().map(|param| (*loc, param))),
                     )?;
+
+                    // there's an issue with function return value that would lead to indent issues because those can be formatted with line breaks <https://github.com/foundry-rs/foundry/issues/4080>
+                    for function_chunk in
+                        returns.iter_mut().filter(|chunk| chunk.content.starts_with("function("))
+                    {
+                        // this will bypass the recursive indent that was applied when the function
+                        // content was formatted in the chunk
+                        function_chunk.content = function_chunk
+                            .content
+                            .split('\n')
+                            .map(|s| s.trim_start())
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                    }
+
                     fmt.write_postfix_comments_before(returns_loc.start())?;
                     fmt.write_whitespace_separator(multiline)?;
                     fmt.indented(1, |fmt| {

--- a/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/fmt.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+contract ReturnFnFormat {
+    function returnsFunction()
+        internal
+        pure
+        returns (
+            function()
+            internal pure returns (uint256)
+        )
+    {}
+}

--- a/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/original.sol
+++ b/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/original.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+contract ReturnFnFormat {
+    function returnsFunction()
+    internal
+    pure
+    returns (
+        function()
+        internal pure returns (uint256)
+    )
+    {}
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -160,6 +160,7 @@ test_directories! {
     ErrorDefinition,
     EventDefinition,
     FunctionDefinition,
+    FunctionDefinitionWithFunctionReturns,
     FunctionType,
     ImportDirective,
     ModifierDefinition,


### PR DESCRIPTION
closes #4080

this adds a hardcoded check for function pointer return values, because they are formatting using the built-in formatter which means indents are applied twice.

maybe the better fix would be to check for this when actually formatting the argument chunk, but it looks like this issue is only limited to function return arguments.