### PR TITLE
fix(forge): add coverage to test setUp

### DIFF
--- a/crates/evm/evm/src/executors/invariant/funcs.rs
+++ b/crates/evm/evm/src/executors/invariant/funcs.rs
@@ -5,6 +5,7 @@ use alloy_json_abi::Function;
 use ethers::types::Log;
 use foundry_common::{ContractsByAddress, ContractsByArtifact};
 use foundry_evm_core::constants::CALLER;
+use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::invariant::{BasicTxDetails, InvariantContract};
 use foundry_evm_traces::{load_contracts, TraceKind, Traces};
 use revm::primitives::U256;
@@ -72,6 +73,7 @@ pub fn replay_run(
     mut ided_contracts: ContractsByAddress,
     logs: &mut Vec<Log>,
     traces: &mut Traces,
+    coverage: &mut Option<HitMaps>,
     func: Function,
     inputs: Vec<BasicTxDetails>,
 ) {
@@ -88,6 +90,20 @@ pub fn replay_run(
 
         logs.extend(call_result.logs);
         traces.push((TraceKind::Execution, call_result.traces.clone().unwrap()));
+
+        let old_coverage = std::mem::take(coverage);
+        match (old_coverage, call_result.coverage) {
+            (Some(old_coverage), Some(call_coverage)) => {
+                *coverage = Some(old_coverage.merge(call_coverage));
+            }
+            (None, Some(call_coverage)) => {
+                *coverage = Some(call_coverage);
+            }
+            (Some(old_coverage), None) => {
+                *coverage = Some(old_coverage);
+            }
+            (None, None) => {}
+        }
 
         // Identify newly generated contracts, if they exist.
         ided_contracts.extend(load_contracts(

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -366,6 +366,7 @@ impl Executor {
             debug,
             script_wallets,
             env,
+            coverage,
             ..
         } = result;
 
@@ -421,7 +422,7 @@ impl Executor {
 
         trace!(address=?address, "deployed contract");
 
-        Ok(DeployResult { address, gas_used, gas_refunded, logs, traces, debug, env })
+        Ok(DeployResult { address, gas_used, gas_refunded, logs, traces, debug, env, coverage })
     }
 
     /// Deploys a contract and commits the new state to the underlying database.
@@ -597,6 +598,8 @@ pub struct DeployResult {
     pub debug: Option<DebugArena>,
     /// The `revm::Env` after deployment
     pub env: Env,
+    /// The coverage info collected during the deployment
+    pub coverage: Option<HitMaps>,
 }
 
 /// The result of a call.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -230,6 +230,8 @@ pub struct TestSetup {
     pub labeled_addresses: BTreeMap<Address, String>,
     /// The reason the setup failed, if it did
     pub reason: Option<String>,
+    /// Coverage info during setup
+    pub coverage: Option<HitMaps>,
 }
 
 impl TestSetup {
@@ -261,8 +263,9 @@ impl TestSetup {
         logs: Vec<Log>,
         traces: Traces,
         labeled_addresses: BTreeMap<Address, String>,
+        coverage: Option<HitMaps>,
     ) -> Self {
-        Self { address, logs, traces, labeled_addresses, reason: None }
+        Self { address, logs, traces, labeled_addresses, reason: None, coverage }
     }
 
     pub fn failed_with(
@@ -271,7 +274,14 @@ impl TestSetup {
         labeled_addresses: BTreeMap<Address, String>,
         reason: String,
     ) -> Self {
-        Self { address: Address::ZERO, logs, traces, labeled_addresses, reason: Some(reason) }
+        Self {
+            address: Address::ZERO,
+            logs,
+            traces,
+            labeled_addresses,
+            reason: Some(reason),
+            coverage: None,
+        }
     }
 
     pub fn failed(reason: String) -> Self {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -660,7 +660,7 @@ impl<'a> ContractRunner<'a> {
     }
 }
 
-// Utility function to merge coverage options
+/// Utility function to merge coverage options
 fn merge_coverages(mut coverage: Option<HitMaps>, other: Option<HitMaps>) -> Option<HitMaps> {
     let old_coverage = std::mem::take(&mut coverage);
     match (old_coverage, other) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Improve forge coverage reporting of functions called during test `setUp`. This allows initializer functions, but not ctors, called during setUp (ex: https://github.com/foundry-rs/foundry/issues/4553) to be covered.

## Solution

The `TestSetup` is extended to include coverage info. The `setUp` coverage is then merged with `HitMaps` generated by test runners.

Consider the coverage reporting of the `CounterTest:test_Increment` test generated by `forge init`. Prior to this change, we see that `Counter.setNumber` isn't covered because it's only called during `setUp`:
![image](https://github.com/foundry-rs/foundry/assets/3516807/4dd1ed7d-5224-4b18-a3a5-4a767264e8fe)

With this patch, we get full test coverage in `Counter.sol`:
![image](https://github.com/foundry-rs/foundry/assets/3516807/c03ff312-fce5-4348-90bf-f298c9fb62e2)
