### PR TITLE
feat(doc): Include extrernal libraries into forge doc scope

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -110,8 +110,7 @@ impl DocBuilder {
             return Ok(())
         }
 
-        let library_sources =
-            self.libraries.iter().flat_map(|lib| source_files_iter(lib)).collect::<Vec<_>>();
+        let library_sources = self.libraries.iter().flat_map(source_files_iter).collect::<Vec<_>>();
 
         let combined_sources = sources
             .iter()

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -127,22 +127,22 @@ impl DocBuilder {
 
                 // Read and parse source file
                 let source = fs::read_to_string(path)?;
-                let parser_result = solang_parser::parse(&source, i);
 
-                if parser_result.is_err() {
-                    if from_library {
-                        // Ignore failures for library files
-                        return Ok(Vec::new());
-                    } else {
-                        return Err(eyre::eyre!(
-                            "Failed to parse Solidity code for {}\nDebug info: {:?}",
-                            path.display(),
-                            parser_result.err().unwrap()
-                        ));
+                let (mut source_unit, comments) = match solang_parser::parse(&source, i) {
+                    Ok(res) => res,
+                    Err(err) => {
+                        if from_library {
+                            // Ignore failures for library files
+                            return Ok(Vec::new());
+                        } else {
+                            return Err(eyre::eyre!(
+                                "Failed to parse Solidity code for {}\nDebug info: {:?}",
+                                path.display(),
+                                err
+                            ));
+                        }
                     }
-                }
-
-                let (mut source_unit, comments) = parser_result.unwrap();
+                };
 
                 // Visit the parse tree
                 let mut doc = Parser::new(comments, source).with_fmt(self.fmt.clone());

--- a/crates/doc/src/document.rs
+++ b/crates/doc/src/document.rs
@@ -17,6 +17,8 @@ pub struct Document {
     pub identity: String,
     /// The preprocessors results.
     context: Mutex<HashMap<PreprocessorId, PreprocessorOutput>>,
+    /// Whether the document is from external library.
+    pub from_library: bool,
 }
 
 /// The content of the document.
@@ -30,10 +32,11 @@ pub enum DocumentContent {
 
 impl Document {
     /// Create new instance of [Document].
-    pub fn new(item_path: PathBuf, target_path: PathBuf) -> Self {
+    pub fn new(item_path: PathBuf, target_path: PathBuf, from_library: bool) -> Self {
         Self {
             item_path,
             target_path,
+            from_library,
             item_content: String::default(),
             identity: String::default(),
             content: DocumentContent::Empty,

--- a/crates/doc/src/preprocessor/contract_inheritance.rs
+++ b/crates/doc/src/preprocessor/contract_inheritance.rs
@@ -13,8 +13,10 @@ pub const CONTRACT_INHERITANCE_ID: PreprocessorId = PreprocessorId("contract_inh
 ///
 /// This preprocessor writes to [Document]'s context.
 #[derive(Default, Debug)]
-#[non_exhaustive]
-pub struct ContractInheritance;
+pub struct ContractInheritance {
+    /// Whether to capture inherited contracts from libraries.
+    pub include_libraries: bool,
+}
 
 impl Preprocessor for ContractInheritance {
     fn id(&self) -> PreprocessorId {
@@ -51,6 +53,9 @@ impl Preprocessor for ContractInheritance {
 impl ContractInheritance {
     fn try_link_base(&self, base: &str, documents: &Vec<Document>) -> Option<PathBuf> {
         for candidate in documents {
+            if candidate.from_library && !self.include_libraries {
+                continue;
+            }
             if let DocumentContent::Single(ref item) = candidate.content {
                 if let ParseSource::Contract(ref contract) = item.source {
                     if base == contract.name.safe_unwrap().name {

--- a/crates/doc/src/preprocessor/git_source.rs
+++ b/crates/doc/src/preprocessor/git_source.rs
@@ -28,6 +28,9 @@ impl Preprocessor for GitSource {
             let repo = repo.trim_end_matches('/');
             let commit = self.commit.clone().unwrap_or("master".to_owned());
             for document in documents.iter() {
+                if document.from_library {
+                    continue;
+                }
                 let git_url = format!(
                     "{repo}/blob/{commit}/{}",
                     document.item_path.strip_prefix(&self.root)?.display()


### PR DESCRIPTION
## Motivation

Closes #5761 and adds ability to generate docs for external dependencies via `--include-libraries` flag

## Solution

List of documents now always contains all `.sol` files found in lib directories. They are getting filtered out if `--include-libraries` is off when the mdbook is generated.
- `ContractInheritance` preprocessor captures inherited contracts from external libraries only if `--include-libraries` is on
- `GitSource` preprocessor never generates git source links for contracts from external libraries
- `InheritDoc` always includes contracts from external libs when matching `@inheritdoc` statements

