### PR TITLE
chore(`script`): remove PUSH0 warnings for superchain testnets

### DIFF
--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -70,12 +70,12 @@ mod verify;
 
 /// List of Chains that support Shanghai.
 static SHANGHAI_ENABLED_CHAINS: &[Chain] = &[
-    // Ethereum Mainnet
     Chain::Mainnet,
-    // Goerli
     Chain::Goerli,
-    // Sepolia
     Chain::Sepolia,
+    Chain::OptimismGoerli,
+    Chain::OptimismSepolia,
+    Chain::BaseGoerli,
 ];
 
 // Loads project's figment and merges the build cli arguments into it


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Per the new [canyon hard fork](https://blog.oplabs.co/canyon-hardfork/), push0 is supported on all superchain testnet networks.

## Solution

Remove the warning

(Eventually we should have a better way to add/remove these warnings rather than a static list, but we can think about this later)