### PR TITLE
feat(cheatcodes): add functionArguments and functionSelectors cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "evmole"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f492d1949e58ef83a1bf8e23fbd042af12b03e7642d50dbb4cfb48112de5e01f"
+checksum = "8ef57dfcf13fc3486c3a760427d88ab0d97cb911f7104fe5a132f2b934d0fe29"
 dependencies = [
  "ruint",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ dependencies = [
  "const-hex",
  "ethers-core",
  "ethers-signers",
+ "evmole",
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 evm-disassembler = "0.4"
+evmole = "0.3.1"
 
 axum = "0.6"
 hyper = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 evm-disassembler = "0.4"
-evmole = "0.3.1"
+evmole = "0.3.2"
 
 axum = "0.6"
 hyper = "0.14"

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -42,6 +42,7 @@ rand.workspace = true
 rayon = "1"
 serde_json.workspace = true
 serde.workspace = true
+evmole.workspace = true
 
 # aws
 rusoto_core = { version = "0.48", default-features = false }
@@ -69,7 +70,6 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "signal"] }
 tracing.workspace = true
 yansi = "0.5"
-evmole = "0.3.1"
 
 [dev-dependencies]
 foundry-test-utils.workspace = true

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -36,5 +36,6 @@ revm.workspace = true
 serde_json.workspace = true
 base64.workspace = true
 tracing.workspace = true
+evmole.workspace = true
 walkdir = "2"
 p256 = "0.13.2"

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -2195,6 +2195,46 @@
     },
     {
       "func": {
+        "id": "functionArguments",
+        "description": "Extracts function arguments from bytecode",
+        "declaration": "function functionArguments(bytes calldata contractBytecode, bytes4 functionSelector) external pure returns (string memory arguments);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "functionArguments(bytes,bytes4)",
+        "selector": "0xbea2c956",
+        "selectorBytes": [
+          190,
+          162,
+          201,
+          86
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "functionSelectors",
+        "description": "Extracts function selectors from bytecode",
+        "declaration": "function functionSelectors(bytes calldata contractBytecode) external pure returns (bytes4[] memory selectors);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "functionSelectors(bytes)",
+        "selector": "0x1387e42d",
+        "selectorBytes": [
+          19,
+          135,
+          228,
+          45
+        ]
+      },
+      "group": "utilities",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getBlockNumber",
         "description": "Gets the current `block.number`.\nYou should use this instead of `block.number` if you use `vm.roll`, as `block.number` is assumed to be constant across a transaction,\nand as a result will get optimized out by the compiler.\nSee https://github.com/foundry-rs/foundry/issues/6180",
         "declaration": "function getBlockNumber() external view returns (uint256 height);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1325,5 +1325,13 @@ interface Vm {
     /// Encodes a `string` value to a base64url string.
     #[cheatcode(group = Utilities)]
     function toBase64URL(string calldata data) external pure returns (string memory);
+
+    /// Extracts function selectors from bytecode
+    #[cheatcode(group = Utilities)]
+    function functionSelectors(bytes calldata contractBytecode) external pure returns (bytes4[] memory selectors);
+
+    /// Extracts function arguments from bytecode
+    #[cheatcode(group = Utilities)]
+    function functionArguments(bytes calldata contractBytecode, bytes4 functionSelector) external pure returns (string memory arguments);
 }
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -135,6 +135,22 @@ impl Cheatcode for computeCreate2Address_1Call {
     }
 }
 
+impl Cheatcode for functionSelectorsCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { contractBytecode } = self;
+        let s = evmole::function_selectors(contractBytecode, 0);
+        Ok(s.abi_encode())
+    }
+}
+
+impl Cheatcode for functionArgumentsCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { contractBytecode, functionSelector } = self;
+        let s = evmole::function_arguments(contractBytecode, functionSelector, 0);
+        Ok(s.abi_encode())
+    }
+}
+
 /// Using a given private key, return its public ETH address, its public key affine x and y
 /// coordinates, and its private key (see the 'Wallet' struct)
 ///

--- a/testdata/cheats/FunctionSelectors.t.sol
+++ b/testdata/cheats/FunctionSelectors.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "./Vm.sol";
+
+contract FunctionSelectorsContract {
+    function transfer(uint32, address, uint224) public {}
+    function balance() public {}
+}
+
+contract FunctionSelectorsTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    FunctionSelectorsContract c = new FunctionSelectorsContract();
+
+    function testFunctionSelectors() public {
+        bytes4[] memory s = vm.functionSelectors(address(c).code);
+
+        assertEq(s.length, 2);
+        if (s[0] == c.transfer.selector) {
+            assertEq(s[1], c.balance.selector);
+        } else {
+            assertEq(s[1], c.transfer.selector);
+            assertEq(s[0], c.balance.selector);
+        }
+    }
+
+    function testFunctionArguments() public {
+        string memory a = vm.functionArguments(address(c).code, c.transfer.selector);
+
+        assertEq(a, "uint32,address,uint224");
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -107,6 +107,8 @@ interface Vm {
     function fee(uint256 newBasefee) external;
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
+    function functionArguments(bytes calldata contractBytecode, bytes4 functionSelector) external pure returns (string memory arguments);
+    function functionSelectors(bytes calldata contractBytecode) external pure returns (bytes4[] memory selectors);
     function getBlockNumber() external view returns (uint256 height);
     function getBlockTimestamp() external view returns (uint256 timestamp);
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);


### PR DESCRIPTION
## Motivation
Requested at https://github.com/foundry-rs/foundry/pull/6684#issuecomment-1879164123

It could be useful to guess functions/arguments from code in tests

## Solution
Wrap evmole library calls (same as in `cast selectors`) to cheatcode


evmole version bumped from 0.3.1 to 0.3.2: the major change for Rust implementation is fixed crash when processing empty bytecode input (`cast selectors 0x`): https://github.com/cdump/evmole/commit/03b9410814e9b2120d35077ccb3c12f0285da69e, full changelog - https://github.com/cdump/evmole/releases/tag/0.3.2

p.s. this is my first cheatcodes commit, so feel free to comment on "best practices", I'll be happy to rewrite it if necessary.