### PR TITLE
fix(fmt): properly format enums

### DIFF
--- a/crates/fmt/testdata/EnumVariants/fmt.sol
+++ b/crates/fmt/testdata/EnumVariants/fmt.sol
@@ -1,0 +1,19 @@
+interface I {
+    enum Empty {}
+
+    /// A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.
+    enum CallerMode {
+        /// No caller modification is currently active.
+        None
+    }
+
+    /// A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.
+    enum CallerMode2 {
+        /// No caller modification is currently active.
+        None,
+        /// No caller modification is currently active2.
+        Some
+    }
+
+    function bar() public {}
+}

--- a/crates/fmt/testdata/EnumVariants/original.sol
+++ b/crates/fmt/testdata/EnumVariants/original.sol
@@ -1,0 +1,23 @@
+interface I {
+    enum Empty {
+
+    }
+
+    /// A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.
+    enum CallerMode
+    {/// No caller modification is currently active.
+        None
+    }
+
+    /// A modification applied to either `msg.sender` or `tx.origin`. Returned by `readCallers`.
+    enum CallerMode2
+    {/// No caller modification is currently active.
+        None,/// No caller modification is currently active2.
+
+        Some
+    }
+
+    function bar() public {
+
+    }
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -229,6 +229,7 @@ test_directories! {
     EmitStatement,
     Repros,
     BlockComments,
+    EnumVariants,
 }
 
 test_dir!(SortedImports, TestConfig::skip_compare_ast_eq());


### PR DESCRIPTION
Closes #6631

use indent based formatting for all variants