### PR TITLE
fix: remove stray cast

### DIFF
--- a/crates/evm/core/src/fork/backend.rs
+++ b/crates/evm/core/src/fork/backend.rs
@@ -747,7 +747,7 @@ mod tests {
     async fn can_read_write_cache() {
         let provider = get_http_provider(ENDPOINT);
 
-        let block_num = provider.get_block_number().await.unwrap().to();
+        let block_num = provider.get_block_number().await.unwrap();
 
         let config = Config::figment();
         let mut evm_opts = config.extract::<EvmOpts>().unwrap();


### PR DESCRIPTION
Remove an old `U64::to` cast (the returned type is no longer `U64`)