### PR TITLE
chore: halve the size of GlobMatcher

### DIFF
--- a/crates/common/src/glob.rs
+++ b/crates/common/src/glob.rs
@@ -24,13 +24,16 @@ pub fn expand_globs(
 /// to be compiled when the filter functions `TestFilter` functions are called.
 #[derive(Clone, Debug)]
 pub struct GlobMatcher {
-    /// The parsed glob
-    pub glob: globset::Glob,
     /// The compiled glob
     pub matcher: globset::GlobMatcher,
 }
 
 impl GlobMatcher {
+    /// Creates a new `GlobMatcher` from a `globset::Glob`.
+    pub fn new(glob: globset::Glob) -> Self {
+        Self { matcher: glob.compile_matcher() }
+    }
+
     /// Tests whether the given path matches this pattern or not.
     ///
     /// The glob `./test/*` won't match absolute paths like `test/Contract.sol`, which is common
@@ -43,15 +46,20 @@ impl GlobMatcher {
         matches
     }
 
+    /// Returns the `globset::Glob`.
+    pub fn glob(&self) -> &globset::Glob {
+        self.matcher.glob()
+    }
+
     /// Returns the `Glob` string used to compile this matcher.
     pub fn as_str(&self) -> &str {
-        self.glob.glob()
+        self.glob().glob()
     }
 }
 
 impl fmt::Display for GlobMatcher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.glob.fmt(f)
+        self.glob().fmt(f)
     }
 }
 
@@ -59,16 +67,16 @@ impl FromStr for GlobMatcher {
     type Err = globset::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<globset::Glob>().map(Into::into)
+        s.parse::<globset::Glob>().map(Self::new)
     }
 }
 
 impl From<globset::Glob> for GlobMatcher {
     fn from(glob: globset::Glob) -> Self {
-        let matcher = glob.compile_matcher();
-        Self { glob, matcher }
+        Self::new(glob)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`GlobMatcher` stores the unparsed glob already

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
