### PR TITLE
chore: pin watchexec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,8 @@ dependencies = [
  "tracing-subscriber",
  "vergen",
  "watchexec",
+ "watchexec-events",
+ "watchexec-signals",
  "yansi 0.5.1",
 ]
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -70,7 +70,9 @@ solang-parser.workspace = true
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }
-watchexec = "2"
+watchexec = "=2.3.0"
+watchexec-events = "=1.0.0"
+watchexec-signals = "=1.0.0"
 
 # doc server
 axum = { workspace = true, features = ["ws"] }


### PR DESCRIPTION
new watchexec releases appear to violate semver
breaks build if lockfile is removed

pin relevant crates for now

ref #6446