### PR TITLE
chore: update required version in the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.74"
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"


### PR DESCRIPTION
## Motivation

When you build the project, if you follow the rust version of the Cargo.toml, the project won't compile because of alloy-sol-macro not compiling.

![image](https://github.com/foundry-rs/foundry/assets/72015889/a4e1089f-783d-46f5-b954-2633657d84c4)


## Solution

The solution is simply to update rust version to 1.74
