### PR TITLE
refactor(cheatcodes): rewrite string parsing with dyn abi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 [[package]]
 name = "alloy-dyn-abi"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -119,6 +119,7 @@ dependencies = [
  "const-hex",
  "derive_arbitrary",
  "derive_more",
+ "ethereum_ssz",
  "getrandom 0.2.10",
  "hex-literal",
  "itoa",
@@ -156,7 +157,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "const-hex",
  "dunce",
@@ -173,7 +174,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "winnow",
 ]
@@ -181,7 +182,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -2031,6 +2032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_ssz"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61ffea29f26e8249d35128a82ec8d3bd4fbc80179ea5f5e5e3daafef6a80fcb"
+dependencies = [
+ "ethereum-types",
+ "itertools 0.10.5",
+ "smallvec",
+]
+
+[[package]]
 name = "ethers"
 version = "2.0.10"
 source = "git+https://github.com/gakonst/ethers-rs?rev=4f7b354ecec0aea38ed165560ae4f3224d644c9e#4f7b354ecec0aea38ed165560ae4f3224d644c9e"
@@ -2417,6 +2429,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "rand 0.8.5",
  "rustc-hex",
@@ -6818,7 +6831,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/core/#818071e6f20cec5c0b7fb465fda5e0553b2e0ed4"
+source = "git+https://github.com/alloy-rs/core/#89f07abf7837f63d22e30d2076e860dac6acef57"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7488,6 +7501,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "crunchy",
  "hex",

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -1,7 +1,8 @@
 //! Implementations of [`Environment`](crate::Group::Environment) cheatcodes.
 
 use crate::{string, Cheatcode, Cheatcodes, Result, Vm::*};
-use alloy_primitives::{Address, Bytes, B256, I256, U256};
+use alloy_dyn_abi::DynSolType;
+use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
 use std::env;
 
@@ -26,98 +27,98 @@ impl Cheatcode for setEnvCall {
 impl Cheatcode for envBool_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<bool>(name, None)
+        env(name, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<U256>(name, None)
+        env(name, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<I256>(name, None)
+        env(name, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<Address>(name, None)
+        env(name, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<B256>(name, None)
+        env(name, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<String>(name, None)
+        env(name, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;
-        env::<Bytes>(name, None)
+        env(name, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for envBool_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<bool>(name, delim, None)
+        env_array(name, delim, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for envUint_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<U256>(name, delim, None)
+        env_array(name, delim, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for envInt_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<I256>(name, delim, None)
+        env_array(name, delim, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for envAddress_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<Address>(name, delim, None)
+        env_array(name, delim, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for envBytes32_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<B256>(name, delim, None)
+        env_array(name, delim, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for envString_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<String>(name, delim, None)
+        env_array(name, delim, &DynSolType::String)
     }
 }
 
 impl Cheatcode for envBytes_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim } = self;
-        env_array::<Bytes>(name, delim, None)
+        env_array(name, delim, &DynSolType::Bytes)
     }
 }
 
@@ -125,7 +126,7 @@ impl Cheatcode for envBytes_1Call {
 impl Cheatcode for envOr_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<bool>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::Bool)
     }
 }
 
@@ -133,7 +134,7 @@ impl Cheatcode for envOr_0Call {
 impl Cheatcode for envOr_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<U256>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::Uint(256))
     }
 }
 
@@ -141,7 +142,7 @@ impl Cheatcode for envOr_1Call {
 impl Cheatcode for envOr_2Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<I256>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::Int(256))
     }
 }
 
@@ -149,7 +150,7 @@ impl Cheatcode for envOr_2Call {
 impl Cheatcode for envOr_3Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<Address>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::Address)
     }
 }
 
@@ -157,7 +158,7 @@ impl Cheatcode for envOr_3Call {
 impl Cheatcode for envOr_4Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<B256>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::FixedBytes(32))
     }
 }
 
@@ -165,7 +166,7 @@ impl Cheatcode for envOr_4Call {
 impl Cheatcode for envOr_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<String>(name, Some(defaultValue))
+        env_default(name, defaultValue, &DynSolType::String)
     }
 }
 
