### PR TITLE
fix(`invariants`): respect `fail_on_revert` properly and do not populate logs/traces twice

### DIFF
--- a/crates/evm/evm/src/executors/invariant/funcs.rs
+++ b/crates/evm/evm/src/executors/invariant/funcs.rs
@@ -11,7 +11,7 @@ use revm::primitives::U256;
 
 /// Given the executor state, asserts that no invariant has been broken. Otherwise, it fills the
 /// external `invariant_failures.failed_invariant` map and returns a generic error.
-/// Returns the mapping of (Invariant Function Name -> Call Result).
+/// Either returns the call result if successful, or nothing if there was an error.
 pub fn assert_invariants(
     invariant_contract: &InvariantContract<'_>,
     executor: &Executor,

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -20,7 +20,7 @@ pub type BasicTxDetails = (Address, (Address, Bytes));
 pub struct InvariantContract<'a> {
     /// Address of the test contract.
     pub address: Address,
-    /// Invariant functions present in the test contract.
+    /// Invariant function present in the test contract.
     pub invariant_function: &'a Function,
     /// Abi of the test contract.
     pub abi: &'a Abi,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -487,12 +487,6 @@ impl<'a> ContractRunner<'a> {
                         error!(?err, "Failed to replay invariant error")
                     }
                 };
-
-                logs.extend(error.logs);
-
-                if let Some(error_traces) = error.traces {
-                    traces.push((TraceKind::Execution, error_traces));
-                }
             }
 
             // If invariants ran successfully, replay the last run to collect logs and

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -114,6 +114,39 @@ async fn test_invariant_override() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_fail_on_revert() {
+    let mut runner = runner().await;
+
+    let mut opts = test_opts();
+    opts.invariant.fail_on_revert = true;
+    opts.invariant.runs = 1;
+    opts.invariant.depth = 10;
+    runner.test_options = opts.clone();
+
+    let results = runner
+        .test(
+            &Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantHandlerFailure.t.sol"),
+            None,
+            opts,
+        )
+        .await;
+
+    assert_multiple(
+        &results,
+        BTreeMap::from([(
+            "fuzz/invariant/common/InvariantHandlerFailure.t.sol:InvariantHandlerFailure",
+            vec![(
+                "statefulFuzz_BrokenInvariant()",
+                false,
+                Some("failed on revert".into()),
+                None,
+                None,
+            )],
+        )]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_invariant_storage() {
     let mut runner = runner().await;

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -21,6 +21,10 @@ async fn test_invariant() {
         &results,
         BTreeMap::from([
             (
+                "fuzz/invariant/common/InvariantHandlerFailure.t.sol:InvariantHandlerFailure",
+                vec![("statefulFuzz_BrokenInvariant()", true, None, None, None)],
+            ),
+            (
                 "fuzz/invariant/common/InvariantInnerContract.t.sol:InvariantInnerContract",
                 vec![("invariantHideJesus()", false, Some("jesus betrayed.".into()), None, None)],
             ),

--- a/testdata/fuzz/invariant/common/InvariantHandlerFailure.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantHandlerFailure.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+
+struct FuzzSelector {
+    address addr;
+    bytes4[] selectors;
+}
+
+contract Handler is DSTest {
+    function doSomething() public {
+        require(false, "failed on revert");
+    }
+}
+
+contract InvariantHandlerFailure is DSTest {
+    bytes4[] internal selectors;
+
+    Handler handler;
+
+    function targetSelectors() public returns (FuzzSelector[] memory) {
+        FuzzSelector[] memory targets = new FuzzSelector[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = handler.doSomething.selector;
+        targets[0] = FuzzSelector(address(handler), selectors);
+        return targets;
+    }
+
+    function setUp() public {
+        handler = new Handler();
+    }
+
+    function statefulFuzz_BrokenInvariant() public {}
+}


### PR DESCRIPTION
Fixes #5726, fixes #6082, fixes #6024 

`fail_on_revert` was not getting respected correctly after a recent refactor, in which we stopped populating the `error` in `InvariantFailures`. This was causing mainly failures in handlers to not be detected leading to erroneous `[PASS]` states.

We were also collecting the logs and traces of the last error _twice_, which is not necessary as we replay the entire run. This could lead to situations where it seems an invariant gets called twice, but it's just the error log popping up twice.

