### PR TITLE
fix: use new `TransportResult`

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -3,6 +3,7 @@ use alloy_primitives::{FixedBytes, B256, U256};
 use alloy_providers::provider::TempProvider;
 use alloy_rpc_types::{Filter, Topic};
 use alloy_sol_types::SolValue;
+use eyre::WrapErr;
 use foundry_common::ProviderBuilder;
 use foundry_compilers::utils::RuntimeOrHandle;
 use foundry_evm_core::fork::CreateFork;
@@ -273,8 +274,7 @@ impl Cheatcode for eth_getLogsCall {
         // todo: handle the errors somehow
         let logs = RuntimeOrHandle::new()
             .block_on(provider.get_logs(filter))
-            .success()
-            .ok_or_else(|| eyre::eyre!("failed to get logs"))?;
+            .wrap_err("failed to get logs")?;
 
         let eth_logs = logs
             .into_iter()

--- a/crates/common/src/provider.rs
+++ b/crates/common/src/provider.rs
@@ -275,12 +275,7 @@ pub async fn estimate_eip1559_fees<P: TempProvider>(
     let chain = if let Some(chain) = chain {
         chain
     } else {
-        provider
-            .get_chain_id()
-            .await
-            .success()
-            .ok_or_else(|| eyre::eyre!("Failed to get chain id"))?
-            .to()
+        provider.get_chain_id().await.wrap_err("Failed to get chain id")?.to()
     };
 
     if let Ok(chain) = NamedChain::try_from(chain) {
@@ -300,11 +295,7 @@ pub async fn estimate_eip1559_fees<P: TempProvider>(
             _ => {}
         }
     }
-    provider
-        .estimate_eip1559_fees(None)
-        .await
-        .success()
-        .ok_or_else(|| eyre::eyre!("Failed fetch EIP1559 fees"))
+    provider.estimate_eip1559_fees(None).await.wrap_err("Failed fetch EIP1559 fees")
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Move to the new `TransportResult` API (so ergonomic now)