### PR TITLE
add timestamp to release tag for nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
               id: release_info
               run: |
                   if [[ $IS_NIGHTLY ]]; then
-                    echo "tag_name=nightly-${GITHUB_SHA}" >> $GITHUB_OUTPUT
+                    echo "tag_name=nightly-${GITHUB_SHA}-$(date '+%s')" >> $GITHUB_OUTPUT
                     echo "release_name=Nightly ($(date '+%Y-%m-%d'))" >> $GITHUB_OUTPUT
                   else
                     echo "tag_name=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/6732

https://github.com/shazow/foundry.nix/pull/32

## Solution

include unix stamp as well as github sha in nightly tags
