### PR TITLE
chore: add deprecation notice to forge create

### DIFF
--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -203,7 +203,7 @@ pub fn get_available_profiles(toml_path: impl AsRef<Path>) -> eyre::Result<Vec<S
     let doc = read_toml(toml_path)?;
 
     if let Some(Item::Table(profiles)) = doc.as_table().get(Config::PROFILE_SECTION) {
-        for (_, (profile, _)) in profiles.iter().enumerate() {
+        for (profile, _) in profiles.iter() {
             let p = profile.to_string();
             if !result.contains(&p) {
                 result.push(p);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -357,7 +357,6 @@ impl<'a> InvariantExecutor<'a> {
                 },
             )
             .into_iter()
-            .map(|(contract, functions)| (contract, functions))
             .collect::<BTreeMap<_, _>>();
 
         // Insert them into the executor `targeted_abi`.

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -17,10 +17,11 @@ use foundry_cli::{
     opts::{CoreBuildArgs, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
-use foundry_common::{compile, estimate_eip1559_fees, fmt::parse_tokens};
+use foundry_common::{compile, estimate_eip1559_fees, fmt::parse_tokens, shell};
 use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalized};
 use foundry_utils::types::{ToAlloy, ToEthers};
 use serde_json::json;
+use yansi::Paint;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
 
 /// CLI arguments for `forge create`.
@@ -77,6 +78,8 @@ pub struct CreateArgs {
 impl CreateArgs {
     /// Executes the command to create a contract
     pub async fn run(mut self) -> Result<()> {
+        shell::println(Paint::yellow("Warning! This command is deprecated and will be removed in v1. use `forge script` instead"))?;
+
         // Find Project & Compile
         let project = self.opts.project()?;
         let mut output = if self.json || self.opts.silent {

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -21,8 +21,8 @@ use foundry_common::{compile, estimate_eip1559_fees, fmt::parse_tokens, shell};
 use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalized};
 use foundry_utils::types::{ToAlloy, ToEthers};
 use serde_json::json;
-use yansi::Paint;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
+use yansi::Paint;
 
 /// CLI arguments for `forge create`.
 #[derive(Debug, Clone, Parser)]

--- a/crates/forge/tests/fixtures/can_create_template_contract-2nd.stdout
+++ b/crates/forge/tests/fixtures/can_create_template_contract-2nd.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 No files changed, compilation skipped
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/crates/forge/tests/fixtures/can_create_template_contract.stdout
+++ b/crates/forge/tests/fixtures/can_create_template_contract.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 Compiling 22 files with 0.8.15
 Solc 0.8.15 finished in 2.27s
 Compiler run successful!

--- a/crates/forge/tests/fixtures/can_create_using_unlocked-2nd.stdout
+++ b/crates/forge/tests/fixtures/can_create_using_unlocked-2nd.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 No files changed, compilation skipped
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
+++ b/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 Compiling 22 files with 0.8.15
 Solc 0.8.15 finished in 1.95s
 Compiler run successful!

--- a/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
+++ b/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 Compiling 23 files with 0.8.15
 Solc 0.8.15 finished in 2.82s
 Compiler run successful!

--- a/crates/forge/tests/fixtures/can_create_with_tuple_constructor_args.stdout
+++ b/crates/forge/tests/fixtures/can_create_with_tuple_constructor_args.stdout
@@ -1,3 +1,4 @@
+Warning! This command is deprecated and will be removed in v1. use `forge script` instead
 Compiling 1 files with 0.8.15
 Solc 0.8.15 finished in 26.44ms
 Compiler run successful!


### PR DESCRIPTION
This command should be deprecated soon, ideally in V1. People should use `forge script` instead.