### PR TITLE
fix(forge): Optionally use create2 factory in tests and non-broadcasting scripts

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -20,6 +20,8 @@ use std::{
 pub struct CheatsConfig {
     /// Whether the FFI cheatcode is enabled.
     pub ffi: bool,
+    /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
+    pub always_use_create_2_factory: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
     pub rpc_storage_caching: StorageCachingConfig,
     /// All known endpoints and their aliases
@@ -52,6 +54,7 @@ impl CheatsConfig {
 
         Self {
             ffi: evm_opts.ffi,
+            always_use_create_2_factory: evm_opts.always_use_create_2_factory,
             rpc_storage_caching: config.rpc_storage_caching.clone(),
             rpc_endpoints,
             paths: config.project_paths(),
@@ -167,6 +170,7 @@ impl Default for CheatsConfig {
     fn default() -> Self {
         Self {
             ffi: false,
+            always_use_create_2_factory: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),
             paths: ProjectPathsConfig::builder().build_with_root("./"),

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1237,7 +1237,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
 
         // Apply the Create2 deployer
         if self.broadcast.is_some() || self.config.always_use_create_2_factory {
-            match apply_create2_deployer(data, call, &self.prank, &self.broadcast) {
+            match apply_create2_deployer(data, call, self.prank.as_ref(), self.broadcast.as_ref()) {
                 Ok(_) => {}
                 Err(err) => return (InstructionResult::Revert, None, gas, Error::encode(err)),
             };
@@ -1430,8 +1430,8 @@ fn mstore_revert_string(interpreter: &mut Interpreter<'_>, bytes: &[u8]) {
 fn apply_create2_deployer<DB: DatabaseExt>(
     data: &mut EVMData<'_, DB>,
     call: &mut CreateInputs,
-    prank: &Option<Prank>,
-    broadcast: &Option<Broadcast>,
+    prank: Option<&Prank>,
+    broadcast: Option<&Broadcast>,
 ) -> Result<(), DB::Error> {
     if let CreateScheme::Create2 { salt: _ } = call.scheme {
         let mut base_depth = 1;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1238,7 +1238,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         // Apply the Create2 deployer
         if self.broadcast.is_some() || self.config.always_use_create_2_factory {
             match apply_create2_deployer(data, call, &self.prank, &self.broadcast) {
-                Ok(_val) => {}
+                Ok(_) => {}
                 Err(err) => return (InstructionResult::Revert, None, gas, Error::encode(err)),
             };
         }

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -95,6 +95,11 @@ pub struct EvmArgs {
     #[serde(skip)]
     pub ffi: bool,
 
+    /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
+    #[clap(long)]
+    #[serde(skip)]
+    pub always_use_create_2_factory: bool,
+
     /// Verbosity of the EVM.
     ///
     /// Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
@@ -159,6 +164,13 @@ impl Provider for EvmArgs {
 
         if self.ffi {
             dict.insert("ffi".to_string(), self.ffi.into());
+        }
+
+        if self.always_use_create_2_factory {
+            dict.insert(
+                "always_use_create_2_factory".to_string(),
+                self.always_use_create_2_factory.into(),
+            );
         }
 
         if self.no_storage_caching {

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -115,6 +115,7 @@ no_match_contract = "Bar"
 match_path = "*/Foo*"
 no_match_path = "*/Bar*"
 ffi = false
+always_use_create_2_factory = false
 # These are the default callers, generated using `address(uint160(uint256(keccak256("foundry default caller"))))`
 sender = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
 tx_origin = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -242,6 +242,8 @@ pub struct Config {
     pub invariant: InvariantConfig,
     /// Whether to allow ffi cheatcodes in test
     pub ffi: bool,
+    /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
+    pub always_use_create_2_factory: bool,
     /// The address which will be executing all tests
     pub sender: Address,
     /// The tx.origin value during EVM execution
@@ -1842,6 +1844,7 @@ impl Default for Config {
             path_pattern_inverse: None,
             fuzz: Default::default(),
             invariant: Default::default(),
+            always_use_create_2_factory: false,
             ffi: false,
             sender: Config::DEFAULT_SENDER,
             tx_origin: Config::DEFAULT_SENDER,
@@ -3408,6 +3411,7 @@ mod tests {
                 revert_strings = "strip"
                 allow_paths = ["allow", "paths"]
                 build_info_path = "build-info"
+                always_use_create_2_factory = true
 
                 [rpc_endpoints]
                 optimism = "https://example.com/"
@@ -3459,6 +3463,7 @@ mod tests {
                         ),
                     ]),
                     build_info_path: Some("build-info".into()),
+                    always_use_create_2_factory: true,
                     ..Config::default()
                 }
             );
@@ -3510,6 +3515,7 @@ mod tests {
                 evm_version = 'london'
                 extra_output = []
                 extra_output_files = []
+                always_use_create_2_factory = false
                 ffi = false
                 force = false
                 gas_limit = 9223372036854775807

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -52,6 +52,9 @@ pub struct EvmOpts {
     /// Enables the FFI cheatcode.
     pub ffi: bool,
 
+    /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
+    pub always_use_create_2_factory: bool,
+
     /// Verbosity mode of EVM output as number of occurrences.
     pub verbosity: u8,
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -69,6 +69,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         },
         invariant: InvariantConfig { runs: 256, ..Default::default() },
         ffi: true,
+        always_use_create_2_factory: false,
         sender: "00a329c0648769A73afAc7F9381D08FB43dBEA72".parse().unwrap(),
         tx_origin: "00a329c0648769A73afAc7F9F81E08FB43dBEA72".parse().unwrap(),
         initial_balance: U256::from(0xffffffffffffffffffffffffu128),

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -303,3 +303,10 @@ test_repro!(6966);
 
 // https://github.com/foundry-rs/foundry/issues/6616
 test_repro!(6616);
+
+// https://github.com/foundry-rs/foundry/issues/5529
+test_repro!(5529; |config| {
+  let mut cheats_config = config.runner.cheats_config.as_ref().clone();
+  cheats_config.always_use_create_2_factory = true;
+  config.runner.cheats_config = std::sync::Arc::new(cheats_config);
+});

--- a/testdata/repros/Issue5529.t.sol
+++ b/testdata/repros/Issue5529.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+
+contract Issue5529Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Counter public counter;
+    address public constant default_create2_factory = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    function testCreate2FactoryUsedInTests() public {
+        address a = vm.computeCreate2Address(0, keccak256(type(Counter).creationCode), address(default_create2_factory));
+        address b = address(new Counter{salt: 0}());
+        require(a == b, "create2 address mismatch");
+    }
+
+    function testCreate2FactoryUsedWhenPranking() public {
+        vm.startPrank(address(1234));
+        address a = vm.computeCreate2Address(0, keccak256(type(Counter).creationCode), address(default_create2_factory));
+        address b = address(new Counter{salt: 0}());
+        require(a == b, "create2 address mismatch");
+    }
+}


### PR DESCRIPTION
## Motivation
#5529 

## Solution
Resolves #5529 by adding logic to allow the default create2 factory to be used in tests and non-broadcasting scripts. I chose to make this change non-breaking by introducing a new config option / CLI flag `always_use_create_2_factory`, which must be set to `true` to enable this behavior.

In the future, this option could be removed or changed relatively easily to make using the create2 factory the default behavior if a breaking change is acceptable.