### PR TITLE
feat: Linking rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,8 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.3.2"
-source = "git+https://github.com/foundry-rs/compilers?branch=main#757652ef7fc2f90cfe490319d99dd1cf13f54564"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5eea089774ef60f8f4aa28a24fcc903ff054ff210cada46a32145213aff71d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,8 +3105,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d88392f8b9848cfac5b11054b14e14268ae5361450bd45169df276f9af748c5"
+source = "git+https://github.com/foundry-rs/compilers?branch=main#757652ef7fc2f90cfe490319d99dd1cf13f54564"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,7 +3105,8 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.2"
-source = "git+https://github.com/foundry-rs/compilers?branch=main#757652ef7fc2f90cfe490319d99dd1cf13f54564"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d88392f8b9848cfac5b11054b14e14268ae5361450bd45169df276f9af748c5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.74" # Remember to update clippy.toml as well
+rust-version = "1.74"                                       # Remember to update clippy.toml as well
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"
@@ -173,7 +173,10 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## misc
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 color-eyre = "0.6"
 derive_more = "0.99"
 eyre = "0.6"
@@ -226,3 +229,5 @@ revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+
+foundry-compilers = { git = "https://github.com/foundry-rs/compilers", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.74"                                       # Remember to update clippy.toml as well
+rust-version = "1.74" # Remember to update clippy.toml as well
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"
@@ -173,10 +173,7 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## misc
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "std",
-] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 color-eyre = "0.6"
 derive_more = "0.99"
 eyre = "0.6"
