### PR TITLE
fix(cheatcodes): env error formatting

### DIFF
--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -271,7 +271,10 @@ fn map_env_err<'a>(key: &'a str, value: &'a str) -> impl FnOnce(Error) -> Error 
         // <value>
         //   ^
         //   expected at least one digit
-        Error::from(e.to_string().replace(value, &format!("${key}")))
+        let mut e = e.to_string();
+        e = e.replacen(&format!("\"{value}\""), &format!("${key}"), 1);
+        e = e.replacen(&format!("\n{value}\n"), &format!("\n${key}\n"), 1);
+        Error::from(e)
     }
 }
 
@@ -282,11 +285,10 @@ mod tests {
     #[test]
     fn parse_env_uint() {
         let key = "parse_env_uint";
-        let value = "123xyz";
+        let value = "t";
         env::set_var(key, value);
 
         let err = env(key, &DynSolType::Uint(256)).unwrap_err().to_string();
-        assert!(!err.contains(value));
         assert_eq!(err.matches("$parse_env_uint").count(), 2, "{err:?}");
         env::remove_var(key);
     }

--- a/testdata/repros/Issue6070.t.sol
+++ b/testdata/repros/Issue6070.t.sol
@@ -11,7 +11,7 @@ contract Issue6066Test is DSTest {
     function testNonPrefixed() public {
         vm.setEnv("__FOUNDRY_ISSUE_6066", "abcd");
         vm.expectRevert(
-            "failed parsing \"$__FOUNDRY_ISSUE_6066\" as type `uint256`: missing hex prefix (\"0x\") for hex string"
+            "failed parsing $__FOUNDRY_ISSUE_6066 as type `uint256`: missing hex prefix (\"0x\") for hex string"
         );
         uint256 x = vm.envUint("__FOUNDRY_ISSUE_6066");
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Small env values could make it ugly

https://github.com/foundry-rs/foundry/pull/6555 followup

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
