### PR TITLE
chore(`anvil`): migrate cheatsmanager to alloy

### DIFF
--- a/crates/anvil/core/src/eth/transaction/ethers_compat.rs
+++ b/crates/anvil/core/src/eth/transaction/ethers_compat.rs
@@ -27,6 +27,23 @@ use ethers_core::types::{
 };
 use foundry_common::types::{ToAlloy, ToEthers};
 
+pub fn to_alloy_signature(signature: ethers_core::types::Signature) -> alloy_rpc_types::Signature {
+    alloy_rpc_types::Signature {
+        r: signature.r.to_alloy(),
+        s: signature.s.to_alloy(),
+        v: signature.v.to_alloy().to::<rU256>(),
+        y_parity: None,
+    }
+}
+
+pub fn to_ethers_signature(signature: alloy_rpc_types::Signature) -> ethers_core::types::Signature {
+    ethers_core::types::Signature {
+        r: signature.r.to_ethers(),
+        s: signature.s.to_ethers(),
+        v: signature.v.to::<u64>(),
+    }
+}
+
 pub fn to_alloy_proof(proof: AccountProof) -> alloy_rpc_types::EIP1186AccountProofResponse {
     alloy_rpc_types::EIP1186AccountProofResponse {
         address: proof.address.to_alloy(),

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -26,7 +26,8 @@ use std::ops::Deref;
 mod ethers_compat;
 
 pub use ethers_compat::{
-    call_to_internal_tx_request, from_ethers_access_list, to_alloy_proof, to_ethers_access_list,
+    call_to_internal_tx_request, from_ethers_access_list, to_alloy_proof, to_alloy_signature,
+    to_ethers_access_list, to_ethers_signature,
 };
 
 /// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -4,10 +4,6 @@ use crate::eth::{
     receipt::Log,
     utils::{enveloped, to_revm_access_list},
 };
-#[cfg(feature = "impersonated-tx")]
-use alloy_primitives::U256 as rU256;
-#[cfg(feature = "impersonated-tx")]
-use alloy_rpc_types::Signature as AlloySignature;
 use ethers_core::{
     types::{
         transaction::eip2930::{AccessList, AccessListItem},
@@ -36,8 +32,12 @@ pub use ethers_compat::{
 
 /// The signature used to bypass signing via the `eth_sendUnsignedTransaction` cheat RPC
 #[cfg(feature = "impersonated-tx")]
-pub const IMPERSONATED_SIGNATURE: AlloySignature =
-    AlloySignature { r: rU256::ZERO, s: rU256::ZERO, v: rU256::ZERO, y_parity: None };
+pub const IMPERSONATED_SIGNATURE: alloy_rpc_types::Signature = alloy_rpc_types::Signature {
+    r: alloy_primitives::U256::ZERO,
+    s: alloy_primitives::U256::ZERO,
+    v: alloy_primitives::U256::ZERO,
+    y_parity: None,
+};
 
 /// Container type for various Ethereum transaction requests
 ///

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -46,8 +46,9 @@ use anvil_core::{
     eth::{
         block::BlockInfo,
         transaction::{
-            call_to_internal_tx_request, to_alloy_proof, EthTransactionRequest, LegacyTransaction,
-            PendingTransaction, TransactionKind, TypedTransaction, TypedTransactionRequest,
+            call_to_internal_tx_request, to_alloy_proof, to_ethers_signature,
+            EthTransactionRequest, LegacyTransaction, PendingTransaction, TransactionKind,
+            TypedTransaction, TypedTransactionRequest,
         },
         EthRequest,
     },
@@ -581,7 +582,7 @@ impl EthApi {
                 .into_iter()
                 .filter(|acc| unique.insert(*acc)),
         );
-        Ok(accounts.into_iter().map(|acc| acc).collect())
+        Ok(accounts.into_iter().collect())
     }
 
     /// Returns the number of most recent block.

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -1,7 +1,8 @@
 //! Support for "cheat codes" / bypass functions
 
+use alloy_primitives::Address;
+use alloy_rpc_types::Signature;
 use anvil_core::eth::transaction::IMPERSONATED_SIGNATURE;
-use ethers::types::{Address, Signature};
 use foundry_evm::hashbrown::HashSet;
 use parking_lot::RwLock;
 use std::sync::Arc;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -312,20 +312,20 @@ impl Backend {
     ///
     /// Returns `true` if the account is already impersonated
     pub async fn impersonate(&self, addr: Address) -> DatabaseResult<bool> {
-        if self.cheats.impersonated_accounts().contains(&addr.to_ethers()) {
+        if self.cheats.impersonated_accounts().contains(&addr) {
             return Ok(true);
         }
         // Ensure EIP-3607 is disabled
         let mut env = self.env.write();
         env.cfg.disable_eip3607 = true;
-        Ok(self.cheats.impersonate(addr.to_ethers()))
+        Ok(self.cheats.impersonate(addr))
     }
 
     /// Removes the account that from the impersonated set
     ///
     /// If the impersonated `addr` is a contract then we also reset the code here
     pub async fn stop_impersonating(&self, addr: Address) -> DatabaseResult<()> {
-        self.cheats.stop_impersonating(&addr.to_ethers());
+        self.cheats.stop_impersonating(&addr);
         Ok(())
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Part of #6715. 

## Solution

Migrates the cheats manager and pushes any conversions straight to the signing step, which will then be removed once signers are migrated. While it doesn't remove many conversions, it makes easier to remove them later with the new signers.
