### PR TITLE
feat: use non atomic tracker for snapshot reverts

### DIFF
--- a/crates/evm/core/src/backend/fuzz.rs
+++ b/crates/evm/core/src/backend/fuzz.rs
@@ -39,16 +39,11 @@ pub struct FuzzBackendWrapper<'a> {
     pub backend: Cow<'a, Backend>,
     /// Keeps track of whether the backed is already initialized
     is_initialized: bool,
-    /// Keeps track of whether there was a snapshot failure.
-    ///
-    /// Necessary as the backend is dropped after usage, but we'll need to persist
-    /// the snapshot failure anyhow.
-    has_snapshot_failure: bool,
 }
 
 impl<'a> FuzzBackendWrapper<'a> {
     pub fn new(backend: &'a Backend) -> Self {
-        Self { backend: Cow::Borrowed(backend), is_initialized: false, has_snapshot_failure: false }
+        Self { backend: Cow::Borrowed(backend), is_initialized: false }
     }
 
     /// Executes the configured transaction of the `env` without committing state changes
@@ -73,14 +68,7 @@ impl<'a> FuzzBackendWrapper<'a> {
     ///
     /// This is bubbled up from the underlying Copy-On-Write backend when a revert occurs.
     pub fn has_snapshot_failure(&self) -> bool {
-        self.has_snapshot_failure
-    }
-
-    /// Sets whether there was a snapshot failure in the fuzz backend.
-    ///
-    /// This is bubbled up from the underlying Copy-On-Write backend when a revert occurs.
-    pub fn set_snapshot_failure(&mut self, has_snapshot_failure: bool) {
-        self.has_snapshot_failure = has_snapshot_failure;
+        self.backend.has_snapshot_failure()
     }
 
     /// Returns a mutable instance of the Backend.
@@ -110,11 +98,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         current: &mut Env,
     ) -> Option<JournaledState> {
         trace!(?id, "fuzz: revert snapshot");
-        let journaled_state = self.backend_mut(current).revert(id, journaled_state, current);
-        // Persist the snapshot failure in the fuzz backend, as the underlying backend state is lost
-        // after the call.
-        self.set_snapshot_failure(self.has_snapshot_failure || self.backend.has_snapshot_failure());
-        journaled_state
+        self.backend_mut(current).revert(id, journaled_state, current)
     }
 
     fn create_fork(&mut self, fork: CreateFork) -> eyre::Result<LocalForkId> {

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -571,6 +571,7 @@ impl Backend {
         self.inner.has_snapshot_failure.load(Ordering::Relaxed)
     }
 
+    /// Sets the snapshot failure flag.
     pub fn set_snapshot_failure(&self, has_snapshot_failure: bool) {
         self.inner.has_snapshot_failure.store(has_snapshot_failure, Ordering::Relaxed);
     }
@@ -913,7 +914,7 @@ impl DatabaseExt for Backend {
             // need to check whether there's a global failure which means an error occurred either
             // during the snapshot or even before
             if self.is_global_failure(current_state) {
-                self.inner.has_snapshot_failure.store(true, Ordering::Relaxed);
+                self.set_snapshot_failure(true);
             }
 
             // merge additional logs

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -26,13 +26,7 @@ use revm::{
     },
     Database, DatabaseCommit, Inspector, JournaledState, EVM,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::collections::{HashMap, HashSet};
 
 mod diagnostic;
 pub use diagnostic::RevertDiagnostic;
@@ -568,12 +562,12 @@ impl Backend {
     ///
     /// This returns whether there was a reverted snapshot that recorded an error
     pub fn has_snapshot_failure(&self) -> bool {
-        self.inner.has_snapshot_failure.load(Ordering::Relaxed)
+        self.inner.has_snapshot_failure
     }
 
     /// Sets the snapshot failure flag.
-    pub fn set_snapshot_failure(&self, has_snapshot_failure: bool) {
-        self.inner.has_snapshot_failure.store(has_snapshot_failure, Ordering::Relaxed);
+    pub fn set_snapshot_failure(&mut self, has_snapshot_failure: bool) {
+        self.inner.has_snapshot_failure = has_snapshot_failure
     }
 
     /// Checks if the test contract associated with this backend failed, See
@@ -1515,7 +1509,7 @@ pub struct BackendInner {
     /// reverted we get the _current_ `revm::JournaledState` which contains the state that we can
     /// check if the `_failed` variable is set,
     /// additionally
-    pub has_snapshot_failure: Arc<AtomicBool>,
+    pub has_snapshot_failure: bool,
     /// Tracks the address of a Test contract
     ///
     /// This address can be used to inspect the state of the contract when a test is being
@@ -1734,7 +1728,7 @@ impl Default for BackendInner {
             created_forks: Default::default(),
             forks: vec![],
             snapshots: Default::default(),
-            has_snapshot_failure: Arc::new(AtomicBool::new(false)),
+            has_snapshot_failure: false,
             test_contract_address: None,
             caller: None,
             next_fork_id: Default::default(),

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -28,9 +28,9 @@ pub use types::{CaseOutcome, CounterExampleOutcome, FuzzOutcome};
 /// After instantiation, calling `fuzz` will proceed to hammer the deployed smart contract with
 /// inputs, until it finds a counterexample. The provided [`TestRunner`] contains all the
 /// configuration which can be overridden via [environment variables](proptest::test_runner::Config)
-pub struct FuzzedExecutor<'a> {
-    /// The VM
-    executor: &'a Executor,
+pub struct FuzzedExecutor {
+    /// The EVM executor
+    executor: Executor,
     /// The fuzzer
     runner: TestRunner,
     /// The account that calls tests
@@ -39,10 +39,10 @@ pub struct FuzzedExecutor<'a> {
     config: FuzzConfig,
 }
 
-impl<'a> FuzzedExecutor<'a> {
+impl FuzzedExecutor {
     /// Instantiates a fuzzed executor given a testrunner
     pub fn new(
-        executor: &'a Executor,
+        executor: Executor,
         runner: TestRunner,
         sender: Address,
         config: FuzzConfig,

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -224,7 +224,7 @@ impl FuzzedExecutor {
             .map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
         let success =
-            self.executor.is_success(address, call.reverted, state_changeset.clone(), should_fail);
+            self.executor.is_raw_call_success(address, state_changeset.clone(), &call, should_fail);
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {

--- a/crates/evm/evm/src/executors/invariant/funcs.rs
+++ b/crates/evm/evm/src/executors/invariant/funcs.rs
@@ -40,10 +40,10 @@ pub fn assert_invariants(
 
     // This will panic and get caught by the executor
     let is_err = call_result.reverted ||
-        !executor.is_success(
+        !executor.is_raw_call_success(
             invariant_contract.address,
-            call_result.reverted,
             call_result.state_changeset.take().expect("we should have a state changeset"),
+            &call_result,
             false,
         );
     if is_err {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -558,7 +558,7 @@ impl<'a> ContractRunner<'a> {
         // Run fuzz test
         let start = Instant::now();
         let fuzzed_executor =
-            FuzzedExecutor::new(&self.executor, runner.clone(), self.sender, fuzz_config);
+            FuzzedExecutor::new(self.executor.clone(), runner.clone(), self.sender, fuzz_config);
         let state = fuzzed_executor.build_fuzz_state();
         let mut result = fuzzed_executor.fuzz(func, address, should_fail, self.errors);
 
@@ -598,7 +598,7 @@ impl<'a> ContractRunner<'a> {
             };
             // rerun the last relevant test with traces
             let debug_result = FuzzedExecutor::new(
-                &debug_executor,
+                debug_executor,
                 runner,
                 self.sender,
                 fuzz_config,

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -199,5 +199,15 @@ test_repro!(6170, false, None, |res| {
 // https://github.com/foundry-rs/foundry/issues/6180
 test_repro!(6180);
 
+// https://github.com/foundry-rs/foundry/issues/6355
+test_repro!(6355, false, None, |res| {
+    let mut res = res.remove("repros/Issue6355.t.sol:Issue6355Test").unwrap();
+    let test = res.test_results.remove("test_shouldFail()").unwrap();
+    assert_eq!(test.status, TestStatus::Failure);
+
+    let test = res.test_results.remove("test_shouldFaillWithRevertTo()").unwrap();
+    assert_eq!(test.status, TestStatus::Failure);
+});
+
 // https://github.com/foundry-rs/foundry/issues/6437
 test_repro!(6437);

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -205,7 +205,7 @@ test_repro!(6355, false, None, |res| {
     let test = res.test_results.remove("test_shouldFail()").unwrap();
     assert_eq!(test.status, TestStatus::Failure);
 
-    let test = res.test_results.remove("test_shouldFaillWithRevertTo()").unwrap();
+    let test = res.test_results.remove("test_shouldFailWithRevertTo()").unwrap();
     assert_eq!(test.status, TestStatus::Failure);
 });
 

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -77,7 +77,7 @@ pub static EVM_OPTS: Lazy<EvmOpts> = Lazy::new(|| EvmOpts {
     ..Default::default()
 });
 
-pub fn fuzz_executor<DB: DatabaseRef>(executor: &Executor) -> FuzzedExecutor {
+pub fn fuzz_executor<DB: DatabaseRef>(executor: Executor) -> FuzzedExecutor {
     let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
 
     FuzzedExecutor::new(

--- a/testdata/repros/Issue6355.t.sol
+++ b/testdata/repros/Issue6355.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6355
+contract Issue6355Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 snapshot;
+    Target targ;
+
+    function setUp() public {
+        snapshot = vm.snapshot();
+        targ = new Target();
+    }
+
+    // this non-deterministically fails sometimes and passes sometimes
+    function test_shouldPass() public {
+        assertEq(2, targ.num());
+    }
+
+    // always fails
+    function test_shouldFaillWithRevertTo() public {
+        assertEq(3, targ.num());
+        vm.revertTo(snapshot);
+    }
+
+    // always fails
+    function test_shouldFail() public {
+        assertEq(3, targ.num());
+    }
+}
+
+contract Target {
+    function num() public pure returns (uint256) {
+        return 2;
+    }
+}

--- a/testdata/repros/Issue6355.t.sol
+++ b/testdata/repros/Issue6355.t.sol
@@ -21,7 +21,7 @@ contract Issue6355Test is DSTest {
     }
 
     // always fails
-    function test_shouldFaillWithRevertTo() public {
+    function test_shouldFailWithRevertTo() public {
         assertEq(3, targ.num());
         vm.revertTo(snapshot);
     }


### PR DESCRIPTION
closes probably #6355

Some background:

due to ds-test legacy behaviour failures are stored in a state variable.

Prior to https://github.com/foundry-rs/foundry/pull/4974

> Fuzzing was having soundness issues with snapshot failures. This is because snapshot failures were not being persisted throughout fuzz runs, and when the Fuzz Backend Wrapper we use was dropped, this information was lost, leading to inconsistent test PASS states.

because we were using a Cow of the `Backend` so regular fuzz runs don't need to clone it per fuzz call, however as #4974 highlighted this is unsound for snapshots because we lose state that contains the the state variable that tracks errors

#4974 tried to fix this by persisting snapshot failures in an AtomicBool. But this is also unsound because this is susceptible to race conditions because this bool is now shared by _all_ tests, even if we clone the Backend (Arc).

The fix is to use a simple boolean again and instead add the `has_snapshot_failure` to the RawCallResult that we then can also check when checking for failures.

That being said, the Executor + ContractRunner, especially the Fuzz variants desperately need a cleanup.
