### PR TITLE
fix(forge): fix debugger out-of-range panic

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -257,6 +257,12 @@ impl DebuggerContext<'_> {
                 // no unused space
             }
 
+            // since above is subtracted from before.len(), and the resulting
+            // start_line is used to index into before, above must be at least
+            // 1 to avoid out-of-range accesses.
+            if above == 0 {
+                above = 1;
+            }
             (before.len().saturating_sub(above), mid_len + below)
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The debugger sometimes panics with an out-of-range error when slicing an array.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Reproduction is tricky because the error depends on the height of the debugger window.

Ensure that `start_line` is always strictly less than `before.len()`.

Closes #7029 



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
