### PR TITLE
feat: add --no-cache and respect cache config value

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -26,6 +26,11 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub force: bool,
 
+    /// Disable the cache.
+    #[clap(long)]
+    #[serde(skip)]
+    pub no_cache: bool,
+
     /// Set pre-linked libraries.
     #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -201,6 +206,10 @@ impl Provider for CoreBuildArgs {
 
         if self.force {
             dict.insert("force".to_string(), self.force.into());
+        }
+        // we need to ensure no_cache set accordingly
+        if self.no_cache {
+            dict.insert("cache".to_string(), false.into());
         }
 
         if self.build_info {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -605,7 +605,7 @@ impl Config {
     /// let project = config.project();
     /// ```
     pub fn project(&self) -> Result<Project, SolcError> {
-        self.create_project(true, false)
+        self.create_project(self.cache, false)
     }
 
     /// Same as [`Self::project()`] but sets configures the project to not emit artifacts and ignore

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -34,23 +34,7 @@ impl FlattenArgs {
         let FlattenArgs { target_path, output, project_paths } = self;
 
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
-        let build_args = CoreBuildArgs {
-            project_paths,
-            out_path: Default::default(),
-            compiler: Default::default(),
-            ignored_error_codes: vec![],
-            deny_warnings: false,
-            no_auto_detect: false,
-            use_solc: None,
-            offline: false,
-            force: false,
-            libraries: vec![],
-            via_ir: false,
-            revert_strings: None,
-            silent: false,
-            build_info: false,
-            build_info_path: None,
-        };
+        let build_args = CoreBuildArgs { project_paths, ..Default::default() };
 
         let config = build_args.try_load_config_emit_warnings()?;
 

--- a/crates/forge/tests/cli/cache.rs
+++ b/crates/forge/tests/cli/cache.rs
@@ -14,3 +14,12 @@ forgetest!(can_list_specific_chain, |_prj, cmd| {
     cmd.args(["cache", "ls", "mainnet"]);
     cmd.assert_success();
 });
+
+forgetest!(can_test_no_cache, |prj, cmd| {
+    cmd.args(["test", "--no-cache"]);
+    cmd.assert_success();
+    assert!(!prj.cache_path().exists(), "cache file should not exist");
+    cmd.args(["test"]);
+    cmd.assert_success();
+    assert!(prj.cache_path().exists(), "cache file should exist");
+});

--- a/crates/forge/tests/cli/cache.rs
+++ b/crates/forge/tests/cli/cache.rs
@@ -19,7 +19,7 @@ forgetest!(can_test_no_cache, |prj, cmd| {
     cmd.args(["test", "--no-cache"]);
     cmd.assert_success();
     assert!(!prj.cache_path().exists(), "cache file should not exist");
-    cmd.args(["test"]);
+    cmd.forge_fuse().args(["test"]);
     cmd.assert_success();
     assert!(prj.cache_path().exists(), "cache file should exist");
 });

--- a/crates/forge/tests/cli/cache.rs
+++ b/crates/forge/tests/cli/cache.rs
@@ -15,7 +15,7 @@ forgetest!(can_list_specific_chain, |_prj, cmd| {
     cmd.assert_success();
 });
 
-forgetest!(can_test_no_cache, |prj, cmd| {
+forgetest_init!(can_test_no_cache, |prj, cmd| {
     cmd.args(["test", "--no-cache"]);
     cmd.assert_success();
     assert!(!prj.cache_path().exists(), "cache file should not exist");


### PR DESCRIPTION
while the config supported a `cache: bool` value already, it was effectively ignored.

this adds a `--no-cache` bool to the build args and uses the config's `cache` value when a project is configured.