### PR TITLE
fix(`config`): actually set remove as default for `hex` underscores in `fmt`

### DIFF
--- a/crates/config/src/fmt.rs
+++ b/crates/config/src/fmt.rs
@@ -50,9 +50,9 @@ pub enum IntTypes {
 #[serde(rename_all = "snake_case")]
 pub enum NumberUnderscore {
     /// Use the underscores defined in the source code
-    #[default]
     Preserve,
     /// Remove all underscores
+    #[default]
     Remove,
     /// Add an underscore every thousand, if greater than 9999
     /// e.g. 1000 -> 1000 and 10000 -> 10_000


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Missed on https://github.com/foundry-rs/foundry/pull/6417

## Solution

Set it as default