### PR TITLE
chore(deps): bump axum to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "const-hex",
  "dunce",
  "heck",
- "indexmap 2.1.0",
+ "indexmap",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -623,9 +623,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "744864363a200a5e724a7e61bc8c11b6628cf2e3ec519c8a1a48e609a8156b40"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -642,8 +642,10 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sha-1",
  "sync_wrapper",
@@ -657,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -667,6 +669,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -2390,11 +2393,12 @@ dependencies = [
 
 [[package]]
 name = "fdlimit"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -3520,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -3530,7 +3534,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -3932,16 +3936,6 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
@@ -4337,9 +4331,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
 
 [[package]]
 name = "md-5"
@@ -4712,7 +4706,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -4887,7 +4881,7 @@ version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5096,7 +5090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -5341,6 +5335,15 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -6208,7 +6211,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6412,9 +6415,19 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -7209,7 +7222,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7231,7 +7244,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -7242,7 +7266,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -31,13 +31,13 @@ foundry-utils.workspace = true
 # evm support
 bytes = "1.4.0"
 ethers = { workspace = true, features = ["rustls", "ws", "ipc"] }
-trie-db = { version = "0.23" }
-hash-db = { version = "0.15" }
-memory-db = { version = "0.29" }
+trie-db = "0.23"
+hash-db = "0.15"
+memory-db = "0.29"
 alloy-primitives = { workspace = true, features = ["serde"] }
 
 # axum related
-axum = { version = "0.5", features = ["ws"] }
+axum = { version = "0.6", features = ["ws"] }
 hyper = "0.14"
 tower = "0.4"
 tower-http = { version = "0.4", features = ["trace"] }
@@ -69,7 +69,7 @@ clap_complete = { version = "4", optional = true }
 chrono.workspace = true
 auto_impl = "1"
 ctrlc = { version = "3", optional = true }
-fdlimit = { version = "0.2", optional = true }
+fdlimit = { version = "0.3", optional = true }
 clap_complete_fig = "4"
 ethereum-forkid = "0.12"
 

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -26,8 +26,8 @@ open-fastrlp = { version = "0.1.4", optional = true }
 hash-db = { version = "0.15", default-features = false }
 hash256-std-hasher = { version = "0.15", default-features = false }
 triehash = { version = "0.8", default-features = false }
-reference-trie = { version = "0.25" }
-keccak-hasher = { version = "0.15" }
+reference-trie = "0.25"
+keccak-hasher = "0.15"
 
 [dev-dependencies]
 anvil-core = { path = ".", features = ["serde"] }

--- a/crates/anvil/server/Cargo.toml
+++ b/crates/anvil/server/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 anvil-rpc = { path = "../rpc" }
 
 # axum related
-axum = { version = "0.5", features = ["ws"] }
+axum = { version = "0.6", features = ["ws"] }
 hyper = "0.14"
 tower-http = { version = "0.4", features = ["trace", "cors"] }
 

--- a/crates/anvil/server/src/handler.rs
+++ b/crates/anvil/server/src/handler.rs
@@ -5,26 +5,26 @@ use anvil_rpc::{
     response::{Response, RpcResponse},
 };
 use axum::{
-    extract::{rejection::JsonRejection, Extension},
+    extract::{rejection::JsonRejection, State},
     Json,
 };
 use futures::{future, FutureExt};
 
-/// Handles incoming JSON-RPC Request
-pub async fn handle<Handler: RpcHandler>(
+/// Handles incoming JSON-RPC Request.
+// NOTE: `handler` must come first because the `request` extractor consumes the request body.
+pub async fn handle<Http: RpcHandler, Ws>(
+    State((handler, _)): State<(Http, Ws)>,
     request: Result<Json<Request>, JsonRejection>,
-    Extension(handler): Extension<Handler>,
 ) -> Json<Response> {
-    match request {
+    Json(match request {
+        Ok(Json(req)) => handle_request(req, handler)
+            .await
+            .unwrap_or_else(|| Response::error(RpcError::invalid_request())),
         Err(err) => {
             warn!(target: "rpc", ?err, "invalid request");
-            Response::error(RpcError::invalid_request()).into()
+            Response::error(RpcError::invalid_request())
         }
-        Ok(req) => handle_request(req.0, handler)
-            .await
-            .unwrap_or_else(|| Response::error(RpcError::invalid_request()))
-            .into(),
-    }
+    })
 }
 
 /// Handle the JSON-RPC [Request]

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -11,7 +11,6 @@ use anvil_rpc::{
     response::{ResponseResult, RpcResponse},
 };
 use axum::{
-    extract::Extension,
     http::{header, HeaderValue, Method},
     routing::{post, IntoMakeService},
     Router, Server,
@@ -52,9 +51,8 @@ where
     let ServerConfig { allow_origin, no_cors } = config;
 
     let svc = Router::new()
-        .route("/", post(handler::handle::<Http>).get(ws::handle_ws::<Ws>))
-        .layer(Extension(http))
-        .layer(Extension(ws))
+        .route("/", post(handler::handle).get(ws::handle_ws))
+        .with_state((http, ws))
         .layer(TraceLayer::new_for_http());
 
     let svc = if no_cors {
@@ -81,8 +79,8 @@ where
     let ServerConfig { allow_origin, no_cors } = config;
 
     let svc = Router::new()
-        .route("/", post(handler::handle::<Http>))
-        .layer(Extension(http))
+        .route("/", post(handler::handle))
+        .with_state((http, ()))
         .layer(TraceLayer::new_for_http());
     let svc = if no_cors {
         svc

--- a/crates/anvil/server/src/ws.rs
+++ b/crates/anvil/server/src/ws.rs
@@ -3,10 +3,9 @@ use anvil_rpc::request::Request;
 use axum::{
     extract::{
         ws::{Message, WebSocket},
-        WebSocketUpgrade,
+        State, WebSocketUpgrade,
     },
-    response::IntoResponse,
-    Extension,
+    response::Response,
 };
 use futures::{ready, Sink, Stream};
 use std::{
@@ -17,10 +16,10 @@ use std::{
 /// Handles incoming Websocket upgrade
 ///
 /// This is the entrypoint invoked by the axum server for a websocket request
-pub async fn handle_ws<Handler: PubSubRpcHandler>(
+pub async fn handle_ws<Http, Ws: PubSubRpcHandler>(
     ws: WebSocketUpgrade,
-    Extension(handler): Extension<Handler>,
-) -> impl IntoResponse {
+    State((_, handler)): State<(Http, Ws)>,
+) -> Response {
     ws.on_upgrade(|socket| PubSubConnection::new(SocketConn(socket), handler))
 }
 


### PR DESCRIPTION
And `fdlimit`

The only breaking change is that only one extractor can consume the response body, so the handler has to come before the response in the HTTP handler function.

Additionally, the [Axum changelog recommends](https://github.com/tokio-rs/axum/blob/main/axum/CHANGELOG.md#extractors) changing `Extension` to `State`.

cc @mattsse 