### PR TITLE
feat: use `TransportError` on Anvil

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1916,18 +1916,19 @@ impl EthApi {
                     if let Some(receipt) = self.backend.mined_transaction_receipt(tx.hash) {
                         if let Some(output) = receipt.out {
                             // insert revert reason if failure
-                            if receipt.inner.status_code.unwrap_or_default().to::<u64>() == 0 {
-                                if let Some(reason) = decode_revert_reason(&output) {
-                                    tx.other.insert(
-                                        "revertReason".to_string(),
-                                        serde_json::to_value(reason).expect("Infallible"),
-                                    );
-                                }
-                            }
-                            tx.other.insert(
-                                "output".to_string(),
-                                serde_json::to_value(output).expect("Infallible"),
-                            );
+                            // TODO: Support for additional fields
+                            // if receipt.inner.status_code.unwrap_or_default().to::<u64>() == 0 {
+                            //     if let Some(reason) = decode_revert_reason(&output) {
+                            //         tx.other.insert(
+                            //             "revertReason".to_string(),
+                            //             serde_json::to_value(reason).expect("Infallible"),
+                            //         );
+                            //     }
+                            // }
+                            // tx.other.insert(
+                            //     "output".to_string(),
+                            //     serde_json::to_value(output).expect("Infallible"),
+                            // );
                         }
                     }
                 }

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -1,6 +1,7 @@
 //! Aggregated error type for this module
 
 use crate::eth::pool::transactions::PoolTransaction;
+use alloy_transport::TransportError;
 use anvil_rpc::{
     error::{ErrorCode, RpcError},
     response::ResponseResult,
@@ -58,6 +59,8 @@ pub enum BlockchainError {
     FeeHistory(#[from] FeeHistoryError),
     #[error(transparent)]
     ForkProvider(#[from] ProviderError),
+    #[error(transparent)]
+    AlloyForkProvider(#[from] TransportError),
     #[error("EVM error {0:?}")]
     EvmError(InstructionResult),
     #[error("Invalid url {0:?}")]
@@ -367,6 +370,10 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 ),
                 BlockchainError::ForkProvider(err) => {
                     error!(%err, "fork provider error");
+                    RpcError::internal_error_with(format!("Fork Error: {err:?}"))
+                }
+                BlockchainError::AlloyForkProvider(err) => {
+                    error!(%err, "alloy fork provider error");
                     RpcError::internal_error_with(format!("Fork Error: {err:?}"))
                 }
                 err @ BlockchainError::EvmError(_) => {


### PR DESCRIPTION
## Motivation

`eyre::Report` on library code is not good.

## Solution

Use `TransportError`.

Note that this introduces a few panics, all marked with TODOs, for which we need a nice way to make a custom error with TransportError.