### PR TITLE
fix(`forge`) expectRevert for cheatcodes

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -438,7 +438,8 @@ fn expect_revert(state: &mut Cheatcodes, reason: Option<&[u8]>, depth: u64) -> R
         state.expected_revert.is_none(),
         "you must call another function prior to expecting a second revert"
     );
-    state.expected_revert = Some(ExpectedRevert { reason: reason.map(<[_]>::to_vec), depth, pending: true });
+    state.expected_revert =
+        Some(ExpectedRevert { reason: reason.map(<[_]>::to_vec), depth, pending: true });
     Ok(Default::default())
 }
 

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -59,6 +59,9 @@ pub struct ExpectedRevert {
     pub reason: Option<Vec<u8>>,
     /// The depth at which the revert is expected
     pub depth: u64,
+    /// Flag which is being switched once we exit `expectRevert` call
+    /// Needed to not fail due to `expectRevert` not reverting
+    pub pending: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -435,7 +438,7 @@ fn expect_revert(state: &mut Cheatcodes, reason: Option<&[u8]>, depth: u64) -> R
         state.expected_revert.is_none(),
         "you must call another function prior to expecting a second revert"
     );
-    state.expected_revert = Some(ExpectedRevert { reason: reason.map(<[_]>::to_vec), depth });
+    state.expected_revert = Some(ExpectedRevert { reason: reason.map(<[_]>::to_vec), depth, pending: true });
     Ok(Default::default())
 }
 

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -155,11 +155,19 @@ contract ParseJsonTest is DSTest {
     function test_parseJsonKeys() public {
         string memory jsonString =
             '{"some_key_to_value": "some_value", "some_key_to_array": [1, 2, 3], "some_key_to_object": {"key1": "value1", "key2": 2}}';
+        
         string[] memory keys = vm.parseJsonKeys(jsonString, "$");
-        assertEq(abi.encode(keys), abi.encode(["some_key_to_value", "some_key_to_array", "some_key_to_object"]));
+        string[] memory expected = new string[](3);
+        expected[0] = "some_key_to_value";
+        expected[1] = "some_key_to_array";
+        expected[2] = "some_key_to_object";
+        assertEq(abi.encode(keys), abi.encode(expected));
 
         keys = vm.parseJsonKeys(jsonString, ".some_key_to_object");
-        assertEq(abi.encode(keys), abi.encode(["key1", "key2"]));
+        expected = new string[](2);
+        expected[0] = "key1";
+        expected[1] = "key2";
+        assertEq(abi.encode(keys), abi.encode(expected));
 
         vm.expectRevert("JSON value at \".some_key_to_array\" is not an object");
         vm.parseJsonKeys(jsonString, ".some_key_to_array");
@@ -167,7 +175,7 @@ contract ParseJsonTest is DSTest {
         vm.expectRevert("JSON value at \".some_key_to_value\" is not an object");
         vm.parseJsonKeys(jsonString, ".some_key_to_value");
 
-        vm.expectRevert("JSON value at \".*\" is not an object");
+        vm.expectRevert("key \".*\" must return exactly one JSON object");
         vm.parseJsonKeys(jsonString, ".*");
     }
 }

--- a/testdata/cheats/Json.t.sol
+++ b/testdata/cheats/Json.t.sol
@@ -155,7 +155,7 @@ contract ParseJsonTest is DSTest {
     function test_parseJsonKeys() public {
         string memory jsonString =
             '{"some_key_to_value": "some_value", "some_key_to_array": [1, 2, 3], "some_key_to_object": {"key1": "value1", "key2": 2}}';
-        
+
         string[] memory keys = vm.parseJsonKeys(jsonString, "$");
         string[] memory expected = new string[](3);
         expected[0] = "some_key_to_value";


### PR DESCRIPTION
## Motivation

Currently `expectRevert` isn't working correctly for reverts coming from cheatcodes invocations and may cause false-positives.
For example, such test will pass at the moment:
```solidity
function test_parseJsonKeys() public {
    string memory jsonString = '{"a": "b"}';
    
    vm.expectRevert('JSON value at ".a" is not an object');
    vm.parseJsonKeys(jsonString, ".a"); 
    
    revert("failed"); // Won't be reached
}
```

This is happening because `call_end` hook in Cheatcodes inspector always exists early for calls to cheatcodes address, forwarding reverts from cheatcodes further. Because of that, test is reverting, but not failing because revert is being processed as an expected revert in the next `call_end` invocation.

## Solution

1. Move expected reverts processing logic so it always run disregarding the call target.
2. Add special internal `pending` flag which is tracking that we've exited `vm.expectRevert` call context, because otherwise we would always expect it to revert which won't happen.
3. Update one cheatcode test which was giving false-positives due to this
