### PR TITLE
fix(cast/call): remove --verbose, fix --debug

### DIFF
--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -42,28 +42,18 @@ pub struct CallArgs {
     #[clap(long, default_value_t = false)]
     trace: bool,
 
-    /// Can only be used with "--trace"
-    ///
-    /// opens an interactive debugger
+    /// Opens an interactive debugger.
+    /// Can only be used with `--trace`.
     #[clap(long, requires = "trace")]
     debug: bool,
 
-    /// Can only be used with "--trace"
-    ///
-    /// prints a more verbose trace
-    #[clap(long, requires = "trace")]
-    verbose: bool,
-
-    /// Can only be used with "--trace"
-    /// Labels to apply to the traces.
-    ///
-    /// Format: `address:label`
+    /// Labels to apply to the traces; format: `address:label`.
+    /// Can only be used with `--trace`.
     #[clap(long, requires = "trace")]
     labels: Vec<String>,
 
-    /// Can only be used with "--trace"
-    ///
     /// The EVM Version to use.
+    /// Can only be used with `--trace`.
     #[clap(long, requires = "trace")]
     evm_version: Option<EvmVersion>,
 
@@ -121,7 +111,6 @@ impl CallArgs {
             trace,
             evm_version,
             debug,
-            verbose,
             labels,
         } = self;
 
@@ -165,7 +154,7 @@ impl CallArgs {
                         Err(evm_err) => TraceResult::try_from(evm_err)?,
                     };
 
-                    handle_traces(trace, &config, chain, labels, verbose).await?;
+                    handle_traces(trace, &config, chain, labels, debug).await?;
 
                     return Ok(());
                 }
@@ -199,7 +188,7 @@ impl CallArgs {
                         tx.value().copied().unwrap_or_default().to_alloy(),
                     )?);
 
-                    handle_traces(trace, &config, chain, labels, verbose).await?;
+                    handle_traces(trace, &config, chain, labels, debug).await?;
 
                     return Ok(());
                 }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -316,6 +316,7 @@ pub fn read_constructor_args_file(constructor_args_path: PathBuf) -> Result<Vec<
 }
 
 /// A slimmed down return from the executor used for returning minimal trace + gas metering info
+#[derive(Debug)]
 pub struct TraceResult {
     pub success: bool,
     pub traces: Traces,

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -97,15 +97,18 @@ impl Debugger {
 
     /// Starts the debugger TUI.
     pub fn try_run(&mut self) -> Result<ExitReason> {
+        eyre::ensure!(!self.debug_arena.is_empty(), "debug arena is empty");
+
         let backend = CrosstermBackend::new(io::stdout());
-        let mut terminal = Terminal::new(backend)?;
-        TerminalGuard::with(&mut terminal, |terminal| self.try_run_real(terminal))
+        let terminal = Terminal::new(backend)?;
+        TerminalGuard::with(terminal, |terminal| self.try_run_real(terminal))
     }
 
     #[instrument(target = "debugger", name = "run", skip_all, ret)]
     fn try_run_real(&mut self, terminal: &mut DebuggerTerminal) -> Result<ExitReason> {
         // Create the context.
         let mut cx = DebuggerContext::new(self);
+
         cx.init();
 
         // Create an event listener in a different thread.
@@ -114,8 +117,6 @@ impl Debugger {
             .name("event-listener".into())
             .spawn(move || Self::event_listener(tx))
             .expect("failed to spawn thread");
-
-        eyre::ensure!(!cx.debug_arena().is_empty(), "debug arena is empty");
 
         // Draw the initial state.
         cx.draw(terminal)?;
@@ -158,16 +159,16 @@ type PanicHandler = Box<dyn Fn(&std::panic::PanicInfo<'_>) + 'static + Sync + Se
 
 /// Handles terminal state.
 #[must_use]
-struct TerminalGuard<'a, B: Backend + io::Write> {
-    terminal: &'a mut Terminal<B>,
+struct TerminalGuard<B: Backend + io::Write> {
+    terminal: Terminal<B>,
     hook: Option<Arc<PanicHandler>>,
 }
 
-impl<'a, B: Backend + io::Write> TerminalGuard<'a, B> {
-    fn with<T>(terminal: &'a mut Terminal<B>, mut f: impl FnMut(&mut Terminal<B>) -> T) -> T {
+impl<B: Backend + io::Write> TerminalGuard<B> {
+    fn with<T>(terminal: Terminal<B>, mut f: impl FnMut(&mut Terminal<B>) -> T) -> T {
         let mut guard = Self { terminal, hook: None };
         guard.setup();
-        f(guard.terminal)
+        f(&mut guard.terminal)
     }
 
     fn setup(&mut self) {
@@ -188,16 +189,21 @@ impl<'a, B: Backend + io::Write> TerminalGuard<'a, B> {
 
     fn restore(&mut self) {
         if !std::thread::panicking() {
+            // Drop the current hook to guarantee that `self.hook` is the only reference to it.
             let _ = std::panic::take_hook();
+            // Restore the previous panic hook.
             let prev = self.hook.take().unwrap();
             let prev = match Arc::try_unwrap(prev) {
                 Ok(prev) => prev,
-                Err(_) => unreachable!(),
+                Err(_) => unreachable!("`self.hook` is not the only reference to the panic hook"),
             };
             std::panic::set_hook(prev);
+
+            // NOTE: Our panic handler calls this function, so we only have to call it here if we're
+            // not panicking.
+            Self::half_restore(self.terminal.backend_mut());
         }
 
-        Self::half_restore(self.terminal.backend_mut());
         let _ = self.terminal.show_cursor();
     }
 
@@ -207,7 +213,7 @@ impl<'a, B: Backend + io::Write> TerminalGuard<'a, B> {
     }
 }
 
-impl<B: Backend + io::Write> Drop for TerminalGuard<'_, B> {
+impl<B: Backend + io::Write> Drop for TerminalGuard<B> {
     #[inline]
     fn drop(&mut self) {
         self.restore();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`cast call --trace --verbose` functionality was removed in https://github.com/foundry-rs/foundry/pull/6219 (it didn't do anything), but it wasn't removed as a flag and it was incorrectly passed instead of `--debug`'s value when calling `handle_traces`.

Drive-by: fix double terminal clear in case of debugger panics, and fix a debugger panic by hoisting a check to before creating the internal context.

Closes https://github.com/foundry-rs/foundry/issues/6938

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
