### PR TITLE
chore: enable anvil-core serde feature by default in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ name = "anvil-core"
 version = "0.2.0"
 dependencies = [
  "alloy-primitives",
+ "anvil-core",
  "bytes",
  "ethers-core",
  "foundry-evm",

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -30,10 +30,10 @@ reference-trie = { version = "0.25" }
 keccak-hasher = { version = "0.15" }
 
 [dev-dependencies]
-serde.workspace = true
+anvil-core = { path = ".", features = ["serde"] }
 
 [features]
-default = []
+default = ["serde"]
 impersonated-tx = []
 fastrlp = ["dep:open-fastrlp"]
 serde = ["dep:serde"]


### PR DESCRIPTION
just making the optional dep non optional in dev-deps isn't sufficient