### PR TITLE
Adds snapshot map to anvil metadata

### DIFF
--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ethers_core::types::{TxHash, H256, U256, U64};
 use revm::primitives::SpecId;
 
@@ -217,6 +219,7 @@ pub struct AnvilMetadata {
     pub latest_block_number: u64,
     pub latest_block_hash: H256,
     pub forked_network: Option<ForkedNetwork>,
+    pub snapshots: HashMap<U256, (u64, H256)>,
 }
 
 /// Information about the forked network.

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use ethers_core::types::{TxHash, H256, U256, U64};
 use revm::primitives::SpecId;
@@ -219,7 +219,7 @@ pub struct AnvilMetadata {
     pub latest_block_number: u64,
     pub latest_block_hash: H256,
     pub forked_network: Option<ForkedNetwork>,
-    pub snapshots: HashMap<U256, (u64, H256)>,
+    pub snapshots: BTreeMap<U256, (u64, H256)>,
 }
 
 /// Information about the forked network.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1708,6 +1708,7 @@ impl EthApi {
     pub async fn anvil_metadata(&self) -> Result<AnvilMetadata> {
         node_info!("anvil_metadata");
         let fork_config = self.backend.get_fork();
+        let snapshots = self.backend.list_snapshots().await;
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION,
@@ -1720,6 +1721,7 @@ impl EthApi {
                 fork_block_number: cfg.block_number().into(),
                 fork_block_hash: cfg.block_hash(),
             }),
+            snapshots,
         })
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1708,7 +1708,7 @@ impl EthApi {
     pub async fn anvil_metadata(&self) -> Result<AnvilMetadata> {
         node_info!("anvil_metadata");
         let fork_config = self.backend.get_fork();
-        let snapshots = self.backend.list_snapshots().await;
+        let snapshots = self.backend.list_snapshots();
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1712,13 +1712,13 @@ impl EthApi {
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION,
-            chain_id: self.backend.chain_id().try_into().unwrap_or(u64::MAX),
+            chain_id: self.backend.chain_id(),
             latest_block_hash: self.backend.best_hash(),
             latest_block_number: self.backend.best_number().as_u64(),
             instance_id: *self.instance_id.read(),
             forked_network: fork_config.map(|cfg| ForkedNetwork {
-                chain_id: cfg.chain_id().into(),
-                fork_block_number: cfg.block_number().into(),
+                chain_id: cfg.chain_id(),
+                fork_block_number: cfg.block_number(),
                 fork_block_hash: cfg.block_hash(),
             }),
             snapshots,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -676,7 +676,7 @@ impl Backend {
         Ok(self.db.write().await.revert(id))
     }
 
-    pub async fn list_snapshots(&self) -> HashMap<U256, (u64, H256)> {
+    pub fn list_snapshots(&self) -> HashMap<U256, (u64, H256)> {
         self.active_snapshots.lock().clone()
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -77,7 +77,7 @@ use futures::channel::mpsc::{unbounded, UnboundedSender};
 use hash_db::HashDB;
 use parking_lot::{Mutex, RwLock};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     io::{Read, Write},
     ops::Deref,
     sync::Arc,
@@ -676,8 +676,8 @@ impl Backend {
         Ok(self.db.write().await.revert(id))
     }
 
-    pub fn list_snapshots(&self) -> HashMap<U256, (u64, H256)> {
-        self.active_snapshots.lock().clone()
+    pub fn list_snapshots(&self) -> BTreeMap<U256, (u64, H256)> {
+        self.active_snapshots.lock().clone().into_iter().collect()
     }
 
     /// Get the current state.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -676,6 +676,10 @@ impl Backend {
         Ok(self.db.write().await.revert(id))
     }
 
+    pub async fn list_snapshots(&self) -> HashMap<U256, (u64, H256)> {
+        self.active_snapshots.lock().clone()
+    }
+
     /// Get the current state.
     pub async fn serialized_state(&self) -> Result<SerializableState, BlockchainError> {
         let state = self.db.read().await.dump_state()?;

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -473,6 +473,7 @@ async fn can_get_metadata() {
         client_version: CLIENT_VERSION,
         instance_id: api.instance_id(),
         forked_network: None,
+        snapshots: Default::default(),
     };
 
     assert_eq!(metadata, expected_metadata);
@@ -501,6 +502,7 @@ async fn can_get_metadata_on_fork() {
             fork_block_number: block_number,
             fork_block_hash: block.hash.unwrap(),
         }),
+        snapshots: Default::default(),
     };
 
     assert_eq!(metadata, expected_metadata);


### PR DESCRIPTION
## Motivation

I need external access to the list of anvil snapshots

my use case: I want to expose snapshot/revert functionality on [Iron wallet](http://github.com/iron-wallet/iron), but it should be able to support snapshots created outside of it too. there's currently no way to get a list of snapshots unless I control their creation too

## Solution

Adding them to the `anvil_metadata` endpoint seemed like the intuitive solution. Not sure if there are unintended side-effects behind this? I  can move to a dedicated endpoint if needed
