### PR TITLE
chore: skip is verified check for script/create deployments

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -185,7 +185,7 @@ impl CreateArgs {
             },
             flatten: false,
             force: false,
-            skip_is_verified_check: false,
+            skip_is_verified_check: true,
             watch: true,
             retry: self.retry,
             libraries: vec![],

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -103,7 +103,7 @@ impl VerifyBundle {
                     etherscan: self.etherscan.clone(),
                     flatten: false,
                     force: false,
-                    skip_is_verified_check: false,
+                    skip_is_verified_check: true,
                     watch: true,
                     retry: self.retry,
                     libraries: libraries.to_vec(),


### PR DESCRIPTION
per #6426

for script/create we want to skip is verified check (often false positives due to similar bytecode) and always try verification