### PR TITLE
refactor: rewrite compile functions to a common builder

### DIFF
--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -33,7 +33,6 @@ pub struct AccessListArgs {
     #[clap(
         long,
         value_name = "DATA",
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix,
         conflicts_with_all = &["sig", "args"]
     )]
     data: Option<String>,

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -34,7 +34,6 @@ pub struct CallArgs {
     /// Data for the transaction.
     #[clap(
         long,
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix,
         conflicts_with_all = &["sig", "args"]
     )]
     data: Option<String>,

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -115,7 +115,7 @@ impl StorageArgs {
 
         // Not a forge project or artifact not found
         // Get code from Etherscan
-        sh_note!("No matching artifacts found, fetching source code from Etherscan...")?;
+        eprintln!("No matching artifacts found, fetching source code from Etherscan...");
 
         if self.etherscan.key.is_none() {
             eyre::bail!("You must provide an Etherscan API key if you're fetching a remote contract's storage.");
@@ -155,7 +155,7 @@ impl StorageArgs {
 
             if is_storage_layout_empty(&artifact.storage_layout) && auto_detect {
                 // try recompiling with the minimum version
-                sh_warn!("The requested contract was compiled with {version} while the minimum version for storage layouts is {MIN_SOLC} and as a result the output may be empty.")?;
+                eprintln!("The requested contract was compiled with {version} while the minimum version for storage layouts is {MIN_SOLC} and as a result the output may be empty.");
                 let solc = Solc::find_or_install_svm_version(MIN_SOLC.to_string())?;
                 project.solc = solc;
                 project.auto_detect = false;
@@ -217,7 +217,8 @@ async fn fetch_and_print_storage(
     pretty: bool,
 ) -> Result<()> {
     if is_storage_layout_empty(&artifact.storage_layout) {
-        sh_note!("Storage layout is empty.")
+        eprintln!("Storage layout is empty.");
+        Ok(())
     } else {
         let layout = artifact.storage_layout.as_ref().unwrap().clone();
         let values = fetch_storage_slots(provider, address, &layout).await?;

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -72,10 +72,7 @@ pub enum WalletSubcommands {
     #[clap(visible_aliases = &["a", "addr"])]
     Address {
         /// If provided, the address will be derived from the specified private key.
-        #[clap(
-            value_name = "PRIVATE_KEY",
-            value_parser = foundry_common::clap_helpers::strip_0x_prefix,
-        )]
+        #[clap(value_name = "PRIVATE_KEY")]
         private_key_override: Option<String>,
 
         #[clap(flatten)]

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -28,8 +28,7 @@ pub mod opts;
 use opts::{Opts, Subcommands, ToBaseArgs};
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    handler::install()?;
+    handler::install();
     utils::load_dotenv();
     utils::subscriber();
     utils::enable_paint();

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -28,6 +28,7 @@ pub mod opts;
 use opts::{Opts, Subcommands, ToBaseArgs};
 
 #[tokio::main]
+async fn main() -> Result<()> {
     handler::install();
     utils::load_dotenv();
     utils::subscriber();

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, B256, U256};
 use clap::{Parser, Subcommand, ValueHint};
 use ethers_core::types::{BlockId, NameOrAddress};
 use eyre::Result;
-use foundry_cli::opts::{EtherscanOpts, RpcOpts};
+use foundry_cli::opts::{EtherscanOpts, RpcOpts, ShellOptions};
 use std::{path::PathBuf, str::FromStr};
 
 const VERSION_MESSAGE: &str = concat!(
@@ -19,19 +19,22 @@ const VERSION_MESSAGE: &str = concat!(
     ")"
 );
 
-#[derive(Debug, Parser)]
-#[clap(name = "cast", version = VERSION_MESSAGE)]
+/// Perform Ethereum RPC calls from the comfort of your command line.
+#[derive(Parser)]
+#[clap(
+    name = "cast",
+    version = VERSION_MESSAGE,
+    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html",
+    next_display_order = None,
+)]
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,
+    #[clap(flatten)]
+    pub shell: ShellOptions,
 }
 
-/// Perform Ethereum RPC calls from the comfort of your command line.
-#[derive(Debug, Subcommand)]
-#[clap(
-    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html",
-    next_display_order = None
-)]
+#[derive(Subcommand)]
 pub enum Subcommands {
     /// Prints the maximum value of the given integer type.
     #[clap(visible_aliases = &["--max-int", "maxi"])]

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, B256, U256};
 use clap::{Parser, Subcommand, ValueHint};
 use ethers_core::types::{BlockId, NameOrAddress};
 use eyre::Result;
-use foundry_cli::opts::{EtherscanOpts, RpcOpts, ShellOptions};
+use foundry_cli::opts::{EtherscanOpts, RpcOpts};
 use std::{path::PathBuf, str::FromStr};
 
 const VERSION_MESSAGE: &str = concat!(
@@ -30,8 +30,6 @@ const VERSION_MESSAGE: &str = concat!(
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,
-    #[clap(flatten)]
-    pub shell: ShellOptions,
 }
 
 #[derive(Subcommand)]

--- a/crates/cast/src/base.rs
+++ b/crates/cast/src/base.rs
@@ -41,12 +41,12 @@ impl FromStr for Base {
             "10" | "d" | "dec" | "decimal" => Ok(Self::Decimal),
             "16" | "h" | "hex" | "hexadecimal" => Ok(Self::Hexadecimal),
             s => Err(eyre::eyre!(
-                r#"Invalid base "{}". Possible values:
-2, b, bin, binary
-8, o, oct, octal
+                "\
+Invalid base \"{s}\". Possible values:
+ 2, b, bin, binary
+ 8, o, oct, octal
 10, d, dec, decimal
-16, h, hex, hexadecimal"#,
-                s
+16, h, hex, hexadecimal"
             )),
         }
     }

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -84,7 +84,7 @@ pub enum ChiselParserSub {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    handler::install()?;
+    handler::install();
     utils::subscriber();
     #[cfg(windows)]
     if !Paint::enable_windows_ascii() {

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -1,4 +1,4 @@
-use eyre::{EyreHandler, Result};
+use eyre::EyreHandler;
 use std::error::Error;
 use yansi::Paint;
 
@@ -47,9 +47,8 @@ impl EyreHandler for Handler {
 /// verbose debug-centric handler is installed.
 ///
 /// Panics are always caught by the more debug-centric handler.
-pub fn install() -> Result<()> {
+pub fn install() {
     let debug_enabled = std::env::var("FOUNDRY_DEBUG").is_ok();
-
     if debug_enabled {
         if let Err(e) = color_eyre::install() {
             debug!("failed to install color eyre error hook: {e}");
@@ -65,6 +64,4 @@ pub fn install() -> Result<()> {
             debug!("failed to install eyre error hook: {e}");
         }
     }
-
-    Ok(())
 }

--- a/crates/cli/src/opts/wallet/mod.rs
+++ b/crates/cli/src/opts/wallet/mod.rs
@@ -42,11 +42,7 @@ pub struct RawWallet {
     pub interactive: bool,
 
     /// Use the provided private key.
-    #[clap(
-        long,
-        value_name = "RAW_PRIVATE_KEY",
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix
-    )]
+    #[clap(long, value_name = "RAW_PRIVATE_KEY")]
     pub private_key: Option<String>,
 
     /// Use the mnemonic phrase of mnemonic file at the specified path.

--- a/crates/cli/src/opts/wallet/multi_wallet.rs
+++ b/crates/cli/src/opts/wallet/multi_wallet.rs
@@ -97,12 +97,7 @@ pub struct MultiWallet {
     pub interactives: u32,
 
     /// Use the provided private keys.
-    #[clap(
-        long,
-        help_heading = "Wallet options - raw",
-        value_name = "RAW_PRIVATE_KEYS",
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix,
-    )]
+    #[clap(long, help_heading = "Wallet options - raw", value_name = "RAW_PRIVATE_KEYS")]
     pub private_keys: Option<Vec<String>>,
 
     /// Use the provided private key.
@@ -110,8 +105,7 @@ pub struct MultiWallet {
         long,
         help_heading = "Wallet options - raw",
         conflicts_with = "private_keys",
-        value_name = "RAW_PRIVATE_KEY",
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix,
+        value_name = "RAW_PRIVATE_KEY"
     )]
     pub private_key: Option<String>,
 

--- a/crates/common/src/clap_helpers.rs
+++ b/crates/common/src/clap_helpers.rs
@@ -1,6 +1,0 @@
-//! Additional utils for clap
-
-/// A `clap` `value_parser` that removes a `0x` prefix if it exists
-pub fn strip_0x_prefix(s: &str) -> Result<String, &'static str> {
-    Ok(s.strip_prefix("0x").unwrap_or(s).to_string())
-}

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -151,7 +151,7 @@ impl ProjectCompiler {
     ///
     /// # Example
     ///
-    /// ```no_run
+    /// ```ignore
     /// use foundry_common::compile::ProjectCompiler;
     /// let config = foundry_config::Config::load();
     /// let prj = config.project().unwrap();

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -15,6 +15,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     convert::Infallible,
     fmt::Display,
+    io::IsTerminal,
     path::{Path, PathBuf},
     result,
     str::FromStr,
@@ -189,7 +190,7 @@ impl ProjectCompiler {
         let reporter = if quiet {
             Report::new(NoReporter::default())
         } else {
-            if false {
+            if std::io::stdout().is_terminal() {
                 Report::new(SpinnerReporter::spawn())
             } else {
                 Report::new(BasicStdoutReporter::default())
@@ -381,12 +382,13 @@ pub fn compile_target_with_filter(
     target_path: &Path,
     project: &Project,
     verify: bool,
+    quiet: bool,
     skip: Vec<SkipBuildFilter>,
 ) -> Result<ProjectCompileOutput> {
     let graph = Graph::resolve(&project.paths)?;
 
     // Checking if it's a standalone script, or part of a project.
-    let mut compiler = ProjectCompiler::new().filters(skip);
+    let mut compiler = ProjectCompiler::new().filters(skip).quiet(quiet);
     if !graph.files().contains_key(target_path) {
         if verify {
             eyre::bail!("You can only verify deployments from inside a project! Make sure it exists with `forge tree`.");

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -65,7 +65,7 @@ impl ProjectCompiler {
             verify: None,
             print_names: None,
             print_sizes: None,
-            quiet: Some(crate::shell::verbosity().is_quiet()),
+            quiet: Some(crate::shell::verbosity().is_silent()),
             filters: Vec::new(),
             files: Vec::new(),
         }
@@ -179,7 +179,7 @@ impl ProjectCompiler {
     {
         // TODO: Avoid process::exit
         if !project.paths.has_input_files() {
-            sh_eprintln!("Nothing to compile")?;
+            println!("Nothing to compile");
             // nothing to do here
             std::process::exit(0);
         }
@@ -189,7 +189,7 @@ impl ProjectCompiler {
         let reporter = if quiet {
             Report::new(NoReporter::default())
         } else {
-            if crate::Shell::get().is_err_tty() {
+            if false {
                 Report::new(SpinnerReporter::spawn())
             } else {
                 Report::new(BasicStdoutReporter::default())
@@ -213,10 +213,10 @@ impl ProjectCompiler {
 
         if !quiet {
             if output.is_unchanged() {
-                sh_println!("No files changed, compilation skipped")?;
+                println!("No files changed, compilation skipped");
             } else {
                 // print the compiler output / warnings
-                sh_println!("{output}")?;
+                println!("{output}");
             }
 
             self.handle_output(&output);
@@ -237,14 +237,12 @@ impl ProjectCompiler {
                 artifacts.entry(version).or_default().push(name);
             }
             for (version, names) in artifacts {
-                let _ = sh_println!(
+                println!(
                     "  compiler version: {}.{}.{}",
-                    version.major,
-                    version.minor,
-                    version.patch
+                    version.major, version.minor, version.patch
                 );
                 for name in names {
-                    let _ = sh_println!("    - {name}");
+                    println!("    - {name}");
                 }
             }
         }
@@ -252,7 +250,7 @@ impl ProjectCompiler {
         if print_sizes {
             // add extra newline if names were already printed
             if print_names {
-                let _ = sh_println!();
+                println!();
             }
 
             let mut size_report = SizeReport { contracts: BTreeMap::new() };
@@ -273,7 +271,7 @@ impl ProjectCompiler {
                 size_report.contracts.insert(name, ContractInfo { size, is_dev_contract });
             }
 
-            let _ = sh_println!("{size_report}");
+            println!("{size_report}");
 
             // TODO: avoid process::exit
             // exit with error if any contract exceeds the size limit, excluding test contracts.

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -9,7 +9,6 @@ extern crate tracing;
 
 pub mod abi;
 pub mod calc;
-pub mod clap_helpers;
 pub mod compile;
 pub mod constants;
 pub mod contracts;

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -1,5 +1,7 @@
+//! Support for handling/identifying selectors.
+
 #![allow(missing_docs)]
-//! Support for handling/identifying selectors
+
 use crate::abi::abi_decode_calldata;
 use alloy_json_abi::JsonAbi;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -410,7 +412,6 @@ pub async fn decode_event_topic(topic: &str) -> eyre::Result<Vec<String>> {
 /// # Ok(())
 /// # }
 /// ```
-
 pub async fn pretty_calldata(
     calldata: impl AsRef<str>,
     offline: bool,

--- a/crates/config/src/warning.rs
+++ b/crates/config/src/warning.rs
@@ -53,30 +53,37 @@ impl fmt::Display for Warning {
         match self {
             Self::UnknownSection { unknown_section, source } => {
                 let source = source.as_ref().map(|src| format!(" in {src}")).unwrap_or_default();
-                f.write_fmt(format_args!("Unknown section [{unknown_section}] found{source}. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.{unknown_section}] instead or run `forge config --fix`."))
+                write!(
+                    f,
+                    "Found unknown config section{source}: [{unknown_section}]\n\
+                     This notation for profiles has been deprecated and may result in the profile \
+                     not being registered in future versions.\n\
+                     Please use [profile.{unknown_section}] instead or run `forge config --fix`."
+                )
             }
-            Self::NoLocalToml(tried) => {
-                let path = tried.display();
-                f.write_fmt(format_args!("No local TOML found to fix at {path}. Change the current directory to a project path or set the foundry.toml path with the FOUNDRY_CONFIG environment variable"))
-            }
+            Self::NoLocalToml(path) => write!(
+                f,
+                "No local TOML found to fix at {}.\n\
+                 Change the current directory to a project path or set the foundry.toml path with \
+                 the `FOUNDRY_CONFIG` environment variable",
+                path.display()
+            ),
+
             Self::CouldNotReadToml { path, err } => {
-                f.write_fmt(format_args!("Could not read TOML at {}: {err}", path.display()))
+                write!(f, "Could not read TOML at {}: {err}", path.display())
             }
             Self::CouldNotWriteToml { path, err } => {
-                f.write_fmt(format_args!("Could not write TOML to {}: {err}", path.display()))
+                write!(f, "Could not write TOML to {}: {err}", path.display())
             }
-            Self::CouldNotFixProfile { path, profile, err } => f.write_fmt(format_args!(
-                "Could not fix [{}] in TOML at {}: {}",
-                profile,
-                path.display(),
-                err
-            )),
-            Self::DeprecatedKey { old, new } if new.is_empty() => f.write_fmt(format_args!(
-                "Key `{old}` is being deprecated and will be removed in future versions.",
-            )),
-            Self::DeprecatedKey { old, new } => f.write_fmt(format_args!(
-                "Key `{old}` is being deprecated in favor of `{new}`. It will be removed in future versions.",
-            )),
+            Self::CouldNotFixProfile { path, profile, err } => {
+                write!(f, "Could not fix [{profile}] in TOML at {}: {err}", path.display())
+            }
+            Self::DeprecatedKey { old, new } if new.is_empty() => {
+                write!(f, "Key `{old}` is being deprecated and will be removed in future versions.")
+            }
+            Self::DeprecatedKey { old, new } => {
+                write!(f, "Key `{old}` is being deprecated in favor of `{new}`. It will be removed in future versions.")
+            }
         }
     }
 }

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -2,7 +2,7 @@ use clap::{Parser, ValueHint};
 use ethers_contract::{Abigen, ContractFilter, ExcludeContracts, MultiAbigen, SelectContracts};
 use eyre::{Result, WrapErr};
 use foundry_cli::{opts::CoreBuildArgs, utils::LoadConfig};
-use foundry_common::{compile, fs::json_files};
+use foundry_common::{compile::ProjectCompiler, fs::json_files};
 use foundry_config::impl_figment_convert;
 use std::{
     fs,
@@ -86,7 +86,7 @@ impl BindArgs {
         if !self.skip_build {
             // run `forge build`
             let project = self.build_args.project()?;
-            compile::compile(&project, false, false)?;
+            let _ = ProjectCompiler::new().compile(&project)?;
         }
 
         let artifacts = self.try_load_config_emit_warnings()?.out;
@@ -216,11 +216,10 @@ No contract artifacts found. Hint: Have you built your contracts yet? `forge bin
                 &self.crate_version,
                 self.bindings_root(&artifacts),
                 self.single_file,
-            )?;
+            )
         } else {
             trace!(single_file = self.single_file, "generating module");
-            bindings.write_to_module(self.bindings_root(&artifacts), self.single_file)?;
+            bindings.write_to_module(self.bindings_root(&artifacts), self.single_file)
         }
-        Ok(())
     }
 }

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -2,7 +2,7 @@ use super::{install, watch::WatchArgs};
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{opts::CoreBuildArgs, utils::LoadConfig};
-use foundry_common::compile::{ProjectCompiler, SkipBuildFilter};
+use foundry_common::compile::{ProjectCompiler, SkipBuildFilter, SkipBuildFilters};
 use foundry_compilers::{Project, ProjectCompileOutput};
 use foundry_config::{
     figment::{
@@ -92,7 +92,7 @@ impl BuildArgs {
             .print_sizes(self.sizes)
             .quiet(self.format_json)
             .bail(!self.format_json)
-            .filters(self.skip.unwrap_or_default())
+            .filter(Box::new(SkipBuildFilters(self.skip.unwrap_or_default())))
             .compile(&project)?;
         if self.format_json {
             println!("{}", serde_json::to_string_pretty(&output.clone().output())?);

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -87,11 +87,17 @@ impl BuildArgs {
             project = config.project()?;
         }
 
-        ProjectCompiler::new()
+        let output = ProjectCompiler::new()
             .print_names(self.names)
             .print_sizes(self.sizes)
+            .quiet(self.format_json)
+            .bail(!self.format_json)
             .filters(self.skip.unwrap_or_default())
-            .compile(&project)
+            .compile(&project)?;
+        if self.format_json {
+            println!("{}", serde_json::to_string_pretty(&output.clone().output())?);
+        }
+        Ok(output)
     }
 
     /// Returns the `Project` for the current workspace

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -69,7 +69,7 @@ pub struct BuildArgs {
 
     /// Output the compilation errors in the json format.
     /// This is useful when you want to use the output in other tools.
-    #[clap(long, conflicts_with = "quiet")]
+    #[clap(long, conflicts_with = "silent")]
     #[serde(skip)]
     pub format_json: bool,
 }

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -79,7 +79,9 @@ impl BuildArgs {
         let mut config = self.try_load_config_emit_warnings()?;
         let mut project = config.project()?;
 
-        if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
+        if install::install_missing_dependencies(&mut config, self.args.silent) &&
+            config.auto_detect_remappings
+        {
             // need to re-configure here to also catch additional remappings
             config = self.load_config();
             project = config.project()?;

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -91,7 +91,8 @@ impl CreateArgs {
     pub async fn run(mut self) -> Result<()> {
         // Find Project & Compile
         let project = self.opts.project()?;
-        let mut output = ProjectCompiler::new().quiet_if(self.json).compile(&project)?;
+        let mut output =
+            ProjectCompiler::new().quiet_if(self.json || self.opts.silent).compile(&project)?;
 
         if let Some(ref mut path) = self.contract.path {
             // paths are absolute in the project's output

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -19,7 +19,8 @@ use foundry_cli::{
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
 use foundry_common::{
-    compile, estimate_eip1559_fees,
+    compile::ProjectCompiler,
+    estimate_eip1559_fees,
     fmt::parse_tokens,
     types::{ToAlloy, ToEthers},
 };
@@ -90,12 +91,7 @@ impl CreateArgs {
     pub async fn run(mut self) -> Result<()> {
         // Find Project & Compile
         let project = self.opts.project()?;
-        let mut output = if self.json || self.opts.silent {
-            // Suppress compile stdout messages when printing json output or when silent
-            compile::suppress_compile(&project)
-        } else {
-            compile::compile(&project, false, false)
-        }?;
+        let mut output = ProjectCompiler::new().quiet_if(self.json).compile(&project)?;
 
         if let Some(ref mut path) = self.contract.path {
             // paths are absolute in the project's output

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -40,9 +40,8 @@ impl FlattenArgs {
 
         let paths = config.project_paths();
         let target_path = dunce::canonicalize(target_path)?;
-        let flattened = paths
-            .flatten(&target_path)
-            .map_err(|err| eyre::Error::msg(format!("Failed to flatten the file: {err}")))?;
+        let flattened =
+            paths.flatten(&target_path).map_err(|err| eyre::eyre!("Failed to flatten: {err}"))?;
 
         match output {
             Some(output) => {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -96,7 +96,7 @@ impl InspectArgs {
                 print_json_str(&artifact.deployed_bytecode, Some("object"))?;
             }
             ContractArtifactField::Assembly | ContractArtifactField::AssemblyOptimized => {
-                print_json(&artifact.assembly)?;
+                print_json_str(&artifact.assembly, None)?;
             }
             ContractArtifactField::MethodIdentifiers => {
                 print_json(&artifact.method_identifiers)?;
@@ -111,7 +111,7 @@ impl InspectArgs {
                 print_json(&artifact.devdoc)?;
             }
             ContractArtifactField::Ir => {
-                print_json(&artifact.ir)?;
+                print_json_str(&artifact.ir, None)?;
             }
             ContractArtifactField::IrOptimized => {
                 print_json_str(&artifact.ir_optimized, None)?;
@@ -361,7 +361,7 @@ impl ContractArtifactField {
 }
 
 fn print_json(obj: &impl serde::Serialize) -> Result<()> {
-    println!("{}", serde_json::to_string(obj)?);
+    println!("{}", serde_json::to_string_pretty(obj)?);
     Ok(())
 }
 
@@ -373,8 +373,10 @@ fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> 
             value_ref = value2;
         }
     }
-    let s = value_ref.as_str().ok_or_else(|| eyre::eyre!("not a string: {value}"))?;
-    println!("{s}");
+    match value_ref.as_str() {
+        Some(s) => println!("{s}"),
+        None => println!("{value_ref:#}"),
+    }
     Ok(())
 }
 

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use comfy_table::{presets::ASCII_MARKDOWN, Table};
 use eyre::Result;
 use foundry_cli::opts::{CompilerArgs, CoreBuildArgs};
-use foundry_common::{compile::ProjectCompiler, Shell};
+use foundry_common::compile::ProjectCompiler;
 use foundry_compilers::{
     artifacts::{
         output_selection::{
@@ -84,10 +84,10 @@ impl InspectArgs {
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
                 if pretty {
                     let source = foundry_cli::utils::abi_to_solidity(abi, "")?;
-                    Shell::get().write_stdout(source, &Default::default())
+                    println!("{source}");
                 } else {
-                    Shell::get().print_json(abi)
-                }?;
+                    print_json(abi)?;
+                }
             }
             ContractArtifactField::Bytecode => {
                 print_json_str(&artifact.bytecode, Some("object"))?;
@@ -139,7 +139,7 @@ impl InspectArgs {
                         );
                     }
                 }
-                Shell::get().print_json(&out)?;
+                print_json(&out)?;
             }
             ContractArtifactField::Events => {
                 let mut out = serde_json::Map::new();
@@ -153,7 +153,7 @@ impl InspectArgs {
                         );
                     }
                 }
-                Shell::get().print_json(&out)?;
+                print_json(&out)?;
             }
         };
 
@@ -186,7 +186,8 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>, pretty: bool
         ]);
     }
 
-    Shell::get().write_stdout(table, &Default::default())
+    println!("{table}");
+    Ok(())
 }
 
 /// Contract level output selection
@@ -360,7 +361,8 @@ impl ContractArtifactField {
 }
 
 fn print_json(obj: &impl serde::Serialize) -> Result<()> {
-    Shell::get().print_json(obj)
+    println!("{}", serde_json::to_string(obj)?);
+    Ok(())
 }
 
 fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> {
@@ -372,7 +374,8 @@ fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> 
         }
     }
     let s = value_ref.as_str().ok_or_else(|| eyre::eyre!("not a string: {value}"))?;
-    sh_println!("{s}")
+    println!("{s}");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -1,9 +1,8 @@
-use alloy_json_abi::JsonAbi;
 use clap::Parser;
 use comfy_table::{presets::ASCII_MARKDOWN, Table};
 use eyre::Result;
 use foundry_cli::opts::{CompilerArgs, CoreBuildArgs};
-use foundry_common::compile;
+use foundry_common::{compile::ProjectCompiler, Shell};
 use foundry_compilers::{
     artifacts::{
         output_selection::{
@@ -15,7 +14,6 @@ use foundry_compilers::{
     info::ContractInfo,
     utils::canonicalize,
 };
-use serde_json::{to_value, Value};
 use std::fmt;
 
 /// CLI arguments for `forge inspect`.
@@ -64,103 +62,68 @@ impl InspectArgs {
 
         // Build the project
         let project = modified_build_args.project()?;
-        let outcome = if let Some(ref mut contract_path) = contract.path {
+        let mut compiler = ProjectCompiler::new().quiet(true);
+        if let Some(contract_path) = &mut contract.path {
             let target_path = canonicalize(&*contract_path)?;
             *contract_path = target_path.to_string_lossy().to_string();
-            compile::compile_files(&project, vec![target_path], true)
-        } else {
-            compile::suppress_compile(&project)
-        }?;
+            compiler = compiler.files([target_path]);
+        }
+        let output = compiler.compile(&project)?;
 
         // Find the artifact
-        let found_artifact = outcome.find_contract(&contract);
-
-        trace!(target: "forge", artifact=?found_artifact, input=?contract, "Found contract");
-
-        // Unwrap the inner artifact
-        let artifact = found_artifact.ok_or_else(|| {
+        let artifact = output.find_contract(&contract).ok_or_else(|| {
             eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
         })?;
 
-        // Match on ContractArtifactFields and Pretty Print
+        // Match on ContractArtifactFields and pretty-print
         match field {
             ContractArtifactField::Abi => {
                 let abi = artifact
                     .abi
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
-                print_abi(abi, pretty)?;
+                if pretty {
+                    let source = foundry_cli::utils::abi_to_solidity(abi, "")?;
+                    Shell::get().write_stdout(source, &Default::default())
+                } else {
+                    Shell::get().print_json(abi)
+                }?;
             }
             ContractArtifactField::Bytecode => {
-                let tval: Value = to_value(&artifact.bytecode)?;
-                println!(
-                    "{}",
-                    tval.get("object").unwrap_or(&tval).as_str().ok_or_else(|| eyre::eyre!(
-                        "Failed to extract artifact bytecode as a string"
-                    ))?
-                );
+                print_json_str(&artifact.bytecode, Some("object"))?;
             }
             ContractArtifactField::DeployedBytecode => {
-                let tval: Value = to_value(&artifact.deployed_bytecode)?;
-                println!(
-                    "{}",
-                    tval.get("object").unwrap_or(&tval).as_str().ok_or_else(|| eyre::eyre!(
-                        "Failed to extract artifact deployed bytecode as a string"
-                    ))?
-                );
+                print_json_str(&artifact.deployed_bytecode, Some("object"))?;
             }
             ContractArtifactField::Assembly | ContractArtifactField::AssemblyOptimized => {
-                println!(
-                    "{}",
-                    to_value(&artifact.assembly)?.as_str().ok_or_else(|| eyre::eyre!(
-                        "Failed to extract artifact assembly as a string"
-                    ))?
-                );
+                print_json(&artifact.assembly)?;
             }
             ContractArtifactField::MethodIdentifiers => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.method_identifiers)?)?
-                );
+                print_json(&artifact.method_identifiers)?;
             }
             ContractArtifactField::GasEstimates => {
-                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.gas_estimates)?)?);
+                print_json(&artifact.gas_estimates)?;
             }
             ContractArtifactField::StorageLayout => {
                 print_storage_layout(artifact.storage_layout.as_ref(), pretty)?;
             }
             ContractArtifactField::DevDoc => {
-                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.devdoc)?)?);
+                print_json(&artifact.devdoc)?;
             }
             ContractArtifactField::Ir => {
-                println!(
-                    "{}",
-                    to_value(&artifact.ir)?
-                        .as_str()
-                        .ok_or_else(|| eyre::eyre!("Failed to extract artifact ir as a string"))?
-                );
+                print_json(&artifact.ir)?;
             }
             ContractArtifactField::IrOptimized => {
-                println!(
-                    "{}",
-                    to_value(&artifact.ir_optimized)?.as_str().ok_or_else(|| eyre::eyre!(
-                        "Failed to extract artifact optimized ir as a string"
-                    ))?
-                );
+                print_json_str(&artifact.ir_optimized, None)?;
             }
             ContractArtifactField::Metadata => {
-                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.metadata)?)?);
+                print_json(&artifact.metadata)?;
             }
             ContractArtifactField::UserDoc => {
-                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.userdoc)?)?);
+                print_json(&artifact.userdoc)?;
             }
             ContractArtifactField::Ewasm => {
-                println!(
-                    "{}",
-                    to_value(&artifact.ewasm)?.as_str().ok_or_else(|| eyre::eyre!(
-                        "Failed to extract artifact ewasm as a string"
-                    ))?
-                );
+                print_json_str(&artifact.ewasm, None)?;
             }
             ContractArtifactField::Errors => {
                 let mut out = serde_json::Map::new();
@@ -176,7 +139,7 @@ impl InspectArgs {
                         );
                     }
                 }
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                Shell::get().print_json(&out)?;
             }
             ContractArtifactField::Events => {
                 let mut out = serde_json::Map::new();
@@ -190,22 +153,12 @@ impl InspectArgs {
                         );
                     }
                 }
-                println!("{}", serde_json::to_string_pretty(&out)?);
+                Shell::get().print_json(&out)?;
             }
         };
 
         Ok(())
     }
-}
-
-pub fn print_abi(abi: &JsonAbi, pretty: bool) -> Result<()> {
-    let s = if pretty {
-        foundry_cli::utils::abi_to_solidity(abi, "")?
-    } else {
-        serde_json::to_string_pretty(&abi)?
-    };
-    println!("{s}");
-    Ok(())
 }
 
 pub fn print_storage_layout(storage_layout: Option<&StorageLayout>, pretty: bool) -> Result<()> {
@@ -214,8 +167,7 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>, pretty: bool
     };
 
     if !pretty {
-        println!("{}", serde_json::to_string_pretty(&to_value(storage_layout)?)?);
-        return Ok(())
+        return print_json(&storage_layout)
     }
 
     let mut table = Table::new();
@@ -234,9 +186,7 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>, pretty: bool
         ]);
     }
 
-    println!("{table}");
-
-    Ok(())
+    Shell::get().write_stdout(table, &Default::default())
 }
 
 /// Contract level output selection
@@ -407,6 +357,22 @@ impl ContractArtifactField {
     pub const fn is_default(&self) -> bool {
         matches!(self, Self::Bytecode | Self::DeployedBytecode)
     }
+}
+
+fn print_json(obj: &impl serde::Serialize) -> Result<()> {
+    Shell::get().print_json(obj)
+}
+
+fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> {
+    let value = serde_json::to_value(obj)?;
+    let mut value_ref = &value;
+    if let Some(key) = key {
+        if let Some(value2) = value.get(key) {
+            value_ref = value2;
+        }
+    }
+    let s = value_ref.as_str().ok_or_else(|| eyre::eyre!("not a string: {value}"))?;
+    sh_println!("{s}")
 }
 
 #[cfg(test)]

--- a/crates/forge/bin/cmd/remappings.rs
+++ b/crates/forge/bin/cmd/remappings.rs
@@ -1,7 +1,6 @@
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::utils::LoadConfig;
-use foundry_compilers::remappings::RelativeRemapping;
 use foundry_config::impl_figment_convert_basic;
 use foundry_evm::hashbrown::HashMap;
 use std::path::PathBuf;
@@ -22,19 +21,15 @@ pub struct RemappingArgs {
 impl_figment_convert_basic!(RemappingArgs);
 
 impl RemappingArgs {
-    // TODO: Do people use `forge remappings >> file`?
     pub fn run(self) -> Result<()> {
         let config = self.try_load_config_emit_warnings()?;
 
         if self.pretty {
-            let groups = config.remappings.into_iter().fold(
-                HashMap::new(),
-                |mut groups: HashMap<Option<String>, Vec<RelativeRemapping>>, remapping| {
-                    groups.entry(remapping.context.clone()).or_default().push(remapping);
-                    groups
-                },
-            );
-            for (group, remappings) in groups.into_iter() {
+            let mut groups = HashMap::<_, Vec<_>>::with_capacity(config.remappings.len());
+            for remapping in config.remappings {
+                groups.entry(remapping.context.clone()).or_default().push(remapping);
+            }
+            for (group, remappings) in groups {
                 if let Some(group) = group {
                     println!("Context: {group}");
                 } else {

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -225,8 +225,8 @@ impl ScriptArgs {
             let output = compile::compile_target_with_filter(
                 &target_contract,
                 &project,
-                self.verify,
                 self.opts.args.silent,
+                self.verify,
                 filters,
             )?;
             return Ok((project, output))
@@ -246,8 +246,8 @@ impl ScriptArgs {
             let output = compile::compile_target_with_filter(
                 &path,
                 &project,
-                self.verify,
                 self.opts.args.silent,
+                self.verify,
                 filters,
             )?;
             self.path = path.to_string_lossy().to_string();

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -226,6 +226,7 @@ impl ScriptArgs {
                 &target_contract,
                 &project,
                 self.verify,
+                self.opts.args.silent,
                 filters,
             )?;
             return Ok((project, output))
@@ -242,8 +243,13 @@ impl ScriptArgs {
         if let Some(path) = contract.path {
             let path =
                 dunce::canonicalize(path).wrap_err("Could not canonicalize the target path")?;
-            let output =
-                compile::compile_target_with_filter(&path, &project, self.verify, filters)?;
+            let output = compile::compile_target_with_filter(
+                &path,
+                &project,
+                self.verify,
+                self.opts.args.silent,
+                filters,
+            )?;
             self.path = path.to_string_lossy().to_string();
             return Ok((project, output))
         }

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -91,12 +91,7 @@ pub struct ScriptArgs {
     pub target_contract: Option<String>,
 
     /// The signature of the function you want to call in the contract, or raw calldata.
-    #[clap(
-        long,
-        short,
-        default_value = "run()",
-        value_parser = foundry_common::clap_helpers::strip_0x_prefix
-    )]
+    #[clap(long, short, default_value = "run()")]
     pub sig: String,
 
     /// Max priority fee per gas for EIP1559 transactions.

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -6,7 +6,7 @@ use foundry_cli::{
     utils::FoundryPathExt,
 };
 use foundry_common::{
-    compile,
+    compile::ProjectCompiler,
     selectors::{import_selectors, SelectorImportData},
 };
 use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
@@ -18,21 +18,14 @@ pub enum SelectorsSubcommands {
     /// Check for selector collisions between contracts
     #[clap(visible_alias = "co")]
     Collision {
-        /// First contract
-        #[clap(
-            help = "The first of the two contracts for which to look selector collisions for, in the form `(<path>:)?<contractname>`",
-            value_name = "FIRST_CONTRACT"
-        )]
+        /// The first of the two contracts for which to look selector collisions for, in the form
+        /// `(<path>:)?<contractname>`.
         first_contract: ContractInfo,
 
-        /// Second contract
-        #[clap(
-            help = "The second of the two contracts for which to look selector collisions for, in the form `(<path>:)?<contractname>`",
-            value_name = "SECOND_CONTRACT"
-        )]
+        /// The second of the two contracts for which to look selector collisions for, in the form
+        /// `(<path>:)?<contractname>`.
         second_contract: ContractInfo,
 
-        /// Support build args
         #[clap(flatten)]
         build: Box<CoreBuildArgs>,
     },
@@ -78,9 +71,9 @@ impl SelectorsSubcommands {
                 };
 
                 let project = build_args.project()?;
-                let outcome = compile::suppress_compile(&project)?;
+                let output = ProjectCompiler::new().quiet(true).compile(&project)?;
                 let artifacts = if all {
-                    outcome
+                    output
                         .into_artifacts_with_files()
                         .filter(|(file, _, _)| {
                             let is_sources_path = file
@@ -93,7 +86,7 @@ impl SelectorsSubcommands {
                         .collect()
                 } else {
                     let contract = contract.unwrap();
-                    let found_artifact = outcome.find_first(&contract);
+                    let found_artifact = output.find_first(&contract);
                     let artifact = found_artifact
                         .ok_or_else(|| {
                             eyre::eyre!(
@@ -122,41 +115,34 @@ impl SelectorsSubcommands {
                 }
             }
             SelectorsSubcommands::Collision { mut first_contract, mut second_contract, build } => {
-                // Build first project
-                let first_project = build.project()?;
-                let first_outcome = if let Some(ref mut contract_path) = first_contract.path {
+                // Compile the project with the two contracts included
+                let project = build.project()?;
+                let mut compiler = ProjectCompiler::new().quiet(true);
+
+                if let Some(contract_path) = &mut first_contract.path {
                     let target_path = canonicalize(&*contract_path)?;
                     *contract_path = target_path.to_string_lossy().to_string();
-                    compile::compile_files(&first_project, vec![target_path], true)
-                } else {
-                    compile::suppress_compile(&first_project)
-                }?;
-
-                // Build second project
-                let second_project = build.project()?;
-                let second_outcome = if let Some(ref mut contract_path) = second_contract.path {
+                    compiler = compiler.files([target_path]);
+                }
+                if let Some(contract_path) = &mut second_contract.path {
                     let target_path = canonicalize(&*contract_path)?;
                     *contract_path = target_path.to_string_lossy().to_string();
-                    compile::compile_files(&second_project, vec![target_path], true)
-                } else {
-                    compile::suppress_compile(&second_project)
-                }?;
+                    compiler = compiler.files([target_path]);
+                }
 
-                // Find the artifacts
-                let first_found_artifact = first_outcome.find_contract(&first_contract);
-                let second_found_artifact = second_outcome.find_contract(&second_contract);
-
-                // Unwrap inner artifacts
-                let first_artifact = first_found_artifact.ok_or_else(|| {
-                    eyre::eyre!("Failed to extract first artifact bytecode as a string")
-                })?;
-                let second_artifact = second_found_artifact.ok_or_else(|| {
-                    eyre::eyre!("Failed to extract second artifact bytecode as a string")
-                })?;
+                let output = compiler.compile(&project)?;
 
                 // Check method selectors for collisions
-                let first_method_map = first_artifact.method_identifiers.as_ref().unwrap();
-                let second_method_map = second_artifact.method_identifiers.as_ref().unwrap();
+                let methods = |contract: &ContractInfo| -> eyre::Result<_> {
+                    let artifact = output
+                        .find_contract(contract)
+                        .ok_or_else(|| eyre::eyre!("Could not find artifact for {contract}"))?;
+                    artifact.method_identifiers.as_ref().ok_or_else(|| {
+                        eyre::eyre!("Could not find method identifiers for {contract}")
+                    })
+                };
+                let first_method_map = methods(&first_contract)?;
+                let second_method_map = methods(&second_contract)?;
 
                 let colliding_methods: Vec<(&String, &String, &String)> = first_method_map
                     .iter()
@@ -197,7 +183,7 @@ impl SelectorsSubcommands {
 
                 // compile the project to get the artifacts/abis
                 let project = build_args.project()?;
-                let outcome = compile::suppress_compile(&project)?;
+                let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
                 let artifacts = if let Some(contract) = contract {
                     let found_artifact = outcome.find_first(&contract);
                     let artifact = found_artifact

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -19,7 +19,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     compact_to_contract,
-    compile::{self, ContractSources, ProjectCompiler},
+    compile::{ContractSources, ProjectCompiler},
     evm::EvmArgs,
     get_contract_name, get_file_name, shell,
 };

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -159,7 +159,7 @@ impl TestArgs {
         }
 
         let output = ProjectCompiler::new()
-            .quiet_if(self.json)
+            .quiet_if(self.json || self.opts.silent)
             .sparse(config.sparse_mode)
             .compile_sparse(&project, filter.clone())?;
         // Create test options from general project settings

--- a/crates/forge/bin/cmd/verify/etherscan/flatten.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/flatten.rs
@@ -80,16 +80,16 @@ impl EtherscanFlattenedSource {
         if out.has_error() {
             let mut o = AggregatedCompilerOutput::default();
             o.extend(version, out);
-            eprintln!("{}", o.diagnostics(&[], Default::default()));
+            let diags = o.diagnostics(&[], Default::default());
 
-            eprintln!(
-                r#"Failed to compile the flattened code locally.
+            eyre::bail!(
+                "\
+Failed to compile the flattened code locally.
 This could be a bug, please inspect the output of `forge flatten {}` and report an issue.
 To skip this solc dry, pass `--force`.
-"#,
+Diagnostics: {diags}",
                 contract_path.display()
             );
-            std::process::exit(1)
         }
 
         Ok(())

--- a/crates/forge/bin/cmd/verify/sourcify.rs
+++ b/crates/forge/bin/cmd/verify/sourcify.rs
@@ -166,17 +166,18 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
         match response.status.as_str() {
             "perfect" => {
                 if let Some(ts) = &response.storage_timestamp {
-                    sh_println!("Contract source code already verified. Storage Timestamp: {ts}")
+                    println!("Contract source code already verified. Storage Timestamp: {ts}");
                 } else {
-                    sh_println!("Contract successfully verified")
+                    println!("Contract successfully verified");
                 }
             }
             "partial" => {
-                sh_println!("The recompiled contract partially matches the deployed version")
+                println!("The recompiled contract partially matches the deployed version");
             }
-            "false" => sh_println!("Contract source code is not verified"),
-            s => Err(eyre::eyre!("Unknown status from sourcify. Status: {s:?}")),
+            "false" => println!("Contract source code is not verified"),
+            s => eyre::bail!("Unknown status from sourcify. Status: {s:?}"),
         }
+        Ok(())
     }
 }
 

--- a/crates/forge/bin/cmd/verify/sourcify.rs
+++ b/crates/forge/bin/cmd/verify/sourcify.rs
@@ -48,14 +48,10 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     let status = response.status();
                     if !status.is_success() {
                         let error: serde_json::Value = response.json().await?;
-                        eprintln!(
-                            "Sourcify verification request for address ({}) failed with status code {}\nDetails: {:#}",
-                            format_args!("{:?}", args.address),
-                            status,
-                            error
+                        eyre::bail!(
+                            "Sourcify verification request for address ({}) failed with status code {status}\nDetails: {error:#}",
+                            args.address,
                         );
-                        warn!("Failed verify submission: {:?}", error);
-                        std::process::exit(1);
                     }
 
                     let text = response.text().await?;
@@ -65,8 +61,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
             })
             .await?;
 
-        self.process_sourcify_response(resp.map(|r| r.result));
-        Ok(())
+        self.process_sourcify_response(resp.map(|r| r.result))
     }
 
     async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
@@ -83,11 +78,10 @@ impl VerificationProvider for SourcifyVerificationProvider {
 
                     let response = reqwest::get(url).await?;
                     if !response.status().is_success() {
-                        eprintln!(
+                        eyre::bail!(
                             "Failed to request verification status with status code {}",
                             response.status()
                         );
-                        std::process::exit(1);
                     };
 
                     Ok(Some(response.json::<Vec<SourcifyResponseElement>>().await?))
@@ -96,8 +90,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
             })
             .await?;
 
-        self.process_sourcify_response(resp);
-        Ok(())
+        self.process_sourcify_response(resp)
     }
 }
 
@@ -165,21 +158,24 @@ metadata output can be enabled via `extra_output = ["metadata"]` in `foundry.tom
         Ok(req)
     }
 
-    fn process_sourcify_response(&self, response: Option<Vec<SourcifyResponseElement>>) {
-        let response = response.unwrap().remove(0);
-        if response.status == "perfect" {
-            if let Some(ts) = response.storage_timestamp {
-                println!("Contract source code already verified. Storage Timestamp: {ts}");
-            } else {
-                println!("Contract successfully verified")
+    fn process_sourcify_response(
+        &self,
+        response: Option<Vec<SourcifyResponseElement>>,
+    ) -> Result<()> {
+        let Some([response, ..]) = response.as_deref() else { return Ok(()) };
+        match response.status.as_str() {
+            "perfect" => {
+                if let Some(ts) = &response.storage_timestamp {
+                    sh_println!("Contract source code already verified. Storage Timestamp: {ts}")
+                } else {
+                    sh_println!("Contract successfully verified")
+                }
             }
-        } else if response.status == "partial" {
-            println!("The recompiled contract partially matches the deployed version")
-        } else if response.status == "false" {
-            println!("Contract source code is not verified")
-        } else {
-            eprintln!("Unknown status from sourcify. Status: {}", response.status);
-            std::process::exit(1);
+            "partial" => {
+                sh_println!("The recompiled contract partially matches the deployed version")
+            }
+            "false" => sh_println!("Contract source code is not verified"),
+            s => Err(eyre::eyre!("Unknown status from sourcify. Status: {s:?}")),
         }
     }
 }

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -12,6 +12,7 @@ mod opts;
 use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
 use opts::{Opts, Subcommands};
 
+fn main() -> Result<()> {
     handler::install();
     utils::load_dotenv();
     utils::subscriber();

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -12,8 +12,7 @@ mod opts;
 use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
 use opts::{Opts, Subcommands};
 
-fn main() -> Result<()> {
-    handler::install()?;
+    handler::install();
     utils::load_dotenv();
     utils::subscriber();
     utils::enable_paint();

--- a/crates/forge/bin/opts.rs
+++ b/crates/forge/bin/opts.rs
@@ -20,7 +20,6 @@ use crate::cmd::{
     verify::{VerifyArgs, VerifyCheckArgs},
 };
 use clap::{Parser, Subcommand, ValueHint};
-use foundry_cli::opts::ShellOptions;
 use std::path::PathBuf;
 
 const VERSION_MESSAGE: &str = concat!(
@@ -43,8 +42,6 @@ const VERSION_MESSAGE: &str = concat!(
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,
-    #[clap(flatten)]
-    pub shell: ShellOptions,
 }
 
 #[derive(Subcommand)]

--- a/crates/forge/bin/opts.rs
+++ b/crates/forge/bin/opts.rs
@@ -20,6 +20,7 @@ use crate::cmd::{
     verify::{VerifyArgs, VerifyCheckArgs},
 };
 use clap::{Parser, Subcommand, ValueHint};
+use foundry_cli::opts::ShellOptions;
 use std::path::PathBuf;
 
 const VERSION_MESSAGE: &str = concat!(
@@ -31,19 +32,22 @@ const VERSION_MESSAGE: &str = concat!(
     ")"
 );
 
-#[derive(Debug, Parser)]
-#[clap(name = "forge", version = VERSION_MESSAGE)]
+/// Build, test, fuzz, debug and deploy Solidity contracts.
+#[derive(Parser)]
+#[clap(
+    name = "forge",
+    version = VERSION_MESSAGE,
+    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html",
+    next_display_order = None,
+)]
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,
+    #[clap(flatten)]
+    pub shell: ShellOptions,
 }
 
-#[derive(Debug, Subcommand)]
-#[clap(
-    about = "Build, test, fuzz, debug and deploy Solidity contracts.",
-    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html",
-    next_display_order = None
-)]
+#[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
     /// Run the project's tests.

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -603,10 +603,10 @@ forgetest!(config_emit_warnings, |prj, cmd| {
     assert_eq!(
         String::from_utf8_lossy(&output.stderr)
             .lines()
-            .filter(|line| { line.contains("Unknown section [default]") })
+            .filter(|line| line.contains("unknown config section") && line.contains("[default]"))
             .count(),
-        1
-    )
+        1,
+    );
 });
 
 forgetest_init!(can_skip_remappings_auto_detection, |prj, cmd| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Alongside other minor cleanups. Extracted from https://github.com/foundry-rs/foundry/pull/6569.

We apparently have a compiler builder, but instead of, you know, using the builder we use helper functions which build the builder

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
