### PR TITLE
fix: update outdated links to external resources

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -187,7 +187,7 @@ async fn can_impersonate_gnosis_safe() {
     let (api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();
 
-    // <https://help.gnosis-safe.io/en/articles/4971293-i-don-t-remember-my-safe-address-where-can-i-find-it>
+    // <https://help.safe.global/en/articles/40824-i-don-t-remember-my-safe-address-where-can-i-find-it>
     let safe: Address = "0xA063Cb7CFd8E57c30c788A0572CBbf2129ae56B6".parse().unwrap();
 
     let code = provider.get_code(safe, None).await.unwrap();

--- a/crates/forge/README.md
+++ b/crates/forge/README.md
@@ -404,7 +404,7 @@ For example, if you have `@openzeppelin` imports, you would
 
 ## Github Actions CI
 
-We recommend using the [Github Actions CI setup](https://book.getfoundry.sh/config/continous-integration.html) from the [📖 Foundry Book](https://book.getfoundry.sh/index.html).
+We recommend using the [Github Actions CI setup](https://book.getfoundry.sh/config/continuous-integration) from the [📖 Foundry Book](https://book.getfoundry.sh/index.html).
 
 ## Future Features
 


### PR DESCRIPTION
## Motivation
GM!

I'm replacing two outdated external links with updated versions. One of them is pointing to GnosisSafe FAQ, second one to Foundry docs/book. Motivation is to keep external resources approachable.

## Solution

The solution is self-explanatory in the changed files.