### PR TITLE
feat(cast): add `selectors` command to extract function selectors and arguments from bytecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "evm-disassembler",
+ "evmole",
  "eyre",
  "foundry-block-explorers",
  "foundry-cli",
@@ -2341,6 +2342,15 @@ checksum = "7ef8b778f0f7ba24aaa7c1d8fa7ec75db869f8a8508907be49eac899865ea52d"
 dependencies = [
  "eyre",
  "hex",
+]
+
+[[package]]
+name = "evmole"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f492d1949e58ef83a1bf8e23fbd042af12b03e7642d50dbb4cfb48112de5e01f"
+dependencies = [
+ "ruint",
 ]
 
 [[package]]

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -69,6 +69,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "signal"] }
 tracing.workspace = true
 yansi = "0.5"
+evmole = "0.3.1"
 
 [dev-dependencies]
 foundry-test-utils.workspace = true

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -269,6 +269,11 @@ async fn main() -> Result<()> {
         Subcommands::Disassemble { bytecode } => {
             println!("{}", SimpleCast::disassemble(&bytecode)?);
         }
+        Subcommands::Selectors { bytecode } => {
+            let s = SimpleCast::extract_selectors(&bytecode)?;
+            let v: Vec<_> = s.into_iter().map(|r| format!("{}\t{}", r.0, r.1)).collect();
+            println!("{}", v.join("\n"));
+        }
         Subcommands::FindBlock(cmd) => cmd.run().await?,
         Subcommands::GasPrice { rpc } => {
             let config = Config::from(&rpc);

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -858,6 +858,10 @@ pub enum Subcommands {
     /// Decodes a raw signed EIP 2718 typed transaction
     #[clap(visible_alias = "dt")]
     DecodeTransaction { tx: Option<String> },
+
+    /// Extracts function selectors and arguments from bytecode
+    #[clap(visible_alias = "sel")]
+    Selectors { bytecode: String },
 }
 
 /// CLI arguments for `cast --to-base`.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1941,6 +1941,27 @@ impl SimpleCast {
         }
     }
 
+    /// Extracts function selectors and arguments from bytecode
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// let bytecode = "6080604052348015600e575f80fd5b50600436106026575f3560e01c80632125b65b14602a575b5f80fd5b603a6035366004603c565b505050565b005b5f805f60608486031215604d575f80fd5b833563ffffffff81168114605f575f80fd5b925060208401356001600160a01b03811681146079575f80fd5b915060408401356001600160e01b03811681146093575f80fd5b80915050925092509256";
+    /// let selectors = Cast::extract_selectors(bytecode)?;
+    /// assert_eq!(selectors, vec![("0x2125b65b".to_string(), "uint32,address,uint224".to_string())]);
+    /// # Ok::<(), eyre::Report>(())
+    /// ```
+    pub fn extract_selectors(bytecode: &str) -> Result<Vec<(String, String)>> {
+        let code = hex::decode(strip_0x(bytecode))?;
+        let s = evmole::function_selectors(&code, 0);
+
+        Ok(s.iter()
+            .map(|s| (hex::encode_prefixed(s), evmole::function_arguments(&code, s, 0)))
+            .collect())
+    }
+
     /// Decodes a raw EIP2718 transaction payload
     /// Returns details about the typed transaction and ECSDA signature components
     ///


### PR DESCRIPTION
## Motivation
Sometimes, you don't have the source code/ABI for the contract but want to determine which functions exist, having only the deployed bytecode.


## Solution
I am the author of the [EVMole](https://github.com/cdump/evmole) library, which addresses this problem. The library includes [reproducible benchmarks](https://github.com/cdump/evmole/tree/master#benchmark) for accuracy and speed, along with a comparison with other existing tools.

In this PR, I have added the `selectors` command to the `cast` tool, which uses my library for the task.

Example of using `cast code` to obtain the bytecode of the USD-T contract and `cast selectors` to extract selectors and arguments:
```sh
$ cast selectors $(cast code 0xdAC17F958D2ee523a2206206994597C13D831ec7)
0x06fdde03
0x0753c30c      address
0x095ea7b3      address,uint256
0x0e136b19
0x0ecb93c0      address
0x18160ddd
0x23b872dd      address,address,uint256
0x26976e3f
0x27e235e3      address
0x313ce567
0x35390714
0x3eaaf86b
0x3f4ba83a
0x59bf1abe      address
0x5c658165      address,address
0x5c975abb
0x70a08231      address
0x8456cb59
0x893d20e8
0x8da5cb5b
0x95d89b41
0xa9059cbb      address,uint256
0xc0324c77      uint256,uint256
0xcc872b66      uint256
0xdb006a75      uint256
0xdd62ed3e      address,address
0xdd644f72
0xe47d6060      address
0xe4997dc5      address
0xe5b5019a
0xf2fde38b      address
0xf3bdc228      address
```