### PR TITLE
test: compile testdata/ only once

### DIFF
--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1,6 +1,6 @@
 //! Contains various tests for checking `forge test`
 use foundry_config::Config;
-use foundry_test_utils::util::{template_lock, OutputExt, OTHER_SOLC_VERSION, SOLC_VERSION};
+use foundry_test_utils::util::{OutputExt, OTHER_SOLC_VERSION, SOLC_VERSION};
 use foundry_utils::rpc;
 use std::{path::PathBuf, process::Command, str::FromStr};
 
@@ -265,8 +265,6 @@ forgetest_init!(
     #[serial_test::serial]
     can_test_forge_std,
     |prj, cmd| {
-        let mut lock = template_lock();
-        let write = lock.write().unwrap();
         let forge_std_dir = prj.root().join("lib/forge-std");
         let status = Command::new("git")
             .current_dir(&forge_std_dir)
@@ -276,7 +274,6 @@ forgetest_init!(
         if !status.success() {
             panic!("failed to update forge-std");
         }
-        drop(write);
 
         // execute in subdir
         cmd.cmd().current_dir(forge_std_dir);

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -31,13 +31,13 @@ impl TestConfig {
         Self::with_filter(runner, Filter::matches_all())
     }
 
+    pub async fn filter(filter: Filter) -> Self {
+        Self::with_filter(runner().await, filter)
+    }
+
     pub fn with_filter(runner: MultiContractRunner, filter: Filter) -> Self {
         init_tracing();
         Self { runner, should_fail: false, filter, opts: test_opts() }
-    }
-
-    pub async fn filter(filter: Filter) -> Self {
-        Self::with_filter(runner().await, filter)
     }
 
     pub fn evm_spec(mut self, spec: SpecId) -> Self {

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -35,6 +35,10 @@ pub static COMPILED: Lazy<ProjectCompileOutput> = Lazy::new(|| {
     let project = &*PROJECT;
     assert!(project.cached);
 
+    // Compile only once per test run.
+    // We need to use a file lock because `cargo-nextest` runs tests in different processes.
+    // This is similar to [`foundry_test_utils::util::initialize`], see its comments for more
+    // details.
     let mut lock = fd_lock::new_lock(LOCK);
     let read = lock.read().unwrap();
     let out;

--- a/crates/test-utils/src/fd_lock.rs
+++ b/crates/test-utils/src/fd_lock.rs
@@ -1,0 +1,21 @@
+//! File locking utilities.
+
+use crate::util::pretty_err;
+use std::{
+    fs::{File, OpenOptions},
+    path::Path,
+};
+
+pub use fd_lock::*;
+
+/// Creates a new lock file at the given path.
+pub fn new_lock(lock_path: impl AsRef<Path>) -> RwLock<File> {
+    fn new_lock(lock_path: &Path) -> RwLock<File> {
+        let lock_file = pretty_err(
+            lock_path,
+            OpenOptions::new().read(true).write(true).create(true).open(lock_path),
+        );
+        RwLock::new(lock_file)
+    }
+    new_lock(lock_path.as_ref())
+}

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,6 +6,8 @@ extern crate tracing;
 // Macros useful for testing.
 mod macros;
 
+pub mod fd_lock;
+
 mod filter;
 pub use filter::Filter;
 
@@ -17,7 +19,6 @@ mod script;
 pub use script::{ScriptOutcome, ScriptTester};
 
 // re-exports for convenience
-pub use fd_lock;
 pub use foundry_compilers;
 
 /// Initializes tracing for tests.

--- a/testdata/.gitignore
+++ b/testdata/.gitignore
@@ -1,3 +1,4 @@
 # Compiler files
 cache/
 out/
+.lock


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Previously, the first N tests, which start concurrently, would all compile testdata/ and write cache independently. Now, the first test will compile it, and the rest will read from cache.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
