### PR TITLE
fix(`forge`): Small fix for `ProjectCompiler`

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -162,7 +162,7 @@ impl ProjectCompiler {
     /// use foundry_common::compile::ProjectCompiler;
     /// let config = foundry_config::Config::load();
     /// let prj = config.project().unwrap();
-    /// ProjectCompiler::new().compile_with(&prj, || Ok(prj.compile()?)).unwrap();
+    /// ProjectCompiler::new().compile_with(|| Ok(prj.compile()?)).unwrap();
     /// ```
     #[instrument(target = "forge::compile", skip_all)]
     fn compile_with<F>(self, f: F) -> Result<ProjectCompileOutput>


### PR DESCRIPTION
## Motivation

Currently `ProjectCompiler` exits with "Nothing to compile" if `project.paths` does not have any input files. However, this is incorrect as we may have non-empty `files` field on it.

The usecase is to compile an arbitrary set of files which does necessarily form a correct foundry project layout.

## Solution

We are `mem:take`'ing `files` field in `compile`, so I moved a "Nothing to compile" check there.
