### PR TITLE
feat: support overlapping permissions

### DIFF
--- a/crates/config/src/fs_permissions.rs
+++ b/crates/config/src/fs_permissions.rs
@@ -51,7 +51,6 @@ impl FsPermissions {
     ///
     /// And we check for `./out/contracts/MyContract.sol` we will get `read-write` as permission.
     pub fn find_permission(&self, path: &Path) -> Option<FsAccessPermission> {
-        // self.permissions.iter().find(|perm| path.starts_with(&perm.path)).map(|perm| perm.access)
         let mut permission: Option<&PathPermission> = None;
         for perm in &self.permissions {
             if path.starts_with(&perm.path) {

--- a/testdata/repros/Issue6554.t.sol
+++ b/testdata/repros/Issue6554.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6554
+contract Issue6554Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testPermissions() public {
+        vm.writeFile("./out/Issue6554.t.sol/cachedFile.txt", "cached data");
+        string memory content = vm.readFile("./out/Issue6554.t.sol/cachedFile.txt");
+        assertEq(content, "cached data");
+    }
+}


### PR DESCRIPTION
Closes #6554

make permission checking more granular.
allows adding deviating rules for sub-folders.

before we found the first matching permission.
now this finds the deepest matching permission.

For example, for path "./cache/file.txt" with

```
fs_permissions = [{ access = "read", path = "./"}, { access = "write", path = "./cache"}]
```

this will use `{ access = "write", path = "./cache"}`
