### PR TITLE
fix: dont record step tracing by default

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -35,13 +35,14 @@ impl Inspector {
 
     /// Configures the `Tracer` [`revm::Inspector`]
     pub fn with_tracing(mut self) -> Self {
-        self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all()));
+        self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all().set_steps(false)));
         self
     }
 
     /// Enables steps recording for `Tracer`.
-    pub fn with_steps_tracing(self) -> Self {
-        self.with_tracing()
+    pub fn with_steps_tracing(mut self) -> Self {
+        self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all()));
+        self
     }
 }
 


### PR DESCRIPTION
#6219 regression

closes #6733

this restores the previous behaviour and doesn't record steps by default which caused the mem spikes