### PR TITLE
chore: add --show-standard-json to forge create --verify

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -62,6 +62,13 @@ pub struct CreateArgs {
     #[clap(long, requires = "from")]
     unlocked: bool,
 
+    /// Prints the standard json compiler input if `--verify` is provided.
+    ///
+    /// The standard json compiler input can be used to manually submit contract verification in
+    /// the browser.
+    #[clap(long, requires = "verify")]
+    show_standard_json_input: bool,
+
     #[clap(flatten)]
     opts: CoreBuildArgs,
 
@@ -183,7 +190,7 @@ impl CreateArgs {
             libraries: vec![],
             root: None,
             verifier: self.verifier.clone(),
-            show_standard_json_input: false,
+            show_standard_json_input: self.show_standard_json_input,
         };
         verify.verification_provider()?.preflight_check(verify).await?;
         Ok(())
@@ -322,7 +329,7 @@ impl CreateArgs {
             libraries: vec![],
             root: None,
             verifier: self.verifier,
-            show_standard_json_input: false,
+            show_standard_json_input: self.show_standard_json_input,
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
         verify.run().await


### PR DESCRIPTION
* adds `show_standard_json_input` to `forge create --verify`