### PR TITLE
feat(`cheatcodes`): `recordAccountAccesses` and `recordStorageAccesses` cheatcodes

### DIFF
--- a/crates/abi/abi/HEVM.sol
+++ b/crates/abi/abi/HEVM.sol
@@ -5,6 +5,8 @@ struct DirEntry { string errorMessage; string path; uint64 depth; bool isDir; bo
 struct FsMetadata { bool isDir; bool isSymlink; uint256 length; bool readOnly; uint256 modified; uint256 accessed; uint256 created; }
 struct Wallet { address addr; uint256 publicKeyX; uint256 publicKeyY; uint256 privateKey; }
 struct FfiResult { int32 exitCode; bytes stdout; bytes stderr; }
+struct AccountAccess { address account; uint8 kind; bool initialized;  uint256 value; bytes data; bool reverted; }
+struct StorageAccess { address account; bytes32 slot; bool isWrite; bytes32 previousValue; bytes32 newValue; bool reverted; }
 
 allowCheatcodes(address)
 
@@ -83,6 +85,12 @@ expectRevert(bytes4)
 record()
 accesses(address)(bytes32[], bytes32[])
 skip(bool)
+
+recordAccountAccesses()
+getRecordedAccountAccesses()(AccountAccess[])
+
+recordStorageAccesses()
+getRecordedStorageAccesses()(StorageAccess[])
 
 recordLogs()
 getRecordedLogs()(Log[])

--- a/crates/abi/src/bindings/hevm.rs
+++ b/crates/abi/src/bindings/hevm.rs
@@ -2309,6 +2309,39 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("getRecordedAccountAccesses"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned(
+                                "getRecordedAccountAccesses",
+                            ),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Array(
+                                        ::std::boxed::Box::new(
+                                            ::ethers_core::abi::ethabi::ParamType::Tuple(
+                                                ::std::vec![
+                                                    ::ethers_core::abi::ethabi::ParamType::Address,
+                                                    ::ethers_core::abi::ethabi::ParamType::Uint(8usize),
+                                                    ::ethers_core::abi::ethabi::ParamType::Bool,
+                                                    ::ethers_core::abi::ethabi::ParamType::Uint(256usize),
+                                                    ::ethers_core::abi::ethabi::ParamType::Bytes,
+                                                    ::ethers_core::abi::ethabi::ParamType::Bool,
+                                                ],
+                                            ),
+                                        ),
+                                    ),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("getRecordedLogs"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
@@ -2327,6 +2360,39 @@ pub mod hevm {
                                                         ),
                                                     ),
                                                     ::ethers_core::abi::ethabi::ParamType::Bytes,
+                                                ],
+                                            ),
+                                        ),
+                                    ),
+                                    internal_type: ::core::option::Option::None,
+                                },
+                            ],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("getRecordedStorageAccesses"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned(
+                                "getRecordedStorageAccesses",
+                            ),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![
+                                ::ethers_core::abi::ethabi::Param {
+                                    name: ::std::string::String::new(),
+                                    kind: ::ethers_core::abi::ethabi::ParamType::Array(
+                                        ::std::boxed::Box::new(
+                                            ::ethers_core::abi::ethabi::ParamType::Tuple(
+                                                ::std::vec![
+                                                    ::ethers_core::abi::ethabi::ParamType::Address,
+                                                    ::ethers_core::abi::ethabi::ParamType::FixedBytes(32usize),
+                                                    ::ethers_core::abi::ethabi::ParamType::Bool,
+                                                    ::ethers_core::abi::ethabi::ParamType::FixedBytes(32usize),
+                                                    ::ethers_core::abi::ethabi::ParamType::FixedBytes(32usize),
+                                                    ::ethers_core::abi::ethabi::ParamType::Bool,
                                                 ],
                                             ),
                                         ),
@@ -3709,10 +3775,38 @@ pub mod hevm {
                     ],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("recordAccountAccesses"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned(
+                                "recordAccountAccesses",
+                            ),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("recordLogs"),
                     ::std::vec![
                         ::ethers_core::abi::ethabi::Function {
                             name: ::std::borrow::ToOwned::to_owned("recordLogs"),
+                            inputs: ::std::vec![],
+                            outputs: ::std::vec![],
+                            constant: ::core::option::Option::None,
+                            state_mutability: ::ethers_core::abi::ethabi::StateMutability::NonPayable,
+                        },
+                    ],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("recordStorageAccesses"),
+                    ::std::vec![
+                        ::ethers_core::abi::ethabi::Function {
+                            name: ::std::borrow::ToOwned::to_owned(
+                                "recordStorageAccesses",
+                            ),
                             inputs: ::std::vec![],
                             outputs: ::std::vec![],
                             constant: ::core::option::Option::None,
@@ -6323,6 +6417,26 @@ pub mod hevm {
                 .method_hash([45, 3, 53, 171], p0)
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `getRecordedAccountAccesses` (0x4452c985) function
+        pub fn get_recorded_account_accesses(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<
+            M,
+            ::std::vec::Vec<
+                (
+                    ::ethers_core::types::Address,
+                    u8,
+                    bool,
+                    ::ethers_core::types::U256,
+                    ::ethers_core::types::Bytes,
+                    bool,
+                ),
+            >,
+        > {
+            self.0
+                .method_hash([68, 82, 201, 133], ())
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `getRecordedLogs` (0x191553a4) function
         pub fn get_recorded_logs(
             &self,
@@ -6332,6 +6446,19 @@ pub mod hevm {
         > {
             self.0
                 .method_hash([25, 21, 83, 164], ())
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `getRecordedStorageAccesses` (0x03f1500a) function
+        pub fn get_recorded_storage_accesses(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<
+            M,
+            ::std::vec::Vec<
+                (::ethers_core::types::Address, [u8; 32], bool, [u8; 32], [u8; 32], bool),
+            >,
+        > {
+            self.0
+                .method_hash([3, 241, 80, 10], ())
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `isDir` (0x7d15d019) function
@@ -6878,10 +7005,26 @@ pub mod hevm {
                 .method_hash([38, 108, 241, 9], ())
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `recordAccountAccesses` (0xd9391303) function
+        pub fn record_account_accesses(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([217, 57, 19, 3], ())
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `recordLogs` (0x41af2f52) function
         pub fn record_logs(&self) -> ::ethers_contract::builders::ContractCall<M, ()> {
             self.0
                 .method_hash([65, 175, 47, 82], ())
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `recordStorageAccesses` (0x71009b87) function
+        pub fn record_storage_accesses(
+            &self,
+        ) -> ::ethers_contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([113, 0, 155, 135], ())
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `rememberKey` (0x22100064) function
@@ -8867,6 +9010,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "getNonce", abi = "getNonce(address)")]
     pub struct GetNonce1Call(pub ::ethers_core::types::Address);
+    ///Container type for all input parameters for the `getRecordedAccountAccesses` function with signature `getRecordedAccountAccesses()` and selector `0x4452c985`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "getRecordedAccountAccesses", abi = "getRecordedAccountAccesses()")]
+    pub struct GetRecordedAccountAccessesCall;
     ///Container type for all input parameters for the `getRecordedLogs` function with signature `getRecordedLogs()` and selector `0x191553a4`
     #[derive(
         Clone,
@@ -8880,6 +9036,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "getRecordedLogs", abi = "getRecordedLogs()")]
     pub struct GetRecordedLogsCall;
+    ///Container type for all input parameters for the `getRecordedStorageAccesses` function with signature `getRecordedStorageAccesses()` and selector `0x03f1500a`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "getRecordedStorageAccesses", abi = "getRecordedStorageAccesses()")]
+    pub struct GetRecordedStorageAccessesCall;
     ///Container type for all input parameters for the `isDir` function with signature `isDir(string)` and selector `0x7d15d019`
     #[derive(
         Clone,
@@ -9623,6 +9792,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "record", abi = "record()")]
     pub struct RecordCall;
+    ///Container type for all input parameters for the `recordAccountAccesses` function with signature `recordAccountAccesses()` and selector `0xd9391303`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "recordAccountAccesses", abi = "recordAccountAccesses()")]
+    pub struct RecordAccountAccessesCall;
     ///Container type for all input parameters for the `recordLogs` function with signature `recordLogs()` and selector `0x41af2f52`
     #[derive(
         Clone,
@@ -9636,6 +9818,19 @@ pub mod hevm {
     )]
     #[ethcall(name = "recordLogs", abi = "recordLogs()")]
     pub struct RecordLogsCall;
+    ///Container type for all input parameters for the `recordStorageAccesses` function with signature `recordStorageAccesses()` and selector `0x71009b87`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthCall,
+        ::ethers_contract::EthDisplay,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    #[ethcall(name = "recordStorageAccesses", abi = "recordStorageAccesses()")]
+    pub struct RecordStorageAccessesCall;
     ///Container type for all input parameters for the `rememberKey` function with signature `rememberKey(uint256)` and selector `0x22100064`
     #[derive(
         Clone,
@@ -10695,7 +10890,9 @@ pub mod hevm {
         GetMappingSlotAt(GetMappingSlotAtCall),
         GetNonce0(GetNonce0Call),
         GetNonce1(GetNonce1Call),
+        GetRecordedAccountAccesses(GetRecordedAccountAccessesCall),
         GetRecordedLogs(GetRecordedLogsCall),
+        GetRecordedStorageAccesses(GetRecordedStorageAccessesCall),
         IsDir(IsDirCall),
         IsFile(IsFileCall),
         IsPersistent(IsPersistentCall),
@@ -10748,7 +10945,9 @@ pub mod hevm {
         ReadLine(ReadLineCall),
         ReadLink(ReadLinkCall),
         Record(RecordCall),
+        RecordAccountAccesses(RecordAccountAccessesCall),
         RecordLogs(RecordLogsCall),
+        RecordStorageAccesses(RecordStorageAccessesCall),
         RememberKey(RememberKeyCall),
         RemoveDir(RemoveDirCall),
         RemoveFile(RemoveFileCall),
@@ -11278,10 +11477,20 @@ pub mod hevm {
             ) {
                 return Ok(Self::GetNonce1(decoded));
             }
+            if let Ok(decoded) = <GetRecordedAccountAccessesCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::GetRecordedAccountAccesses(decoded));
+            }
             if let Ok(decoded) = <GetRecordedLogsCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
             ) {
                 return Ok(Self::GetRecordedLogs(decoded));
+            }
+            if let Ok(decoded) = <GetRecordedStorageAccessesCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::GetRecordedStorageAccesses(decoded));
             }
             if let Ok(decoded) = <IsDirCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
@@ -11543,10 +11752,20 @@ pub mod hevm {
             ) {
                 return Ok(Self::Record(decoded));
             }
+            if let Ok(decoded) = <RecordAccountAccessesCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::RecordAccountAccesses(decoded));
+            }
             if let Ok(decoded) = <RecordLogsCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
             ) {
                 return Ok(Self::RecordLogs(decoded));
+            }
+            if let Ok(decoded) = <RecordStorageAccessesCall as ::ethers_core::abi::AbiDecode>::decode(
+                data,
+            ) {
+                return Ok(Self::RecordStorageAccesses(decoded));
             }
             if let Ok(decoded) = <RememberKeyCall as ::ethers_core::abi::AbiDecode>::decode(
                 data,
@@ -12099,7 +12318,13 @@ pub mod hevm {
                 Self::GetNonce1(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
+                Self::GetRecordedAccountAccesses(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
                 Self::GetRecordedLogs(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
+                Self::GetRecordedStorageAccesses(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
                 Self::IsDir(element) => ::ethers_core::abi::AbiEncode::encode(element),
@@ -12228,7 +12453,13 @@ pub mod hevm {
                 Self::ReadLine(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::ReadLink(element) => ::ethers_core::abi::AbiEncode::encode(element),
                 Self::Record(element) => ::ethers_core::abi::AbiEncode::encode(element),
+                Self::RecordAccountAccesses(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
                 Self::RecordLogs(element) => {
+                    ::ethers_core::abi::AbiEncode::encode(element)
+                }
+                Self::RecordStorageAccesses(element) => {
                     ::ethers_core::abi::AbiEncode::encode(element)
                 }
                 Self::RememberKey(element) => {
@@ -12504,7 +12735,13 @@ pub mod hevm {
                 Self::GetMappingSlotAt(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetNonce0(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetNonce1(element) => ::core::fmt::Display::fmt(element, f),
+                Self::GetRecordedAccountAccesses(element) => {
+                    ::core::fmt::Display::fmt(element, f)
+                }
                 Self::GetRecordedLogs(element) => ::core::fmt::Display::fmt(element, f),
+                Self::GetRecordedStorageAccesses(element) => {
+                    ::core::fmt::Display::fmt(element, f)
+                }
                 Self::IsDir(element) => ::core::fmt::Display::fmt(element, f),
                 Self::IsFile(element) => ::core::fmt::Display::fmt(element, f),
                 Self::IsPersistent(element) => ::core::fmt::Display::fmt(element, f),
@@ -12569,7 +12806,13 @@ pub mod hevm {
                 Self::ReadLine(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ReadLink(element) => ::core::fmt::Display::fmt(element, f),
                 Self::Record(element) => ::core::fmt::Display::fmt(element, f),
+                Self::RecordAccountAccesses(element) => {
+                    ::core::fmt::Display::fmt(element, f)
+                }
                 Self::RecordLogs(element) => ::core::fmt::Display::fmt(element, f),
+                Self::RecordStorageAccesses(element) => {
+                    ::core::fmt::Display::fmt(element, f)
+                }
                 Self::RememberKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RemoveDir(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RemoveFile(element) => ::core::fmt::Display::fmt(element, f),
@@ -13100,9 +13343,19 @@ pub mod hevm {
             Self::GetNonce1(value)
         }
     }
+    impl ::core::convert::From<GetRecordedAccountAccessesCall> for HEVMCalls {
+        fn from(value: GetRecordedAccountAccessesCall) -> Self {
+            Self::GetRecordedAccountAccesses(value)
+        }
+    }
     impl ::core::convert::From<GetRecordedLogsCall> for HEVMCalls {
         fn from(value: GetRecordedLogsCall) -> Self {
             Self::GetRecordedLogs(value)
+        }
+    }
+    impl ::core::convert::From<GetRecordedStorageAccessesCall> for HEVMCalls {
+        fn from(value: GetRecordedStorageAccessesCall) -> Self {
+            Self::GetRecordedStorageAccesses(value)
         }
     }
     impl ::core::convert::From<IsDirCall> for HEVMCalls {
@@ -13365,9 +13618,19 @@ pub mod hevm {
             Self::Record(value)
         }
     }
+    impl ::core::convert::From<RecordAccountAccessesCall> for HEVMCalls {
+        fn from(value: RecordAccountAccessesCall) -> Self {
+            Self::RecordAccountAccesses(value)
+        }
+    }
     impl ::core::convert::From<RecordLogsCall> for HEVMCalls {
         fn from(value: RecordLogsCall) -> Self {
             Self::RecordLogs(value)
+        }
+    }
+    impl ::core::convert::From<RecordStorageAccessesCall> for HEVMCalls {
+        fn from(value: RecordStorageAccessesCall) -> Self {
+            Self::RecordStorageAccesses(value)
         }
     }
     impl ::core::convert::From<RememberKeyCall> for HEVMCalls {
@@ -14358,6 +14621,29 @@ pub mod hevm {
         Hash
     )]
     pub struct GetNonce0Return(pub u64);
+    ///Container type for all return fields from the `getRecordedAccountAccesses` function with signature `getRecordedAccountAccesses()` and selector `0x4452c985`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct GetRecordedAccountAccessesReturn(
+        pub ::std::vec::Vec<
+            (
+                ::ethers_core::types::Address,
+                u8,
+                bool,
+                ::ethers_core::types::U256,
+                ::ethers_core::types::Bytes,
+                bool,
+            ),
+        >,
+    );
     ///Container type for all return fields from the `getRecordedLogs` function with signature `getRecordedLogs()` and selector `0x191553a4`
     #[derive(
         Clone,
@@ -14371,6 +14657,22 @@ pub mod hevm {
     )]
     pub struct GetRecordedLogsReturn(
         pub ::std::vec::Vec<(::std::vec::Vec<[u8; 32]>, ::ethers_core::types::Bytes)>,
+    );
+    ///Container type for all return fields from the `getRecordedStorageAccesses` function with signature `getRecordedStorageAccesses()` and selector `0x03f1500a`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct GetRecordedStorageAccessesReturn(
+        pub ::std::vec::Vec<
+            (::ethers_core::types::Address, [u8; 32], bool, [u8; 32], [u8; 32], bool),
+        >,
     );
     ///Container type for all return fields from the `isDir` function with signature `isDir(string)` and selector `0x7d15d019`
     #[derive(
@@ -15152,6 +15454,25 @@ pub mod hevm {
         Hash
     )]
     pub struct UnixTimeReturn(pub ::ethers_core::types::U256);
+    ///`AccountAccess(address,uint8,bool,uint256,bytes,bool)`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct AccountAccess {
+        pub account: ::ethers_core::types::Address,
+        pub kind: u8,
+        pub initialized: bool,
+        pub value: ::ethers_core::types::U256,
+        pub data: ::ethers_core::types::Bytes,
+        pub reverted: bool,
+    }
     ///`DirEntry(string,string,uint64,bool,bool)`
     #[derive(
         Clone,
@@ -15257,6 +15578,25 @@ pub mod hevm {
     pub struct Rpc {
         pub name: ::std::string::String,
         pub url: ::std::string::String,
+    }
+    ///`StorageAccess(address,bytes32,bool,bytes32,bytes32,bool)`
+    #[derive(
+        Clone,
+        ::ethers_contract::EthAbiType,
+        ::ethers_contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash
+    )]
+    pub struct StorageAccess {
+        pub account: ::ethers_core::types::Address,
+        pub slot: [u8; 32],
+        pub is_write: bool,
+        pub previous_value: [u8; 32],
+        pub new_value: [u8; 32],
+        pub reverted: bool,
     }
     ///`Wallet(address,uint256,uint256,uint256)`
     #[derive(

--- a/testdata/cheats/ReadStorageAccesses.t.sol
+++ b/testdata/cheats/ReadStorageAccesses.t.sol
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "./Vm.sol";
+
+/// @notice Helper contract with a constructor that stores a value in storage
+///         and then optionally reverts.
+contract ConstructorStorer {
+    constructor(bool shouldRevert) {
+        assembly {
+            sstore(0x00, 0x01)
+            if shouldRevert { revert(0, 0) }
+        }
+    }
+}
+
+/// @notice Helper contract that stores and reads in addition to calling a
+///         function on itself (which also accesses storage)
+contract Doer {
+    uint256[10] spacer;
+    mapping(bytes32 key => uint256 value) slots;
+
+    constructor() {
+        slots[bytes32("doer 1")] = 10;
+    }
+
+    function run() public {
+        slots[bytes32("doer 1")]++;
+        this.doStuff();
+    }
+
+    function doStuff() external {
+        slots[bytes32("doer 2")]++;
+    }
+}
+
+/// @notice Helper contract that reverts after incrementing a storage slot.
+contract Reverter {
+    Doer immutable doer;
+    mapping(bytes32 key => uint256 value) slots;
+
+    constructor(Doer _doer) {
+        doer = _doer;
+    }
+
+    function run() public {
+        doer.run();
+        slots[bytes32("reverter")]++;
+        revert();
+    }
+}
+
+/// @notice Helper contract that increments a storage slot and then calls a
+///         function on another contract (which also accesses storage)
+contract Succeeder {
+    Doer immutable doer;
+    mapping(bytes32 key => uint256 value) slots;
+
+    constructor(Doer _doer) {
+        doer = _doer;
+    }
+
+    function run() public {
+        slots[bytes32("succeeder")]++;
+        doer.run();
+    }
+}
+
+/// @notice Helper dispatch contract that reverts if intended with Reverter
+///         and calls Succeeder otherwise
+contract NestedRunner {
+    Doer public immutable doer;
+    Reverter public immutable reverter;
+    Succeeder public immutable succeeder;
+    mapping(bytes32 key => uint256 value) slots;
+
+    constructor() {
+        doer = new Doer();
+        reverter = new Reverter(doer);
+        succeeder = new Succeeder(doer);
+    }
+
+    function run(bool shouldRevert) public {
+        slots[bytes32("runner")]++;
+        try reverter.run() {
+            if (shouldRevert) {
+                revert();
+            }
+        } catch {}
+        succeeder.run();
+        if (shouldRevert) {
+            revert();
+        }
+    }
+}
+
+/// @notice Helper contract that directly reads from and writes to storage
+contract StorageAccessor {
+    function read(bytes32 slot) public view returns (bytes32 value) {
+        assembly {
+            value := sload(slot)
+        }
+    }
+
+    function write(bytes32 slot, bytes32 value) public {
+        assembly {
+            sstore(slot, value)
+        }
+    }
+}
+
+/// @notice Helper contract that creates contracts with create2
+contract Create2or {
+    function create2(bytes32 salt, bytes memory initcode) external payable returns (address result) {
+        assembly {
+            result := create2(callvalue(), add(initcode, 0x20), mload(initcode), salt)
+        }
+    }
+}
+
+/// @notice Test contract for recording storage accesses
+contract RecordStorageAccessesTest is DSTest {
+    Create2or immutable create2or;
+    Vm constant cheats = Vm(HEVM_ADDRESS);
+    StorageAccessor test1;
+    StorageAccessor test2;
+    NestedRunner runner;
+    uint256 counter;
+
+    constructor() {
+        create2or = new Create2or();
+    }
+
+    function setUp() public {
+        test1 = new StorageAccessor();
+        test2 = new StorageAccessor();
+        runner = new NestedRunner();
+        counter = 5;
+    }
+
+    /// @notice Test normal, non-nested storage accesses
+    function testRecordAccesses() public {
+        StorageAccessor one = test1;
+        StorageAccessor two = test2;
+        cheats.recordStorageAccesses();
+        one.read(bytes32(uint256(1234)));
+        one.write(bytes32(uint256(1235)), bytes32(uint256(5678)));
+        two.write(bytes32(uint256(5678)), bytes32(uint256(123469)));
+        two.write(bytes32(uint256(5678)), bytes32(uint256(1234)));
+
+        two.read(bytes32(uint256(5678)));
+
+        Vm.StorageAccess[] memory accessed = cheats.getRecordedStorageAccesses();
+        assertEq(accessed.length, 5, "incorrect length");
+        Vm.StorageAccess memory access = accessed[0];
+        assertEq(
+            access,
+            Vm.StorageAccess({
+                account: address(one),
+                slot: bytes32(uint256(1234)),
+                isWrite: false,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(0)),
+                reverted: false
+            })
+        );
+
+        access = accessed[1];
+        assertEq(
+            access,
+            Vm.StorageAccess({
+                account: address(one),
+                slot: bytes32(uint256(1235)),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(5678)),
+                reverted: false
+            })
+        );
+
+        access = accessed[2];
+        assertEq(
+            access,
+            Vm.StorageAccess({
+                account: address(two),
+                slot: bytes32(uint256(5678)),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(123469)),
+                reverted: false
+            })
+        );
+
+        access = accessed[3];
+        assertEq(
+            access,
+            Vm.StorageAccess({
+                account: address(two),
+                slot: bytes32(uint256(5678)),
+                isWrite: true,
+                previousValue: bytes32(uint256(123469)),
+                newValue: bytes32(uint256(1234)),
+                reverted: false
+            })
+        );
+        access = accessed[4];
+        assertEq(
+            access,
+            Vm.StorageAccess({
+                account: address(two),
+                slot: bytes32(uint256(5678)),
+                isWrite: false,
+                previousValue: bytes32(uint256(1234)),
+                newValue: bytes32(uint256(1234)),
+                reverted: false
+            })
+        );
+    }
+
+    /// @notice Test storage access recordings with multiple nested calls, some
+    ///         reverting, but overall successful.
+    function testNested() public {
+        cheats.recordStorageAccesses();
+        runNested(false, false);
+    }
+
+    /// @notice Test storage access recordings with multiple nested calls, some
+    ///         reverting, with the first call reverting
+    function testNested_Revert() public {
+        cheats.recordStorageAccesses();
+
+        runNested(true, false);
+    }
+
+    /// @notice Test that constructor storage accesses are recorded, including reverts
+    function testConstructorStorage() public {
+        cheats.recordStorageAccesses();
+        address storer = address(new ConstructorStorer(false));
+        try create2or.create2(bytes32(0), abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(true))) {}
+            catch {}
+        bytes memory creationCode = abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(true));
+
+        address hypotheticalStorer = deriveCreate2Address(address(create2or), bytes32(0), keccak256(creationCode));
+        Vm.StorageAccess[] memory accessed = cheats.getRecordedStorageAccesses();
+        assertEq(accessed.length, 2, "incorrect length");
+        assertEq(
+            accessed[0],
+            Vm.StorageAccess({
+                account: storer,
+                slot: bytes32(uint256(0)),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: false
+            })
+        );
+        assertEq(
+            accessed[1],
+            Vm.StorageAccess({
+                account: hypotheticalStorer,
+                slot: bytes32(uint256(0)),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: true
+            })
+        );
+    }
+
+    /// @notice Test that storage accesses are still recorded when the recording is started
+    ///         from a lower call depth than the results are read from.
+    function testNested_LowerDepth() public {
+        this.startRecordingFromLowerDepth();
+        runNested(false, true);
+    }
+
+    /// @notice Test that storage accesses are still recorded when the recording is started
+    ///         from a lower call depth than the results are read from, and the first call
+    ///         reverts.
+    function testNested_LowerDepth_Revert() public {
+        this.startRecordingFromLowerDepth();
+        runNested(true, true);
+    }
+
+    function runNested(bool shouldRevert, bool expectFirst) internal {
+        try runner.run(shouldRevert) {} catch {}
+        Vm.StorageAccess[] memory accessed = cheats.getRecordedStorageAccesses();
+        assertEq(accessed.length, 15 + toUint(expectFirst), "incorrect length");
+
+        uint256 startingIndex = toUint(expectFirst);
+        if (expectFirst) {
+            bytes32 counterSlot;
+            assembly {
+                counterSlot := counter.slot
+            }
+            assertEq(
+                accessed[0],
+                Vm.StorageAccess({
+                    account: address(this),
+                    slot: counterSlot,
+                    isWrite: false,
+                    previousValue: bytes32(uint256(5)),
+                    newValue: bytes32(uint256(5)),
+                    reverted: false
+                })
+            );
+        }
+        bytes32 runnerSlot;
+        assembly {
+            runnerSlot := runner.slot
+        }
+        assertEq(
+            accessed[startingIndex],
+            Vm.StorageAccess({
+                account: address(this),
+                slot: runnerSlot,
+                isWrite: false,
+                previousValue: bytes32(uint256(uint160(address(runner)))),
+                newValue: bytes32(uint256(uint160(address(runner)))),
+                reverted: false
+            })
+        );
+
+        assertIncrementEq(
+            accessed[startingIndex + 1],
+            accessed[startingIndex + 2],
+            Vm.StorageAccess({
+                account: address(runner),
+                slot: keccak256(abi.encodePacked(bytes32("runner"), bytes32(0))),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: shouldRevert
+            })
+        );
+        assertIncrementEq(
+            accessed[startingIndex + 3],
+            accessed[startingIndex + 4],
+            Vm.StorageAccess({
+                account: address(runner.doer()),
+                slot: keccak256(abi.encodePacked(bytes32("doer 1"), uint256(10))),
+                isWrite: true,
+                previousValue: bytes32(uint256(10)),
+                newValue: bytes32(uint256(11)),
+                reverted: true
+            })
+        );
+
+        assertIncrementEq(
+            accessed[startingIndex + 5],
+            accessed[startingIndex + 6],
+            Vm.StorageAccess({
+                account: address(runner.doer()),
+                slot: keccak256(abi.encodePacked(bytes32("doer 2"), uint256(10))),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: true
+            })
+        );
+
+        assertIncrementEq(
+            accessed[startingIndex + 7],
+            accessed[startingIndex + 8],
+            Vm.StorageAccess({
+                account: address(runner.reverter()),
+                slot: keccak256(abi.encodePacked(bytes32("reverter"), uint256(0))),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: true
+            })
+        );
+
+        assertIncrementEq(
+            accessed[startingIndex + 9],
+            accessed[startingIndex + 10],
+            Vm.StorageAccess({
+                account: address(runner.succeeder()),
+                slot: keccak256(abi.encodePacked(bytes32("succeeder"), uint256(0))),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: shouldRevert
+            })
+        );
+
+        Vm.StorageAccess memory expected = Vm.StorageAccess({
+            account: address(runner.doer()),
+            slot: keccak256(abi.encodePacked(bytes32("doer 1"), uint256(10))),
+            isWrite: true,
+            previousValue: bytes32(uint256(10)),
+            newValue: bytes32(uint256(11)),
+            reverted: shouldRevert
+        });
+
+        assertIncrementEq(accessed[startingIndex + 11], accessed[startingIndex + 12], expected);
+
+        assertIncrementEq(
+            accessed[startingIndex + 13],
+            accessed[startingIndex + 14],
+            Vm.StorageAccess({
+                account: address(runner.doer()),
+                slot: keccak256(abi.encodePacked(bytes32("doer 2"), uint256(10))),
+                isWrite: true,
+                previousValue: bytes32(uint256(0)),
+                newValue: bytes32(uint256(1)),
+                reverted: shouldRevert
+            })
+        );
+    }
+
+    function startRecordingFromLowerDepth() external returns (uint256 value) {
+        cheats.recordStorageAccesses();
+        assembly {
+            // assign to a return value otherwise optimizer will remove
+            value := sload(counter.slot)
+        }
+    }
+
+    function assertIncrementEq(
+        Vm.StorageAccess memory read,
+        Vm.StorageAccess memory write,
+        Vm.StorageAccess memory expected
+    ) internal {
+        assertEq(
+            read,
+            Vm.StorageAccess({
+                account: expected.account,
+                slot: expected.slot,
+                isWrite: false,
+                previousValue: expected.previousValue,
+                newValue: expected.previousValue,
+                reverted: expected.reverted
+            })
+        );
+        assertEq(
+            write,
+            Vm.StorageAccess({
+                account: expected.account,
+                slot: expected.slot,
+                isWrite: true,
+                previousValue: expected.previousValue,
+                newValue: expected.newValue,
+                reverted: expected.reverted
+            })
+        );
+    }
+
+    function assertEq(Vm.StorageAccess memory actual, Vm.StorageAccess memory expected) internal {
+        assertEq(actual.account, expected.account, "incorrect account");
+        assertEq(actual.slot, expected.slot, "incorrect slot");
+        assertEq(toUint(actual.isWrite), toUint(expected.isWrite), "incorrect isWrite");
+        assertEq(actual.previousValue, expected.previousValue, "incorrect previousValue");
+        assertEq(actual.newValue, expected.newValue, "incorrect newValue");
+        assertEq(toUint(actual.reverted), toUint(expected.reverted), "incorrect reverted");
+    }
+
+    function toUint(bool a) internal pure returns (uint256) {
+        return a ? 1 : 0;
+    }
+
+    function deriveCreate2Address(address deployer, bytes32 salt, bytes32 codeHash) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, codeHash)))));
+    }
+}

--- a/testdata/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/cheats/RecordAccountAccesses.t.sol
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "./Vm.sol";
+
+/// @notice Helper contract with a constructo that makes a call to itself then
+///         optionally reverts if zero-length data is passed
+contract SelfCaller {
+    constructor(bytes memory) payable {
+        assembly {
+            // call self to test that the cheatcote correctly reports the
+            // account as initialized even when there is no code at the
+            // contract address
+            pop(call(gas(), address(), div(callvalue(), 10), 0, 0, 0, 0))
+            if eq(calldataload(0x04), 1) { revert(0, 0) }
+        }
+    }
+}
+
+/// @notice Helper contract that calls itself from the run method
+contract Doer {
+    function run() public payable {
+        this.doStuff{value: msg.value / 10}();
+    }
+
+    function doStuff() external payable {}
+}
+
+/// @notice Helper contract that selfdestructs to a target address within its
+///         constructor
+contract SelfDestructor {
+    constructor(address target) payable {
+        selfdestruct(payable(target));
+    }
+}
+
+/// @notice Helper contract that calls a Doer from the run method
+contract Create2or {
+    function create2(bytes32 salt, bytes memory initcode) external payable returns (address result) {
+        assembly {
+            result := create2(callvalue(), add(initcode, 0x20), mload(initcode), salt)
+        }
+    }
+}
+
+/// @notice Helper contract that calls a Doer from the run method and then
+///         reverts
+contract Reverter {
+    Doer immutable doer;
+
+    constructor(Doer _doer) {
+        doer = _doer;
+    }
+
+    function run() public payable {
+        doer.run{value: msg.value / 10}();
+        revert();
+    }
+}
+
+/// @notice Helper contract that calls a Doer from the run method
+contract Succeeder {
+    Doer immutable doer;
+
+    constructor(Doer _doer) {
+        doer = _doer;
+    }
+
+    function run() public payable {
+        doer.run{value: msg.value / 10}();
+    }
+}
+
+/// @notice Helper contract that calls a Reverter and Succeeder from the run
+///         method
+contract NestedRunner {
+    Doer public immutable doer;
+    Reverter public immutable reverter;
+    Succeeder public immutable succeeder;
+
+    constructor() {
+        doer = new Doer();
+        reverter = new Reverter(doer);
+        succeeder = new Succeeder(doer);
+    }
+
+    function run(bool shouldRevert) public payable {
+        try reverter.run{value: msg.value / 10}() {
+            if (shouldRevert) {
+                revert();
+            }
+        } catch {}
+        succeeder.run{value: msg.value / 10}();
+        if (shouldRevert) {
+            revert();
+        }
+    }
+}
+
+/// @notice Test that the cheatcode correctly records account accesses
+contract RecordAccountAccessesTest is DSTest {
+    Vm constant cheats = Vm(HEVM_ADDRESS);
+    NestedRunner runner;
+    Create2or create2or;
+
+    function setUp() public {
+        runner = new NestedRunner();
+        create2or = new Create2or();
+    }
+
+    /// @notice Test that basic account accesses are correctly recorded
+    function testRecordAccountAccesses() public {
+        cheats.recordAccountAccesses();
+
+        (bool succ,) = address(1234).call("");
+        (succ,) = address(5678).call{value: 1 ether}("");
+        (succ,) = address(123469).call("hello world");
+        (succ,) = address(5678).call("");
+        // contract calls to self in constructor
+        SelfCaller caller = new SelfCaller{value: 2 ether}('hello2 world2');
+
+        Vm.AccountAccess[] memory called = cheats.getRecordedAccountAccesses();
+        assertEq(called.length, 6);
+        assertEq(
+            called[0],
+            Vm.AccountAccess({
+                account: address(1234),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: false,
+                value: 0,
+                data: "",
+                reverted: false
+            })
+        );
+
+        assertEq(
+            called[1],
+            Vm.AccountAccess({
+                account: address(5678),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: false,
+                value: 1 ether,
+                data: "",
+                reverted: false
+            })
+        );
+        assertEq(
+            called[2],
+            Vm.AccountAccess({
+                account: address(123469),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: false,
+                value: 0,
+                data: "hello world",
+                reverted: false
+            })
+        );
+        assertEq(
+            called[3],
+            Vm.AccountAccess({
+                account: address(5678),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0,
+                data: "",
+                reverted: false
+            })
+        );
+        assertEq(
+            called[4],
+            Vm.AccountAccess({
+                account: address(caller),
+                kind: Vm.AccountAccessKind.Create,
+                initialized: true,
+                value: 2 ether,
+                data: abi.encodePacked(type(SelfCaller).creationCode, abi.encode("hello2 world2")),
+                reverted: false
+            })
+        );
+        assertEq(
+            called[5],
+            Vm.AccountAccess({
+                account: address(caller),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.2 ether,
+                data: "",
+                reverted: false
+            })
+        );
+    }
+
+    /// @notice Test that account accesses are correctly recorded when a call
+    ///         reverts
+    function testRevertingCall() public {
+        cheats.recordAccountAccesses();
+        try this.revertingCall{value: 1 ether}(address(1234), "") {} catch {}
+        Vm.AccountAccess[] memory called = cheats.getRecordedAccountAccesses();
+        assertEq(called.length, 2);
+        assertEq(
+            called[0],
+            Vm.AccountAccess({
+                account: address(this),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 1 ether,
+                data: abi.encodeCall(this.revertingCall, (address(1234), "")),
+                reverted: true
+            })
+        );
+        assertEq(
+            called[1],
+            Vm.AccountAccess({
+                account: address(1234),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: false,
+                value: 0.1 ether,
+                data: "",
+                reverted: true
+            })
+        );
+    }
+
+    /// @notice Test that nested account accesses are correctly recorded
+    function testNested() public {
+        cheats.recordAccountAccesses();
+        runNested(false, false);
+    }
+
+    /// @notice Test that nested account accesses are correctly recorded when
+    ///         the first call reverts
+    function testNested_Revert() public {
+        cheats.recordAccountAccesses();
+        runNested(true, false);
+    }
+
+    /// @notice Helper function to test nested account accesses
+    /// @param shouldRevert Whether the first call should revert
+    function runNested(bool shouldRevert, bool expectFirstCall) public {
+        try runner.run{value: 1 ether}(shouldRevert) {} catch {}
+        Vm.AccountAccess[] memory called = cheats.getRecordedAccountAccesses();
+        assertEq(called.length, 7 + toUint(expectFirstCall), "incorrect length");
+        if (expectFirstCall) {
+            assertEq(
+                called[0],
+                Vm.AccountAccess({
+                    account: address(1234),
+                    kind: Vm.AccountAccessKind.Call,
+                    initialized: false,
+                    value: 0,
+                    data: "",
+                    reverted: false
+                })
+            );
+        }
+
+        uint256 startingIndex = toUint(expectFirstCall);
+        assertEq(
+            called[startingIndex],
+            Vm.AccountAccess({
+                account: address(runner),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 1 ether,
+                data: abi.encodeCall(NestedRunner.run, (shouldRevert)),
+                reverted: shouldRevert
+            })
+        );
+        assertEq(
+            called[startingIndex + 1],
+            Vm.AccountAccess({
+                account: address(runner.reverter()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.1 ether,
+                data: abi.encodeCall(Reverter.run, ()),
+                reverted: true
+            })
+        );
+        assertEq(
+            called[startingIndex + 2],
+            Vm.AccountAccess({
+                account: address(runner.doer()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.01 ether,
+                data: abi.encodeCall(Doer.run, ()),
+                reverted: true
+            })
+        );
+        assertEq(
+            called[startingIndex + 3],
+            Vm.AccountAccess({
+                account: address(runner.doer()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.001 ether,
+                data: abi.encodeCall(Doer.doStuff, ()),
+                reverted: true
+            })
+        );
+
+        assertEq(
+            called[startingIndex + 4],
+            Vm.AccountAccess({
+                account: address(runner.succeeder()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.1 ether,
+                data: abi.encodeCall(Succeeder.run, ()),
+                reverted: shouldRevert
+            })
+        );
+        assertEq(
+            called[startingIndex + 5],
+            Vm.AccountAccess({
+                account: address(runner.doer()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.01 ether,
+                data: abi.encodeCall(Doer.run, ()),
+                reverted: shouldRevert
+            })
+        );
+        assertEq(
+            called[startingIndex + 6],
+            Vm.AccountAccess({
+                account: address(runner.doer()),
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0.001 ether,
+                data: abi.encodeCall(Doer.doStuff, ()),
+                reverted: shouldRevert
+            })
+        );
+    }
+
+    /// @notice Test that account accesses are correctly recorded when the
+    ///         recording is started from a lower depth than they are
+    ///         retrieved
+    function testNested_LowerDepth() public {
+        this.startRecordingFromLowerDepth();
+        runNested(true, true);
+        this.startRecordingFromLowerDepth();
+        runNested(false, true);
+    }
+
+    /// @notice Test that constructor calls and calls made within a constructor
+    ///         are correctly recorded, even if it reverts
+    function testCreateRevert() public {
+        cheats.recordAccountAccesses();
+        bytes memory creationCode = abi.encodePacked(type(SelfCaller).creationCode, abi.encode(""));
+        try create2or.create2(bytes32(0), creationCode) {} catch {}
+        address hypotheticalAddress = deriveCreate2Address(address(create2or), bytes32(0), keccak256(creationCode));
+        Vm.AccountAccess[] memory called = cheats.getRecordedAccountAccesses();
+        assertEq(called.length, 3, "incorrect length");
+        assertEq(
+            called[1],
+            Vm.AccountAccess({
+                account: hypotheticalAddress,
+                kind: Vm.AccountAccessKind.Create,
+                initialized: true,
+                value: 0,
+                data: creationCode,
+                reverted: true
+            })
+        );
+        assertEq(
+            called[2],
+            Vm.AccountAccess({
+                account: hypotheticalAddress,
+                kind: Vm.AccountAccessKind.Call,
+                initialized: true,
+                value: 0,
+                data: "",
+                reverted: true
+            })
+        );
+    }
+
+    /// @notice It is important to test SELFDESTRUCT behavior as long as there
+    ///         are public networks that support the opcode, regardless of whether
+    ///         or not Ethereum mainnet does.
+    function testSelfDestruct() public {
+        this.startRecordingFromLowerDepth();
+        address a = address(new SelfDestructor{value:1 ether}(address(this)));
+        address b = address(new SelfDestructor{value:1 ether}(address(bytes20("doesn't exist yet"))));
+        Vm.AccountAccess[] memory called = cheats.getRecordedAccountAccesses();
+        assertEq(called.length, 5, "incorrect length");
+        assertEq(
+            called[1],
+            Vm.AccountAccess({
+                account: a,
+                kind: Vm.AccountAccessKind.Create,
+                initialized: true,
+                value: 1 ether,
+                data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(this))),
+                reverted: false
+            })
+        );
+        assertEq(
+            called[2],
+            Vm.AccountAccess({
+                account: address(this),
+                kind: Vm.AccountAccessKind.SelfDestruct,
+                initialized: true,
+                value: 1 ether,
+                data: "",
+                reverted: false
+            })
+        );
+        assertEq(
+            called[3],
+            Vm.AccountAccess({
+                account: b,
+                kind: Vm.AccountAccessKind.Create,
+                initialized: true,
+                value: 1 ether,
+                data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(bytes20("doesn't exist yet")))),
+                reverted: false
+            })
+        );
+        assertEq(
+            called[4],
+            Vm.AccountAccess({
+                account: address(bytes20("doesn't exist yet")),
+                kind: Vm.AccountAccessKind.SelfDestruct,
+                initialized: false,
+                value: 1 ether,
+                data: "",
+                reverted: false
+            })
+        );
+    }
+
+    function startRecordingFromLowerDepth() external {
+        cheats.recordAccountAccesses();
+        assembly {
+            pop(call(gas(), 1234, 0, 0, 0, 0, 0))
+        }
+    }
+
+    function revertingCall(address target, bytes memory data) external payable {
+        assembly {
+            pop(call(gas(), target, div(callvalue(), 10), add(data, 0x20), mload(data), 0, 0))
+        }
+        revert();
+    }
+
+    function assertEq(Vm.AccountAccess memory actualAccess, Vm.AccountAccess memory expectedAccess) internal {
+        assertEq(actualAccess.account, expectedAccess.account, "incorrect account");
+        assertEq(toUint(actualAccess.kind), toUint(expectedAccess.kind), "incorrect isCreate");
+        assertEq(toUint(actualAccess.initialized), toUint(expectedAccess.initialized), "incorrect initialized");
+        assertEq(actualAccess.value, expectedAccess.value, "incorrect value");
+        assertEq(actualAccess.data, expectedAccess.data, "incorrect data");
+    }
+
+    function toUint(Vm.AccountAccessKind kind) internal pure returns (uint256 value) {
+        assembly {
+            value := and(kind, 0xff)
+        }
+    }
+
+    function toUint(bool a) internal pure returns (uint256) {
+        return a ? 1 : 0;
+    }
+
+    function deriveCreate2Address(address deployer, bytes32 salt, bytes32 codeHash) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, codeHash)))));
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -11,6 +11,13 @@ interface Vm {
         RecurrentPrank
     }
 
