### PR TITLE
feat(doc): inline doc links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "mdbook",
  "once_cell",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "solang-parser",

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -31,3 +31,4 @@ solang-parser.workspace = true
 thiserror = "1"
 toml.workspace = true
 tracing.workspace = true
+regex = "1.10.2"

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -42,7 +42,7 @@ pub struct DocBuilder {
 
 // TODO: consider using `tfio`
 impl DocBuilder {
-    const SRC: &'static str = "src";
+    pub(crate) const SRC: &'static str = "src";
     const SOL_EXT: &'static str = "sol";
     const README: &'static str = "README.md";
     const SUMMARY: &'static str = "SUMMARY.md";

--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use forge_fmt::solang_ext::SafeUnwrap;
+
+use crate::{
+    document::DocumentContent, Comments, Document, ParseItem, ParseSource, PreprocessorOutput,
+};
+
+use super::{Preprocessor, PreprocessorId};
+
+/// [InferHyperlinks] preprocessor id.
+pub const INFER_HYPERLINKS_ID: PreprocessorId = PreprocessorId("infer hyperlinks");
+
+/// The infer hyperlinks preprocessor tries to map @dev tags to referenced items
+/// Traverses the documents and attempts to find referenced items
+/// comments for dev comment tags.
+///
+/// This preprocessor writes to [Document]'s context.
+#[derive(Default, Debug)]
+#[non_exhaustive]
+pub struct InferHyperlinks;
+
+impl Preprocessor for InferHyperlinks {
+    fn id(&self) -> PreprocessorId {
+        INFER_HYPERLINKS_ID
+    }
+
+    fn preprocess(&self, documents: Vec<Document>) -> Result<Vec<Document>, eyre::Error> {
+        // for document in documents.iter() {
+        //     if let DocumentContent::Single(ref item) = document.content {
+        //         let context = self.visit_item(item, &documents);
+        //         if !context.is_empty() {
+        //             document.add_context(self.id(), PreprocessorOutput::Inheritdoc(context));
+        //         }
+        //     }
+        // }
+
+        Ok(documents)
+    }
+}
+
+impl InferHyperlinks {
+    fn visit_item(&self, item: &ParseItem, documents: &Vec<Document>) -> HashMap<String, Comments> {
+        let mut context = HashMap::new();
+
+        // Match for the item first.
+        let matched = item
+            .comments
+            .find_inheritdoc_base()
+            .and_then(|base| self.try_match_inheritdoc(base, &item.source, documents));
+        if let Some((key, comments)) = matched {
+            context.insert(key, comments);
+        }
+
+        // Match item's children.
+        for ch in item.children.iter() {
+            let matched = ch
+                .comments
+                .find_inheritdoc_base()
+                .and_then(|base| self.try_match_inheritdoc(base, &ch.source, documents));
+            if let Some((key, comments)) = matched {
+                context.insert(key, comments);
+            }
+        }
+
+        context
+    }
+
+    fn try_match_inheritdoc(
+        &self,
+        base: &str,
+        source: &ParseSource,
+        documents: &Vec<Document>,
+    ) -> Option<(String, Comments)> {
+        for candidate in documents {
+            if let DocumentContent::Single(ref item) = candidate.content {
+                if let ParseSource::Contract(ref contract) = item.source {
+                    if base == contract.name.safe_unwrap().name {
+                        // Not matched for the contract because it's a noop
+                        // https://docs.soliditylang.org/en/v0.8.17/natspec-format.html#tags
+
+                        for children in item.children.iter() {
+                            // TODO: improve matching logic
+                            if source.ident() == children.source.ident() {
+                                let key = format!("{}.{}", base, source.ident());
+                                return Some((key, children.comments.clone()))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -13,7 +13,7 @@ use std::{
 /// Overloaded functions are referenced by including the exact function arguments in the `part`
 /// section of the placeholder.
 static RE_INLINE_LINK: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?m)(\{(?P<xref>xref-)?(?P<identifier>[a-zA-Z_][0-9a-zA-Z_]*)(-(?P<part>[a-zA-Z_][0-9a-zA-Z_-]*))?}(\[?P<link>(.*?)\])?)").unwrap()
+    Regex::new(r"(?m)(\{(?P<xref>xref-)?(?P<identifier>[a-zA-Z_][0-9a-zA-Z_]*)(-(?P<part>[a-zA-Z_][0-9a-zA-Z_-]*))?}(\[(?P<link>(.*?))\])?)").unwrap()
 });
 
 /// [InferInlineHyperlinks] preprocessor id.
@@ -55,7 +55,7 @@ impl Preprocessor for InferInlineHyperlinks {
                 for child_idx in 0..item_children_len {
                     let mut comments = {
                         let item = document.content.get_mut(idx).unwrap();
-                        
+
                         std::mem::take(&mut item.children[child_idx].comments)
                     };
                     Self::inline_doc_links(&documents, &target_path, &mut comments, &document);
@@ -305,5 +305,10 @@ mod tests {
         let link = InlineLink::capture(s).unwrap();
         assert_eq!(link.ref_name(), "_safeMint");
         assert_eq!(link.as_str(), "{xref-ERC721-_safeMint-address-uint256-}");
+
+        let s = "{xref-ERC721-_safeMint-address-uint256-}[`Named link`]";
+        let link = InlineLink::capture(s).unwrap();
+        assert_eq!(link.link, Some("`Named link`"));
+        assert_eq!(link.markdown_link_display_value(), "`Named link`");
     }
 }

--- a/crates/doc/src/preprocessor/infer_hyperlinks.rs
+++ b/crates/doc/src/preprocessor/infer_hyperlinks.rs
@@ -1,95 +1,309 @@
-use std::collections::HashMap;
-
+use super::{Preprocessor, PreprocessorId};
+use crate::{Comments, Document, ParseItem, ParseSource};
 use forge_fmt::solang_ext::SafeUnwrap;
-
-use crate::{
-    document::DocumentContent, Comments, Document, ParseItem, ParseSource, PreprocessorOutput,
+use once_cell::sync::Lazy;
+use regex::{Captures, Match, Regex};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
 };
 
-use super::{Preprocessor, PreprocessorId};
+/// A regex that matches `{identifier-part}` placeholders
+///
+/// Overloaded functions are referenced by including the exact function arguments in the `part`
+/// section of the placeholder.
+static RE_INLINE_LINK: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?m)(\{(?P<xref>xref-)?(?P<identifier>[a-zA-Z_][0-9a-zA-Z_]*)(-(?P<part>[a-zA-Z_][0-9a-zA-Z_-]*))?}(\[?P<link>(.*?)\])?)").unwrap()
+});
 
-/// [InferHyperlinks] preprocessor id.
-pub const INFER_HYPERLINKS_ID: PreprocessorId = PreprocessorId("infer hyperlinks");
+/// [InferInlineHyperlinks] preprocessor id.
+pub const INFER_INLINE_HYPERLINKS_ID: PreprocessorId = PreprocessorId("infer inline hyperlinks");
 
 /// The infer hyperlinks preprocessor tries to map @dev tags to referenced items
 /// Traverses the documents and attempts to find referenced items
 /// comments for dev comment tags.
 ///
-/// This preprocessor writes to [Document]'s context.
+/// This preprocessor replaces inline links in comments with the links to the referenced items.
 #[derive(Default, Debug)]
 #[non_exhaustive]
-pub struct InferHyperlinks;
+pub struct InferInlineHyperlinks;
 
-impl Preprocessor for InferHyperlinks {
+impl Preprocessor for InferInlineHyperlinks {
     fn id(&self) -> PreprocessorId {
-        INFER_HYPERLINKS_ID
+        INFER_INLINE_HYPERLINKS_ID
     }
 
-    fn preprocess(&self, documents: Vec<Document>) -> Result<Vec<Document>, eyre::Error> {
-        // for document in documents.iter() {
-        //     if let DocumentContent::Single(ref item) = document.content {
-        //         let context = self.visit_item(item, &documents);
-        //         if !context.is_empty() {
-        //             document.add_context(self.id(), PreprocessorOutput::Inheritdoc(context));
-        //         }
-        //     }
-        // }
+    fn preprocess(&self, mut documents: Vec<Document>) -> Result<Vec<Document>, eyre::Error> {
+        // traverse all comments and try to match inline links and replace with inline links for
+        // markdown
+        let mut docs = Vec::with_capacity(documents.len());
+        while !documents.is_empty() {
+            let mut document = documents.remove(0);
+            let target_path = document.relative_output_path().to_path_buf();
+            for idx in 0..document.content.len() {
+                let (mut comments, item_children_len) = {
+                    let item = document.content.get_mut(idx).unwrap();
+                    let comments = std::mem::take(&mut item.comments);
+                    let children = item.children.len();
+                    (comments, children)
+                };
+                Self::inline_doc_links(&documents, &target_path, &mut comments, &document);
+                document.content.get_mut(idx).unwrap().comments = comments;
 
-        Ok(documents)
+                // we also need to iterate over all child items
+                // This is a bit horrible but we need to traverse all items in all documents
+                for child_idx in 0..item_children_len {
+                    let mut comments = {
+                        let item = document.content.get_mut(idx).unwrap();
+                        
+                        std::mem::take(&mut item.children[child_idx].comments)
+                    };
+                    Self::inline_doc_links(&documents, &target_path, &mut comments, &document);
+                    document.content.get_mut(idx).unwrap().children[child_idx].comments = comments;
+                }
+            }
+
+            docs.push(document);
+        }
+
+        Ok(docs)
     }
 }
 
-impl InferHyperlinks {
-    fn visit_item(&self, item: &ParseItem, documents: &Vec<Document>) -> HashMap<String, Comments> {
-        let mut context = HashMap::new();
-
-        // Match for the item first.
-        let matched = item
-            .comments
-            .find_inheritdoc_base()
-            .and_then(|base| self.try_match_inheritdoc(base, &item.source, documents));
-        if let Some((key, comments)) = matched {
-            context.insert(key, comments);
-        }
-
-        // Match item's children.
-        for ch in item.children.iter() {
-            let matched = ch
-                .comments
-                .find_inheritdoc_base()
-                .and_then(|base| self.try_match_inheritdoc(base, &ch.source, documents));
-            if let Some((key, comments)) = matched {
-                context.insert(key, comments);
+impl InferInlineHyperlinks {
+    /// Finds the first match for the given link.
+    ///
+    /// All items get their own section in the markdown file.
+    /// This section uses the identifier of the item: `#functionname`
+    ///
+    /// Note: the target path is the relative path to the markdown file.
+    fn find_match<'a>(
+        link: &InlineLink<'a>,
+        target_path: &Path,
+        items: impl Iterator<Item = &'a ParseItem>,
+    ) -> Option<InlineLinkTarget<'a>> {
+        for item in items {
+            match &item.source {
+                ParseSource::Contract(contract) => {
+                    let name = &contract.name.safe_unwrap().name;
+                    if name == link.identifier {
+                        if link.part.is_none() {
+                            return Some(InlineLinkTarget::borrowed(name, target_path.to_path_buf()))
+                        }
+                        // try to find the referenced item in the contract's children
+                        return Self::find_match(link, target_path, item.children.iter())
+                    }
+                }
+                ParseSource::Function(fun) => {
+                    // TODO: handle overloaded functions
+                    // functions can be overloaded so we need to keep track of how many matches we
+                    // have so we can match the correct one
+                    let fun_name = &fun.name.safe_unwrap().name;
+                    if fun_name == link.ref_name() {
+                        return Some(InlineLinkTarget::borrowed(fun_name, target_path.to_path_buf()))
+                    }
+                }
+                ParseSource::Variable(_) => {}
+                ParseSource::Event(ev) => {
+                    let ev_name = &ev.name.safe_unwrap().name;
+                    if ev_name == link.ref_name() {
+                        return Some(InlineLinkTarget::borrowed(ev_name, target_path.to_path_buf()))
+                    }
+                }
+                ParseSource::Error(err) => {
+                    let err_name = &err.name.safe_unwrap().name;
+                    if err_name == link.ref_name() {
+                        return Some(InlineLinkTarget::borrowed(err_name, target_path.to_path_buf()))
+                    }
+                }
+                ParseSource::Struct(structdef) => {
+                    let struct_name = &structdef.name.safe_unwrap().name;
+                    if struct_name == link.ref_name() {
+                        return Some(InlineLinkTarget::borrowed(
+                            struct_name,
+                            target_path.to_path_buf(),
+                        ))
+                    }
+                }
+                ParseSource::Enum(_) => {}
+                ParseSource::Type(_) => {}
             }
         }
 
-        context
+        None
     }
 
-    fn try_match_inheritdoc(
-        &self,
-        base: &str,
-        source: &ParseSource,
-        documents: &Vec<Document>,
-    ) -> Option<(String, Comments)> {
-        for candidate in documents {
-            if let DocumentContent::Single(ref item) = candidate.content {
-                if let ParseSource::Contract(ref contract) = item.source {
-                    if base == contract.name.safe_unwrap().name {
-                        // Not matched for the contract because it's a noop
-                        // https://docs.soliditylang.org/en/v0.8.17/natspec-format.html#tags
-
-                        for children in item.children.iter() {
-                            // TODO: improve matching logic
-                            if source.ident() == children.source.ident() {
-                                let key = format!("{}.{}", base, source.ident());
-                                return Some((key, children.comments.clone()))
-                            }
-                        }
-                    }
+    /// Attempts to convert inline links to markdown links.
+    fn inline_doc_links(
+        documents: &[Document],
+        target_path: &Path,
+        comments: &mut Comments,
+        parent: &Document,
+    ) {
+        // loop over all comments in the item
+        for comment in comments.iter_mut() {
+            let val = comment.value.clone();
+            // replace all links with inline markdown links
+            for link in InlineLink::captures(val.as_str()) {
+                let target = if link.is_external() {
+                    // find in all documents
+                    documents.iter().find_map(|doc| {
+                        Self::find_match(
+                            &link,
+                            doc.relative_output_path(),
+                            doc.content.iter_items().flat_map(|item| {
+                                Some(item).into_iter().chain(item.children.iter())
+                            }),
+                        )
+                    })
+                } else {
+                    // find matches in the document
+                    Self::find_match(
+                        &link,
+                        target_path,
+                        parent
+                            .content
+                            .iter_items()
+                            .flat_map(|item| Some(item).into_iter().chain(item.children.iter())),
+                    )
+                };
+                if let Some(target) = target {
+                    let display_value = link.markdown_link_display_value();
+                    let markdown_link = format!("[{}]({})", display_value, target);
+                    // replace the link with the markdown link
+                    comment.value =
+                        comment.value.as_str().replacen(link.as_str(), markdown_link.as_str(), 1);
                 }
             }
         }
-        None
+    }
+}
+
+struct InlineLinkTarget<'a> {
+    section: Cow<'a, str>,
+    target_path: PathBuf,
+}
+
+impl<'a> InlineLinkTarget<'a> {
+    fn borrowed(section: &'a str, target_path: PathBuf) -> Self {
+        Self { section: Cow::Borrowed(section), target_path }
+    }
+}
+
+impl<'a> std::fmt::Display for InlineLinkTarget<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // NOTE: the url should be absolute for markdown and section names are lowercase
+        write!(f, "/{}#{}", self.target_path.display(), self.section.to_lowercase())
+    }
+}
+
+/// A parsed link to an item.
+#[derive(Debug)]
+struct InlineLink<'a> {
+    outer: Match<'a>,
+    identifier: &'a str,
+    part: Option<&'a str>,
+    link: Option<&'a str>,
+}
+
+impl<'a> InlineLink<'a> {
+    fn from_capture(cap: Captures<'a>) -> Option<Self> {
+        Some(Self {
+            outer: cap.get(1)?,
+            identifier: cap.name("identifier")?.as_str(),
+            part: cap.name("part").map(|m| m.as_str()),
+            link: cap.name("link").map(|m| m.as_str()),
+        })
+    }
+
+    fn captures(s: &'a str) -> impl Iterator<Item = Self> + '_ {
+        RE_INLINE_LINK.captures(s).map(Self::from_capture).into_iter().flatten()
+    }
+
+    /// Parses the first inline link.
+    #[allow(unused)]
+    fn capture(s: &'a str) -> Option<Self> {
+        let cap = RE_INLINE_LINK.captures(s)?;
+        Self::from_capture(cap)
+    }
+
+    /// Returns the name of the link
+    fn markdown_link_display_value(&self) -> Cow<'_, str> {
+        if let Some(link) = self.link {
+            Cow::Borrowed(link)
+        } else if let Some(part) = self.part {
+            Cow::Owned(format!("{}-{}", self.identifier, part))
+        } else {
+            Cow::Borrowed(self.identifier)
+        }
+    }
+
+    /// Returns the name of the referenced item.
+    fn ref_name(&self) -> &str {
+        self.exact_identifier().split('-').next().unwrap()
+    }
+
+    fn exact_identifier(&self) -> &str {
+        let mut name = self.identifier;
+        if let Some(part) = self.part {
+            name = part;
+        }
+        name
+    }
+
+    /// Returns the name of the referenced item and its arguments, if any.
+    ///
+    /// Eg: `safeMint-address-uint256-` returns `("safeMint", ["address", "uint256"])`
+    #[allow(unused)]
+    fn ref_name_exact(&self) -> (&str, impl Iterator<Item = &str> + '_) {
+        let identifier = self.exact_identifier();
+        let mut iter = identifier.split('-');
+        (iter.next().unwrap(), iter.filter(|s| !s.is_empty()))
+    }
+
+    /// Returns the content of the matched link.
+    fn as_str(&self) -> &str {
+        self.outer.as_str()
+    }
+
+    /// Returns true if the link is external.
+    fn is_external(&self) -> bool {
+        self.part.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_inline_links() {
+        let s = "    {IERC165-supportsInterface}   ";
+        let cap = RE_INLINE_LINK.captures(s).unwrap();
+
+        let identifier = cap.name("identifier").unwrap().as_str();
+        assert_eq!(identifier, "IERC165");
+        let part = cap.name("part").unwrap().as_str();
+        assert_eq!(part, "supportsInterface");
+
+        let s = "    {supportsInterface}   ";
+        let cap = RE_INLINE_LINK.captures(s).unwrap();
+
+        let identifier = cap.name("identifier").unwrap().as_str();
+        assert_eq!(identifier, "supportsInterface");
+
+        let s = "{xref-ERC721-_safeMint-address-uint256-}";
+        let cap = RE_INLINE_LINK.captures(s).unwrap();
+
+        let identifier = cap.name("identifier").unwrap().as_str();
+        assert_eq!(identifier, "ERC721");
+        let identifier = cap.name("xref").unwrap().as_str();
+        assert_eq!(identifier, "xref-");
+        let identifier = cap.name("part").unwrap().as_str();
+        assert_eq!(identifier, "_safeMint-address-uint256-");
+
+        let link = InlineLink::capture(s).unwrap();
+        assert_eq!(link.ref_name(), "_safeMint");
+        assert_eq!(link.as_str(), "{xref-ERC721-_safeMint-address-uint256-}");
     }
 }

--- a/crates/doc/src/preprocessor/mod.rs
+++ b/crates/doc/src/preprocessor/mod.rs
@@ -10,7 +10,7 @@ mod inheritdoc;
 pub use inheritdoc::{Inheritdoc, INHERITDOC_ID};
 
 mod infer_hyperlinks;
-pub use infer_hyperlinks::{InferHyperlinks, INFER_HYPERLINKS_ID};
+pub use infer_hyperlinks::{InferInlineHyperlinks, INFER_INLINE_HYPERLINKS_ID};
 
 mod git_source;
 pub use git_source::{GitSource, GIT_SOURCE_ID};

--- a/crates/doc/src/preprocessor/mod.rs
+++ b/crates/doc/src/preprocessor/mod.rs
@@ -9,6 +9,9 @@ pub use contract_inheritance::{ContractInheritance, CONTRACT_INHERITANCE_ID};
 mod inheritdoc;
 pub use inheritdoc::{Inheritdoc, INHERITDOC_ID};
 
+mod infer_hyperlinks;
+pub use infer_hyperlinks::{InferHyperlinks, INFER_HYPERLINKS_ID};
+
 mod git_source;
 pub use git_source::{GitSource, GIT_SOURCE_ID};
 

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -8,7 +8,7 @@ use crate::{
 use forge_fmt::solang_ext::SafeUnwrap;
 use itertools::Itertools;
 use solang_parser::pt::{Base, FunctionDefinition};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// The result of [Asdoc::as_doc] method.
 pub type AsDocResult = Result<String, std::fmt::Error>;
@@ -127,9 +127,8 @@ impl AsDoc for Document {
                         if !contract.base.is_empty() {
                             writer.write_bold("Inherits:")?;
 
-                            // Where all the source files are written to
                             // we need this to find the _relative_ paths
-                            let src_target_dir = self.out_target_dir.join("src");
+                            let src_target_dir = self.target_src_dir();
 
                             let mut bases = vec![];
                             let linked =
@@ -273,53 +272,41 @@ impl AsDoc for Document {
 }
 
 impl Document {
+    /// Where all the source files are written to
+    fn target_src_dir(&self) -> PathBuf {
+        self.out_target_dir.join("src")
+    }
 
     /// Writes a function to the buffer.
-    fn write_function(&self, writer: &mut BufWriter, func: &FunctionDefinition, comments: &Comments, code: &str) -> Result<(), std::fmt::Error> {
-        let func_name = func
-            .name
-            .as_ref()
-            .map_or(func.ty.to_string(), |n| n.name.to_owned());
-        let comments = comments.merge_inheritdoc(
-            &func_name,
-            read_context!(self, INHERITDOC_ID, Inheritdoc),
-        );
+    fn write_function(
+        &self,
+        writer: &mut BufWriter,
+        func: &FunctionDefinition,
+        comments: &Comments,
+        code: &str,
+    ) -> Result<(), std::fmt::Error> {
+        let func_name = func.name.as_ref().map_or(func.ty.to_string(), |n| n.name.to_owned());
+        let comments =
+            comments.merge_inheritdoc(&func_name, read_context!(self, INHERITDOC_ID, Inheritdoc));
 
         // Write function name
         writer.write_heading(&func_name)?;
+
         writer.writeln()?;
 
         // Write function docs
-        writer.writeln_doc(
-            comments.exclude_tags(&[CommentTag::Param, CommentTag::Return]),
-        )?;
+        writer.writeln_doc(comments.exclude_tags(&[CommentTag::Param, CommentTag::Return]))?;
 
         // Write function header
         writer.write_code(code)?;
 
         // Write function parameter comments in a table
-        let params = func
-            .params
-            .iter()
-            .filter_map(|p| p.1.as_ref())
-            .collect::<Vec<_>>();
-        writer.try_write_param_table(
-            CommentTag::Param,
-            &params,
-            &comments,
-        )?;
+        let params = func.params.iter().filter_map(|p| p.1.as_ref()).collect::<Vec<_>>();
+        writer.try_write_param_table(CommentTag::Param, &params, &comments)?;
 
         // Write function parameter comments in a table
-        let returns = func
-            .returns
-            .iter()
-            .filter_map(|p| p.1.as_ref())
-            .collect::<Vec<_>>();
-        writer.try_write_param_table(
-            CommentTag::Return,
-            &returns,
-            &comments,
-        )?;
+        let returns = func.returns.iter().filter_map(|p| p.1.as_ref()).collect::<Vec<_>>();
+        writer.try_write_param_table(CommentTag::Return, &returns, &comments)?;
 
         writer.writeln()?;
         Ok(())

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use forge_doc::{
-    ContractInheritance, Deployments, DocBuilder, GitSource, InferHyperlinks, Inheritdoc,
+    ContractInheritance, Deployments, DocBuilder, GitSource, InferInlineHyperlinks, Inheritdoc,
 };
 use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
 use foundry_config::{find_project_root_path, load_config_with_root};
@@ -100,7 +100,7 @@ impl DocArgs {
         .with_fmt(config.fmt)
         .with_preprocessor(ContractInheritance { include_libraries: self.include_libraries })
         .with_preprocessor(Inheritdoc::default())
-        .with_preprocessor(InferHyperlinks::default())
+        .with_preprocessor(InferInlineHyperlinks::default())
         .with_preprocessor(GitSource {
             root: root.clone(),
             commit,

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, ValueHint};
 use eyre::Result;
-use forge_doc::{ContractInheritance, Deployments, DocBuilder, GitSource, Inheritdoc};
+use forge_doc::{
+    ContractInheritance, Deployments, DocBuilder, GitSource, InferHyperlinks, Inheritdoc,
+};
 use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
 use foundry_config::{find_project_root_path, load_config_with_root};
 use std::{path::PathBuf, process::Command};
@@ -98,6 +100,7 @@ impl DocArgs {
         .with_fmt(config.fmt)
         .with_preprocessor(ContractInheritance { include_libraries: self.include_libraries })
         .with_preprocessor(Inheritdoc::default())
+        .with_preprocessor(InferHyperlinks::default())
         .with_preprocessor(GitSource {
             root: root.clone(),
             commit,


### PR DESCRIPTION
Closes #4541

<img width="281" alt="image" src="https://github.com/foundry-rs/foundry/assets/19890894/ec368ddf-6958-4f73-92e1-3dbdb526ebdf">

This replaces `{<Contract>-identifier}([display name])?` with a link to the referenced item if it can be found.

There are likely some edge cases that I've missed but we can fix them once they get reported.

wdyt @PaulRBerg 
