### PR TITLE
(fix): correctly redact private keys in traces #6995

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -387,8 +387,8 @@ impl CallTraceDecoder {
 
                 // Redact private key and replace in trace
                 // sign(uint256,bytes32) / signP256(uint256,bytes32) / sign(Wallet,bytes32)
-                if !decoded.is_empty()
-                    && (func.inputs[0].ty == "uint256" || func.inputs[0].ty == "tuple")
+                if !decoded.is_empty() &&
+                    (func.inputs[0].ty == "uint256" || func.inputs[0].ty == "tuple")
                 {
                     decoded[0] = DynSolValue::String("<pk>".to_string());
                 }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -395,30 +395,30 @@ impl CallTraceDecoder {
 
                 Some(decoded.iter().map(format_token).collect())
             }
-            "parseJson"
-            | "parseJsonUint"
-            | "parseJsonUintArray"
-            | "parseJsonInt"
-            | "parseJsonIntArray"
-            | "parseJsonString"
-            | "parseJsonStringArray"
-            | "parseJsonAddress"
-            | "parseJsonAddressArray"
-            | "parseJsonBool"
-            | "parseJsonBoolArray"
-            | "parseJsonBytes"
-            | "parseJsonBytesArray"
-            | "parseJsonBytes32"
-            | "parseJsonBytes32Array"
-            | "writeJson"
-            | "keyExists"
-            | "serializeBool"
-            | "serializeUint"
-            | "serializeInt"
-            | "serializeAddress"
-            | "serializeBytes32"
-            | "serializeString"
-            | "serializeBytes" => {
+            "parseJson" |
+            "parseJsonUint" |
+            "parseJsonUintArray" |
+            "parseJsonInt" |
+            "parseJsonIntArray" |
+            "parseJsonString" |
+            "parseJsonStringArray" |
+            "parseJsonAddress" |
+            "parseJsonAddressArray" |
+            "parseJsonBool" |
+            "parseJsonBoolArray" |
+            "parseJsonBytes" |
+            "parseJsonBytesArray" |
+            "parseJsonBytes32" |
+            "parseJsonBytes32Array" |
+            "writeJson" |
+            "keyExists" |
+            "serializeBool" |
+            "serializeUint" |
+            "serializeInt" |
+            "serializeAddress" |
+            "serializeBytes32" |
+            "serializeString" |
+            "serializeBytes" => {
                 if self.verbosity >= 5 {
                     None
                 } else {

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -375,7 +375,7 @@ impl CallTraceDecoder {
                 }
             }
             "getNonce" => {
-                // Redact private key in Wallet struct if defined
+                // Redact private key if defined
                 if !func.inputs.is_empty() && func.inputs[0].ty == "tuple" {
                     Some(vec!["<pk>".to_string()])
                 } else {
@@ -582,6 +582,7 @@ mod tests {
     fn test_should_redact_pk() {
         let decoder = CallTraceDecoder::new();
 
+        // [function_signature, data, expected]
         let cheatcode_input_test_cases = vec![
             // Should redact private key from traces in all cases:
             ("addr(uint256)", vec![], Some(vec!["<pk>".to_string()])),
@@ -632,6 +633,7 @@ mod tests {
             ),
         ];
 
+        // [function_signature, expected]
         let cheatcode_output_test_cases = vec![
             // Should redact private key on output in all cases:
             ("createWallet(string)", Some("<pk>".to_string())),

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -368,6 +368,7 @@ impl CallTraceDecoder {
             }
             "broadcast" | "startBroadcast" => {
                 // Redact private key if defined
+                // broadcast(uint256) / startBroadcast(uint256)
                 if !func.inputs.is_empty() && func.inputs[0].ty == "uint256" {
                     Some(vec!["<pk>".to_string()])
                 } else {
@@ -376,6 +377,7 @@ impl CallTraceDecoder {
             }
             "getNonce" => {
                 // Redact private key if defined
+                // getNonce(Wallet)
                 if !func.inputs.is_empty() && func.inputs[0].ty == "tuple" {
                     Some(vec!["<pk>".to_string()])
                 } else {
@@ -577,6 +579,7 @@ fn indexed_inputs(event: &Event) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::hex;
 
     #[test]
     fn test_should_redact_pk() {
@@ -605,12 +608,14 @@ mod tests {
             // Should redact private key and replace in trace in cases:
             (
                 "sign(uint256,bytes32)",
-                vec![
-                    227, 65, 234, 164, 124, 133, 33, 24, 41, 78, 81, 230, 83, 113, 42, 129, 224,
-                    88, 0, 244, 25, 20, 23, 81, 190, 88, 246, 5, 195, 113, 225, 81, 65, 176, 7,
-                    166, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0,
-                ],
+                hex!(
+                    "
+                    e341eaa4
+                    7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
+                    0000000000000000000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
                 Some(vec![
                     "\"<pk>\"".to_string(),
                     "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -619,12 +624,14 @@ mod tests {
             ),
             (
                 "signP256(uint256,bytes32)",
-                vec![
-                    131, 33, 27, 64, 124, 133, 33, 24, 41, 78, 81, 230, 83, 113, 42, 129, 224, 88,
-                    0, 244, 25, 20, 23, 81, 190, 88, 246, 5, 195, 113, 225, 81, 65, 176, 7, 166, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0,
-                ],
+                hex!(
+                    "
+                    83211b40
+                    7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
+                    0000000000000000000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
                 Some(vec![
                     "\"<pk>\"".to_string(),
                     "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -360,9 +360,6 @@ impl CallTraceDecoder {
 
     /// Custom decoding for cheatcode inputs.
     fn decode_cheatcode_inputs(&self, func: &Function, data: &[u8]) -> Option<Vec<String>> {
-        info!("{:?}", func);
-        info!("{:?}", data);
-
         match func.name.as_str() {
             "expectRevert" => Some(vec![decode::decode_revert(data, Some(&self.errors), None)]),
             "addr" | "createWallet" | "deriveKey" | "rememberKey" => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes issue of private keys not being redacted in traces.

Previously there was a [logical error](https://github.com/foundry-rs/foundry/issues/6995#issuecomment-1932377769) causing inputs to not correctly be redacted.

Closes #6995 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This change should cover all cheatcode cases where a `private key` is passed (directly or through the `Wallet` struct) or is returned.

This includes missing cases:
- `createWallet(...)`
- `getNonce(Wallet)`
- `signP256(uint256,bytes32)`
- `sign(Wallet,bytes32)`

I've added a parameterized test to verify all cases (incl. exceptions) and in a way so it is easy to maintain.

To be able to quickly check the proposed fixes I've created a minimal repo: https://github.com/zerosnacks/foundry-pr-6995

PS: dummy data included in the test was generated using the dummy private key of `0x90F79bf6EB2c4f870365E785982E1f101E93b906`, one of the Anvil defaults.