### PR TITLE
fix(`abi`): sanitize function args to avoid passing in prefixed empty bytes

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2020,6 +2020,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn calldata_encode_bytes() {
+        assert_eq!(
+            "0xd45754f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+            Cast::calldata_encode("f(bytes x)", &["0x00"]).unwrap().as_str()
+        );
+    }
+
     // <https://github.com/foundry-rs/foundry/issues/2681>
     #[test]
     fn calldata_array() {

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -192,11 +192,11 @@ fn coerce_value(ty: &str, arg: &str) -> Result<DynSolValue> {
 
 /// Sanitizes arguments for encoding function arguments.
 /// If it's an empty sequence, it returns "0x00" to avoid encoding errors.
-fn sanitize_arg<'a>(arg: &'a str) -> &'a str {
+fn sanitize_arg(arg: &str) -> &str {
     if arg == "0x" {
-        return "0x00"
+        "0x00"
     } else {
-        return arg
+        arg
     }
 }
 

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -16,7 +16,7 @@ where
     S: AsRef<str>,
 {
     let params = std::iter::zip(&func.inputs, args)
-        .map(|(input, arg)| coerce_value(&input.selector_type(), arg.as_ref()))
+        .map(|(input, arg)| coerce_value(&input.selector_type(), sanitize_arg(arg.as_ref())))
         .collect::<Result<Vec<_>>>()?;
     func.abi_encode_input(params.as_slice()).map_err(Into::into)
 }
@@ -188,6 +188,16 @@ pub fn find_source(
 fn coerce_value(ty: &str, arg: &str) -> Result<DynSolValue> {
     let ty = DynSolType::parse(ty)?;
     Ok(DynSolType::coerce_str(&ty, arg)?)
+}
+
+/// Sanitizes arguments for encoding function arguments.
+/// If it's an empty sequence, it returns "0x00" to avoid encoding errors.
+fn sanitize_arg<'a>(arg: &'a str) -> &'a str {
+    if arg == "0x" {
+        return "0x00"
+    } else {
+        return arg
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #6211. Maybe we want alloy to support this?