### PR TITLE
fix: print actual length in bytes in `trimmed_hex`

### DIFF
--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -124,11 +124,28 @@ pub fn maybe_decode_revert(
 }
 
 fn trimmed_hex(s: &[u8]) -> String {
-    let s = hex::encode(s);
-    let n = 32 * 2;
+    let n = 32;
     if s.len() <= n {
-        s
+        hex::encode(s)
     } else {
-        format!("{}…{} ({} bytes)", &s[..n / 2], &s[s.len() - n / 2..], s.len())
+        format!(
+            "{}…{} ({} bytes)",
+            &hex::encode(&s[..n / 2]),
+            &hex::encode(&s[s.len() - n / 2..]),
+            s.len()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_trimmed_hex() {
+        assert_eq!(trimmed_hex(&hex::decode("1234567890").unwrap()), "1234567890");
+        assert_eq!(
+        trimmed_hex(&hex::decode("492077697368207275737420737570706F72746564206869676865722D6B696E646564207479706573").unwrap()),
+        "49207769736820727573742073757070…6865722d6b696e646564207479706573 (41 bytes)"
+    );
     }
 }


### PR DESCRIPTION
## Motivation

The `trimmed_hex` function turns a slice of bytes into a hex string, trimming the output if the slice is longer than 32 bytes. If longer, an ellipsis is inserted in the middle, and the number of bytes is rendered into the output. Currently, this number actually corresponds to the length of the hex string, i.e. it's twice the number of bytes.

## Solution

Render the length of the original slice instead of the hex string. I also slightly changed the code so only the visible parts of the slice are encoded as hex, which saves a bit of allocation.
