### PR TITLE
fix: update env in transact cheatcode

### DIFF
--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -50,6 +50,7 @@ macro_rules! test_repro {
 }
 
 async fn repro_config(issue: usize, should_fail: bool, sender: Option<Address>) -> TestConfig {
+    foundry_test_utils::init_tracing();
     let filter = Filter::path(&format!(".*repros/Issue{issue}.t.sol"));
 
     let mut config = Config::with_root(PROJECT.root());
@@ -279,6 +280,9 @@ test_repro!(6501, false, None, |res| {
         );
     }
 });
+
+// https://github.com/foundry-rs/foundry/issues/6538
+test_repro!(6538);
 
 // https://github.com/foundry-rs/foundry/issues/6554
 test_repro!(6554; |config| {

--- a/testdata/repros/Issue6538.t.sol
+++ b/testdata/repros/Issue6538.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6538
+contract Issue6538Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function test_transact() public {
+        bytes32 lastHash = 0xdbdce1d5c14a6ca17f0e527ab762589d6a73f68697606ae0bb90df7ac9ec5087;
+        vm.createSelectFork("rpcAlias", lastHash);
+        bytes32 txhash = 0xadbe5cf9269a001d50990d0c29075b402bcc3a0b0f3258821881621b787b35c6;
+        vm.transact(txhash);
+    }
+}


### PR DESCRIPTION
closes #6538

see docs for more context.

TLDR: we need to update the env.block to the transaction's block so we can transact it in the block env it was mined in