### PR TITLE
chore: don't use ethers in evm-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,6 @@ source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a68
 dependencies = [
  "chrono",
  "ethers-core",
- "ethers-solc",
  "reqwest",
  "semver 1.0.21",
  "serde",
@@ -3180,8 +3179,8 @@ dependencies = [
  "alloy-transport",
  "const-hex",
  "derive_more",
- "ethers",
  "ethers-core",
+ "ethers-providers",
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -34,9 +34,9 @@ revm = { workspace = true, default-features = false, features = [
 alloy-providers = { workspace = true }
 alloy-transport = { workspace = true }
 alloy-rpc-types = { workspace = true }
-ethers = { workspace = true, features = ["ethers-solc"] }
 
 ethers-core.workspace = true
+ethers-providers.workspace = true
 
 derive_more.workspace = true
 eyre = "0.6"

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloy_primitives::{b256, keccak256, Address, B256, U256, U64};
 use alloy_rpc_types::{Block, BlockNumberOrTag, BlockTransactions, Transaction};
-use ethers::utils::GenesisAccount;
+use ethers_core::utils::GenesisAccount;
 use foundry_common::{is_known_system_sender, types::ToAlloy, SYSTEM_TRANSACTION_TYPE};
 use revm::{
     db::{CacheDB, DatabaseRef},

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -6,9 +6,8 @@
 use crate::fork::{BackendHandler, BlockchainDb, BlockchainDbMeta, CreateFork, SharedBackend};
 use alloy_providers::provider::Provider;
 use alloy_transport::BoxTransport;
-use ethers::types::BlockNumber;
+use ethers_core::types::BlockNumber;
 use foundry_common::provider::alloy::ProviderBuilder;
-
 use foundry_config::Config;
 use futures::{
     channel::mpsc::{channel, Receiver, Sender},

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -2,7 +2,7 @@ use super::fork::environment;
 use crate::fork::CreateFork;
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::Block;
-use ethers::providers::{Middleware, Provider};
+use ethers_providers::{Middleware, Provider};
 use eyre::WrapErr;
 use foundry_common::{
     self,

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,7 +1,7 @@
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::FixedBytes;
 use alloy_rpc_types::{Block, Transaction};
-use ethers::types::{ActionType, CallType, Chain, H256, U256};
+use ethers_core::types::{ActionType, CallType, Chain, H256, U256};
 use eyre::ContextCompat;
 use foundry_common::types::ToAlloy;
 use revm::{


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I don't know why these are not Alloy, but for now they can be scoped down to just ethers-core and ethers-providers.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
