### PR TITLE
test: add sablier-v2

### DIFF
--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -9,6 +9,13 @@ forgetest_external!(
     prb_proxy,
     "PaulRBerg/prb-proxy"
 );
+forgetest_external!(
+    #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
+    sablier_v2,
+    "sablier-labs/v2-core",
+    // skip fork tests
+    &["--nmc", "Fork"]
+);
 forgetest_external!(solady, "Vectorized/solady");
 forgetest_external!(
     #[cfg_attr(windows, ignore = "weird git fail")]


### PR DESCRIPTION
add sablier-v2 repo to external forgetests https://github.com/sablier-labs/v2-core
this is a useful test target to check nodejs deps

cc @PaulRBerg 