### PR TITLE
fix(`cast`): use selector() instead of signature for cast event-sig

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -451,7 +451,7 @@ async fn main() -> Result<()> {
         Subcommands::SigEvent { event_string } => {
             let event_string = stdin::unwrap_line(event_string)?;
             let parsed_event = get_event(&event_string)?;
-            println!("{:?}", parsed_event.signature());
+            println!("{:?}", parsed_event.selector());
         }
         Subcommands::LeftShift { value, bits, base_in, base_out } => {
             println!("{}", SimpleCast::left_shift(&value, &bits, base_in.as_deref(), &base_out)?);


### PR DESCRIPTION
Closes #6264 