### PR TITLE
fix(`common`): properly parse functions in their usual form

### DIFF
--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -296,6 +296,16 @@ mod tests {
         assert_eq!(func.inputs.len(), 2);
         assert_eq!(func.inputs[0].ty, "uint256");
         assert_eq!(func.inputs[1].ty, "uint256");
+
+        // Stripped down function, which [Function] can parse.
+        let func = get_func("foo(bytes4 a, uint8 b)(bytes4)");
+        assert!(func.is_ok());
+        let func = func.unwrap();
+        assert_eq!(func.name, "foo");
+        assert_eq!(func.inputs.len(), 2);
+        assert_eq!(func.inputs[0].ty, "bytes4");
+        assert_eq!(func.inputs[1].ty, "uint8");
+        assert_eq!(func.outputs[0].ty, "bytes4");
     }
 
     #[test]

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -1,6 +1,6 @@
 //! ABI related helper functions
 use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt, JsonAbiExt};
-use alloy_json_abi::{Event, Function, AbiItem};
+use alloy_json_abi::{AbiItem, Event, Function};
 use alloy_primitives::{hex, Address, Log, U256};
 use ethers_core::types::Chain;
 use eyre::{ContextCompat, Result};
@@ -176,8 +176,8 @@ pub fn get_func(sig: &str) -> Result<Function> {
         Ok(item) => match item {
             AbiItem::Function(func) => func,
             _ => return Err(eyre::eyre!("Expected function, got {:?}", item)),
-        }
-        Err(e) => return Err(e.into())
+        },
+        Err(e) => return Err(e.into()),
     };
     Ok(item.into_owned().to_owned())
 }

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -172,14 +172,19 @@ impl<'a> IntoFunction for &'a str {
 
 /// Given a function signature string, it tries to parse it as a `Function`
 pub fn get_func(sig: &str) -> Result<Function> {
-    let item = match AbiItem::parse(sig) {
-        Ok(item) => match item {
-            AbiItem::Function(func) => func,
-            _ => return Err(eyre::eyre!("Expected function, got {:?}", item)),
-        },
-        Err(e) => return Err(e.into()),
-    };
-    Ok(item.into_owned().to_owned())
+    if let Ok(func) = Function::parse(sig) {
+        Ok(func)
+    } else {
+        // Try to parse as human readable ABI.
+        let item = match AbiItem::parse(sig) {
+            Ok(item) => match item {
+                AbiItem::Function(func) => func,
+                _ => return Err(eyre::eyre!("Expected function, got {:?}", item)),
+            },
+            Err(e) => return Err(e.into()),
+        };
+        Ok(item.into_owned().to_owned())
+    }
 }
 
 /// Given an event signature string, it tries to parse it as a `Event`

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -283,6 +283,17 @@ mod tests {
     use alloy_primitives::B256;
 
     #[test]
+    fn test_get_func() {
+        let func = get_func("function foo(uint256 a, uint256 b) returns (uint256)");
+        assert!(func.is_ok());
+        let func = func.unwrap();
+        assert_eq!(func.name, "foo");
+        assert_eq!(func.inputs.len(), 2);
+        assert_eq!(func.inputs[0].ty, "uint256");
+        assert_eq!(func.inputs[1].ty, "uint256");
+    }
+
+    #[test]
     fn parse_hex_uint_tokens() {
         let param = DynSolType::Uint(256);
 


### PR DESCRIPTION
Closes #6135 

Alloy's `Function` only parses functions without their return arguments and without the `function` prefix. We can use `AbiItem::parse` to parse them as human-readable abi strings and get a `Function` in return.