### PR TITLE
[Alloy providers migration]: Fix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "alloy-networks"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-networks",
  "alloy-primitives",
@@ -210,7 +210,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.5",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#60bfad94de1c756abfd7c430dae34c5539ec46b8"
+source = "git+https://github.com/alloy-rs/alloy/?branch=onbjerg/alloy-temp-provider-trait#d6ec3478d8c68e3c12b0eb9bdb65870a113e46a6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, TxHash, B256, B64, U256};
 use alloy_rpc_types::{
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
     state::StateOverride,
-    BlockId, BlockNumberOrTag as BlockNumber, CallRequest, Filter, TransactionRequest,
+    BlockId, BlockNumberOrTag as BlockNumber, CallRequest, Filter,
 };
 use ethers_core::types::{transaction::eip712::TypedData, GethDebugTracingOptions};
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -45,7 +45,6 @@ use alloy_rpc_types::{
     Log,
     Transaction,
     TransactionReceipt,
-    TransactionRequest as AlloyTransactionRequest,
     TxpoolContent,
     TxpoolInspect,
     // trace::{geth::{DefaultFrame, GethDebugTracingOptions, GethTrace},
@@ -59,8 +58,8 @@ use anvil_core::{
         block::BlockInfo,
         transaction::{
             call_to_internal_tx_request, to_alloy_proof, to_ethers_access_list,
-            to_internal_tx_request, EthTransactionRequest, LegacyTransaction, PendingTransaction,
-            TransactionKind, TypedTransaction, TypedTransactionRequest,
+            EthTransactionRequest, LegacyTransaction, PendingTransaction, TransactionKind,
+            TypedTransaction, TypedTransactionRequest,
         },
         EthRequest,
     },
@@ -867,9 +866,17 @@ impl EthApi {
     pub async fn sign_transaction(&self, request: EthTransactionRequest) -> Result<String> {
         node_info!("eth_signTransaction");
 
-        let from = request.from.map(Ok).unwrap_or_else(|| {
-            self.accounts()?.first().cloned().ok_or(BlockchainError::NoSignerAvailable).map(|a| a.to_ethers())
-        })?.to_alloy();
+        let from = request
+            .from
+            .map(Ok)
+            .unwrap_or_else(|| {
+                self.accounts()?
+                    .first()
+                    .cloned()
+                    .ok_or(BlockchainError::NoSignerAvailable)
+                    .map(|a| a.to_ethers())
+            })?
+            .to_alloy();
 
         let (nonce, _) = self.request_nonce(&request, from).await?;
 
@@ -886,9 +893,17 @@ impl EthApi {
     pub async fn send_transaction(&self, request: EthTransactionRequest) -> Result<TxHash> {
         node_info!("eth_sendTransaction");
 
-        let from = request.from.map(Ok).unwrap_or_else(|| {
-            self.accounts()?.first().cloned().ok_or(BlockchainError::NoSignerAvailable).map(|a| a.to_ethers())
-        })?.to_alloy();
+        let from = request
+            .from
+            .map(Ok)
+            .unwrap_or_else(|| {
+                self.accounts()?
+                    .first()
+                    .cloned()
+                    .ok_or(BlockchainError::NoSignerAvailable)
+                    .map(|a| a.to_ethers())
+            })?
+            .to_alloy();
 
         let (nonce, on_chain_nonce) = self.request_nonce(&request, from).await?;
         let request = self.build_typed_tx_request(request, nonce)?;
@@ -1275,7 +1290,7 @@ impl EthApi {
                 return fork
                     .fee_history(block_count, BlockNumber::Number(number), &reward_percentiles)
                     .await
-                    .map_err(|e| BlockchainError::AlloyForkProvider(e));
+                    .map_err(BlockchainError::AlloyForkProvider);
             }
         }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1275,7 +1275,7 @@ impl EthApi {
                 return fork
                     .fee_history(block_count, BlockNumber::Number(number), &reward_percentiles)
                     .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                    .map_err(|e| BlockchainError::AlloyForkProvider(e));
             }
         }
 
@@ -1302,7 +1302,7 @@ impl EthApi {
             oldest_block: U256::from(lowest),
             base_fee_per_gas: Vec::new(),
             gas_used_ratio: Vec::new(),
-            reward: Default::default(),
+            reward: Some(Default::default()),
         };
 
         let mut rewards = Vec::new();

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -421,7 +421,11 @@ impl ClientFork {
             return Ok(Some(self.convert_to_tx_only_block(block)));
         }
 
-        let block = self.fetch_full_block(hash).await?.map(Into::into).map(|b| self.convert_to_tx_only_block(b));
+        let block = self
+            .fetch_full_block(hash)
+            .await?
+            .map(Into::into)
+            .map(|b| self.convert_to_tx_only_block(b));
 
         Ok(block)
     }
@@ -447,7 +451,11 @@ impl ClientFork {
             return Ok(Some(self.convert_to_tx_only_block(block)));
         }
 
-        let block = self.fetch_full_block(block_number).await?.map(Into::into).map(|b| self.convert_to_tx_only_block(b));
+        let block = self
+            .fetch_full_block(block_number)
+            .await?
+            .map(Into::into)
+            .map(|b| self.convert_to_tx_only_block(b));
         Ok(block)
     }
 
@@ -529,7 +537,11 @@ impl ClientFork {
 
         let mut uncles = Vec::with_capacity(block.uncles.len());
         for (uncle_idx, _) in block.uncles.iter().enumerate() {
-            let uncle = match self.provider().get_uncle(block_number.to::<u64>(), U64::from(uncle_idx)).await? {
+            let uncle = match self
+                .provider()
+                .get_uncle(block_number.to::<u64>(), U64::from(uncle_idx))
+                .await?
+            {
                 Some(u) => u,
                 None => return Ok(None),
             };
@@ -559,7 +571,7 @@ impl ClientFork {
 
     /// Converts a full block into a block with only its tx hashes.
     fn convert_to_tx_only_block(&self, mut block: Block) -> Block {
-        let hashes = block.transactions.iter().map(|tx| tx.clone()).collect();
+        let hashes = block.transactions.iter().collect();
         block.transactions = BlockTransactions::Hashes(hashes);
         block
     }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -142,10 +142,7 @@ async fn test_fork_eth_get_code() {
 
     for address in utils::contract_addresses(Chain::Mainnet) {
         let prev_code = api
-            .get_code(
-                address.to_alloy(),
-                Some(BlockNumberOrTag::Number((BLOCK_NUMBER - 10)).into()),
-            )
+            .get_code(address.to_alloy(), Some(BlockNumberOrTag::Number(BLOCK_NUMBER - 10).into()))
             .await
             .unwrap();
         let code = api.get_code(address.to_alloy(), None).await.unwrap();

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -415,9 +415,9 @@ async fn test_fork_timestamp() {
     let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(tx.status, Some(1u64.into()));
 
-    let elapsed = start.elapsed().as_secs();
-
     let block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
+
+    let elapsed = start.elapsed().as_secs() + 1;
 
     // ensure the diff between the new mined block and the original block is within the elapsed time
     let diff = block.timestamp - BLOCK_TIMESTAMP;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2,7 +2,7 @@
 
 use crate::{abi::*, utils};
 use anvil::{eth::EthApi, spawn, NodeConfig, NodeHandle};
-use anvil_core::{eth::transaction::EthTransactionRequest, types::Forking};
+use anvil_core::types::Forking;
 use ethers::{
     core::rand,
     prelude::{Bytes, LocalWallet, Middleware, SignerMiddleware},
@@ -13,8 +13,10 @@ use ethers::{
         U256,
     },
 };
+use alloy_primitives::U256 as rU256;
+use alloy_rpc_types::{BlockNumberOrTag, CallRequest};
 use foundry_common::{
-    get_http_provider, rpc,
+    provider::ethers::get_http_provider, rpc,
     rpc::next_http_rpc_endpoint,
     types::{ToAlloy, ToEthers},
 };
@@ -67,18 +69,18 @@ async fn test_spawn_fork() {
     assert!(api.is_fork());
 
     let head = api.block_number().unwrap();
-    assert_eq!(head, BLOCK_NUMBER.into())
+    assert_eq!(head, rU256::from(BLOCK_NUMBER))
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_balance() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     for _ in 0..10 {
         let addr = Address::random();
-        let balance = api.balance(addr, None).await.unwrap();
+        let balance = api.balance(addr.to_alloy(), None).await.unwrap();
         let provider_balance = provider.get_balance(addr, None).await.unwrap();
-        assert_eq!(balance, provider_balance)
+        assert_eq!(balance, provider_balance.to_alloy())
     }
 }
 
@@ -86,7 +88,7 @@ async fn test_fork_eth_get_balance() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_balance_after_mine() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     let info = api.anvil_node_info().await.unwrap();
     let number = info.fork_config.fork_block_number.unwrap();
     assert_eq!(number, BLOCK_NUMBER);
@@ -110,7 +112,7 @@ async fn test_fork_eth_get_balance_after_mine() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_code_after_mine() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     let info = api.anvil_node_info().await.unwrap();
     let number = info.fork_config.fork_block_number.unwrap();
     assert_eq!(number, BLOCK_NUMBER);
@@ -129,23 +131,23 @@ async fn test_fork_eth_get_code_after_mine() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_code() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     for _ in 0..10 {
         let addr = Address::random();
-        let code = api.get_code(addr, None).await.unwrap();
+        let code = api.get_code(addr.to_alloy(), None).await.unwrap();
         let provider_code = provider.get_code(addr, None).await.unwrap();
-        assert_eq!(code, provider_code)
+        assert_eq!(code, provider_code.to_alloy())
     }
 
     for address in utils::contract_addresses(Chain::Mainnet) {
         let prev_code = api
-            .get_code(address, Some(BlockNumber::Number((BLOCK_NUMBER - 10).into()).into()))
+            .get_code(address.to_alloy(), Some(BlockNumberOrTag::Number((BLOCK_NUMBER - 10).into()).into()))
             .await
             .unwrap();
-        let code = api.get_code(address, None).await.unwrap();
+        let code = api.get_code(address.to_alloy(), None).await.unwrap();
         let provider_code = provider.get_code(address, None).await.unwrap();
         assert_eq!(code, prev_code);
-        assert_eq!(code, provider_code);
+        assert_eq!(code, provider_code.to_alloy());
         assert!(!code.as_ref().is_empty());
     }
 }
@@ -153,35 +155,35 @@ async fn test_fork_eth_get_code() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_get_nonce() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     for _ in 0..10 {
         let addr = Address::random();
-        let api_nonce = api.transaction_count(addr, None).await.unwrap();
+        let api_nonce = api.transaction_count(addr.to_alloy(), None).await.unwrap();
         let provider_nonce = provider.get_transaction_count(addr, None).await.unwrap();
-        assert_eq!(api_nonce, provider_nonce);
+        assert_eq!(api_nonce, provider_nonce.to_alloy());
     }
 
     let addr = Config::DEFAULT_SENDER;
-    let api_nonce = api.transaction_count(addr.to_ethers(), None).await.unwrap();
+    let api_nonce = api.transaction_count(addr, None).await.unwrap();
     let provider_nonce = provider.get_transaction_count(addr.to_ethers(), None).await.unwrap();
-    assert_eq!(api_nonce, provider_nonce);
+    assert_eq!(api_nonce, provider_nonce.to_alloy());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_fee_history() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let count = 10u64;
-    let _history = api.fee_history(count.into(), BlockNumber::Latest, vec![]).await.unwrap();
+    let _history = api.fee_history(rU256::from(count), BlockNumberOrTag::Latest, vec![]).await.unwrap();
     let _provider_history = provider.fee_history(count, BlockNumber::Latest, &[]).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_reset() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
     let from = accounts[0].address();
@@ -229,7 +231,7 @@ async fn test_fork_reset() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_reset_setup() {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let dead_addr: Address = "000000000000000000000000000000000000dEaD".parse().unwrap();
 
@@ -256,7 +258,7 @@ async fn test_fork_reset_setup() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_snapshotting() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let snapshot = api.evm_snapshot().await.unwrap();
 
@@ -295,14 +297,14 @@ async fn test_fork_snapshotting() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_separate_states() {
     let (api, handle) = spawn(fork_config().with_fork_block_number(Some(14723772u64))).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let addr: Address = "000000000000000000000000000000000000dEaD".parse().unwrap();
 
     let remote_balance = provider.get_balance(addr, None).await.unwrap();
     assert_eq!(remote_balance, 12556104082473169733500u128.into());
 
-    api.anvil_set_balance(addr, 1337u64.into()).await.unwrap();
+    api.anvil_set_balance(addr.to_alloy(), rU256::from(1337u64)).await.unwrap();
     let balance = provider.get_balance(addr, None).await.unwrap();
     assert_eq!(balance, 1337u64.into());
 
@@ -324,7 +326,7 @@ async fn test_separate_states() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deploy_greeter_on_fork() {
     let (_api, handle) = spawn(fork_config().with_fork_block_number(Some(14723772u64))).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
     let client = Arc::new(SignerMiddleware::new(provider, wallet));
@@ -349,17 +351,17 @@ async fn can_deploy_greeter_on_fork() {
 async fn can_reset_properly() {
     let (origin_api, origin_handle) = spawn(NodeConfig::test()).await;
     let account = origin_handle.dev_accounts().next().unwrap();
-    let origin_provider = origin_handle.http_provider();
-    let origin_nonce = 1u64.into();
-    origin_api.anvil_set_nonce(account, origin_nonce).await.unwrap();
+    let origin_provider = origin_handle.ethers_http_provider();
+    let origin_nonce = rU256::from(1u64);
+    origin_api.anvil_set_nonce(account.to_alloy(), origin_nonce).await.unwrap();
 
-    assert_eq!(origin_nonce, origin_provider.get_transaction_count(account, None).await.unwrap());
+    assert_eq!(origin_nonce, origin_provider.get_transaction_count(account, None).await.unwrap().to_alloy());
 
     let (fork_api, fork_handle) =
         spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_handle.http_endpoint()))).await;
 
-    let fork_provider = fork_handle.http_provider();
-    assert_eq!(origin_nonce, fork_provider.get_transaction_count(account, None).await.unwrap());
+    let fork_provider = fork_handle.ethers_http_provider();
+    assert_eq!(origin_nonce, fork_provider.get_transaction_count(account, None).await.unwrap().to_alloy());
 
     let to = Address::random();
     let to_balance = fork_provider.get_balance(to, None).await.unwrap();
@@ -367,19 +369,19 @@ async fn can_reset_properly() {
     let tx = fork_provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
 
     // nonce incremented by 1
-    assert_eq!(origin_nonce + 1, fork_provider.get_transaction_count(account, None).await.unwrap());
+    assert_eq!(origin_nonce + rU256::from(1), fork_provider.get_transaction_count(account, None).await.unwrap().to_alloy());
 
     // resetting to origin state
     fork_api.anvil_reset(Some(Forking::default())).await.unwrap();
 
     // nonce reset to origin
-    assert_eq!(origin_nonce, fork_provider.get_transaction_count(account, None).await.unwrap());
+    assert_eq!(origin_nonce, fork_provider.get_transaction_count(account, None).await.unwrap().to_alloy());
 
     // balance is reset
     assert_eq!(to_balance, fork_provider.get_balance(to, None).await.unwrap());
 
     // tx does not exist anymore
-    assert!(fork_provider.get_transaction(tx.transaction_hash).await.unwrap().is_none())
+    assert!(fork_provider.get_transaction(tx.transaction_hash).await.is_err())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -387,7 +389,7 @@ async fn test_fork_timestamp() {
     let start = std::time::Instant::now();
 
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let block = provider.get_block(BLOCK_NUMBER).await.unwrap().unwrap();
     assert_eq!(block.timestamp.as_u64(), BLOCK_TIMESTAMP);
@@ -462,9 +464,9 @@ async fn test_fork_can_send_tx() {
 
     let wallet = LocalWallet::new(&mut rand::thread_rng());
 
-    api.anvil_set_balance(wallet.address(), U256::from(1e18 as u64)).await.unwrap();
+    api.anvil_set_balance(wallet.address().to_alloy(), rU256::from(1e18 as u64)).await.unwrap();
 
-    let provider = SignerMiddleware::new(handle.http_provider(), wallet);
+    let provider = SignerMiddleware::new(handle.ethers_http_provider(), wallet);
 
     let addr = Address::random();
     let val = 1337u64;
@@ -490,9 +492,9 @@ async fn test_fork_nft_set_approve_all() {
 
     // create and fund a random wallet
     let wallet = LocalWallet::new(&mut rand::thread_rng());
-    api.anvil_set_balance(wallet.address(), U256::from(1000e18 as u64)).await.unwrap();
+    api.anvil_set_balance(wallet.address().to_alloy(), rU256::from(1000e18 as u64)).await.unwrap();
 
-    let provider = Arc::new(SignerMiddleware::new(handle.http_provider(), wallet.clone()));
+    let provider = Arc::new(SignerMiddleware::new(handle.ethers_http_provider(), wallet.clone()));
 
     // pick a random nft <https://opensea.io/assets/ethereum/0x9c8ff314c9bc7f6e59a9d9225fb22946427edc03/154>
     let nouns_addr: Address = "0x9c8ff314c9bc7f6e59a9d9225fb22946427edc03".parse().unwrap();
@@ -508,14 +510,16 @@ async fn test_fork_nft_set_approve_all() {
     let tx = approval.send().await.unwrap().await.unwrap().unwrap();
     assert_eq!(tx.status, Some(1u64.into()));
 
+    let real_owner = real_owner.to_alloy();
+
     // transfer: impersonate real owner and transfer nft
     api.anvil_impersonate_account(real_owner).await.unwrap();
 
-    api.anvil_set_balance(real_owner, U256::from(10000e18 as u64)).await.unwrap();
+    api.anvil_set_balance(real_owner, rU256::from(10000e18 as u64)).await.unwrap();
 
-    let call = nouns.transfer_from(real_owner, wallet.address(), token_id);
+    let call = nouns.transfer_from(real_owner.to_ethers(), wallet.address(), token_id);
     let mut tx: TypedTransaction = call.tx;
-    tx.set_from(real_owner);
+    tx.set_from(real_owner.to_ethers());
     provider.fill_transaction(&mut tx, None).await.unwrap();
     let tx = provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(tx.status, Some(1u64.into()));
@@ -544,7 +548,7 @@ async fn test_fork_with_custom_chain_id() {
     let config_chain_id = handle.config().chain_id;
 
     // check that the chainIds are the same
-    assert_eq!(eth_chain_id.unwrap().unwrap().as_u64(), 3145u64);
+    assert_eq!(eth_chain_id.unwrap().unwrap().to::<u64>(), 3145u64);
     assert_eq!(txn_chain_id, 3145u64);
     assert_eq!(config_chain_id, Some(3145u64));
 }
@@ -562,9 +566,9 @@ async fn test_fork_can_send_opensea_tx() {
     let sender: Address = "0x8fdbae54b6d9f3fc2c649e3dd4602961967fd42f".parse().unwrap();
 
     // transfer: impersonate real sender
-    api.anvil_impersonate_account(sender).await.unwrap();
+    api.anvil_impersonate_account(sender.to_alloy()).await.unwrap();
 
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let input: Bytes = "0xfb0f3ee1000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003ff2e795f5000000000000000000000000000023f28ae3e9756ba982a6290f9081b6a84900b758000000000000000000000000004c00500000ad104d7dbd00e3ae0a5c00560c0000000000000000000000000003235b597a78eabcb08ffcb4d97411073211dbcb0000000000000000000000000000000000000000000000000000000000000e72000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000062ad47c20000000000000000000000000000000000000000000000000000000062d43104000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000df44e65d2a2cf40000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f00000000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f00000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000002e000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000001c6bf526340000000000000000000000000008de9c5a032463c561423387a9648c5c7bcc5bc900000000000000000000000000000000000000000000000000005543df729c0000000000000000000000000006eb234847a9e3a546539aac57a071c01dc3f398600000000000000000000000000000000000000000000000000000000000000416d39b5352353a22cf2d44faa696c2089b03137a13b5acfee0366306f2678fede043bc8c7e422f6f13a3453295a4a063dac7ee6216ab7bade299690afc77397a51c00000000000000000000000000000000000000000000000000000000000000".parse().unwrap();
     let to: Address = "0x00000000006c3852cbef3e08e8df289169ede581".parse().unwrap();
@@ -587,9 +591,9 @@ async fn test_fork_base_fee() {
     let accounts: Vec<_> = handle.dev_wallets().collect();
     let from = accounts[0].address();
 
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
-    api.anvil_set_next_block_base_fee_per_gas(U256::zero()).await.unwrap();
+    api.anvil_set_next_block_base_fee_per_gas(rU256::ZERO).await.unwrap();
 
     let addr = Address::random();
     let val = 1337u64;
@@ -602,7 +606,7 @@ async fn test_fork_base_fee() {
 async fn test_fork_init_base_fee() {
     let (api, handle) = spawn(fork_config().with_fork_block_number(Some(13184859u64))).await;
 
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
     // <https://etherscan.io/block/13184859>
@@ -625,7 +629,7 @@ async fn test_reset_fork_on_new_blocks() {
     )
     .await;
 
-    let anvil_provider = handle.http_provider();
+    let anvil_provider = handle.ethers_http_provider();
 
     let endpoint = next_http_rpc_endpoint();
     let provider = Arc::new(get_http_provider(&endpoint).interval(Duration::from_secs(2)));
@@ -662,25 +666,25 @@ async fn test_fork_call() {
 
     let res1 = api
         .call(
-            EthTransactionRequest { to: Some(to), data: Some(input), ..Default::default() },
+            CallRequest { to: Some(to.to_alloy()), input: input.to_alloy().into(), ..Default::default() },
             None,
             None,
         )
         .await
         .unwrap();
 
-    assert_eq!(res0, res1);
+    assert_eq!(res0, res1.to_ethers());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_block_timestamp() {
     let (api, _) = spawn(fork_config()).await;
 
-    let initial_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
-    api.anvil_mine(Some(1.into()), None).await.unwrap();
-    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+    let initial_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    api.anvil_mine(Some(rU256::from(1)), None).await.unwrap();
+    let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
-    assert!(initial_block.timestamp.as_u64() < latest_block.timestamp.as_u64());
+    assert!(initial_block.header.timestamp.to::<u64>() < latest_block.header.timestamp.to::<u64>());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -688,33 +692,33 @@ async fn test_fork_snapshot_block_timestamp() {
     let (api, _) = spawn(fork_config()).await;
 
     let snapshot_id = api.evm_snapshot().await.unwrap();
-    api.anvil_mine(Some(1.into()), None).await.unwrap();
-    let initial_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+    api.anvil_mine(Some(rU256::from(1)), None).await.unwrap();
+    let initial_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     api.evm_revert(snapshot_id).await.unwrap();
-    api.evm_set_next_block_timestamp(initial_block.timestamp.as_u64()).unwrap();
-    api.anvil_mine(Some(1.into()), None).await.unwrap();
-    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+    api.evm_set_next_block_timestamp(initial_block.header.timestamp.to::<u64>()).unwrap();
+    api.anvil_mine(Some(rU256::from(1)), None).await.unwrap();
+    let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
-    assert_eq!(initial_block.timestamp.as_u64(), latest_block.timestamp.as_u64());
+    assert_eq!(initial_block.header.timestamp.to::<u64>(), latest_block.header.timestamp.to::<u64>());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_uncles_fetch() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     // Block on ETH mainnet with 2 uncles
     let block_with_uncles = 190u64;
 
     let block =
-        api.block_by_number(BlockNumber::Number(block_with_uncles.into())).await.unwrap().unwrap();
+        api.block_by_number(BlockNumberOrTag::Number(block_with_uncles.into())).await.unwrap().unwrap();
 
     assert_eq!(block.uncles.len(), 2);
 
     let count = provider.get_uncle_count(block_with_uncles).await.unwrap();
     assert_eq!(count.as_usize(), block.uncles.len());
 
-    let count = provider.get_uncle_count(block.hash.unwrap()).await.unwrap();
+    let count = provider.get_uncle_count(block.header.hash.unwrap().to_ethers()).await.unwrap();
     assert_eq!(count.as_usize(), block.uncles.len());
 
     for (uncle_idx, uncle_hash) in block.uncles.iter().enumerate() {
@@ -724,22 +728,22 @@ async fn test_fork_uncles_fetch() {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*uncle_hash, uncle.hash.unwrap());
+        assert_eq!(*uncle_hash, uncle.hash.unwrap().to_alloy());
 
         // Try with block hash
         let uncle = provider
-            .get_uncle(block.hash.unwrap(), (uncle_idx as u64).into())
+            .get_uncle(block.header.hash.unwrap().to_ethers(), (uncle_idx as u64).into())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(*uncle_hash, uncle.hash.unwrap());
+        assert_eq!(*uncle_hash, uncle.hash.unwrap().to_alloy());
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_block_transaction_count() {
     let (api, handle) = spawn(fork_config()).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let accounts: Vec<_> = handle.dev_wallets().collect();
     let sender = accounts[0].address();
@@ -747,36 +751,36 @@ async fn test_fork_block_transaction_count() {
     // disable automine (so there are pending transactions)
     api.anvil_set_auto_mine(false).await.unwrap();
     // transfer: impersonate real sender
-    api.anvil_impersonate_account(sender).await.unwrap();
+    api.anvil_impersonate_account(sender.to_alloy()).await.unwrap();
 
     let tx = TransactionRequest::new().from(sender).value(42u64).gas(100_000);
     provider.send_transaction(tx, None).await.unwrap();
 
     let pending_txs =
-        api.block_transaction_count_by_number(BlockNumber::Pending).await.unwrap().unwrap();
-    assert_eq!(pending_txs.as_usize(), 1);
+        api.block_transaction_count_by_number(BlockNumberOrTag::Pending).await.unwrap().unwrap();
+    assert_eq!(pending_txs.to::<u64>(), 1);
 
     // mine a new block
     api.anvil_mine(None, None).await.unwrap();
 
     let pending_txs =
-        api.block_transaction_count_by_number(BlockNumber::Pending).await.unwrap().unwrap();
-    assert_eq!(pending_txs.as_usize(), 0);
+        api.block_transaction_count_by_number(BlockNumberOrTag::Pending).await.unwrap().unwrap();
+    assert_eq!(pending_txs.to::<u64>(), 0);
     let latest_txs =
-        api.block_transaction_count_by_number(BlockNumber::Latest).await.unwrap().unwrap();
-    assert_eq!(latest_txs.as_usize(), 1);
-    let latest_block = api.block_by_number(BlockNumber::Latest).await.unwrap().unwrap();
+        api.block_transaction_count_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(latest_txs.to::<u64>(), 1);
+    let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     let latest_txs =
-        api.block_transaction_count_by_hash(latest_block.hash.unwrap()).await.unwrap().unwrap();
-    assert_eq!(latest_txs.as_usize(), 1);
+        api.block_transaction_count_by_hash(latest_block.header.hash.unwrap()).await.unwrap().unwrap();
+    assert_eq!(latest_txs.to::<u64>(), 1);
 
     // check txs count on an older block: 420000 has 3 txs on mainnet
     let count_txs = api
-        .block_transaction_count_by_number(BlockNumber::Number(420000.into()))
+        .block_transaction_count_by_number(BlockNumberOrTag::Number(420000))
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(count_txs.as_usize(), 3);
+    assert_eq!(count_txs.to::<u64>(), 3);
     let count_txs = api
         .block_transaction_count_by_hash(
             "0xb3b0e3e0c64e23fb7f1ccfd29245ae423d2f6f1b269b63b70ff882a983ce317c".parse().unwrap(),
@@ -784,28 +788,28 @@ async fn test_fork_block_transaction_count() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(count_txs.as_usize(), 3);
+    assert_eq!(count_txs.to::<u64>(), 3);
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2931>
 #[tokio::test(flavor = "multi_thread")]
 async fn can_impersonate_in_fork() {
     let (api, handle) = spawn(fork_config().with_fork_block_number(Some(15347924u64))).await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let token_holder: Address = "0x2f0b23f53734252bda2277357e97e1517d6b042a".parse().unwrap();
     let to = Address::random();
     let val = 1337u64;
 
     // fund the impersonated account
-    api.anvil_set_balance(token_holder, U256::from(1e18 as u64)).await.unwrap();
+    api.anvil_set_balance(token_holder.to_alloy(), rU256::from(1e18 as u64)).await.unwrap();
 
     let tx = TransactionRequest::new().from(token_holder).to(to).value(val);
 
     let res = provider.send_transaction(tx.clone(), None).await;
     res.unwrap_err();
 
-    api.anvil_impersonate_account(token_holder).await.unwrap();
+    api.anvil_impersonate_account(token_holder.to_alloy()).await.unwrap();
 
     let res = provider.send_transaction(tx.clone(), None).await.unwrap().await.unwrap().unwrap();
     assert_eq!(res.from, token_holder);
@@ -814,7 +818,7 @@ async fn can_impersonate_in_fork() {
     let balance = provider.get_balance(to, None).await.unwrap();
     assert_eq!(balance, val.into());
 
-    api.anvil_stop_impersonating_account(token_holder).await.unwrap();
+    api.anvil_stop_impersonating_account(token_holder.to_alloy()).await.unwrap();
     let res = provider.send_transaction(tx, None).await;
     res.unwrap_err();
 }
@@ -827,7 +831,7 @@ async fn test_total_difficulty_fork() {
     let total_difficulty: U256 = 46_673_965_560_973_856_260_636u128.into();
     let difficulty: U256 = 13_680_435_288_526_144u128.into();
 
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     let block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
     assert_eq!(block.total_difficulty, Some(total_difficulty));
     assert_eq!(block.difficulty, difficulty);
@@ -875,7 +879,7 @@ async fn can_override_fork_chain_id() {
             .with_chain_id(Some(chain_id_override)),
     )
     .await;
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
 
     let wallet = handle.dev_wallets().next().unwrap();
     let client = Arc::new(SignerMiddleware::new(provider, wallet));
@@ -895,7 +899,7 @@ async fn can_override_fork_chain_id() {
     let greeting = greeter_contract.greet().call().await.unwrap();
     assert_eq!("Hello World!", greeting);
 
-    let provider = handle.http_provider();
+    let provider = handle.ethers_http_provider();
     let chain_id = provider.get_chainid().await.unwrap();
     assert_eq!(chain_id.as_u64(), chain_id_override);
 }

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -2,7 +2,7 @@ mod abi;
 mod anvil;
 // mod anvil_api;
 mod api;
-// mod fork;
+mod fork;
 mod ganache;
 mod gas;
 mod genesis;

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -82,12 +82,14 @@ async fn test_send_value_deposit_transaction() {
     });
 
     let pending = provider.send_transaction(deposit_tx.clone(), None).await.unwrap();
-    let receipt = pending.await.unwrap().expect("dropped");
-    assert_eq!(receipt.from, from_addr);
-    assert_eq!(receipt.to, Some(to_addr));
 
     // mine block
     api.evm_mine(None).await.unwrap();
+
+    let receipt = provider.get_transaction_receipt(pending.tx_hash()).await.unwrap().unwrap();
+    assert_eq!(receipt.from, from_addr);
+    assert_eq!(receipt.to, Some(to_addr));
+
 
     // the recipient should have received the value
     let balance = provider.get_balance(to_addr, None).await.unwrap();
@@ -129,12 +131,13 @@ async fn test_send_value_raw_deposit_transaction() {
 
     let rlpbytes = deposit_tx.rlp();
     let pending = provider.send_raw_transaction(rlpbytes).await.unwrap();
-    let receipt = pending.await.unwrap().expect("dropped");
-    assert_eq!(receipt.from, from_addr);
-    assert_eq!(receipt.to, Some(to_addr));
 
     // mine block
     api.evm_mine(None).await.unwrap();
+
+    let receipt = provider.get_transaction_receipt(pending.tx_hash()).await.unwrap().unwrap();
+    assert_eq!(receipt.from, from_addr);
+    assert_eq!(receipt.to, Some(to_addr));
 
     // the recipient should have received the value
     let balance = provider.get_balance(to_addr, None).await.unwrap();

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -90,7 +90,6 @@ async fn test_send_value_deposit_transaction() {
     assert_eq!(receipt.from, from_addr);
     assert_eq!(receipt.to, Some(to_addr));
 
-
     // the recipient should have received the value
     let balance = provider.get_balance(to_addr, None).await.unwrap();
     assert_eq!(balance, send_value);

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -139,6 +139,7 @@ impl ToAlloy for ethers_core::types::Transaction {
     }
 }
 
+/// Converts from a [TransactionRequest] to a [CallRequest].
 pub fn to_call_request_from_tx_request(tx: TransactionRequest) -> CallRequest {
     CallRequest {
         from: tx.from.map(|f| f.to_alloy()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

fixes most tests failures in #6219, which mainly happened due to us returning full blocks instead of non-full blocks when non-full blocks were requested. It also enables fork tests again which pass after fixing some edge cases regarding uncles.

The tests which are expected to fail are `ws` and `ipc`-related tests, as they still haven't been implemented.
