### PR TITLE
fix(`create`): concat bytecode and constructor call to match old ethabi behavior

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -536,18 +536,21 @@ where
             (None, true) => self.bytecode.clone(),
             (Some(constructor), _) => {
                 let input: Bytes = constructor
-                .abi_encode_input(&params)
-                .map_err(|f| ContractError::DetokenizationError(InvalidOutputType(f.to_string())))?
-                .into();
+                    .abi_encode_input(&params)
+                    .map_err(|f| {
+                        ContractError::DetokenizationError(InvalidOutputType(f.to_string()))
+                    })?
+                    .into();
                 // Concatenate the bytecode and abi-encoded constructor call.
-                self.bytecode.to_vec().into_iter().chain(input).collect()
-            },
+                self.bytecode.iter().copied().chain(input).collect()
+            }
         };
 
         // create the tx object. Since we're deploying a contract, `to` is `None`
         // We default to EIP1559 transactions, but the sender can convert it back
         // to a legacy one.
-        let tx = Eip1559TransactionRequest { to: None, data: Some(data.0.into()), ..Default::default() };
+        let tx =
+            Eip1559TransactionRequest { to: None, data: Some(data.0.into()), ..Default::default() };
 
         let tx = tx.into();
 


### PR DESCRIPTION
Alloy's `alloy_json_abi::Constructor` does not concat the bytecode to calls like `ethabi`, so we need to do it manually.

It'd be nice to have this on Alloy, so made an issue: https://github.com/alloy-rs/core/issues/388