### PR TITLE
fix: forge build spinner output

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -193,6 +193,9 @@ impl ProjectCompiler {
             r
         })?;
 
+        // need to drop the reporter here, so that the spinner terminates
+        drop(reporter);
+
         if bail && output.has_compiler_errors() {
             eyre::bail!("{output}")
         }

--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -86,6 +86,7 @@ impl Spinner {
 ///
 /// This reporter will prefix messages with a spinning cursor
 #[derive(Debug)]
+#[must_use = "Terminates the spinner on drop"]
 pub struct SpinnerReporter {
     /// The sender to the spinner thread.
     sender: mpsc::Sender<SpinnerMsg>,

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -24,3 +24,24 @@ contract Dummy {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/compile_json.stdout"),
     );
 });
+
+// tests build output is as expected
+forgetest_init!(exact_build_output, |prj, cmd| {
+    cmd.args(["build", "--force"]);
+    let (stdout, _) = cmd.unchecked_output_lossy();
+    // Expected output from build
+    let expected = r#"Compiling 24 files with 0.8.23
+Solc 0.8.23 finished in 2.36s
+Compiler run successful!
+"#;
+
+    // skip all dynamic parts of the output (numbers)
+    let expected_words =
+        expected.split(|c: char| c == ' ').filter(|w| !w.chars().next().unwrap().is_numeric());
+    let output_words =
+        stdout.split(|c: char| c == ' ').filter(|w| !w.chars().next().unwrap().is_numeric());
+
+    for (expected, output) in expected_words.zip(output_words) {
+        assert_eq!(expected, output, "expected: {}, output: {}", expected, output);
+    }
+});


### PR DESCRIPTION
smol regression of #6702

the spinner must be dropped so it terminates properly 

This fixes additional output introduced by the spinner stdout flush

```
[⠒] Compiling...
[⠒] Compiling 22 files with 0.8.23
[⠔] Solc 0.8.23 finished in 3.00sCompiler run successful!
[⠒] Solc 0.8.23 finished in 3.00s
```