### PR TITLE
fix: skip trailing white space for doc comments

### DIFF
--- a/crates/fmt/src/comments.rs
+++ b/crates/fmt/src/comments.rs
@@ -398,13 +398,13 @@ impl Iterator for CommentStateCharIndices<'_> {
     }
 
     #[inline]
-    fn count(self) -> usize {
-        self.iter.count()
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+    fn count(self) -> usize {
+        self.iter.count()
     }
 }
 

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -528,8 +528,12 @@ impl<'a, W: Write> Formatter<'a, W> {
             .take_while(|(idx, ch)| ch.is_whitespace() && *idx <= self.buf.current_indent_len())
             .count();
         let to_skip = indent_whitespace_count - indent_whitespace_count % self.config.tab_width;
-        write!(self.buf(), " * ")?;
-        self.write_comment_line(comment, &line[to_skip..])?;
+        write!(self.buf(), " *")?;
+        let content = &line[to_skip..];
+        if !content.trim().is_empty() {
+            write!(self.buf(), " ")?;
+            self.write_comment_line(comment, &line[to_skip..])?;
+        }
         self.write_whitespace_separator(true)?;
         Ok(())
     }

--- a/crates/fmt/testdata/BlockCommentsFunction/fmt.sol
+++ b/crates/fmt/testdata/BlockCommentsFunction/fmt.sol
@@ -1,0 +1,20 @@
+contract A {
+    Counter public counter;
+    /**
+     *  TODO: this fuzz use too much time to execute
+     * function testGetFuzz(bytes[2][] memory kvs) public {
+     *     for (uint256 i = 0; i < kvs.length; i++) {
+     *         bytes32 root = trie.update(kvs[i][0], kvs[i][1]);
+     *         console.logBytes32(root);
+     *     }
+     *
+     *     for (uint256 i = 0; i < kvs.length; i++) {
+     *         (bool exist, bytes memory value) = trie.get(kvs[i][0]);
+     *         console.logBool(exist);
+     *         console.logBytes(value);
+     *         require(exist);
+     *         require(BytesSlice.equal(value, trie.getRaw(kvs[i][0])));
+     *     }
+     * }
+     */
+}

--- a/crates/fmt/testdata/BlockCommentsFunction/original.sol
+++ b/crates/fmt/testdata/BlockCommentsFunction/original.sol
@@ -1,0 +1,20 @@
+contract A {
+    Counter public counter;
+    /**
+     *  TODO: this fuzz use too much time to execute
+    function testGetFuzz(bytes[2][] memory kvs) public {
+        for (uint256 i = 0; i < kvs.length; i++) {
+            bytes32 root = trie.update(kvs[i][0], kvs[i][1]);
+            console.logBytes32(root);
+        }
+
+        for (uint256 i = 0; i < kvs.length; i++) {
+            (bool exist, bytes memory value) = trie.get(kvs[i][0]);
+            console.logBool(exist);
+            console.logBytes(value);
+            require(exist);
+            require(BytesSlice.equal(value, trie.getRaw(kvs[i][0])));
+        }
+    }
+    */
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -230,6 +230,7 @@ test_directories! {
     EmitStatement,
     Repros,
     BlockComments,
+    BlockCommentsFunction,
     EnumVariants,
 }
 


### PR DESCRIPTION
closes #6812

don't write trailing white space for empty doc lines