### PR TITLE
fix: fix off by one debugger draw

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -237,8 +237,9 @@ impl DebuggerContext<'_> {
 
         // adjust what text we show of the source code
         let (start_line, end_line) = if needed_highlight > height {
-            // highlighted section is more lines than we have avail
-            (before.len(), before.len() + needed_highlight)
+            // highlighted section is more lines than we have available
+            let start_line = before.len().saturating_sub(1);
+            (start_line, before.len() + needed_highlight)
         } else if height > num_lines {
             // we can fit entire source
             (0, num_lines)


### PR DESCRIPTION
optimistically closes #6878

see https://github.com/foundry-rs/foundry/issues/6878#issuecomment-1904903566

this should fix an off by one here:

https://github.com/foundry-rs/foundry/blob/master/crates/debugger/src/tui/draw.rs#L281-L281

but tbh I don't know for sure without a repro, perhaps @ethever can try?

FYI @brockelmore 