### PR TITLE
fix(`forge`): forge script --json always returns zero exit code #2508

### DIFF
--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -364,6 +364,13 @@ impl ScriptArgs {
         let j = serde_json::to_string(&output)?;
         shell::println(j)?;
 
+        if !result.success {
+            return Err(eyre::eyre!(
+                "script failed: {}",
+                decode::decode_revert(&result.returned[..], None, None)
+            ));
+        }
+
         Ok(())
     }
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -107,6 +107,41 @@ contract Demo {
     );
 });
 
+static FAILING_SCRIPT: &str = r#"
+import "forge-std/Script.sol";
+
+contract FailingScript is Script {
+    function run() external {
+        revert("failed");
+    }
+}
+"#;
+
+// Tests that execution throws upon encountering a revert in the script.
+forgetest_async!(test_exit_code_error_on_script, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let script = prj.add_source("failing_script", FAILING_SCRIPT).unwrap();
+
+    // set up command
+    cmd.arg("script").arg(script);
+
+    // run command and assert error exit code
+    cmd.assert_err();
+});
+
+// Tests that execution throws upon encountering a revert in the script with --json option.
+// <https://github.com/foundry-rs/foundry/issues/2508>
+forgetest_async!(test_exit_code_error_on_script_with_json, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let script = prj.add_source("failing_script", FAILING_SCRIPT).unwrap();
+
+    // set up command
+    cmd.arg("script").arg(script).arg("--json");
+
+    // run command and assert error exit code
+    cmd.assert_err();
+});
+
 // Tests that the manually specified gas limit is used when using the --unlocked option
 forgetest_async!(can_execute_script_command_with_manual_gas_limit_unlocked, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -134,7 +134,7 @@ forgetest_async!(assert_exit_code_error_on_failure_script, |prj, cmd| {
 
 // Tests that execution throws upon encountering a revert in the script with --json option.
 // <https://github.com/foundry-rs/foundry/issues/2508>
-forgetest_async!(test_exit_code_error_on_failure_script_with_json, |prj, cmd| {
+forgetest_async!(assert_exit_code_error_on_failure_script_with_json, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     let script = prj.add_source("FailingScript", FAILING_SCRIPT).unwrap();
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -118,28 +118,34 @@ contract FailingScript is Script {
 "#;
 
 // Tests that execution throws upon encountering a revert in the script.
-forgetest_async!(test_exit_code_error_on_script, |prj, cmd| {
+forgetest_async!(assert_exit_code_error_on_failure_script, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
-    let script = prj.add_source("failing_script", FAILING_SCRIPT).unwrap();
+    let script = prj.add_source("FailingScript", FAILING_SCRIPT).unwrap();
 
     // set up command
     cmd.arg("script").arg(script);
 
     // run command and assert error exit code
     cmd.assert_err();
+
+    let output = cmd.stderr_lossy();
+    assert!(output.contains("script failed: revert: failed"));
 });
 
 // Tests that execution throws upon encountering a revert in the script with --json option.
 // <https://github.com/foundry-rs/foundry/issues/2508>
-forgetest_async!(test_exit_code_error_on_script_with_json, |prj, cmd| {
+forgetest_async!(test_exit_code_error_on_failure_script_with_json, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
-    let script = prj.add_source("failing_script", FAILING_SCRIPT).unwrap();
+    let script = prj.add_source("FailingScript", FAILING_SCRIPT).unwrap();
 
     // set up command
     cmd.arg("script").arg(script).arg("--json");
 
     // run command and assert error exit code
     cmd.assert_err();
+
+    let output = cmd.stderr_lossy();
+    assert!(output.contains("script failed: revert: failed"));
 });
 
 // Tests that the manually specified gas limit is used when using the --unlocked option


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/2508

Currently there is an issue where script errors get skipped if `--json` is passed to `forge script` as the execution path lacks the `success` check.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds missing success check and two test cases to check equivalency of behaviour.

Similar to `show_traces` the error check is performed at the end so that useful stdout logs can still be captured.