### PR TITLE
feat(cast): support `cast wallet derive-private-key`

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -360,7 +360,6 @@ flag to set your key via:
                 let phrase = Mnemonic::<English>::new_from_phrase(mnemonic.as_str())?.to_phrase();
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";
-                
                 let index = if let Some(i) = mnemonic_index { i } else { 0 };
                 let wallet = builder
                     .clone()

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -139,12 +139,8 @@ pub enum WalletSubcommands {
     #[clap(visible_alias = "ls")]
     List,
 
-
     #[clap(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
-    DerivePrivateKey {
-        mnemonic: String,
-        mnemonic_index: Option<u8>,
-    }
+    DerivePrivateKey { mnemonic: String, mnemonic_index: Option<u8> },
 }
 
 impl WalletSubcommands {
@@ -365,8 +361,11 @@ flag to set your key via:
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";
                 
-                let index = if let Some(i) = mnemonic_index { i } else {0};
-                let wallet = builder.clone().derivation_path(&format!("{derivation_path}{index}"))?.build()?;
+                let index = if let Some(i) = mnemonic_index { i } else { 0 };
+                let wallet = builder
+                    .clone()
+                    .derivation_path(&format!("{derivation_path}{index}"))?
+                    .build()?;
                 println!("- Account:");
                 println!("Address:     {}", wallet.address().to_alloy());
                 println!("Private key: 0x{}\n", hex::encode(wallet.signer().to_bytes()));

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -140,8 +140,8 @@ pub enum WalletSubcommands {
     List,
 
 
-    #[clap(name = "get-private-key", visible_aliases = &["--get-private-key"])]
-    GetPrivateKey {
+    #[clap(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
+    DerivePrivateKey {
         mnemonic: String,
         mnemonic_index: Option<u8>,
     }
@@ -360,7 +360,7 @@ flag to set your key via:
                     Err(e) => return Err(e),
                 }
             }
-            WalletSubcommands::GetPrivateKey { mnemonic, mnemonic_index } => {
+            WalletSubcommands::DerivePrivateKey { mnemonic, mnemonic_index } => {
                 let phrase = Mnemonic::<English>::new_from_phrase(mnemonic.as_str())?.to_phrase();
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
                 let derivation_path = "m/44'/60'/0'/0/";

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -138,6 +138,13 @@ pub enum WalletSubcommands {
     /// List all the accounts in the keystore default directory
     #[clap(visible_alias = "ls")]
     List,
+
+
+    #[clap(name = "get-private-key", visible_aliases = &["--get-private-key"])]
+    GetPrivateKey {
+        mnemonic: String,
+        mnemonic_index: Option<u8>,
+    }
 }
 
 impl WalletSubcommands {
@@ -352,6 +359,17 @@ flag to set your key via:
                     }
                     Err(e) => return Err(e),
                 }
+            }
+            WalletSubcommands::GetPrivateKey { mnemonic, mnemonic_index } => {
+                let phrase = Mnemonic::<English>::new_from_phrase(mnemonic.as_str())?.to_phrase();
+                let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
+                let derivation_path = "m/44'/60'/0'/0/";
+                
+                let index = if let Some(i) = mnemonic_index { i } else {0};
+                let wallet = builder.clone().derivation_path(&format!("{derivation_path}{index}"))?.build()?;
+                println!("- Account:");
+                println!("Address:     {}", wallet.address().to_alloy());
+                println!("Private key: 0x{}\n", hex::encode(wallet.signer().to_bytes()));
             }
         };
 


### PR DESCRIPTION
## Motivation
support cast wallet get-private-key from `mnemonic` and `mnemonic_index`
And I think `derive-private-key` would be more appropriate.

This PR implemented the feature request from issue #6729. 

Closes #6729 

mnemonic_index would be 0 by default. 
```
cast wallet derive-private-key "ten able puppy cart gadget change health must creek human bracket above"  
- Account:
Address:     0x688DB4fC60816A5838485d0ab9b4ef358f849c35
Private key: 0x9a900f2e6171a60dfd7871226c8a2a55e754678e62765d1ab189097e62dee418
```


```
cast wallet derive-private-key "ten able puppy cart gadget change health must creek human bracket above" 1
- Account:
Address:     0x81EbdaCabf245849412183f13cb83E9a7ffF2da4
Private key: 0x5fcd6ddc5471acbe3c0f48b43c5a0c4ca364b137a0340f01e38efbb85e7ce0ac
```


