### PR TITLE
🚸 script: ignore interfaces when inferring target

### DIFF
--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -151,7 +151,13 @@ impl ScriptArgs {
 
                 // if it's the target contract, grab the info
                 if extra.no_target_name {
-                    if id.source == std::path::PathBuf::from(&extra.target_fname) {
+                    // Match artifact source, and ignore interfaces
+                    if id.source == std::path::PathBuf::from(&extra.target_fname) &&
+                        match contract.bytecode.as_ref() {
+                            Some(bytecode) => bytecode.object.bytes_len() > 0,
+                            None => false,
+                        }
+                    {
                         if extra.matched {
                             eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`")
                         }

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -152,11 +152,8 @@ impl ScriptArgs {
                 // if it's the target contract, grab the info
                 if extra.no_target_name {
                     // Match artifact source, and ignore interfaces
-                    if id.source == std::path::PathBuf::from(&extra.target_fname) &&
-                        match contract.bytecode.as_ref() {
-                            Some(bytecode) => bytecode.object.bytes_len() > 0,
-                            None => false,
-                        }
+                    if id.source == std::path::Path::new(&extra.target_fname) &&
+                        contract.bytecode.as_ref().map_or(false, |b| b.object.bytes_len() > 0)
                     {
                         if extra.matched {
                             eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`")

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1108,3 +1108,24 @@ contract NestedCreateFail is Script {
     cmd.arg("script").arg(script).args(["--tc", "NestedCreateFail"]);
     assert!(cmd.stdout_lossy().contains("Script ran successfully."));
 });
+
+forgetest_async!(assert_can_detect_target_contract_with_interfaces, |prj, cmd| {
+    let script = prj
+        .inner()
+        .add_script(
+            "ScriptWithInterface.s.sol",
+            r#"
+pragma solidity ^0.8.22;
+
+contract Script {
+  function run() external {}
+}
+
+interface Interface {}
+            "#,
+        )
+        .unwrap();
+
+    cmd.arg("script").arg(script);
+    assert!(cmd.stdout_lossy().contains("Script ran successfully."));
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
currently, when running `forge script` without the `--target-contract`/`--tc` argument, forge will fail to identify the expected target contract if interfaces are declared in the same file, like in the following example:
```solidity
// SPDX-License-Identifier: AGPL-3.0
pragma solidity ^0.8.22;

contract Script {
  function run() external {}
}

interface Interface {}
```
error:
```
Multiple contracts in the target path. Please specify the contract name with `--tc ContractName
```
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
the ux can be improved by ignoring artifacts with zero-length bytecode.