### PR TITLE
fix: format `web3_sha3` result as an hexadecimal string

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -473,7 +473,7 @@ impl EthApi {
     pub fn sha3(&self, bytes: Bytes) -> Result<String> {
         node_info!("web3_sha3");
         let hash = ethers::utils::keccak256(bytes.as_ref());
-        let hex_hash = ethers::utils::hex::encode(&hash[..]);
+        let hex_hash = alloy_primitives::utils::hex::encode(&hash[..]);
         Ok(format!("0x{hex_hash}"))
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -473,7 +473,8 @@ impl EthApi {
     pub fn sha3(&self, bytes: Bytes) -> Result<String> {
         node_info!("web3_sha3");
         let hash = ethers::utils::keccak256(bytes.as_ref());
-        Ok(ethers::utils::hex::encode(&hash[..]))
+        let hex_hash = ethers::utils::hex::encode(&hash[..]);
+        Ok(format!("0x{hex_hash}"))
     }
 
     /// Returns protocol version encoded as a string (quotes are necessary).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The result returned by `anvil` `web3_sha3` does not include the "0x" prefix in the hexadecimal string.

Comparing `geth` and `anvil` outputs, with the same parameter, we can see the difference:

```bash
# geth result
$ curl -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "method": "web3_sha3", "params": ["0x68656c6c6f20776f726c64"], "id": 74}' http://localhost:8545
{"jsonrpc":"2.0","id":74,"result":"0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"}

# anvil result
$ curl -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "method": "web3_sha3", "params": ["0x68656c6c6f20776f726c64"], "id": 74}' http://localhost:8545
{"jsonrpc":"2.0","id":74,"result":"47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"}
```

## Solution

Add the `0x` prefix to the result of sha3.
