### PR TITLE
fix: overflow of memory offset or size in debugger

### DIFF
--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -974,10 +974,10 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
                         Span::styled(
                             format!("{byte:02x} "),
                             if let (Some(offset), Some(size), Some(color)) = (offset, size, color) {
-                                if (i == offset / 32 && j >= offset % 32)
-                                    || (i > offset / 32 && i < (offset + size - 1) / 32)
-                                    || (i == (offset + size - 1) / 32
-                                        && j <= (offset + size - 1) % 32)
+                                if (i == offset / 32 && j >= offset % 32) ||
+                                    (i > offset / 32 && i < (offset + size - 1) / 32) ||
+                                    (i == (offset + size - 1) / 32 &&
+                                        j <= (offset + size - 1) % 32)
                                 {
                                     // [offset, offset + size] is the memory region to be colored.
                                     // If a byte at row i and column j in the memory panel
@@ -1055,18 +1055,18 @@ impl Ui for Tui {
                         let event = event::read().unwrap();
                         if let Event::Key(key) = event {
                             if tx.send(Interrupt::KeyPressed(key)).is_err() {
-                                return;
+                                return
                             }
                         } else if let Event::Mouse(mouse) = event {
                             if tx.send(Interrupt::MouseEvent(mouse)).is_err() {
-                                return;
+                                return
                             }
                         }
                     }
                     // Force update if time has passed
                     if last_tick.elapsed() > tick_rate {
                         if tx.send(Interrupt::IntervalElapsed).is_err() {
-                            return;
+                            return
                         }
                         last_tick = Instant::now();
                     }
@@ -1111,7 +1111,7 @@ impl Ui for Tui {
                                 {
                                     draw_memory.inner_call_index = i;
                                     self.current_step = step;
-                                    break;
+                                    break
                                 }
                             }
                         }
@@ -1127,7 +1127,7 @@ impl Ui for Tui {
                                 LeaveAlternateScreen,
                                 DisableMouseCapture
                             )?;
-                            return Ok(TUIExitReason::CharExit);
+                            return Ok(TUIExitReason::CharExit)
                         }
                         // Move down
                         KeyCode::Char('j') | KeyCode::Down => {
@@ -1137,9 +1137,9 @@ impl Ui for Tui {
                                     let max_mem = (debug_call[draw_memory.inner_call_index].1
                                         [self.current_step]
                                         .memory
-                                        .len()
-                                        / 32)
-                                        .saturating_sub(1);
+                                        .len() /
+                                        32)
+                                    .saturating_sub(1);
                                     if draw_memory.current_mem_startline < max_mem {
                                         draw_memory.current_mem_startline += 1;
                                     }
@@ -1256,8 +1256,8 @@ impl Ui for Tui {
                                     .find_map(|(i, op)| {
                                         if i > 0 {
                                             match (
-                                                prev_ops[i - 1].contains("JUMP")
-                                                    && prev_ops[i - 1] != "JUMPDEST",
+                                                prev_ops[i - 1].contains("JUMP") &&
+                                                    prev_ops[i - 1] != "JUMPDEST",
                                                 &**op,
                                             ) {
                                                 (true, "JUMPDEST") => Some(i - 1),
@@ -1363,7 +1363,7 @@ impl Interrupt {
         if let Self::KeyPressed(event) = &self {
             if let KeyCode::Char(c) = event.code {
                 if c.is_alphanumeric() || c == '\'' {
-                    return Some(c);
+                    return Some(c)
                 }
             }
         }

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -894,7 +894,7 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
             -2 => Some(1),
             -1 => Some(32),
             0 => None,
-            1.. => Some(stack[stack_len - stack_index as usize].to()),
+            1.. => Some(stack[stack_len - stack_index as usize].saturating_to()),
             _ => panic!("invalid stack index"),
         };
 
@@ -917,7 +917,7 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
         draw_mem: &DrawMemory,
     ) {
         let memory = &debug_steps[current_step].memory;
-        let stack_space = Block::default()
+        let memory_space = Block::default()
             .title(format!("Memory (max expansion: {} bytes)", memory.len()))
             .borders(Borders::ALL);
         let max_i = memory.len() / 32;
@@ -974,10 +974,10 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
                         Span::styled(
                             format!("{byte:02x} "),
                             if let (Some(offset), Some(size), Some(color)) = (offset, size, color) {
-                                if (i == offset / 32 && j >= offset % 32) ||
-                                    (i > offset / 32 && i < (offset + size - 1) / 32) ||
-                                    (i == (offset + size - 1) / 32 &&
-                                        j <= (offset + size - 1) % 32)
+                                if (i == offset / 32 && j >= offset % 32)
+                                    || (i > offset / 32 && i < (offset + size - 1) / 32)
+                                    || (i == (offset + size - 1) / 32
+                                        && j <= (offset + size - 1) % 32)
                                 {
                                     // [offset, offset + size] is the memory region to be colored.
                                     // If a byte at row i and column j in the memory panel
@@ -1023,7 +1023,7 @@ Line::from(Span::styled("[t]: stack labels | [m]: memory decoding | [shift + j/k
                 Line::from(spans)
             })
             .collect();
-        let paragraph = Paragraph::new(text).block(stack_space).wrap(Wrap { trim: true });
+        let paragraph = Paragraph::new(text).block(memory_space).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
     }
 }
@@ -1055,18 +1055,18 @@ impl Ui for Tui {
                         let event = event::read().unwrap();
                         if let Event::Key(key) = event {
                             if tx.send(Interrupt::KeyPressed(key)).is_err() {
-                                return
+                                return;
                             }
                         } else if let Event::Mouse(mouse) = event {
                             if tx.send(Interrupt::MouseEvent(mouse)).is_err() {
-                                return
+                                return;
                             }
                         }
                     }
                     // Force update if time has passed
                     if last_tick.elapsed() > tick_rate {
                         if tx.send(Interrupt::IntervalElapsed).is_err() {
-                            return
+                            return;
                         }
                         last_tick = Instant::now();
                     }
@@ -1111,7 +1111,7 @@ impl Ui for Tui {
                                 {
                                     draw_memory.inner_call_index = i;
                                     self.current_step = step;
-                                    break
+                                    break;
                                 }
                             }
                         }
@@ -1127,7 +1127,7 @@ impl Ui for Tui {
                                 LeaveAlternateScreen,
                                 DisableMouseCapture
                             )?;
-                            return Ok(TUIExitReason::CharExit)
+                            return Ok(TUIExitReason::CharExit);
                         }
                         // Move down
                         KeyCode::Char('j') | KeyCode::Down => {
@@ -1137,9 +1137,9 @@ impl Ui for Tui {
                                     let max_mem = (debug_call[draw_memory.inner_call_index].1
                                         [self.current_step]
                                         .memory
-                                        .len() /
-                                        32)
-                                    .saturating_sub(1);
+                                        .len()
+                                        / 32)
+                                        .saturating_sub(1);
                                     if draw_memory.current_mem_startline < max_mem {
                                         draw_memory.current_mem_startline += 1;
                                     }
@@ -1256,8 +1256,8 @@ impl Ui for Tui {
                                     .find_map(|(i, op)| {
                                         if i > 0 {
                                             match (
-                                                prev_ops[i - 1].contains("JUMP") &&
-                                                    prev_ops[i - 1] != "JUMPDEST",
+                                                prev_ops[i - 1].contains("JUMP")
+                                                    && prev_ops[i - 1] != "JUMPDEST",
                                                 &**op,
                                             ) {
                                                 (true, "JUMPDEST") => Some(i - 1),
@@ -1363,7 +1363,7 @@ impl Interrupt {
         if let Self::KeyPressed(event) = &self {
             if let KeyCode::Char(c) = event.code {
                 if c.is_alphanumeric() || c == '\'' {
-                    return Some(c)
+                    return Some(c);
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Motivation can be found in #6472. This fixes a crash of the debugger when accessing memory offset or size for read/writes that are bigger than usize::MAX. The case presented in 6472 is now solved with this PR.
Also applied some formatting from rustfmt.

Closes #6472

## Solution

Change the call to `to()` on `Uint256` to a call to `saturing_to()`.