### PR TITLE
feat(forge): add --ignore-already-verified flag to verify-contract

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -184,6 +184,7 @@ impl CreateArgs {
             root: None,
             verifier: self.verifier.clone(),
             show_standard_json_input: false,
+            ignore_already_verified: false,
         };
         verify.verification_provider()?.preflight_check(verify).await?;
         Ok(())
@@ -323,6 +324,7 @@ impl CreateArgs {
             root: None,
             verifier: self.verifier,
             show_standard_json_input: false,
+            ignore_already_verified: true,
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -109,6 +109,7 @@ impl VerifyBundle {
                     root: None,
                     verifier: self.verifier.clone(),
                     show_standard_json_input: false,
+                    ignore_already_verified: true,
                 };
 
                 return Some(verify)

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -57,7 +57,9 @@ impl VerificationProvider for EtherscanVerificationProvider {
     async fn verify(&mut self, args: VerifyArgs) -> Result<()> {
         let (etherscan, verify_args) = self.prepare_request(&args).await?;
 
-        if self.is_contract_verified(&etherscan, &verify_args).await? {
+        if !args.ignore_already_verified &&
+            self.is_contract_verified(&etherscan, &verify_args).await?
+        {
             println!(
                 "\nContract [{}] {:?} is already verified. Skipping verification.",
                 verify_args.contract_name,

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -98,6 +98,12 @@ pub struct VerifyArgs {
 
     #[clap(flatten)]
     pub verifier: VerifierArgs,
+
+    /// Attempt to verify the contract even if it is already verified.
+    ///
+    /// This can be used to fully verify a partially verified contract.
+    #[clap(long)]
+    pub ignore_already_verified: bool,
 }
 
 impl_figment_convert!(VerifyArgs);


### PR DESCRIPTION
Set this flag to true when deploying new contracts to ensure that they are fully verified instead of partially verified.
Set this flag to false by default when running forge verify-contract manually.

CLOSES #6424

## Motivation

`forge verify-contract` does not attempt to re-verify an already-verified contract as this is an expensive operation. However there are some cases in which this behavior is desired e.g. to re-verify a partially-verified contract with source code that matches the metadata hash.

## Solution

 I suggest adding a flag `--ignore-already-verified` to the verifier command-line arguments to skip the contract already verified check.