### PR TITLE
feat(`cast create2`): Added `--caller` flag

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1711,13 +1711,13 @@ impl EthApi {
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION,
-            chain_id: self.backend.chain_id().try_into().unwrap_or(u64::MAX),
+            chain_id: self.backend.chain_id(),
             latest_block_hash: self.backend.best_hash(),
             latest_block_number: self.backend.best_number().as_u64(),
             instance_id: *self.instance_id.read(),
             forked_network: fork_config.map(|cfg| ForkedNetwork {
-                chain_id: cfg.chain_id().into(),
-                fork_block_number: cfg.block_number().into(),
+                chain_id: cfg.chain_id(),
+                fork_block_number: cfg.block_number(),
                 fork_block_hash: cfg.block_hash(),
             }),
         })

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -139,7 +139,11 @@ impl Create2Args {
 
         let top_bytes = match caller {
             None => B256::ZERO,
-            Some(caller_address) => address_to_b256_right_pad(caller_address),
+            Some(caller_address) => {
+                let mut slice = B256::ZERO;
+                slice[..20].copy_from_slice(&caller_address.into_array());
+                slice
+            }
         };
 
         println!("Starting to generate deterministic contract address...");
@@ -220,37 +224,12 @@ fn get_regex_hex_string(s: String) -> Result<String> {
     Ok(s.to_string())
 }
 
-fn address_to_b256_right_pad(a: Address) -> B256 {
-    let mut left_pad = a.into_word();
-    for idx in 0..32 {
-        if idx > 19 {
-            left_pad[idx] = 0;
-        } else {
-            left_pad[idx] = left_pad[idx + 12];
-        }
-    }
-    left_pad
-}
-
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
-
     use super::*;
     use std::str::FromStr;
 
     const DEPLOYER: &str = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
-
-    #[test]
-    fn address_right_pad() {
-        let padded = address_to_b256_right_pad(
-            Address::parse_checksummed("0x66f9664f97F2b50F62D13eA064982f936dE76657", None).unwrap(),
-        );
-        assert_eq!(
-            padded,
-            b256!("66f9664f97F2b50F62D13eA064982f936dE76657000000000000000000000000")
-        );
-    }
 
     #[test]
     fn basic_create2() {

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -161,12 +161,8 @@ impl Create2Args {
                 let mut salt = B256Aligned(top_bytes, []);
                 // SAFETY: B256 is aligned to `usize`.
                 let salt_word = unsafe {
-                    let ptr: *mut u8 = &mut salt.0[0];
-                    // Offset to preserve caller address at the beginning of the salt.
-                    // Must offset by 24 and not 20 to align u8s and usize.
-                    &mut *ptr.add(24).cast::<usize>()
+                    &mut *salt.0.as_mut_ptr().add(32 - usize::BITS as usize / 8).cast::<usize>()
                 };
-
                 // Important: set the salt to the start value, otherwise all threads loop over the
                 // same values.
                 *salt_word = i;

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -137,14 +137,10 @@ impl Create2Args {
             n_threads = n_threads.min(2);
         }
 
-        let top_bytes = match caller {
-            None => B256::ZERO,
-            Some(caller_address) => {
-                let mut slice = B256::ZERO;
-                slice[..20].copy_from_slice(&caller_address.into_array());
-                slice
-            }
-        };
+        let mut top_bytes = B256::ZERO;
+        if let Some(caller_address) = caller {
+            top_bytes[..20].copy_from_slice(&caller_address.into_array());
+        }
 
         println!("Starting to generate deterministic contract address...");
         let mut handles = Vec::with_capacity(n_threads);


### PR DESCRIPTION
See #6353 for full motivation.

The `--caller` flag just picks the first 20 bytes (address) of the salt to be used in different CREATE2 factories that require such a protection.

## Motivation

closes #6353 

## Solution

The salt generation will now start from the 24th byte of the 32 byte salt, instead of the first byte.

If the flag is empty, the first 20 bytes of the salt will be left empty. If not, the first 20 bytes will be filled with the address and the next 4 bytes will always be empty (the pointer offset is 24 and not 20 so the address of the `usize` object it's being cast to stays aligned)

I have also written unit tests for this flag.

Also, @DaniPopes please double check that the program remains memory safe. The loop should still need to fill up an entire u32/u64 object in order to overflow, like in the previous state (https://github.com/foundry-rs/foundry/pull/6212/files#r1382238402), but just to be sure.
