### PR TITLE
fix(cast): pass blocknum to cast storage rather than always using latest

### DIFF
--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -107,7 +107,8 @@ impl StorageArgs {
                 artifact.get_deployed_bytecode_bytes().is_some_and(|b| *b == address_code)
             });
             if let Some((_, artifact)) = artifact {
-                return fetch_and_print_storage(provider, address.clone(), artifact, true).await;
+                return fetch_and_print_storage(provider, address.clone(), block, artifact, true)
+                    .await;
             }
         }
 
@@ -173,7 +174,7 @@ impl StorageArgs {
         // Clear temp directory
         root.close()?;
 
-        fetch_and_print_storage(provider, address, artifact, true).await
+        fetch_and_print_storage(provider, address, block, artifact, true).await
     }
 }
 
@@ -211,6 +212,7 @@ impl StorageValue {
 async fn fetch_and_print_storage(
     provider: RetryProvider,
     address: NameOrAddress,
+    block: Option<BlockId>,
     artifact: &ConfigurableContractArtifact,
     pretty: bool,
 ) -> Result<()> {
@@ -219,7 +221,7 @@ async fn fetch_and_print_storage(
         Ok(())
     } else {
         let layout = artifact.storage_layout.as_ref().unwrap().clone();
-        let values = fetch_storage_slots(provider, address, &layout).await?;
+        let values = fetch_storage_slots(provider, address, block, &layout).await?;
         print_storage(layout, values, pretty)
     }
 }
@@ -227,12 +229,13 @@ async fn fetch_and_print_storage(
 async fn fetch_storage_slots(
     provider: RetryProvider,
     address: NameOrAddress,
+    block: Option<BlockId>,
     layout: &StorageLayout,
 ) -> Result<Vec<StorageValue>> {
     let requests = layout.storage.iter().map(|storage_slot| async {
         let slot = B256::from(U256::from_str(&storage_slot.slot)?);
         let raw_slot_value =
-            provider.get_storage_at(address.clone(), slot.to_ethers(), None).await?.to_alloy();
+            provider.get_storage_at(address.clone(), slot.to_ethers(), block).await?.to_alloy();
 
         let value = StorageValue { slot, raw_slot_value };
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -555,6 +555,32 @@ casttest!(storage, |_prj, cmd| {
     let six = "0x0000000000000000000000000000000000000000000000000000000000000006";
     cmd.cast_fuse().args(["storage", usdt, decimals_slot, "--rpc-url", &rpc]);
     assert_eq!(cmd.stdout_lossy().trim(), six);
+
+    let rpc = next_http_rpc_endpoint();
+    let total_supply_slot = "0x01";
+    let issued = "0x000000000000000000000000000000000000000000000000000000174876e800";
+    let block_before = "4634747";
+    let block_after = "4634748";
+    cmd.cast_fuse().args([
+        "storage",
+        usdt,
+        total_supply_slot,
+        "--rpc-url",
+        &rpc,
+        "--block",
+        block_before,
+    ]);
+    assert_eq!(cmd.stdout_lossy().trim(), empty);
+    cmd.cast_fuse().args([
+        "storage",
+        usdt,
+        total_supply_slot,
+        "--rpc-url",
+        &rpc,
+        "--block",
+        block_after,
+    ]);
+    assert_eq!(cmd.stdout_lossy().trim(), issued);
 });
 
 casttest!(balance, |_prj, cmd| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`cast storage` currently passes `None` to `provider.get_storage_at()` for `block`, rather than the block number if provided by the user. This causes storage for the latest block to always be pulled, regardless of what the user provides.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Pass the `block` (already a flag for `storage` and parsed as `BlockId` ) along to `provider.get_storage_at()`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
