### PR TITLE
#6981: `fs_permissions` find permission also sym links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,6 +3146,7 @@ dependencies = [
  "alloy-chains",
  "alloy-primitives",
  "dirs-next",
+ "dunce",
  "eyre",
  "figment",
  "foundry-block-explorers",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,6 +19,7 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 revm-primitives = { workspace = true, default-features = false, features = ["std"] }
 
 dirs-next = "2"
+dunce = "1"
 eyre.workspace = true
 figment = { version = "0.10", features = ["toml", "env"] }
 globset = "0.4"

--- a/crates/config/src/fs_permissions.rs
+++ b/crates/config/src/fs_permissions.rs
@@ -44,7 +44,8 @@ impl FsPermissions {
 
     /// Returns the permission for the matching path.
     ///
-    /// This finds the longest matching path, e.g. if we have the following permissions:
+    /// This finds the longest matching path with resolved sym links, e.g. if we have the following
+    /// permissions:
     ///
     /// `./out` = `read`
     /// `./out/contracts` = `read-write`
@@ -53,7 +54,7 @@ impl FsPermissions {
     pub fn find_permission(&self, path: &Path) -> Option<FsAccessPermission> {
         let mut permission: Option<&PathPermission> = None;
         for perm in &self.permissions {
-            if path.starts_with(&perm.path) {
+            if path.starts_with(&perm.path.canonicalize().unwrap_or(perm.path.clone())) {
                 if let Some(active_perm) = permission.as_ref() {
                     // the longest path takes precedence
                     if perm.path < active_perm.path {

--- a/crates/config/src/fs_permissions.rs
+++ b/crates/config/src/fs_permissions.rs
@@ -54,7 +54,8 @@ impl FsPermissions {
     pub fn find_permission(&self, path: &Path) -> Option<FsAccessPermission> {
         let mut permission: Option<&PathPermission> = None;
         for perm in &self.permissions {
-            if path.starts_with(&perm.path.canonicalize().unwrap_or(perm.path.clone())) {
+            let permission_path = dunce::canonicalize(&perm.path).unwrap_or(perm.path.clone());
+            if path.starts_with(permission_path) {
                 if let Some(active_perm) = permission.as_ref() {
                     // the longest path takes precedence
                     if perm.path < active_perm.path {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -678,7 +678,7 @@ forgetest_init!(can_resolve_symlink_fs_permissions, |prj, cmd| {
     // write config in packages/files/config.json
     let config_path = prj.root().join("packages").join("files");
     fs::create_dir_all(&config_path).unwrap();
-    fs::write(&config_path.join("config.json"), "{ enabled: true }").unwrap();
+    fs::write(config_path.join("config.json"), "{ enabled: true }").unwrap();
 
     // symlink packages/files dir as links/
     std::os::unix::fs::symlink(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

see https://github.com/foundry-rs/foundry/issues/6981

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- resolve configured `fs_permissions` symlinks paths when finding permissions

## Tests
- could write a test for unix family  that creates sym link in temp dir and check permissions, didn't find this approach in project, pls advise
