### PR TITLE
Fix #6162: failed to build `foundry-cheatcodes` when enabling feature `impls`

### DIFF
--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -45,6 +45,7 @@ impls = [
     "dep:foundry-common",
     "dep:foundry-config",
     "dep:foundry-utils",
+    "dep:foundry-compilers",
     "dep:alloy-dyn-abi",
     "dep:alloy-json-abi",
     "dep:ethers",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- cmd: `cargo build --package foundry-cheatcodes --features=impls`
- error:

```sh
error[E0433]: failed to resolve: use of undeclared crate or module `foundry_compilers`
 --> crates/cheatcodes/src/impls/config.rs:4:5
  |
4 | use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
  |     ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `foundry_compilers`

error[E0432]: unresolved import `foundry_compilers`
 --> crates/cheatcodes/src/impls/config.rs:4:5
  |
4 | use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
  |     ^^^^^^^^^^^^^^^^^ help: a similar path exists: `foundry_config::foundry_compilers`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
warning: `foundry-cheatcodes` (lib) generated 1 warning
error: could not compile `foundry-cheatcodes` (lib) due to 2 previous errors; 1 warning emitted
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add the dependence `foundry-compilers` in feature `impls`