### PR TITLE
fix(`evm`): properly generate `bytesX` values with `arbitrary_from_type`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-types",
+ "arbitrary",
  "auto_impl",
  "bytes",
  "const-hex",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -56,6 +56,7 @@ alloy-primitives = { workspace = true, features = ["serde", "getrandom", "arbitr
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-json-abi = { workspace = true }
 alloy-sol-types.workspace = true
+arbitrary = "1.3.1"
 
 # Fuzzer
 proptest = "1"

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -302,3 +302,9 @@ async fn test_issue_6006() {
 async fn test_issue_5808() {
     test_repro!("Issue5808");
 }
+
+// <https://github.com/foundry-rs/foundry/issues/6115>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_6115() {
+    test_repro!("Issue6115");
+}

--- a/testdata/repros/Issue6115.t.sol
+++ b/testdata/repros/Issue6115.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/6115
+contract Issue6115Test is DSTest {
+    Counter public counter;
+
+    function setUp() public {
+        counter = new Counter();
+        counter.setNumber(0);
+    }
+
+    // We should be able to fuzz bytes4
+    function testFuzz_SetNumber(uint256 x, bytes4 test) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+
+    // We should be able to fuzz bytes8
+    function testFuzz_SetNumber2(uint256 x, bytes8 test) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+
+    // We should be able to fuzz bytes12
+    function testFuzz_SetNumber3(uint256 x, bytes12 test) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+}


### PR DESCRIPTION
Closes #6115

This fix should stop invalid `bytesX` values from being generated.

In general, we should refactor this part of the fuzzer to be able to handle errors more gracefully.