### PR TITLE
fix(forge): Don't ignore config.toml when running invariant tests for coverage

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -301,7 +301,7 @@ impl CoverageArgs {
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, evm_opts.clone()))
-            .with_test_options(TestOptions { fuzz: config.fuzz, ..Default::default() })
+            .with_test_options(TestOptions { fuzz: config.fuzz, invariant: config.invariant, ..Default::default() })
             .set_coverage(true)
             .build(root.clone(), output, env, evm_opts)?;
 
@@ -310,7 +310,7 @@ impl CoverageArgs {
         let filter = self.filter;
         let (tx, rx) = channel::<(String, SuiteResult)>();
         let handle =
-            tokio::task::spawn(async move { runner.test(&filter, tx, Default::default()).await });
+            tokio::task::spawn(async move { runner.test(&filter, tx, runner.test_options.clone()).await });
 
         // Add hit data to the coverage report
         let data = rx

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -301,7 +301,11 @@ impl CoverageArgs {
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, env.clone()))
             .with_cheats_config(CheatsConfig::new(&config, evm_opts.clone()))
-            .with_test_options(TestOptions { fuzz: config.fuzz, invariant: config.invariant, ..Default::default() })
+            .with_test_options(TestOptions {
+                fuzz: config.fuzz,
+                invariant: config.invariant,
+                ..Default::default()
+            })
             .set_coverage(true)
             .build(root.clone(), output, env, evm_opts)?;
 
@@ -309,8 +313,9 @@ impl CoverageArgs {
         let known_contracts = runner.known_contracts.clone();
         let filter = self.filter;
         let (tx, rx) = channel::<(String, SuiteResult)>();
-        let handle =
-            tokio::task::spawn(async move { runner.test(&filter, tx, runner.test_options.clone()).await });
+        let handle = tokio::task::spawn(async move {
+            runner.test(&filter, tx, runner.test_options.clone()).await
+        });
 
         // Add hit data to the coverage report
         let data = rx


### PR DESCRIPTION
`forge coverage` ignores the `config.toml` file for invariant tests. 

Invariant testing in coverage mode thus uses the default 256 runs which is small, making coverage for big invariant tests noisy/useless. This is not the case for regular (non-invariant) tests. 

## Motivation

This would bring us closer to having invariant tests as contributing fully to coverage (#4007).
Fixes #6565.

## Solution

The coverage runner now takes the correct `config` given when running tests. 

This is my first time writing Rust ever, so do feel free to ignore/rewrite completely. 

