### PR TITLE
Fix multichain scripts with verify

### DIFF
--- a/crates/forge/bin/cmd/script/multi.rs
+++ b/crates/forge/bin/cmd/script/multi.rs
@@ -155,12 +155,8 @@ impl ScriptArgs {
                 )
                 .await
             {
-                Ok(_) => {
-                    if self.verify {
-                        return sequence.verify_contracts(config, verify.clone()).await
-                    }
-                    Ok(())
-                }
+                Ok(_) if self.verify => sequence.verify_contracts(config, verify.clone()).await,
+                Ok(_) => Ok(()),
                 Err(err) => Err(err),
             };
             results.push(result);


### PR DESCRIPTION
## Motivation

Fixes bug introduced in #6271 which causes all multichain scripts ran with `--verify` flag to exit after broadcasting first sequence.

## Solution

Bug happens because in the following match statement when `self.verify` is true, `return` statement returns from the function and skips all left sequences
```rust
Ok(_) => {
    if self.verify {
        return sequence.verify_contracts(config, verify.clone()).await
    }
    Ok(())
}
```