### PR TITLE
fix(forge): debugger should load sourcemaps by file_id

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -274,9 +274,9 @@ impl ProjectCompiler {
 /// Contract source code and bytecode.
 #[derive(Clone, Debug, Default)]
 pub struct ContractSources {
-    /// Map over artifacts contract sources name -> file_id -> (source, contract)
+    /// Map over artifacts' contract names -> vector of file IDs
     pub ids_by_name: HashMap<String, Vec<u32>>,
-    /// Map over artifacts contract sources file_id -> (source, contract)
+    /// Map over file_id -> (source code, contract)
     pub sources_by_id: HashMap<u32, (String, ContractBytecodeSome)>,
 }
 
@@ -299,21 +299,20 @@ impl ContractSources {
     }
 
     /// Returns all sources for a contract by name.
-    pub fn get_sources(&self, name: &str) -> Option<Vec<(u32, &(String, ContractBytecodeSome))>> {
-        self.ids_by_name.get(name).map(|ids| {
-            ids.iter().filter_map(|id| Some((*id, self.sources_by_id.get(id)?))).collect()
-        })
+    pub fn get_sources(
+        &self,
+        name: &str,
+    ) -> Option<impl Iterator<Item = (u32, &(String, ContractBytecodeSome))>> {
+        self.ids_by_name
+            .get(name)
+            .map(|ids| ids.iter().filter_map(|id| Some((*id, self.sources_by_id.get(id)?))))
     }
 
     /// Returns all (name, source) pairs.
-    pub fn entries(&self) -> Vec<(String, &(String, ContractBytecodeSome))> {
-        self.ids_by_name
-            .iter()
-            .flat_map(|(name, ids)| {
-                ids.iter()
-                    .filter_map(move |id| self.sources_by_id.get(id).map(|s| (name.clone(), s)))
-            })
-            .collect()
+    pub fn entries(&self) -> impl Iterator<Item = (String, &(String, ContractBytecodeSome))> {
+        self.ids_by_name.iter().flat_map(|(name, ids)| {
+            ids.iter().filter_map(|id| self.sources_by_id.get(id).map(|s| (name.clone(), s)))
+        })
     }
 }
 

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -271,9 +271,41 @@ impl ProjectCompiler {
     }
 }
 
-/// Map over artifacts contract sources name -> file_id -> (source, contract)
+/// Contract source code and bytecode.
 #[derive(Clone, Debug, Default)]
-pub struct ContractSources(pub HashMap<String, HashMap<u32, (String, ContractBytecodeSome)>>);
+pub struct ContractSources {
+    /// Map over artifacts contract sources name -> file_id -> (source, contract)
+    pub sources_by_name: HashMap<String, HashMap<u32, (String, ContractBytecodeSome)>>,
+    /// Map over artifacts contract sources file_id -> (source, contract)
+    pub sources_by_id: HashMap<u32, (String, ContractBytecodeSome)>,
+}
+
+impl ContractSources {
+    /// Inserts a contract into the sources.
+    pub fn insert(
+        &mut self,
+        artifact_id: &ArtifactId,
+        file_id: u32,
+        source: String,
+        bytecode: ContractBytecodeSome,
+    ) {
+        self.sources_by_name
+            .entry(artifact_id.name.clone())
+            .or_default()
+            .insert(file_id, (source.clone(), bytecode.clone()));
+        self.sources_by_id.insert(file_id, (source, bytecode));
+    }
+
+    /// Returns the sources for contracts by name.
+    pub fn get(&self, name: &str) -> Option<&HashMap<u32, (String, ContractBytecodeSome)>> {
+        self.sources_by_name.get(name)
+    }
+
+    /// Returns the source for a contract by file ID.
+    pub fn get_by_id(&self, id: u32) -> Option<&(String, ContractBytecodeSome)> {
+        self.sources_by_id.get(&id)
+    }
+}
 
 // https://eips.ethereum.org/EIPS/eip-170
 const CONTRACT_SIZE_LIMIT: usize = 24576;

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -334,7 +334,8 @@ impl DebuggerContext<'_> {
             return Err(format!("Unknown contract at address {address}"));
         };
 
-        let Some(mut files_source_code) = self.debugger.contracts_sources.get_sources(contract_name)
+        let Some(mut files_source_code) =
+            self.debugger.contracts_sources.get_sources(contract_name)
         else {
             return Err(format!("No source map index for contract {contract_name}"));
         };
@@ -358,20 +359,20 @@ impl DebuggerContext<'_> {
                 let ic = pc_ic_map.get(pc)?;
                 let source_element = source_map.swap_remove(ic);
                 // if the source element has an index, find the sourcemap for that index
