### PR TITLE
chore: symlink config to crates/config for visibility

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+crates/config


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Old foundry config files point to /config which was moved to /crates/config.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
