### PR TITLE
feat: cast wallet generation - json output and many wallets generation

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -158,7 +158,7 @@ impl WalletSubcommands {
                                 "path": path.join(uuid).display(),
                             }));
                         } else {
-                            println!("Successfully created new keystore file.");
+                            println!("Created new encrypted keystore file: {}", path.join(uuid).display());
                             println!("Address: {}", wallet.address().to_alloy().to_checksum(None));
                         }
                     }

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -43,7 +43,7 @@ pub enum WalletSubcommands {
         number: u32,
 
         /// Json output
-        #[clap(long, short, deafult_value = "false")]
+        #[clap(long, short, default_value = "false")]
         json: bool,
     },
 
@@ -153,9 +153,9 @@ impl WalletSubcommands {
                             LocalWallet::new_keystore(&path, &mut rng, password.clone(), None)?;
 
                         if json {
-                            json_values.unwrap().push(json!({
+                            json_values.as_mut().unwrap().push(json!({
                                 "address": wallet.address().to_alloy().to_checksum(None),
-                                "path": path.join(uuid).display(),
+                                "path": format!("{}", path.join(uuid).display()),
                             }));
                         } else {
                             println!("Created new encrypted keystore file: {}", path.join(uuid).display());
@@ -172,9 +172,9 @@ impl WalletSubcommands {
                         let wallet = LocalWallet::new(&mut rng);
 
                         if json {
-                            json_values.unwrap().push(json!({
+                            json_values.as_mut().unwrap().push(json!({
                                 "address": wallet.address().to_alloy().to_checksum(None),
-                                "private_key": format!("0x{}", hex::encode(wallet.private_key())),
+                                "private_key": format!("0x{}", hex::encode(wallet.signer().to_bytes())),
                             }));
                         } else {
                             println!("Successfully created new keypair.");

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -38,7 +38,7 @@ pub enum WalletSubcommands {
         #[clap(long, requires = "path", env = "CAST_PASSWORD", value_name = "PASSWORD")]
         unsafe_password: Option<String>,
 
-        /// Number wallet generation
+        /// Number of wallets to generate.
         #[clap(long, short, default_value = "1")]
         number: u32,
 

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -42,7 +42,7 @@ pub enum WalletSubcommands {
         #[clap(long, short, default_value = "1")]
         number: u32,
 
-        /// Json output
+        /// Output generated wallets as JSON.
         #[clap(long, short, default_value = "false")]
         json: bool,
     },

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -10,8 +10,8 @@ use foundry_cli::opts::{RawWallet, Wallet};
 use foundry_common::fs;
 use foundry_config::Config;
 use foundry_utils::types::{ToAlloy, ToEthers};
-use std::path::Path;
 use serde_json::json;
+use std::path::Path;
 use yansi::Paint;
 
 pub mod vanity;
@@ -132,7 +132,7 @@ impl WalletSubcommands {
             WalletSubcommands::New { path, unsafe_password, number, json, .. } => {
                 let mut rng = thread_rng();
 
-                let mut json_values = if json { Some(vec![] )} else { None };
+                let mut json_values = if json { Some(vec![]) } else { None };
                 if let Some(path) = path {
                     let path = dunce::canonicalize(path)?;
                     if !path.is_dir() {
@@ -147,44 +147,49 @@ impl WalletSubcommands {
                         rpassword::prompt_password("Enter secret: ")?
                     };
 
-
                     for _ in 0..number {
                         let (wallet, uuid) =
                             LocalWallet::new_keystore(&path, &mut rng, password.clone(), None)?;
 
-                        if json {
-                            json_values.as_mut().unwrap().push(json!({
+                        if let Some(json) = json_values.as_mut() {
+                            json.push(json!({
                                 "address": wallet.address().to_alloy().to_checksum(None),
                                 "path": format!("{}", path.join(uuid).display()),
-                            }));
+                            }
+                            ));
                         } else {
-                            println!("Created new encrypted keystore file: {}", path.join(uuid).display());
+                            println!(
+                                "Created new encrypted keystore file: {}",
+                                path.join(uuid).display()
+                            );
                             println!("Address: {}", wallet.address().to_alloy().to_checksum(None));
                         }
                     }
 
-                    if json {
-                        println!("{}", serde_json::to_string_pretty(&json_values.unwrap())?);
+                    if let Some(json) = json_values.as_ref() {
+                        println!("{}", serde_json::to_string_pretty(json)?);
                     }
                 } else {
-                    let mut json_values = if json { Some(vec![] )} else { None };
                     for _ in 0..number {
                         let wallet = LocalWallet::new(&mut rng);
 
-                        if json {
-                            json_values.as_mut().unwrap().push(json!({
+                        if let Some(json) = json_values.as_mut() {
+                            json.push(json!({
                                 "address": wallet.address().to_alloy().to_checksum(None),
                                 "private_key": format!("0x{}", hex::encode(wallet.signer().to_bytes())),
-                            }));
+                            }))
                         } else {
                             println!("Successfully created new keypair.");
-                            println!("Address:     {}", wallet.address().to_alloy().to_checksum(None));
+                            println!(
+                                "Address:     {}",
+                                wallet.address().to_alloy().to_checksum(None)
+                            );
                             println!("Private key: 0x{}", hex::encode(wallet.signer().to_bytes()));
                         }
                     }
 
-                    if json {
-                        println!("{}", serde_json::to_string_pretty(&json_values.unwrap())?);
+                    if let Some(json) = json_values.as_ref() {
+                        println!("{}", serde_json::to_string_pretty(json)?);
                     }
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I lacked the generation of multiple wallets as well as convenient output, so that parse values afterwards would be quite easy.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added two parameters: json and number, whose values are initially set to false and 1 respectively. 
