### PR TITLE
Raise error when neither `to` nor `--create` are present

### DIFF
--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -108,6 +108,10 @@ impl SendTxArgs {
             None
         };
 
+        if code.is_none() && to.is_none() {
+            eyre::bail!("Must specify a destination or contract code to deploy");
+        }
+
         // Case 1:
         // Default to sending via eth_sendTransaction if the --unlocked flag is passed.
         // This should be the only way this RPC method is used as it requires a local node


### PR DESCRIPTION
## Motivation

I have just wasted some ETH by running command `cast send --value X --rpc-url mainnet` without `to` param :(
`cast send --help` has the following statement:
```
Arguments:
  [TO]
          The destination of the transaction.
          
          If not provided, you must use cast send --create.
```

However, by default, `cast send` without `to` will send transaction to zero address

## Solution

Raise error when `cast send` is called without both `to` and `--create`
