### PR TITLE
chore(cast): Bump evm-disassembler dependency to add PUSH0 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "evm-disassembler"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef8b778f0f7ba24aaa7c1d8fa7ec75db869f8a8508907be49eac899865ea52d"
+checksum = "0f6fc9c732a3210153e6aa26746f0abd8773dbf204c64ae3e824309b32b384c5"
 dependencies = [
  "eyre",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ base64 = "0.21"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-evm-disassembler = "0.3"
+evm-disassembler = "0.4"
 
 axum = "0.6"
 hyper = "0.14"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Add Support for PUSH0 opcode when using `--disassemble` flag in `cast code`
closes: https://github.com/foundry-rs/foundry/issues/6840
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
See: https://github.com/ckoopmann/evm-disassembler/pull/10
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
