### PR TITLE
Document BTreeMap lexicographical order

### DIFF
--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -414,7 +414,7 @@ fn parse_json_keys(json_str: &str, key: &str) -> Result {
 /// a new object in itself. The function will return a stringified version of the object, so that
 /// the user can use that as a value to a new invocation of the same function with a new object key.
 /// This enables the user to reuse the same function to crate arbitrarily complex object structures
-/// (JSON). Note that the Rust BTreeMap crate is used to serialize in lexicographical order, meaning
+/// (JSON). Note that the `BTreeMap` is used to serialize in lexicographical order, meaning
 /// uppercase precedes lowercase. More: <https://doc.rust-lang.org/std/collections/struct.BTreeMap.html>
 fn serialize_json(
     state: &mut Cheatcodes,

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -321,10 +321,10 @@ fn parse_json_values(values: Vec<&Value>, key: &str) -> Result<Vec<DynSolValue>>
 }
 
 /// Parses a JSON and returns a single value, an array or an entire JSON object encoded as tuple.
-/// As the JSON object is parsed serially, with the keys ordered alphabetically according to the     
-/// Rust BTreeMap crate serialization, they must be deserialized in the same order. That means that 
+/// As the JSON object is parsed serially, with the keys ordered alphabetically according to the
+/// Rust BTreeMap crate serialization, they must be deserialized in the same order. That means that
 /// the solidity `struct` should order its fields not by efficient packing or some other taxonomy
-/// but instead alphabetically, with attention to upper/lower casing since uppercase precedes 
+/// but instead alphabetically, with attention to upper/lower casing since uppercase precedes
 /// lowercase in BTreeMap lexicographical ordering.
 fn parse_json(json_str: &str, key: &str, coerce: Option<DynSolType>) -> Result {
     trace!(%json_str, %key, ?coerce, "parsing json");

--- a/crates/evm/src/executor/inspector/cheatcodes/ext.rs
+++ b/crates/evm/src/executor/inspector/cheatcodes/ext.rs
@@ -415,7 +415,7 @@ fn parse_json_keys(json_str: &str, key: &str) -> Result {
 /// the user can use that as a value to a new invocation of the same function with a new object key.
 /// This enables the user to reuse the same function to crate arbitrarily complex object structures
 /// (JSON). Note that the Rust BTreeMap crate is used to serialize in lexicographical order, meaning
-/// uppercase precedes lowercase. More: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
+/// uppercase precedes lowercase. More: <https://doc.rust-lang.org/std/collections/struct.BTreeMap.html>
 fn serialize_json(
     state: &mut Cheatcodes,
     object_key: &str,


### PR DESCRIPTION
Added short blurbs on Rust's BTreeMap crate ordering system, specifying the caveat that Solidity structs must be declared alphabetically *except that uppercase and lowercase strings are treated differently where uppercase characters precede lowercase ones.

This should add clarity for developers using Foundry's nifty json parsing :)

++Typo/grammar fixes

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
