### PR TITLE
refactor: use `TransactionRequest` everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -133,7 +133,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.7",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
+source = "git+https://github.com/alloy-rs/alloy#098ad5657d55bbc5fe9469ede2a9ca79def738f2"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -133,10 +133,10 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "serde",
 ]
 
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -205,13 +205,13 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-trace-types",
- "alloy-rpc-types",
+ "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -280,12 +280,36 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-trace-types"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -304,7 +328,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -365,7 +389,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.7",
@@ -381,7 +405,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -394,7 +418,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -412,7 +436,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -519,8 +543,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-providers",
  "alloy-rlp",
- "alloy-rpc-trace-types",
- "alloy-rpc-types",
+ "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
@@ -580,8 +604,8 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-trace-types",
- "alloy-rpc-types",
+ "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "anvil-core",
  "bytes",
  "foundry-common",
@@ -1358,7 +1382,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "clap",
  "criterion",
  "dirs 5.0.1",
@@ -2835,7 +2859,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "anvil",
  "async-trait",
  "axum",
@@ -2976,7 +3000,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-providers",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-signer",
  "alloy-sol-types",
  "base64 0.21.7",
@@ -3061,7 +3085,7 @@ dependencies = [
  "alloy-providers",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
@@ -3194,7 +3218,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-signer",
  "alloy-sol-types",
  "const-hex",
@@ -3228,7 +3252,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-providers",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
  "alloy-sol-types",
  "alloy-transport",
  "const-hex",
@@ -6163,8 +6187,8 @@ version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=e90052361276aebcdc67cb24d8e2c4d907b6d299#e90052361276aebcdc67cb24d8e2c4d907b6d299"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-trace-types",
- "alloy-rpc-types",
+ "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
  "alloy-sol-types",
  "revm",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -122,7 +122,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -133,10 +133,10 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "serde",
 ]
 
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -205,13 +205,13 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -280,21 +280,10 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-trace-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-rpc-types",
  "serde",
  "serde_json",
 ]
@@ -302,20 +291,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -328,7 +304,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -389,7 +365,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.7",
@@ -405,7 +381,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -418,7 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -436,7 +412,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest#093af2313ed25104ff7ca9e0850e0fcbe2256111"
+source = "git+https://github.com/alloy-rs/alloy#80206e7ba7686c514da291c06a5e7912b5361047"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -543,8 +519,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-providers",
  "alloy-rlp",
- "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
@@ -604,8 +580,8 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "anvil-core",
  "bytes",
  "foundry-common",
@@ -1382,7 +1358,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "clap",
  "criterion",
  "dirs 5.0.1",
@@ -2859,7 +2835,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "anvil",
  "async-trait",
  "axum",
@@ -3000,7 +2976,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-providers",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-sol-types",
  "base64 0.21.7",
