### PR TITLE
fix(anvil): TypedTransaction rlp decode, bump k256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -4093,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -7,7 +7,7 @@ use crate::eth::{
 use ethers_core::{
     types::{
         transaction::eip2930::{AccessList, AccessListItem},
-        Address, Bloom, Bytes, RecoveryMessage, Signature, SignatureError, TxHash, H256, U256, U64,
+        Address, Bloom, Bytes, Signature, SignatureError, TxHash, H256, U256, U64,
     },
     utils::{
         keccak256, rlp,
@@ -883,10 +883,7 @@ impl LegacyTransaction {
 
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, SignatureError> {
-        dbg!(ethers_core::utils::hex::encode(self.signature.to_vec()));
-        self.signature.recover(dbg!(RecoveryMessage::Hash(
-            LegacyTransactionRequest::from(self.clone()).hash()
-        )))
+        self.signature.recover(LegacyTransactionRequest::from(self.clone()).hash())
     }
 
     pub fn chain_id(&self) -> Option<u64> {

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -749,9 +749,11 @@ impl Decodable for TypedTransaction {
         if rlp.is_list() {
             return Ok(TypedTransaction::Legacy(rlp.as_val()?))
         }
-        let [first, s @ ..] = rlp.as_raw() else {
+        let [first, s @ ..] = rlp.data()? else {
             return Err(DecoderError::Custom("empty slice"));
         };
+        // "advance" the header, see comments in fastrlp impl below
+        let s = if s.is_empty() { &rlp.as_raw()[1..] } else { s };
         match *first {
             0x01 => rlp::decode(s).map(TypedTransaction::EIP2930),
             0x02 => rlp::decode(s).map(TypedTransaction::EIP1559),

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -138,8 +138,6 @@ contract Contract {
     let call = contract.method::<_, ()>("deploy", ()).unwrap();
 
     let receipt = call.send().await.unwrap().await.unwrap().unwrap();
-    dbg!(&receipt);
-
     let res = api.ots_get_internal_operations(receipt.transaction_hash).await.unwrap();
 
     assert_eq!(res.len(), 1);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

RLP decoding is incomplete: `rlp.data()` decodes a header and returns the next `header.num` bytes, but this is always 0 if the raw rlp data already starts with a tx type

See also Reth impl and docs https://github.com/paradigmxyz/reth/blob/0b46e16dcdc9012810726bee410047fea8be7cf9/crates/primitives/src/transaction/mod.rs#L1317C1-L1347C2

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
