### PR TITLE
fix(cast) lowercase selectors before send API request to openchain.xyz

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -158,6 +158,7 @@ impl SignEthClient {
         let selectors: Vec<String> = selectors
             .into_iter()
             .map(Into::into)
+            .map(|s| s.to_lowercase())
             .map(|s| if s.starts_with("0x") { s } else { format!("0x{s}") })
             .collect();
 


### PR DESCRIPTION
## Motivation
`cast 4byte-decode` is broken, using the command from [reference example](https://book.getfoundry.sh/reference/cast/cast-4byte-decode#examples):

on [Nightly (2023-12-02)](https://github.com/foundry-rs/foundry/releases/tag/nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a):
```
$ cast 4byte-decode 0x1F1F897F676d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e7

Error:
Could not decode response:
 {"ok":true,"result":{"event":{},"function":{"0x1F1F897F":null,"0x1f1f897f":[{"name":"fulfillRandomness(bytes32,uint256)","filtered":false}]}}}
.
Error: invalid type: null, expected a sequence at line 1 column 61
```

on master:
```
$ cast 4byte-decode 0x1F1F897F676d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e7

Error:
No signature found
```


## Solution
We need to lowercase the selectors before sending API request to openchain API, after the fix:

```
$ cast 4byte-decode 0x1F1F897F676d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e7

1) "fulfillRandomness(bytes32,uint256)"
0x676d000000000000000000000000000000000000000000000000000000000000
999
```