### PR TITLE
Additional contracts serialization fix

### DIFF
--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -172,7 +172,7 @@ impl ScriptArgs {
                                         return Some(AdditionalContract {
                                             opcode: node.kind(),
                                             address: node.trace.address,
-                                            init_code: node.trace.data.as_bytes().to_vec(),
+                                            init_code: node.trace.data.as_bytes().to_vec().into(),
                                         })
                                     }
                                     None

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -1,7 +1,7 @@
 use super::{artifacts::ArtifactInfo, ScriptResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, Bytes, B256};
 use ethers_core::types::{transaction::eip2718::TypedTransaction, NameOrAddress};
 use eyre::{ContextCompat, Result, WrapErr};
 use foundry_common::{fmt::format_token_raw, RpcUrl, SELECTOR_LEN};

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -1,7 +1,7 @@
 use super::{artifacts::ArtifactInfo, ScriptResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, Bytes};
 use ethers_core::types::{transaction::eip2718::TypedTransaction, NameOrAddress};
 use eyre::{ContextCompat, Result, WrapErr};
 use foundry_common::{fmt::format_token_raw, RpcUrl, SELECTOR_LEN};
@@ -17,8 +17,7 @@ pub struct AdditionalContract {
     pub opcode: CallKind,
     #[serde(serialize_with = "wrapper::serialize_addr")]
     pub address: Address,
-    #[serde(with = "hex")]
-    pub init_code: Vec<u8>,
+    pub init_code: Bytes,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1075,3 +1075,16 @@ interface Interface {}
     cmd.arg("script").arg(script);
     assert!(cmd.stdout_lossy().contains("Script ran successfully."));
 });
+
+forgetest_async!(assert_can_resume_with_additional_contracts, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+
+    tester
+        .add_deployer(0)
+        .add_sig("ScriptAdditionalContracts", "run()")
+        .broadcast(ScriptOutcome::MissingWallet)
+        .load_private_keys(&[0])
+        .await
+        .resume(ScriptOutcome::OkBroadcast);
+});

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -517,12 +517,12 @@ contract Child {}
 contract Parent {
     constructor() {
         new Child();
-    }  
+    }
 }
 
 contract ScriptAdditionalContracts is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
-    
+
     function run() external {
         vm.startBroadcast();
         new Parent();

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -511,3 +511,20 @@ contract CheckOverrides is DSTest {
         vm.stopBroadcast();
     }
 }
+
+contract Child {}
+
+contract Parent {
+    constructor() {
+        new Child();
+    }  
+}
+
+contract ScriptAdditionalContracts is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    
+    function run() external {
+        vm.startBroadcast();
+        new Parent();
+    }
+}


### PR DESCRIPTION
## Motivation

Right now `AdditionalContract.init_code` is written with `0x` prefix and deserialized with `"hex"` which is not able to parse '0x' prefix.

This makes impossible resuming any deployments which have non-empty `additionalContracts` for any transaction.

## Solution

Change type to `alloy_primitives::Bytes`
