### PR TITLE
fix: improve compiler version check in create --verify

### DIFF
--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -39,12 +39,29 @@ function doStuff() external {}
     .unwrap();
 }
 
+fn add_single_verify_target_file(prj: &TestProject) {
+    let timestamp = utils::millis_since_epoch();
+    let contract = format!(
+        r#"
+contract Unique {{
+    uint public _timestamp = {timestamp};
+}}
+contract Verify is Unique {{
+function doStuff() external {{}}
+}}
+"#
+    );
+
+    prj.add_source("Verify.sol", &contract).unwrap();
+}
+
 fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Result<()> {
     // give etherscan some time to verify the contract
     let retry = Retry::new(retries, Some(Duration::from_secs(30)));
     retry.run(|| -> eyre::Result<()> {
         let output = cmd.unchecked_output();
         let out = String::from_utf8_lossy(&output.stdout);
+        println!("{}", out);
         if out.contains("Contract successfully verified") {
             return Ok(())
         }
@@ -75,6 +92,7 @@ fn verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: Te
             info.chain.to_string(),
             address,
             contract_path.to_string(),
+            "--etherscan-api-key".to_string(),
             info.etherscan.to_string(),
             "--verifier".to_string(),
             info.verifier.to_string(),
@@ -114,6 +132,26 @@ fn verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: Te
     }
 }
 
+/// Executes create --verify on the given chain
+fn create_verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: TestCommand) {
+    // only execute if keys present
+    if let Some(info) = info {
+        println!("verifying on {}", info.chain);
+        add_single_verify_target_file(&prj);
+
+        let contract_path = "src/Verify.sol:Verify";
+        cmd.arg("create").args(info.create_args()).args([
+            contract_path,
+            "--etherscan-api-key",
+            info.etherscan.as_str(),
+            "--verify",
+        ]);
+
+        let out = cmd.stdout_lossy();
+        assert!(out.contains("Contract successfully verified"), "{}", out);
+    }
+}
+
 // tests `create && contract-verify && verify-check` on Fantom testnet if correct env vars are set
 forgetest!(can_verify_random_contract_fantom_testnet, |prj, cmd| {
     verify_on_chain(EnvExternalities::ftm_testnet(), prj, cmd);
@@ -122,4 +160,17 @@ forgetest!(can_verify_random_contract_fantom_testnet, |prj, cmd| {
 // tests `create && contract-verify && verify-check` on Optimism kovan if correct env vars are set
 forgetest!(can_verify_random_contract_optimism_kovan, |prj, cmd| {
     verify_on_chain(EnvExternalities::optimism_kovan(), prj, cmd);
+});
+
+// tests `create && contract-verify && verify-check` on Sepolia testnet if correct env vars are set
+forgetest!(can_verify_random_contract_sepolia, |prj, cmd| {
+    verify_on_chain(EnvExternalities::sepolia(), prj, cmd);
+});
+
+// tests `create --verify on Sepolia testnet if correct env vars are set
+// SEPOLIA_RPC_URL=https://rpc.sepolia.org
+// TEST_PRIVATE_KEY=0x...
+// ETHERSCAN_API_KEY=
+forgetest!(can_create_verify_random_contract_sepolia, |prj, cmd| {
+    create_verify_on_chain(EnvExternalities::sepolia(), prj, cmd);
 });


### PR DESCRIPTION
This fixes a bug in the compiler_version detection if there are more artifacts in a single file.

This now checks if the versions of an artifact are unique