-                source_element.index.and_then(|index| 
+                source_element
+                    .index
+                    .and_then(|index| 
                     // if index matches current file_id, return current source code
-                    (index == file_id).then_some((source_element.clone(), source_code))).or_else(
-                        || {
-                            // otherwise find the source code for the element's index
-                            self.debugger
-                                .contracts_sources
-                                .sources_by_id
-                                .get(&(source_element.index?))
-                                .map(|(source_code, _)| (source_element.clone(), source_code))
-                        },
-                    )
-                })
-            
+                    (index == file_id).then_some((source_element.clone(), source_code)))
+                    .or_else(|| {
+                        // otherwise find the source code for the element's index
+                        self.debugger
+                            .contracts_sources
+                            .sources_by_id
+                            .get(&(source_element.index?))
+                            .map(|(source_code, _)| (source_element.clone(), source_code))
+                    })
+            })
         else {
             return Err(format!("No source map for contract {contract_name}"));
         };

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -358,20 +358,20 @@ impl DebuggerContext<'_> {
                 let ic = pc_ic_map.get(pc)?;
                 let source_element = source_map.swap_remove(ic);
                 // if the source element has an index, find the sourcemap for that index
-                source_element.index.and_then(|index| {
+                source_element.index.and_then(|index| 
                     // if index matches current file_id, return current source code
-                    (index == *file_id).then_some((source_element.clone(), source_code)).or_else(
+                    (index == *file_id).then_some((source_element.clone(), source_code))).or_else(
                         || {
                             // otherwise find the source code for the element's index
                             self.debugger
                                 .contracts_sources
                                 .sources_by_id
-                                .get(&index)
+                                .get(&(source_element.index?))
                                 .map(|(source_code, _)| (source_element.clone(), source_code))
                         },
                     )
                 })
-            })
+            
         else {
             return Err(format!("No source map for contract {contract_name}"));
         };

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -363,7 +363,7 @@ impl DebuggerContext<'_> {
                     .index
                     .and_then(|index| 
                     // if index matches current file_id, return current source code
-                    (index == file_id).then_some((source_element.clone(), source_code)))
+                    (index == file_id).then(|| (source_element.clone(), source_code)))
                     .or_else(|| {
                         // otherwise find the source code for the element's index
                         self.debugger

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -334,7 +334,7 @@ impl DebuggerContext<'_> {
             return Err(format!("Unknown contract at address {address}"));
         };
 
-        let Some(files_source_code) = self.debugger.contracts_sources.get_sources(contract_name)
+        let Some(mut files_source_code) = self.debugger.contracts_sources.get_sources(contract_name)
         else {
             return Err(format!("No source map index for contract {contract_name}"));
         };
@@ -346,7 +346,7 @@ impl DebuggerContext<'_> {
         let is_create = matches!(self.call_kind(), CallKind::Create | CallKind::Create2);
         let pc = self.current_step().pc;
         let Some((source_element, source_code)) =
-            files_source_code.iter().find_map(|(file_id, (source_code, contract_source))| {
+            files_source_code.find_map(|(file_id, (source_code, contract_source))| {
                 let bytecode = if is_create {
                     &contract_source.bytecode
                 } else {
@@ -360,7 +360,7 @@ impl DebuggerContext<'_> {
                 // if the source element has an index, find the sourcemap for that index
                 source_element.index.and_then(|index| 
                     // if index matches current file_id, return current source code
-                    (index == *file_id).then_some((source_element.clone(), source_code))).or_else(
+                    (index == file_id).then_some((source_element.clone(), source_code))).or_else(
                         || {
                             // otherwise find the source code for the element's index
                             self.debugger

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -334,8 +334,7 @@ impl DebuggerContext<'_> {
             return Err(format!("Unknown contract at address {address}"));
         };
 
-        let Some(files_source_code) =
-            self.debugger.contracts_sources.sources_by_name.get(contract_name)
+        let Some(files_source_code) = self.debugger.contracts_sources.get_sources(contract_name)
         else {
             return Err(format!("No source map index for contract {contract_name}"));
         };

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -361,7 +361,7 @@ impl DebuggerContext<'_> {
                 // if the source element has an index, find the sourcemap for that index
                 source_element
                     .index
-                    .and_then(|index| 
+                    .and_then(|index|
                     // if index matches current file_id, return current source code
                     (index == file_id).then(|| (source_element.clone(), source_code)))
                     .or_else(|| {

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -67,7 +67,6 @@ impl Debugger {
     ) -> Self {
         let pc_ic_maps = contracts_sources
             .entries()
-            .iter()
             .filter_map(|(contract_name, (_, contract))| {
                 Some((
                     contract_name.clone(),

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -66,18 +66,16 @@ impl Debugger {
         breakpoints: Breakpoints,
     ) -> Self {
         let pc_ic_maps = contracts_sources
-            .sources_by_name
+            .entries()
             .iter()
-            .flat_map(|(contract_name, files_sources)| {
-                files_sources.iter().filter_map(|(_, (_, contract))| {
-                    Some((
-                        contract_name.clone(),
-                        (
-                            PcIcMap::new(SpecId::LATEST, contract.bytecode.bytes()?),
-                            PcIcMap::new(SpecId::LATEST, contract.deployed_bytecode.bytes()?),
-                        ),
-                    ))
-                })
+            .filter_map(|(contract_name, (_, contract))| {
+                Some((
+                    contract_name.clone(),
+                    (
+                        PcIcMap::new(SpecId::LATEST, contract.bytecode.bytes()?),
+                        PcIcMap::new(SpecId::LATEST, contract.deployed_bytecode.bytes()?),
+                    ),
+                ))
             })
             .collect();
         Self { debug_arena, identified_contracts, contracts_sources, pc_ic_maps, breakpoints }

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -66,7 +66,7 @@ impl Debugger {
         breakpoints: Breakpoints,
     ) -> Self {
         let pc_ic_maps = contracts_sources
-            .0
+            .sources_by_name
             .iter()
             .flat_map(|(contract_name, files_sources)| {
                 files_sources.iter().filter_map(|(_, (_, contract))| {

--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -87,11 +87,7 @@ impl EtherscanIdentifier {
         for (results, (_, metadata)) in artifacts.into_iter().zip(contracts_iter) {
             // get the inner type
             let (artifact_id, file_id, bytecode) = results?;
-            sources
-                .0
-                .entry(artifact_id.clone().name)
-                .or_default()
-                .insert(file_id, (metadata.source_code(), bytecode));
+            sources.insert(&artifact_id, file_id, metadata.source_code(), bytecode);
         }
 
         Ok(sources)

--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -48,11 +48,7 @@ impl ScriptArgs {
                     })?;
                     let contract = artifact.clone().into_contract_bytecode();
                     let source_contract = compact_to_contract(contract)?;
-                    sources
-                        .0
-                        .entry(id.clone().name)
-                        .or_default()
-                        .insert(source.id, (source_code, source_contract));
+                    sources.insert(&id, source.id, source_code, source_contract);
                 } else {
                     warn!(?id, "source not found");
                 }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -272,11 +272,7 @@ impl TestArgs {
                     let source_code = fs::read_to_string(abs_path)?;
                     let contract = artifact.clone().into_contract_bytecode();
                     let source_contract = compact_to_contract(contract)?;
-                    sources
-                        .0
-                        .entry(id.name.clone())
-                        .or_default()
-                        .insert(source.id, (source_code, source_contract));
+                    sources.insert(&id, source.id, source_code, source_contract);
                 }
             }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Summary from #7043:

> [ContractSources](https://github.com/foundry-rs/foundry/blob/725c9a95b1331c67b55facd4da1598cbc8e03112/crates/common/src/compile.rs#L276) is a mapping of name -> id -> (source code, bytecode)
> 
> In src_map, the source for the contract is [looked up by name](https://github.com/foundry-rs/foundry/blob/3344e2ceeb68fd77d6be001ce7990742debc2e9a/crates/debugger/src/tui/draw.rs#L331). Since this may return multiple contracts with the same name, the entries are iterated over and the SourceElement's index is compared to the file_id of the current contract source. [If they match, the source code is returned](https://github.com/foundry-rs/foundry/blob/3344e2ceeb68fd77d6be001ce7990742debc2e9a/crates/debugger/src/tui/draw.rs#L353).
> 
> The problem is that this will never return source code for inherited contracts, because it is only loading source code for (contracts with the same name as) the contract being invoked; if the SourceElement points to a different index (aka file_id), it will never match any of the contract sources loaded from ContractSources.
> 
> ContractSources should maintain an index both of name -> id -> (source, bytecode) and id -> (source, bytecode) for looking up cross-source sourcemaps.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`ContractSources` now also maintains a mapping of `file_id/index -> (source code, bytecode)`. When the loaded `file_id` does not match `source_element.index`, it looks up the contract source using the `source_element`'s `index`.

I could use some help testing this – it looks to me like the [`debug.rs` test](https://github.com/foundry-rs/foundry/blob/bacacceb97da35ccd03b955aab2a6642ccfedd37/crates/forge/tests/cli/debug.rs#L6) doesn't actually make any assertions, so I don't have much to go off of. 

Closes #7043

Before:
<img width="1305" alt="Screenshot 2024-02-08 at 6 40 40 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/54aea570-f0f7-40eb-977c-d5dc94f80d9e">

After: 
<img width="1305" alt="Screenshot 2024-02-08 at 6 41 06 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/fa97ea74-f0a5-41d0-92a6-46840c410032">

