### PR TITLE
fix: tightly pack doc comments

### DIFF
--- a/crates/fmt/src/comments.rs
+++ b/crates/fmt/src/comments.rs
@@ -152,6 +152,10 @@ impl CommentWithMetadata {
         matches!(self.ty, CommentType::Line | CommentType::DocLine)
     }
 
+    pub fn is_doc_block(&self) -> bool {
+        matches!(self.ty, CommentType::DocBlock)
+    }
+
     pub fn is_prefix(&self) -> bool {
         matches!(self.position, CommentPosition::Prefix)
     }

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1002,9 +1002,10 @@ impl<'a, W: Write> Formatter<'a, W> {
                                 last_loc = *last_item;
                             }
 
-                            // The blank lines check is susceptible to block comments because the
-                            // block docs can contain multiple lines, but the function def should be
-                            // follow directly after the block comment
+                            // The blank lines check is susceptible additional trailing new lines
+                            // because the block docs can contain
+                            // multiple lines, but the function def should follow directly after the
+                            // block comment
                             let is_last_doc_comment = matches!(
                                 last_comment,
                                 Some(CommentWithMetadata { ty: CommentType::DocBlock, .. })

--- a/crates/fmt/testdata/BlockComments/fmt.sol
+++ b/crates/fmt/testdata/BlockComments/fmt.sol
@@ -1,0 +1,25 @@
+contract CounterTest is Test {
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function test_Increment() public {
+        counter.increment();
+        assertEq(counter.number(), 1);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function test_Increment() public {
+        counter.increment();
+        assertEq(counter.number(), 1);
+    }
+}

--- a/crates/fmt/testdata/BlockComments/original.sol
+++ b/crates/fmt/testdata/BlockComments/original.sol
@@ -1,0 +1,26 @@
+contract CounterTest is Test {
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+
+    constructor(string memory name_, string memory symbol_) {
+                _name = name_;
+        _symbol = symbol_;
+    }
+
+        /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function test_Increment() public {
+            counter.increment();
+        assertEq(counter.number(), 1);
+    }
+
+    /**
+ * @dev See {IERC165-supportsInterface}.
+     */    function test_Increment() public {
+    counter.increment();
+    assertEq(counter.number(), 1);
+}
+
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -228,6 +228,7 @@ test_directories! {
     MappingType,
     EmitStatement,
     Repros,
+    BlockComments,
 }
 
 test_dir!(SortedImports, TestConfig::skip_compare_ast_eq());


### PR DESCRIPTION
fixes a formatting bug where forge fmt would format with an additional new line before the function body

```
    /**
     * @dev See {IERC721-balanceOf}.
     */

    function test_Increment() public {
        counter.increment();
        assertEq(counter.number(), 1);
    }
```