### PR TITLE
feat: re-implement event selector printing

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -450,7 +450,7 @@ fn format_event_definition(event_definition: &pt::EventDefinition) -> Result<Str
         alloy_json_abi::Event { name: event_name, inputs, anonymous: event_definition.anonymous };
 
     Ok(format!(
-        "Type: {}\n├ Name: {}\n└ Signature: {:?}",
+        "Type: {}\n├ Name: {}\n├ Signature: {:?}\n└ Selector: {:?}",
         Paint::red("event"),
         SolidityHelper::highlight(&format!(
             "{}({})",
@@ -472,6 +472,7 @@ fn format_event_definition(event_definition: &pt::EventDefinition) -> Result<Str
                 .join(", ")
         )),
         Paint::cyan(event.signature()),
+        Paint::cyan(event.selector()),
     ))
 }
 


### PR DESCRIPTION
## Motivation
#4455 implemented the printing of event selectors (the hash of the event signature, similar to function selectors). During the migration to Alloy, this seems to have been accidentally removed / replaced.

## Solution
This PR re-implements the printing of event signatures.

## Example
See `Selector` in the output below.
```
Welcome to Chisel! Type `!help` to show available commands.
➜ event SomeEvent(address addr);
➜ SomeEvent
Type: event
├ Name: SomeEvent(address addr)
├ Signature: "SomeEvent(address)"
└ Selector: 0x62e1088ac332ffa611ac64bd5a2aef2c27de42d3c61c686ec5c53753c35c7f68
```