### PR TITLE
feat(cli): Update Flashbots URL to use `fast` endpoint to improve transaction inclusion guarantees

### DIFF
--- a/crates/cli/src/opts/ethereum.rs
+++ b/crates/cli/src/opts/ethereum.rs
@@ -12,7 +12,7 @@ use foundry_config::{
 use serde::Serialize;
 use std::borrow::Cow;
 
-const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
+const FLASHBOTS_URL: &str = "https://rpc.flashbots.net/fast";
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct RpcOpts {

--- a/crates/cli/src/opts/ethereum.rs
+++ b/crates/cli/src/opts/ethereum.rs
@@ -20,7 +20,9 @@ pub struct RpcOpts {
     #[clap(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
     pub url: Option<String>,
 
-    /// Use the Flashbots RPC URL (https://rpc.flashbots.net).
+    /// Use the Flashbots RPC URL with fast mode (https://rpc.flashbots.net/fast).
+    /// This shares the transaction privately with all registered builders.
+    /// https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions
     #[clap(long)]
     pub flashbots: bool,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

To improve transaction inclusion guarantees Flashbots offers a [fast](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions) endpoint that shares the transaction with all [registered builders](https://github.com/flashbots/dowg/blob/main/builder-registrations.json).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

To prevent introducing unnecessary breaking changes whilst offering major benefits I suggest using Flashbots' fast route.

A future solution could be to allow the user to define their own `BUILDER_RPC_URL` (separate from the `ETH_RPC_URL`). and get rid of the vendor lock-in naming of `flashbots` to something more neutral like `private`. 