### PR TITLE
fix: always install error hook first

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -27,8 +27,8 @@ use opts::{Opts, Subcommands, ToBaseArgs};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    utils::load_dotenv();
     handler::install()?;
+    utils::load_dotenv();
     utils::subscriber();
     utils::enable_paint();
 

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -10,8 +10,8 @@ use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
 use opts::{Opts, Subcommands};
 
 fn main() -> Result<()> {
-    utils::load_dotenv();
     handler::install()?;
+    utils::load_dotenv();
     utils::subscriber();
     utils::enable_paint();
 


### PR DESCRIPTION
we were loading the config before installing the error hook.

when we're loading the config we try to determine the project dir via git, if this results in an error (which we gracefully handle), eyre auto install an error hook if there isn't one set already

https://github.com/foundry-rs/foundry/blob/master/crates/config/src/utils.rs#L36-L36

fixed by installing error hook first