### PR TITLE
Add support for events and errors in `forge selectors upload`

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -304,9 +304,7 @@ impl SignEthClient {
                     .flat_map(|abi| {
                         abi.abi
                             .functions()
-                            .map(|func| {
-                                func.signature().split(':').next().unwrap_or("").to_string()
-                            })
+                            .map(|func| func.signature())
                             .chain(abi.abi.errors().map(|error| error.signature()))
                             .collect::<Vec<_>>()
                     })

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -299,7 +299,7 @@ impl SignEthClient {
 
         let request = match data {
             SelectorImportData::Abi(abis) => {
-                let names: Vec<String> = abis
+                let functions_and_errors: Vec<String> = abis
                     .iter()
                     .flat_map(|abi| {
                         abi.abi
@@ -307,10 +307,17 @@ impl SignEthClient {
                             .map(|func| {
                                 func.signature().split(':').next().unwrap_or("").to_string()
                             })
+                            .chain(abi.abi.errors().map(|error| error.signature()))
                             .collect::<Vec<_>>()
                     })
                     .collect();
-                SelectorImportRequest { function: names, event: Default::default() }
+
+                let events = abis
+                    .iter()
+                    .flat_map(|abi| abi.abi.events().map(|event| event.signature()))
+                    .collect::<Vec<_>>();
+
+                SelectorImportRequest { function: functions_and_errors, event: events }
             }
             SelectorImportData::Raw(raw) => {
                 SelectorImportRequest { function: raw.function, event: raw.event }


### PR DESCRIPTION
## Motivation

Currently `forge selectors upload` command does not upload errors and events.
Closes #5924, #5241 and maybe #5012

## Solution

Upload errors and events also. openchain.xyz API does not have a separate field for errors, so functions and errors are uploaded together. Same solution is used by openchain.xyz ["Import" page](https://openchain.xyz/signatures/import), so it seems to be considered a correct way which does not pollute the database.

<img width="1642" alt="image" src="https://github.com/foundry-rs/foundry/assets/62447812/7b850981-fbc2-4a13-9d20-26c2578b2ab8">