@@ -229,5 +226,3 @@ revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
-
-foundry-compilers = { git = "https://github.com/foundry-rs/compilers", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,3 +226,5 @@ revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+
+foundry-compilers = { git = "https://github.com/foundry-rs/compilers", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.74" # Remember to update clippy.toml as well
+rust-version = "1.74"                                       # Remember to update clippy.toml as well
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"
@@ -127,7 +127,7 @@ foundry-test-utils = { path = "crates/test-utils" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.3", default-features = false }
-foundry-compilers = { version = "0.3.2", default-features = false }
+foundry-compilers = { version = "0.3.3", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg
@@ -173,7 +173,10 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## misc
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 color-eyre = "0.6"
 derive_more = "0.99"
 eyre = "0.6"
@@ -226,5 +229,3 @@ revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
-
-foundry-compilers = { git = "https://github.com/foundry-rs/compilers", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.74"                                       # Remember to update clippy.toml as well
+rust-version = "1.74" # Remember to update clippy.toml as well
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -150,7 +150,7 @@ impl ScriptArgs {
         let LinkOutput { libs_to_deploy, contracts, libraries } =
             linker.link_with_nonce_or_address(libraries, sender, nonce, &target)?;
 
-        // Collect all linked contracts
+        // Collect all linked contracts with non-empty bytecode
         let highlevel_known_contracts = contracts
             .iter()
             .filter_map(|(id, contract)| {
@@ -158,7 +158,7 @@ impl ScriptArgs {
                     .ok()
                     .map(|tc| (id.clone(), tc))
             })
-            .filter(|(_, tc)| !tc.bytecode.object.is_unlinked())
+            .filter(|(_, tc)| tc.bytecode.object.is_non_empty_bytecode())
             .collect();
 
         Ok((highlevel_known_contracts, libraries, libs_to_deploy))

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -79,6 +79,7 @@ impl ScriptArgs {
         Ok(output)
     }
 
+    /// Tries to find artifact for the target script contract.
     pub fn find_target<'a>(
         &self,
         project: &Project,
@@ -125,6 +126,11 @@ impl ScriptArgs {
         target.ok_or_eyre(format!("Could not find target contract: {}", target_fname))
     }
 
+    /// Links script artifact with given libraries or library addresses computed from script sender
+    /// and nonce.
+    ///
+    /// Populates [BuildOutput] with linked target contract, libraries, bytes of libs that need to
+    /// be predeployed and `highlevel_known_contracts` - set of known fully linked contracts
     pub fn link_script_target(
         &self,
         project: Project,

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -138,7 +138,14 @@ impl ScriptArgs {
             libs_to_deploy: predeploy_libraries,
             contracts: linked_contracts,
             libraries,
-        } = link_with_nonce_or_address(&contracts, libraries, sender, nonce, &target)?;
+        } = link_with_nonce_or_address(
+            &contracts,
+            libraries,
+            sender,
+            nonce,
+            &target,
+            project.root(),
+        )?;
 
         // Get linked target artifact
         let contract = linked_contracts

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -160,6 +160,7 @@ impl ScriptArgs {
         let contract =
             contracts.get(target).ok_or_eyre("Target contract not found in artifacts")?.clone();
 
+        // Collect all linked contracts
         let highlevel_known_contracts = contracts
             .iter()
             .filter_map(|(id, contract)| {
@@ -167,6 +168,7 @@ impl ScriptArgs {
                     .ok()
                     .map(|tc| (id.clone(), tc))
             })
+            .filter(|(_, tc)| !tc.bytecode.object.is_unlinked())
             .collect();
 
         Ok(BuildOutput {

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -123,7 +123,7 @@ impl ScriptArgs {
             }
         }
 
-        target.ok_or_eyre(format!("Could not find target contract: {}", target_fname))
+        target.ok_or_else(|| eyre::eyre!("Could not find target contract: {}", target_fname))
     }
 
     /// Links script artifact with given libraries or library addresses computed from script sender

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -273,6 +273,8 @@ impl ScriptArgs {
 
         if self.verify {
             let target = self.find_target(&project, &default_known_contracts)?.clone();
+            let libraries = Libraries::parse(&deployment_sequence.libraries)?
+                .with_stripped_file_prefixes(project.root());
             // We might have predeployed libraries from the broadcasting, so we need to
             // relink the contracts with them, since their mapping is
             // not included in the solc cache files.
@@ -280,7 +282,7 @@ impl ScriptArgs {
                 .link_script_target(
                     project,
                     default_known_contracts,
-                    Libraries::parse(&deployment_sequence.libraries)?,
+                    libraries,
                     script_config.config.sender, // irrelevant, since we're not creating any
                     0,                           // irrelevant, since we're not creating any
                     target,

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -272,15 +272,17 @@ impl ScriptArgs {
         }
 
         if self.verify {
+            let target = self.find_target(&project, &default_known_contracts)?;
             // We might have predeployed libraries from the broadcasting, so we need to
             // relink the contracts with them, since their mapping is
             // not included in the solc cache files.
             let BuildOutput { highlevel_known_contracts, .. } = self.link(
                 project,
-                default_known_contracts,
+                &default_known_contracts,
                 Libraries::parse(&deployment_sequence.libraries)?,
                 script_config.config.sender, // irrelevant, since we're not creating any
                 0,                           // irrelevant, since we're not creating any
+                target,
             )?;
 
             verify.known_contracts = flatten_contracts(&highlevel_known_contracts, false);
@@ -311,15 +313,17 @@ impl ScriptArgs {
         )
         .await?;
         script_config.sender_nonce = nonce;
+        let target = self.find_target(&project, &default_known_contracts)?;
 
         let BuildOutput {
             libraries, contract, highlevel_known_contracts, predeploy_libraries, ..
         } = self.link(
             project,
-            default_known_contracts,
+            &default_known_contracts,
             script_config.config.parsed_libraries()?,
             new_sender,
             nonce,
+            target,
         )?;
 
         let mut txs = self.create_deploy_transactions(

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -272,13 +272,13 @@ impl ScriptArgs {
         }
 
         if self.verify {
-            let target = self.find_target(&project, &default_known_contracts)?;
+            let target = self.find_target(&project, &default_known_contracts)?.clone();
             // We might have predeployed libraries from the broadcasting, so we need to
             // relink the contracts with them, since their mapping is
             // not included in the solc cache files.
             let BuildOutput { highlevel_known_contracts, .. } = self.link(
                 project,
-                &default_known_contracts,
+                default_known_contracts,
                 Libraries::parse(&deployment_sequence.libraries)?,
                 script_config.config.sender, // irrelevant, since we're not creating any
                 0,                           // irrelevant, since we're not creating any
@@ -313,13 +313,13 @@ impl ScriptArgs {
         )
         .await?;
         script_config.sender_nonce = nonce;
-        let target = self.find_target(&project, &default_known_contracts)?;
+        let target = self.find_target(&project, &default_known_contracts)?.clone();
 
         let BuildOutput {
             libraries, contract, highlevel_known_contracts, predeploy_libraries, ..
         } = self.link(
             project,
-            &default_known_contracts,
+            default_known_contracts,
             script_config.config.parsed_libraries()?,
             new_sender,
             nonce,

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -286,7 +286,7 @@ impl ScriptArgs {
                     target,
                 )?;
 
-            if predeploy_libraries.len() > 0 {
+            if !predeploy_libraries.is_empty() {
                 eyre::bail!("Incomplete set of libraries in deployment artifact.");
             }
 

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -320,12 +320,14 @@ impl ScriptArgs {
         script_config.sender_nonce = nonce;
         let target = self.find_target(&project, &default_known_contracts)?.clone();
 
+        let libraries = script_config.config.solc_settings()?.libraries;
+
         let BuildOutput {
             libraries, contract, highlevel_known_contracts, predeploy_libraries, ..
         } = self.link_script_target(
             project,
             default_known_contracts,
-            script_config.config.parsed_libraries()?,
+            libraries,
             new_sender,
             nonce,
             target,

--- a/crates/forge/bin/cmd/script/cmd.rs
+++ b/crates/forge/bin/cmd/script/cmd.rs
@@ -3,7 +3,8 @@ use alloy_primitives::Bytes;
 
 use ethers_providers::Middleware;
 use ethers_signers::Signer;
-use eyre::Result;
+use eyre::{OptionExt, Result};
+use forge::link::Linker;
 use foundry_cli::utils::LoadConfig;
 use foundry_common::{
     contracts::flatten_contracts, provider::ethers::try_get_http_provider, types::ToAlloy,
@@ -51,11 +52,10 @@ impl ScriptArgs {
         );
 
         let BuildOutput {
-            project,
             contract,
             mut highlevel_known_contracts,
             predeploy_libraries,
-            known_contracts: default_known_contracts,
+            linker,
             sources,
             mut libraries,
             ..
@@ -70,16 +70,7 @@ impl ScriptArgs {
             self.execute(&mut script_config, contract, sender, &predeploy_libraries).await?;
 
         if self.resume || (self.verify && !self.broadcast) {
-            return self
-                .resume_deployment(
-                    script_config,
-                    project,
-                    default_known_contracts,
-                    libraries,
-                    result,
-                    verify,
-                )
-                .await;
+            return self.resume_deployment(script_config, linker, libraries, result, verify).await;
         }
 
         let known_contracts = flatten_contracts(&highlevel_known_contracts, true);
@@ -96,13 +87,7 @@ impl ScriptArgs {
         }
 
         if let Some((new_traces, updated_libraries, updated_contracts)) = self
-            .maybe_prepare_libraries(
-                &mut script_config,
-                project,
-                default_known_contracts,
-                predeploy_libraries,
-                &mut result,
-            )
+            .maybe_prepare_libraries(&mut script_config, linker, predeploy_libraries, &mut result)
             .await?
         {
             decoder = new_traces;
@@ -128,8 +113,7 @@ impl ScriptArgs {
     async fn maybe_prepare_libraries(
         &mut self,
         script_config: &mut ScriptConfig,
-        project: Project,
-        default_known_contracts: ArtifactContracts,
+        linker: Linker,
         predeploy_libraries: Vec<Bytes>,
         result: &mut ScriptResult,
     ) -> Result<Option<NewSenderChanges>> {
@@ -139,15 +123,8 @@ impl ScriptArgs {
             &predeploy_libraries,
         )? {
             // We have a new sender, so we need to relink all the predeployed libraries.
-            let (libraries, highlevel_known_contracts) = self
-                .rerun_with_new_deployer(
-                    project,
-                    script_config,
-                    new_sender,
-                    result,
-                    default_known_contracts,
-                )
-                .await?;
+            let (libraries, highlevel_known_contracts) =
+                self.rerun_with_new_deployer(script_config, new_sender, result, linker).await?;
 
             // redo traces for the new addresses
             let new_traces = self.decode_traces(
@@ -184,8 +161,7 @@ impl ScriptArgs {
     async fn resume_deployment(
         &mut self,
         script_config: ScriptConfig,
-        project: Project,
-        default_known_contracts: ArtifactContracts,
+        linker: Linker,
         libraries: Libraries,
         result: ScriptResult,
         verify: VerifyBundle,
@@ -207,8 +183,7 @@ impl ScriptArgs {
         }
         self.resume_single_deployment(
             script_config,
-            project,
-            default_known_contracts,
+            linker,
             result,
             verify,
         )
@@ -222,8 +197,7 @@ impl ScriptArgs {
     async fn resume_single_deployment(
         &mut self,
         script_config: ScriptConfig,
-        project: Project,
-        default_known_contracts: ArtifactContracts,
+        linker: Linker,
         result: ScriptResult,
         mut verify: VerifyBundle,
     ) -> Result<()> {
@@ -272,21 +246,19 @@ impl ScriptArgs {
         }
 
         if self.verify {
-            let target = self.find_target(&project, &default_known_contracts)?.clone();
+            let target = script_config.target_contract();
             let libraries = Libraries::parse(&deployment_sequence.libraries)?
-                .with_stripped_file_prefixes(project.root());
+                .with_stripped_file_prefixes(linker.root.as_path());
             // We might have predeployed libraries from the broadcasting, so we need to
             // relink the contracts with them, since their mapping is
             // not included in the solc cache files.
-            let BuildOutput { highlevel_known_contracts, predeploy_libraries, .. } = self
-                .link_script_target(
-                    project,
-                    default_known_contracts,
-                    libraries,
-                    script_config.config.sender, // irrelevant, since we're not creating any
-                    0,                           // irrelevant, since we're not creating any
-                    target,
-                )?;
+            let (highlevel_known_contracts, _, predeploy_libraries) = self.link_script_target(
+                &linker,
+                libraries,
+                script_config.config.sender, // irrelevant, since we're not creating any
+                0,                           // irrelevant, since we're not creating any
+                target.clone(),
+            )?;
 
             if !predeploy_libraries.is_empty() {
                 eyre::bail!("Incomplete set of libraries in deployment artifact.");
@@ -303,11 +275,10 @@ impl ScriptArgs {
     /// Reruns the execution with a new sender and relinks the libraries accordingly
     async fn rerun_with_new_deployer(
         &mut self,
-        project: Project,
         script_config: &mut ScriptConfig,
         new_sender: Address,
         first_run_result: &mut ScriptResult,
-        default_known_contracts: ArtifactContracts,
+        linker: Linker,
     ) -> Result<(Libraries, ArtifactContracts<ContractBytecodeSome>)> {
         // if we had a new sender that requires relinking, we need to
         // get the nonce mainnet for accurate addresses for predeploy libs
@@ -320,20 +291,17 @@ impl ScriptArgs {
         )
         .await?;
         script_config.sender_nonce = nonce;
-        let target = self.find_target(&project, &default_known_contracts)?.clone();
+        let target = script_config.target_contract();
 
         let libraries = script_config.config.solc_settings()?.libraries;
 
-        let BuildOutput {
-            libraries, contract, highlevel_known_contracts, predeploy_libraries, ..
-        } = self.link_script_target(
-            project,
-            default_known_contracts,
-            libraries,
-            new_sender,
-            nonce,
-            target,
-        )?;
+        let (highlevel_known_contracts, libraries, predeploy_libraries) =
+            self.link_script_target(&linker, libraries, new_sender, nonce, target.clone())?;
+
+        let contract = highlevel_known_contracts
+            .get(target)
+            .ok_or_eyre("target not found in linked artifacts")?
+            .clone();
 
         let mut txs = self.create_deploy_transactions(
             new_sender,

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -14,7 +14,6 @@ use forge::{
 };
 use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
 use foundry_common::{provider::ethers::RpcUrl, shell};
-use foundry_compilers::artifacts::CompactContractBytecode;
 use futures::future::join_all;
 use parking_lot::RwLock;
 use std::{collections::VecDeque, sync::Arc};
@@ -25,21 +24,17 @@ impl ScriptArgs {
     pub async fn execute(
         &self,
         script_config: &mut ScriptConfig,
-        contract: CompactContractBytecode,
+        contract: ContractBytecodeSome,
         sender: Address,
         predeploy_libraries: &[Bytes],
     ) -> Result<ScriptResult> {
         trace!(target: "script", "start executing script");
 
-        let CompactContractBytecode { abi, bytecode, .. } = contract;
+        let ContractBytecodeSome { abi, bytecode, .. } = contract;
 
-        let abi = abi.ok_or_else(|| eyre::eyre!("no ABI found for contract"))?;
-        let bytecode = bytecode
-            .ok_or_else(|| eyre::eyre!("no bytecode found for contract"))?
-            .into_bytes()
-            .ok_or_else(|| {
-                eyre::eyre!("expected fully linked bytecode, found unlinked bytecode")
-            })?;
+        let bytecode = bytecode.into_bytes().ok_or_else(|| {
+            eyre::eyre!("expected fully linked bytecode, found unlinked bytecode")
+        })?;
 
         ensure_clean_constructor(&abi)?;
 

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -32,7 +32,7 @@ use foundry_common::{
 use foundry_compilers::{
     artifacts::{ContractBytecodeSome, Libraries},
     contracts::ArtifactContracts,
-    ArtifactId, Project,
+    ArtifactId,
 };
 use foundry_config::{
     figment,

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -2,11 +2,7 @@ use alloy_primitives::{Address, Bytes};
 use eyre::Result;
 use foundry_compilers::{artifacts::Libraries, contracts::ArtifactContracts, Artifact, ArtifactId};
 use semver::Version;
-use std::{
-    collections::{BTreeSet, HashSet},
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{collections::BTreeSet, path::PathBuf, str::FromStr};
 
 /// Helper method to convert [ArtifactId] to the format in which libraries are stored in [Libraries]
 /// object.

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -67,10 +67,9 @@ pub fn collect_dependencies<'a>(
                 Some(&target.version),
                 root_path,
             )
-            .ok_or_eyre(format!(
-                "wasn't able to find artifact for library {} at {}",
-                file, contract
-            ))?;
+            .ok_or_else(|| {
+                eyre::eyre!("wasn't able to find artifact for library {} at {}", file, contract)
+            })?;
             if deps.insert(id) {
                 collect_dependencies(id, contracts, deps, root_path)?;
             }

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -21,7 +21,7 @@ pub struct LinkOutput {
     /// It is guaranteed to contain `target` and all it's dependencies fully linked, and any other
     /// contract may still be partially unlinked.
     pub contracts: ArtifactContracts,
-    /// Resulted library addresses. Contains both user-provided and newly deployed libraries.
+    /// Resolved library addresses. Contains both user-provided and newly deployed libraries.
     /// It will always contain library paths with stripped path prefixes.
     pub libraries: Libraries,
     /// Vector of libraries that need to be deployed from sender address.

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -173,8 +173,8 @@ impl Linker {
 
                 for (file, libs) in &libraries.libs {
                     for (name, address) in libs {
-                        let address = Address::from_str(address)
-                            .map_err(|err| LinkerError::InvalidAddress(err))?;
+                        let address =
+                            Address::from_str(address).map_err(LinkerError::InvalidAddress)?;
                         if let Some(bytecode) = contract.bytecode.as_mut() {
                             bytecode.link(file.to_string_lossy(), name, address);
                         }

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -108,6 +108,10 @@ impl Linker {
     ///
     /// Each key in `libraries` should either be a global path or relative to project root. All
     /// remappings should be resolved.
+    ///
+    /// When calling for `target` being an external library itself, you should check that `target`
+    /// does not appear in `libs_to_deploy` to avoid deploying it twice. It may happen in cases
+    /// when there is a dependency cycle including `target`.
     pub fn link_with_nonce_or_address<'a>(
         &'a self,
         libraries: Libraries,

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -1,411 +1,130 @@
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::Address;
 use eyre::Result;
-use foundry_compilers::{
-    artifacts::{BytecodeObject, CompactBytecode, CompactContractBytecode, Libraries},
-    contracts::ArtifactContracts,
-    ArtifactId,
-};
+use foundry_compilers::{artifacts::Libraries, contracts::ArtifactContracts, ArtifactId};
+use semver::Version;
 use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    path::{Path, PathBuf},
+    collections::{HashMap, HashSet},
     str::FromStr,
 };
 
-/// Data passed to the post link handler of the linker for each linked artifact.
-#[derive(Debug)]
-pub struct PostLinkInput<'a, T, U> {
-    /// The fully linked bytecode of the artifact
-    pub contract: CompactContractBytecode,
-    /// All artifacts passed to the linker
-    pub known_contracts: &'a mut BTreeMap<ArtifactId, T>,
-    /// The ID of the artifact
-    pub id: ArtifactId,
-    /// Extra data passed to the handler, which can be used as a scratch space.
-    pub extra: &'a mut U,
-    /// Each dependency of the contract in their resolved form.
-    pub dependencies: Vec<ResolvedDependency>,
-}
-
-/// Dependencies for an artifact.
-#[derive(Debug)]
-struct ArtifactDependencies {
-    /// All references to dependencies in the artifact's unlinked bytecode.
-    dependencies: Vec<ArtifactDependency>,
-    /// The ID of the artifact
-    artifact_id: ArtifactId,
-}
-
-/// A dependency of an artifact.
-#[derive(Debug)]
-struct ArtifactDependency {
-    file: String,
-    key: String,
-    version: String,
-}
-
-struct ArtifactCode {
-    code: CompactContractBytecode,
-    artifact_id: ArtifactId,
-}
-
-impl std::fmt::Debug for ArtifactCode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.artifact_id.fmt(f)
-    }
-}
-
-#[derive(Debug)]
-struct AllArtifactsBySlug {
-    /// all artifacts grouped by identifier
-    inner: BTreeMap<String, ArtifactCode>,
-}
-
-impl AllArtifactsBySlug {
-    /// Finds the code for the target of the artifact and the matching key.
-    fn find_code(&self, identifier: &String, version: &String) -> Option<CompactContractBytecode> {
-        trace!(target: "forge::link", identifier, "fetching artifact by identifier");
-        let code = self
-            .inner
-            .get(identifier)
-            .or(self.inner.get(&format!("{}.{}", identifier, version)))?;
-
-        Some(code.code.clone())
-    }
-}
-
-#[derive(Debug)]
-pub struct ResolvedDependency {
-    /// The address the linker resolved
-    pub address: Address,
-    /// The nonce used to resolve the dependency
-    pub nonce: u64,
-    pub id: String,
-    pub bytecode: Bytes,
-}
-
-impl std::fmt::Display for ResolvedDependency {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} @ {} (resolved with nonce {})", self.id, self.address, self.nonce)
-    }
-}
-
-/// Links the given artifacts with a link key constructor function, passing the result of each
-/// linkage to the given callback.
-///
-/// This function will recursively link all artifacts until none are unlinked. It does this by:
-///
-/// 1. Using the specified predeployed library addresses (`deployed_library_addresses`) for known
-/// libraries (specified by the user) 2. Otherwise, computing the address the library would live at
-/// if deployed by `sender`, given a starting nonce of `nonce`.
-///
-/// If the library was already deployed previously in step 2, the linker will re-use the previously
-/// computed address instead of re-computing it.
-///
-/// The linker will call `post_link` for each linked artifact, providing:
-///
-/// 1. User-specified data (`extra`)
-/// 2. The linked artifact's bytecode
-/// 3. The ID of the artifact
-/// 4. The dependencies necessary to deploy the contract
-///
-/// # Note
-///
-/// If you want to collect all dependencies of a set of contracts, you cannot just collect the
-/// `dependencies` passed to the callback in a `Vec`, since the same library contract (with the
-/// exact same address) might show up as a dependency for multiple contracts.
-///
-/// Instead, you must deduplicate *and* preserve the deployment order by pushing the dependencies to
-/// a `Vec` iff it has not been seen before.
-///
-/// For an example of this, see [here](https://github.com/foundry-rs/foundry/blob/2308972dbc3a89c03488a05aceb3c428bb3e08c0/cli/src/cmd/forge/script/build.rs#L130-L151C9).
-#[allow(clippy::too_many_arguments)]
-pub fn link_with_nonce_or_address<T, U>(
-    contracts: ArtifactContracts,
-    known_contracts: &mut BTreeMap<ArtifactId, T>,
-    deployed_library_addresses: Libraries,
-    sender: Address,
-    nonce: u64,
-    extra: &mut U,
-    post_link: impl Fn(PostLinkInput<T, U>) -> eyre::Result<()>,
-    root: impl AsRef<Path>,
-) -> Result<()> {
-    // create a mapping of fname => Vec<(fname, file, key)>,
-    let link_tree: BTreeMap<String, ArtifactDependencies> = contracts
-        .iter()
-        .map(|(id, contract)| {
-            let key = id.identifier();
-            let version = id.version.to_string();
-            // Check if the version has metadata appended to it, which will be after the semver
-            // version with a `+` separator. If so, strip it off.
-            let version = match version.find('+') {
-                Some(idx) => (version[..idx]).to_string(),
-                None => version,
-            };
-            let references = contract
-                .all_link_references()
-                .iter()
-                .flat_map(|(file, link)| link.keys().map(|key| (file.to_string(), key.to_string())))
-                .map(|(file, key)| ArtifactDependency {
-                    file,
-                    key,
-                    version: version.clone().to_owned(),
-                })
-                .collect();
-
-            let references =
-                ArtifactDependencies { dependencies: references, artifact_id: id.clone() };
-            (key, references)
-        })
-        .collect();
-
-    let artifacts_by_slug = AllArtifactsBySlug {
-        inner: contracts
-            .iter()
-            .map(|(artifact_id, c)| {
-                (
-                    artifact_id.identifier(),
-                    ArtifactCode { code: c.clone(), artifact_id: artifact_id.clone() },
-                )
-            })
-            .collect(),
-    };
-
-    for (id, contract) in contracts.into_iter() {
-        let (abi, maybe_deployment_bytes, maybe_runtime) = (
-            contract.abi.as_ref(),
-            contract.bytecode.as_ref(),
-            contract.deployed_bytecode.as_ref(),
-        );
-        let mut internally_deployed_libraries = HashMap::new();
-
-        if let (Some(abi), Some(bytecode), Some(runtime)) =
-            (abi, maybe_deployment_bytes, maybe_runtime)
-        {
-            // we are going to mutate, but library contract addresses may change based on
-            // the test so we clone
-            let mut target_bytecode = bytecode.clone();
-            let mut rt = runtime.clone();
-            let mut target_bytecode_runtime = rt.bytecode.expect("No target runtime").clone();
-
-            // instantiate a vector that gets filled with library deployment bytecode
-            let mut dependencies = vec![];
-
-            match bytecode.object {
-                BytecodeObject::Unlinked(_) => {
-                    trace!(target: "forge::link", target=id.identifier(), version=?id.version, "unlinked contract");
-
-                    // link needed
-                    recurse_link(
-                        id.identifier(),
-                        (&mut target_bytecode, &mut target_bytecode_runtime),
-                        &artifacts_by_slug,
-                        &link_tree,
-                        &mut dependencies,
-                        &mut internally_deployed_libraries,
-                        &deployed_library_addresses,
-                        &mut nonce.clone(),
-                        sender,
-                        root.as_ref(),
-                    );
-                }
-                BytecodeObject::Bytecode(ref bytes) => {
-                    if bytes.as_ref().is_empty() {
-                        // Handle case where bytecode bytes are empty
-                        let tc = CompactContractBytecode {
-                            abi: Some(abi.clone()),
-                            bytecode: None,
-                            deployed_bytecode: None,
-                        };
-
-                        let post_link_input = PostLinkInput {
-                            contract: tc,
-                            known_contracts,
-                            id,
-                            extra,
-                            dependencies,
-                        };
-
-                        post_link(post_link_input)?;
-                        continue
-                    }
-                }
+fn find_artifact_id_by_library_path<'a>(
+    contracts: &'a ArtifactContracts,
+    file: &String,
+    name: &String,
+    version: Option<&Version>,
+) -> &'a ArtifactId {
+    for id in contracts.keys() {
+        if let Some(version) = version {
+            if id.version != *version {
+                continue;
             }
+        }
+        // name is either {LibName} or {LibName}.{version}
+        if id.name.split('.').next().unwrap() != name {
+            continue;
+        }
 
-            rt.bytecode = Some(target_bytecode_runtime);
-            let tc = CompactContractBytecode {
-                abi: Some(abi.clone()),
-                bytecode: Some(target_bytecode),
-                deployed_bytecode: Some(rt),
-            };
+        if !(id.source.ends_with(file)) {
+            continue;
+        }
 
-            let post_link_input =
-                PostLinkInput { contract: tc, known_contracts, id, extra, dependencies };
+        return id;
+    }
 
-            post_link(post_link_input)?;
+    panic!("artifact not found for library {file} {name}");
+}
+
+pub fn collect_dependencies<'a>(
+    target: &'a ArtifactId,
+    contracts: &'a ArtifactContracts,
+    deps: &mut HashSet<&'a ArtifactId>,
+) {
+    let references = contracts.get(target).unwrap().all_link_references();
+    for (file, libs) in &references {
+        for contract in libs.keys() {
+            let id =
+                find_artifact_id_by_library_path(contracts, file, contract, Some(&target.version));
+            if deps.insert(id) {
+                collect_dependencies(id, contracts, deps);
+            }
         }
     }
-    Ok(())
 }
 
-/// Recursively links bytecode given a target contract artifact name, the bytecode(s) to be linked,
-/// a mapping of contract artifact name to bytecode, a dependency mapping, a mutable list that
-/// will be filled with the predeploy libraries, initial nonce, and the sender.
-#[allow(clippy::too_many_arguments)]
-fn recurse_link<'a>(
-    // target name
-    target: String,
-    // to-be-modified/linked bytecode
-    target_bytecode: (&'a mut CompactBytecode, &'a mut CompactBytecode),
-    // All contract artifacts
-    artifacts: &'a AllArtifactsBySlug,
-    // fname => Vec<(fname, file, key)>
-    dependency_tree: &'a BTreeMap<String, ArtifactDependencies>,
-    // library deployment vector (file:contract:address, bytecode)
-    deployment: &'a mut Vec<ResolvedDependency>,
-    // libraries we have already deployed during the linking process.
-    // the key is `file:contract` and the value is the address we computed
-    internally_deployed_libraries: &'a mut HashMap<String, (u64, Address)>,
-    // deployed library addresses fname => address
-    deployed_library_addresses: &'a Libraries,
-    // nonce to start at
-    nonce: &mut u64,
-    // sender
+pub struct LinkOutput<'a> {
+    pub contracts: ArtifactContracts,
+    pub predeployed_libs: Vec<(&'a ArtifactId, Address)>,
+    pub libs_to_deploy: Vec<(&'a ArtifactId, Address)>,
+}
+
+pub fn link_with_nonce_or_address<'a>(
+    contracts: &'a ArtifactContracts,
+    deployed_library_addresses: &Libraries,
     sender: Address,
-    // project root path
-    root: impl AsRef<Path>,
-) {
-    // check if we have dependencies
-    if let Some(dependencies) = dependency_tree.get(&target) {
-        trace!(target: "forge::link", ?target, "linking contract");
+    mut nonce: u64,
+    target: &'a ArtifactId,
+) -> Result<LinkOutput<'a>> {
+    let mut needed_libraries = HashSet::new();
+    collect_dependencies(target, contracts, &mut needed_libraries);
 
-        // for each dependency, try to link
-        dependencies.dependencies.iter().for_each(|dep| {
-            let ArtifactDependency {  file, key, version } = dep;
-            let next_target = format!("{file}:{key}");
-            let root = PathBuf::from(root.as_ref().to_str().unwrap());
-            // get the dependency
-            trace!(target: "forge::link", dependency=next_target, file, key, version=?dependencies.artifact_id.version, "get dependency");
-            let  artifact = match artifacts
-                .find_code(&next_target, version) {
-                    Some(artifact) => artifact,
-                    None => {
-                        // In some project setups, like JS-style workspaces, you might not have node_modules available at the root of the foundry project.
-                        // In this case, imported dependencies from outside the root might not have their paths tripped correctly.
-                        // Therefore, we fall back to a manual path join to locate the file.
-                        let fallback_path =  dunce::canonicalize(root.join(file)).unwrap_or_else(|e| panic!("No artifact for contract \"{next_target}\". Attempted to compose fallback path but got got error {e}"));
-                        let fallback_path = fallback_path.to_str().unwrap_or("No artifact for contract \"{next_target}\". Attempted to compose fallback path but could not create valid string");
-                        let fallback_target = format!("{fallback_path}:{key}");
+    let mut predeployed_libs = HashMap::new();
 
-                        trace!(target: "forge::link", fallback_dependency=fallback_target, file, key, version=?dependencies.artifact_id.version, "get dependency with fallback path");
-
-                        match artifacts.find_code(&fallback_target, version) {
-                        Some(artifact) => artifact,
-                        None => panic!("No artifact for contract {next_target}"),
-                    }},
-                };
-            let mut next_target_bytecode = artifact
-                .bytecode
-                .unwrap_or_else(|| panic!("No bytecode for contract {next_target}"));
-            let mut next_target_runtime_bytecode = artifact
-                .deployed_bytecode
-                .expect("No target runtime bytecode")
-                .bytecode
-                .expect("No target runtime");
-
-            // make sure dependency is fully linked
-            if let Some(deps) = dependency_tree.get(&format!("{file}:{key}")) {
-                if !deps.dependencies.is_empty() {
-                    trace!(target: "forge::link", dependency=next_target, file, key, version=?dependencies.artifact_id.version, "dependency has dependencies");
-
-                    // actually link the nested dependencies to this dependency
-                    recurse_link(
-                        format!("{file}:{key}"),
-                        (&mut next_target_bytecode, &mut next_target_runtime_bytecode),
-                        artifacts,
-                        dependency_tree,
-                        deployment,
-                        internally_deployed_libraries,
-                        deployed_library_addresses,
-                        nonce,
-                        sender,
-                        root,
-                    );
-                }
+    // Populate predeployed libs firstly
+    for (path, libs) in &deployed_library_addresses.libs {
+        let path = path.to_string_lossy().to_string();
+        for (name, address) in libs {
+            let artifact_id = find_artifact_id_by_library_path(contracts, &path, name, None);
+            if needed_libraries.contains(artifact_id) {
+                let address = Address::from_str(address)?;
+                predeployed_libs.insert(artifact_id, address);
             }
-
-            let mut deployed_address = None;
-
-            if let Some(library_file) = deployed_library_addresses
-                .libs
-                .get(&PathBuf::from_str(file).expect("Invalid library path."))
-            {
-                if let Some(address) = library_file.get(key) {
-                    deployed_address =
-                        Some(Address::from_str(address).expect("Invalid library address passed."));
-                }
-            }
-
-            let address = if let Some(deployed_address) = deployed_address {
-                trace!(target: "forge::link", dependency=next_target, file, key, "dependency has pre-defined address");
-
-                // the user specified the library address
-                deployed_address
-            } else if let Some((cached_nonce, deployed_address)) = internally_deployed_libraries.get(&format!("{file}:{key}")) {
-                trace!(target: "forge::link", dependency=next_target, file, key, "dependency was previously deployed");
-
-                // we previously deployed the library
-                let library = format!("{file}:{key}:0x{deployed_address:x}");
-
-                // push the dependency into the library deployment vector
-                deployment.push(ResolvedDependency {
-                    id: library,
-                    address: *deployed_address,
-                    nonce: *cached_nonce,
-                    bytecode: next_target_bytecode.object.into_bytes().unwrap_or_else(|| panic!("Bytecode should be linked for {next_target}")),
-                });
-                *deployed_address
-            } else {
-                trace!(target: "forge::link", dependency=next_target, file, key, "dependency has to be deployed");
-
-                // we need to deploy the library
-                let used_nonce = *nonce;
-                let computed_address = sender.create(used_nonce);
-                *nonce += 1;
-                let library = format!("{file}:{key}:0x{computed_address:x}");
-
-                // push the dependency into the library deployment vector
-                deployment.push(ResolvedDependency {
-                    id: library,
-                    address: computed_address,
-                    nonce: used_nonce,
-                    bytecode: next_target_bytecode.object.into_bytes().unwrap_or_else(|| panic!("Bytecode should be linked for {next_target}")),
-                });
-
-                // remember this library for later
-                internally_deployed_libraries.insert(format!("{file}:{key}"), (used_nonce, computed_address));
-
-                computed_address
-            };
-
-            // link the dependency to the target
-            target_bytecode.0.link(file.clone(), key.clone(), address);
-            target_bytecode.1.link(file.clone(), key.clone(), address);
-            trace!(target: "forge::link", ?target, dependency=next_target, file, key, "linking dependency done");
-        });
+        }
     }
+
+    let mut libs_to_deploy = Vec::new();
+
+    for id in needed_libraries {
+        if !predeployed_libs.contains_key(id) {
+            libs_to_deploy.push((id, sender.create(nonce)));
+            nonce += 1;
+        }
+    }
+
+    let predeployed_libs = predeployed_libs.into_iter().collect::<Vec<_>>();
+
+    // Link contracts
+    let contracts = contracts
+        .iter()
+        .map(|(id, contract)| {
+            let mut contract = contract.clone();
+
+            for (id, address) in libs_to_deploy.iter().chain(predeployed_libs.iter()) {
+                if let Some(bytecode) = contract.bytecode.as_mut() {
+                    bytecode.link(id.source.to_string_lossy(), &id.name, *address);
+                }
+                if let Some(deployed_bytecode) =
+                    contract.deployed_bytecode.as_mut().and_then(|b| b.bytecode.as_mut())
+                {
+                    deployed_bytecode.link(id.source.to_string_lossy(), &id.name, *address);
+                }
+            }
+            (id.clone(), contract)
+        })
+        .collect::<ArtifactContracts>();
+
+    Ok(LinkOutput { contracts, predeployed_libs, libs_to_deploy })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
-    use foundry_common::ContractsByArtifact;
     use foundry_compilers::{Project, ProjectPathsConfig};
 
     struct LinkerTest {
         contracts: ArtifactContracts,
         dependency_assertions: HashMap<String, Vec<(String, u64, Address)>>,
-        project: Project,
     }
 
     impl LinkerTest {
@@ -429,7 +148,7 @@ mod tests {
                 .map(|(id, c)| (id, c.into_contract_bytecode()))
                 .collect::<ArtifactContracts>();
 
-            Self { contracts, dependency_assertions: HashMap::new(), project }
+            Self { contracts, dependency_assertions: HashMap::new() }
         }
 
         fn assert_dependencies(
@@ -442,51 +161,58 @@ mod tests {
         }
 
         fn test_with_sender_and_nonce(self, sender: Address, initial_nonce: u64) {
-            let mut called_once = false;
-            link_with_nonce_or_address(
-                self.contracts,
-                &mut ContractsByArtifact::default(),
-                Default::default(),
-                sender,
-                initial_nonce,
-                &mut called_once,
-                |post_link_input| {
-                    *post_link_input.extra = true;
-                    let identifier = post_link_input.id.identifier();
+            for id in self.contracts.keys() {
+                let identifier = id.identifier();
 
-                    // Skip ds-test as it always has no dependencies etc. (and the path is outside root so is not sanitized)
-                    if identifier.contains("DSTest") {
-                        return Ok(())
-                    }
+                // Skip ds-test as it always has no dependencies etc. (and the path is outside root
+                // so is not sanitized)
+                if identifier.contains("DSTest") {
+                    continue;
+                }
 
-                    let assertions = self
-                        .dependency_assertions
-                        .get(&identifier)
-                        .unwrap_or_else(|| panic!("Unexpected artifact: {identifier}"));
+                let LinkOutput { libs_to_deploy, .. } = link_with_nonce_or_address(
+                    &self.contracts,
+                    &Default::default(),
+                    sender,
+                    initial_nonce,
+                    id,
+                )
+                .expect("Linking failed");
 
-                    assert_eq!(
-                        post_link_input.dependencies.len(),
-                        assertions.len(),
-                        "artifact {identifier} has more/less dependencies than expected ({} vs {}): {:#?}",
-                        post_link_input.dependencies.len(),
-                        assertions.len(),
-                        post_link_input.dependencies
-                    );
+                let assertions = self
+                    .dependency_assertions
+                    .get(&identifier)
+                    .unwrap_or_else(|| panic!("Unexpected artifact: {identifier}"));
 
-                    for (expected, actual) in assertions.iter().zip(post_link_input.dependencies.iter()) {
-                        let expected_lib_id = format!("{}:{:?}", expected.0, expected.2);
-                        assert_eq!(expected_lib_id, actual.id, "unexpected dependency, expected: {}, got: {}", expected_lib_id, actual.id);
-                        assert_eq!(actual.nonce, expected.1, "nonce wrong for dependency, expected: {}, got: {}", expected.1, actual.nonce);
-                        assert_eq!(actual.address, expected.2, "address wrong for dependency, expected: {}, got: {}", expected.2, actual.address);
-                    }
+                let expected_libs =
+                    assertions.iter().map(|(identifier, _, _)| identifier).collect::<HashSet<_>>();
 
-                    Ok(())
-                },
-                self.project.root(),
-            )
-            .expect("Linking failed");
+                assert_eq!(
+                    libs_to_deploy.len(),
+                    expected_libs.len(),
+                    "artifact {identifier} has more/less dependencies than expected ({} vs {}): {:#?}",
+                    libs_to_deploy.len(),
+                    assertions.len(),
+                    libs_to_deploy
+                );
 
-            assert!(called_once, "linker did nothing");
+                let identifiers =
+                    libs_to_deploy.iter().map(|(id, _)| id.identifier()).collect::<HashSet<_>>();
+
+                for lib in expected_libs {
+                    assert!(identifiers.contains(lib));
+                }
+
+                let unique_libs =
+                    libs_to_deploy.iter().map(|(_, addr)| addr).collect::<HashSet<_>>();
+
+                assert_eq!(
+                    unique_libs.len(),
+                    libs_to_deploy.len(),
+                    "not all libraries are unqiue: {:#?}",
+                    libs_to_deploy
+                );
+            }
         }
     }
 

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -457,4 +457,42 @@ mod tests {
                 .test_with_sender_and_nonce(Address::default(), 1);
         });
     }
+
+    #[test]
+    fn link_cycle() {
+        link_test("../../testdata/linking/cycle", |linker| {
+            linker
+                .assert_dependencies(
+                    "cycle/Cycle.t.sol:Foo".to_string(),
+                    vec![
+                        (
+                            "cycle/Cycle.t.sol:Foo".to_string(),
+                            Address::from_str("0x47e9Fbef8C83A1714F1951F142132E6e90F5fa5D")
+                                .unwrap(),
+                        ),
+                        (
+                            "cycle/Cycle.t.sol:Bar".to_string(),
+                            Address::from_str("0x5a443704dd4B594B382c22a083e2BD3090A6feF3")
+                                .unwrap(),
+                        ),
+                    ],
+                )
+                .assert_dependencies(
+                    "cycle/Cycle.t.sol:Bar".to_string(),
+                    vec![
+                        (
+                            "cycle/Cycle.t.sol:Foo".to_string(),
+                            Address::from_str("0x47e9Fbef8C83A1714F1951F142132E6e90F5fa5D")
+                                .unwrap(),
+                        ),
+                        (
+                            "cycle/Cycle.t.sol:Bar".to_string(),
+                            Address::from_str("0x5a443704dd4B594B382c22a083e2BD3090A6feF3")
+                                .unwrap(),
+                        ),
+                    ],
+                )
+                .test_with_sender_and_nonce(Address::default(), 1);
+        });
+    }
 }

--- a/crates/forge/src/link.rs
+++ b/crates/forge/src/link.rs
@@ -7,6 +7,10 @@ use std::{
     str::FromStr,
 };
 
+/// Finds an [ArtifactId] object in the given [ArtifactContracts] keys which corresponds to the
+/// library path in the form of "./path/to/Lib.sol:Lib"
+///
+/// Optionally accepts solc version, and if present, only compares artifacts with given version.
 fn find_artifact_id_by_library_path<'a>(
     contracts: &'a ArtifactContracts,
     file: &String,
@@ -34,6 +38,7 @@ fn find_artifact_id_by_library_path<'a>(
     panic!("artifact not found for library {file} {name}");
 }
 
+/// Performs DFS on the graph of link references, and populates `deps` with all found libraries.
 pub fn collect_dependencies<'a>(
     target: &'a ArtifactId,
     contracts: &'a ArtifactContracts,
@@ -51,9 +56,17 @@ pub fn collect_dependencies<'a>(
     }
 }
 
+/// Output of the `link_with_nonce_or_address`
 pub struct LinkOutput<'a> {
+    /// [ArtifactContracts] object containing all artifacts linked with known libraries
+    /// It is guaranteed to contain `target` and all it's dependencies fully linked, and any other
+    /// contract may still be partially unlinked.
     pub contracts: ArtifactContracts,
+    /// Vector of libraries predeployed by user (basically another form of
+    /// `deployed_library_addresses`).
     pub predeployed_libs: Vec<(&'a ArtifactId, Address)>,
+    /// Vector of libraries that need to be deployed from sender address.
+    /// The order in which they appear in the vector is the order in which they should be deployed.
     pub libs_to_deploy: Vec<(&'a ArtifactId, Address)>,
 }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -314,7 +314,7 @@ impl MultiContractRunnerBuilder {
                 deployable_contracts.insert(id.clone(), (abi.clone(), bytecode, libs_to_deploy));
             }
 
-            contract
+            linked_contract
                 .deployed_bytecode
                 .and_then(|d_bcode| d_bcode.bytecode)
                 .and_then(|bcode| bcode.object.into_bytes())

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -297,11 +297,14 @@ impl MultiContractRunnerBuilder {
 
             let linked_contract = contracts.get(&id).unwrap().clone();
 
-            // get bytes if deployable, else add to known contracts and return.
+            // get bytes if deployable, else add to known contracts and continue.
             // interfaces and abstract contracts should be known to enable fuzzing of their ABI
             // but they should not be deployable and their source code should be skipped by the
             // debugger and linker.
-            let Some(bytecode) = linked_contract.bytecode.and_then(|b| b.object.into_bytes())
+            let Some(bytecode) = linked_contract
+                .bytecode
+                .and_then(|b| b.object.into_bytes())
+                .filter(|b| !b.is_empty())
             else {
                 known_contracts.insert(id.clone(), (abi.clone(), vec![]));
                 continue;

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -10,7 +10,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use eyre::{OptionExt, Result};
 use foundry_common::{ContractsByArtifact, TestFunctionExt};
 use foundry_compilers::{
-    artifacts::CompactContractBytecode, contracts::ArtifactContracts, Artifact, ArtifactId,
+    artifacts::CompactContractBytecode, Artifact, ArtifactId,
     ArtifactOutput, ProjectCompileOutput,
 };
 use foundry_evm::{
@@ -282,7 +282,7 @@ impl MultiContractRunnerBuilder {
         // create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
 
-        let artifact_contracts = ArtifactContracts::from_iter(contracts.clone());
+        let artifact_contracts = contracts.iter().cloned().collect();
 
         let linker = Linker::new(root.as_ref(), artifact_contracts);
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -299,8 +299,8 @@ impl MultiContractRunnerBuilder {
             // but they should not be deployable and their source code should be skipped by the
             // debugger and linker.
             let Some(bytecode) = linked_contract
-                .bytecode
-                .and_then(|b| b.object.into_bytes())
+                .get_bytecode_bytes()
+                .map(|b| b.into_owned())
                 .filter(|b| !b.is_empty())
             else {
                 known_contracts.insert(id.clone(), (abi.clone(), vec![]));
@@ -314,13 +314,9 @@ impl MultiContractRunnerBuilder {
                 deployable_contracts.insert(id.clone(), (abi.clone(), bytecode, libs_to_deploy));
             }
 
-            linked_contract
-                .deployed_bytecode
-                .and_then(|d_bcode| d_bcode.bytecode)
-                .and_then(|bcode| bcode.object.into_bytes())
-                .and_then(|bytes| {
-                    known_contracts.insert(id.clone(), (abi.clone(), bytes.to_vec()))
-                });
+            linked_contract.get_deployed_bytecode_bytes().map(|b| b.into_owned()).and_then(
+                |bytes| known_contracts.insert(id.clone(), (abi.clone(), bytes.to_vec())),
+            );
         }
 
         let execution_info = known_contracts.flatten();

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -1,7 +1,7 @@
 //! Forge test runner for multiple contracts.
 
 use crate::{
-    link::{link_with_nonce_or_address, LinkOutput},
+    link::{LinkOutput, Linker},
     result::SuiteResult,
     ContractRunner, TestFilter, TestOptions,
 };
@@ -284,17 +284,13 @@ impl MultiContractRunnerBuilder {
 
         let artifact_contracts = ArtifactContracts::from_iter(contracts.clone());
 
+        let linker = Linker::new(root.as_ref(), artifact_contracts);
+
         for (id, contract) in contracts {
             let abi = contract.abi.as_ref().ok_or_eyre("we should have an abi by now")?;
 
-            let LinkOutput { contracts, libs_to_deploy, .. } = link_with_nonce_or_address(
-                &artifact_contracts,
-                Default::default(),
-                evm_opts.sender,
-                1,
-                &id,
-                root.as_ref(),
-            )?;
+            let LinkOutput { contracts, libs_to_deploy, .. } =
+                linker.link_with_nonce_or_address(Default::default(), evm_opts.sender, 1, &id)?;
 
             let linked_contract = contracts.get(&id).unwrap().clone();
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -10,8 +10,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use eyre::{OptionExt, Result};
 use foundry_common::{ContractsByArtifact, TestFunctionExt};
 use foundry_compilers::{
-    artifacts::CompactContractBytecode, Artifact, ArtifactId,
-    ArtifactOutput, ProjectCompileOutput,
+    artifacts::CompactContractBytecode, Artifact, ArtifactId, ArtifactOutput, ProjectCompileOutput,
 };
 use foundry_evm::{
     backend::Backend,

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -293,6 +293,7 @@ impl MultiContractRunnerBuilder {
                 evm_opts.sender,
                 1,
                 &id,
+                &root.as_ref().to_path_buf(),
             )?;
 
             let linked_contract = contracts.get(&id).unwrap().clone();

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -289,7 +289,7 @@ impl MultiContractRunnerBuilder {
 
             let LinkOutput { contracts, libs_to_deploy, .. } = link_with_nonce_or_address(
                 &artifact_contracts,
-                &Default::default(),
+                Default::default(),
                 evm_opts.sender,
                 1,
                 &id,
@@ -314,18 +314,7 @@ impl MultiContractRunnerBuilder {
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                 abi.functions().any(|func| func.name.is_test() || func.name.is_invariant_test())
             {
-                deployable_contracts.insert(
-                    id.clone(),
-                    (
-                        abi.clone(),
-                        bytecode,
-                        libs_to_deploy
-                            .into_iter()
-                            .filter_map(|(id, _)| contracts.get(id).unwrap().bytecode.clone())
-                            .filter_map(|bcode| bcode.object.into_bytes())
-                            .collect::<Vec<_>>(),
-                    ),
-                );
+                deployable_contracts.insert(id.clone(), (abi.clone(), bytecode, libs_to_deploy));
             }
 
             contract

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
-use eyre::Result;
+use eyre::{OptionExt, Result};
 use foundry_common::{ContractsByArtifact, TestFunctionExt};
 use foundry_compilers::{
     artifacts::CompactContractBytecode, contracts::ArtifactContracts, Artifact, ArtifactId,
@@ -285,7 +285,7 @@ impl MultiContractRunnerBuilder {
         let artifact_contracts = ArtifactContracts::from_iter(contracts.clone());
 
         for (id, contract) in contracts {
-            let abi = contract.abi.as_ref().expect("We should have an abi by now");
+            let abi = contract.abi.as_ref().ok_or_eyre("we should have an abi by now")?;
 
             let LinkOutput { contracts, libs_to_deploy, .. } = link_with_nonce_or_address(
                 &artifact_contracts,
@@ -293,7 +293,7 @@ impl MultiContractRunnerBuilder {
                 evm_opts.sender,
                 1,
                 &id,
-                &root.as_ref().to_path_buf(),
+                root.as_ref(),
             )?;
 
             let linked_contract = contracts.get(&id).unwrap().clone();

--- a/testdata/linking/cycle/Cycle.t.sol
+++ b/testdata/linking/cycle/Cycle.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+library Foo {
+    function foo() external {
+        Bar.bar();
+    }
+
+    function flum() external {}
+}
+
+library Bar {
+    function bar() external {
+        Foo.flum();
+    }
+}


### PR DESCRIPTION
## Motivation

The way current linking implementation works is by linking _each_ individual artifact in an isolated way. For each artifact `post_link` hook is getting called with the following data (`PostLinkInput`).
- `id` of the linked artifact
- `contract` containing linked contract artifact
- `known_contracts` which seems to be just a mutable reference getting passed around
- `dependencies` - vector of libraries that needs to be deployed for the given artifact

The `dependencies` vector contents is explained here:
https://github.com/foundry-rs/foundry/blob/2cf84d9f3ba7b6f4a9296299e7036ecc24cfa1da/crates/forge/src/link.rs#L580-L583

The thing which highlights the downside of this approach is that for different artifact `dependencies` may include different libraries with different nonces. This is expected behavior but it results in verifiaction issues (#6506).

## Solution

Considering that current approach does not really make much sense, I've decided to implement new linling algorithm to be less complex and linking just one `target` artifact. If we need to link more artifacts, it can just be invoked several times as it's done in tests right now.

I believe that one of the most sensitive places of the linker is conversion between `ArtifactId` and solc library format (`src/Lib.sol:Lib`) as it's related to paths. Even though we strip paths everywhere I think there might be some edge cases here and would like to do some testing in that direction.

Closes #6506 
Closes #5014 
