### PR TITLE
feat(cast): Copy verified source contract from one blockexplorer to another

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "clap_complete_fig",
  "comfy-table",
  "const-hex",
+ "contract-verification-migrator",
  "criterion",
  "dunce",
  "eth-keystore",
@@ -1412,6 +1413,23 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "contract-verification-migrator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7981e4f5a1da62a08913bbad187cb0904eb95ef51f862c74d5dc0ffc35db1b0"
+dependencies = [
+ "clap",
+ "console",
+ "eyre",
+ "foundry-block-explorers",
+ "futures",
+ "hex",
+ "indicatif",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "convert_case"
@@ -3052,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3067,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3077,15 +3095,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3094,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-locks"
@@ -3110,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3121,15 +3139,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -3143,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -69,6 +69,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "signal"] }
 tracing.workspace = true
 yansi = "0.5"
+contract-verification-migrator = "0.1.0" 
 
 [dev-dependencies]
 foundry-test-utils.workspace = true

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -5,9 +5,9 @@ use alloy_primitives::{keccak256, Address, B256};
 use cast::{Cast, SimpleCast};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
+use contract_verification_migrator::copy_etherscan_verification;
 use ethers_core::types::{BlockId, BlockNumber::Latest};
 use ethers_providers::Middleware;
-use contract_verification_migrator::copy_etherscan_verification;
 use eyre::Result;
 use foundry_cli::{handler, prompt, stdin, utils};
 use foundry_common::{
@@ -475,11 +475,32 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Subcommands::CopyVerifiedSource { addresses,  source_api_key, source_url, target_api_key, target_url } => {
-            let results = copy_etherscan_verification(addresses.clone(), source_api_key, source_url, target_api_key, target_url, true).await;
-            let failed_results = results.iter().zip(addresses.iter()).filter(|(r,_)| r.is_err()).collect::<Vec<_>>();
+        Subcommands::CopyVerifiedSource {
+            addresses,
+            source_api_key,
+            source_url,
+            target_api_key,
+            target_url,
+        } => {
+            let results = copy_etherscan_verification(
+                addresses.clone(),
+                source_api_key,
+                source_url,
+                target_api_key,
+                target_url,
+                true,
+            )
+            .await;
+            let failed_results = results
+                .iter()
+                .zip(addresses.iter())
+                .filter(|(r, _)| r.is_err())
+                .collect::<Vec<_>>();
             if !failed_results.is_empty() {
-                return Result::Err(eyre::eyre!("Failed to copy verification for the following contracts: {:#?}", failed_results));
+                return Result::Err(eyre::eyre!(
+                    "Failed to copy verification for the following contracts: {:#?}",
+                    failed_results
+                ));
             }
         }
         Subcommands::Create2(cmd) => {

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -7,6 +7,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use ethers_core::types::{BlockId, BlockNumber::Latest};
 use ethers_providers::Middleware;
+use contract_verification_migrator::copy_etherscan_verification;
 use eyre::Result;
 use foundry_cli::{handler, prompt, stdin, utils};
 use foundry_common::{
@@ -472,6 +473,13 @@ async fn main() -> Result<()> {
                 None => {
                     println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?);
                 }
+            }
+        }
+        Subcommands::CopyVerifiedSource { addresses,  source_api_key, source_url, target_api_key, target_url } => {
+            let results = copy_etherscan_verification(addresses.clone(), source_api_key, source_url, target_api_key, target_url, true).await;
+            let failed_results = results.iter().zip(addresses.iter()).filter(|(r,_)| r.is_err()).collect::<Vec<_>>();
+            if !failed_results.is_empty() {
+                return Result::Err(eyre::eyre!("Failed to copy verification for the following contracts: {:#?}", failed_results));
             }
         }
         Subcommands::Create2(cmd) => {

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -781,6 +781,22 @@ pub enum Subcommands {
         etherscan: EtherscanOpts,
     },
 
+    /// Copy source code verification from one block explorer / contract to another
+    #[clap(visible_aliases = &["cvs"])]
+    CopyVerifiedSource {
+        /// The contract's address.
+        addresses: Vec<String>,
+
+        #[clap(long)]
+        source_url: String,
+        #[clap(long)]
+        source_api_key: String,
+        #[clap(long)]
+        target_url: String,
+        #[clap(long)]
+        target_api_key: String,
+    },
+
     /// Wallet management utilities.
     #[clap(visible_alias = "w")]
     Wallet {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Recently I ran into the issue where I wanted to get a bunch of contracts verified on Blockscout, which were already verfied on etherscan. For some of these contracts I did not have ready access to the original source code repo, so it would have been difficult / tedious to verify them manually.

## Solution

 I wrote a little script that downloads the source code / metadata from the source explorer (etherscan in that case) and then uses that data to verify the contracts on the target explorer.

I thought this might be interesting for other people as well so I turned it into a [crate](https://crates.io/crates/contract-verification-migrator) and extended the cast cli to include this functionality.

## Demo

![demo](https://github.com/foundry-rs/foundry/assets/15629702/bbcdbcad-23e2-4002-940d-072dac459148)
