### PR TITLE
chore: bump foundry-compilers 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-block-explorers"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa44d981bf2493204dee4af1116ed9250656050d48b5569fa1e153fa4af75bdd"
+checksum = "43408b384e5888fed99a5f25f86cef7e19dca10c750e948cbeb219f59847712f"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82d3c3ef0ea3749b6e873c3f24e8bf6ead058757fa793de8940c03fc01bb83b"
+checksum = "723188b46b06f9a9836a5c6e21a5cb97c12e7411c2104afffba06a6c2beee518"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -139,7 +139,7 @@ impl ProjectCompiler {
             if !files.is_empty() {
                 project.compile_files(files)
             } else if let Some(filter) = filter {
-                project.compile_sparse(move |file: &_| filter.is_match(file))
+                project.compile_sparse(Box::new(move |file: &_| filter.is_match(file)))
             } else {
                 project.compile()
             }


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/6707

supports parsing evmVersion