### PR TITLE
test: manually add install commands

### DIFF
--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -67,7 +67,11 @@ fn lil_web3() {
 #[test]
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn snekmate() {
-    ExtTester::new("pcaversaccio", "snekmate", "ed49a0454393673cdf9a4250dd7051c28e6ac35f").run();
+    ExtTester::new("pcaversaccio", "snekmate", "ed49a0454393673cdf9a4250dd7051c28e6ac35f")
+        .install_command(&["pnpm", "install", "--prefer-offline"])
+        // Try npm if pnpm fails / is not installed
+        .install_command(&["npm", "install", "--prefer-offline"])
+        .run();
 }
 
 #[test]

--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -8,13 +8,17 @@ fn solmate() {
 #[test]
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn prb_math() {
-    ExtTester::new("PaulRBerg", "prb-math", "5b6279a0cf7c1b1b6a5cc96082811f7ef620cf60").run();
+    ExtTester::new("PaulRBerg", "prb-math", "5b6279a0cf7c1b1b6a5cc96082811f7ef620cf60")
+        .install_command(&["bun", "install", "--prefer-offline"])
+        .run();
 }
 
 #[test]
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn prb_proxy() {
-    ExtTester::new("PaulRBerg", "prb-proxy", "fa13cf09fbf544a2d575b45884b8e94a79a02c06").run();
+    ExtTester::new("PaulRBerg", "prb-proxy", "fa13cf09fbf544a2d575b45884b8e94a79a02c06")
+        .install_command(&["bun", "install", "--prefer-offline"])
+        .run();
 }
 
 #[test]
@@ -25,6 +29,7 @@ fn sablier_v2() {
         .args(["--nmc", "Fork"])
         // run tests without optimizations
         .env("FOUNDRY_PROFILE", "lite")
+        .install_command(&["bun", "install", "--prefer-offline"])
         .run();
 }
 
@@ -49,7 +54,9 @@ fn stringutils() {
 
 #[test]
 fn lootloose() {
-    ExtTester::new("gakonst", "lootloose", "7b639efe97836155a6a6fc626bf1018d4f8b2495").run();
+    ExtTester::new("gakonst", "lootloose", "7b639efe97836155a6a6fc626bf1018d4f8b2495")
+        .install_command(&["make", "install"])
+        .run();
 }
 
 #[test]
@@ -93,7 +100,7 @@ fn gunilev() {
 }
 
 #[test]
-fn convex() {
+fn convex_shutdown_simulation() {
     ExtTester::new(
         "mds1",
         "convex-shutdown-simulation",

--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -10,7 +10,7 @@ fn solmate() {
 fn prb_math() {
     ExtTester::new("PaulRBerg", "prb-math", "5b6279a0cf7c1b1b6a5cc96082811f7ef620cf60")
         .install_command(&["bun", "install", "--prefer-offline"])
-        // Try npm if bun fails / is not installed
+        // Try npm if bun fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
@@ -20,7 +20,7 @@ fn prb_math() {
 fn prb_proxy() {
     ExtTester::new("PaulRBerg", "prb-proxy", "fa13cf09fbf544a2d575b45884b8e94a79a02c06")
         .install_command(&["bun", "install", "--prefer-offline"])
-        // Try npm if bun fails / is not installed
+        // Try npm if bun fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
@@ -29,12 +29,12 @@ fn prb_proxy() {
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn sablier_v2() {
     ExtTester::new("sablier-labs", "v2-core", "84758a40077bf3ccb1c8f7bb8d00278e672fbfef")
-        // skip fork tests
+        // Skip fork tests.
         .args(["--nmc", "Fork"])
-        // run tests without optimizations
+        // Run tests without optimizations.
         .env("FOUNDRY_PROFILE", "lite")
         .install_command(&["bun", "install", "--prefer-offline"])
-        // Try npm if bun fails / is not installed
+        // Try npm if bun fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
@@ -75,16 +75,14 @@ fn lil_web3() {
 fn snekmate() {
     ExtTester::new("pcaversaccio", "snekmate", "ed49a0454393673cdf9a4250dd7051c28e6ac35f")
         .install_command(&["pnpm", "install", "--prefer-offline"])
-        // Try npm if pnpm fails / is not installed
+        // Try npm if pnpm fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
 
 #[test]
 fn makerdao_multicall() {
-    ExtTester::new("makerdao", "multicall", "103a8a28e4e372d582d6539b30031bda4cd48e21")
-        .args(["--block-number", "1"])
-        .run();
+    ExtTester::new("makerdao", "multicall", "103a8a28e4e372d582d6539b30031bda4cd48e21").run();
 }
 
 #[test]

--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -10,6 +10,8 @@ fn solmate() {
 fn prb_math() {
     ExtTester::new("PaulRBerg", "prb-math", "5b6279a0cf7c1b1b6a5cc96082811f7ef620cf60")
         .install_command(&["bun", "install", "--prefer-offline"])
+        // Try npm if bun fails / is not installed
+        .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
 
@@ -18,6 +20,8 @@ fn prb_math() {
 fn prb_proxy() {
     ExtTester::new("PaulRBerg", "prb-proxy", "fa13cf09fbf544a2d575b45884b8e94a79a02c06")
         .install_command(&["bun", "install", "--prefer-offline"])
+        // Try npm if bun fails / is not installed
+        .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
 
@@ -30,6 +34,8 @@ fn sablier_v2() {
         // run tests without optimizations
         .env("FOUNDRY_PROFILE", "lite")
         .install_command(&["bun", "install", "--prefer-offline"])
+        // Try npm if bun fails / is not installed
+        .install_command(&["npm", "install", "--prefer-offline"])
         .run();
 }
 

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -184,9 +184,7 @@ impl ExtTester {
                         break;
                     }
                 }
-                Err(e) => {
-                    eprintln!("\n\n{install_cmd:?}: {e}")
-                }
+                Err(e) => eprintln!("\n\n{install_cmd:?}: {e}"),
             }
         }
 

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -191,10 +191,9 @@ impl ExtTester {
         // Run the tests.
         test_cmd.arg("test");
         test_cmd.args(&self.args);
-        test_cmd.args(["--fuzz-runs=256", "--ffi", "-vvvvv"]);
+        test_cmd.args(["--fuzz-runs=32", "--ffi", "-vvvvv"]);
 
         test_cmd.envs(self.envs.iter().map(|(k, v)| (k, v)));
-        test_cmd.env("FOUNDRY_FUZZ_RUNS", "1");
         if let Some(fork_block) = self.fork_block {
             test_cmd
                 .env("FOUNDRY_ETH_RPC_URL", foundry_common::rpc::next_http_archive_rpc_endpoint());
@@ -614,7 +613,8 @@ impl TestProject {
 
     /// Returns the path to the forge executable.
     pub fn forge_bin(&self) -> Command {
-        let forge = self.exe_root.join(format!("../forge{}", env::consts::EXE_SUFFIX));
+        let forge = self.exe_root.join("../forge").with_extension(env::consts::EXE_SUFFIX);
+        let forge = forge.canonicalize().unwrap();
         let mut cmd = Command::new(forge);
         cmd.current_dir(self.inner.root());
         // disable color output for comparisons
@@ -624,7 +624,8 @@ impl TestProject {
 
     /// Returns the path to the cast executable.
     pub fn cast_bin(&self) -> Command {
-        let cast = self.exe_root.join(format!("../cast{}", env::consts::EXE_SUFFIX));
+        let cast = self.exe_root.join("../cast").with_extension(env::consts::EXE_SUFFIX);
+        let cast = cast.canonicalize().unwrap();
         let mut cmd = Command::new(cast);
         // disable color output for comparisons
         cmd.env("NO_COLOR", "1");

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -60,6 +60,7 @@ pub struct ExtTester {
     pub fork_block: Option<u64>,
     pub args: Vec<String>,
     pub envs: Vec<(String, String)>,
+    pub install_command: Vec<String>,
 }
 
 impl ExtTester {
@@ -73,6 +74,7 @@ impl ExtTester {
             fork_block: None,
             args: vec![],
             envs: vec![],
+            install_command: vec![],
         }
     }
 
@@ -121,6 +123,15 @@ impl ExtTester {
         self
     }
 
+    /// Adds a command to run after the project is cloned.
+    ///
+    /// Note that the command is run in the project's root directory, and it won't fail the test if
+    /// it fails.
+    pub fn install_command(mut self, command: &[&str]) -> Self {
+        self.install_command.extend(command.iter().map(|s| s.to_string()));
+        self
+    }
+
     /// Runs the test.
     pub fn run(&self) {
         // Skip fork tests if the RPC url is not set.
@@ -129,7 +140,7 @@ impl ExtTester {
             return;
         }
 
-        let (prj, mut cmd) = setup_forge(self.name, self.style.clone());
+        let (prj, mut test_cmd) = setup_forge(self.name, self.style.clone());
 
         // Wipe the default structure.
         prj.wipe();
@@ -141,10 +152,10 @@ impl ExtTester {
 
         // Checkout the revision.
         if self.rev.is_empty() {
-            let mut cmd = Command::new("git");
-            cmd.current_dir(root).args(["log", "-n", "1"]);
-            eprintln!("$ {cmd:?}");
-            let output = cmd.output().unwrap();
+            let mut git = Command::new("git");
+            git.current_dir(root).args(["log", "-n", "1"]);
+            eprintln!("$ {git:?}");
+            let output = git.output().unwrap();
             if !output.status.success() {
                 panic!("git log failed: {output:?}");
             }
@@ -152,31 +163,44 @@ impl ExtTester {
             let commit = stdout.lines().next().unwrap().split_whitespace().nth(1).unwrap();
             panic!("pin to latest commit: {commit}");
         } else {
-            let mut cmd = Command::new("git");
-            cmd.current_dir(root).args(["checkout", self.rev]);
-            eprintln!("$ {cmd:?}");
-            let status = cmd.status().unwrap();
+            let mut git = Command::new("git");
+            git.current_dir(root).args(["checkout", self.rev]);
+            eprintln!("$ {git:?}");
+            let status = git.status().unwrap();
             if !status.success() {
                 panic!("git checkout failed: {status}");
             }
         }
 
-        // Run common installation commands.
-        run_install_commands(prj.root());
-
-        // Run the tests.
-        cmd.arg("test");
-        cmd.args(&self.args);
-        cmd.args(["--fuzz-runs=256", "--ffi", "-vvvvv"]);
-
-        cmd.envs(self.envs.iter().map(|(k, v)| (k, v)));
-        cmd.env("FOUNDRY_FUZZ_RUNS", "1");
-        if let Some(fork_block) = self.fork_block {
-            cmd.env("FOUNDRY_ETH_RPC_URL", foundry_common::rpc::next_http_archive_rpc_endpoint());
-            cmd.env("FOUNDRY_FORK_BLOCK_NUMBER", fork_block.to_string());
+        // Run installation command.
+        if !self.install_command.is_empty() {
+            let mut install_cmd = Command::new(&self.install_command[0]);
+            install_cmd.args(&self.install_command[1..]).current_dir(root);
+            eprintln!("cd {root}; {install_cmd:?}");
+            match install_cmd.status() {
+                Ok(s) => {
+                    eprintln!("\n\n{install_cmd:?}: {s}");
+                }
+                Err(e) => {
+                    eprintln!("\n\n{install_cmd:?}: {e}");
+                }
+            }
         }
 
-        cmd.assert_non_empty_stdout();
+        // Run the tests.
+        test_cmd.arg("test");
+        test_cmd.args(&self.args);
+        test_cmd.args(["--fuzz-runs=256", "--ffi", "-vvvvv"]);
+
+        test_cmd.envs(self.envs.iter().map(|(k, v)| (k, v)));
+        test_cmd.env("FOUNDRY_FUZZ_RUNS", "1");
+        if let Some(fork_block) = self.fork_block {
+            test_cmd
+                .env("FOUNDRY_ETH_RPC_URL", foundry_common::rpc::next_http_archive_rpc_endpoint());
+            test_cmd.env("FOUNDRY_FORK_BLOCK_NUMBER", fork_block.to_string());
+        }
+
+        test_cmd.assert_non_empty_stdout();
     }
 }
 
@@ -250,45 +274,6 @@ pub fn clone_remote(repo_url: &str, target_dir: &str) {
         panic!("git clone failed: {status}");
     }
     eprintln!();
-}
-
-/// Runs common installation commands, such as `make` and `npm`. Continues if any command fails.
-pub fn run_install_commands(root: &Path) {
-    let root_files =
-        std::fs::read_dir(root).unwrap().flatten().map(|x| x.path()).collect::<Vec<_>>();
-    let contains = |path: &str| root_files.iter().any(|p| p.to_str().unwrap().contains(path));
-    let run = |args: &[&str]| {
-        let mut cmd = Command::new(args[0]);
-        cmd.args(&args[1..]).current_dir(root);
-        eprintln!("cd {}; {cmd:?}", root.display());
-        match cmd.status() {
-            Ok(s) => {
-                eprintln!("\n\n{cmd:?}: {s}");
-                s.success()
-            }
-            Err(e) => {
-                eprintln!("\n\n{cmd:?}: {e}");
-                false
-            }
-        }
-    };
-    let maybe_run = |path: &str, args: &[&str]| {
-        if contains(path) {
-            run(args)
-        } else {
-            false
-        }
-    };
-
-    maybe_run("Makefile", &["make", "install"]);
-
-    // Only run one of these for `node_modules`.
-    let mut nm = false;
-    nm = nm || maybe_run("bun.lockb", &["bun", "install", "--prefer-offline"]);
-    nm = nm || maybe_run("pnpm-lock.yaml", &["pnpm", "install", "--prefer-offline"]);
-    nm = nm || maybe_run("yarn.lock", &["yarn", "install", "--prefer-offline"]);
-    nm = nm || maybe_run("package.json", &["npm", "install", "--prefer-offline"]);
-    let _ = nm;
 }
 
 /// Setup an empty test project and return a command pointing to the forge


### PR DESCRIPTION
Instead of automatically detecting based on the files in the root.

This was not done initially because adding args to the macro was annoying.

Should fix external test "ran out of space" error by not running unnecessary installing commands.