### PR TITLE
feat: add trace_filter RPC method

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -4,7 +4,7 @@ use crate::{
         subscription::{SubscriptionId, SubscriptionKind, SubscriptionParams},
         transaction::EthTransactionRequest,
     },
-    types::{EvmMineOptions, Forking, Index},
+    types::{EvmMineOptions, Forking, Index, TraceFilter as EthTraceFilter},
 };
 use ethers_core::{
     abi::ethereum_types::H64,
@@ -284,6 +284,10 @@ pub enum EthRequest {
         serde(rename = "trace_block", deserialize_with = "lenient_block_number_seq")
     )]
     TraceBlock(BlockNumber),
+
+    /// Trace filter endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "trace_filter", with = "sequence"))]
+    TraceFilter(EthTraceFilter),
 
     // Custom endpoints, they're not extracted to a separate type out of serde convenience
     /// send transactions impersonating specific account and contract addresses.

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use ethers_core::types::{TxHash, H256, U256, U64};
+use ethers_core::types::{Address, BlockNumber, TxHash, H256, U256, U64};
 use revm::primitives::SpecId;
 
 #[cfg(feature = "serde")]
@@ -231,6 +231,48 @@ pub struct ForkedNetwork {
     pub chain_id: u64,
     pub fork_block_number: u64,
     pub fork_block_hash: TxHash,
+}
+
+/// Type forked from ethers-rs due to private struct fields in ethers-rs lib.
+/// Contains extra flag (mode) which allows to select address filtering mode.
+/// See <https://openethereum.github.io/JSONRPC-trace-module#trace_filter>
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "camelCase"))]
+pub struct TraceFilter {
+    /// From block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_block: Option<BlockNumber>,
+    /// To block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_block: Option<BlockNumber>,
+    /// From address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_address: Option<Vec<Address>>,
+    /// To address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_address: Option<Vec<Address>>,
+    /// Output offset
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<usize>,
+    /// Output amount
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<usize>,
+    /// From/To Addresses filtering mode
+    pub mode: TraceFilterMode,
+}
+
+/// Enum for selecting address trace filtering mode.
+///
+/// This enum is used to choose whether the code logic should verify both
+/// `from_address` and `to_address` (Intersection) or only one of them (Union).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum TraceFilterMode {
+    #[default]
+    Intersection,
+    Union,
 }
 
 #[cfg(test)]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -42,7 +42,7 @@ use anvil_core::{
     },
     types::{
         AnvilMetadata, EvmMineOptions, ForkedNetwork, Forking, Index, NodeEnvironment,
-        NodeForkConfig, NodeInfo, Work,
+        NodeForkConfig, NodeInfo, TraceFilter, Work,
     },
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
@@ -269,6 +269,7 @@ impl EthApi {
             }
             EthRequest::TraceTransaction(tx) => self.trace_transaction(tx).await.to_rpc_result(),
             EthRequest::TraceBlock(block) => self.trace_block(block).await.to_rpc_result(),
+            EthRequest::TraceFilter(filter) => self.trace_filter(filter).await.to_rpc_result(),
             EthRequest::ImpersonateAccount(addr) => {
                 self.anvil_impersonate_account(addr).await.to_rpc_result()
             }
@@ -1425,6 +1426,14 @@ impl EthApi {
     pub async fn trace_block(&self, block: BlockNumber) -> Result<Vec<Trace>> {
         node_info!("trace_block");
         self.backend.trace_block(block).await
+    }
+
+    /// Returns traces for the transaction hash via parity's tracing endpoint
+    ///
+    /// Handler for RPC call: `trace_filter`
+    pub async fn trace_filter(&self, filter: TraceFilter) -> Result<Vec<Trace>> {
+        node_info!("trace_filter");
+        self.backend.trace_filter(filter).await
     }
 }
 


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/4129

## Solution

I took a liberty of extending the the `filter_trace` call with `mode` parameter which allows to specify whether `fromAddress` and `toAddress` should be checked as a union or intersection. That is, if I pass two lists of both `from` and `to` addresses, should the trace addresses match both of them or either one of them. This isn't explicitly specified by the open ethereum docs so it makes sense to allow both and make it configurable.

### tbd

- [ ] unit tests
