### PR TITLE
fix(`invariant`): do not record newly created contracts as targetContracts

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -174,7 +174,6 @@ impl<'a> InvariantExecutor<'a> {
                     self.project_contracts,
                     self.setup_contracts,
                     &self.artifact_filters,
-                    targeted_contracts.clone(),
                     &mut created_contracts,
                 ) {
                     warn!(target: "forge::test", "{error}");

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -253,22 +253,16 @@ pub fn collect_created_contracts(
     project_contracts: &ContractsByArtifact,
     setup_contracts: &ContractsByAddress,
     artifact_filters: &ArtifactFilters,
-    targeted_contracts: FuzzRunIdentifiedContracts,
     created_contracts: &mut Vec<Address>,
 ) -> eyre::Result<()> {
-    let mut writable_targeted = targeted_contracts.lock();
     for (address, account) in state_changeset {
         if !setup_contracts.contains_key(address) {
             if let (true, Some(code)) = (&account.is_touched(), &account.info.code) {
                 if !code.is_empty() {
                     if let Some((artifact, (abi, _))) = project_contracts.find_by_code(code.bytes())
                     {
-                        if let Some(functions) =
-                            artifact_filters.get_targeted_functions(artifact, abi)?
-                        {
+                        if let Some(_) = artifact_filters.get_targeted_functions(artifact, abi)? {
                             created_contracts.push(*address);
-                            writable_targeted
-                                .insert(*address, (artifact.name.clone(), abi.clone(), functions));
                         }
                     }
                 }

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -1,5 +1,5 @@
 use super::fuzz_param_from_state;
-use crate::invariant::{ArtifactFilters, FuzzRunIdentifiedContracts};
+use crate::invariant::ArtifactFilters;
 use alloy_dyn_abi::{DynSolType, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, Bytes, B256, U256};
@@ -261,7 +261,7 @@ pub fn collect_created_contracts(
                 if !code.is_empty() {
                     if let Some((artifact, (abi, _))) = project_contracts.find_by_code(code.bytes())
                     {
-                        if let Some(_) = artifact_filters.get_targeted_functions(artifact, abi)? {
+                        if artifact_filters.get_targeted_functions(artifact, abi)?.is_some() {
                             created_contracts.push(*address);
                         }
                     }


### PR DESCRIPTION
## Motivation

Potential fix to #6166 and #5625 cc @mds1 @patrickalphac

## Solution

Right now, `targetContracts()` is not "static" after `setUp()`—it gets updated after each depth call with the newly created contracts and their selectors. This has been foundry's behavior since invariants were added.

However, people expect to _only_ see contracts added in `targetContracts` during setup to be used for creating inputs. This means that if contracts are deployed after setup they should not see them in fuzz runs.

The fix is to stop adding these new contracts to the targeted contracts.