### PR TITLE
fix: don't reinitialize created accounts

### DIFF
--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -43,7 +43,8 @@ async fn repro_config(issue: usize, should_fail: bool, sender: Option<Address>) 
     let filter = Filter::path(&format!(".*repros/Issue{issue}.t.sol"));
 
     let mut config = Config::with_root(PROJECT.root());
-    config.fs_permissions = FsPermissions::new(vec![PathPermission::read("./fixtures")]);
+    config.fs_permissions =
+        FsPermissions::new(vec![PathPermission::read("./fixtures"), PathPermission::read("out")]);
     if let Some(sender) = sender {
         config.sender = sender;
     }
@@ -189,6 +190,9 @@ test_repro!(5948);
 
 // https://github.com/foundry-rs/foundry/issues/6006
 test_repro!(6006);
+
+// https://github.com/foundry-rs/foundry/issues/6032
+test_repro!(6032);
 
 // https://github.com/foundry-rs/foundry/issues/6070
 test_repro!(6070);

--- a/testdata/repros/Issue6032.t.sol
+++ b/testdata/repros/Issue6032.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6032
+contract Issue6032Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testEtchFork() public {
+        // Deploy initial contract
+        Counter counter = new Counter();
+        counter.setNumber(42);
+
+        address counterAddress = address(counter);
+        // Enter the fork
+        vm.createSelectFork("rpcAlias");
+        assert(counterAddress.code.length > 0);
+        // `Counter` is not deployed on the fork, which is expected.
+
+        // Etch the contract into the fork.
+        bytes memory code = vm.getDeployedCode("Issue6032.t.sol:CounterEtched");
+        vm.etch(counterAddress, code);
+        //  `Counter` is now deployed on the fork.
+        assert(counterAddress.code.length > 0);
+
+        // Now we can etch the code, but state will remain.
+        CounterEtched counterEtched = CounterEtched(counterAddress);
+        assertEq(counterEtched.numberHalf(), 21);
+    }
+}
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+}
+
+contract CounterEtched {
+    uint256 public number;
+
+    function numberHalf() public view returns (uint256) {
+        return number / 2;
+    }
+}


### PR DESCRIPTION
Closes #6032

There was an edge case where the initialization function incorrectly replaced the AccountInfo of created accounts with the account info fetched from the fork.

The reason this function exists, is so we can reinitialize accounts that were touched before a fork was active with the account info of the fork. This is required so that the fork can use real accounts even if the account has been loaded previously. for example a getNonce check.

However, newly created accounts should be exempt from this check.