### PR TITLE
Revert k256 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -30,6 +30,8 @@ foundry-utils.workspace = true
 
 # evm support
 bytes = "1.4.0"
+# needed as documented in https://github.com/foundry-rs/foundry/pull/6358
+k256 = "=0.13.1"
 ethers = { workspace = true, features = ["rustls", "ws", "ipc"] }
 trie-db = "0.23"
 hash-db = "0.15"


### PR DESCRIPTION
This k256 version breaks revm, as documented in
https://github.com/RustCrypto/elliptic-curves/issues/988, which breaks foundry.

While I would instead wait to bump revm, foundry nightly (the only supported version per the provided GH action) is broken and I'd rather correct it ASAP.

## Motivation

Foundry nightly is broken.

## Solution

Revert the k256 bump until revm supports k256 0.13.2.