### PR TITLE
chore(`common`): remove unneeded ethers conversions

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,6 +1,5 @@
 //! Temporary utility conversion traits between ethers-rs and alloy types.
 
-use alloy_json_abi::{Event, EventParam, Function, InternalType, Param, StateMutability};
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, I256, U128, U256, U64};
 use alloy_rpc_types::{
     other::OtherFields,
@@ -8,15 +7,12 @@ use alloy_rpc_types::{
     AccessList, AccessListItem, Signature, Transaction,
 };
 use alloy_signer::{LocalWallet, Signer};
-use ethers_core::{
-    abi as ethabi,
-    types::{
-        transaction::eip2930::{
-            AccessList as EthersAccessList, AccessListItem as EthersAccessListItem,
-        },
-        Bloom as EthersBloom, Bytes as EthersBytes, TransactionRequest, H160, H256, H64,
-        I256 as EthersI256, U256 as EthersU256, U64 as EthersU64,
+use ethers_core::types::{
+    transaction::eip2930::{
+        AccessList as EthersAccessList, AccessListItem as EthersAccessListItem,
     },
+    Bloom as EthersBloom, Bytes as EthersBytes, TransactionRequest, H160, H256, H64,
+    I256 as EthersI256, U256 as EthersU256, U64 as EthersU64,
 };
 
 /// Conversion trait to easily convert from Ethers types to Alloy types.
@@ -207,101 +203,6 @@ impl ToAlloy for EthersAccessListItem {
         AccessListItem {
             address: self.address.to_alloy(),
             storage_keys: self.storage_keys.into_iter().map(ToAlloy::to_alloy).collect(),
-        }
-    }
-}
-
-impl ToAlloy for ethabi::Event {
-    type To = Event;
-
-    fn to_alloy(self) -> Self::To {
-        Event {
-            name: self.name,
-            inputs: self.inputs.into_iter().map(ToAlloy::to_alloy).collect(),
-            anonymous: self.anonymous,
-        }
-    }
-}
-
-impl ToAlloy for ethabi::Function {
-    type To = Function;
-
-    fn to_alloy(self) -> Self::To {
-        Function {
-            name: self.name,
-            inputs: self.inputs.into_iter().map(ToAlloy::to_alloy).collect(),
-            outputs: self.outputs.into_iter().map(ToAlloy::to_alloy).collect(),
-            state_mutability: self.state_mutability.to_alloy(),
-        }
-    }
-}
-
-impl ToAlloy for ethabi::Param {
-    type To = Param;
-
-    fn to_alloy(self) -> Self::To {
-        let (ty, components) = self.kind.to_alloy();
-        Param {
-            name: self.name,
-            ty,
-            internal_type: self.internal_type.as_deref().and_then(InternalType::parse),
-            components,
-        }
-    }
-}
-
-impl ToAlloy for ethabi::EventParam {
-    type To = EventParam;
-
-    fn to_alloy(self) -> Self::To {
-        let (ty, components) = self.kind.to_alloy();
-        EventParam { name: self.name, ty, internal_type: None, components, indexed: self.indexed }
-    }
-}
-
-impl ToAlloy for ethabi::ParamType {
-    type To = (String, Vec<Param>);
-
-    fn to_alloy(self) -> Self::To {
-        let (s, t) = split_pt(self);
-        (s, t.into_iter().map(pt_to_param).collect())
-    }
-}
-
-fn split_pt(x: ethabi::ParamType) -> (String, Vec<ethabi::ParamType>) {
-    let s = ethabi::ethabi::param_type::Writer::write_for_abi(&x, false);
-    let t = get_tuple(x);
-    (s, t)
-}
-
-fn get_tuple(x: ethabi::ParamType) -> Vec<ethabi::ParamType> {
-    match x {
-        ethabi::ParamType::FixedArray(x, _) | ethabi::ParamType::Array(x) => get_tuple(*x),
-        ethabi::ParamType::Tuple(t) => t,
-        _ => Default::default(),
-    }
-}
-
-fn pt_to_param(x: ethabi::ParamType) -> Param {
-    let (ty, components) = split_pt(x);
-    Param {
-        name: String::new(),
-        ty,
-        internal_type: None,
-        components: components.into_iter().map(pt_to_param).collect(),
-    }
-}
-
-impl ToAlloy for ethabi::StateMutability {
-    type To = StateMutability;
-
-    #[inline(always)]
-    fn to_alloy(self) -> Self::To {
-        match self {
-            ethabi::StateMutability::Pure => StateMutability::Pure,
-            ethabi::StateMutability::View => StateMutability::View,
-            ethabi::StateMutability::NonPayable => StateMutability::NonPayable,
-            ethabi::StateMutability::Payable => StateMutability::Payable,
         }
     }
 }


### PR DESCRIPTION
These are unneeded.
