### PR TITLE
ci: don't fail-fast on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         timeout-minutes: 60
         needs: prepare
         strategy:
+            fail-fast: false
             matrix:
                 job:
                     # The OS is used for the runner


### PR DESCRIPTION
If one fails, don't block the others from finishing