@@ -173,7 +174,7 @@ impl Cheatcode for envOr_5Call {
 impl Cheatcode for envOr_6Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env::<Bytes>(name, Some(&defaultValue.clone().into()))
+        env_default(name, defaultValue, &DynSolType::Bytes)
     }
 }
 
@@ -181,7 +182,7 @@ impl Cheatcode for envOr_6Call {
 impl Cheatcode for envOr_7Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<bool>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::Bool)
     }
 }
 
@@ -189,7 +190,7 @@ impl Cheatcode for envOr_7Call {
 impl Cheatcode for envOr_8Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<U256>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::Uint(256))
     }
 }
 
@@ -197,7 +198,7 @@ impl Cheatcode for envOr_8Call {
 impl Cheatcode for envOr_9Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<I256>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::Int(256))
     }
 }
 
@@ -205,7 +206,7 @@ impl Cheatcode for envOr_9Call {
 impl Cheatcode for envOr_10Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<Address>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::Address)
     }
 }
 
@@ -213,7 +214,7 @@ impl Cheatcode for envOr_10Call {
 impl Cheatcode for envOr_11Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<B256>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::FixedBytes(32))
     }
 }
 
@@ -221,7 +222,7 @@ impl Cheatcode for envOr_11Call {
 impl Cheatcode for envOr_12Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
-        env_array::<String>(name, delim, Some(defaultValue))
+        env_array_default(name, delim, defaultValue, &DynSolType::String)
     }
 }
 
@@ -230,32 +231,24 @@ impl Cheatcode for envOr_13Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, delim, defaultValue } = self;
         let default = defaultValue.iter().map(|vec| vec.clone().into()).collect::<Vec<Bytes>>();
-        env_array::<Bytes>(name, delim, Some(&default))
+        env_array_default(name, delim, &default, &DynSolType::Bytes)
     }
 }
 
-fn env<T>(key: &str, default: Option<&T>) -> Result
-where
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
-    match (get_env(key), default) {
-        (Ok(val), _) => string::parse::<T>(&val),
-        (Err(_), Some(default)) => Ok(default.abi_encode()),
-        (Err(e), None) => Err(e),
-    }
+fn env(key: &str, ty: &DynSolType) -> Result {
+    get_env(key).and_then(|val| string::parse(&val, ty))
 }
 
-fn env_array<T>(key: &str, delim: &str, default: Option<&[T]>) -> Result
-where
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
-    match (get_env(key), default) {
-        (Ok(val), _) => string::parse_array::<_, _, T>(val.split(delim).map(str::trim)),
-        (Err(_), Some(default)) => Ok(default.abi_encode()),
-        (Err(e), None) => Err(e),
-    }
+fn env_default<T: SolValue>(key: &str, default: &T, ty: &DynSolType) -> Result {
+    Ok(env(key, ty).unwrap_or_else(|_| default.abi_encode()))
+}
+
+fn env_array(key: &str, delim: &str, ty: &DynSolType) -> Result {
+    get_env(key).and_then(|val| string::parse_array(val.split(delim).map(str::trim), ty))
+}
+
+fn env_array_default<T: SolValue>(key: &str, delim: &str, default: &T, ty: &DynSolType) -> Result {
+    Ok(env_array(key, delim, ty).unwrap_or_else(|_| default.abi_encode()))
 }
 
 fn get_env(key: &str) -> Result<String> {

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -1,8 +1,8 @@
 //! Implementations of [`Json`](crate::Group::Json) cheatcodes.
 
 use crate::{string, Cheatcode, Cheatcodes, Result, Vm::*};
-use alloy_dyn_abi::DynSolValue;
-use alloy_primitives::{Address, Bytes, B256, I256, U256};
+use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_primitives::{Address, B256, I256};
 use alloy_sol_types::SolValue;
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
@@ -36,98 +36,98 @@ impl Cheatcode for parseJson_1Call {
 impl Cheatcode for parseJsonUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<U256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseJsonUintArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<U256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseJsonIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<I256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseJsonIntArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<I256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseJsonBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<bool>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseJsonBoolArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<bool>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Bool)
     }
 }
 
 impl Cheatcode for parseJsonAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<Address>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseJsonAddressArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<Address>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseJsonStringCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<String>(json, key)
