### PR TITLE
feat: Adding call depth for ```vm.stopAndReturnStateDiff()```

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -372,6 +372,11 @@
           "name": "storageAccesses",
           "ty": "StorageAccess[]",
           "description": "An ordered list of storage accesses made during an account access operation."
+        },
+		{
+		  "name": "depth",
+          "ty": "uint256",
+          "description": "Call depth traversed during the execution of the function"
         }
       ]
     },

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -373,10 +373,10 @@
           "ty": "StorageAccess[]",
           "description": "An ordered list of storage accesses made during an account access operation."
         },
-		{
-		  "name": "depth",
+        {
+          "name": "depth",
           "ty": "uint256",
-          "description": "Call depth traversed during the execution of the function"
+          "description": "Call depth traversed during the recording of state differences"
         }
       ]
     },

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -203,6 +203,8 @@ interface Vm {
         bool reverted;
         /// An ordered list of storage accesses made during an account access operation.
         StorageAccess[] storageAccesses;
+        /// Call depth traversed during the recording of state differences
+        uint256 depth;
     }
 
     /// The storage accessed during an `AccountAccess`.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -477,6 +477,8 @@ pub(super) fn journaled_account<'a, DB: DatabaseExt>(
 /// In the case where `stopAndReturnStateDiff` is called at a lower
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
+///
+/// Depth value will be preserved in each AccountAccess member depth
 fn get_state_diff(state: &mut Cheatcodes) -> Result {
     let res = state
         .recorded_account_diffs_stack
@@ -484,7 +486,10 @@ fn get_state_diff(state: &mut Cheatcodes) -> Result {
         .unwrap_or_default()
         .into_iter()
         .flatten()
-        .map(|record| record.access)
+        .map(|mut record| {
+            record.access.depth = U256::from(record.depth);
+            record.access
+        })
         .collect::<Vec<_>>();
     Ok(res.abi_encode())
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -438,6 +438,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],
                     storageAccesses: vec![],
+                    depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                 };
                 // Ensure that we're not selfdestructing a context recording was initiated on
                 if let Some(last) = account_accesses.last_mut() {
@@ -545,6 +546,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         reverted: false,
                         deployedCode: vec![],
                         storageAccesses: vec![],
+                        depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                     };
                     let access = AccountAccess {
                         access: account_access,
@@ -903,6 +905,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],
                     storageAccesses: vec![], // updated on step
+                    depth: U256::from(0),    // updated on cheatcodes::evm::get_state_diff
                 },
                 depth: data.journaled_state.depth(),
             }]);
@@ -1247,6 +1250,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],    // updated on create_end
                     storageAccesses: vec![], // updated on create_end
+                    depth: U256::from(0),    // updated on cheatcodes::evm::get_state_diff
                 },
                 depth: data.journaled_state.depth(),
             }]);
@@ -1510,6 +1514,7 @@ fn append_storage_access(
                         value: U256::ZERO,
                         data: vec![],
                         deployedCode: vec![],
+                        depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                     };
                     last.push(AccountAccess { access: resume_record, depth: entry.depth });
                 }

--- a/testdata/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/cheats/RecordAccountAccesses.t.sol
@@ -348,7 +348,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             })
         );
 
@@ -366,7 +367,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -383,7 +385,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "hello world",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
         assertEq(
@@ -400,7 +403,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -417,7 +421,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 2 ether,
                 data: abi.encodePacked(type(SelfCaller).creationCode, abi.encode("hello2 world2")),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -434,7 +439,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.2 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
     }
@@ -461,7 +467,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodeCall(this.revertingCall, (address(1234), "")),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             })
         );
         assertEq(
@@ -478,7 +485,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: "",
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
     }
@@ -519,7 +527,8 @@ contract RecordAccountAccessesTest is DSTest {
                     value: 0,
                     data: "",
                     reverted: false,
-                    storageAccesses: new Vm.StorageAccess[](0)
+                    storageAccesses: new Vm.StorageAccess[](0),
+		    depth: startingIndex
                 })
             );
         }
@@ -551,7 +560,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodeCall(NestedRunner.run, (shouldRevert)),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex
             }),
             false
         );
@@ -583,7 +593,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: abi.encodeCall(Reverter.run, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 1
             }),
             false
         );
@@ -615,7 +626,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.01 ether,
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 2
             }),
             false
         );
@@ -647,7 +659,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.001 ether,
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 3
             }),
             false
         );
@@ -679,7 +692,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: abi.encodeCall(Succeeder.run, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 4
             }),
             false
         );
@@ -711,7 +725,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.01 ether,
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 5
             }),
             false
         );
@@ -743,7 +758,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.001 ether,
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 6
             }),
             false
         );
@@ -782,7 +798,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodeCall(NestedStorer.run, ()),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             }),
             false
         );
@@ -826,7 +843,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodeCall(NestedStorer.run2, ()),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             }),
             false
         );
@@ -858,7 +876,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             }),
             false
         );
@@ -903,7 +922,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(false)),
                 reverted: false,
-                storageAccesses: storageAccesses
+                storageAccesses: storageAccesses,
+		depth: 0
             })
         );
 
@@ -925,7 +945,8 @@ contract RecordAccountAccessesTest is DSTest {
                     (bytes32(0), abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(true)))
                     ),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
 
@@ -953,7 +974,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: creationCode,
                 reverted: true,
-                storageAccesses: storageAccesses
+                storageAccesses: storageAccesses,
+		depth: 2
             })
         );
     }
@@ -998,7 +1020,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: creationCode,
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -1015,7 +1038,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
     }
@@ -1044,7 +1068,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(this))),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -1061,7 +1086,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
         assertEq(
@@ -1078,7 +1104,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(bytes20("doesn't exist yet")))),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -1095,7 +1122,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 4
             })
         );
     }
@@ -1190,7 +1218,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: expected.reverted,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             }),
             false
         );


### PR DESCRIPTION
Add call depth for Recorded AccountAccess Calls
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Adds  #6632 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
While changing the struct definition also fix initialization instances for arguments.
The call depth is already recorded in the wrapper ```cheatcodes::inspector::AccountAccess```. 
So in the function ```cheatcodes::evm::get_state_diff``` just add the wrapper depth value to the function return values of now modified ```cheatcodes::Vm::AccountAccess```. 
