### PR TITLE
fix(cheatcodes): recorded created account during broadcast

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1102,9 +1102,6 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
     ) -> (InstructionResult, Option<Address>, Gas, Bytes) {
         let gas = Gas::new(call.gas_limit);
 
-        // allow cheatcodes from the address of the new contract
-        let address = self.allow_cheatcodes_on_create(data, call);
-
         // Apply our prank
         if let Some(prank) = &self.prank {
             if data.journaled_state.depth() >= prank.depth && call.caller == prank.prank_caller {
@@ -1171,6 +1168,10 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             }
         }
 
+        // allow cheatcodes from the address of the new contract
+        // Compute the address *after* any possible broadcast updates, so it's based on the updated
+        // call inputs
+        let address = self.allow_cheatcodes_on_create(data, call);
         // If `recordAccountAccesses` has been called, record the create
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             // Record the create context as an account access and create a new vector to record all

--- a/testdata/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/cheats/RecordAccountAccesses.t.sol
@@ -1085,6 +1085,20 @@ contract RecordAccountAccessesTest is DSTest {
         );
     }
 
+    /// @notice Asserts interaction between broadcast and recording cheatcodes
+    function testIssue6514() public {
+        cheats.startStateDiffRecording();
+        cheats.startBroadcast();
+
+        StorageAccessor a = new StorageAccessor();
+
+        cheats.stopBroadcast();
+        Vm.AccountAccess[] memory called = cheats.stopAndReturnStateDiff();
+        assertEq(called.length, 1, "incorrect length");
+        assertEq(toUint(called[0].kind), toUint(Vm.AccountAccessKind.Create));
+        assertEq(called[0].account, address(a));
+    }
+
     function startRecordingFromLowerDepth() external {
         cheats.startStateDiffRecording();
         assembly {


### PR DESCRIPTION
## Motivation

Deployed address is incorrect when broadcasting. Fixes https://github.com/foundry-rs/foundry/issues/6514.

## Solution

The EVM behavior is slightly different when broadcast, `vm.startBroadcast()`, is enabled. During broadcast, the deployer address is set to the configured wallet. Previously, the record access cheatcode would always use the current EVM caller to compute the created address. This patch ensures that the appropriate caller is used.