### PR TITLE
feat: add additional snapshot cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -999,6 +999,46 @@
     },
     {
       "func": {
+        "id": "deleteSnapshot",
+        "description": "Removes the snapshot with the given ID created by `snapshot`.\nTakes the snapshot ID to delete.\nReturns `true` if the snapshot was successfully deleted.\nReturns `false` if the snapshot does not exist.",
+        "declaration": "function deleteSnapshot(uint256 snapshotId) external returns (bool success);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deleteSnapshot(uint256)",
+        "selector": "0xa6368557",
+        "selectorBytes": [
+          166,
+          54,
+          133,
+          87
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "deleteSnapshots",
+        "description": "Removes _all_ snapshots previously created by `snapshot`.",
+        "declaration": "function deleteSnapshots() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "deleteSnapshots()",
+        "selector": "0x421ae469",
+        "selectorBytes": [
+          66,
+          26,
+          228,
+          105
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "deriveKey_0",
         "description": "Derive a private key from a provided mnenomic string (or mnenomic file path)\nat the derivation path `m/44'/60'/0'/0/{index}`.",
         "declaration": "function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);",
@@ -3460,7 +3500,7 @@
     {
       "func": {
         "id": "revertTo",
-        "description": "Revert the state of the EVM to a previous snapshot\nTakes the snapshot ID to revert to.\nThis deletes the snapshot and all snapshots taken after the given snapshot ID.",
+        "description": "Revert the state of the EVM to a previous snapshot\nTakes the snapshot ID to revert to.\nReturns `true` if the snapshot was successfully reverted.\nReturns `false` if the snapshot does not exist.\n**Note:** This does not automatically delete the snapshot. To delete the snapshot use `deleteSnapshot`.",
         "declaration": "function revertTo(uint256 snapshotId) external returns (bool success);",
         "visibility": "external",
         "mutability": "",
@@ -3471,6 +3511,26 @@
           215,
           240,
           164
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "revertToAndDelete",
+        "description": "Revert the state of the EVM to a previous snapshot and automatically deletes the snapshots\nTakes the snapshot ID to revert to.\nReturns `true` if the snapshot was successfully reverted and deleted.\nReturns `false` if the snapshot does not exist.",
+        "declaration": "function revertToAndDelete(uint256 snapshotId) external returns (bool success);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "revertToAndDelete(uint256)",
+        "selector": "0x03e0aca9",
+        "selectorBytes": [
+          3,
+          224,
+          172,
+          169
         ]
       },
       "group": "evm",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -412,17 +412,26 @@ interface Vm {
     /// Revert the state of the EVM to a previous snapshot
     /// Takes the snapshot ID to revert to.
     ///
+    /// Returns `true` if the snapshot was successfully reverted.
+    /// Returns `false` if the snapshot does not exist.
+    ///
     /// **Note:** This does not automatically delete the snapshot. To delete the snapshot use `deleteSnapshot`.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function revertTo(uint256 snapshotId) external returns (bool success);
 
     /// Revert the state of the EVM to a previous snapshot and automatically deletes the snapshots
     /// Takes the snapshot ID to revert to.
+    ///
+    /// Returns `true` if the snapshot was successfully reverted and deleted.
+    /// Returns `false` if the snapshot does not exist.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function revertToAndDelete(uint256 snapshotId) external returns (bool success);
 
     /// Removes the snapshot with the given ID created by `snapshot`.
     /// Takes the snapshot ID to delete.
+    ///
+    /// Returns `true` if the snapshot was successfully deleted.
+    /// Returns `false` if the snapshot does not exist.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function deleteSnapshot(uint256 snapshotId) external returns (bool success);
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -411,9 +411,24 @@ interface Vm {
 
     /// Revert the state of the EVM to a previous snapshot
     /// Takes the snapshot ID to revert to.
-    /// This deletes the snapshot and all snapshots taken after the given snapshot ID.
+    ///
+    /// **Note:** This does not automatically delete the snapshot. To delete the snapshot use `deleteSnapshot`.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function revertTo(uint256 snapshotId) external returns (bool success);
+
+    /// Revert the state of the EVM to a previous snapshot and automatically deletes the snapshots
+    /// Takes the snapshot ID to revert to.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function revertToAndDelete(uint256 snapshotId) external returns (bool success);
+
+    /// Removes the snapshot with the given ID created by `snapshot`.
+    /// Takes the snapshot ID to delete.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function deleteSnapshot(uint256 snapshotId) external returns (bool success);
+
+    /// Removes _all_ snapshots previously created by `snapshot`.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function deleteSnapshots() external;
 
     // -------- Forking --------
     // --- Creation and Selection ---

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -6,7 +6,7 @@ use alloy_sol_types::SolValue;
 use ethers_core::utils::{Genesis, GenesisAccount};
 use ethers_signers::Signer;
 use foundry_common::{fs::read_json_file, types::ToAlloy};
-use foundry_evm_core::backend::DatabaseExt;
+use foundry_evm_core::backend::{DatabaseExt, RevertSnapshotAction};
 use revm::{
     primitives::{Account, Bytecode, SpecId, KECCAK_EMPTY},
     EVMData,
@@ -327,9 +327,12 @@ impl Cheatcode for snapshotCall {
 impl Cheatcode for revertToCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { snapshotId } = self;
-        let result = if let Some(journaled_state) =
-            ccx.data.db.revert(*snapshotId, &ccx.data.journaled_state, ccx.data.env)
-        {
+        let result = if let Some(journaled_state) = ccx.data.db.revert(
+            *snapshotId,
+            &ccx.data.journaled_state,
+            ccx.data.env,
+            RevertSnapshotAction::RevertKeep,
+        ) {
             // we reset the evm's journaled_state to the state of the snapshot previous state
             ccx.data.journaled_state = journaled_state;
             true
@@ -337,6 +340,40 @@ impl Cheatcode for revertToCall {
             false
         };
         Ok(result.abi_encode())
+    }
+}
+
+impl Cheatcode for revertToAndDeleteCall {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { snapshotId } = self;
+        let result = if let Some(journaled_state) = ccx.data.db.revert(
+            *snapshotId,
+            &ccx.data.journaled_state,
+            ccx.data.env,
+            RevertSnapshotAction::RevertRemove,
+        ) {
+            // we reset the evm's journaled_state to the state of the snapshot previous state
+            ccx.data.journaled_state = journaled_state;
+            true
+        } else {
+            false
+        };
+        Ok(result.abi_encode())
+    }
+}
+
+impl Cheatcode for deleteSnapshotCall {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { snapshotId } = self;
+        let result = ccx.data.db.delete_snapshot(*snapshotId);
+        Ok(result.abi_encode())
+    }
+}
+impl Cheatcode for deleteSnapshotsCall {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self {} = self;
+        ccx.data.db.delete_snapshots();
+        Ok(Default::default())
     }
 }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -82,13 +82,25 @@ pub trait DatabaseExt: Database<Error = DatabaseError> {
     /// since the snapshots was created. This way we can show logs that were emitted between
     /// snapshot and its revert.
     /// This will also revert any changes in the `Env` and replace it with the captured `Env` of
-    /// `Self::snapshot`
+    /// `Self::snapshot`.
+    ///
+    /// Depending on [RevertSnapshotAction] it will keep the snapshot alive or delete it.
     fn revert(
         &mut self,
         id: U256,
         journaled_state: &JournaledState,
         env: &mut Env,
+        action: RevertSnapshotAction,
     ) -> Option<JournaledState>;
+
+    /// Deletes the snapshot with the given `id`
+    ///
+    /// Returns `true` if the snapshot was successfully deleted, `false` if no snapshot for that id
+    /// exists.
+    fn delete_snapshot(&mut self, id: U256) -> bool;
+
+    /// Deletes all snapshots.
+    fn delete_snapshots(&mut self);
 
     /// Creates and also selects a new fork
     ///
@@ -918,11 +930,14 @@ impl DatabaseExt for Backend {
         id: U256,
         current_state: &JournaledState,
         current: &mut Env,
+        action: RevertSnapshotAction,
     ) -> Option<JournaledState> {
         trace!(?id, "revert snapshot");
         if let Some(mut snapshot) = self.inner.snapshots.remove_at(id) {
             // Re-insert snapshot to persist it
-            self.inner.snapshots.insert_at(snapshot.clone(), id);
+            if action.is_keep() {
+                self.inner.snapshots.insert_at(snapshot.clone(), id);
+            }
             // need to check whether there's a global failure which means an error occurred either
             // during the snapshot or even before
             if self.is_global_failure(current_state) {
@@ -967,6 +982,14 @@ impl DatabaseExt for Backend {
             warn!(target: "backend", "No snapshot to revert for {}", id);
             None
         }
+    }
+
+    fn delete_snapshot(&mut self, id: U256) -> bool {
+        self.inner.snapshots.remove_at(id).is_some()
+    }
+
+    fn delete_snapshots(&mut self) {
+        self.inner.snapshots.clear()
     }
 
     fn create_fork(&mut self, mut create_fork: CreateFork) -> eyre::Result<LocalForkId> {

--- a/crates/evm/core/src/snapshot.rs
+++ b/crates/evm/core/src/snapshot.rs
@@ -39,6 +39,11 @@ impl<T> Snapshots<T> {
         snapshot
     }
 
+    /// Removes all snapshots
+    pub fn clear(&mut self) {
+        self.snapshots.clear();
+    }
+
     /// Removes the snapshot with the given `id`.
     ///
     /// Does not remove snapshots after it.

--- a/testdata/cheats/Snapshots.t.sol
+++ b/testdata/cheats/Snapshots.t.sol
@@ -32,6 +32,53 @@ contract SnapshotTest is DSTest {
         assertEq(store.slot1, 20, "snapshot revert for slot 1 unsuccessful");
     }
 
+    function testSnapshotRevertDelete() public {
+        uint256 snapshot = vm.snapshot();
+        store.slot0 = 300;
+        store.slot1 = 400;
+
+        assertEq(store.slot0, 300);
+        assertEq(store.slot1, 400);
+
+        vm.revertToAndDelete(snapshot);
+        assertEq(store.slot0, 10, "snapshot revert for slot 0 unsuccessful");
+        assertEq(store.slot1, 20, "snapshot revert for slot 1 unsuccessful");
+        // nothing to revert to anymore
+        assert(!vm.revertTo(snapshot));
+    }
+
+    function testSnapshotDelete() public {
+        uint256 snapshot = vm.snapshot();
+        store.slot0 = 300;
+        store.slot1 = 400;
+
+        vm.deleteSnapshot(snapshot);
+        // nothing to revert to anymore
+        assert(!vm.revertTo(snapshot));
+    }
+
+    function testSnapshotDeleteAll() public {
+        uint256 snapshot = vm.snapshot();
+        store.slot0 = 300;
+        store.slot1 = 400;
+
+        vm.deleteSnapshots();
+        // nothing to revert to anymore
+        assert(!vm.revertTo(snapshot));
+    }
+
+    // <https://github.com/foundry-rs/foundry/issues/6411>
+    function testSnapshotsMany() public {
+        uint256 preState;
+        for (uint256 c = 0; c < 10; c++) {
+            for (uint256 cc = 0; cc < 10; cc++) {
+                preState = vm.snapshot();
+                vm.revertToAndDelete(preState);
+                assert(!vm.revertTo(preState));
+            }
+        }
+    }
+
     // tests that snapshots can also revert changes to `block`
     function testBlockValues() public {
         uint256 num = block.number;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -48,7 +48,7 @@ interface Vm {
     function createWallet(uint256 privateKey) external returns (Wallet memory wallet);
     function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);
     function deal(address account, uint256 newBalance) external;
-    function deleteSnapshot(uint256 snapshot) external returns (bool);
+    function deleteSnapshot(uint256 snapshotId) external returns (bool success);
     function deleteSnapshots() external;
     function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256 privateKey);

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -48,6 +48,8 @@ interface Vm {
     function createWallet(uint256 privateKey) external returns (Wallet memory wallet);
     function createWallet(uint256 privateKey, string calldata walletLabel) external returns (Wallet memory wallet);
     function deal(address account, uint256 newBalance) external;
+    function deleteSnapshot(uint256 snapshot) external returns (bool);
+    function deleteSnapshots() external;
     function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256 privateKey);
     function deriveKey(string calldata mnemonic, uint32 index, string calldata language) external pure returns (uint256 privateKey);
@@ -172,6 +174,7 @@ interface Vm {
     function resetNonce(address account) external;
     function resumeGasMetering() external;
     function revertTo(uint256 snapshotId) external returns (bool success);
+    function revertToAndDelete(uint256 snapshotId) external returns (bool success);
     function revokePersistent(address account) external;
     function revokePersistent(address[] calldata accounts) external;
     function roll(uint256 newHeight) external;


### PR DESCRIPTION
ref #6411

since we're persisting snapshots on `revertTo` we have unbounded memory growth.
We want to keep them for convenience, so we need additional cheatcodes to handle cleanup:

* revertToAndDelete (I picked this one over overloading `revertTo`, not sure what would be the best UX, but we could add an overloaded function as well (id, bool))
* deleteSnapshot
* deleteSnapshots

FYI @maa105 @karlb 