### PR TITLE
feat(cast/forge): add label addresses in foundry config

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -1,5 +1,6 @@
 use super::Result;
 use crate::Vm::Rpc;
+use alloy_primitives::Address;
 use foundry_common::fs::normalize_path;
 use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
 use foundry_config::{
@@ -7,7 +8,10 @@ use foundry_config::{
     ResolvedRpcEndpoints,
 };
 use foundry_evm_core::opts::EvmOpts;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 /// Additional, configurable context the `Cheatcodes` inspector has access to
 ///
@@ -30,6 +34,8 @@ pub struct CheatsConfig {
     pub allowed_paths: Vec<PathBuf>,
     /// How the evm was configured by the user
     pub evm_opts: EvmOpts,
+    /// Address labels from config
+    pub labels: HashMap<Address, String>,
 }
 
 impl CheatsConfig {
@@ -51,6 +57,7 @@ impl CheatsConfig {
             root: config.__root.0.clone(),
             allowed_paths,
             evm_opts,
+            labels: config.labels.clone(),
         }
     }
 
@@ -164,6 +171,7 @@ impl Default for CheatsConfig {
             root: Default::default(),
             allowed_paths: vec![],
             evm_opts: Default::default(),
+            labels: Default::default(),
         }
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -225,6 +225,13 @@ impl Cheatcodes {
         Self { config, fs_commit: true, ..Default::default() }
     }
 
+    /// Returns all labeled address to label mappings.
+    pub fn get_labels(&self) -> HashMap<Address, String> {
+        let mut labels = self.labels.clone();
+        labels.extend(self.config.labels.clone().into_iter());
+        labels
+    }
+
     fn apply_cheatcode<DB: DatabaseExt>(
         &mut self,
         data: &mut EVMData<'_, DB>,
@@ -1056,7 +1063,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         // return a better error here
         if status == InstructionResult::Revert {
             if let Some(err) = diag {
-                return (status, remaining_gas, Error::encode(err.to_error_msg(&self.labels)))
+                return (status, remaining_gas, Error::encode(err.to_error_msg(&self.get_labels())))
             }
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -222,14 +222,8 @@ impl Cheatcodes {
     /// Creates a new `Cheatcodes` with the given settings.
     #[inline]
     pub fn new(config: Arc<CheatsConfig>) -> Self {
-        Self { config, fs_commit: true, ..Default::default() }
-    }
-
-    /// Returns all labeled address to label mappings.
-    pub fn get_labels(&self) -> HashMap<Address, String> {
-        let mut labels = self.labels.clone();
-        labels.extend(self.config.labels.clone().into_iter());
-        labels
+        let labels = config.labels.clone();
+        Self { config, fs_commit: true, labels, ..Default::default() }
     }
 
     fn apply_cheatcode<DB: DatabaseExt>(
@@ -269,7 +263,7 @@ impl Cheatcodes {
         if data.journaled_state.depth > 1 && !data.db.has_cheatcode_access(inputs.caller) {
             // we only grant cheat code access for new contracts if the caller also has
             // cheatcode access and the new contract is created in top most call
-            return created_address
+            return created_address;
         }
 
         data.db.allow_cheatcode_access(created_address);
@@ -286,12 +280,12 @@ impl Cheatcodes {
 
         // Delay revert clean up until expected revert is handled, if set.
         if self.expected_revert.is_some() {
-            return
+            return;
         }
 
         // we only want to apply cleanup top level
         if data.journaled_state.depth() > 0 {
-            return
+            return;
         }
 
         // Roll back all previously applied deals
@@ -729,11 +723,11 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             return match self.apply_cheatcode(data, call) {
                 Ok(retdata) => (InstructionResult::Return, gas, retdata.into()),
                 Err(err) => (InstructionResult::Revert, gas, err.abi_encode().into()),
-            }
+            };
         }
 
         if call.contract == HARDHAT_CONSOLE_ADDRESS {
-            return (InstructionResult::Continue, gas, Bytes::new())
+            return (InstructionResult::Continue, gas, Bytes::new());
         }
 
         // Handle expected calls
@@ -776,7 +770,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     })
                     .map(|(_, v)| v)
             }) {
-                return (return_data.ret_type, gas, return_data.data.clone())
+                return (return_data.ret_type, gas, return_data.data.clone());
             }
         }
 
@@ -833,7 +827,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     if let Err(err) =
                         data.journaled_state.load_account(broadcast.new_origin, data.db)
                     {
-                        return (InstructionResult::Revert, gas, Error::encode(err))
+                        return (InstructionResult::Revert, gas, Error::encode(err));
                     }
 
                     let is_fixed_gas_limit = check_if_fixed_gas_limit(data, call.gas_limit);
