### PR TITLE
feat(cast): trace and debug on local contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "alloy-sol-types",
  "const-hex",
  "ethers-core",
+ "ethers-providers",
  "eyre",
  "foundry-block-explorers",
  "foundry-common",

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -166,7 +166,7 @@ impl CallArgs {
                         Err(evm_err) => TraceResult::try_from(evm_err)?,
                     };
 
-                    handle_traces(trace, &config, chain, labels, verbose, debug).await?;
+                    handle_traces(trace, &config, chain, labels, verbose, debug, provider).await?;
 
                     return Ok(())
                 }
@@ -200,7 +200,7 @@ impl CallArgs {
                         tx.value().copied().unwrap_or_default().to_alloy(),
                     )?);
 
-                    handle_traces(trace, &config, chain, labels, verbose, debug).await?;
+                    handle_traces(trace, &config, chain, labels, verbose, debug, provider).await?;
 
                     return Ok(())
                 }

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -204,8 +204,7 @@ impl RunArgs {
                 }
             }
         };
-
-        handle_traces(result, &config, chain, self.label, self.verbose, self.debug).await?;
+        handle_traces(result, &config, chain, self.label, self.verbose, self.debug, provider).await?;
 
         Ok(())
     }

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -17,7 +17,7 @@ use std::{
 type ArtifactWithContractRef<'a> = (&'a ArtifactId, &'a (Abi, Vec<u8>));
 
 /// Wrapper type that maps an artifact to a contract ABI and bytecode.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ContractsByArtifact(pub BTreeMap<ArtifactId, (Abi, Vec<u8>)>);
 
 impl ContractsByArtifact {

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -24,6 +24,7 @@ alloy-sol-types.workspace = true
 revm.workspace = true
 
 ethers-core.workspace = true
+ethers-providers.workspace = true
 
 eyre = "0.6"
 futures = "0.3"

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -196,7 +196,7 @@ impl CallTraceDecoder {
     }
 
     #[inline(always)]
-    fn addresses<'a>(
+    pub fn addresses<'a>(
         &'a self,
         trace: &'a CallTraceArena,
     ) -> impl Iterator<Item = (&'a Address, Option<&'a [u8]>)> + 'a {

--- a/crates/evm/traces/src/identifier/mod.rs
+++ b/crates/evm/traces/src/identifier/mod.rs
@@ -6,6 +6,9 @@ use std::borrow::Cow;
 mod local;
 pub use local::LocalTraceIdentifier;
 
+mod rpc;
+pub use rpc::RPCTraceIdentifier;
+
 mod etherscan;
 pub use etherscan::EtherscanIdentifier;
 
@@ -13,6 +16,7 @@ mod signatures;
 pub use signatures::{SignaturesIdentifier, SingleSignaturesIdentifier};
 
 /// An address identity
+#[derive(Debug)]
 pub struct AddressIdentity<'a> {
     /// The address this identity belongs to
     pub address: Address,

--- a/crates/evm/traces/src/identifier/rpc.rs
+++ b/crates/evm/traces/src/identifier/rpc.rs
@@ -1,0 +1,59 @@
+use super::{AddressIdentity, TraceIdentifier};
+use alloy_primitives::Address;
+use ethers_core::types::H160;
+use ethers_providers::Middleware;
+use foundry_common::contracts::{diff_score, ContractsByArtifact};
+use foundry_compilers::utils::RuntimeOrHandle;
+use ordered_float::OrderedFloat;
+use std::borrow::Cow;
+
+/// A trace identifier that tries to identify addresses using RPC contracts.
+pub struct RPCTraceIdentifier<'a> {
+    known_contracts: &'a ContractsByArtifact,
+    provider: &'a ethers_providers::Provider<foundry_common::runtime_client::RuntimeClient>,
+}
+
+impl<'a> RPCTraceIdentifier<'a> {
+    pub fn new(known_contracts: &'a ContractsByArtifact, provider: &'a ethers_providers::Provider<foundry_common::runtime_client::RuntimeClient>) -> Self {
+        Self { known_contracts, provider}
+    }
+}
+
+impl TraceIdentifier for RPCTraceIdentifier<'_> {
+
+    fn identify_addresses<'a, A>(&mut self, addresses: A) -> Vec<AddressIdentity<'_>>
+    where
+        A: Iterator<Item = (&'a Address, Option<&'a [u8]>)>,
+    {
+        let provider = self.provider;
+
+        addresses
+            .filter_map(|(address, _)| {
+                let code = RuntimeOrHandle::new().block_on(provider.get_code(Into::<H160>::into(address.into_array()), None)).expect("");
+                let (_, id, abi) = self
+                    .known_contracts
+                    .iter()
+                    .filter_map(|(id, (abi, known_code))| {
+                        let score = diff_score(known_code, code.0.as_ref());
+                        // Note: the diff score can be inaccurate for small contracts so we're using
+                        // a relatively high threshold here to avoid filtering out too many
+                        // contracts.
+                        if score < 0.85 {
+                            Some((OrderedFloat(score), id, abi))
+                        } else {
+                            None
+                        }
+                    })
+                    .min_by_key(|(score, _, _)| *score)?;
+
+                Some(AddressIdentity {
+                    address: *address,
+                    contract: Some(id.identifier()),
+                    label: Some(id.name.clone()),
+                    abi: Some(Cow::Borrowed(abi)),
+                    artifact_id: Some(id.clone()),
+                })
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
## Motivation

Using `cast run` and `cast call` to trace and debug can currently only fetch abi and source from explorers such as etherscan. In situations where no explorer is available, it would be intuitive to use the abi and source provided by the local files.

## Solution

As with `forge debug` - [using local files is preferred](https://github.com/foundry-rs/foundry/blob/master/crates/forge/bin/cmd/script/mod.rs#L224) over fetching data from remote explorer. Only if `etherscan_api_key` is defined, will we fetch abi and source from the explorer.
Without explorer it will now compile solidity files and fetch contract bytecode from build output. To identify contract addresses it fetches on chain bytecode via RPC call. Most of the required code change happens in `handle_traces`, where the decoder and debugger is fed with the required data fetched from local files (and RPC).

## Unresolved issues

- Debugging on inherited contracts does not resolve to the respective source code.
- Can we use existing build artifacts instead of running the builder each time? This also solves the problem where the building source requires additional parameters.
