### PR TITLE
fix(cheatcodes): always omit pk on `addr`

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -357,7 +357,7 @@ impl CallTraceDecoder {
     fn decode_cheatcode_inputs(&self, func: &Function, data: &[u8]) -> Option<Vec<String>> {
         match func.name.as_str() {
             "expectRevert" => Some(vec![decode::decode_revert(data, Some(&self.errors), None)]),
-            "rememberKey" | "addr" | "startBroadcast" | "broadcast" => {
+            "rememberKey" | "startBroadcast" | "broadcast" => {
                 // these functions accept a private key as uint256, which should not be
                 // converted to plain text
                 if !func.inputs.is_empty() && func.inputs[0].ty != "uint256" {
@@ -375,6 +375,7 @@ impl CallTraceDecoder {
                 }
                 Some(decoded.iter().map(format_token).collect())
             }
+            "addr" => Some(vec!["<pk>".to_string()]),
             "deriveKey" => Some(vec!["<pk>".to_string()]),
             "parseJson" |
             "parseJsonUint" |


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #6696 

## Solution

Always omits the pk on addr, instead of doing so conditionally.
