### PR TITLE
chore(`anvil`): extend alloy types until entry lib, cleanup warnings

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -2,13 +2,13 @@ use crate::{
     eth::subscription::SubscriptionId,
     types::{EvmMineOptions, Forking, Index},
 };
-use alloy_primitives::{Address, Bytes, TxHash, B256, B64};
+use alloy_primitives::{Address, Bytes, TxHash, B256, B64, U256};
 use alloy_rpc_types::{
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
     state::StateOverride,
     BlockId, BlockNumberOrTag as BlockNumber, CallRequest, Filter, TransactionRequest,
 };
-use ethers_core::types::{transaction::eip712::TypedData, GethDebugTracingOptions, U256};
+use ethers_core::types::{transaction::eip712::TypedData, GethDebugTracingOptions};
 
 pub mod block;
 pub mod proof;
@@ -23,10 +23,10 @@ pub mod state;
 pub mod serde_helpers;
 
 #[cfg(feature = "serde")]
-use ethers_core::types::serde_helpers::{deserialize_number, deserialize_number_opt, deserialize_number_seq};
+use self::serde_helpers::*;
 
 #[cfg(feature = "serde")]
-use self::serde_helpers::*;
+use foundry_common::serde_helpers::{deserialize_number, deserialize_number_opt, deserialize_number_seq};
 
 /// Wrapper type that ensures the type is named `params`
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1377,7 +1377,6 @@ true}]}"#;         let value: serde_json::Value = serde_json::from_str(s).unwrap
     }
 
     #[test]
