### PR TITLE
feat: keep debug symbols in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ incremental = false
 [profile.release]
 opt-level = 3
 lto = "fat"
-strip = true
+strip = "debuginfo"
 panic = "abort"
 codegen-units = 1
 

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -48,6 +48,11 @@ impl EyreHandler for Handler {
 ///
 /// Panics are always caught by the more debug-centric handler.
 pub fn install() {
+    // If the user has not explicitly overridden "RUST_BACKTRACE", then produce full backtraces.
+    if std::env::var_os("RUST_BACKTRACE").is_none() {
+        std::env::set_var("RUST_BACKTRACE", "full");
+    }
+
     let debug_enabled = std::env::var("FOUNDRY_DEBUG").is_ok();
     if debug_enabled {
         if let Err(e) = color_eyre::install() {


### PR DESCRIPTION
And always show backtraces on panics.

This is a 10% size increase (40M -> 44M) for much better debugging panics. See below.

<details><summary><strong>Benchmarks</strong></summary>
<p>

NOTE: `forge-<strip = >-<panic = >`

```

------------- PANIC= ./forge-debuginfo-abort
The application panicked (crashed).
Message:  test
Location: crates/forge/bin/main.rs:25

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: forge::main::hd66a31dbefd0b4bf
      at <unknown source file>:<unknown line>
   9: std::sys_common::backtrace::__rust_begin_short_backtrace::h621274431205cf82
      at <unknown source file>:<unknown line>
  10: std::rt::lang_start::{{closure}}::h2b3f351f16e75c4f
      at <unknown source file>:<unknown line>
  11: std::rt::lang_start_internal::hf76339a38b4f124b
      at <unknown source file>:<unknown line>
  12: main<unknown>
      at <unknown source file>:<unknown line>
  13: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  14: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
./test.sh: line 9: 2131946 Aborted                 (core dumped) RUST_BACKTRACE=full PANIC=$panic $bin

------------- PANIC= ./forge-debuginfo-unwind
The application panicked (crashed).
Message:  test
Location: crates/forge/bin/main.rs:23

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: forge::main::h5069bbdeccde792d
      at <unknown source file>:<unknown line>
   9: std::sys_common::backtrace::__rust_begin_short_backtrace::h21681e747fd41e51
      at <unknown source file>:<unknown line>
  10: std::rt::lang_start::{{closure}}::h6ed8ba4300b81c2a
      at <unknown source file>:<unknown line>
  11: std::rt::lang_start_internal::hf76339a38b4f124b
      at <unknown source file>:<unknown line>
  12: main<unknown>
      at <unknown source file>:<unknown line>
  13: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  14: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.

------------- PANIC= ./forge-symbols-abort
The application panicked (crashed).
Message:  test
Location: crates/forge/bin/main.rs:25

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
./test.sh: line 9: 2131968 Aborted                 (core dumped) RUST_BACKTRACE=full PANIC=$panic $bin

------------- PANIC= ./forge-symbols-unwind
The application panicked (crashed).
Message:  test
Location: crates/forge/bin/main.rs:25

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.

------------- PANIC=untracked ./forge-debuginfo-abort
The application panicked (crashed).
Message:  align_offset: align is not a power-of-two
Location: /rustc/62d7ed4a6775c4490e493093ca98ef7c215b835b/library/core/src/ptr/const_ptr.rs:1368

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: forge::main::hd66a31dbefd0b4bf
      at <unknown source file>:<unknown line>
   9: std::sys_common::backtrace::__rust_begin_short_backtrace::h621274431205cf82
      at <unknown source file>:<unknown line>
  10: std::rt::lang_start::{{closure}}::h2b3f351f16e75c4f
      at <unknown source file>:<unknown line>
  11: std::rt::lang_start_internal::hf76339a38b4f124b
      at <unknown source file>:<unknown line>
  12: main<unknown>
      at <unknown source file>:<unknown line>
  13: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  14: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
./test.sh: line 9: 2132000 Aborted                 (core dumped) RUST_BACKTRACE=full PANIC=$panic $bin

------------- PANIC=untracked ./forge-debuginfo-unwind
The application panicked (crashed).
Message:  align_offset: align is not a power-of-two
Location: /rustc/62d7ed4a6775c4490e493093ca98ef7c215b835b/library/core/src/ptr/const_ptr.rs:1368

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: forge::main::h5069bbdeccde792d
      at <unknown source file>:<unknown line>
   9: std::sys_common::backtrace::__rust_begin_short_backtrace::h21681e747fd41e51
      at <unknown source file>:<unknown line>
  10: std::rt::lang_start::{{closure}}::h6ed8ba4300b81c2a
      at <unknown source file>:<unknown line>
  11: std::rt::lang_start_internal::hf76339a38b4f124b
      at <unknown source file>:<unknown line>
  12: main<unknown>
      at <unknown source file>:<unknown line>
  13: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
  14: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.

------------- PANIC=untracked ./forge-symbols-abort
The application panicked (crashed).
Message:  align_offset: align is not a power-of-two
Location: /rustc/62d7ed4a6775c4490e493093ca98ef7c215b835b/library/core/src/ptr/const_ptr.rs:1368

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
./test.sh: line 9: 2132151 Aborted                 (core dumped) RUST_BACKTRACE=full PANIC=$panic $bin

------------- PANIC=untracked ./forge-symbols-unwind
The application panicked (crashed).
Message:  align_offset: align is not a power-of-two
Location: /rustc/62d7ed4a6775c4490e493093ca98ef7c215b835b/library/core/src/ptr/const_ptr.rs:1368

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.

------------
44M     ./forge-debuginfo-abort
52M     ./forge-debuginfo-unwind
40M     ./forge-symbols-abort
47M     ./forge-symbols-unwind
```

</p>
</details>
