### PR TITLE
feat(`cheatcodes`): add computeCreateAddress cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -527,6 +527,66 @@
     },
     {
       "func": {
+        "id": "computeCreate2Address_0",
+        "description": "Compute the address of a contract created with CREATE2 using the given CREATE2 deployer.",
+        "declaration": "function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer) external pure returns (address);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "computeCreate2Address(bytes32,bytes32,address)",
+        "selector": "0xd323826a",
+        "selectorBytes": [
+          211,
+          35,
+          130,
+          106
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "computeCreate2Address_1",
+        "description": "Compute the address of a contract created with CREATE2 using the default CREATE2 deployer.",
+        "declaration": "function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external pure returns (address);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "computeCreate2Address(bytes32,bytes32)",
+        "selector": "0x890c283b",
+        "selectorBytes": [
+          137,
+          12,
+          40,
+          59
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "computeCreateAddress",
+        "description": "Compute the address a contract will be deployed at for a given deployer address and nonce.",
+        "declaration": "function computeCreateAddress(address deployer, uint256 nonce) external pure returns (address);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "computeCreateAddress(address,uint256)",
+        "selector": "0x74637a7a",
+        "selectorBytes": [
+          116,
+          99,
+          122,
+          122
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "cool",
         "description": "Marks the slots of an account and the account address as cold.",
         "declaration": "function cool(address target) external;",

--- a/crates/cheatcodes/defs/src/vm.rs
+++ b/crates/cheatcodes/defs/src/vm.rs
@@ -1155,5 +1155,17 @@ interface Vm {
     /// Gets the label for the specified address.
     #[cheatcode(group = Utilities)]
     function getLabel(address account) external returns (string memory currentLabel);
+
+    /// Compute the address a contract will be deployed at for a given deployer address and nonce.
+    #[cheatcode(group = Utilities)]
+    function computeCreateAddress(address deployer, uint256 nonce) external pure returns (address);
+
+    /// Compute the address of a contract created with CREATE2 using the given CREATE2 deployer.
+    #[cheatcode(group = Utilities)]
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer) external pure returns (address);
+
+    /// Compute the address of a contract created with CREATE2 using the default CREATE2 deployer.
+    #[cheatcode(group = Utilities)]
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external pure returns (address);
 }
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -115,6 +115,7 @@ impl Cheatcode for getLabelCall {
 impl Cheatcode for computeCreateAddressCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { nonce, deployer } = self;
+        ensure!(*nonce <= U256::from(u64::MAX), "nonce must be less than 2^64 - 1");
         Ok(deployer.create(nonce.to()).abi_encode())
     }
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -1,7 +1,7 @@
 //! Implementations of [`Utils`](crate::Group::Utils) cheatcodes.
 
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result, Vm::*};
-use alloy_primitives::{keccak256, B256, U256};
+use alloy_primitives::{keccak256, Address, Uint, B256, U256};
 use alloy_sol_types::SolValue;
 use ethers_core::k256::{
     ecdsa::SigningKey,
@@ -15,6 +15,7 @@ use ethers_signers::{
     },
     LocalWallet, MnemonicBuilder, Signer,
 };
+use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
 use foundry_utils::types::{ToAlloy, ToEthers};
 
 /// The BIP32 default derivation path prefix.
@@ -111,6 +112,59 @@ impl Cheatcode for getLabelCall {
     }
 }
 
+impl Cheatcode for computeCreateAddressCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { nonce, deployer } = self;
+        if *nonce == Uint::from(0x00) {
+            return address_from_last_20_bytes(&keccak256(
+                &[&[0xd6], &[0x94], deployer.as_slice(), &[0x80]].abi_encode_packed(),
+            ));
+        }
+        if *nonce <= Uint::from(0x7f) {
+            return address_from_last_20_bytes(&keccak256(
+                &[&[0xd6], &[0x94], deployer.as_slice(), &nonce.to_be_bytes::<1>()]
+                    .abi_encode_packed(),
+            ));
+        }
+        if *nonce <= Uint::from(0xff) {
+            return address_from_last_20_bytes(&keccak256(
+                &[&[0xd7], &[0x94], deployer.as_slice(), &[0x81], &nonce.to_be_bytes::<1>()]
+                    .abi_encode_packed(),
+            ));
+        }
+        if *nonce <= Uint::from(0xffff) {
+            return address_from_last_20_bytes(&keccak256(
+                &[&[0xd8], &[0x94], deployer.as_slice(), &[0x82], &nonce.to_be_bytes::<2>()]
+                    .abi_encode_packed(),
+            ));
+        }
+        if *nonce <= Uint::from(0xffffff) {
+            return address_from_last_20_bytes(&keccak256(
+                &[&[0xd9], &[0x94], deployer.as_slice(), &[0x83], &nonce.to_be_bytes::<3>()]
+                    .abi_encode_packed(),
+            ));
+        }
+        address_from_last_20_bytes(&keccak256(
+            &[&[0xda], &[0x94], deployer.as_slice(), &[0x84], &nonce.to_be_bytes::<4>()]
+                .abi_encode_packed(),
+        ))
+    }
+}
+
+impl Cheatcode for computeCreate2Address_0Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { salt, initCodeHash, deployer } = self;
+        compute_create2_address(salt, initCodeHash, deployer)
+    }
+}
+
+impl Cheatcode for computeCreate2Address_1Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { salt, initCodeHash } = self;
+        compute_create2_address(salt, initCodeHash, &DEFAULT_CREATE2_DEPLOYER)
+    }
+}
+
 /// Using a given private key, return its public ETH address, its public key affine x and y
 /// coodinates, and its private key (see the 'Wallet' struct)
 ///
@@ -195,4 +249,19 @@ fn derive_key<W: Wordlist>(mnemonic: &str, path: &str, index: u32) -> Result {
         .build()?;
     let private_key = U256::from_be_bytes(wallet.signer().to_bytes().into());
     Ok(private_key.abi_encode())
+}
+
+fn compute_create2_address(salt: &B256, init_code_hash: &B256, deployer: &Address) -> Result {
+    let mut data = Vec::with_capacity(1 + 20 + 32 + 32);
+    data.extend_from_slice(&[0xff]);
+    data.extend_from_slice(deployer.as_slice());
+    data.extend_from_slice(salt.as_slice());
+    data.extend_from_slice(init_code_hash.as_slice());
+    address_from_last_20_bytes(&keccak256(&data))
+}
+
+fn address_from_last_20_bytes(bytes: &B256) -> Result {
+    let mut addr_bytes = [0u8; 20];
+    addr_bytes.copy_from_slice(&bytes[12..]);
+    Ok(addr_bytes.abi_encode())
 }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -28,6 +28,9 @@ interface Vm {
     function clearMockedCalls() external;
     function closeFile(string calldata path) external;
     function coinbase(address newCoinbase) external;
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer) external pure returns (address);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external pure returns (address);
+    function computeCreateAddress(address deployer, uint256 nonce) external pure returns (address);
     function cool(address target) external;
     function copyFile(string calldata from, string calldata to) external returns (uint64 copied);
     function createDir(string calldata path, bool recursive) external;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #6270
add `computeCreateAddress` and `computeCreate2Address` to cheatcodes.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

As suggested in [comment](https://github.com/foundry-rs/foundry/issues/6270#issuecomment-1807187525), I transformed these code in [forge-std](https://github.com/foundry-rs/forge-std/blob/37a37ab73364d6644bfe11edf88a07880f99bd56/src/StdUtils.sol#L97-L134) to cheatcodes.

I am very new to rust, please correct me if any thing is wrong.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
