### PR TITLE
fix(`forge`): fail fast after processing traces

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -407,11 +407,6 @@ impl TestArgs {
             for (name, result) in &mut tests {
                 short_test_result(name, result);
 
-                // If the test failed, we want to stop processing the rest of the tests
-                if self.fail_fast && result.status == TestStatus::Failure {
-                    break 'outer
-                }
-
                 // We only display logs at level 2 and above
                 if verbosity >= 2 {
                     // We only decode logs from Hardhat and DS-style console events
@@ -481,6 +476,11 @@ impl TestArgs {
 
                 if self.gas_report {
                     gas_report.analyze(&result.traces);
+                }
+
+                // If the test failed, we want to stop processing the rest of the tests
+                if self.fail_fast && result.status == TestStatus::Failure {
+                    break 'outer
                 }
             }
             let block_outcome = TestOutcome::new(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5528 
Closes #6613 

## Solution

We were exiting before processing & printing traces. We wanna exit after.