### PR TITLE
fix(`forge`): pre-emptively create `lib` dir if it doesn't exist for updating submodules

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -540,6 +540,7 @@ https://github.com/foundry-rs/foundry/issues/new/choose"
             .map(|stdout| stdout.lines().any(|line| line.starts_with('-')))
     }
 
+    /// Returns true if the given path has no submodules by checking `git submodule status`
     pub fn has_submodules<I, S>(self, paths: I) -> Result<bool>
     where
         I: IntoIterator<Item = S>,
@@ -549,7 +550,7 @@ https://github.com/foundry-rs/foundry/issues/new/choose"
             .args(["submodule", "status"])
             .args(paths)
             .get_stdout_lossy()
-            .map(|stdout| stdout.lines().next().is_some())
+            .map(|stdout| stdout.trim().lines().next().is_some())
     }
 
     pub fn submodule_add(

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -540,6 +540,18 @@ https://github.com/foundry-rs/foundry/issues/new/choose"
             .map(|stdout| stdout.lines().any(|line| line.starts_with('-')))
     }
 
+    pub fn has_submodules<I, S>(self, paths: I) -> Result<bool>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.cmd()
+            .args(["submodule", "status"])
+            .args(paths)
+            .get_stdout_lossy()
+            .map(|stdout| stdout.lines().next().is_some())
+    }
+
     pub fn submodule_add(
         self,
         force: bool,

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -126,7 +126,9 @@ impl DependencyInstallOpts {
         // Pre-emptively create the directory where deps will be installed if it's missing
         fs::create_dir_all(&libs)?;
 
-        if dependencies.is_empty() && !self.no_git {
+        // Only update submodule deps if there are no other deps to install, we're using git
+        // and an appropiate .gitmodules file exists.
+        if dependencies.is_empty() && !self.no_git && git.root.join(".gitmodules").exists() {
             p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
 
             let empty_install_dir = libs.read_dir()?.next().is_none();

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -122,12 +122,15 @@ impl DependencyInstallOpts {
 
         let install_lib_dir = config.install_lib_dir();
         let libs = git.root.join(install_lib_dir);
-        let root = Git::root_of(git.root)?;
 
-        if dependencies.is_empty() && !self.no_git && git.has_submodules(Some(&root))? {
-            p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
-            // recursively fetch all submodules (without fetching latest)
-            git.submodule_update(false, false, false, true, Some(&libs))?;
+        if dependencies.is_empty() && !self.no_git {
+            // Use the root of the git repository to look for submodules.
+            let root = Git::root_of(git.root)?;
+            if git.has_submodules(Some(&root))? {
+                p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
+                // recursively fetch all submodules (without fetching latest)
+                git.submodule_update(false, false, false, true, Some(&libs))?;
+            }
         }
 
         fs::create_dir_all(&libs)?;
@@ -163,6 +166,7 @@ impl DependencyInstallOpts {
 
                     // update .gitmodules which is at the root of the repo,
                     // not necessarily at the root of the current Foundry project
+                    let root = Git::root_of(git.root)?;
                     git.root(&root).add(Some(".gitmodules"))?;
                 }
 

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -136,17 +136,13 @@ impl DependencyInstallOpts {
             if !empty_install_dir {
                 fs::create_file(libs.join(".keep"))?;
                 // Update the git project with the newly created folder if we're using git.
-                if !self.no_git {
-                    git.add(Some(&libs.join(".keep")))?;
-                }
+                git.add(Some(&libs.join(".keep")))?;
                 // recursively fetch all submodules (without fetching latest)
                 git.submodule_update(false, false, false, true, Some(&libs))?;
                 // remove the temporary file
                 fs::remove_file(libs.join(".keep"))?;
                 // Update the git project with the newly deleted folder if we're using git.
-                if !self.no_git {
-                    git.add(Some(&libs.join(".keep")))?;
-                }
+                git.add(Some(&libs.join(".keep")))?;
             } else {
                 // just recursively fetch all submodules (without fetching latest)
                 git.submodule_update(false, false, false, true, Some(&libs))?;

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -126,10 +126,19 @@ impl DependencyInstallOpts {
         if dependencies.is_empty() && !self.no_git {
             // Use the root of the git repository to look for submodules.
             let root = Git::root_of(git.root)?;
-            if git.has_submodules(Some(&root))? {
-                p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
-                // recursively fetch all submodules (without fetching latest)
-                git.submodule_update(false, false, false, true, Some(&libs))?;
+            match git.has_submodules(Some(&root)) {
+                Ok(true) => {
+                    p_println!(!quiet => "Updating dependencies in {}", libs.display());
+                    // recursively fetch all submodules (without fetching latest)
+                    git.submodule_update(false, false, false, true, Some(&libs))?;
+                }
+
+                Err(err) => {
+                    warn!(?err, "Failed to check for submodules");
+                }
+                _ => {
+                    // no submodules, nothing to do
+                }
             }
         }
 

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -127,26 +127,9 @@ impl DependencyInstallOpts {
         fs::create_dir_all(&libs)?;
 
         if dependencies.is_empty() && !self.no_git {
-            p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
-
-            let empty_install_dir = libs.read_dir()?.next().is_none();
-
-            if empty_install_dir {
-                fs::create_file(libs.join(".keep"))?;
-                // Update the git project with the newly created folder if we're using git.
-                if !self.no_git {
-                    git.add(Some(&libs.join(".keep")))?;
-                }
-                // recursively fetch all submodules (without fetching latest)
-                git.submodule_update(false, false, false, true, Some(&libs))?;
-                // remove the temporary file
-                fs::remove_file(libs.join(".keep"))?;
-                // Update the git project with the newly deleted folder if we're using git.
-                if !self.no_git {
-                    git.add(Some(&libs.join(".keep")))?;
-                }
-            } else {
-                // just recursively fetch all submodules (without fetching latest)
+            // recursively fetch all submodules (without fetching latest) if the dir is not empty
+            if libs.read_dir()?.next().is_some() {
+                p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
                 git.submodule_update(false, false, false, true, Some(&libs))?;
             }
         }

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -127,9 +127,26 @@ impl DependencyInstallOpts {
         fs::create_dir_all(&libs)?;
 
         if dependencies.is_empty() && !self.no_git {
-            // recursively fetch all submodules (without fetching latest) if the dir is not empty
-            if libs.read_dir()?.next().is_some() {
-                p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
+            p_println!(!self.quiet => "Updating dependencies in {}", libs.display());
+
+            let empty_install_dir = libs.read_dir()?.next().is_none();
+
+            if !empty_install_dir {
+                fs::create_file(libs.join(".keep"))?;
+                // Update the git project with the newly created folder if we're using git.
+                if !self.no_git {
+                    git.add(Some(&libs.join(".keep")))?;
+                }
+                // recursively fetch all submodules (without fetching latest)
+                git.submodule_update(false, false, false, true, Some(&libs))?;
+                // remove the temporary file
+                fs::remove_file(libs.join(".keep"))?;
+                // Update the git project with the newly deleted folder if we're using git.
+                if !self.no_git {
+                    git.add(Some(&libs.join(".keep")))?;
+                }
+            } else {
+                // just recursively fetch all submodules (without fetching latest)
                 git.submodule_update(false, false, false, true, Some(&libs))?;
             }
         }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -895,6 +895,23 @@ forgetest!(can_install_and_remove, |prj, cmd| {
     remove(&mut cmd, "lib/forge-std");
 });
 
+// test to check we can run `forge install` in an empty dir <https://github.com/foundry-rs/foundry/issues/6519>
+forgetest!(can_install_empty, |prj, cmd| {
+    // create
+    cmd.git_init();
+    cmd.forge_fuse().args(["install"]);
+    cmd.assert_empty_stdout();
+
+    // create initial commit
+    fs::write(prj.root().join("README.md"), "Initial commit").unwrap();
+
+    cmd.git_add().unwrap();
+    cmd.git_commit("Initial commit").unwrap();
+
+    cmd.forge_fuse().args(["install"]);
+    cmd.assert_empty_stdout();
+});
+
 // test to check that package can be reinstalled after manually removing the directory
 forgetest!(can_reinstall_after_manual_remove, |prj, cmd| {
     cmd.git_init();

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -680,6 +680,31 @@ impl TestCommand {
         output
     }
 
+    /// Returns a new [Command] that is inside the current project dir
+    pub fn cmd_in_current_dir(&self, program: &str) -> Command {
+        let mut cmd = Command::new(program);
+        cmd.current_dir(self.project.root());
+        cmd
+    }
+
+    /// Runs `git add .` inside the project's dir
+    #[track_caller]
+    pub fn git_add(&self) -> Result<()> {
+        let mut cmd = self.cmd_in_current_dir("git");
+        cmd.arg("add").arg(".");
+        let output = cmd.output()?;
+        self.ensure_success(&output)
+    }
+
+    /// Runs `git commit .` inside the project's dir
+    #[track_caller]
+    pub fn git_commit(&self, msg: &str) -> Result<()> {
+        let mut cmd = self.cmd_in_current_dir("git");
+        cmd.arg("commit").arg("-m").arg(msg);
+        let output = cmd.output()?;
+        self.ensure_success(&output)
+    }
+
     /// Executes the command and returns the `(stdout, stderr)` of the output as lossy `String`s.
     ///
     /// Expects the command to be successful.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #6519 

## Solution

Check if there are any submodules at all in the repo, and only update if so.