### PR TITLE
fix(forge): `loadAllocs` cheatcode doesn't persist when called in `setUp`

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1315,6 +1315,9 @@ impl DatabaseExt for Backend {
             // Set the account's nonce and balance.
             state_acc.info.nonce = acc.nonce.unwrap_or_default();
             state_acc.info.balance = acc.balance.to_alloy();
+
+            // Touch the account to ensure the loaded information persists if called in `setUp`.
+            journaled_state.touch(addr);
         }
 
         Ok(())


### PR DESCRIPTION
## Overview

The `loadAllocs` cheatcode currently does not persist loaded account information if it is called in the `setUp` function. This is because none of the loaded accounts were marked as touched during the loading process.

## Solution

Touch each account that is loaded into the `revm` journal in the `load_allocs` function in the DB backend.

## Tests

Added a regression test for the fixed bug, asserting that the loaded accounts are persisted when the cheatcode is called in `setUp`.