### PR TITLE
fix: Improve `cast` performance on macos - Only load root TLS certificates with HTTPs rpc-url

### DIFF
--- a/crates/common/src/runtime_client.rs
+++ b/crates/common/src/runtime_client.rs
@@ -128,7 +128,9 @@ impl RuntimeClient {
     async fn connect(&self) -> Result<InnerClient, RuntimeClientError> {
         match self.url.scheme() {
             "http" | "https" => {
-                let mut client_builder = reqwest::Client::builder().timeout(self.timeout);
+                let mut client_builder = reqwest::Client::builder()
+                    .timeout(self.timeout)
+                    .tls_built_in_root_certs(self.url.scheme() == "https");
                 let mut headers = reqwest::header::HeaderMap::new();
 
                 if let Some(jwt) = self.jwt.as_ref() {


### PR DESCRIPTION
Hi, this is my first contribution to foundry so hello everyone :wave: ! The explanation for this simple fix is pretty long, so please bear with me 😅 , because performance is greatly increased.

I was looking at issue #6204 and noticed the profiler logs that @DaniPopes provided:
https://github.com/foundry-rs/foundry/issues/6204#issuecomment-1798317194
> Can reproduce as well. Profiling shows that 80% of the time is spent in `rustls_native_certs::load_native_certs`: https://share.firefox.dev/463tYIx

`rustls_native_certs::load_native_certs` will load the root TLS certificates of the system in order to use them when making HTTPs requests. This happens when we build our HTTP request provider for `ethers_providers` using `reqwest` inside the `RuntimeClient` (and coincidentally, where my fix is made). `rustls_native_certs::load_native_certs` is subsequently called inside the `reqwest` client builder ([source](https://docs.rs/reqwest/latest/src/reqwest/async_impl/client.rs.html#482-487)) if `tls_built_in_root_certs` is set to true.

However, `rustls_native_certs::load_native_certs` is a pretty expensive function:
```
Load root certificates found in the platform’s native certificate store.
...
This function can be expensive: on some platforms it involves loading and parsing a ~300KB disk file. It’s therefore prudent to call this sparingly.
```
[Source](https://docs.rs/rustls-native-certs/latest/rustls_native_certs/fn.load_native_certs.html)

I believe (and please correct me if I'm wrong, this is just a guess), that this part slows down `cast bn` and other rpc based commands on MacOS and not on Linux because of how MacOS stores the certificates in the Keychain module. Maybe loading the certificates from this module is more complex than how other systems handle loading certificates. Or maybe the `rustls_native_certs` crate is not optimised for this architecture. I could research this more but it seems out of scope for this issue.

## Motivation

Performance improvement
closes #6204

## Solution

The fix is really simple and should not compromise anything. It simply tells the `reqwest` client builder to not load TLS certificates if the jsonrpc node url is `http` and not `https` (most common use case, when using a local node) by setting `tls_built_in_root_certs` to false. This increases performance **significantly** for local cast requests (~9 times faster).

Keep in mind this doesn't only improve the performance of `cast bn`, but should improve the performance for all `cast` commands that use the `reqwest` client. Also, the performane for HTTPs requests stays the same, and is **NOT** improved.

Another solution which should also increase performance for HTTPs requests would be to only load the TLS certificate for the URL of the node we will be talking to, but this is more complex (not sure if even possible without loading all the certificates).

## Benchmarks

Environment: M1 Macbook Pro - Sonoma 14.0

*cast 0.2.0 (3e12d88 2023-11-17T00:33:21.466278000Z)*
```
❯ time cast bn
0
cast bn  0.13s user 0.03s system 65% cpu 0.243 total

❯ time cast bn --rpc-url https://uk.rpc.blxrbdn.com     
18595977
cast bn --rpc-url https://uk.rpc.blxrbdn.com  0.13s user 0.03s system 19% cpu 0.854 total
```

*`tls_built_in_root_certs` false with http - this PR*
```
❯ time ./target/release/cast bn
0
./target/release/cast bn  0.01s user 0.01s system 76% cpu 0.026 total

❯ time ./target/release/cast bn --rpc-url https://uk.rpc.blxrbdn.com
18596090
./target/release/cast bn --rpc-url https://uk.rpc.blxrbdn.com  0.14s user 0.03s system 18% cpu 0.864 total
```