### PR TITLE
fix: forge create to use config values for verify preflight check

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -172,7 +172,7 @@ impl CreateArgs {
     ) -> Result<()> {
         // NOTE: this does not represent the same `VerifyArgs` that would be sent after deployment,
         // since we don't know the address yet.
-        let verify = verify::VerifyArgs {
+        let mut verify = verify::VerifyArgs {
             address: Default::default(),
             contract: self.contract.clone(),
             compiler_version: None,
@@ -192,6 +192,13 @@ impl CreateArgs {
             verifier: self.verifier.clone(),
             show_standard_json_input: self.show_standard_json_input,
         };
+
+        // Check config for Etherscan API Keys to avoid preflight check failing if no
+        // ETHERSCAN_API_KEY value set.
+        let config = verify.load_config_emit_warnings();
+        verify.etherscan.key =
+            config.get_etherscan_config_with_chain(Some(chain.into()))?.map(|c| c.key);
+
         verify.verification_provider()?.preflight_check(verify).await?;
         Ok(())
     }


### PR DESCRIPTION
## Motivation

As described in #6466 , `forge create --verify` could not be called using `foundry.toml`

## Solution

Update the etherscan API key from the Config in the information that is checked in the preflight. This means if no `ETHERSCAN_API_KEY` is set as an env var or flag, the config files will be used as opposed to failing the preflight check.

## Note

If a test is needed here, I might need my handheld. Very new to Rust, so also unsure if it's okay here to make `verify` mutable.
