### PR TITLE
chore: revise contract empty error

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -122,7 +122,7 @@ where
                         if let Some(NameOrAddress::Address(addr)) = tx.to() {
                             if let Ok(code) = self.provider.get_code(*addr, block).await {
                                 if code.is_empty() {
-                                    eyre::bail!("contract {addr:?} does not exist")
+                                    eyre::bail!("contract {addr:?} does not have any code")
                                 }
                             }
                         }


### PR DESCRIPTION
ref #6332

wasn't able to reprocude this manually with a simple test case.
Though, I noticed after the crate refactor we can no longer use e2e tests for both forge and cast binary because they are in separate crates.

at least revised the error for empty contract. 