### PR TITLE
feat: prefix local address with http scheme

### DIFF
--- a/crates/common/src/provider.rs
+++ b/crates/common/src/provider.rs
@@ -79,7 +79,7 @@ impl ProviderBuilder {
         // invalid url: non-prefixed URL scheme is not allowed, so we prepend the default http
         // prefix
         let storage;
-        if url_str.starts_with("localhost:") {
+        if url_str.starts_with("localhost:") || url_str.starts_with("127.0.0.1:") {
             storage = format!("http://{url_str}");
             url_str = storage.as_str();
         }


### PR DESCRIPTION
if 127.0.0.1:8545 is provided, the URL will be a file, resulting in obscure OS errors.

since this input is very common, like localhost, prefix it with http