### PR TITLE
tracing: Improve decoding of functions output

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -1,5 +1,7 @@
 use crate::{
-    identifier::{AddressIdentity, SingleSignaturesIdentifier, TraceIdentifier},
+    identifier::{
+        AddressIdentity, LocalTraceIdentifier, SingleSignaturesIdentifier, TraceIdentifier,
+    },
     CallTrace, CallTraceArena, TraceCallData, TraceLog, TraceRetData,
 };
 use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt};
@@ -62,6 +64,12 @@ impl CallTraceDecoderBuilder {
                 .push(event);
         }
         self
+    }
+
+    #[inline]
+    pub fn with_local_identifier_abis(self, identifier: &LocalTraceIdentifier<'_>) -> Self {
+        self.with_events(identifier.events().cloned())
+            .with_functions(identifier.functions().cloned())
     }
 
     /// Sets the verbosity level of the decoder.

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -42,6 +42,15 @@ impl CallTraceDecoderBuilder {
         self
     }
 
+    /// Add known functions to the decoder.
+    #[inline]
+    pub fn with_functions(mut self, functions: impl IntoIterator<Item = Function>) -> Self {
+        for function in functions {
+            self.decoder.functions.entry(function.selector()).or_default().push(function);
+        }
+        self
+    }
+
     /// Add known events to the decoder.
     #[inline]
     pub fn with_events(mut self, events: impl IntoIterator<Item = Event>) -> Self {

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -1,5 +1,5 @@
 use super::{AddressIdentity, TraceIdentifier};
-use alloy_json_abi::Event;
+use alloy_json_abi::{Event, Function};
 use alloy_primitives::Address;
 use foundry_common::contracts::{diff_score, ContractsByArtifact};
 use ordered_float::OrderedFloat;
@@ -13,6 +13,11 @@ pub struct LocalTraceIdentifier<'a> {
 impl<'a> LocalTraceIdentifier<'a> {
     pub fn new(known_contracts: &'a ContractsByArtifact) -> Self {
         Self { known_contracts }
+    }
+
+    /// Get all the functions of the local contracts.
+    pub fn functions(&self) -> impl Iterator<Item = &Function> {
+        self.known_contracts.iter().flat_map(|(_, (abi, _))| abi.functions())
     }
 
     /// Get all the events of the local contracts.

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -220,6 +220,8 @@ impl ScriptArgs {
         let mut decoder = CallTraceDecoderBuilder::new()
             .with_labels(result.labeled_addresses.clone())
             .with_verbosity(verbosity)
+            .with_events(local_identifier.events().cloned())
+            .with_functions(local_identifier.functions().cloned())
             .with_signature_identifier(SignaturesIdentifier::new(
                 Config::foundry_cache_dir(),
                 script_config.config.offline,

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -220,8 +220,7 @@ impl ScriptArgs {
         let mut decoder = CallTraceDecoderBuilder::new()
             .with_labels(result.labeled_addresses.clone())
             .with_verbosity(verbosity)
-            .with_events(local_identifier.events().cloned())
-            .with_functions(local_identifier.functions().cloned())
+            .with_local_identifier_abis(&local_identifier)
             .with_signature_identifier(SignaturesIdentifier::new(
                 Config::foundry_cache_dir(),
                 script_config.config.offline,

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -242,8 +242,7 @@ impl TestArgs {
                 // Identify addresses in each trace
                 let mut builder = CallTraceDecoderBuilder::new()
                     .with_labels(result.labeled_addresses.clone())
-                    .with_events(local_identifier.events().cloned())
-                    .with_functions(local_identifier.functions().cloned())
+                    .with_local_identifier_abis(&local_identifier)
                     .with_verbosity(verbosity);
 
                 // Signatures are of no value for gas reports
@@ -693,8 +692,7 @@ async fn test(
             // Identify addresses in each trace
             let mut builder = CallTraceDecoderBuilder::new()
                 .with_labels(result.labeled_addresses.iter().map(|(a, s)| (*a, s.clone())))
-                .with_events(local_identifier.events().cloned())
-                .with_functions(local_identifier.functions().cloned())
+                .with_local_identifier_abis(&local_identifier)
                 .with_verbosity(verbosity);
 
             // Signatures are of no value for gas reports

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -243,6 +243,7 @@ impl TestArgs {
                 let mut builder = CallTraceDecoderBuilder::new()
                     .with_labels(result.labeled_addresses.clone())
                     .with_events(local_identifier.events().cloned())
+                    .with_functions(local_identifier.functions().cloned())
                     .with_verbosity(verbosity);
 
                 // Signatures are of no value for gas reports
@@ -693,6 +694,7 @@ async fn test(
             let mut builder = CallTraceDecoderBuilder::new()
                 .with_labels(result.labeled_addresses.iter().map(|(a, s)| (*a, s.clone())))
                 .with_events(local_identifier.events().cloned())
+                .with_functions(local_identifier.functions().cloned())
                 .with_verbosity(verbosity);
 
             // Signatures are of no value for gas reports

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -373,7 +373,7 @@ forgetest_init!(repro_6531, |prj, cmd| {
 
     prj.add_test(
         "Contract.t.sol",
-        &r#"
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 interface IERC20 {

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -386,13 +386,12 @@ contract USDCCallingTest is Test {
         IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48).name();
     }
 }
-   "#
+   "#,
     )
     .unwrap();
 
     cmd.args(["test", "-vvvv"]);
     cmd.unchecked_output().stdout_matches_path(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/repro_6531.stdout"),
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/repro_6531.stdout"),
     )
 });

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -1,12 +1,12 @@
-Compiling 1 files
+Compiling 1 files with 0.8.23
  
 Compiler run successful!
 
 Running 1 test for test/Contract.t.sol:USDCCallingTest
-[PASS] test() (gas: 16769)
+[PASS] test() (gas: 16799)
 Traces:
-  [16769] USDCCallingTest::test()
-    ├─ [0] VM::createSelectFork("mainnet")
+  [16799] USDCCallingTest::test()
+    ├─ [0] VM::createSelectFork("<url>")
     │   └─ ← 0
     ├─ [10350] 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48::name() [staticcall]
     │   ├─ [3061] 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF::name() [delegatecall]

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -1,0 +1,19 @@
+Compiling 1 files
+ 
+Compiler run successful!
+
+Running 1 test for test/Contract.t.sol:USDCCallingTest
+[PASS] test() (gas: 16769)
+Traces:
+  [16769] USDCCallingTest::test()
+    ├─ [0] VM::createSelectFork("mainnet")
+    │   └─ ← 0
+    ├─ [10350] 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48::name() [staticcall]
+    │   ├─ [3061] 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF::name() [delegatecall]
+    │   │   └─ ← "USD Coin"
+    │   └─ ← "USD Coin"
+    └─ ← ()
+
+Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.43s
+ 
+Ran 1 test suites: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -898,6 +898,9 @@ stderr:
 /// terminal is tty, the path argument can be wrapped in [tty_fixture_path()]
 pub trait OutputExt {
     /// Ensure the command wrote the expected data to `stdout`.
+    fn stdout_matches_content(&self, expected: &str);
+
+    /// Ensure the command wrote the expected data to `stdout`.
     fn stdout_matches_path(&self, expected_path: impl AsRef<Path>);
 
     /// Ensure the command wrote the expected data to `stderr`.
@@ -932,10 +935,15 @@ fn normalize_output(s: &str) -> String {
 
 impl OutputExt for Output {
     #[track_caller]
+    fn stdout_matches_content(&self, expected: &str) {
+        let out = lossy_string(&self.stdout);
+        pretty_assertions::assert_eq!(normalize_output(&out), normalize_output(expected));
+    }
+
+    #[track_caller]
     fn stdout_matches_path(&self, expected_path: impl AsRef<Path>) {
         let expected = fs::read_to_string(expected_path).unwrap();
-        let out = lossy_string(&self.stdout);
-        pretty_assertions::assert_eq!(normalize_output(&out), normalize_output(&expected));
+        self.stdout_matches_content(&expected);
     }
 
     #[track_caller]


### PR DESCRIPTION
## Motivation

Currently, while decoding result of function execution in traces, the following is done:
1. If function appears in ABIs of some contract seen during execution and identified by it's bytecode, ABI is taken from this contract bytecode.
2. Otherwise, ABI is fetched from openchain.xyz

This works fine for decoding inputs, however, openchain.xyz does not (and can not) tell anything about output types of a function.

Due to this, outputs for any calls to external contract accessed by an interface in forked environment are not decoded at the moment.

An example of this behavior is following test:
```solidity
pragma solidity 0.8.20;

import {Test} from "forge-std/Test.sol";

interface IERC20 {
    function balanceOf(address) external view returns (uint256);
}

contract TestTracing is Test {
    function test() public {
        vm.createSelectFork("mainnet");

        IERC20 usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
        usdc.balanceOf(address(0));
    }
}
```

Traces for it will look like this:
```
  [15795] TestTracing::test()
    ├─ [0] VM::createSelectFork("mainnet")
    │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    ├─ [9815] 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48::balanceOf(0x0000000000000000000000000000000000000000) [staticcall]
    │   ├─ [2529] 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF::balanceOf(0x0000000000000000000000000000000000000000) [delegatecall]
    │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    └─ ← ()
```
However, it should be decoded into this:
```
  [15795] TestTracing::test()
    ├─ [0] VM::createSelectFork("mainnet")
    │   └─ ← 0
    ├─ [9815] 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48::balanceOf(0x0000000000000000000000000000000000000000) [staticcall]
    │   ├─ [2529] 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF::balanceOf(0x0000000000000000000000000000000000000000) [delegatecall]
    │   │   └─ ← 0
    │   └─ ← 0
    └─ ← ()
```

And this gets much uglier when working with contracts returning tuples/addresses/bytes
## Solution

There is already `with_events` function which is used for importing events from known contracts when constructing a `CallTraceDecoder`, so I've just added similar logic for functions as well
https://github.com/foundry-rs/foundry/blob/fdad9fb0dde45d3476fc5d1fe6f40e8dc7c17caa/crates/forge/bin/cmd/test/mod.rs#L692-L695
