### PR TITLE
feat(`anvil`): `anvil_metadata`

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -490,6 +490,10 @@ pub enum EthRequest {
     #[cfg_attr(feature = "serde", serde(rename = "anvil_nodeInfo", with = "empty_params"))]
     NodeInfo(()),
 
+    /// Retrieves the Anvil node metadata.
+    #[cfg_attr(feature = "serde", serde(rename = "anvil_metadata", with = "empty_params"))]
+    AnvilMetadata(()),
+
     // Ganache compatible calls
     /// Snapshot the state of the blockchain at the current block.
     #[cfg_attr(

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -491,7 +491,10 @@ pub enum EthRequest {
     NodeInfo(()),
 
     /// Retrieves the Anvil node metadata.
-    #[cfg_attr(feature = "serde", serde(rename = "anvil_metadata", with = "empty_params"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "anvil_metadata", alias = "hardhat_metadata", with = "empty_params")
+    )]
     AnvilMetadata(()),
 
     // Ganache compatible calls

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -1,4 +1,4 @@
-use ethers_core::types::{H256, U256, U64};
+use ethers_core::types::{TxHash, H256, U256, U64};
 use revm::primitives::SpecId;
 
 #[cfg(feature = "serde")]
@@ -202,6 +202,32 @@ pub struct NodeForkConfig {
     pub fork_url: Option<String>,
     pub fork_block_number: Option<u64>,
     pub fork_retry_backoff: Option<u128>,
+}
+
+/// Anvil equivalent of `hardhat_metadata`.
+/// Metadata about the current Anvil instance.
+/// See <https://hardhat.org/hardhat-network/docs/reference#hardhat_metadata>
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct AnvilMetadata {
+    pub client_version: &'static str,
+    pub chain_id: U256,
+    pub instance_id: H256,
+    pub latest_block_number: U64,
+    pub latest_block_hash: H256,
+    pub forked_network: Option<ForkedNetwork>,
+}
+
+/// Information about the forked network.
+/// See <https://hardhat.org/hardhat-network/docs/reference#hardhat_metadata>
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ForkedNetwork {
+    pub chain_id: U256,
+    pub fork_block_number: U64,
+    pub fork_block_hash: TxHash,
 }
 
 #[cfg(test)]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -39,7 +39,10 @@ use anvil_core::{
         },
         EthRequest,
     },
-    types::{EvmMineOptions, Forking, Index, NodeEnvironment, NodeForkConfig, NodeInfo, Work},
+    types::{
+        AnvilMetadata, EvmMineOptions, ForkedNetwork, Forking, Index, NodeEnvironment,
+        NodeForkConfig, NodeInfo, Work,
+    },
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
 use ethers::{
@@ -108,6 +111,8 @@ pub struct EthApi {
     transaction_order: Arc<RwLock<TransactionOrder>>,
     /// Whether we're listening for RPC calls
     net_listening: bool,
+    /// The instance ID. Changes on every reset.
+    instance_id: Arc<RwLock<H256>>,
 }
 
 // === impl Eth RPC API ===
@@ -138,6 +143,7 @@ impl EthApi {
             filters,
             net_listening: true,
             transaction_order: Arc::new(RwLock::new(transactions_order)),
+            instance_id: Arc::new(RwLock::new(H256::random())),
         }
     }
 
@@ -315,6 +321,7 @@ impl EthApi {
             EthRequest::DumpState(_) => self.anvil_dump_state().await.to_rpc_result(),
             EthRequest::LoadState(buf) => self.anvil_load_state(buf).await.to_rpc_result(),
             EthRequest::NodeInfo(_) => self.anvil_node_info().await.to_rpc_result(),
+            EthRequest::AnvilMetadata(_) => self.anvil_metadata().await.to_rpc_result(),
             EthRequest::EvmSnapshot(_) => self.evm_snapshot().await.to_rpc_result(),
             EthRequest::EvmRevert(id) => self.evm_revert(id).await.to_rpc_result(),
             EthRequest::EvmIncreaseTime(time) => self.evm_increase_time(time).await.to_rpc_result(),
@@ -1532,6 +1539,8 @@ impl EthApi {
     pub async fn anvil_reset(&self, forking: Option<Forking>) -> Result<()> {
         node_info!("anvil_reset");
         if let Some(forking) = forking {
+            // if we're resetting the fork we need to reset the instance id
+            self.reset_instance_id();
             self.backend.reset_fork(forking).await
         } else {
             Err(BlockchainError::RpcUnimplemented)
@@ -1692,6 +1701,27 @@ impl EthApi {
                     }
                 })
                 .unwrap_or_default(),
+        })
+    }
+
+    /// Retrieves metadata about the Anvil instance.
+    ///
+    /// Handler for RPC call: `anvil_metadata`
+    pub async fn anvil_metadata(&self) -> Result<AnvilMetadata> {
+        node_info!("anvil_metadata");
+        let fork_config = self.backend.get_fork();
+
+        Ok(AnvilMetadata {
+            client_version: CLIENT_VERSION,
+            chain_id: self.backend.chain_id(),
+            latest_block_hash: self.backend.best_hash(),
+            latest_block_number: self.backend.best_number(),
+            instance_id: *self.instance_id.read(),
+            forked_network: fork_config.map(|cfg| ForkedNetwork {
+                chain_id: cfg.chain_id().into(),
+                fork_block_number: cfg.block_number().into(),
+                fork_block_hash: cfg.block_hash(),
+            }),
         })
     }
 
@@ -2278,6 +2308,16 @@ impl EthApi {
 
     pub fn get_fork(&self) -> Option<ClientFork> {
         self.backend.get_fork()
+    }
+
+    /// Returns the current instance's ID.
+    pub fn instance_id(&self) -> H256 {
+        *self.instance_id.read()
+    }
+
+    /// Resets the instance ID.
+    pub fn reset_instance_id(&self) {
+        *self.instance_id.write() = H256::random();
     }
 
     /// Returns the first signer that can sign for the given address


### PR DESCRIPTION
Closes #6221. ref @antazoey

Adds the `anvil_metadata` method, which is the anvil equivalent of [`hardhat_metadata`](https://hardhat.org/hardhat-network/docs/reference#hardhat_metadata).

The instance ID is random and changes on every node boot, or when `anvil_reset` is called.