### PR TITLE
Multichain Scripts: Deploy each sequence of transactions sequentially instead of in parallel. 

### DIFF
--- a/crates/forge/bin/cmd/script/multi.rs
+++ b/crates/forge/bin/cmd/script/multi.rs
@@ -148,8 +148,6 @@ impl ScriptArgs {
         let mut results: Vec<Result<(), Report>> = Vec::new(); // Declare a Vec of Result<(), Report>
 
         for sequence in deployments.deployments.iter_mut() {
-            let fork_url = &sequence.typed_transactions().first().unwrap().0.clone();
-            println!("fork url is {fork_url}");
             let result = match self
                 .send_transactions(
                     sequence,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
As explained [here](https://book.getfoundry.sh/tutorials/solidity-scripting?highlight=sequentially#high-level-overview) foundry first runs a simulation, collects all the transactions then batch runs all the transactions. This causes issues in scenarios where the script has a flow like this: 
1. Fork chain A, deploy contracts to Chain A 
2. Fork chain B, deploy contracts to Chain B
3. Switch back to Chain A, let contracts in Chain A know of Contracts in Chain B (this is very common where there's cross-chain messaging to be done between the contracts. I.e. Configuring LayerZero to deliver messages to the destination chain.) 
4. Switch to Chain B, etc. etc. 

In this case, steps 1 and 3 will generate two sequences of transactions both pertaining to Chain A. From the simulation that was previously run, the nonce of the first transaction in Sequence 3 will be one more than the nonce of the last transaction in Sequence 1. However, since foundry attempts to run both Sequences 1 & 3 in parallel, the nonce returned from the RPC will mismatch the first transaction in Sequence 3, and it'll result in the following error: 

```
EOA nonce changed unexpectedly while sending transactions. Expected 58 got 54 from provider.
```
## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We can still run the transactions in each DeploySequence in parallel and enjoy the performances of batch transactions! However, in between sequence changes we have to wait until the last sequence's transactions are all submitted.

### Potential Optimization
We could chunk the neighbouring sequences and execute those in parallel. Consider Chains A, B, C and a deploy script that results in these sequences: 

A, B, A, B, B, C, A, B, B, A, A, C, C, C

We could chunk the neighbouring sequences like so: 
A, B, A, (B, B), C, A, (B, B), (A, A), (C, C, C)

Although this may already be the case, I'm not sure how these sequences get generated. 