### PR TITLE
fix: use provided name for inspect pretty

### DIFF
--- a/crates/fmt/src/helpers.rs
+++ b/crates/fmt/src/helpers.rs
@@ -46,7 +46,10 @@ pub fn format_to<W: Write>(
 
 /// Parse and format a string with default settings
 pub fn format(src: &str) -> Result<String, FormatterError> {
-    let parsed = parse(src).map_err(|_| FormatterError::Fmt(std::fmt::Error))?;
+    let parsed = parse(src).map_err(|err| {
+        debug!(?err, "Parse error");
+        FormatterError::Fmt(std::fmt::Error)
+    })?;
 
     let mut output = String::new();
     format_to(&mut output, parsed, FormatterConfig::default())?;
@@ -103,5 +106,17 @@ pub fn import_path_string(path: &ImportPath) -> String {
     match path {
         ImportPath::Filename(s) => s.string.clone(),
         ImportPath::Path(p) => p.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // <https://github.com/foundry-rs/foundry/issues/6816>
+    #[test]
+    fn test_interface_format() {
+        let s = "interface I {\n    function increment() external;\n    function number() external view returns (uint256);\n    function setNumber(uint256 newNumber) external;\n}";
+        let _formatted = format(s).unwrap();
     }
 }

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -83,7 +83,7 @@ impl InspectArgs {
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
                 if pretty {
-                    let source = foundry_cli::utils::abi_to_solidity(abi, "")?;
+                    let source = foundry_cli::utils::abi_to_solidity(abi, &contract.name)?;
                     println!("{source}");
                 } else {
                     print_json(abi)?;

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1611,3 +1611,17 @@ forgetest_init!(can_build_names_repeatedly, |prj, cmd| {
     let unchanged = cmd.stdout_lossy();
     assert!(unchanged.contains(list), "{}", list);
 });
+
+// <https://github.com/foundry-rs/foundry/issues/6816>
+forgetest_init!(can_inspect_counter_pretty, |prj, cmd| {
+    cmd.args(["inspect", "src/Counter.sol:Counter", "abi", "--pretty"]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(
+        output.trim(),
+        "interface Counter {
+    function increment() external;
+    function number() external view returns (uint256);
+    function setNumber(uint256 newNumber) external;
+}"
+    );
+});


### PR DESCRIPTION
Closes #6816

formatted abi needs a name