### PR TITLE
feat(cheatcodes): Add contract broadcast cheatcode

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4255,6 +4255,26 @@
     },
     {
       "func": {
+        "id": "startContractBroadcast",
+        "description": "Has all subsequent calls (at this call depth only) create transactions with the address\nprovided using nonces determined as if the address is a contract (incrementing only when\na contract is deployed using CREATE or CREATE2).",
+        "declaration": "function startContractBroadcast(address signer) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "startContractBroadcast(address)",
+        "selector": "0x732c0600",
+        "selectorBytes": [
+          115,
+          44,
+          6,
+          0
+        ]
+      },
+      "group": "scripting",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "startMappingRecording",
         "description": "Starts recording all map SSTOREs for later retrieval.",
         "declaration": "function startMappingRecording() external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -973,6 +973,12 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function startBroadcast(uint256 privateKey) external;
 
+    /// Has all subsequent calls (at this call depth only) create transactions with the address
+    /// provided using nonces determined as if the address is a contract (incrementing only when
+    /// a contract is deployed using CREATE or CREATE2).
+    #[cheatcode(group = Scripting)]
+    function startContractBroadcast(address signer) external;
+
     /// Stops collecting onchain transactions.
     #[cheatcode(group = Scripting)]
     function stopBroadcast() external;

--- a/testdata/cheats/Broadcast.t.sol
+++ b/testdata/cheats/Broadcast.t.sol
@@ -528,3 +528,29 @@ contract ScriptAdditionalContracts is DSTest {
         new Parent();
     }
 }
+
+contract Box {
+    uint value;
+
+    constructor(uint256 _value) {
+        value = _value;
+    }
+
+    function setValue(uint256 _value) public {
+        value = _value;
+    }
+}
+
+contract ScriptBroadcastContract is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function run() external {
+        vm.startContractBroadcast(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+        Box box1 = new Box(0);
+        box1.setValue(1);
+        box1.setValue(2);
+        Box box2 = new Box{salt: 0}(0);
+        box2.setValue(1);
+        box2.setValue(2);
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -210,6 +210,7 @@ interface Vm {
     function startBroadcast() external;
     function startBroadcast(address signer) external;
     function startBroadcast(uint256 privateKey) external;
+    function startContractBroadcast(address signer) external;
     function startMappingRecording() external;
     function startPrank(address msgSender) external;
     function startPrank(address msgSender, address txOrigin) external;


### PR DESCRIPTION
## Motivation
The current broadcast commands cannot accurately simulate sending transactions from a smart contract wallet due to the way that nonces are calculated for EOAs vs contracts. See #6564 for more information.

## Solution
Add a new cheat code, `vm.startContractBroadcast(address)` that causes the sender nonce to be calculated as if it is a smart contract [according to EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md#specification). So the nonce is incremented only if a new contract is deployed using `CREATE`. In the future, this cheat code could handle other cases where smart contract wallets differ from EOAs. Improving the simulation of smart contract wallets enables third-party plugins like [Sphinx](https://github.com/sphinx-labs/sphinx), which I am a maintainer of, to support Foundry better. It also opens the door to Foundry supporting smart contract wallets in some capacity natively.