### PR TITLE
[forge] verify-contract: support --via-ir flag

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -188,6 +188,7 @@ impl CreateArgs {
             libraries: vec![],
             root: None,
             verifier: self.verifier.clone(),
+            via_ir: self.opts.via_ir,
             show_standard_json_input: self.show_standard_json_input,
         };
 
@@ -335,6 +336,7 @@ impl CreateArgs {
             libraries: vec![],
             root: None,
             verifier: self.verifier,
+            via_ir: self.opts.via_ir,
             show_standard_json_input: self.show_standard_json_input,
         };
         println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);

--- a/crates/forge/bin/cmd/script/verify.rs
+++ b/crates/forge/bin/cmd/script/verify.rs
@@ -18,6 +18,7 @@ pub struct VerifyBundle {
     pub etherscan: EtherscanOpts,
     pub retry: RetryArgs,
     pub verifier: VerifierArgs,
+    pub via_ir: bool,
 }
 
 impl VerifyBundle {
@@ -44,6 +45,8 @@ impl VerifyBundle {
             config_path: if config_path.exists() { Some(config_path) } else { None },
         };
 
+        let via_ir = config.via_ir;
+
         VerifyBundle {
             num_of_optimizations,
             known_contracts,
@@ -51,6 +54,7 @@ impl VerifyBundle {
             project_paths,
             retry,
             verifier,
+            via_ir,
         }
     }
 
@@ -109,6 +113,7 @@ impl VerifyBundle {
                     libraries: libraries.to_vec(),
                     root: None,
                     verifier: self.verifier.clone(),
+                    via_ir: self.via_ir,
                     show_standard_json_input: false,
                 };
 

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -252,8 +252,8 @@ mod tests {
             "foundry-cli",
             "0x0000000000000000000000000000000000000000",
             "src/Domains.sol:Domains",
-            "--via-ir"
+            "--via-ir",
         ]);
-        assert_eq!(args.via_ir, true);
+        assert!(args.via_ir);
     }
 }

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -107,6 +107,10 @@ pub struct VerifyArgs {
 
     #[clap(flatten)]
     pub verifier: VerifierArgs,
+
+    /// Use the Yul intermediate representation compilation pipeline.
+    #[clap(long)]
+    pub via_ir: bool,
 }
 
 impl_figment_convert!(VerifyArgs);
@@ -128,6 +132,9 @@ impl figment::Provider for VerifyArgs {
                 "optimizer_runs".to_string(),
                 figment::value::Value::serialize(optimizer_runs)?,
             );
+        }
+        if self.via_ir {
+            dict.insert("via_ir".to_string(), figment::value::Value::serialize(self.via_ir)?);
         }
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
     }
@@ -237,5 +244,16 @@ mod tests {
         assert!(!is_host_only(&Url::parse("https://blockscout.net/api").unwrap()));
         assert!(is_host_only(&Url::parse("https://blockscout.net/").unwrap()));
         assert!(is_host_only(&Url::parse("https://blockscout.net").unwrap()));
+    }
+
+    #[test]
+    fn can_parse_verify_contract() {
+        let args: VerifyArgs = VerifyArgs::parse_from([
+            "foundry-cli",
+            "0x0000000000000000000000000000000000000000",
+            "src/Domains.sol:Domains",
+            "--via-ir"
+        ]);
+        assert_eq!(args.via_ir, true);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When you `forge create --via-ir`, you cannot verify later with `forge verify-contract`, which does not support the `--via-ir` flag.

## Solution

Introduces a `--via-ir` flag into `verify-contract` which causes the standard json-input passed to etherscan to include `"viaIR":true`, which fixes verification.

Fixes the original problem in #3507, although that issue seems to have evolved to include #6780.