### PR TITLE
feat: docker buildkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY --from=planner /opt/foundry /opt/foundry
 # Get the lock-like file
 COPY --from=planner /opt/foundry/recipe.json recipe.json
 
-RUN apt-get update -y && apt-get install -y gcc-aarch64-linux-gnu
+RUN apt-get update -y && apt-get install -y gcc-aarch64-linux-gnu linux-headers-$(uname -r)
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Build our project dependencies, not our application!
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -37,6 +38,9 @@ RUN strip /opt/foundry/target/release/forge \
 
 FROM debian:bookworm-slim AS foundry
 
+RUN apt-get update -y && apt-get install -y linux-headers-$(uname -r) git
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Foundry tools
 COPY --from=builder /opt/foundry/target/release/forge /usr/local/bin/forge
 COPY --from=builder /opt/foundry/target/release/cast /usr/local/bin/cast
@@ -50,3 +54,13 @@ USER foundry
 # TODO(User and group here)
 
 ENTRYPOINT ["/bin/sh", "-c"]
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Foundry" \
+      org.label-schema.description="Foundry" \
+      org.label-schema.url="https://getfoundry.sh" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/foundry-rs/foundry.git" \
+      org.label-schema.vendor="Foundry-rs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1.72.1 as chef
-WORKDIR /opt
+WORKDIR /opt/foundry
 
 FROM chef as planner
 
 # Get the foundry project
-RUN git clone https://github.com/foundry-rs/foundry.git
-
-WORKDIR /opt/foundry
+COPY . .
 
 # Compute a lock-like file for our project
 RUN cargo chef prepare  --recipe-path recipe.json
@@ -27,7 +25,8 @@ RUN cargo chef cook --release --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 
-# Conditional for cross compliation
+# TODO(Conditional for cross compliation)
+# There seem to be some undocumented particulars here
 RUN CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc CFLAGS=-mno-outline-atomics cargo build --release
 
 # Strip any debug symbols

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=planner /opt/foundry /opt/foundry
 # Get the lock-like file
 COPY --from=planner /opt/foundry/recipe.json recipe.json
 
-RUN apt-get update -y && apt-get install -y gcc-aarch64-linux-gnu linux-headers-$(uname -r)
+RUN apt-get update -y && apt-get install -y gcc-aarch64-linux-gnu linux-headers
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Build our project dependencies, not our application!
@@ -38,7 +38,7 @@ RUN strip /opt/foundry/target/release/forge \
 
 FROM debian:bookworm-slim AS foundry
 
-RUN apt-get update -y && apt-get install -y linux-headers-$(uname -r) git
+RUN apt-get update -y && apt-get install -y linux-headers git
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Foundry tools


### PR DESCRIPTION
This pull request migrates the docker image to a modern buildkit build and debian rather than alpine.

## Motivation

Supporting multiple architectures for a critical tool like Foundry is key. Right now the docker image does not build/is not available for ARM, which is going to power an increasing percentage of workbooks, workstations, servers and phones in the coming years.

https://github.com/valorem-labs-inc/anvil-runner

Started work on this for an ARM anvil runner for use in CI.

## Solution

This PR implements an architecture agnostic build process for use with docker buildkit cross-platform compilation to output multiple images for multiple architectures. It also migrates from alpine to debian bookworm-slim, which has much better performance characteristics and a similarly lean size.
