### PR TITLE
perf: dont record sharedmemory

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -420,9 +420,7 @@ impl ChiselDispatcher {
                                                 i,
                                                 i + 32
                                             )),
-                                            Paint::cyan(hex::encode_prefixed(
-                                                &mem.context_memory()[i..i + 32]
-                                            ))
+                                            Paint::cyan(hex::encode_prefixed(&mem[i..i + 32]))
                                         );
                                     });
                                 } else {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -223,11 +223,10 @@ impl SessionSource {
         // the file compiled correctly, thus the last stack item must be the memory offset of
         // the `bytes memory inspectoor` value
         let mut offset = stack.data().last().unwrap().to_ethers().as_usize();
-        let mem = memory.context_memory();
-        let mem_offset = &mem[offset..offset + 32];
+        let mem_offset = &memory[offset..offset + 32];
         let len = U256::try_from_be_slice(mem_offset).unwrap().to::<usize>();
         offset += 32;
-        let data = &mem[offset..offset + len];
+        let data = &memory[offset..offset + len];
         // `tokens` is guaranteed to have the same length as the provided types
         let token =
             DynSolType::abi_decode(&ty, data).wrap_err("Could not decode inspected values")?;

--- a/crates/chisel/src/runner.rs
+++ b/crates/chisel/src/runner.rs
@@ -50,11 +50,7 @@ pub struct ChiselResult {
     /// Called address
     pub address: Option<Address>,
     /// EVM State at the final instruction of the `run()` function
-    pub state: Option<(
-        revm::interpreter::Stack,
-        revm::interpreter::SharedMemory,
-        revm::interpreter::InstructionResult,
-    )>,
+    pub state: Option<(revm::interpreter::Stack, Vec<u8>, InstructionResult)>,
 }
 
 /// ChiselRunner implementation

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -920,7 +920,6 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
         let stack_space = Block::default()
             .title(format!("Memory (max expansion: {} bytes)", memory.len()))
             .borders(Borders::ALL);
-        let memory = memory.context_memory();
         let max_i = memory.len() / 32;
         let min_len = format!("{:x}", max_i * 32).len();
 

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -1,6 +1,6 @@
 use crate::utils::CallKind;
 use alloy_primitives::{Address, U256};
-use revm::interpreter::{OpCode, SharedMemory};
+use revm::interpreter::OpCode;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -114,7 +114,7 @@ pub struct DebugStep {
     /// Stack *prior* to running the associated opcode
     pub stack: Vec<U256>,
     /// Memory *prior* to running the associated opcode
-    pub memory: SharedMemory,
+    pub memory: Vec<u8>,
     /// Opcode to be executed
     pub instruction: Instruction,
     /// Optional bytes that are being pushed onto the stack

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -28,7 +28,7 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::CallTraceArena;
 use revm::{
     db::{DatabaseCommit, DatabaseRef},
-    interpreter::{return_ok, CreateScheme, InstructionResult, SharedMemory, Stack},
+    interpreter::{return_ok, CreateScheme, InstructionResult, Stack},
     primitives::{
         BlockEnv, Bytecode, Env, ExecutionResult, Output, ResultAndState, SpecId, TransactTo, TxEnv,
     },
@@ -680,7 +680,7 @@ pub struct RawCallResult {
     /// The raw output of the execution
     pub out: Option<Output>,
     /// The chisel state
-    pub chisel_state: Option<(Stack, SharedMemory, InstructionResult)>,
+    pub chisel_state: Option<(Stack, Vec<u8>, InstructionResult)>,
 }
 
 impl Default for RawCallResult {

--- a/crates/evm/evm/src/inspectors/chisel_state.rs
+++ b/crates/evm/evm/src/inspectors/chisel_state.rs
@@ -1,5 +1,5 @@
 use revm::{
-    interpreter::{InstructionResult, Interpreter, SharedMemory, Stack},
+    interpreter::{InstructionResult, Interpreter, Stack},
     Database, Inspector,
 };
 
@@ -9,7 +9,7 @@ pub struct ChiselState {
     /// The PC of the final instruction
     pub final_pc: usize,
     /// The final state of the REPL contract call
-    pub state: Option<(Stack, SharedMemory, InstructionResult)>,
+    pub state: Option<(Stack, Vec<u8>, InstructionResult)>,
 }
 
 impl ChiselState {
@@ -28,7 +28,7 @@ impl<DB: Database> Inspector<DB> for ChiselState {
         if self.final_pc == interp.program_counter() - 1 {
             self.state = Some((
                 interp.stack().clone(),
-                interp.shared_memory.clone(),
+                interp.shared_memory.context_memory().to_vec(),
                 interp.instruction_result,
             ))
         }

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -73,7 +73,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
         self.arena.arena[self.head].steps.push(DebugStep {
             pc,
             stack: interpreter.stack().data().clone(),
-            memory: interpreter.shared_memory.clone(),
+            memory: interpreter.shared_memory.context_memory().to_vec(),
             instruction: Instruction::OpCode(op),
             push_bytes,
             total_gas_used,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -10,8 +10,7 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::CallTraceArena;
 use revm::{
     interpreter::{
-        return_revert, CallInputs, CreateInputs, Gas, InstructionResult, Interpreter, SharedMemory,
-        Stack,
+        return_revert, CallInputs, CreateInputs, Gas, InstructionResult, Interpreter, Stack,
     },
     primitives::{BlockEnv, Env},
     EVMData, Inspector,
@@ -192,7 +191,7 @@ pub struct InspectorData {
     pub coverage: Option<HitMaps>,
     pub cheatcodes: Option<Cheatcodes>,
     pub script_wallets: Vec<LocalWallet>,
-    pub chisel_state: Option<(Stack, SharedMemory, InstructionResult)>,
+    pub chisel_state: Option<(Stack, Vec<u8>, InstructionResult)>,
 }
 
 /// An inspector that calls multiple inspectors in sequence.

--- a/crates/evm/traces/src/inspector.rs
+++ b/crates/evm/traces/src/inspector.rs
@@ -87,7 +87,7 @@ impl Tracer {
             op: OpCode(interp.current_opcode()),
             contract: interp.contract.address,
             stack: interp.stack.clone(),
-            memory: interp.shared_memory.clone(),
+            memory: interp.shared_memory.context_memory().to_vec(),
             gas: interp.gas.remaining(),
             gas_refund_counter: interp.gas.refunded() as u64,
             gas_cost: 0,

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -14,7 +14,7 @@ use foundry_evm_core::{constants::CHEATCODE_ADDRESS, debug::Instruction, utils::
 use foundry_utils::types::ToEthers;
 use hashbrown::HashMap;
 use itertools::Itertools;
-use revm::interpreter::{opcode, CallContext, InstructionResult, SharedMemory, Stack};
+use revm::interpreter::{opcode, CallContext, InstructionResult, Stack};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
@@ -390,7 +390,7 @@ pub struct CallTraceStep {
     /// Stack before step execution
     pub stack: Stack,
     /// Memory before step execution
-    pub memory: SharedMemory,
+    pub memory: Vec<u8>,
     /// Remaining gas before step execution
     pub gas: u64,
     /// Gas refund counter before step execution
@@ -412,7 +412,7 @@ impl From<&CallTraceStep> for StructLog {
             error: step.error.clone(),
             gas: step.gas,
             gas_cost: step.gas_cost,
-            memory: Some(convert_memory(step.memory.context_memory())),
+            memory: Some(convert_memory(&step.memory)),
             op: step.op.to_string(),
             pc: step.pc as u64,
             refund_counter: if step.gas_refund_counter > 0 {


### PR DESCRIPTION
likely fixes #6396

we were recording Sharedmemory which is very excessive.

This only records the context memory