### PR TITLE
fix(cast): add description to 'cast wallet derive-private-key'

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -139,6 +139,7 @@ pub enum WalletSubcommands {
     #[clap(visible_alias = "ls")]
     List,
 
+    /// Derives private key from mnemonic
     #[clap(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
     DerivePrivateKey { mnemonic: String, mnemonic_index: Option<u8> },
 }


### PR DESCRIPTION

## Motivation
[book scripts](https://github.com/foundry-rs/book/blob/master/scripts/gen_output/help.py#L194) are broken after adding the new `cast wallet derive-private-key` in https://github.com/foundry-rs/foundry/pull/6774 because of missing description


## Solution
Add the description to the command