### PR TITLE
feat(cast/selectors): add optional selectors resolving

### DIFF
--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -862,7 +862,14 @@ pub enum Subcommands {
 
     /// Extracts function selectors and arguments from bytecode
     #[clap(visible_alias = "sel")]
-    Selectors { bytecode: String },
+    Selectors {
+        /// The hex encoded bytecode.
+        bytecode: String,
+
+        /// Resolve the function signatures for the extracted selectors using https://openchain.xyz
+        #[clap(long, short)]
+        resolve: bool,
+    },
 }
 
 /// CLI arguments for `cast --to-base`.


### PR DESCRIPTION
## Motivation

4byte selector lookups for `cast selectors` was requested in comments https://github.com/foundry-rs/foundry/pull/6684#issuecomment-1878139763


## Solution

Add optional selectors resolving (`--resolve`, default=false).
After the https://github.com/foundry-rs/foundry/pull/6719 has been merged, we don't have a problem with a lot of openchain API calls.



```
$ cast selectors --resolve $(cast code 0xdAC17F958D2ee523a2206206994597C13D831ec7)

0x06fdde03                              name()
0x0753c30c      address                 deprecate(address)
0x095ea7b3      address,uint256         approve(address,uint256)
0x0e136b19                              deprecated()
0x0ecb93c0      address                 addBlackList(address)
0x23b872dd      address,address,uint256 transferFrom(address,address,uint256)
...
```

output with `| tr ' ' '.' | tr '\t' '|'` (spaces replaced with `.` and tabs replaced with `|`)
```
0x06fdde03|.......................|name()
0x0753c30c|address................|deprecate(address)
0x095ea7b3|address,uint256........|approve(address,uint256)
0x0e136b19|.......................|deprecated()
0x23b872dd|address,address,uint256|transferFrom(address,address,uint256)
...
```
output is readable by humans (columns are aligned) and by shell scripts (no ` ` and `\t` chars in column values)