### PR TITLE
fix(`fuzz`): remove harcoded hex prefix from calldata

### DIFF
--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -109,7 +109,7 @@ impl fmt::Display for BaseCounterExample {
         if let Some(sig) = &self.signature {
             write!(f, "calldata={sig}")?
         } else {
-            write!(f, "calldata=0x{}", self.calldata)?
+            write!(f, "calldata={}", self.calldata)?
         }
 
         write!(f, ", args=[{args}]")


### PR DESCRIPTION
Fixes #6208 