### PR TITLE
Update cheatcodes.md

### DIFF
--- a/docs/dev/cheatcodes.md
+++ b/docs/dev/cheatcodes.md
@@ -120,7 +120,7 @@ interface's items, as well as the `sol!`-generated items, such as the `VmCalls` 
 
 This macro performs extra checks on functions and structs at compile time to make sure they are
 documented and have named parameters, and generates a macro which is later used to implement the
-`match { ... }` function that is be used to dispatch the cheatcode implementations after a call is
+`match { ... }` function that is to be used to dispatch the cheatcode implementations after a call is
 decoded.
 
 The latter is what fails compilation when adding a new cheatcode, and is fixed by implementing the


### PR DESCRIPTION
In the sentence "This macro performs extra checks on functions and structs at compile time to make sure they are documented and have named parameters, and generates a macro which is later used to implement the match { ... } function that is be used to dispatch the cheatcode implementations after a call is decoded.", there's a grammatical error. It should be "that is to be used" instead of "that is be used".

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
