### PR TITLE
fix: make ForkIds unique

### DIFF
--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -258,7 +258,7 @@ impl MultiForkHandler {
             let backend = fork.backend.clone();
             let env = fork.opts.env.clone();
             self.forks.insert(unique_fork_id.clone(), fork);
-            let _ = sender.send(Ok((fork_id, backend, env)));
+            let _ = sender.send(Ok((unique_fork_id, backend, env)));
         } else {
             // there could already be a task for the requested fork in progress
             if let Some(in_progress) = self.find_in_progress_task(&fork_id) {

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -287,3 +287,6 @@ test_repro!(6554; |config| {
     cheats_config.fs_permissions.add(PathPermission::read_write(path));
     config.runner.cheats_config = std::sync::Arc::new(cheats_config);
 });
+
+// https://github.com/foundry-rs/foundry/issues/6759
+test_repro!(6759);

--- a/testdata/repros/Issue6759.t.sol
+++ b/testdata/repros/Issue6759.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6759
+contract Issue6759Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testCreateMulti() public {
+        uint256 fork1 = vm.createFork("rpcAlias", 10);
+        uint256 fork2 = vm.createFork("rpcAlias", 10);
+        uint256 fork3 = vm.createFork("rpcAlias", 10);
+        assert(fork1 != fork2);
+        assert(fork1 != fork3);
+        assert(fork2 != fork3);
+    }
+}


### PR DESCRIPTION
closes #6759

this removes the URL hack and instead makes forks unique on the id level while also reusing existing backends.

This means forkIds are always unique but they can reuse existing backends