### PR TITLE
fix(`forge`): fix cache search for verification

### DIFF
--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -485,11 +485,10 @@ async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Address;
     use clap::Parser;
     use foundry_cli::utils::LoadConfig;
     use foundry_common::fs;
-    use foundry_test_utils::{forgetest, forgetest_async};
+    use foundry_test_utils::forgetest_async;
     use tempfile::tempdir;
 
     #[test]
@@ -639,7 +638,7 @@ mod tests {
         let args = VerifyArgs::parse_from([
             "foundry-cli",
             "0x0000000000000000000000000000000000000000",
-            &format!("src/Counter1.sol:Counter"),
+            "src/Counter1.sol:Counter",
             "--root",
             &prj.root().to_string_lossy(),
         ]);

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -221,18 +221,17 @@ impl EtherscanVerificationProvider {
         }
 
         let cache = project.read_cache_file()?;
-        let (path, entry) = match contract.path.as_ref() {
-            Some(path) => {
-                let path = project.root().join(path);
-                (
-                    path.clone(),
-                    cache
-                        .entry(&path)
-                        .ok_or_eyre(format!("Cache entry not found for {}", path.display()))?
-                        .to_owned(),
-                )
-            }
-            None => get_cached_entry_by_name(&cache, &contract.name)?,
+        let (path, entry) = if let Some(path) = contract.path.as_ref() {
+            let path = project.root().join(path);
+            (
+                path.clone(),
+                cache
+                    .entry(&path)
+                    .ok_or_eyre(format!("Cache entry not found for {}", path.display()))?
+                    .to_owned(),
+            )
+        } else {
+            get_cached_entry_by_name(&cache, &contract.name)?
         };
         let contract: CompactContract = cache.read_artifact(path.clone(), &contract.name)?;
         Ok(self.cached_entry.insert((path, entry, contract)))

--- a/crates/forge/bin/cmd/verify/etherscan/mod.rs
+++ b/crates/forge/bin/cmd/verify/etherscan/mod.rs
@@ -630,24 +630,21 @@ mod tests {
         );
     }
 
-    forgetest_async!(
-        respects_path_for_duplicate,
-        |prj, cmd| {
-            prj.add_source("Counter1", "contract Counter {}").unwrap();
-            prj.add_source("Counter2", "contract Counter {}").unwrap();
+    forgetest_async!(respects_path_for_duplicate, |prj, cmd| {
+        prj.add_source("Counter1", "contract Counter {}").unwrap();
+        prj.add_source("Counter2", "contract Counter {}").unwrap();
 
-            cmd.args(["build", "--force"]).ensure_execute_success().unwrap();
+        cmd.args(["build", "--force"]).ensure_execute_success().unwrap();
 
-            let args = VerifyArgs::parse_from([
-                "foundry-cli",
-                "0x0000000000000000000000000000000000000000",
-                &format!("src/Counter1.sol:Counter"),
-                "--root",
-                &prj.root().to_string_lossy()
-            ]);
-            
-            let mut etherscan = EtherscanVerificationProvider::default();
-            etherscan.preflight_check(args).await.unwrap();
-        }
-    );
+        let args = VerifyArgs::parse_from([
+            "foundry-cli",
+            "0x0000000000000000000000000000000000000000",
+            &format!("src/Counter1.sol:Counter"),
+            "--root",
+            &prj.root().to_string_lossy(),
+        ]);
+
+        let mut etherscan = EtherscanVerificationProvider::default();
+        etherscan.preflight_check(args).await.unwrap();
+    });
 }


### PR DESCRIPTION
## Motivation

Closes #7042

## Solution

Current `EtherscanVerificationProvider::cache_entry` always looks for contract in cache by name, even if path present, this PR fixes it and uses path where possible.
