### PR TITLE
chore: tweak `debug` config for all profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,19 +35,20 @@ homepage = "https://github.com/foundry-rs/foundry"
 repository = "https://github.com/foundry-rs/foundry"
 exclude = ["benches/", "tests/", "test-data/", "testdata/"]
 
+# Speed up compilation time for dev builds by reducing emitted debug info.
+# NOTE: Debuggers may provide less useful information with this setting.
+# Uncomment this section if you're using a debugger.
 [profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much
-debug = 0
+debug = 1
 
-# Speed up tests and dev build
+# Speed up tests and dev build.
 [profile.dev.package]
-# solc
+# Solc and artifacts
 foundry-compilers.opt-level = 3
 solang-parser.opt-level = 3
 serde_json.opt-level = 3
 
-# evm
+# EVM
 alloy-primitives.opt-level = 3
 alloy-sol-types.opt-level = 3
 hashbrown.opt-level = 3
@@ -67,11 +68,11 @@ scrypt.opt-level = 3
 # forking
 axum.opt-level = 3
 
-# Local "release" mode, more optimized than dev but much faster to compile than release
+# Local "release" mode, more optimized than dev but much faster to compile than release.
 [profile.local]
 inherits = "dev"
 opt-level = 1
-strip = true
+strip = "debuginfo"
 panic = "abort"
 codegen-units = 16
 
@@ -83,15 +84,16 @@ strip = "none"
 panic = "unwind"
 incremental = false
 
-# Optimized release profile
+# Optimized release profile.
 [profile.release]
 opt-level = 3
+debug = "line-tables-only"
 lto = "fat"
 strip = "debuginfo"
 panic = "abort"
 codegen-units = 1
 
-# Override packages which aren't perf-sensitive for faster compilation speed
+# Override packages which aren't perf-sensitive for faster compilation speed.
 [profile.release.package]
 mdbook.opt-level = 1
 protobuf.opt-level = 1


### PR DESCRIPTION
- `debug = 1` for debug builds: this is a minor loss (about 10% or 4s, from ~40s to ~44s) in a clean dev build for much better backtraces (including normal errors with FOUNDRY_DEBUG=1).
- `debug = "line-tables-only"` for optimized builds: negligible binary size increase (<100KB) for source locations in backtraces, see [the profiles reference](https://doc.rust-lang.org/cargo/reference/profiles.html#debug)


<details><summary><strong>Measurements dump</strong></summary>
<p>

```
--- DEBUG = 0 ---
      Timing report saved to /home/doni/github/foundry-rs/foundry/target/cargo-timings/cargo-timing-20240129T180147Z.html
    Finished dev [unoptimized] target(s) in 39.50s
        Command being timed: "cargo b --bin forge -p forge --timings"
        User time (seconds): 452.77
        System time (seconds): 37.59
        Percent of CPU this job got: 1240%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:39.54
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1372164
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 3123
        Minor (reclaiming a frame) page faults: 8253885
        Voluntary context switches: 73661
        Involuntary context switches: 98882
        Swaps: 0
        File system inputs: 5344
        File system outputs: 5771336
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0



--- DEBUG = 1 ---
      Timing report saved to /home/doni/github/foundry-rs/foundry/target/cargo-timings/cargo-timing-20240129T180316Z.html
    Finished dev [unoptimized + debuginfo] target(s) in 44.14s
        Command being timed: "cargo b --bin forge -p forge --timings"
        User time (seconds): 525.31
        System time (seconds): 40.35
        Percent of CPU this job got: 1279%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:44.19
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1574724
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 2274
        Minor (reclaiming a frame) page faults: 9384116
        Voluntary context switches: 72666
        Involuntary context switches: 133939
        Swaps: 0
        File system inputs: 256
        File system outputs: 7795176
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

--- DEBUG = 2 ---
      Timing report saved to /home/doni/github/foundry-rs/foundry/target/cargo-timings/cargo-timing-20240129T180437Z.html
    Finished dev [unoptimized + debuginfo] target(s) in 50.45s
        Command being timed: "cargo b --bin forge -p forge --timings"
        User time (seconds): 636.03
        System time (seconds): 46.90
        Percent of CPU this job got: 1352%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:50.49
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 2170188
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 3284
        Minor (reclaiming a frame) page faults: 11830261
        Voluntary context switches: 72178
        Involuntary context switches: 148842
        Swaps: 0
        File system inputs: 1960
        File system outputs: 12122296
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0

--- DEBUG = "line-tables-only" ---
      Timing report saved to /home/doni/github/foundry-rs/foundry/target/cargo-timings/cargo-timing-20240129T180605Z.html
    Finished dev [unoptimized + debuginfo] target(s) in 44.25s
        Command being timed: "cargo b --bin forge -p forge --timings"
        User time (seconds): 519.49
        System time (seconds): 39.51
        Percent of CPU this job got: 1261%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:44.29
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1453480
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 4374
        Minor (reclaiming a frame) page faults: 9289883
        Voluntary context switches: 72269
        Involuntary context switches: 125890
        Swaps: 0
        File system inputs: 0
        File system outputs: 7012336
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</p>
</details>
