### PR TITLE
chore(`anvil`): remove ethers usage on subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ dependencies = [
  "hash256-std-hasher",
  "keccak-hasher",
  "open-fastrlp",
+ "rand 0.8.5",
  "reference-trie",
  "revm",
  "serde",

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -35,6 +35,9 @@ triehash = { version = "0.8", default-features = false }
 reference-trie = "0.25"
 keccak-hasher = "0.15"
 
+# misc
+rand = "0.8"
+
 [dev-dependencies]
 anvil-core = { path = ".", features = ["serde"] }
 

--- a/crates/anvil/core/src/eth/subscription.rs
+++ b/crates/anvil/core/src/eth/subscription.rs
@@ -1,6 +1,6 @@
 //! Subscription types
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use alloy_primitives::hex;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::fmt;
 
 /// Unique subscription id

--- a/crates/anvil/core/src/eth/subscription.rs
+++ b/crates/anvil/core/src/eth/subscription.rs
@@ -1,77 +1,7 @@
 //! Subscription types
-
-use crate::eth::block::Header;
-use ethers_core::{
-    rand::{distributions::Alphanumeric, thread_rng, Rng},
-    types::{Filter, Log, TxHash},
-    utils::hex,
-};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use alloy_primitives::hex;
 use std::fmt;
-
-/// Result of a subscription
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-pub enum SubscriptionResult {
-    /// New block header
-    Header(Box<Header>),
-    /// Log
-    Log(Box<Log>),
-    /// Transaction hash
-    TransactionHash(TxHash),
-    /// SyncStatus
-    Sync(SyncStatus),
-}
-
-/// Sync status
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct SyncStatus {
-    pub syncing: bool,
-}
-
-/// Params for a subscription request
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-pub struct SubscriptionParams {
-    /// holds the filter params field if present in the request
-    pub filter: Option<Filter>,
-}
-
-#[cfg(feature = "serde")]
-impl<'a> serde::Deserialize<'a> for SubscriptionParams {
-    fn deserialize<D>(deserializer: D) -> Result<SubscriptionParams, D::Error>
-    where
-        D: serde::Deserializer<'a>,
-    {
-        use serde::de::Error;
-
-        let val = serde_json::Value::deserialize(deserializer)?;
-        if val.is_null() {
-            return Ok(SubscriptionParams::default())
-        }
-
-        let filter: Filter = serde_json::from_value(val)
-            .map_err(|e| D::Error::custom(format!("Invalid Subscription parameters: {e}")))?;
-        Ok(SubscriptionParams { filter: Some(filter) })
-    }
-}
-
-/// Subscription kind
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub enum SubscriptionKind {
-    /// subscribe to new heads
-    NewHeads,
-    /// subscribe to new logs
-    Logs,
-    /// subscribe to pending transactions
-    NewPendingTransactions,
-    /// syncing subscription
-    Syncing,
-}
 
 /// Unique subscription id
 #[derive(Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Part of #6715.

## Solution

Removed all the unneeded types, and only `SubscriptionId` remains. Just use alloy/rand for this instead of pulling it from ethers.
