### PR TITLE
Update prune-prereleases.js pruning rules

### DIFF
--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -35,10 +35,11 @@ module.exports = async ({ github, context }) => {
     );
 
     // Pruning rules:
-    //   1. only keep the earliest release of the month
+    //   1. only keep the earliest (by created_at) release of the month
     //   2. to keep the newest 3 nightlies
-    // 
-    // This addresses https://github.com/foundry-rs/foundry/issues/6732
+    // Notes:
+    //   - This addresses https://github.com/foundry-rs/foundry/issues/6732
+    //   - Name of the release may deviate from created_at due to the usage of different timezones.
 
     // Group releases by months.
     // Per doc:

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -38,15 +38,15 @@ module.exports = async ({ github, context }) => {
     //   1. only keep the earliest release of the month
     //   2. to keep the newest 3 nightlies
     // 
-    // This addresses https://github.com/foundry-rs/foundry/issues/6732)
+    // This addresses https://github.com/foundry-rs/foundry/issues/6732
 
     // group releases by months
     const groups = groupBy(nightlies, i => i.created_at.slice(0, 7));
-    const toPrune = Object.values(groups)
+    const nightliesToPrune = Object.values(groups)
         .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), [])
         .slice(3);
 
-    for (const nightly of nightlies) {
+    for (const nightly of nightliesToPrune) {
         console.log(`Deleting nightly: ${nightly.tag_name}`);
         await github.rest.repos.deleteRelease({
             owner: context.repo.owner,

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -40,11 +40,13 @@ module.exports = async ({ github, context }) => {
     // 
     // This addresses https://github.com/foundry-rs/foundry/issues/6732
 
-    // group releases by months
+    // Group releases by months.
+    // Per doc:
+    // > The latest release is the most recent non-prerelease, non-draft release, sorted by the created_at attribute.
     const groups = groupBy(nightlies, i => i.created_at.slice(0, 7));
     const nightliesToPrune = Object.values(groups)
-        .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), [])
-        .slice(3);
+        .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), []) // rule 1
+        .slice(3); // rule 2
 
     for (const nightly of nightliesToPrune) {
         console.log(`Deleting nightly: ${nightly.tag_name}`);

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -1,3 +1,23 @@
+// In case node 21 is not used.
+function groupBy(array, keyOrIterator) {
+    var iterator;
+
+    // use the function passed in, or create one
+    if(typeof keyOrIterator !== 'function') {
+        const key = String(keyOrIterator);
+        iterator = function (item) { return item[key]; };
+    } else {
+        iterator = keyOrIterator;
+    }
+
+    return array.reduce(function (memo, item) {
+        const key = iterator(item);
+        memo[key] = memo[key] || [];
+        memo[key].push(item);
+        return memo;
+    }, {});
+}
+
 module.exports = async ({ github, context }) => {
     console.log("Pruning old prereleases");
 
@@ -11,14 +31,20 @@ module.exports = async ({ github, context }) => {
         release =>
             // Only consider releases tagged `nightly-${SHA}` for deletion
             release.tag_name.includes("nightly") &&
-            release.tag_name !== "nightly" &&
-            // ref: https://github.com/foundry-rs/foundry/issues/3881
-            // Skipping pruning the build on 1st day of each month
-            !release.created_at.includes("-01T")
+            release.tag_name !== "nightly"
     );
 
-    // Keep newest 3 nightlies
-    nightlies = nightlies.slice(3);
+    // Pruning rules:
+    //   1. only keep the earliest release of the month
+    //   2. to keep the newest 3 nightlies
+    // 
+    // This addresses https://github.com/foundry-rs/foundry/issues/6732)
+
+    // group releases by months
+    const groups = groupBy(nightlies, i => i.created_at.slice(0, 7));
+    const toPrune = Object.values(groups)
+        .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), [])
+        .slice(3);
 
     for (const nightly of nightlies) {
         console.log(`Deleting nightly: ${nightly.tag_name}`);


### PR DESCRIPTION
 Pruning rules:
   1. only keep the earliest release of the month
   2. to keep the newest 3 nightlies

Fixes #6732

Here is my local testing:

```
import { Octokit, App } from "octokit";

// Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
const octokit = new Octokit({ });

// In case node 21 is not used.
function groupBy(array, keyOrIterator) {
    var iterator;

    // use the function passed in, or create one
    if(typeof keyOrIterator !== 'function') {
        const key = String(keyOrIterator);
        iterator = function (item) { return item[key]; };
    } else {
        iterator = keyOrIterator;
    }

    return array.reduce(function (memo, item) {
        const key = iterator(item);
        memo[key] = memo[key] || [];
        memo[key].push(item);
        return memo;
    }, {});
}

async function separateReleases({ github, context }) {
    console.log("Pruning old prereleases");

    // doc: https://docs.github.com/en/rest/releases/releases
    const { data: releases } = await github.rest.repos.listReleases({
        owner: context.repo.owner,
        repo: context.repo.repo,
    });

    let nightlies = releases.filter(
        release =>
        // Only consider releases tagged `nightly-${SHA}` for deletion
        release.tag_name.includes("nightly") &&
        release.tag_name !== "nightly"
    );

    // group releases by months
    const groups = groupBy(nightlies, i => i.created_at.slice(0, 7));

    // Pruning rules:
    //   1. only keep the earliest release of the month
    //   2. to keep the newest 3 nightlies
    const toPrune = Object.values(groups)
        .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), [])
        .slice(3);

    const toKeep = Object.values(groups).reduce((acc, cur) => acc.concat(cur.slice(-1)), []);

    return {
        toPrune,
        toKeep,
    };
};

(async() => {
    const releases = await separateReleases({
        github : octokit,
        context : {
            repo : { owner: "foundry-rs", repo: "foundry" }
        },
    });
    console.log("To prune:", releases.toPrune.map(i => i.name));
    console.log("To keep:", releases.toKeep.map(i => i.name));
})();
```

```
$ node index.mjs 
Pruning old prereleases
To prune: [ 'Nightly (2023-11-01)' ]
To keep: [
  'Nightly (2024-01-12)',
  'Nightly (2023-12-02)',
  'Nightly (2023-11-02)',
  'Nightly (2023-10-02)',
  'Nightly (2023-08-02)',
  'Nightly (2023-07-02)',
  'Nightly (2023-06-02)',
  'Nightly (2023-05-02)',
  'Nightly (2023-04-02)',
  'Nightly (2023-03-02)',
  'Nightly (2023-01-03)'
]
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
