### PR TITLE
chore(`deny`): ignore shlex

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 # Temporarily exclude rusoto and ethers-providers from bans since we've yet to transition to the 
 # Rust AWS SDK.
-exclude = ["rusoto_core", "rusoto_kms", "rusoto_credential", "ethers-providers", "tungstenite"]
+exclude = ["rusoto_core", "rusoto_kms", "rusoto_credential", "ethers-providers", "tungstenite", "shlex"]
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We've got an advisory complaining on the deny check for `shlex`, which is used in mdbook. We can wait for mdbook to patch this, and we shouldn't avoid the CI being green for this in the meanwhile

## Solution

Ignore it