### PR TITLE
chore: improve invalid url error

### DIFF
--- a/crates/common/src/provider.rs
+++ b/crates/common/src/provider.rs
@@ -225,6 +225,11 @@ impl ProviderBuilder {
             headers,
         } = self;
         let url = url?;
+        if url.scheme() == "file" {
+            eyre::bail!(
+                "URLs with `file` scheme are not supported: {url}\nExpected `http` or `https`"
+            );
+        }
 
         let client_builder = RuntimeClientBuilder::new(
             url.clone(),


### PR DESCRIPTION
`127.0.0.1:8545` gets parsed as file url
resulting in file not found OS errors

This improves the error but perhaps we could also just prefix it manually for common cases