-        #[test]
     fn test_serde_debug_trace_call() {
         let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();

--- a/crates/anvil/core/src/eth/transaction/ethers_compat.rs
+++ b/crates/anvil/core/src/eth/transaction/ethers_compat.rs
@@ -10,8 +10,7 @@ use crate::eth::{
 };
 use alloy_primitives::{U128 as rU128, U256 as rU256, U64 as rU64};
 use alloy_rpc_types::{
-    AccessList as AlloyAccessList, AccessListItem as AlloyAccessListItem, CallRequest,
-    EIP1186StorageProof, Signature, Transaction as AlloyTransaction,
+    AccessList as AlloyAccessList, CallRequest, Signature, Transaction as AlloyTransaction,
     TransactionRequest as AlloyTransactionRequest, state::{StateOverride, AccountOverride as AlloyAccountOverride},
 };
 use ethers_core::types::{

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -6,11 +6,13 @@ use crate::{
 };
 use anvil_server::ServerConfig;
 use clap::Parser;
+use foundry_utils::types::ToAlloy;
 use core::fmt;
 use ethers::{
     signers::coins_bip39::{English, Mnemonic},
     utils::WEI_IN_ETHER,
 };
+use alloy_primitives::U256;
 use foundry_config::{Chain, Config};
 use futures::FutureExt;
 use rand::{rngs::StdRng, SeedableRng};
@@ -192,14 +194,14 @@ impl NodeArgs {
         };
 
         NodeConfig::default()
-            .with_gas_limit(self.evm_opts.gas_limit)
+            .with_gas_limit(self.evm_opts.gas_limit.map(|g| U256::from(g)))
             .disable_block_gas_limit(self.evm_opts.disable_block_gas_limit)
-            .with_gas_price(self.evm_opts.gas_price)
+            .with_gas_price(self.evm_opts.gas_price.map(|g| U256::from(g)))
             .with_hardfork(self.hardfork)
             .with_blocktime(self.block_time.map(Duration::from_secs))
             .with_no_mining(self.no_mining)
             .with_account_generator(self.account_generator())
-            .with_genesis_balance(genesis_balance)
+            .with_genesis_balance(genesis_balance.to_alloy())
             .with_genesis_timestamp(self.timestamp)
             .with_port(self.port)
             .with_fork_block_number(
@@ -208,13 +210,13 @@ impl NodeArgs {
                     .or_else(|| self.evm_opts.fork_url.as_ref().and_then(|f| f.block)),
             )
             .with_fork_headers(self.evm_opts.fork_headers)
-            .with_fork_chain_id(self.evm_opts.fork_chain_id.map(u64::from))
+            .with_fork_chain_id(self.evm_opts.fork_chain_id.map(u64::from).map(|c| U256::from(c)))
             .fork_request_timeout(self.evm_opts.fork_request_timeout.map(Duration::from_millis))
             .fork_request_retries(self.evm_opts.fork_request_retries)
             .fork_retry_backoff(self.evm_opts.fork_retry_backoff.map(Duration::from_millis))
             .fork_compute_units_per_second(compute_units_per_second)
             .with_eth_rpc_url(self.evm_opts.fork_url.map(|fork| fork.url))
-            .with_base_fee(self.evm_opts.block_base_fee_per_gas)
+            .with_base_fee(self.evm_opts.block_base_fee_per_gas.map(|f| U256::from(f)))
             .with_storage_caching(self.evm_opts.no_storage_caching)
             .with_server_config(self.server_config)
             .with_host(self.host)

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -10,8 +10,6 @@ use alloy_rpc_types::{
     TransactionReceipt,
 };
 use alloy_transport::TransportError;
-use ethers::providers::ProviderError;
-use eyre::Context;
 use foundry_common::provider::alloy::{ProviderBuilder, RetryProvider};
 use parking_lot::{
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
@@ -19,8 +17,6 @@ use parking_lot::{
 };
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::RwLock as AsyncRwLock;
-
-use super::mem::storage::Blockchain;
 
 /// Represents a fork of a remote client
 ///

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1255,7 +1255,7 @@ impl Backend {
             let logs = transaction.logs.clone();
             let transaction_hash = transaction.transaction_hash;
 
-            for (_, log) in logs.into_iter().enumerate() {
+            for log in logs.into_iter() {
                 let mut log = Log {
                     address: log.address.to_alloy(),
                     topics: log.topics.into_iter().map(|t| t.to_alloy()).collect(),

--- a/crates/anvil/src/genesis.rs
+++ b/crates/anvil/src/genesis.rs
@@ -2,11 +2,11 @@
 use crate::revm::primitives::AccountInfo;
 use ethers::{
     signers::LocalWallet,
-    types::{serde_helpers::*, Address, Bytes, H256, U256},
+    types::serde_helpers::*,
 };
+use alloy_primitives::{Address, Bytes, B256, U256};
 use foundry_common::errors::FsPathError;
 use foundry_evm::revm::primitives::{Bytecode, Env, KECCAK_EMPTY, U256 as rU256};
-use foundry_utils::types::ToAlloy;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -39,7 +39,7 @@ pub struct Genesis {
     #[serde(deserialize_with = "deserialize_stringified_u64")]
     pub difficulty: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mix_hash: Option<H256>,
+    pub mix_hash: Option<B256>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coinbase: Option<Address>,
     #[serde(default)]
@@ -57,10 +57,9 @@ pub struct Genesis {
     )]
     pub gas_used: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent_hash: Option<H256>,
+    pub parent_hash: Option<B256>,
     #[serde(
         default,
-        deserialize_with = "deserialize_stringified_numeric_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub base_fee_per_gas: Option<U256>,
@@ -87,19 +86,19 @@ impl Genesis {
             env.cfg.chain_id = chain_id;
         }
         if let Some(timestamp) = self.timestamp {
-            env.block.timestamp = rU256::from(timestamp);
+            env.block.timestamp = U256::from(timestamp);
         }
         if let Some(base_fee) = self.base_fee_per_gas {
-            env.block.basefee = base_fee.to_alloy();
+            env.block.basefee = base_fee;
         }
         if let Some(number) = self.number {
             env.block.number = rU256::from(number);
         }
         if let Some(coinbase) = self.coinbase {
-            env.block.coinbase = coinbase.to_alloy();
+            env.block.coinbase = coinbase;
         }
-        env.block.difficulty = rU256::from(self.difficulty);
-        env.block.gas_limit = rU256::from(self.gas_limit);
+        env.block.difficulty = U256::from(self.difficulty);
+        env.block.gas_limit = U256::from(self.gas_limit);
     }
 
     /// Returns all private keys from the genesis accounts, if they exist
@@ -119,8 +118,7 @@ pub struct GenesisAccount {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code: Option<Bytes>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub storage: HashMap<H256, H256>,
-    #[serde(deserialize_with = "deserialize_stringified_numeric")]
+    pub storage: HashMap<B256, B256>,
     pub balance: U256,
     #[serde(
         default,
@@ -142,7 +140,7 @@ impl From<GenesisAccount> for AccountInfo {
         let GenesisAccount { code, balance, nonce, .. } = acc;
         let code = code.map(|code| Bytecode::new_raw(code.to_vec().into()));
         AccountInfo {
-            balance: balance.to_alloy(),
+            balance: balance,
             nonce: nonce.unwrap_or_default(),
             code_hash: code.as_ref().map(|code| code.hash_slow()).unwrap_or(KECCAK_EMPTY),
             code,
@@ -170,7 +168,7 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eip150_block: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub eip150_hash: Option<H256>,
+    pub eip150_hash: Option<B256>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eip155_block: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -26,6 +26,7 @@ use ethers::{
 use foundry_common::provider::alloy::{ProviderBuilder, RetryProvider};
 use foundry_common::provider::ethers::{ProviderBuilder as EthersProviderBuilder, RetryProvider as EthersRetryProvider};
 use foundry_evm::revm;
+use foundry_utils::types::ToEthers;
 use futures::{FutureExt, TryFutureExt};
 use parking_lot::Mutex;
 use std::{
@@ -35,7 +36,6 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::Duration,
 };
 use tokio::{
     runtime::Handle,
@@ -315,12 +315,12 @@ impl NodeHandle {
 
     /// Native token balance of every genesis account in the genesis block
     pub fn genesis_balance(&self) -> U256 {
-        self.config.genesis_balance
+        self.config.genesis_balance.to_ethers()
     }
 
     /// Default gas price for all txs
     pub fn gas_price(&self) -> U256 {
-        self.config.get_gas_price()
+        self.config.get_gas_price().to_ethers()
     }
 
     /// Returns the shutdown signal

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -2,7 +2,7 @@ use crate::{
     eth::{backend::notifications::NewBlockNotifications, error::to_rpc_result},
     StorageInfo,
 };
-use alloy_primitives::{TxHash, B256, U256, U64};
+use alloy_primitives::{TxHash, B256, U256};
 use alloy_rpc_types::{pubsub::SubscriptionResult, FilteredParams, Log as AlloyLog};
 use anvil_core::eth::{
     block::Block,
@@ -190,7 +190,7 @@ pub fn filter_logs(
         } else {
             None
         };
-        for (transaction_log_index, log) in receipt_logs.into_iter().enumerate() {
+        for (_, log) in receipt_logs.into_iter().enumerate() {
             if add_log(block_hash.to_alloy(), &log, &block, filter) {
                 logs.push(AlloyLog {
                     address: log.address.to_alloy(),

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -190,7 +190,7 @@ pub fn filter_logs(
         } else {
             None
         };
-        for (_, log) in receipt_logs.into_iter().enumerate() {
+        for  log in receipt_logs.into_iter() {
             if add_log(block_hash.to_alloy(), &log, &block, filter) {
                 logs.push(AlloyLog {
                     address: log.address.to_alloy(),

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -6,7 +6,7 @@ use anvil::{
     eth::{api::CLIENT_VERSION, EthApi},
     spawn, NodeConfig, CHAIN_ID,
 };
-use anvil_core::eth::{state::AccountOverride, transaction::{EthTransactionRequest, to_ethers_state_override, to_alloy_state_override}};
+use anvil_core::eth::{state::AccountOverride, transaction::to_alloy_state_override};
 use ethers::{
     abi::{Address, Tokenizable},
     prelude::{builders::ContractCall, decode_function_data, Middleware, SignerMiddleware},
@@ -14,7 +14,7 @@ use ethers::{
     types::{Block, BlockNumber, Chain, Transaction, TransactionRequest, H256, U256},
     utils::get_contract_address,
 };
-use alloy_primitives::{U256 as rU256};
+use alloy_primitives::U256 as rU256;
 use foundry_utils::types::ToAlloy;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -186,7 +186,7 @@ async fn can_call_on_pending_block() {
     let accounts: Vec<Address> = handle.dev_wallets().map(|w| w.address()).collect();
     for i in 1..10 {
         api.anvil_set_coinbase(accounts[i % accounts.len()].to_alloy()).await.unwrap();
-        api.evm_set_block_gas_limit(rU256::from((30_000_000 + i))).unwrap();
+        api.evm_set_block_gas_limit(rU256::from(30_000_000 + i)).unwrap();
 
         api.anvil_mine(Some(rU256::from(1)), None).await.unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -8,13 +8,15 @@ use ethers::{
         TransactionRequest,
     },
 };
+use alloy_primitives::U256;
+use foundry_utils::types::ToAlloy;
 
 const GAS_TRANSFER: u64 = 21_000u64;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_full_block() {
     let (_api, handle) = spawn(
-        NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE)).with_gas_limit(Some(GAS_TRANSFER)),
+        NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE.to_alloy())).with_gas_limit(Some(GAS_TRANSFER.to_alloy())),
     )
     .await;
     let provider = handle.ethers_http_provider();
@@ -36,8 +38,8 @@ async fn test_basefee_full_block() {
 async fn test_basefee_half_block() {
     let (_api, handle) = spawn(
         NodeConfig::test()
-            .with_base_fee(Some(INITIAL_BASE_FEE))
-            .with_gas_limit(Some(GAS_TRANSFER * 2)),
+            .with_base_fee(Some(INITIAL_BASE_FEE.to_alloy()))
+            .with_gas_limit(Some(GAS_TRANSFER.to_alloy() * U256::from(2))),
     )
     .await;
     let provider = handle.ethers_http_provider();
@@ -53,7 +55,7 @@ async fn test_basefee_half_block() {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_empty_block() {
-    let (api, handle) = spawn(NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE))).await;
+    let (api, handle) = spawn(NodeConfig::test().with_base_fee(Some(INITIAL_BASE_FEE.to_alloy()))).await;
 
     let provider = handle.ethers_http_provider();
     let tx = TransactionRequest::new().to(Address::random()).value(1337u64);
@@ -74,7 +76,7 @@ async fn test_basefee_empty_block() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_respect_base_fee() {
     let base_fee = 50u64;
-    let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee))).await;
+    let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee.to_alloy()))).await;
     let provider = handle.ethers_http_provider();
     let mut tx = TypedTransaction::default();
     tx.set_value(100u64);
@@ -94,7 +96,7 @@ async fn test_respect_base_fee() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tip_above_fee_cap() {
     let base_fee = 50u64;
-    let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee))).await;
+    let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee.to_alloy()))).await;
     let provider = handle.ethers_http_provider();
     let tx = TypedTransaction::Eip1559(
         Eip1559TransactionRequest::new()

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -10,11 +10,11 @@ use ethers::{
     abi::Address,
     prelude::{ContractFactory, ContractInstance, Middleware, SignerMiddleware},
     signers::Signer,
-    types::{BlockNumber, Bytes, TransactionRequest, U256},
+    types::{Bytes, TransactionRequest, U256},
     utils::get_contract_address,
 };
-use alloy_primitives::{U256 as rU256, Address as rAddress, B256};
-use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions, Block};
+use alloy_primitives::U256 as rU256;
+use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
 use foundry_utils::types::{ToAlloy, ToEthers};
 use ethers_solc::{project_util::TempProject, Artifact};
 use std::{collections::VecDeque, str::FromStr, sync::Arc};

--- a/crates/anvil/tests/it/proof/mod.rs
+++ b/crates/anvil/tests/it/proof/mod.rs
@@ -4,7 +4,7 @@ use crate::proof::eip1186::verify_proof;
 use alloy_rpc_types::EIP1186AccountProofResponse;
 use anvil::{spawn, NodeConfig};
 use anvil_core::eth::{
-    proof::{AccountProof, BasicAccount},
+    proof::BasicAccount,
     trie::ExtensionLayout,
 };
 use ethers::{

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -971,7 +971,7 @@ async fn test_reject_gas_too_low() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_call_with_high_gas_limit() {
     let (_api, handle) =
-        spawn(NodeConfig::test().with_gas_limit(Some(U256::from(100_000_000)))).await;
+        spawn(NodeConfig::test().with_gas_limit(Some(U256::from(100_000_000).to_alloy()))).await;
     let provider = handle.ethers_http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -24,6 +24,7 @@ pub mod term;
 pub mod traits;
 pub mod transactions;
 pub mod units;
+pub mod serde_helpers;
 
 pub use constants::*;
 pub use contracts::*;

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -1,2 +1,4 @@
+//! Provider-related instantiation and usage utilities.
+
 pub mod alloy;
 pub mod ethers;


### PR DESCRIPTION
## Motivation

This removes some glue that was added from the RPC types by adding alloy types all over anvil unless they're internal types, which we can do later.

## Solution

Remove glue, cleanup warnings on anvil.