### PR TITLE
fix: precompile trace decoding

### DIFF
--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -71,14 +71,13 @@ pub(super) fn decode(trace: &mut CallTrace, _chain_id: u64) -> bool {
         0x08 => (ecpairingCall::SIGNATURE, tri!(decode_ecpairing(data))),
         0x09 => (blake2fCall::SIGNATURE, tri!(decode_blake2f(data))),
         0x0a => (pointEvaluationCall::SIGNATURE, tri!(decode_kzg(data))),
-        _ => unreachable!(),
+        0x00 | 0x0b.. => unreachable!(),
     };
 
     // TODO: Other chain precompiles
 
     trace.data = TraceCallData::Decoded { signature: signature.to_string(), args };
-
-    trace.contract = Some("PRECOMPILES".into());
+    trace.label = Some("PRECOMPILES".into());
 
     true
 }

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -530,10 +530,12 @@ impl fmt::Display for CallTrace {
         } else {
             let (func_name, inputs) = match &self.data {
                 TraceCallData::Raw(bytes) => {
-                    // We assume that the fallback function (`data.len() < 4`) counts as decoded
-                    // calldata
-                    let (selector, data) = bytes.split_at(4);
-                    (hex::encode(selector), hex::encode(data))
+                    if bytes.len() < 4 {
+                        ("<unknown>".into(), hex::encode(bytes))
+                    } else {
+                        let (selector, data) = bytes.split_at(4);
+                        (hex::encode(selector), hex::encode(data))
+                    }
                 }
                 TraceCallData::Decoded { signature, args } => {
                     let name = signature.split('(').next().unwrap();

--- a/crates/evm/traces/src/node.rs
+++ b/crates/evm/traces/src/node.rs
@@ -167,37 +167,4 @@ impl CallTraceNode {
             }
         }
     }
-
-    /// Decode the node's tracing data for the given precompile function
-    pub fn decode_precompile(
-        &mut self,
-        precompile_fn: &Function,
-        labels: &HashMap<Address, String>,
-    ) {
-        if let TraceCallData::Raw(ref bytes) = self.trace.data {
-            self.trace.label = Some("PRECOMPILE".to_string());
-            self.trace.data = TraceCallData::Decoded {
-                signature: precompile_fn.signature(),
-                args: precompile_fn.abi_decode_input(bytes, false).map_or_else(
-                    |_| vec![hex::encode(bytes)],
-                    |tokens| tokens.iter().map(|token| utils::label(token, labels)).collect(),
-                ),
-            };
-
-            if let TraceRetData::Raw(ref bytes) = self.trace.output {
-                self.trace.output = TraceRetData::Decoded(
-                    precompile_fn.abi_decode_output(bytes, false).map_or_else(
-                        |_| hex::encode(bytes),
-                        |tokens| {
-                            tokens
-                                .iter()
-                                .map(|token| utils::label(token, labels))
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        },
-                    ),
-                );
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes #6262

Two bugs here:
- shouldn't assume that raw calldata is at least 4 bytes
- return is wrong because we're in a loop