+        parse_json_coerce(json, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseJsonStringArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<String>(json, key)
+        parse_json_coerce(json, key, &DynSolType::String)
     }
 }
 
 impl Cheatcode for parseJsonBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<Bytes>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseJsonBytesArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<Bytes>(json, key)
+        parse_json_coerce(json, key, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseJsonBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<B256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseJsonBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { json, key } = self;
-        parse_json_coerce::<B256>(json, key)
+        parse_json_coerce(json, key, &DynSolType::FixedBytes(32))
     }
 }
 
@@ -284,11 +284,7 @@ fn parse_json(json: &str, path: &str) -> Result {
     parse_json_inner(json, path, None::<fn(Vec<&Value>) -> Result>)
 }
 
-fn parse_json_coerce<T>(json: &str, path: &str) -> Result
-where
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
+fn parse_json_coerce(json: &str, path: &str, ty: &DynSolType) -> Result {
     parse_json_inner(
         json,
         path,
@@ -306,9 +302,9 @@ where
                 s
             };
             if let Some(array) = values[0].as_array() {
-                string::parse_array::<_, _, T>(array.iter().map(to_string))
+                string::parse_array(array.iter().map(to_string), ty)
             } else {
-                string::parse::<T>(&to_string(values[0]))
+                string::parse(&to_string(values[0]), ty)
             }
         }),
     )

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -147,7 +147,7 @@ fn parse_value_fallback(s: &str, ty: &DynSolType) -> Option<Result<DynSolValue, 
                 return Some(Err("missing hex prefix (\"0x\") for hex string"))
             }
         }
-        DynSolType::String => return Some(Ok(DynSolValue::String(s.to_owned()))),
+        // DynSolType::String => return Some(Ok(DynSolValue::String(s.to_owned()))),
         _ => {}
     }
     None

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -1,8 +1,8 @@
 //! Implementations of [`String`](crate::Group::String) cheatcodes.
 
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
-use alloy_primitives::{Address, Bytes, B256, I256, U256};
-use alloy_sol_types::{SolType, SolValue};
+use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_sol_types::SolValue;
 
 // address
 impl Cheatcode for toString_0Call {
@@ -55,78 +55,66 @@ impl Cheatcode for toString_5Call {
 impl Cheatcode for parseBytesCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<Bytes>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::Bytes)
     }
 }
 
 impl Cheatcode for parseAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<Address>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for parseUintCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<U256>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::Uint(256))
     }
 }
 
 impl Cheatcode for parseIntCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<I256>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::Int(256))
     }
 }
 
 impl Cheatcode for parseBytes32Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<B256>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::FixedBytes(32))
     }
 }
 
 impl Cheatcode for parseBoolCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { stringifiedValue } = self;
-        parse::<bool>(stringifiedValue)
+        parse(stringifiedValue, &DynSolType::Bool)
     }
 }
 
-pub(super) fn parse<T>(s: &str) -> Result
-where
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
-    parse_t::<T>(s).map(|v| v.abi_encode())
+pub(super) fn parse(s: &str, ty: &DynSolType) -> Result {
+    parse_value(s, ty).map(|v| v.abi_encode())
 }
 
-pub(super) fn parse_array<I, S, T>(values: I) -> Result
+pub(super) fn parse_array<I, S>(values: I, ty: &DynSolType) -> Result
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
 {
     let mut values = values.into_iter();
     match values.next() {
         Some(first) if !first.as_ref().is_empty() => std::iter::once(first)
             .chain(values)
-            .map(|s| parse_t::<T>(s.as_ref()))
+            .map(|s| parse_value(s.as_ref(), ty))
             .collect::<Result<Vec<_>, _>>()
-            .map(|vec| vec.abi_encode()),
+            .map(|vec| DynSolValue::Tuple(vec).abi_encode()),
         // return the empty encoded Bytes when values is empty or the first element is empty
         _ => Ok("".abi_encode()),
     }
 }
 
-fn parse_t<T>(s: &str) -> Result<T>
-where
-    T: SolValue + std::str::FromStr,
-    T::Err: std::fmt::Display,
-{
-    s.parse::<T>().map_err(|e| {
-        fmt_err!("failed parsing {s:?} as type `{}`: {e}", T::SolType::sol_type_name())
-    })
+fn parse_value(s: &str, ty: &DynSolType) -> Result<DynSolValue> {
+    ty.coerce_str(s).map_err(|e| fmt_err!("failed parsing {s:?} as type `{ty}`: {e}"))
 }

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -147,7 +147,6 @@ fn parse_value_fallback(s: &str, ty: &DynSolType) -> Option<Result<DynSolValue, 
                 return Some(Err("missing hex prefix (\"0x\") for hex string"))
             }
         }
