### PR TITLE
fix: force end of lists in notices

### DIFF
--- a/crates/doc/src/parser/mod.rs
+++ b/crates/doc/src/parser/mod.rs
@@ -124,7 +124,7 @@ impl Parser {
             .into_iter()
             .filter(|c| c.tag.trim() != "solidity" && !c.tag.trim().is_empty())
             .collect_vec();
-        Ok(res.into())
+        Ok(Comments::new(res))
     }
 }
 

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -48,7 +48,7 @@ impl<'a> AsDoc for CommentsRef<'a> {
         // Write notice tags
         let notices = self.include_tag(CommentTag::Notice);
         for notice in notices.iter() {
-            writer.writeln_raw(&notice.value)?;
+            writer.writeln_raw(notice.comment_value())?;
             writer.writeln()?;
         }
 


### PR DESCRIPTION
Closes #6425

Apparently, the solang doc parsing does not preserve multiple empty lines, which results in invalid markdown lists.

This adds a formatting wrapper that injects a new line when the list ends

I assume this could have some sideffects if the listitem is a multine string, so perhaps this should rather be fixed in solang itself which strips whitespace...

So this fix is a bit ambiguous and not sure we should include it


<img width="197" alt="image" src="https://github.com/foundry-rs/foundry/assets/19890894/3bd84ac4-4b30-4809-973d-f7e99e1d2937">
