### PR TITLE
fix (anvil): error E0063 when compile on macOS due to alloy-rs

### DIFF
--- a/crates/anvil/README.md
+++ b/crates/anvil/README.md
@@ -20,7 +20,7 @@ A local Ethereum node, akin to Ganache, designed for development with [**Forge**
 ```sh
 git clone https://github.com/foundry-rs/foundry
 cd foundry
-cargo install --path ./crates/anvil --profile local --force
+cargo install --path ./crates/anvil --profile local --locked --offline --force
 ```
 
 ## Getting started


### PR DESCRIPTION
## Motivation
An error occurs when Anvil is compiled from the `crates/` directory as instructed. The error message states that the `base_fee_per_blob_gas` and `blob_gas_used_ratio` fields are missing in the `alloy_rpc_types::FeeHistory` initializer. This error is caused by recent changes made to the `FeeHistory` struct in `alloy-rs` [`fee.rs`](https://github.com/alloy-rs/alloy/blob/main/crates/rpc-types/src/eth/fee.rs).
Here is the error message for reference:
```
Compiling anvil v0.2.0 (/Users/benji/Develop/blockchain/foundry/crates/anvil)
error[E0063]: missing fields ﻿base_fee_per_blob_gas and ﻿blob_gas_used_ratio in initializer of ﻿alloy_rpc_types::FeeHistory
--> crates/anvil/src/eth/[api.rs:1312](http://api.rs:1312/):28
|
1312 |         let mut response = FeeHistory {
|                            ^^^^^^^^^^ missing ﻿base_fee_per_blob_gas and ﻿blob_gas_used_ratio
For more information about this error, try ﻿rustc --explain E0063.
error: could not compile ﻿anvil (lib) due to previous error
```

## Solution
Update the `﻿README.md` file and modify the install command by including the ﻿`--offline` and ﻿`--locked` flags to ensure Cargo utilizes locally cached crates and avoids fetching newer versions from the internet.
