### PR TITLE
chore: use EvmVersion::Cancun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5409d75d032836be70c1786c20cd135e3c4ae21e397db97f2cd0a321d3e41c37"
+checksum = "343530a6efe3786d26e1357f15605bb5cd28bd1133e6aab812126508a064bca7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ foundry-test-utils = { path = "crates/test-utils" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.0", default-features = false }
-foundry-compilers = { version = "0.2.2", default-features = false }
+foundry-compilers = { version = "0.2.3", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,8 +36,8 @@ use std::{
     fs,
     path::{Path, PathBuf},
     str::FromStr,
+    string::ToString,
 };
-use std::string::ToString;
 
 // Macros useful for creating a figment.
 mod macros;
@@ -403,7 +403,8 @@ pub static STANDALONE_FALLBACK_SECTIONS: Lazy<HashMap<&'static str, &'static str
 /// Deprecated keys and their replacements.
 ///
 /// See [Warning::DeprecatedKey]
-pub static DEPRECATIONS: Lazy<HashMap<String, String>> = Lazy::new(|| HashMap::from([("cancun".to_string(), "evm_version = Cancun".to_string()) ]));
+pub static DEPRECATIONS: Lazy<HashMap<String, String>> =
+    Lazy::new(|| HashMap::from([("cancun".to_string(), "evm_version = Cancun".to_string())]));
 
 impl Config {
     /// The default profile: "default"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -25,7 +25,6 @@ use foundry_compilers::{
     ConfigurableArtifacts, EvmVersion, Project, ProjectPathsConfig, Solc, SolcConfig,
 };
 use inflector::Inflector;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use revm_primitives::SpecId;
 use semver::Version;
@@ -397,14 +396,12 @@ pub struct Config {
 }
 
 /// Mapping of fallback standalone sections. See [`FallbackProfileProvider`]
-pub static STANDALONE_FALLBACK_SECTIONS: Lazy<HashMap<&'static str, &'static str>> =
-    Lazy::new(|| HashMap::from([("invariant", "fuzz")]));
+pub const STANDALONE_FALLBACK_SECTIONS: &[(&str, &str)] = &[("invariant", "fuzz")];
 
 /// Deprecated keys and their replacements.
 ///
 /// See [Warning::DeprecatedKey]
-pub static DEPRECATIONS: Lazy<HashMap<String, String>> =
-    Lazy::new(|| HashMap::from([("cancun".to_string(), "evm_version = Cancun".to_string())]));
+pub const DEPRECATIONS: &[(&str, &str)] = &[("cancun", "evm_version = Cancun")];
 
 impl Config {
     /// The default profile: "default"
@@ -1538,7 +1535,9 @@ impl Config {
         }
         // merge special keys into config
         for standalone_key in Config::STANDALONE_SECTIONS {
-            if let Some(fallback) = STANDALONE_FALLBACK_SECTIONS.get(standalone_key) {
+            if let Some((_, fallback)) =
+                STANDALONE_FALLBACK_SECTIONS.iter().find(|(key, fallback)| key == fallback)
+            {
                 figment = figment.merge(
                     provider
                         .fallback(standalone_key, fallback)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -37,6 +37,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use std::string::ToString;
 
 // Macros useful for creating a figment.
 mod macros;
@@ -399,8 +400,10 @@ pub struct Config {
 pub static STANDALONE_FALLBACK_SECTIONS: Lazy<HashMap<&'static str, &'static str>> =
     Lazy::new(|| HashMap::from([("invariant", "fuzz")]));
 
-/// Deprecated keys.
-pub static DEPRECATIONS: Lazy<HashMap<String, String>> = Lazy::new(|| HashMap::from([]));
+/// Deprecated keys and their replacements.
+///
+/// See [Warning::DeprecatedKey]
+pub static DEPRECATIONS: Lazy<HashMap<String, String>> = Lazy::new(|| HashMap::from([("cancun".to_string(), "evm_version = Cancun".to_string()) ]));
 
 impl Config {
     /// The default profile: "default"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1536,7 +1536,7 @@ impl Config {
         // merge special keys into config
         for standalone_key in Config::STANDALONE_SECTIONS {
             if let Some((_, fallback)) =
-                STANDALONE_FALLBACK_SECTIONS.iter().find(|(key, fallback)| key == fallback)
+                STANDALONE_FALLBACK_SECTIONS.iter().find(|(key, _)| standalone_key == key)
             {
                 figment = figment.merge(
                     provider

--- a/crates/config/src/providers/mod.rs
+++ b/crates/config/src/providers/mod.rs
@@ -66,10 +66,17 @@ impl<P: Provider> WarningsProvider<P> {
                 .unwrap_or_default()
                 .iter()
                 .flat_map(|(profile, dict)| dict.keys().map(move |key| format!("{profile}.{key}")))
-                .filter(|k| DEPRECATIONS.contains_key(k))
-                .map(|deprecated_key| Warning::DeprecatedKey {
-                    old: deprecated_key.clone(),
-                    new: DEPRECATIONS.get(&deprecated_key).unwrap().to_string(),
+                .filter_map(|key| {
+                    DEPRECATIONS.iter().find_map(|(deprecated_key, new_value)| {
+                        if key == *deprecated_key {
+                            Some(Warning::DeprecatedKey {
+                                old: deprecated_key.to_string(),
+                                new: new_value.to_string(),
+                            })
+                        } else {
+                            None
+                        }
+                    })
                 }),
         );
         Ok(out)

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -309,6 +309,7 @@ pub fn evm_spec_id(evm_version: &EvmVersion) -> SpecId {
         EvmVersion::London => SpecId::LONDON,
         EvmVersion::Paris => SpecId::MERGE,
         EvmVersion::Shanghai => SpecId::SHANGHAI,
+        EvmVersion::Cancun => SpecId::CANCUN,
     }
 }
 


### PR DESCRIPTION
this deprecates the tmp cancun config value and supports new `EvmVersion::Cancun`

blocked by svm 0.8.24 release