### PR TITLE
fix(`ci`): create heavy profile for heavy integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
 [profile.default]
 retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
 slow-timeout = "3m"
+
+[profile.heavy]
+retries = 1

--- a/.github/workflows/heavy-integration.yml
+++ b/.github/workflows/heavy-integration.yml
@@ -38,7 +38,7 @@ jobs:
               run: git config --global url."https://github.com/".insteadOf "git@github.com:"
             - name: test
               run: |
-                  cargo nextest run --profile local -p forge \
+                  cargo nextest run --profile heavy -p forge \
                     --test cli --features heavy-integration-tests -E "test(~heavy_integration)"
 
     # If any of the jobs fail, this will create a high-priority issue to signal so.


### PR DESCRIPTION
## Motivation

Heavy integration tests ci is broken because the `local` profile doesn't exist

## Solution

Create a `heavy` profile which is simple rn but we can modify later if we change this workflow