### PR TITLE
Bytecode level coverage reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,6 +2528,7 @@ dependencies = [
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
+ "evm-disassembler",
  "eyre",
  "forge-doc",
  "forge-fmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+evm-disassembler = "0.3"
 
 axum = "0.6"
 hyper = "0.14"

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -34,7 +34,7 @@ ethers-core.workspace = true
 ethers-providers.workspace = true
 
 chrono.workspace = true
-evm-disassembler = "0.3"
+evm-disassembler.workspace = true
 eyre.workspace = true
 futures = "0.3"
 hex.workspace = true

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     ops::{AddAssign, Deref, DerefMut},
 };
 
-use eyre::{Result, Context};
+use eyre::{Context, Result};
 
 pub mod analysis;
 pub mod anchors;
@@ -57,9 +57,11 @@ impl CoverageReport {
     }
 
     /// Add the source maps
-    pub fn add_source_maps(&mut self, source_maps: HashMap<ContractId, (Vec<SourceElement>, Vec<SourceElement>)>) {
+    pub fn add_source_maps(
+        &mut self,
+        source_maps: HashMap<ContractId, (Vec<SourceElement>, Vec<SourceElement>)>,
+    ) {
         self.source_maps.extend(source_maps);
-
     }
 
     /// Add coverage items to this report
@@ -124,13 +126,13 @@ impl CoverageReport {
     /// added to the map (see [add_source]).
     pub fn add_hit_map(&mut self, contract_id: &ContractId, hit_map: &HitMap) -> Result<()> {
         // Add bytecode level hits
-        let e = self.bytecode_hits
+        let e = self
+            .bytecode_hits
             .entry(contract_id.clone())
-            .or_insert_with( || HitMap::new(hit_map.bytecode.clone()));
-        e.merge(hit_map)
-        .context(format!(
+            .or_insert_with(|| HitMap::new(hit_map.bytecode.clone()));
+        e.merge(hit_map).context(format!(
             "contract_id {:?}, hash {}, hash {}",
-            contract_id, 
+            contract_id,
             e.bytecode.clone(),
             hit_map.bytecode.clone(),
         ))?;
@@ -203,13 +205,13 @@ impl HitMap {
     }
 
     /// Merge another hitmap into this, assuming the bytecode is consistent
-    pub fn merge(&mut self, other: &HitMap) -> Result<(),eyre::Report> {
+    pub fn merge(&mut self, other: &HitMap) -> Result<(), eyre::Report> {
         // why does this check fail for some codebases ?
         //
         // if !self.consistent_bytecode(self, other) {
         //     return Err(eyre::eyre!("can't merge hits for inconsistent bytecode".to_owned()));
         // }
-        for (pc,hits) in &other.hits {
+        for (pc, hits) in &other.hits {
             *self.hits.entry(*pc).or_default() += hits;
         }
         Ok(())
@@ -220,7 +222,7 @@ impl HitMap {
         // recorded hits
         let len1 = hm1.hits.last_key_value();
         let len2 = hm2.hits.last_key_value();
-        if let (Some(len1), Some(len2)) = (len1,len2) {
+        if let (Some(len1), Some(len2)) = (len1, len2) {
             let len = std::cmp::max(len1.0, len2.0);
             let ok = hm1.bytecode.0[..*len] == hm2.bytecode.0[..*len];
             println!("consistent_bytecode: {}, {}, {}, {}", ok, len1.0, len2.0, len);
@@ -228,7 +230,6 @@ impl HitMap {
         }
         true
     }
-
 }
 
 /// A unique identifier for a contract

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -58,7 +58,7 @@ impl CoverageReport {
 
     /// Add the source maps
     pub fn add_source_maps(&mut self, source_maps: HashMap<ContractId, (Vec<SourceElement>, Vec<SourceElement>)>) {
-        self.source_maps.extend(source_maps.into_iter());
+        self.source_maps.extend(source_maps);
 
     }
 
@@ -127,7 +127,7 @@ impl CoverageReport {
         let e = self.bytecode_hits
             .entry(contract_id.clone())
             .or_insert_with( || HitMap::new(hit_map.bytecode.clone()));
-        e.merge(&hit_map)
+        e.merge(hit_map)
         .context(format!(
             "contract_id {:?}, hash {}, hash {}",
             contract_id, 
@@ -226,7 +226,7 @@ impl HitMap {
             println!("consistent_bytecode: {}, {}, {}, {}", ok, len1.0, len2.0, len);
             return ok;
         }
-        return true;
+        true
     }
 
 }

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -206,11 +206,6 @@ impl HitMap {
 
     /// Merge another hitmap into this, assuming the bytecode is consistent
     pub fn merge(&mut self, other: &HitMap) -> Result<(), eyre::Report> {
-        // why does this check fail for some codebases ?
-        //
-        // if !self.consistent_bytecode(self, other) {
-        //     return Err(eyre::eyre!("can't merge hits for inconsistent bytecode".to_owned()));
-        // }
         for (pc, hits) in &other.hits {
             *self.hits.entry(*pc).or_default() += hits;
         }

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate tracing;
 
 use alloy_primitives::{Bytes, B256};
+use foundry_compilers::sourcemap::SourceElement;
 use semver::Version;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -39,6 +40,8 @@ pub struct CoverageReport {
     pub anchors: HashMap<ContractId, Vec<ItemAnchor>>,
     /// All the bytecode hits for the codebase
     pub bytecode_hits: HashMap<ContractId, HitMap>,
+    /// The bytecode -> source mappings
+    pub source_maps: HashMap<ContractId, (Vec<SourceElement>, Vec<SourceElement>)>,
 }
 
 impl CoverageReport {
@@ -51,6 +54,12 @@ impl CoverageReport {
     /// Get the source ID for a specific source file path.
     pub fn get_source_id(&self, version: Version, path: String) -> Option<&usize> {
         self.source_paths_to_ids.get(&(version, path))
+    }
+
+    /// Add the source maps
+    pub fn add_source_maps(&mut self, source_maps: HashMap<ContractId, (Vec<SourceElement>, Vec<SourceElement>)>) {
+        self.source_maps.extend(source_maps.into_iter());
+
     }
 
     /// Add coverage items to this report

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -71,6 +71,7 @@ strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }
 watchexec = "2.3.2"
+evm-disassembler.workspace = true
 
 # doc server
 axum = { workspace = true, features = ["ws"] }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -161,6 +161,8 @@ impl CoverageArgs {
         let mut versioned_asts: HashMap<Version, HashMap<usize, Ast>> = HashMap::new();
         let mut versioned_sources: HashMap<Version, HashMap<usize, String>> = HashMap::new();
         for (path, mut source_file, version) in sources.into_sources_with_version() {
+            report.add_source(version.clone(), source_file.id as usize, path.clone());
+            
             // Filter out dependencies
             if project_paths.has_library_ancestor(std::path::Path::new(&path)) {
                 continue
@@ -180,7 +182,6 @@ impl CoverageArgs {
                     fs::read_to_string(&file)
                         .wrap_err("Could not read source code for analysis")?,
                 );
-                report.add_source(version, source_file.id as usize, path);
             }
         }
 
@@ -278,6 +279,8 @@ impl CoverageArgs {
             report.add_items(version, source_analysis.items);
             report.add_anchors(anchors);
         }
+
+        report.add_source_maps(source_maps);
 
         Ok(report)
     }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -368,7 +368,7 @@ impl CoverageArgs {
                 CoverageReportKind::Bytecode => {
                     let destdir = root.join("bytecode-coverage");
                     fs::create_dir_all(&destdir)?;
-                    BytecodeReporter::new(destdir).report(&report)?;
+                    BytecodeReporter::new(root.clone(), destdir).report(&report)?;
                     Ok(())
                 },
                 CoverageReportKind::Debug => DebugReporter.report(&report),

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -4,8 +4,8 @@ use clap::{Parser, ValueEnum, ValueHint};
 use eyre::{Context, Result};
 use forge::{
     coverage::{
-        analysis::SourceAnalyzer, anchors::find_anchors, ContractId, CoverageReport,
-        CoverageReporter, DebugReporter, ItemAnchor, LcovReporter, SummaryReporter, BytecodeReporter,
+        analysis::SourceAnalyzer, anchors::find_anchors, BytecodeReporter, ContractId,
+        CoverageReport, CoverageReporter, DebugReporter, ItemAnchor, LcovReporter, SummaryReporter,
     },
     inspectors::CheatsConfig,
     opts::EvmOpts,
@@ -162,7 +162,7 @@ impl CoverageArgs {
         let mut versioned_sources: HashMap<Version, HashMap<usize, String>> = HashMap::new();
         for (path, mut source_file, version) in sources.into_sources_with_version() {
             report.add_source(version.clone(), source_file.id as usize, path.clone());
-            
+
             // Filter out dependencies
             if project_paths.has_library_ancestor(std::path::Path::new(&path)) {
                 continue
@@ -370,7 +370,7 @@ impl CoverageArgs {
                     fs::create_dir_all(&destdir)?;
                     BytecodeReporter::new(root.clone(), destdir).report(&report)?;
                     Ok(())
-                },
+                }
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;
         }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -5,7 +5,7 @@ use eyre::{Context, Result};
 use forge::{
     coverage::{
         analysis::SourceAnalyzer, anchors::find_anchors, ContractId, CoverageReport,
-        CoverageReporter, DebugReporter, ItemAnchor, LcovReporter, SummaryReporter,
+        CoverageReporter, DebugReporter, ItemAnchor, LcovReporter, SummaryReporter, BytecodeReporter,
     },
     inspectors::CheatsConfig,
     opts::EvmOpts,
@@ -337,7 +337,7 @@ impl CoverageArgs {
                         contract_name: artifact_id.name.clone(),
                     },
                     &hits,
-                );
+                )?;
             }
         }
 
@@ -362,6 +362,12 @@ impl CoverageArgs {
                             .report(&report)
                     }
                 }
+                CoverageReportKind::Bytecode => {
+                    let destdir = root.join("bytecode-coverage");
+                    fs::create_dir_all(&destdir)?;
+                    BytecodeReporter::new(destdir).report(&report)?;
+                    Ok(())
+                },
                 CoverageReportKind::Debug => DebugReporter.report(&report),
             }?;
         }
@@ -380,6 +386,7 @@ pub enum CoverageReportKind {
     Summary,
     Lcov,
     Debug,
+    Bytecode,
 }
 
 /// Helper function that will link references in unlinked bytecode to the 0 address.

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -183,7 +183,7 @@ impl BytecodeReporter {
     }
 }
 
-impl<'a> CoverageReporter for BytecodeReporter {
+impl CoverageReporter for BytecodeReporter {
     fn report(self, report: &CoverageReport) -> eyre::Result<()> {
         use std::fmt::Write;
         let no_source_elements = Vec::new();
@@ -211,8 +211,8 @@ impl<'a> CoverageReporter for BytecodeReporter {
                 let end = source_element.offset + source_element.length;
 
                 if let Some(source_path) = source_path {
-                    let (sline,spos) =  line_number_cache.get_position(&source_path, start)?;
-                    let (eline,epos) =  line_number_cache.get_position(&source_path, end)?;
+                    let (sline,spos) =  line_number_cache.get_position(source_path, start)?;
+                    let (eline,epos) =  line_number_cache.get_position(source_path, end)?;
                     writeln!(formatted, "{} {:40} // {}: {}:{}-{}:{} ({}-{})", hits, code, source_path,sline, spos, eline, epos, start, end )?;
                 } else if let Some(source_id) = source_id {
                     writeln!(formatted, "{} {:40} // SRCID{}: ({}-{})", hits, code, source_id, start, end )?;

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -2,10 +2,10 @@
 
 use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Row, Table};
 use evm_disassembler::disassemble_bytes;
+use foundry_common::fs;
 pub use foundry_evm::coverage::*;
 use std::{
     collections::{hash_map, HashMap},
-    fs,
     io::Write,
     path::PathBuf,
 };
@@ -191,6 +191,7 @@ impl BytecodeReporter {
 impl CoverageReporter for BytecodeReporter {
     fn report(self, report: &CoverageReport) -> eyre::Result<()> {
         use std::fmt::Write;
+
         let no_source_elements = Vec::new();
         let mut line_number_cache = LineNumberCache::new(self.root.clone());
 
@@ -244,7 +245,7 @@ impl CoverageReporter for BytecodeReporter {
     }
 }
 
-// Cache line number offsets for source files
+/// Cache line number offsets for source files
 struct LineNumberCache {
     root: PathBuf,
     line_offsets: HashMap<String, Vec<usize>>,

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -1,9 +1,14 @@
 //! Coverage reports.
 
 use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Row, Table};
+use evm_disassembler::disassemble_bytes;
 pub use foundry_evm::coverage::*;
-use evm_disassembler::{disassemble_bytes};
-use std::{io::Write, path::PathBuf, fs, collections::{hash_map, HashMap}};
+use std::{
+    collections::{hash_map, HashMap},
+    fs,
+    io::Write,
+    path::PathBuf,
+};
 
 /// A coverage reporter.
 pub trait CoverageReporter {
@@ -192,35 +197,47 @@ impl CoverageReporter for BytecodeReporter {
         for (contract_id, hits) in &report.bytecode_hits {
             let ops = disassemble_bytes(hits.bytecode.to_vec())?;
             let mut formatted = String::new();
-            
-            let source_elements = report.source_maps.get(contract_id)
-                .map(|sm| &sm.1)
-                .unwrap_or(&no_source_elements);
+
+            let source_elements =
+                report.source_maps.get(contract_id).map(|sm| &sm.1).unwrap_or(&no_source_elements);
 
             for (code, source_element) in std::iter::zip(ops.iter(), source_elements) {
-                let hits = hits.hits.get(&(code.offset as usize))
+                let hits = hits
+                    .hits
+                    .get(&(code.offset as usize))
                     .map(|h| format!("[{:03}]", h))
                     .unwrap_or("     ".to_owned());
                 let source_id = source_element.index;
-                let source_path = source_id.and_then(|i|
+                let source_path = source_id.and_then(|i| {
                     report.source_paths.get(&(contract_id.version.clone(), i as usize))
-                );
+                });
 
                 let code = format!("{:?}", code);
                 let start = source_element.offset;
                 let end = source_element.offset + source_element.length;
 
                 if let Some(source_path) = source_path {
-                    let (sline,spos) =  line_number_cache.get_position(source_path, start)?;
-                    let (eline,epos) =  line_number_cache.get_position(source_path, end)?;
-                    writeln!(formatted, "{} {:40} // {}: {}:{}-{}:{} ({}-{})", hits, code, source_path,sline, spos, eline, epos, start, end )?;
+                    let (sline, spos) = line_number_cache.get_position(source_path, start)?;
+                    let (eline, epos) = line_number_cache.get_position(source_path, end)?;
+                    writeln!(
+                        formatted,
+                        "{} {:40} // {}: {}:{}-{}:{} ({}-{})",
+                        hits, code, source_path, sline, spos, eline, epos, start, end
+                    )?;
                 } else if let Some(source_id) = source_id {
-                    writeln!(formatted, "{} {:40} // SRCID{}: ({}-{})", hits, code, source_id, start, end )?;
+                    writeln!(
+                        formatted,
+                        "{} {:40} // SRCID{}: ({}-{})",
+                        hits, code, source_id, start, end
+                    )?;
                 } else {
                     writeln!(formatted, "{} {:40}", hits, code)?;
                 }
-            }                        
-            fs::write( &self.destdir.join(contract_id.contract_name.clone()).with_extension("asm"), formatted)?;
+            }
+            fs::write(
+                &self.destdir.join(contract_id.contract_name.clone()).with_extension("asm"),
+                formatted,
+            )?;
         }
 
         Ok(())
@@ -233,16 +250,12 @@ struct LineNumberCache {
     line_offsets: HashMap<String, Vec<usize>>,
 }
 
-
 impl LineNumberCache {
     pub fn new(root: PathBuf) -> Self {
-        LineNumberCache{
-            root,
-            line_offsets: HashMap::new(),
-        }
+        LineNumberCache { root, line_offsets: HashMap::new() }
     }
 
-    pub fn get_position(&mut self, path: &str, offset: usize) -> eyre::Result<(usize,usize)> {
+    pub fn get_position(&mut self, path: &str, offset: usize) -> eyre::Result<(usize, usize)> {
         let line_offsets = match self.line_offsets.entry(path.to_owned()) {
             hash_map::Entry::Occupied(o) => o.into_mut(),
             hash_map::Entry::Vacant(v) => {
@@ -257,9 +270,9 @@ impl LineNumberCache {
         };
         let lo = match line_offsets.binary_search(&offset) {
             Ok(lo) => lo,
-            Err(lo) => lo - 1
+            Err(lo) => lo - 1,
         };
         let pos = offset - line_offsets.get(lo).unwrap() + 1;
-        Ok((lo,pos))
+        Ok((lo, pos))
     }
 }


### PR DESCRIPTION
## Motivation

The coverage testing in foundry is useful, but has many outstanding issues, eg those mentioned here:

https://github.com/foundry-rs/foundry/issues/1961

The barrier to entry in addressing these issues is relatively high, as the pipeline used to generate the reports is somewhat complex:

```
1.    build code ->
2.    execute tests recording EVM instruction level coverage ->
3.    construct mapping from bytecode addresses to source level coverage items -> 
4.    apply the mapping to the instruction level coverage to generage an abstract CoverageReport ->
5.    process  the CoverageReport to generate user friendly output as requested
```

and there is no useful visibility into the interior stages of this pipeline.

## Solution

This PR adds a new coverage report, that provided human readable bytecode level (ie per instruction) output.

```
forge coverage --report bytecode
```

This generates a directory of disassembled bytecode files that include hit counts for each instruction, along with a precise source reference. This output corresponds to the results from stage 2 in the pipeline description above.

An example snippet from a bytecode coverage file:

```
[002] 000012b0: JUMPDEST                       // contracts/common/Range.sol: 13:5-19:6 (251-484)
[002] 000012b1: DUP1                           // contracts/common/Range.sol: 14:21-14:28 (347-354)
[002] 000012b2: PUSH1 0xff                     // contracts/common/Range.sol: 14:13-14:28 (339-354)
[002] 000012c3: AND                            // contracts/common/Range.sol: 14:13-14:28 (339-354)
[002] 000012c4: DUP3                           // contracts/common/Range.sol: 14:13-14:18 (339-344)
[002] 000012c5: PUSH1 0xff                     // contracts/common/Range.sol: 14:13-14:28 (339-354)
[002] 000012d6: AND                            // contracts/common/Range.sol: 14:13-14:28 (339-354)
[002] 000012d7: GT                             // contracts/common/Range.sol: 14:13-14:28 (339-354)
[002] 000012d8: ISZERO                         // contracts/common/Range.sol: 14:9-16:10 (335-416)
[002] 000012d9: PUSH2 0x131b                   // contracts/common/Range.sol: 14:9-16:10 (335-416)
[002] 000012dc: JUMPI                          // contracts/common/Range.sol: 14:9-16:10 (335-416)
      000012dd: DUP2                           // contracts/common/Range.sol: 15:33-15:38 (390-395)
```

