### PR TITLE
fix: handle nulls in 4byte response

### DIFF
--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -153,8 +153,8 @@ impl SignEthClient {
 
         #[derive(Deserialize)]
         struct ApiResult {
-            event: HashMap<String, Vec<Decoded>>,
-            function: HashMap<String, Vec<Decoded>>,
+            event: HashMap<String, Option<Vec<Decoded>>>,
+            function: HashMap<String, Option<Vec<Decoded>>>,
         }
 
         #[derive(Deserialize)]
@@ -189,6 +189,7 @@ impl SignEthClient {
 
         Ok(decoded
             .get(selector)
+            .and_then(Option::as_ref)
             .ok_or_else(|| eyre::eyre!("No signature found"))?
             .iter()
             .filter(|&d| !d.filtered)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Values in the `function` and `event` maps may be `null`: `SignatureResponse` in <https://docs.openchain.xyz/#/>

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Handle `null` responses by making the selector maps' values optional.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
