### PR TITLE
chore: better parse error messages

### DIFF
--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1,5 +1,5 @@
 use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt};
-use alloy_json_abi::{ContractObject, Function};
+use alloy_json_abi::ContractObject;
 use alloy_primitives::{Address, I256, U256};
 use alloy_rlp::Decodable;
 use base::{Base, NumberWithBase, ToBase};

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -16,7 +16,7 @@ use evm_disassembler::{disassemble_bytes, disassemble_str, format_operations};
 use eyre::{Context, ContextCompat, Result};
 use foundry_block_explorers::Client;
 use foundry_common::{
-    abi::encode_function_args,
+    abi::{encode_function_args, get_func},
     fmt::*,
     types::{ToAlloy, ToEthers},
     TransactionReceiptWithRevertReason,
@@ -1561,12 +1561,7 @@ impl SimpleCast {
     /// # Ok::<_, eyre::Report>(())
     /// ```
     pub fn abi_encode(sig: &str, args: &[impl AsRef<str>]) -> Result<String> {
-        let func = match Function::parse(sig) {
-            Ok(func) => func,
-            Err(err) => {
-                eyre::bail!("Could not process human-readable ABI. Please check if you've left the parenthesis unclosed or if some type is incomplete.\nError:\n{}", err)
-            }
-        };
+        let func = get_func(sig)?;
         let calldata = match encode_function_args(&func, args) {
             Ok(res) => hex::encode(res),
             Err(e) => eyre::bail!("Could not ABI encode the function and arguments. Did you pass in the right types?\nError\n{}", e),
@@ -1589,7 +1584,7 @@ impl SimpleCast {
     /// # Ok::<_, eyre::Report>(())
     /// ```
     pub fn calldata_encode(sig: impl AsRef<str>, args: &[impl AsRef<str>]) -> Result<String> {
-        let func = Function::parse(sig.as_ref())?;
+        let func = get_func(sig.as_ref())?;
         let calldata = encode_function_args(&func, args)?;
         Ok(hex::encode_prefixed(calldata))
     }
@@ -1909,7 +1904,7 @@ impl SimpleCast {
             eyre::bail!("number of leading zeroes must not be greater than 4");
         }
         if optimize == 0 {
-            let selector = Function::parse(signature)?.selector();
+            let selector = get_func(signature)?.selector();
             return Ok((selector.to_string(), String::from(signature)))
         }
         let Some((name, params)) = signature.split_once('(') else {

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -166,14 +166,14 @@ pub fn fuzz_param_from_state(
 #[cfg(test)]
 mod tests {
     use crate::strategies::{build_initial_state, fuzz_calldata, fuzz_calldata_from_state};
-    use alloy_json_abi::Function;
+    use foundry_common::abi::get_func;
     use foundry_config::FuzzDictionaryConfig;
     use revm::db::{CacheDB, EmptyDB};
 
     #[test]
     fn can_fuzz_array() {
         let f = "testArray(uint64[2] calldata values)";
-        let func = Function::parse(f).unwrap();
+        let func = get_func(f).unwrap();
         let db = CacheDB::new(EmptyDB::default());
         let state = build_initial_state(&db, &FuzzDictionaryConfig::default());
         let strat = proptest::strategy::Union::new_weighted(vec![

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -24,7 +24,7 @@ use forge::{
 };
 use foundry_cli::opts::MultiWallet;
 use foundry_common::{
-    abi::encode_function_args,
+    abi::{encode_function_args, get_func},
     contracts::get_contract_name,
     errors::UnlinkedByteCode,
     evm::{Breakpoints, EvmArgs},
@@ -445,7 +445,7 @@ impl ScriptArgs {
     ///
     /// Note: We assume that the `sig` is already stripped of its prefix, See [`ScriptArgs`]
     fn get_method_and_calldata(&self, abi: &Abi) -> Result<(Function, Bytes)> {
-        let (func, data) = if let Ok(func) = Function::parse(&self.sig) {
+        let (func, data) = if let Ok(func) = get_func(&self.sig) {
             (
                 abi.functions().find(|&abi_func| abi_func.selector() == func.selector()).wrap_err(
                     format!("Function `{}` is not implemented in your script.", self.sig),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Since 0.5, double-parse workaround is not needed anymore. 
Ref bad error message in #6497

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