@@ -864,7 +858,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     debug!(target: "cheatcodes", address=%broadcast.new_origin, nonce=prev+1, prev, "incremented nonce");
                 } else if broadcast.single_call {
                     let msg = "`staticcall`s are not allowed after `broadcast`; use `startBroadcast` instead";
-                    return (InstructionResult::Revert, Gas::new(0), Error::encode(msg))
+                    return (InstructionResult::Revert, Gas::new(0), Error::encode(msg));
                 }
             }
         }
@@ -927,7 +921,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         retdata: Bytes,
     ) -> (InstructionResult, Gas, Bytes) {
         if call.contract == CHEATCODE_ADDRESS || call.contract == HARDHAT_CONSOLE_ADDRESS {
-            return (status, remaining_gas, retdata)
+            return (status, remaining_gas, retdata);
         }
 
         if data.journaled_state.depth() == 0 && self.skip {
@@ -935,7 +929,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 InstructionResult::Revert,
                 remaining_gas,
                 super::Error::from(MAGIC_SKIP).abi_encode().into(),
-            )
+            );
         }
 
         // Clean up pranks
@@ -977,7 +971,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         (InstructionResult::Revert, remaining_gas, error.abi_encode().into())
                     }
                     Ok((_, retdata)) => (InstructionResult::Return, remaining_gas, retdata),
-                }
+                };
             }
         }
 
@@ -1046,7 +1040,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     InstructionResult::Revert,
                     remaining_gas,
                     "log != expected log".abi_encode().into(),
-                )
+                );
             } else {
                 // All emits were found, we're good.
                 // Clear the queue, as we expect the user to declare more events for the next call
@@ -1063,7 +1057,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         // return a better error here
         if status == InstructionResult::Revert {
             if let Some(err) = diag {
-                return (status, remaining_gas, Error::encode(err.to_error_msg(&self.get_labels())))
+                return (status, remaining_gas, Error::encode(err.to_error_msg(&self.labels)));
             }
         }
 
@@ -1087,7 +1081,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             // earlier error that happened first with unrelated information about
             // another error when using cheatcodes.
             if status == InstructionResult::Revert {
-                return (status, remaining_gas, retdata)
+                return (status, remaining_gas, retdata);
             }
 
             // If there's not a revert, we can continue on to run the last logic for expect*
@@ -1132,7 +1126,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                             "expected call to {address} with {expected_values} \
                              to be called {count} time{s}, but {but}"
                         );
-                        return (InstructionResult::Revert, remaining_gas, Error::encode(msg))
+                        return (InstructionResult::Revert, remaining_gas, Error::encode(msg));
                     }
                 }
             }
@@ -1149,7 +1143,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     "expected an emit, but the call reverted instead. \
                      ensure you're testing the happy path when using `expectEmit`"
                 };
-                return (InstructionResult::Revert, remaining_gas, Error::encode(msg))
+                return (InstructionResult::Revert, remaining_gas, Error::encode(msg));
             }
         }
 
@@ -1184,7 +1178,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 call.caller == broadcast.original_caller
             {
                 if let Err(err) = data.journaled_state.load_account(broadcast.new_origin, data.db) {
-                    return (InstructionResult::Revert, None, gas, Error::encode(err))
+                    return (InstructionResult::Revert, None, gas, Error::encode(err));
                 }
 
                 data.env.tx.caller = broadcast.new_origin;
@@ -1311,7 +1305,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     Err(err) => {
                         (InstructionResult::Revert, None, remaining_gas, err.abi_encode().into())
                     }
-                }
+                };
             }
         }
 

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -105,7 +105,7 @@ impl Cheatcode for labelCall {
 impl Cheatcode for getLabelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account } = self;
