### PR TITLE
Modified git fetch command to method to use correct root folder.

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -363,11 +363,12 @@ impl<'a> Git<'a> {
     }
 
     pub fn fetch(
+        self,
         shallow: bool,
         remote: impl AsRef<OsStr>,
         branch: Option<impl AsRef<OsStr>>,
     ) -> Result<()> {
-        Self::cmd_no_root()
+        self.cmd()
             .stderr(Stdio::inherit())
             .arg("fetch")
             .args(shallow.then_some("--no-tags"))

--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -68,7 +68,7 @@ impl InitArgs {
 
             // fetch the template - always fetch shallow for templates since git history will be
             // collapsed. gitmodules will be initialized after the template is fetched
-            Git::fetch(true, &template, branch)?;
+            git.fetch(true, &template, branch)?;
             // reset git history to the head of the template
             // first get the commit hash that was fetched
             let commit_hash = git.commit_hash(true, "FETCH_HEAD")?;

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -278,6 +278,33 @@ forgetest!(can_init_with_dir, |prj: TestProject, mut cmd: TestCommand| {
     assert!(prj.root().join("foobar").exists());
 });
 
+// `forge init foobar` works with dir argument
+forgetest!(can_init_with_dir_and_template, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template"]);
+
+    cmd.assert_success(); cmd.assert_non_empty_stdout();
+    assert!(prj.root().join("foobar/.git").exists());
+    assert!(prj.root().join("foobar/foundry.toml").exists());
+    assert!(prj.root().join("foobar/lib/forge-std").exists());
+    // assert that gitmodules were correctly initialized
+    assert!(prj.root().join("foobar/.git/modules").exists());
+    assert!(prj.root().join("foobar/src").exists());
+    assert!(prj.root().join("foobar/test").exists());
+});
+
+// `forge init foobar` works with dir argument
+forgetest!(can_init_with_dir_and_template_and_branch, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template", "--branch", "test/deployments"]);
+
+    cmd.assert_success(); cmd.assert_non_empty_stdout();
+    assert!(prj.root().join("foobar/.dapprc").exists());
+    assert!(prj.root().join("foobar/lib/ds-test").exists());
+    // assert that gitmodules were correctly initialized
+    assert!(prj.root().join("foobar/.git/modules").exists());
+    assert!(prj.root().join("foobar/src").exists());
+    assert!(prj.root().join("foobar/scripts").exists());
+});
+
 // `forge init --force` works on non-empty dirs
 forgetest!(can_init_non_empty, |prj: TestProject, mut cmd: TestCommand| {
     prj.create_file("README.md", "non-empty dir");

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -282,7 +282,8 @@ forgetest!(can_init_with_dir, |prj: TestProject, mut cmd: TestCommand| {
 forgetest!(can_init_with_dir_and_template, |prj: TestProject, mut cmd: TestCommand| {
     cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template"]);
 
-    cmd.assert_success(); cmd.assert_non_empty_stdout();
+    cmd.assert_success();
+    cmd.assert_non_empty_stdout();
     assert!(prj.root().join("foobar/.git").exists());
     assert!(prj.root().join("foobar/foundry.toml").exists());
     assert!(prj.root().join("foobar/lib/forge-std").exists());
@@ -294,9 +295,17 @@ forgetest!(can_init_with_dir_and_template, |prj: TestProject, mut cmd: TestComma
 
 // `forge init foobar --template [template] --branch [branch]` works with dir argument
 forgetest!(can_init_with_dir_and_template_and_branch, |prj: TestProject, mut cmd: TestCommand| {
-    cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template", "--branch", "test/deployments"]);
+    cmd.args([
+        "init",
+        "foobar",
+        "--template",
+        "foundry-rs/forge-template",
+        "--branch",
+        "test/deployments",
+    ]);
 
-    cmd.assert_success(); cmd.assert_non_empty_stdout();
+    cmd.assert_success();
+    cmd.assert_non_empty_stdout();
     assert!(prj.root().join("foobar/.dapprc").exists());
     assert!(prj.root().join("foobar/lib/ds-test").exists());
     // assert that gitmodules were correctly initialized

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -278,7 +278,7 @@ forgetest!(can_init_with_dir, |prj: TestProject, mut cmd: TestCommand| {
     assert!(prj.root().join("foobar").exists());
 });
 
-// `forge init foobar` works with dir argument
+// `forge init foobar --template [template]` works with dir argument
 forgetest!(can_init_with_dir_and_template, |prj: TestProject, mut cmd: TestCommand| {
     cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template"]);
 
@@ -292,7 +292,7 @@ forgetest!(can_init_with_dir_and_template, |prj: TestProject, mut cmd: TestComma
     assert!(prj.root().join("foobar/test").exists());
 });
 
-// `forge init foobar` works with dir argument
+// `forge init foobar --template [template] --branch [branch]` works with dir argument
 forgetest!(can_init_with_dir_and_template_and_branch, |prj: TestProject, mut cmd: TestCommand| {
     cmd.args(["init", "foobar", "--template", "foundry-rs/forge-template", "--branch", "test/deployments"]);
 


### PR DESCRIPTION
## Motivation
#6108 
Forge init --template fails when passing a directory that's different than the CWD since a git command is not ran in the correct context.

## Solution
Change Git::fetch to a method and use the context from the instantiate Git object
