### PR TITLE
feat: include block env in --dump state

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1721,7 +1721,7 @@ impl EthApi {
     /// Handler for RPC call: `anvil_loadState`
     pub async fn anvil_load_state(&self, buf: Bytes) -> Result<bool> {
         node_info!("anvil_loadState");
-        self.backend.load_state(buf).await
+        self.backend.load_state_bytes(buf).await
     }
 
     /// Retrieves the Anvil node configuration params.

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -14,6 +14,7 @@ use foundry_evm::{
 };
 
 pub use foundry_evm::fork::database::ForkedDatabase;
+use foundry_evm::revm::primitives::BlockEnv;
 
 /// Implement the helper for the fork database
 impl Db for ForkedDatabase {
@@ -31,7 +32,7 @@ impl Db for ForkedDatabase {
         self.inner().block_hashes().write().insert(number, hash);
     }
 
-    fn dump_state(&self) -> DatabaseResult<Option<SerializableState>> {
+    fn dump_state(&self, at: BlockEnv) -> DatabaseResult<Option<SerializableState>> {
         let mut db = self.database().clone();
         let accounts = self
             .database()
@@ -56,7 +57,7 @@ impl Db for ForkedDatabase {
                 ))
             })
             .collect::<Result<_, _>>()?;
-        Ok(Some(SerializableState { accounts }))
+        Ok(Some(SerializableState { block: Some(at), accounts }))
     }
 
     fn snapshot(&mut self) -> U256 {

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -14,7 +14,9 @@ mod proof;
 mod pubsub;
 // mod revert; // TODO uncomment <https://github.com/gakonst/ethers-rs/issues/2186>
 mod otterscan;
+
 mod sign;
+mod state;
 mod traces;
 mod transaction;
 mod txpool;

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -1,0 +1,23 @@
+//! general eth api tests
+
+use anvil::{spawn, NodeConfig};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_load_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state_file = tmp.path().join("state.json");
+
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    api.mine_one().await;
+
+    let num = api.block_number().unwrap();
+
+    let state = api.serialized_state().await.unwrap();
+    foundry_common::fs::write_json_file(&state_file, &state).unwrap();
+
+    let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;
+
+    let num2 = api.block_number().unwrap();
+    assert_eq!(num, num2);
+}


### PR DESCRIPTION
Closes #5460

captures the BlockEnv when dumping the state and reinitializes it when reloading from file