### PR TITLE
fix: derive Inherit relative link properly

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -180,8 +180,13 @@ impl DocBuilder {
                         let relative_path = path.strip_prefix(&self.root)?.join(item.filename());
                         let target_path = self.config.out.join(Self::SRC).join(relative_path);
                         let ident = item.source.ident();
-                        Ok(Document::new(path.clone(), target_path, from_library)
-                            .with_content(DocumentContent::Single(item), ident))
+                        Ok(Document::new(
+                            path.clone(),
+                            target_path,
+                            from_library,
+                            self.config.out.clone(),
+                        )
+                        .with_content(DocumentContent::Single(item), ident))
                     })
                     .collect::<eyre::Result<Vec<_>>>()?;
 
@@ -207,8 +212,13 @@ impl DocBuilder {
                     };
 
                     files.push(
-                        Document::new(path.clone(), target_path, from_library)
-                            .with_content(DocumentContent::Constants(consts), identity),
+                        Document::new(
+                            path.clone(),
+                            target_path,
+                            from_library,
+                            self.config.out.clone(),
+                        )
+                        .with_content(DocumentContent::Constants(consts), identity),
                     )
                 }
 
@@ -219,8 +229,13 @@ impl DocBuilder {
                         let relative_path = path.strip_prefix(&self.root)?.join(filename);
                         let target_path = self.config.out.join(Self::SRC).join(relative_path);
                         files.push(
-                            Document::new(path.clone(), target_path, from_library)
-                                .with_content(DocumentContent::OverloadedFunctions(funcs), ident),
+                            Document::new(
+                                path.clone(),
+                                target_path,
+                                from_library,
+                                self.config.out.clone(),
+                            )
+                            .with_content(DocumentContent::OverloadedFunctions(funcs), ident),
                         );
                     }
                 }

--- a/crates/doc/src/document.rs
+++ b/crates/doc/src/document.rs
@@ -19,20 +19,18 @@ pub struct Document {
     context: Mutex<HashMap<PreprocessorId, PreprocessorOutput>>,
     /// Whether the document is from external library.
     pub from_library: bool,
-}
-
-/// The content of the document.
-#[derive(Debug)]
-pub enum DocumentContent {
-    Empty,
-    Single(ParseItem),
-    Constants(Vec<ParseItem>),
-    OverloadedFunctions(Vec<ParseItem>),
+    /// The target directory for the doc output.
+    pub out_target_dir: PathBuf,
 }
 
 impl Document {
     /// Create new instance of [Document].
-    pub fn new(item_path: PathBuf, target_path: PathBuf, from_library: bool) -> Self {
+    pub fn new(
+        item_path: PathBuf,
+        target_path: PathBuf,
+        from_library: bool,
+        out_target_dir: PathBuf,
+    ) -> Self {
         Self {
             item_path,
             target_path,
@@ -40,6 +38,7 @@ impl Document {
             item_content: String::default(),
             identity: String::default(),
             content: DocumentContent::Empty,
+            out_target_dir,
             context: Mutex::new(HashMap::default()),
         }
     }
@@ -63,6 +62,15 @@ impl Document {
         let context = self.context.lock().expect("failed to lock context");
         context.get(&id).cloned()
     }
+}
+
+/// The content of the document.
+#[derive(Debug)]
+pub enum DocumentContent {
+    Empty,
+    Single(ParseItem),
+    Constants(Vec<ParseItem>),
+    OverloadedFunctions(Vec<ParseItem>),
 }
 
 /// Read the preprocessor output variant from document context.


### PR DESCRIPTION
Closes #6386

we used the hardcoded default output dir when computing the relative path for `Inherits: <path>`

this now uses the configured output target