### PR TITLE
Fix sender_nonce shadowing

### DIFF
--- a/crates/forge/bin/cmd/script/runner.rs
+++ b/crates/forge/bin/cmd/script/runner.rs
@@ -70,8 +70,7 @@ impl ScriptRunner {
             .map(|traces| (TraceKind::Deployment, traces))
             .collect();
 
-        let sender_nonce = self.executor.get_nonce(CALLER)?;
-        let address = CALLER.create(sender_nonce);
+        let address = CALLER.create(self.executor.get_nonce(CALLER)?);
 
         // Set the contracts initial balance before deployment, so it is available during the
         // construction

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -115,8 +115,7 @@ impl<'a> ContractRunner<'a> {
             }
         }
 
-        let sender_nonce = self.executor.get_nonce(self.sender)?;
-        let address = self.sender.create(sender_nonce);
+        let address = self.sender.create(self.executor.get_nonce(self.sender)?);
 
         // Set the contracts initial balance before deployment, so it is available during
         // construction


### PR DESCRIPTION
## Motivation

I have accidentally shadowed `sender_nonce` parameter while implementing #6300

Ref #6571

cc @mds1
