### PR TITLE
chore: revert k256 bump (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,9 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 evm-disassembler = "0.4"
-k256 = "0.13"
+# TODO: bumping to >=0.13.2 breaks ecrecover: https://github.com/foundry-rs/foundry/pull/6969
+# TODO: unpin on next revm release: https://github.com/bluealloy/revm/pull/870
+k256 = "=0.13.1"
 
 axum = "0.6"
 hyper = "0.14"

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -297,3 +297,6 @@ test_repro!(6554; |config| {
 
 // https://github.com/foundry-rs/foundry/issues/6759
 test_repro!(6759);
+
+// https://github.com/foundry-rs/foundry/issues/6966
+test_repro!(6966);

--- a/testdata/repros/Issue6966.t.sol
+++ b/testdata/repros/Issue6966.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+
+// https://github.com/foundry-rs/foundry/issues/6966
+// See also https://github.com/RustCrypto/elliptic-curves/issues/988#issuecomment-1817681013
+contract Issue6966Test is DSTest {
+    function testEcrecover() public {
+        bytes32 h = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        uint8 v = 27;
+        bytes32 r = bytes32(0xf87fff3202dfeae34ce9cb8151ce2e176bee02a937baac6de85c4ea03d6a6618);
+        bytes32 s = bytes32(0xedf9ab5c7d3ec1df1c2b48600ab0a35f586e069e9a69c6cdeebc99920128d1a5);
+        assert(ecrecover(h, v, r, s) != address(0));
+    }
+}


### PR DESCRIPTION

Related https://github.com/foundry-rs/foundry/pull/6358
Closes https://github.com/foundry-rs/foundry/issues/6966

Nice