-        // DynSolType::String => return Some(Ok(DynSolValue::String(s.to_owned()))),
         _ => {}
     }
     None

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -109,7 +109,7 @@ where
             .chain(values)
             .map(|s| parse_value(s.as_ref(), ty))
             .collect::<Result<Vec<_>, _>>()
-            .map(|vec| DynSolValue::Tuple(vec).abi_encode()),
+            .map(|vec| DynSolValue::Array(vec).abi_encode()),
         // return the empty encoded Bytes when values is empty or the first element is empty
         _ => Ok("".abi_encode()),
     }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -302,6 +302,12 @@ async fn test_issue_5808() {
     test_repro!("Issue5808");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/6070>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_6070() {
+    test_repro!("Issue6070");
+}
+
 // <https://github.com/foundry-rs/foundry/issues/6115>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_issue_6115() {

--- a/testdata/repros/Issue5808.t.sol
+++ b/testdata/repros/Issue5808.t.sol
@@ -9,10 +9,9 @@ contract Issue5808Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testReadInt() public {
-        // TODO: blocked on https://github.com/alloy-rs/core/issues/387
-        // string memory str1 = '["ffffffff","00000010"]';
-        // vm.expectRevert();
-        // int256[] memory ints1 = vm.parseJsonIntArray(str1, "");
+        string memory str1 = '["ffffffff","00000010"]';
+        vm.expectRevert();
+        int256[] memory ints1 = vm.parseJsonIntArray(str1, "");
 
         string memory str2 = '["0xffffffff","0x00000010"]';
         int256[] memory ints2 = vm.parseJsonIntArray(str2, "");

--- a/testdata/repros/Issue6070.t.sol
+++ b/testdata/repros/Issue6070.t.sol
@@ -10,7 +10,9 @@ contract Issue6066Test is DSTest {
 
     function testNonPrefixed() public {
         vm.setEnv("__FOUNDRY_ISSUE_6066", "abcd");
-        vm.expectRevert("failed parsing $__FOUNDRY_ISSUE_6066 as type `uint256`: missing hex prefix (\"0x\") for hex string");
+        vm.expectRevert(
+            "failed parsing $__FOUNDRY_ISSUE_6066 as type `uint256`: missing hex prefix (\"0x\") for hex string"
+        );
         uint256 x = vm.envUint("__FOUNDRY_ISSUE_6066");
     }
 }

--- a/testdata/repros/Issue6070.t.sol
+++ b/testdata/repros/Issue6070.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6070
+contract Issue6066Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testNonPrefixed() public {
+        vm.setEnv("__FOUNDRY_ISSUE_6066", "abcd");
+        vm.expectRevert("failed parsing \"abcd\" as type `uint256`: missing hex prefix (\"0x\") for hex string");
+        uint256 x = vm.envUint("__FOUNDRY_ISSUE_6066");
+    }
+}

--- a/testdata/repros/Issue6070.t.sol
+++ b/testdata/repros/Issue6070.t.sol
@@ -10,7 +10,7 @@ contract Issue6066Test is DSTest {
 
     function testNonPrefixed() public {
         vm.setEnv("__FOUNDRY_ISSUE_6066", "abcd");
-        vm.expectRevert("failed parsing \"abcd\" as type `uint256`: missing hex prefix (\"0x\") for hex string");
+        vm.expectRevert("failed parsing $__FOUNDRY_ISSUE_6066 as type `uint256`: missing hex prefix (\"0x\") for hex string");
         uint256 x = vm.envUint("__FOUNDRY_ISSUE_6066");
     }
 }


### PR DESCRIPTION
The static encoder is too inflexible for this task. We can still use it for defaults tho.

Closes https://github.com/foundry-rs/foundry/issues/6070
Closes https://github.com/foundry-rs/foundry/pull/6268
Closes #6265 via alloy-rs/core#410