### PR TITLE
fix(cheatcodes): Include calls to create2 factory in state diff recording

### DIFF
--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -285,3 +285,6 @@ test_repro!(6554; |config| {
     cheats_config.fs_permissions.add(PathPermission::read_write(path));
     config.runner.cheats_config = std::sync::Arc::new(cheats_config);
 });
+
+// https://github.com/foundry-rs/foundry/issues/6634
+test_repro!(6634);

--- a/testdata/repros/Issue6634.t.sol
+++ b/testdata/repros/Issue6634.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+contract Box {
+    uint256 public number;
+
+    constructor(uint256 _number) {
+        number = _number;
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/6634
+contract Issue6634Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function test() public {
+        address CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+        vm.startStateDiffRecording();
+        Box a = new Box{salt: 0}(1);
+
+        Vm.AccountAccess[] memory called = vm.stopAndReturnStateDiff();
+        assertEq(called.length, 2, "incorrect length");
+        assertEq(uint256(called[0].kind), uint256(Vm.AccountAccessKind.Call), "first AccountAccess is incorrect kind");
+        assertEq(called[0].account, CREATE2_DEPLOYER, "first AccountAccess accout is incorrect");
+        assertEq(
+            uint256(called[1].kind), uint256(Vm.AccountAccessKind.Create), "second AccountAccess is incorrect kind"
+        );
+        assertEq(called[1].accessor, CREATE2_DEPLOYER, "second AccountAccess accessor is incorrect");
+        assertEq(called[1].account, address(a), "first AccountAccess accout is incorrect");
+    }
+}


### PR DESCRIPTION
## Motivation
Resolves #6634 by including the call to the create2 factory in the state diff results. Note that this PR does not resolve a related issue where the [call to the create2 factory is not included in traces](https://github.com/foundry-rs/foundry/issues/6634#issuecomment-1865167767). As far as I can tell, these issues resemble each other but are not directly related. So, I think it makes sense to solve them separately.  

## Solution
Resolved by adding logic to record an additional call to the create2 factory if the call scheme is `CreateScheme::Create2` and the call depth is equal to the prank/broadcast depth. 