### PR TITLE
perf: touch up flatten_contracts

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -125,12 +125,9 @@ pub fn flatten_contracts(
         contracts
             .iter()
             .filter_map(|(id, c)| {
-                let bytecode = if deployed_code {
-                    c.deployed_bytecode.clone().into_bytes()
-                } else {
-                    c.bytecode.clone().into_bytes()
-                };
-                bytecode.map(|bytecode| (id.clone(), (c.abi.clone(), bytecode.into())))
+                let bytecode =
+                    if deployed_code { c.deployed_bytecode.bytes() } else { c.bytecode.bytes() };
+                bytecode.cloned().map(|code| (id.clone(), (c.abi.clone(), code.into())))
             })
             .collect(),
     )


### PR DESCRIPTION
Don't clone the entire code object to get only the bytes out of it.