### PR TITLE
feat(chisel): add bit size information to `int` & `uint` types

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -321,26 +321,44 @@ fn format_token(token: DynSolValue) -> String {
         DynSolValue::Address(a) => {
             format!("Type: {}\n└ Data: {}", Paint::red("address"), Paint::cyan(a.to_string()))
         }
-        DynSolValue::FixedBytes(b, _) => {
+        DynSolValue::FixedBytes(b, byte_len) => {
             format!(
                 "Type: {}\n└ Data: {}",
-                Paint::red(format!("bytes{}", b.len())),
+                Paint::red(format!("bytes{byte_len}")),
                 Paint::cyan(hex::encode_prefixed(b))
             )
         }
-        DynSolValue::Int(i, _) => {
+        DynSolValue::Int(i, bit_len) => {
             format!(
-                "Type: {}\n├ Hex: {}\n└ Decimal: {}",
-                Paint::red("int"),
-                Paint::cyan(format!("0x{i:x}")),
+                "Type: {}\n├ Hex: {}\n├ Hex (full word): {}\n└ Decimal: {}",
+                Paint::red(format!("int{}", bit_len)),
+                Paint::cyan(format!(
+                    "0x{}",
+                    format!("{i:x}")
+                        .char_indices()
+                        .skip(64 - bit_len / 4)
+                        .take(bit_len / 4)
+                        .map(|(_, c)| c)
+                        .collect::<String>()
+                )),
+                Paint::cyan(format!("{i:#x}")),
                 Paint::cyan(i)
             )
         }
-        DynSolValue::Uint(i, _) => {
+        DynSolValue::Uint(i, bit_len) => {
             format!(
-                "Type: {}\n├ Hex: {}\n└ Decimal: {}",
-                Paint::red("uint"),
-                Paint::cyan(format!("0x{i:x}")),
+                "Type: {}\n├ Hex: {}\n├ Hex (full word): {}\n└ Decimal: {}",
+                Paint::red(format!("uint{}", bit_len)),
+                Paint::cyan(format!(
+                    "0x{}",
+                    format!("{i:x}")
+                        .char_indices()
+                        .skip(64 - bit_len / 4)
+                        .take(bit_len / 4)
+                        .map(|(_, c)| c)
+                        .collect::<String>()
+                )),
+                Paint::cyan(format!("{i:#x}")),
                 Paint::cyan(i)
             )
         }


### PR DESCRIPTION
## Overview

Now that we have `alloy`, `chisel` can display information about the size of `uint` / `int` types.

![Screenshot 2023-12-18 at 1 23 44 PM](https://github.com/foundry-rs/foundry/assets/8406232/29b1d42b-13a0-4667-9795-80605b3b60fa)

**Metadata**
closes #5705