+    // The type of account access for getAccessedAccounts()
+    enum AccountAccessKind {
+        Call,
+        Create,
+        SelfDestruct
+    }
+
     // This allows us to getRecordedLogs()
     struct Log {
         bytes32[] topics;
@@ -69,6 +76,26 @@ interface Vm {
         int32 exit_code;
         bytes stdout;
         bytes stderr;
+    }
+
+    // The account access
+    struct AccountAccess {
+        address account;
+        AccountAccessKind kind;
+        bool initialized;
+        uint256 value;
+        bytes data;
+        bool reverted;
+    }
+
+    // A storage access
+    struct StorageAccess {
+        address account;
+        bytes32 slot;
+        bool isWrite;
+        bytes32 previousValue;
+        bytes32 newValue;
+        bool reverted;
     }
 
     // Set block.timestamp (newTimestamp)
@@ -249,6 +276,19 @@ interface Vm {
 
     // Gets all accessed reads and write slot from a recording session, for a given address
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+
+    // Record all account accesses as part of CREATE or CALL opcodes in order,
+    // along with the context of the calls
+    function recordAccountAccesses() external;
+
+    // Returns an ordered array of all account accesses
+    function getRecordedAccountAccesses() external returns (AccountAccess[] memory);
+
+    // Record all storage accesses in order, along with the context of the accesses
+    function recordStorageAccesses() external;
+
+    // Returns an ordered array of all storage accesses
+    function getRecordedStorageAccesses() external returns (StorageAccess[] memory);
 
     // Record all the transaction logs
     function recordLogs() external;


### PR DESCRIPTION
## Motivation

> **Warning**
>
> This pr takes up the work from #5794 to port it to the new alloy types as well as address review comments. Picking this up since it's critical work for external stakeholders and there hasn't been an update in almost two months.

**-- Original Context Below --**

Currently, it is not possible to get an ordered list of account or storage accesses made by the EVM during test execution.

For account accesses, there are cheats such as `vm.expectCall`, but this requires knowing the exact destination and parameters of calls ahead of time.

For storage accesses, there are the `vm.record`/`vm.accesses` cheats, but these are not enumerated or ordered overall, and since it is a mapping, it require knowing which accounts exactly you'd like to check storage accesses for (this is made easier by the new mapping cheatcodes).

Further, it is useful to know the context of account and storage accesses, in particular:

#### For accounts

- What account is being accessed?
- Is the account access the result of a create or a call opcode?
- Is the account initialized or empty?
- Is value passed along with the account access?
- What input data was provided to the create or call?
- Was this access made as part of a context that was reverted?

#### For storage

- Which account's storage was accessed?
- Which slot was accessed?
- Was this access a read or a write?
- What was the value before this access?
- What was the value after this access?
- Was this access made as part of a context that was reverted? 

This would allow for things like manual gas accounting due to accounts and storage slots marked as "warm" during test setup during execution.

## Solution

This PR adds the following cheatcodes and structs:

```rust
struct AccountAccess {
    address account;
    bool isCreate;
    bool initialized;
    uint256 value;
    bytes data;
    bool reverted;
}

struct StorageAccess {
    address account;
    bytes32 slot;
    bool isWrite;
    bytes32 previousValue;
    bytes32 newValue;
    bool reverted;
}

// Record all account accesses as part of CREATE or CALL opcodes in order,
// along with the context of the calls
function recordAccountAccesses() external;

// Returns an ordered array of all account accesses
function getRecordedAccountAccesses() external returns (AccountAccess[] memory);

// Record all storage accesses in order, along with the context of the accesses
function recordStorageAccesses() external;

// Returns an ordered array of all storage accesses
function getRecordedStorageAccesses() external returns (StorageAccess[] memory);
```

#### For accounts

Internally, Forge maintains a `Vec<Vec<RecordedAccountAccess>>`. The vector is 2-dimensional to allow for grouping account accesses by relative call depth, so they can be updated with the eventual failure status of that callframe before being merged with the previous `Vec` to preserve absolute ordering.

On each call or create, a single-element `Vec<RecordedAccountAccess>` is appended to the state with the context of the `CALL` or `CREATE` opcode.

On `call_end` or `create_end`, the last `Vec<RecordedAccountAccess>` is `pop()`'d off and the accesses therein are updated with the failure status of the `CREATE` or `CALL` opcode. This `Vec<RecordedAccountAccess>` is then merged with the previous in the `Vec<Vec<...>>`, or else re-appended to the empty `Vec<Vec<...>>`.

#### For storage

Internally, Forge maintains a `Vec<Vec<RecordedStorageAccess>>`. The vector is 2-dimensional to allow for grouping storage accesses by relative call depth, so they can be updated with the eventual failure status of that callframe before being merged with the previous `Vec` to preserve absolute ordering.

On each `SLOAD` or `SSTORE`, a `RecordedStorageAccess` is appended to the last `Vec<RecordedStorageAccess>`, or else appended as a single-element `Vec`.

On `call_end` or `create_end`, the last `Vec<RecordedStorageAccess>` is `pop()`'d off and the accesses therein are updated with the failure status of the `CREATE` or `CALL` opcode. This `Vec<RecordedStorageAccess>` is then merged with the previous in the `Vec<Vec<...>>`, or else re-appended to the empty `Vec<Vec<...>>`

#### Reasoning

Ordering is important when manually calculating account or storage-slot "warm-ness," as is the eventual reverted status of a callframe in which an account or storage access happened.

Opcodes have different costs depending on whether or not a storage slot is "warm," "cold," or going from zero-to-non-zero value, or when sending value to an empty/uninitialized account. [On an even lower-level, the EVM does not mark "cold" accounts or slots as "warm" if the context from which they were accessed reverts (with the exception of the counterfactual create address)](https://twitter.com/emo_eth/status/1696281639201259677).

Thus, context like `previousValue`, `newValue`, `isCreate`, `initialized`, and `reverted` are important for understanding and evaluating the (hypothetical) behavior of the EVM.