### PR TITLE
refactor: replace internal `CallKind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,6 +2847,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "revm-inspectors",
  "semver 1.0.21",
  "serde",
  "serde_json",
@@ -3150,6 +3151,7 @@ dependencies = [
  "foundry-evm-traces",
  "ratatui",
  "revm",
+ "revm-inspectors",
  "tracing",
 ]
 
@@ -3180,6 +3182,7 @@ dependencies = [
  "proptest",
  "rayon",
  "revm",
+ "revm-inspectors",
  "thiserror",
  "tracing",
 ]
@@ -3210,6 +3213,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "revm",
+ "revm-inspectors",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -14,6 +14,7 @@ foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-evm-core.workspace = true
 foundry-evm-traces.workspace = true
+revm-inspectors.workspace = true
 
 alloy-primitives.workspace = true
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -3,10 +3,8 @@
 use crate::{Debugger, ExitReason};
 use alloy_primitives::Address;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use foundry_evm_core::{
-    debug::{DebugNodeFlat, DebugStep},
-    utils::CallKind,
-};
+use foundry_evm_core::debug::{DebugNodeFlat, DebugStep};
+use revm_inspectors::tracing::types::CallKind;
 use std::{cell::RefCell, ops::ControlFlow};
 
 /// This is currently used to remember last scroll position so screen doesn't wiggle as much.
@@ -232,8 +230,8 @@ impl DebuggerContext<'_> {
                         .find_map(|(i, op)| {
                             if i > 0 {
                                 match (
-                                    prev_ops[i - 1].contains("JUMP") &&
-                                        prev_ops[i - 1] != "JUMPDEST",
+                                    prev_ops[i - 1].contains("JUMP")
+                                        && prev_ops[i - 1] != "JUMPDEST",
                                     &**op,
                                 ) {
                                     (true, "JUMPDEST") => Some(i - 1),
@@ -271,7 +269,7 @@ impl DebuggerContext<'_> {
                     if let Some(step) = node.steps.iter().position(|step| step.pc == *pc) {
                         self.draw_memory.inner_call_index = i;
                         self.current_step = step;
-                        break
+                        break;
                     }
                 }
             }

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -230,8 +230,8 @@ impl DebuggerContext<'_> {
                         .find_map(|(i, op)| {
                             if i > 0 {
                                 match (
-                                    prev_ops[i - 1].contains("JUMP")
-                                        && prev_ops[i - 1] != "JUMPDEST",
+                                    prev_ops[i - 1].contains("JUMP") &&
+                                        prev_ops[i - 1] != "JUMPDEST",
                                     &**op,
                                 ) {
                                     (true, "JUMPDEST") => Some(i - 1),

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -4,7 +4,7 @@ use super::context::DebuggerContext;
 use crate::op::OpcodeParam;
 use alloy_primitives::U256;
 use foundry_compilers::sourcemap::SourceElement;
-use foundry_evm_core::{debug::Instruction, utils::CallKind};
+use foundry_evm_core::debug::Instruction;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -13,6 +13,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 use revm::interpreter::opcode;
+use revm_inspectors::tracing::types::CallKind;
 use std::{cmp, collections::VecDeque, fmt::Write, io};
 
 impl DebuggerContext<'_> {

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -31,6 +31,7 @@ revm = { workspace = true, default-features = false, features = [
     "arbitrary",
     "optimism",
 ] }
+revm-inspectors.workspace = true
 alloy-providers = { workspace = true }
 alloy-transport = { workspace = true }
 alloy-rpc-types = { workspace = true }

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -1,6 +1,6 @@
-use crate::utils::CallKind;
 use alloy_primitives::{Address, U256};
 use revm::interpreter::OpCode;
+use revm_inspectors::tracing::types::CallKind;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -96,10 +96,10 @@ pub fn apply_chain_and_block_specific_env_changes(env: &mut revm::primitives::En
 
                 return;
             }
-            Chain::Arbitrum
-            | Chain::ArbitrumGoerli
-            | Chain::ArbitrumNova
-            | Chain::ArbitrumTestnet => {
+            Chain::Arbitrum |
+            Chain::ArbitrumGoerli |
+            Chain::ArbitrumNova |
+            Chain::ArbitrumTestnet => {
                 // on arbitrum `block.number` is the L1 block which is included in the
                 // `l1BlockNumber` field
                 if let Some(l1_block_number) = block.other.get("l1BlockNumber").cloned() {

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,78 +1,18 @@
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::FixedBytes;
 use alloy_rpc_types::{Block, Transaction};
-use ethers_core::types::{ActionType, CallType, Chain, H256, U256};
+use ethers_core::types::{Chain, H256, U256};
 use eyre::ContextCompat;
 use foundry_common::types::ToAlloy;
 use revm::{
-    interpreter::{CallScheme, InstructionResult},
-    primitives::{CreateScheme, Eval, Halt, SpecId, TransactTo},
+    interpreter::InstructionResult,
+    primitives::{Eval, Halt, SpecId, TransactTo},
 };
-use serde::{Deserialize, Serialize};
 
 pub use foundry_compilers::utils::RuntimeOrHandle;
 pub use revm::primitives::State as StateChangeset;
 
 pub use crate::ic::*;
-
-// TODO(onbjerg): Remove this and use `CallKind` from the tracer.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-#[derive(Default)]
-pub enum CallKind {
-    #[default]
-    Call,
-    StaticCall,
-    CallCode,
-    DelegateCall,
-    Create,
-    Create2,
-}
-
-impl From<CallScheme> for CallKind {
-    fn from(scheme: CallScheme) -> Self {
-        match scheme {
-            CallScheme::Call => CallKind::Call,
-            CallScheme::StaticCall => CallKind::StaticCall,
-            CallScheme::CallCode => CallKind::CallCode,
-            CallScheme::DelegateCall => CallKind::DelegateCall,
-        }
-    }
-}
-
-impl From<CreateScheme> for CallKind {
-    fn from(create: CreateScheme) -> Self {
-        match create {
-            CreateScheme::Create => CallKind::Create,
-            CreateScheme::Create2 { .. } => CallKind::Create2,
-        }
-    }
-}
-
-impl From<CallKind> for ActionType {
-    fn from(kind: CallKind) -> Self {
-        match kind {
-            CallKind::Call | CallKind::StaticCall | CallKind::DelegateCall | CallKind::CallCode => {
-                ActionType::Call
-            }
-            CallKind::Create => ActionType::Create,
-            CallKind::Create2 => ActionType::Create,
-        }
-    }
-}
-
-impl From<CallKind> for CallType {
-    fn from(ty: CallKind) -> Self {
-        match ty {
-            CallKind::Call => CallType::Call,
-            CallKind::StaticCall => CallType::StaticCall,
-            CallKind::CallCode => CallType::CallCode,
-            CallKind::DelegateCall => CallType::DelegateCall,
-            CallKind::Create => CallType::None,
-            CallKind::Create2 => CallType::None,
-        }
-    }
-}
 
 /// Small helper function to convert [U256] into [H256].
 #[inline]
@@ -156,10 +96,10 @@ pub fn apply_chain_and_block_specific_env_changes(env: &mut revm::primitives::En
 
                 return;
             }
-            Chain::Arbitrum |
-            Chain::ArbitrumGoerli |
-            Chain::ArbitrumNova |
-            Chain::ArbitrumTestnet => {
+            Chain::Arbitrum
+            | Chain::ArbitrumGoerli
+            | Chain::ArbitrumNova
+            | Chain::ArbitrumTestnet => {
                 // on arbitrum `block.number` is the L1 block which is included in the
                 // `l1BlockNumber` field
                 if let Some(l1_block_number) = block.other.get("l1BlockNumber").cloned() {

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -35,7 +35,7 @@ revm = { workspace = true, default-features = false, features = [
     "optional_no_base_fee",
     "arbitrary",
 ] }
-
+revm-inspectors.workspace = true
 ethers-core.workspace = true
 ethers-signers.workspace = true
 itertools.workspace = true

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -4,7 +4,7 @@ use foundry_evm_core::{
     backend::DatabaseExt,
     constants::CHEATCODE_ADDRESS,
     debug::{DebugArena, DebugNode, DebugStep, Instruction},
-    utils::{gas_used, CallKind},
+    utils::gas_used,
 };
 use revm::{
     interpreter::{
@@ -13,6 +13,7 @@ use revm::{
     },
     EVMData, Inspector,
 };
+use revm_inspectors::tracing::types::CallKind;
 
 /// An inspector that collects debug nodes on every step of the interpreter.
 #[derive(Clone, Debug, Default)]
@@ -127,7 +128,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
         // TODO: Does this increase gas cost?
         if let Err(err) = data.journaled_state.load_account(call.caller, data.db) {
             let gas = Gas::new(call.gas_limit);
-            return (InstructionResult::Revert, None, gas, err.abi_encode_revert())
+            return (InstructionResult::Revert, None, gas, err.abi_encode_revert());
         }
 
         let nonce = data.journaled_state.account(call.caller).info.nonce;

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -35,6 +35,8 @@ ethers-middleware.workspace = true
 ethers-providers.workspace = true
 ethers-signers.workspace = true
 
+revm-inspectors.workspace = true
+
 comfy-table = "7"
 eyre.workspace = true
 proptest = "1"

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -10,10 +10,8 @@ use foundry_common::{
     types::{ToAlloy, ToEthers},
     SELECTOR_LEN,
 };
-use foundry_evm::{
-    constants::DEFAULT_CREATE2_DEPLOYER,
-    traces::{CallKind, CallTraceDecoder},
-};
+use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, traces::CallTraceDecoder};
+use revm_inspectors::tracing::types::CallKind;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Replace `CallKind` in Foundry with the one from `revm-inspectors`. Might be worth extracting the type into Alloy, although I'm unsure where it would fit (since it's not used in Alloy at all) to avoid crates depending on `revm-inspectors` for that type only.

Closes #6725 