### PR TITLE
perf: add a dyn Cheatcode trait to reduce generated code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,7 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## misc
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "std",
-] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 color-eyre = "0.6"
 derive_more = "0.99"
 eyre = "0.6"
@@ -194,7 +191,7 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 evm-disassembler = "0.4"
-vergen = "8"
+vergen = { version = "8", default-features = false }
 # TODO: bumping to >=0.13.2 breaks ecrecover: https://github.com/foundry-rs/foundry/pull/6969
 # TODO: unpin on next revm release: https://github.com/bluealloy/revm/pull/870
 k256 = "=0.13.1"


### PR DESCRIPTION
Removes 280_854 LLVM lines in `foundry-evm` (1_868_826 to 1_587_972, -15%)

With the next Revm update this should go down a further 30-40%, as currently basically all of revm is parameterized across 16 evm specs and 2 dbs of our own.

This should significantly improve compile times and compile memory usage.

Raw data (random `cargo llvm-lines --lib --release -p ...` and `cargo bloat --bin forge --release`): [bloat.zip](https://github.com/foundry-rs/foundry/files/14233578/bloat.zip)
