### PR TITLE
feat(`evm`): use alloy provider to fetch chain id, remove `ethers-providers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,7 +3201,6 @@ dependencies = [
  "const-hex",
  "derive_more",
  "ethers-core",
- "ethers-providers",
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -38,7 +38,6 @@ revm = { workspace = true, default-features = false, features = [
 revm-inspectors.workspace = true
 
 ethers-core.workspace = true
-ethers-providers.workspace = true
 
 derive_more.workspace = true
 eyre = "0.6"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

With this and #6880, the evm crate is ethers free.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
