### PR TITLE
fix: `foundryup` URI scheme

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -81,16 +81,7 @@ main() {
     FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
 
     # Normalize versions (handle channels, versions without v prefix
-    if [[ "$FOUNDRYUP_VERSION" == "nightly" ]]; then
-      # Locate real nightly tag
-      SHA=$(ensure curl -sSf "https://api.github.com/repos/$FOUNDRYUP_REPO/git/refs/tags/nightly" \
-        | grep -Eo '"sha"[^,]*' \
-        | grep -Eo '[^:]*$' \
-        | tr -d '"' \
-        | tr -d ' ' \
-        | cut -d ':' -f2 )
-      FOUNDRYUP_TAG="nightly-${SHA}"
-    elif [[ "$FOUNDRYUP_VERSION" == nightly* ]]; then
+    if [[ "$FOUNDRYUP_VERSION" =~ ^nightly ]]; then
       FOUNDRYUP_VERSION="nightly"
     elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
       # Add v prefix


### PR DESCRIPTION
## Motivation

Issue https://github.com/foundry-rs/foundry/issues/6152

## Solution

Fix the `foundryup` URI scheme to match that of GitHub's releases.

`https://github.com/foundry-rs/foundry/releases/download/<TAG>/foundry_<VERSION (no SHA)>_<PLATFORM>_<ARCH>.<EXT>`

**Metadata**
closes #6152 
