### PR TITLE
RPC-based Gas Estimation for Moonbeam-based Networks

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -167,14 +167,14 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
         return matches!(
             chain,
-            NamedChain::Arbitrum
-                | NamedChain::ArbitrumTestnet
-                | NamedChain::ArbitrumGoerli
-                | NamedChain::ArbitrumSepolia
-                | NamedChain::Moonbeam
-                | NamedChain::Moonriver
-                | NamedChain::Moonbase
-                | NamedChain::MoonbeamDev
+            NamedChain::Arbitrum |
+                NamedChain::ArbitrumTestnet |
+                NamedChain::ArbitrumGoerli |
+                NamedChain::ArbitrumSepolia |
+                NamedChain::Moonbeam |
+                NamedChain::Moonriver |
+                NamedChain::Moonbase |
+                NamedChain::MoonbeamDev
         )
     }
     false
@@ -185,10 +185,10 @@ pub fn has_batch_support(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
         return !matches!(
             chain,
-            NamedChain::Arbitrum
-                | NamedChain::ArbitrumTestnet
-                | NamedChain::ArbitrumGoerli
-                | NamedChain::ArbitrumSepolia
+            NamedChain::Arbitrum |
+                NamedChain::ArbitrumTestnet |
+                NamedChain::ArbitrumGoerli |
+                NamedChain::ArbitrumSepolia
         )
     }
     true

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -93,7 +93,7 @@ pub fn get_cached_entry_by_name(
     }
 
     if let Some(entry) = cached_entry {
-        return Ok(entry)
+        return Ok(entry);
     }
 
     let mut err = format!("could not find artifact: `{name}`");
@@ -167,15 +167,15 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
         return matches!(
             chain,
-            NamedChain::Arbitrum |
-                NamedChain::ArbitrumTestnet |
-                NamedChain::ArbitrumGoerli |
-                NamedChain::ArbitrumSepolia | 
-                NamedChain::Moonbeam |
-                NamedChain::Moonriver |
-                NamedChain::Moonbase |
-                NamedChain::MoonbeamDev
-        )
+            NamedChain::Arbitrum
+                | NamedChain::ArbitrumTestnet
+                | NamedChain::ArbitrumGoerli
+                | NamedChain::ArbitrumSepolia
+                | NamedChain::Moonbeam
+                | NamedChain::Moonriver
+                | NamedChain::Moonbase
+                | NamedChain::MoonbeamDev
+        );
     }
     false
 }
@@ -185,11 +185,11 @@ pub fn has_batch_support(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
         return !matches!(
             chain,
-            NamedChain::Arbitrum |
-                NamedChain::ArbitrumTestnet |
-                NamedChain::ArbitrumGoerli |
-                NamedChain::ArbitrumSepolia
-        )
+            NamedChain::Arbitrum
+                | NamedChain::ArbitrumTestnet
+                | NamedChain::ArbitrumGoerli
+                | NamedChain::ArbitrumSepolia
+        );
     }
     true
 }
@@ -384,7 +384,7 @@ pub async fn handle_traces(
 
         if let Some(addr) = iter.next() {
             if let (Ok(address), Some(label)) = (Address::from_str(addr), iter.next()) {
-                return Some((address, label.to_string()))
+                return Some((address, label.to_string()));
             }
         }
         None

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -93,7 +93,7 @@ pub fn get_cached_entry_by_name(
     }
 
     if let Some(entry) = cached_entry {
-        return Ok(entry);
+        return Ok(entry)
     }
 
     let mut err = format!("could not find artifact: `{name}`");
@@ -175,7 +175,7 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                 | NamedChain::Moonriver
                 | NamedChain::Moonbase
                 | NamedChain::MoonbeamDev
-        );
+        )
     }
     false
 }
@@ -189,7 +189,7 @@ pub fn has_batch_support(chain_id: u64) -> bool {
                 | NamedChain::ArbitrumTestnet
                 | NamedChain::ArbitrumGoerli
                 | NamedChain::ArbitrumSepolia
-        );
+        )
     }
     true
 }
@@ -384,7 +384,7 @@ pub async fn handle_traces(
 
         if let Some(addr) = iter.next() {
             if let (Ok(address), Some(label)) = (Address::from_str(addr), iter.next()) {
-                return Some((address, label.to_string()));
+                return Some((address, label.to_string()))
             }
         }
         None

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -170,7 +170,11 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
             NamedChain::Arbitrum |
                 NamedChain::ArbitrumTestnet |
                 NamedChain::ArbitrumGoerli |
-                NamedChain::ArbitrumSepolia
+                NamedChain::ArbitrumSepolia | 
+                NamedChain::Moonbeam |
+                NamedChain::Moonriver |
+                NamedChain::Moonbase |
+                NamedChain::MoonbeamDev
         )
     }
     false


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Moonbeam introduced MBIP-5 in which gas estimation deviated from Ethereum. The reasoning is that now storage changes are reflected now on gas estimation. This is to prevent spamming the network with junk data. This is a problem on a lot of cheap-to-transact networks

## Solution

Solution was simple, just add Moonbeam-based networks to the `has_different_gas_calc` function (like with Arbitrum) [here](https://github.com/foundry-rs/foundry/compare/master...albertov19:foundry:albertov19/use-rpc-gas-estimation-moonbeam)

If this function returns `true` then gas estimation is done using the actual provider URL and `eth_estimateGas`.