@@ -3085,7 +3061,7 @@ dependencies = [
  "alloy-providers",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
@@ -3218,7 +3194,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "alloy-signer",
  "alloy-sol-types",
  "const-hex",
@@ -3252,7 +3228,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-providers",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?branch=onbjerg/rm-callrequest)",
+ "alloy-rpc-types",
  "alloy-sol-types",
  "alloy-transport",
  "const-hex",
@@ -6187,8 +6163,8 @@ version = "0.1.0"
 source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=e90052361276aebcdc67cb24d8e2c4d907b6d299#e90052361276aebcdc67cb24d8e2c4d907b6d299"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-trace-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
  "alloy-sol-types",
  "revm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,22 +146,22 @@ ethers-middleware = { version = "2.0", default-features = false }
 ethers-solc = { version = "2.0", default-features = false }
 
 ## alloy
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy" }
-alloy-providers = { git = "https://github.com/alloy-rs/alloy" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-providers = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
 alloy-primitives = "0.6.2"
 alloy-dyn-abi = "0.6.2"
 alloy-json-abi = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,22 +146,22 @@ ethers-middleware = { version = "2.0", default-features = false }
 ethers-solc = { version = "2.0", default-features = false }
 
 ## alloy
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-providers = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", branch = "onbjerg/rm-callrequest" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy" }
+alloy-providers = { git = "https://github.com/alloy-rs/alloy" }
+alloy-pubsub = { git = "https://github.com/alloy-rs/alloy" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy" }
+alloy-rpc-trace-types = { git = "https://github.com/alloy-rs/alloy" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy" }
+alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy" }
+alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy" }
 alloy-primitives = "0.6.2"
 alloy-dyn-abi = "0.6.2"
 alloy-json-abi = "0.6.2"

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,13 +1,14 @@
 use crate::{
-    eth::{subscription::SubscriptionId, transaction::EthTransactionRequest},
+    eth::subscription::SubscriptionId,
     types::{EvmMineOptions, Forking, Index},
 };
 use alloy_primitives::{Address, Bytes, TxHash, B256, B64, U256};
 use alloy_rpc_trace_types::geth::{GethDebugTracingOptions, GethDefaultTracingOptions};
 use alloy_rpc_types::{
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
+    request::TransactionRequest,
     state::StateOverride,
-    BlockId, BlockNumberOrTag as BlockNumber, CallRequest, Filter,
+    BlockId, BlockNumberOrTag as BlockNumber, Filter,
 };
 
 pub mod block;
@@ -142,7 +143,7 @@ pub enum EthRequest {
     EthSign(Address, Bytes),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_signTransaction"))]
-    EthSignTransaction(Box<EthTransactionRequest>),
+    EthSignTransaction(Box<TransactionRequest>),
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
     #[cfg_attr(feature = "serde", serde(rename = "eth_signTypedData"))]
@@ -157,27 +158,27 @@ pub enum EthRequest {
     EthSignTypedDataV4(Address, alloy_dyn_abi::TypedData),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_sendTransaction", with = "sequence"))]
-    EthSendTransaction(Box<EthTransactionRequest>),
+    EthSendTransaction(Box<TransactionRequest>),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_sendRawTransaction", with = "sequence"))]
     EthSendRawTransaction(Bytes),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_call"))]
     EthCall(
-        CallRequest,
+        TransactionRequest,
         #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
         #[cfg_attr(feature = "serde", serde(default))] Option<StateOverride>,
     ),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_createAccessList"))]
     EthCreateAccessList(
-        CallRequest,
+        TransactionRequest,
         #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
     ),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_estimateGas"))]
     EthEstimateGas(
-        CallRequest,
+        TransactionRequest,
         #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
         #[cfg_attr(feature = "serde", serde(default))] Option<StateOverride>,
     ),
@@ -271,7 +272,7 @@ pub enum EthRequest {
     /// geth's `debug_traceCall`  endpoint
     #[cfg_attr(feature = "serde", serde(rename = "debug_traceCall"))]
     DebugTraceCall(
-        CallRequest,
+        TransactionRequest,
         #[cfg_attr(feature = "serde", serde(default))] Option<BlockId>,
         #[cfg_attr(feature = "serde", serde(default))] GethDefaultTracingOptions,
     ),
@@ -596,7 +597,7 @@ pub enum EthRequest {
         feature = "serde",
         serde(rename = "eth_sendUnsignedTransaction", with = "sequence")
     )]
-    EthSendUnsignedTransaction(Box<EthTransactionRequest>),
+    EthSendUnsignedTransaction(Box<TransactionRequest>),
 
     /// Turn on call traces for transactions that are returned to the user when they execute a
     /// transaction (instead of just txhash/receipt)
@@ -1451,7 +1452,7 @@ true}]}"#;
     #[test]
     fn test_eth_call() {
         let req = r#"{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}"#;
-        let _req = serde_json::from_str::<CallRequest>(req).unwrap();
+        let _req = serde_json::from_str::<TransactionRequest>(req).unwrap();
 
         let s = r#"{"method": "eth_call", "params":[{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"},"latest"]}"#;
         let _req = serde_json::from_str::<EthRequest>(s).unwrap();

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -9,8 +9,9 @@ use alloy_network::{Signed, Transaction, TxKind};
 use alloy_primitives::{Address, Bloom, Bytes, Log, Signature, TxHash, B256, U128, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::{
-    request::TransactionRequest, AccessList, AccessListItem, CallInput, CallRequest,
-    Signature as RpcSignature, Transaction as RpcTransaction,
+    optimism::OptimismTransactionFields,
+    request::{TransactionInput, TransactionRequest},
+    AccessList, AccessListItem, Signature as RpcSignature, Transaction as RpcTransaction,
 };
 use foundry_evm::traces::CallTraceNode;
 use revm::{
@@ -30,199 +31,7 @@ pub fn impersonated_signature() -> Signature {
         .unwrap()
 }
 
-/// Represents _all_ transaction requests received from RPC
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct EthTransactionRequest {
-    /// from address
-    pub from: Option<Address>,
-    /// to address
-    pub to: Option<Address>,
-    /// legacy, gas Price
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub gas_price: Option<U256>,
-    /// max base fee per gas sender is willing to pay
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub max_fee_per_gas: Option<U256>,
-    /// miner tip
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub max_priority_fee_per_gas: Option<U256>,
-    /// gas
-    pub gas: Option<U256>,
-    /// value of th tx in wei
-    pub value: Option<U256>,
-    /// Any additional data sent
-    #[cfg_attr(feature = "serde", serde(alias = "input"))]
-    pub data: Option<Bytes>,
-    /// Transaction nonce
-    pub nonce: Option<U256>,
-    /// chain id
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub chain_id: Option<U64>,
-    /// warm storage access pre-payment
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub access_list: Option<Vec<AccessListItem>>,
-    /// EIP-2718 type
-    #[cfg_attr(feature = "serde", serde(rename = "type"))]
-    pub transaction_type: Option<U256>,
-    /// Optimism Deposit Request Fields
-    #[serde(flatten)]
-    pub optimism_fields: Option<OptimismDepositRequestFields>,
-}
-
-impl EthTransactionRequest {
-    pub fn into_call_request(self) -> CallRequest {
-        let Self {
-            from,
-            to,
-            gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            gas,
-            value,
-            data,
-            nonce,
-            chain_id,
-            access_list,
-            transaction_type,
-            optimism_fields: _,
-        } = self;
-        CallRequest {
-            from,
-            to,
-            gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            gas,
-            value,
-            input: CallInput::maybe_input(data),
-            nonce: nonce.map(|n| n.to()),
-            chain_id,
-            access_list: access_list.map(AccessList),
-            max_fee_per_blob_gas: None,
-            blob_versioned_hashes: None,
-            transaction_type: transaction_type.map(|ty| ty.to()),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OptimismDepositRequestFields {
-    /// op-stack deposit source hash
-    pub source_hash: B256,
-    /// op-stack deposit mint
-    pub mint: U256,
-    /// op-stack deposit system tx
-    pub is_system_tx: bool,
-}
-
-impl EthTransactionRequest {
-    pub fn into_typed_request(self) -> Option<TypedTransactionRequest> {
-        let EthTransactionRequest {
-            from,
-            to,
-            gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            gas,
-            value,
-            data,
-            nonce,
-            mut access_list,
-            transaction_type,
-            optimism_fields,
-            ..
-        } = self;
-        let transaction_type = transaction_type.map(|id| id.to::<u64>());
-        let data = data.clone().unwrap_or_default();
-        // Special case: OP-stack deposit tx
-        if transaction_type == Some(126) {
-            return Some(TypedTransactionRequest::Deposit(DepositTransactionRequest {
-                from: from.unwrap_or_default(),
-                source_hash: optimism_fields.clone()?.source_hash,
-                kind: match to {
-                    Some(to) => TxKind::Call(to),
-                    None => TxKind::Create,
-                },
-                mint: optimism_fields.clone()?.mint,
-                value: value.unwrap_or_default(),
-                gas_limit: gas.unwrap_or_default(),
-                is_system_tx: optimism_fields.clone()?.is_system_tx,
-                input: data,
-            }))
-        }
-
-        match (
-            transaction_type,
-            gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            access_list.take(),
-        ) {
-            // legacy transaction
-            (Some(0), _, None, None, None) | (None, Some(_), None, None, None) => {
-                Some(TypedTransactionRequest::Legacy(TxLegacy {
-                    nonce: nonce.unwrap_or_default().to::<u64>(),
-                    gas_price: gas_price.unwrap_or_default().to::<u128>(),
-                    gas_limit: gas.unwrap_or_default().to::<u64>(),
-                    value: value.unwrap_or(U256::ZERO),
-                    input: data,
-                    to: match to {
-                        Some(to) => TxKind::Call(to),
-                        None => TxKind::Create,
-                    },
-                    chain_id: None,
-                }))
-            }
-            // EIP2930
-            (Some(1), _, None, None, _) | (None, _, None, None, Some(_)) => {
-                Some(TypedTransactionRequest::EIP2930(TxEip2930 {
-                    nonce: nonce.unwrap_or_default().to::<u64>(),
-                    gas_price: gas_price.unwrap_or_default().to(),
-                    gas_limit: gas.unwrap_or_default().to::<u64>(),
-                    value: value.unwrap_or(U256::ZERO),
-                    input: data,
-                    to: match to {
-                        Some(to) => TxKind::Call(to),
-                        None => TxKind::Create,
-                    },
-                    chain_id: 0,
-                    access_list: to_eip_access_list(AccessList(access_list.unwrap_or_default())),
-                }))
-            }
-            // EIP1559
-            (Some(2), None, _, _, _) |
-            (None, None, Some(_), _, _) |
-            (None, None, _, Some(_), _) |
-            (None, None, None, None, None) => {
-                // Empty fields fall back to the canonical transaction schema.
-                Some(TypedTransactionRequest::EIP1559(TxEip1559 {
-                    nonce: nonce.unwrap_or_default().to::<u64>(),
-                    max_fee_per_gas: max_fee_per_gas.unwrap_or_default().to::<u128>(),
-                    max_priority_fee_per_gas: max_priority_fee_per_gas
-                        .unwrap_or_default()
-                        .to::<u128>(),
-                    gas_limit: gas.unwrap_or_default().to::<u64>(),
-                    value: value.unwrap_or(U256::ZERO),
-                    input: data,
-                    to: match to {
-                        Some(to) => TxKind::Call(to),
-                        None => TxKind::Create,
-                    },
-                    chain_id: 0,
-                    access_list: to_eip_access_list(AccessList(access_list.unwrap_or_default())),
-                }))
-            }
-            _ => None,
-        }
-    }
-}
-
+/// Converts a [TransactionRequest] into a [TypedTransactionRequest].
 pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTransactionRequest> {
     let TransactionRequest {
         from,
@@ -232,7 +41,7 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
         max_priority_fee_per_gas,
         gas,
         value,
-        data,
+        input,
         nonce,
         mut access_list,
         transaction_type,
@@ -251,7 +60,7 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
             value: value.unwrap_or_default(),
             gas_limit: gas.unwrap_or_default(),
             is_system_tx: other.get_deserialized::<bool>("isSystemTx")?.ok()?,
-            input: data.unwrap_or_default(),
+            input: input.into_input().unwrap_or_default(),
         }))
     }
 
@@ -269,7 +78,7 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
                 gas_price: gas_price.unwrap_or_default().to::<u128>(),
                 gas_limit: gas.unwrap_or_default().to::<u64>(),
                 value: value.unwrap_or(U256::ZERO),
-                input: data.unwrap_or_default(),
+                input: input.into_input().unwrap_or_default(),
                 to: match to {
                     Some(to) => TxKind::Call(to),
                     None => TxKind::Create,
@@ -284,7 +93,7 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
                 gas_price: gas_price.unwrap_or_default().to(),
                 gas_limit: gas.unwrap_or_default().to::<u64>(),
                 value: value.unwrap_or(U256::ZERO),
-                input: data.unwrap_or_default(),
+                input: input.into_input().unwrap_or_default(),
                 to: match to {
                     Some(to) => TxKind::Call(to),
                     None => TxKind::Create,
@@ -305,93 +114,12 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
                 max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default().to::<u128>(),
                 gas_limit: gas.unwrap_or_default().to::<u64>(),
                 value: value.unwrap_or(U256::ZERO),
-                input: data.unwrap_or_default(),
+                input: input.into_input().unwrap_or_default(),
                 to: match to {
                     Some(to) => TxKind::Call(to),
                     None => TxKind::Create,
                 },
                 chain_id: 0,
-                access_list: to_eip_access_list(access_list.unwrap_or_default()),
-            }))
-        }
-        _ => None,
-    }
-}
-
-pub fn call_request_to_typed(tx: CallRequest) -> Option<TypedTransactionRequest> {
-    let CallRequest {
-        to,
-        gas_price,
-        max_fee_per_gas,
-        max_priority_fee_per_gas,
-        gas,
-        value,
-        input,
-        chain_id,
-        nonce,
-        mut access_list,
-        transaction_type,
-        ..
-    } = tx;
-    let chain_id = chain_id.map(|id| id.to::<u64>());
-    let transaction_type = transaction_type.map(|id| id.to::<u64>());
-
-    match (
-        transaction_type,
-        gas_price,
-        max_fee_per_gas,
-        max_priority_fee_per_gas,
-        access_list.take(),
-    ) {
-        // legacy transaction
-        (Some(0), _, None, None, None) | (None, Some(_), None, None, None) => {
-            Some(TypedTransactionRequest::Legacy(TxLegacy {
-                nonce: nonce.unwrap_or_default().to::<u64>(),
-                gas_price: gas_price.unwrap_or_default().to::<u128>(),
-                gas_limit: gas.unwrap_or_default().to::<u64>(),
-                value: value.unwrap_or(U256::ZERO),
-                input: input.try_into_unique_input().unwrap_or_default().unwrap_or_default(),
-                to: match to {
-                    Some(to) => TxKind::Call(to),
-                    None => TxKind::Create,
-                },
-                chain_id,
-            }))
-        }
-        // EIP2930
-        (Some(1), _, None, None, _) | (None, _, None, None, Some(_)) => {
-            Some(TypedTransactionRequest::EIP2930(TxEip2930 {
-                nonce: nonce.unwrap_or_default().to::<u64>(),
-                gas_price: gas_price.unwrap_or_default().to(),
-                gas_limit: gas.unwrap_or_default().to::<u64>(),
-                value: value.unwrap_or(U256::ZERO),
-                input: input.try_into_unique_input().unwrap_or_default().unwrap_or_default(),
-                to: match to {
-                    Some(to) => TxKind::Call(to),
-                    None => TxKind::Create,
-                },
-                chain_id: chain_id.unwrap_or_default(),
-                access_list: to_eip_access_list(access_list.unwrap_or_default()),
-            }))
-        }
-        // EIP1559
-        (Some(2), None, _, _, _) |
-        (None, None, Some(_), _, _) |
-        (None, None, _, Some(_), _) |
-        (None, None, None, None, None) => {
-            // Empty fields fall back to the canonical transaction schema.
-            Some(TypedTransactionRequest::EIP1559(TxEip1559 {
-                nonce: nonce.unwrap_or_default().to::<u64>(),
-                max_fee_per_gas: max_fee_per_gas.unwrap_or_default().to::<u128>(),
-                max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default().to::<u128>(),
-                gas_limit: gas.unwrap_or_default().to::<u64>(),
-                value: value.unwrap_or(U256::ZERO),
-                input: input.try_into_unique_input().unwrap_or_default().unwrap_or_default(),
-                to: match to {
-                    Some(to) => TxKind::Call(to),
-                    None => TxKind::Create,
-                },
-                chain_id: chain_id.unwrap_or_default(),
                 access_list: to_eip_access_list(access_list.unwrap_or_default()),
             }))
         }

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -55,7 +55,7 @@ pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTrans
         return Some(TypedTransactionRequest::Deposit(DepositTransactionRequest {
             from: from.unwrap_or_default(),
             source_hash: other.get_deserialized::<B256>("sourceHash")?.ok()?,
-            kind: TxKind::Create,
+            kind: to.into(),
             mint: other.get_deserialized::<U256>("mint")?.ok()?,
             value: value.unwrap_or_default(),
             gas_limit: gas.unwrap_or_default(),

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -9,9 +9,8 @@ use alloy_network::{Signed, Transaction, TxKind};
 use alloy_primitives::{Address, Bloom, Bytes, Log, Signature, TxHash, B256, U128, U256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::{
-    optimism::OptimismTransactionFields,
-    request::{TransactionInput, TransactionRequest},
-    AccessList, AccessListItem, Signature as RpcSignature, Transaction as RpcTransaction,
+    request::TransactionRequest, AccessList, Signature as RpcSignature,
+    Transaction as RpcTransaction,
 };
 use foundry_evm::traces::CallTraceNode;
 use revm::{
@@ -32,6 +31,7 @@ pub fn impersonated_signature() -> Signature {
 }
 
 /// Converts a [TransactionRequest] into a [TypedTransactionRequest].
+/// Should be removed once the call builder abstraction for providers is in place.
 pub fn transaction_request_to_typed(tx: TransactionRequest) -> Option<TypedTransactionRequest> {
     let TransactionRequest {
         from,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1311,6 +1311,8 @@ impl EthApi {
             base_fee_per_gas: Vec::new(),
             gas_used_ratio: Vec::new(),
             reward: Some(Default::default()),
+            base_fee_per_blob_gas: Default::default(),
+            blob_gas_used_ratio: Default::default(),
         };
 
         let mut rewards = Vec::new();

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -8,9 +8,9 @@ use alloy_rpc_trace_types::{
     parity::LocalizedTransactionTrace as Trace,
 };
 use alloy_rpc_types::{
-    AccessListWithGasUsed, Block, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
-    CallRequest, EIP1186AccountProofResponse, FeeHistory, Filter, Log, Transaction,
-    TransactionReceipt,
+    request::TransactionRequest, AccessListWithGasUsed, Block, BlockId,
+    BlockNumberOrTag as BlockNumber, BlockTransactions, EIP1186AccountProofResponse, FeeHistory,
+    Filter, Log, Transaction, TransactionReceipt,
 };
 use alloy_transport::TransportError;
 use foundry_common::provider::alloy::{ProviderBuilder, RetryProvider};
@@ -169,7 +169,7 @@ impl ClientFork {
     /// Sends `eth_call`
     pub async fn call(
         &self,
-        request: &CallRequest,
+        request: &TransactionRequest,
         block: Option<BlockNumber>,
     ) -> Result<Bytes, TransportError> {
         let request = Arc::new(request.clone());
@@ -199,7 +199,7 @@ impl ClientFork {
     /// Sends `eth_call`
     pub async fn estimate_gas(
         &self,
-        request: &CallRequest,
+        request: &TransactionRequest,
         block: Option<BlockNumber>,
     ) -> Result<U256, TransportError> {
         let request = Arc::new(request.clone());
@@ -229,7 +229,7 @@ impl ClientFork {
     /// Sends `eth_createAccessList`
     pub async fn create_access_list(
         &self,
-        request: &CallRequest,
+        request: &TransactionRequest,
         block: Option<BlockNumber>,
     ) -> Result<AccessListWithGasUsed, TransportError> {
         self.provider().create_access_list(request.clone(), block.map(|b| b.into())).await
@@ -674,8 +674,8 @@ pub struct ForkedStorage {
     pub geth_transaction_traces: HashMap<B256, GethTrace>,
     pub block_traces: HashMap<u64, Vec<Trace>>,
     pub block_receipts: HashMap<u64, Vec<TransactionReceipt>>,
-    pub eth_gas_estimations: HashMap<(Arc<CallRequest>, u64), U256>,
-    pub eth_call: HashMap<(Arc<CallRequest>, u64), Bytes>,
+    pub eth_gas_estimations: HashMap<(Arc<TransactionRequest>, u64), U256>,
+    pub eth_call: HashMap<(Arc<TransactionRequest>, u64), Bytes>,
     pub code_at: HashMap<(Address, u64), Bytes>,
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -38,8 +38,8 @@ use alloy_rpc_trace_types::{
     parity::LocalizedTransactionTrace,
 };
 use alloy_rpc_types::{
-    state::StateOverride, AccessList, Block as AlloyBlock, BlockId,
-    BlockNumberOrTag as BlockNumber, CallRequest, EIP1186AccountProofResponse as AccountProof,
+    request::TransactionRequest, state::StateOverride, AccessList, Block as AlloyBlock, BlockId,
+    BlockNumberOrTag as BlockNumber, EIP1186AccountProofResponse as AccountProof,
     EIP1186StorageProof as StorageProof, Filter, FilteredParams, Header as AlloyHeader, Log,
     Transaction, TransactionReceipt,
 };
@@ -1015,14 +1015,14 @@ impl Backend {
         outcome
     }
 
-    /// Executes the [CallRequest] without writing to the DB
+    /// Executes the [TransactionRequest] without writing to the DB
     ///
     /// # Errors
     ///
     /// Returns an error if the `block_number` is greater than the current height
     pub async fn call(
         &self,
-        request: CallRequest,
+        request: TransactionRequest,
         fee_details: FeeDetails,
         block_request: Option<BlockRequest>,
         overrides: Option<StateOverride>,
@@ -1043,11 +1043,11 @@ impl Backend {
 
     fn build_call_env(
         &self,
-        request: CallRequest,
+        request: TransactionRequest,
         fee_details: FeeDetails,
         block_env: BlockEnv,
     ) -> Env {
-        let CallRequest { from, to, gas, value, input, nonce, access_list, .. } = request;
+        let TransactionRequest { from, to, gas, value, input, nonce, access_list, .. } = request;
 
         let FeeDetails { gas_price, max_fee_per_gas, max_priority_fee_per_gas } = fee_details;
 
@@ -1094,7 +1094,7 @@ impl Backend {
     pub fn call_with_state<D>(
         &self,
         state: D,
-        request: CallRequest,
+        request: TransactionRequest,
         fee_details: FeeDetails,
         block_env: BlockEnv,
     ) -> Result<(InstructionResult, Option<Output>, u64, State), BlockchainError>
@@ -1140,7 +1140,7 @@ impl Backend {
 
     pub async fn call_with_tracing(
         &self,
-        request: CallRequest,
+        request: TransactionRequest,
         fee_details: FeeDetails,
         block_request: Option<BlockRequest>,
         opts: GethDefaultTracingOptions,
@@ -1180,7 +1180,7 @@ impl Backend {
     pub fn build_access_list_with_state<D>(
         &self,
         state: D,
-        request: CallRequest,
+        request: TransactionRequest,
         fee_details: FeeDetails,
         block_env: BlockEnv,
     ) -> Result<(InstructionResult, Option<Output>, u64, AccessList), BlockchainError>

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -7,8 +7,8 @@ use crate::{
 use alloy_primitives::{Address as rAddress, B256, U256 as rU256};
 use alloy_providers::provider::TempProvider;
 use alloy_rpc_types::{
+    request::{TransactionInput as CallInput, TransactionRequest as CallRequest},
     state::{AccountOverride, StateOverride},
-    CallInput, CallRequest,
 };
 use alloy_signer::Signer as AlloySigner;
 use anvil::{

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_primitives::U256 as rU256;
 use alloy_providers::provider::TempProvider;
-use alloy_rpc_types::{BlockNumberOrTag, CallRequest};
+use alloy_rpc_types::{request::TransactionRequest as CallRequest, BlockNumberOrTag};
 use alloy_signer::Signer as AlloySigner;
 use anvil::{eth::EthApi, spawn, NodeConfig, NodeHandle};
 use anvil_core::types::Forking;

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -4,12 +4,12 @@ use crate::{
 };
 use alloy_primitives::U256 as rU256;
 use alloy_rpc_types::{
+    request::TransactionRequest as AlloyTransactionRequest,
     state::{AccountOverride, StateOverride},
     BlockNumberOrTag,
 };
 use alloy_signer::Signer as AlloySigner;
 use anvil::{spawn, Hardfork, NodeConfig};
-use anvil_core::eth::transaction::EthTransactionRequest;
 use ethers::{
     abi::ethereum_types::BigEndianHash,
     prelude::{
@@ -1088,7 +1088,7 @@ async fn can_mine_multiple_in_block() {
     // disable auto mine
     api.anvil_set_auto_mine(false).await.unwrap();
 
-    let tx = EthTransactionRequest {
+    let tx = AlloyTransactionRequest {
         from: Some("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse().unwrap()),
         ..Default::default()
     };

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -15,7 +15,7 @@ use crate::{
     CheatsConfig, CheatsCtxt, Error, Result, Vm,
 };
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
-use alloy_rpc_types::request::TransactionRequest;
+use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use alloy_signer::LocalWallet;
 use alloy_sol_types::{SolInterface, SolValue};
 use foundry_common::{evm::Breakpoints, provider::alloy::RpcUrl};
@@ -836,7 +836,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                             from: Some(broadcast.new_origin),
                             to: Some(call.contract),
                             value: Some(call.transfer.value),
-                            data: Some(call.input.clone()),
+                            input: TransactionInput::new(call.input.clone()),
                             nonce: Some(U64::from(account.info.nonce)),
                             gas: if is_fixed_gas_limit {
                                 Some(U256::from(call.gas_limit))
@@ -1222,7 +1222,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                             from: Some(broadcast.new_origin),
                             to,
                             value: Some(call.value),
-                            data: Some(bytecode),
+                            input: TransactionInput::new(bytecode),
                             nonce: Some(U64::from(nonce)),
                             gas: if is_fixed_gas_limit {
                                 Some(U256::from(call.gas_limit))

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -2,7 +2,11 @@
 
 use alloy_json_abi::{Event, EventParam, Function, InternalType, Param, StateMutability};
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, I256, U128, U256, U64};
-use alloy_rpc_types::{AccessList, AccessListItem, CallInput, CallRequest, Signature, Transaction};
+use alloy_rpc_types::{
+    other::OtherFields,
+    request::{TransactionInput, TransactionRequest as CallRequest},
+    AccessList, AccessListItem, Signature, Transaction,
+};
 use alloy_signer::{LocalWallet, Signer};
 use ethers_core::{
     abi as ethabi,
@@ -177,13 +181,15 @@ pub fn to_call_request_from_tx_request(tx: TransactionRequest) -> CallRequest {
         max_priority_fee_per_gas: None,
         gas: tx.gas.map(|g| g.to_alloy()),
         value: tx.value.map(|v| v.to_alloy()),
-        input: CallInput::maybe_input(tx.data.map(|b| b.0.into())),
+        input: TransactionInput::maybe_input(tx.data.map(|b| b.0.into())),
         nonce: tx.nonce.map(|n| U64::from(n.as_u64())),
         chain_id: tx.chain_id.map(|c| c.to_alloy()),
         access_list: None,
         max_fee_per_blob_gas: None,
         blob_versioned_hashes: None,
         transaction_type: None,
+        sidecar: None,
+        other: OtherFields::default(),
     }
 }
 

--- a/crates/forge/bin/cmd/script/executor.rs
+++ b/crates/forge/bin/cmd/script/executor.rs
@@ -143,7 +143,7 @@ impl ScriptArgs {
                         tx.from
                             .expect("transaction doesn't have a `from` address at execution time"),
                         tx.to,
-                        tx.data.clone(),
+                        tx.input.clone().into_input(),
                         tx.value,
                     )
                     .wrap_err("Internal EVM error during simulation")?;

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -415,7 +415,7 @@ impl ScriptArgs {
                 rpc: fork_url.clone(),
                 transaction: TransactionRequest {
                     from: Some(from),
-                    data: Some(bytes.clone()),
+                    input: Some(bytes.clone()).into(),
                     nonce: Some(U64::from(nonce + i as u64)),
                     ..Default::default()
                 },
@@ -510,8 +510,9 @@ impl ScriptArgs {
         for (data, to) in result.transactions.iter().flat_map(|txes| {
             txes.iter().filter_map(|tx| {
                 tx.transaction
-                    .data
+                    .input
                     .clone()
+                    .into_input()
                     .filter(|data| data.len() > max_size)
                     .map(|data| (data, tx.transaction.to))
             })

--- a/crates/forge/bin/cmd/script/transaction.rs
+++ b/crates/forge/bin/cmd/script/transaction.rs
@@ -69,7 +69,7 @@ impl TransactionWithMetadata {
                 from: transaction.from.map(ToEthers::to_ethers),
                 to: transaction.to.map(ToEthers::to_ethers).map(Into::into),
                 value: transaction.value.map(ToEthers::to_ethers),
-                data: transaction.data.map(ToEthers::to_ethers),
+                data: transaction.input.into_input().map(ToEthers::to_ethers),
                 nonce: transaction.nonce.map(|n| n.to::<u64>().into()),
                 gas: transaction.gas.map(ToEthers::to_ethers),
                 ..Default::default()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Previously we were using `CallRequest`, and an in-house `TransactionRequest`.
## Solution

Switches to using `TransactionRequest` everywhere.

Depends on https://github.com/alloy-rs/alloy/pull/178
