### PR TITLE
chore: patch revm to reth_freeze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "3.5.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#74643d37fc6231d558868ccc8b97400506e10906"
 dependencies = [
  "auto_impl",
  "revm-interpreter",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#74643d37fc6231d558868ccc8b97400506e10906"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "2.2.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#74643d37fc6231d558868ccc8b97400506e10906"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "1.3.0"
-source = "git+https://github.com/bluealloy/revm?rev=1609e07c68048909ad1682c98cf2b9baa76310b5#1609e07c68048909ad1682c98cf2b9baa76310b5"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#74643d37fc6231d558868ccc8b97400506e10906"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,5 +208,5 @@ alloy-sol-types = { git = "https://github.com/alloy-rs/core/" }
 alloy-sol-type-parser = { git = "https://github.com/alloy-rs/core/" }
 syn-solidity = { git = "https://github.com/alloy-rs/core/" }
 
-revm = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "1609e07c68048909ad1682c98cf2b9baa76310b5" }
+revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }

--- a/crates/anvil/src/eth/util.rs
+++ b/crates/anvil/src/eth/util.rs
@@ -81,6 +81,7 @@ pub fn to_precompile_id(spec_id: SpecId) -> revm::precompile::SpecId {
         SpecId::CANCUN |
         SpecId::BEDROCK |
         SpecId::REGOLITH |
+        SpecId::CANYON |
         SpecId::LATEST => revm::precompile::SpecId::BERLIN,
     }
 }


### PR DESCRIPTION
pin revm to same branch that reth uses

ref 
https://github.com/foundry-rs/foundry/pull/6416
https://github.com/bluealloy/revm/pull/875

FYI @DaniPopes 