### PR TITLE
Update debugging.md

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -4,7 +4,7 @@ This is a working document intended to outline some commands contributors can us
 
 ### Logs
 
-All crates use [tracing](https://docs.rs/tracing/latest/tracing/) for logging. An console formatter is installed in each binary (`cast`, `forge`, `anvil`).
+All crates use [tracing](https://docs.rs/tracing/latest/tracing/) for logging. A console formatter is installed in each binary (`cast`, `forge`, `anvil`).
 
 By setting `RUST_LOG=<filter>` you can get a lot more info out of Forge and Cast. For example, running Forge with `RUST_LOG=forge` will emit all logs of the `cli` crate, same for Cast.
 


### PR DESCRIPTION
### Correction: Article Usage

#### Description
The article usage in the original text is incorrect. The indefinite article "An" is appropriate when preceding words that start with a vowel sound. However, in this case, "console" begins with a consonant sound, so the correct usage should be "A."

#### Changes Made
Replaced "An" with "A" to ensure proper article usage.

Original: An console formatter is.
Corrected: A console formatter is.

Additional Notes
- No additional dependencies or changes are required.
- This fix is straightforward and does not impact any other functionalities.

Thank you.




<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
