### PR TITLE
fix: use both indexed and unindexed params when decoding logs

### DIFF
--- a/crates/evm/traces/src/decoder.rs
+++ b/crates/evm/traces/src/decoder.rs
@@ -347,7 +347,6 @@ impl CallTraceDecoder {
                             })
                             .collect(),
                     );
-                    println!("got log {log:?}");
                     break
                 }
             }


### PR DESCRIPTION
Fixes #6121.

This bug happened because we were only adding labels for unindexed params. We now need to restore the order of the indexed and unindexed params as alloy returns them separately, to be able to assign the labels properly.