### PR TITLE
refactor(cheatcode): use rate limit args in create fork cheatcode

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -55,6 +55,13 @@ pub struct EvmArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
 
+    /// Number of retries.
+    ///
+    /// See --fork-url.
+    #[clap(long, requires = "fork_url", value_name= "RETRIES")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_retries: Option<u32>,
+
     /// Initial retry backoff on encountering errors.
     ///
     /// See --fork-url.

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -58,7 +58,7 @@ pub struct EvmArgs {
     /// Number of retries.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name= "RETRIES")]
+    #[clap(long, requires = "fork_url", value_name = "RETRIES")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_retries: Option<u32>,
 

--- a/crates/common/src/provider.rs
+++ b/crates/common/src/provider.rs
@@ -96,9 +96,9 @@ impl ProviderBuilder {
         Self {
             url,
             chain: Chain::Mainnet,
-            max_retry: 100,
-            timeout_retry: 5,
-            initial_backoff: 100,
+            max_retry: 8,
+            timeout_retry: 8,
+            initial_backoff: 800,
             timeout: REQUEST_TIMEOUT,
             // alchemy max cpus <https://github.com/alchemyplatform/alchemy-docs/blob/master/documentation/compute-units.md#rate-limits-cups>
             compute_units_per_second: ALCHEMY_FREE_TIER_CUPS,

--- a/crates/common/src/provider.rs
+++ b/crates/common/src/provider.rs
@@ -131,6 +131,19 @@ impl ProviderBuilder {
         self
     }
 
+    /// How often to retry a failed request. If `None`, defaults to the already-set value.
+    pub fn maybe_max_retry(mut self, max_retry: Option<u32>) -> Self {
+        self.max_retry = max_retry.unwrap_or(self.max_retry);
+        self
+    }
+
+    /// The starting backoff delay to use after the first failed request. If `None`, defaults to
+    /// the already-set value.
+    pub fn maybe_initial_backoff(mut self, initial_backoff: Option<u64>) -> Self {
+        self.initial_backoff = initial_backoff.unwrap_or(self.initial_backoff);
+        self
+    }
+
     /// How often to retry a failed request due to connection issues
     pub fn timeout_retry(mut self, timeout_retry: u32) -> Self {
         self.timeout_retry = timeout_retry;

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -24,6 +24,9 @@ pub struct EvmOpts {
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
 
+    /// The number of retries
+    pub fork_retries: Option<u32>,
+
     /// initial retry backoff
     pub fork_retry_backoff: Option<u64>,
 


### PR DESCRIPTION
Rebases #6085 to use the new file structure and refactor—couldn't rebase online on github and it was going to be a pain. Thanks @gr4yha7!