### PR TITLE
docs(crates/config): correct README.md link path

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -56,7 +56,7 @@ The selected profile is the value of the `FOUNDRY_PROFILE` environment variable,
 
 ### All Options
 
-The following is a foundry.toml file with all configuration options set. See also [/config/src/lib.rs](/config/src/lib.rs) and [/cli/tests/it/config.rs](/cli/tests/it/config.rs).
+The following is a foundry.toml file with all configuration options set. See also [/config/src/lib.rs](./src/lib.rs) and [/cli/tests/it/config.rs](../forge/tests/it/config.rs).
 
 ```toml
 ## defaults for _all_ profiles


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.



Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
<img width="1452" alt="image" src="https://github.com/foundry-rs/foundry/assets/153156292/12285ad7-eab2-4ee4-a5ee-71de46f33afc">

this link relative path is broken

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

replace those links
