### PR TITLE
fix(`anvil`): ensure prevrandao is set

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -419,7 +419,7 @@ impl Backend {
                     timestamp: fork_block.header.timestamp,
                     gas_limit: fork_block.header.gas_limit,
                     difficulty: fork_block.header.difficulty,
-                    prevrandao: fork_block.header.mix_hash,
+                    prevrandao: Some(fork_block.header.mix_hash.unwrap_or_default()),
                     // Keep previous `coinbase` and `basefee` value
                     coinbase: env.block.coinbase,
                     basefee: env.block.basefee,
@@ -700,7 +700,7 @@ impl Backend {
                 timestamp: block.header.timestamp,
                 difficulty: block.header.difficulty,
                 // ensures prevrandao is set
-                prevrandao: block.header.mix_hash,
+                prevrandao: Some(block.header.mix_hash.unwrap_or_default()),
                 gas_limit: block.header.gas_limit,
                 // Keep previous `coinbase` and `basefee` value
                 coinbase: env.block.coinbase,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1213,7 +1213,7 @@ impl DatabaseExt for Backend {
         env.block.timestamp = block.header.timestamp;
         env.block.coinbase = block.header.miner;
         env.block.difficulty = block.header.difficulty;
-        env.block.prevrandao = block.header.mix_hash;
+        env.block.prevrandao = Some(block.header.mix_hash.unwrap_or_default());
         env.block.basefee = block.header.base_fee_per_gas.unwrap_or_default();
         env.block.gas_limit = block.header.gas_limit;
         env.block.number = block.header.number.map(|n| n.to()).unwrap_or(fork_block.to());

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -63,7 +63,7 @@ pub async fn environment<P: TempProvider>(
             timestamp: block.header.timestamp,
             coinbase: block.header.miner,
             difficulty: block.header.difficulty,
-            prevrandao: block.header.mix_hash,
+            prevrandao: Some(block.header.mix_hash.unwrap_or_default()),
             basefee: block.header.base_fee_per_gas.unwrap_or_default(),
             gas_limit: block.header.gas_limit,
             ..Default::default()


### PR DESCRIPTION
Fixes the failing moonbeam test.