### PR TITLE
anvil: Fix snapshot revert not updating block-env correctly

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -518,3 +518,32 @@ async fn test_fork_revert_next_block_timestamp() {
     let block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
     assert!(block.timestamp > latest_block.timestamp);
 }
+
+// test that after a snapshot revert, the env block is reset
+// to its correct value (block number, etc.)
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_revert_call_latest_block_timestamp() {
+    let (api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+
+    // Mine a new block, and check the new block gas limit
+    api.mine_one().await;
+    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+
+    let snapshot_id = api.evm_snapshot().await.unwrap();
+    api.mine_one().await;
+    api.evm_revert(snapshot_id).await.unwrap();
+
+    let multicall = MulticallContract::new(
+        Address::from_str("0xeefba1e63905ef1d7acba5a8513c70307c1ce441").unwrap(),
+        provider.into(),
+    );
+
+    assert_eq!(multicall.get_current_block_timestamp().await.unwrap(), latest_block.timestamp);
+    assert_eq!(multicall.get_current_block_difficulty().await.unwrap(), latest_block.difficulty);
+    assert_eq!(multicall.get_current_block_gas_limit().await.unwrap(), latest_block.gas_limit);
+    assert_eq!(
+        multicall.get_current_block_coinbase().await.unwrap(),
+        latest_block.author.unwrap_or_default()
+    );
+}


### PR DESCRIPTION
It seems that https://github.com/foundry-rs/foundry/pull/6097 wasn't sufficient to properly revert the block environment (latest block) after a snapshot revert. A simple `eth_call` that would return the latest block timestamp would show that it wasn't properly reverted.

## Solution

I update the whole `self.env.block` to the past block-env, so that all fields for the current "latest" block are correct.

I also added a test, which calls the already on-chain deployed Multicall contract.