-        Ok(match state.get_labels().get(account) {
+        Ok(match state.labels.get(account) {
             Some(label) => label.abi_encode(),
             None => format!("unlabeled:{account}").abi_encode(),
         })

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -105,7 +105,7 @@ impl Cheatcode for labelCall {
 impl Cheatcode for getLabelCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { account } = self;
-        Ok(match state.labels.get(account) {
+        Ok(match state.get_labels().get(account) {
             Some(label) => label.abi_encode(),
             None => format!("unlabeled:{account}").abi_encode(),
         })

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -390,8 +390,12 @@ pub async fn handle_traces(
         None
     });
 
+    let labeled_addresses_in_config = config.labels.clone().into_iter();
+
+    let concatenated_addresses = labeled_addresses.chain(labeled_addresses_in_config);
+
     let mut decoder = CallTraceDecoderBuilder::new()
-        .with_labels(labeled_addresses)
+        .with_labels(concatenated_addresses)
         .with_signature_identifier(SignaturesIdentifier::new(
             Config::foundry_cache_dir(),
             config.offline,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -301,7 +301,7 @@ impl InspectorStack {
                 .cheatcodes
                 .as_ref()
                 .map(|cheatcodes| {
-                    cheatcodes.get_labels().clone().into_iter().map(|l| (l.0, l.1)).collect()
+                    cheatcodes.labels.clone().into_iter().map(|l| (l.0, l.1)).collect()
                 })
                 .unwrap_or_default(),
             traces: self.tracer.map(|tracer| tracer.traces),
@@ -344,7 +344,7 @@ impl InspectorStack {
                 if new_status != status ||
                     (new_status == InstructionResult::Revert && new_retdata != retdata)
                 {
-                    return (new_status, new_gas, new_retdata)
+                    return (new_status, new_gas, new_retdata);
                 }
             }
         );
@@ -371,7 +371,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
                 // Allow inspectors to exit early
                 if interpreter.instruction_result != res {
                     #[allow(clippy::needless_return)]
-                    return
+                    return;
                 }
             }
         );
@@ -395,7 +395,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
                 // Allow inspectors to exit early
                 if interpreter.instruction_result != res {
                     #[allow(clippy::needless_return)]
-                    return
+                    return;
                 }
             }
         );
@@ -433,7 +433,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
                 // Allow inspectors to exit early
                 if interpreter.instruction_result != res {
                     #[allow(clippy::needless_return)]
-                    return
+                    return;
                 }
             }
         );
@@ -460,7 +460,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
                 // Allow inspectors to exit early
                 #[allow(clippy::needless_return)]
                 if status != InstructionResult::Continue {
-                    return (status, gas, retdata)
+                    return (status, gas, retdata);
                 }
             }
         );
@@ -509,7 +509,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
 
                 // Allow inspectors to exit early
                 if status != InstructionResult::Continue {
-                    return (status, addr, gas, retdata)
+                    return (status, addr, gas, retdata);
                 }
             }
         );
@@ -546,7 +546,7 @@ impl<DB: DatabaseExt> Inspector<DB> for InspectorStack {
                 );
 
                 if new_status != status {
-                    return (new_status, new_address, new_gas, new_retdata)
+                    return (new_status, new_address, new_gas, new_retdata);
                 }
             }
         );

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -301,7 +301,7 @@ impl InspectorStack {
                 .cheatcodes
                 .as_ref()
                 .map(|cheatcodes| {
-                    cheatcodes.labels.clone().into_iter().map(|l| (l.0, l.1)).collect()
+                    cheatcodes.get_labels().clone().into_iter().map(|l| (l.0, l.1)).collect()
                 })
                 .unwrap_or_default(),
             traces: self.tracer.map(|tracer| tracer.traces),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -111,6 +111,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fmt: Default::default(),
         doc: Default::default(),
         fs_permissions: Default::default(),
+        labels: Default::default(),
         cancun: true,
         __non_exhaustive: (),
         __warnings: vec![],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Inspecting & testing transactions that require multiple address labels is quite painful at this point because it makes the cast command or test script unnecessarily verbose.

```bash
$ cast run <tx> \
  --label 0x1F98431c8aD98523631AE4a59f267346ea31F984:"Uniswap V3: Factory" \
  --label 0xC36442b4a4522E871399CD717aBDD847Ab11FE88:"Uniswap V3: Positions NFT" # ...
```

```solidity
function setUp() public {
    vm.label(address(0x1F98431c8aD98523631AE4a59f267346ea31F984), "Uniswap V3: Factory");
    vm.label(address(0xC36442b4a4522E871399CD717aBDD847Ab11FE88), "Uniswap V3: Positions NFT");
    // ...
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `labels` section in foundry config that allows to pre-label frequently used addresses. Most evm addresses are used as the same purpose across multiple chains, so the config is considered standalone section. The config is then merged with given cli argument in `cast run` / given cheatcode labeled addresses in `forge test` and the merged labels collection is used to label the final trace.

```toml
# ...
[labels]
0x1F98431c8aD98523631AE4a59f267346ea31F984 = "Uniswap V3: Factory"
0xC36442b4a4522E871399CD717aBDD847Ab11FE88 = "Uniswap V3: Positions NFT"
```