### PR TITLE
test: add arbitrum fork test

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -594,7 +594,9 @@ impl ClientFork {
 #[derive(Clone, Debug)]
 pub struct ClientForkConfig {
     pub eth_rpc_url: String,
+    /// The block number of the forked block
     pub block_number: u64,
+    /// The hash of the forked block
     pub block_hash: B256,
     // TODO make provider agnostic
     pub provider: Arc<RetryProvider>,

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1092,3 +1092,21 @@ async fn test_fork_reset_basefee() {
     // basefee of the forked block: <https://etherscan.io/block/18835000>
     assert_eq!(latest.header.base_fee_per_gas.unwrap(), rU256::from(59017001138u64));
 }
+
+// <https://github.com/foundry-rs/foundry/issues/6795>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_fork_dev_balance() {
+    let (api, handle) = spawn(
+        fork_config()
+            .with_fork_block_number(None::<u64>)
+            .with_eth_rpc_url(Some("https://arb1.arbitrum.io/rpc".to_string())),
+    )
+    .await;
+
+    let accounts: Vec<_> = handle.dev_wallets().collect();
+    for acc in accounts {
+        let balance =
+            api.balance(acc.address().to_alloy(), Some(Default::default())).await.unwrap();
+        assert_eq!(balance, rU256::from(100000000000000000000u128));
+    }
+}


### PR DESCRIPTION
test case for https://github.com/foundry-rs/foundry/issues/6795

we still need to change how we track the best number for arbitrum forks and decouple it from env.blocknumber because those are L1 vs L2