### PR TITLE
perf: `LocalTraceIdentifier` optimization

### DIFF
--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -2,17 +2,25 @@ use super::{AddressIdentity, TraceIdentifier};
 use alloy_json_abi::{Event, Function};
 use alloy_primitives::Address;
 use foundry_common::contracts::{diff_score, ContractsByArtifact};
-use ordered_float::OrderedFloat;
+use foundry_compilers::ArtifactId;
 use std::borrow::Cow;
 
 /// A trace identifier that tries to identify addresses using local contracts.
 pub struct LocalTraceIdentifier<'a> {
     known_contracts: &'a ContractsByArtifact,
+    // Vector of pairs of artifact id and the code length of the given artifact.
+    // Stored in descending order of code length to optimize the search.
+    ordered_ids: Vec<(&'a ArtifactId, usize)>,
 }
 
 impl<'a> LocalTraceIdentifier<'a> {
     pub fn new(known_contracts: &'a ContractsByArtifact) -> Self {
-        Self { known_contracts }
+        let mut ordered_ids =
+            known_contracts.iter().map(|(id, contract)| (id, contract.1.len())).collect::<Vec<_>>();
+        ordered_ids.sort_by_key(|(_, len)| *len);
+        ordered_ids.reverse();
+
+        Self { known_contracts, ordered_ids }
     }
 
     /// Get all the functions of the local contracts.
@@ -24,6 +32,36 @@ impl<'a> LocalTraceIdentifier<'a> {
     pub fn events(&self) -> impl Iterator<Item = &Event> {
         self.known_contracts.iter().flat_map(|(_, (abi, _))| abi.events())
     }
+
+    /// Iterates over artifacts with code length less than or equal to the given code and tries to
+    /// find a match.
+    ///
+    /// We do not consider artifacts with code length greater than the given code length as it is
+    /// considered that after compilation code can only be extended by additional parameters
+    /// (immutables) and cannot be shortened.
+    pub fn identify_code(&'a self, code: &[u8]) -> Option<&'a ArtifactId> {
+        let ids = self
+            .ordered_ids
+            .iter()
+            .filter(|(_, known_code_len)| code.len() >= *known_code_len)
+            .map(|(id, _)| *id);
+
+        let mut min_score = 1.0;
+        let mut min_score_id = None;
+        for id in ids {
+            let (_, known_code) = self.known_contracts.get(id)?;
+            let score = diff_score(code, known_code);
+            if score < 0.1 {
+                return Some(id);
+            }
+            if score < min_score {
+                min_score = score;
+                min_score_id = Some(id);
+            }
+        }
+
+        min_score_id
+    }
 }
 
 impl TraceIdentifier for LocalTraceIdentifier<'_> {
@@ -33,22 +71,8 @@ impl TraceIdentifier for LocalTraceIdentifier<'_> {
     {
         addresses
             .filter_map(|(address, code)| {
-                let code = code?;
-                let (_, id, abi) = self
-                    .known_contracts
-                    .iter()
-                    .filter_map(|(id, (abi, known_code))| {
-                        let score = diff_score(known_code, code);
-                        // Note: the diff score can be inaccurate for small contracts so we're using
-                        // a relatively high threshold here to avoid filtering out too many
-                        // contracts.
-                        if score < 0.85 {
-                            Some((OrderedFloat(score), id, abi))
-                        } else {
-                            None
-                        }
-                    })
-                    .min_by_key(|(score, _, _)| *score)?;
+                let id = self.identify_code(code?)?;
+                let (abi, _) = self.known_contracts.get(id)?;
 
                 Some(AddressIdentity {
                     address: *address,


### PR DESCRIPTION
I believe that it's safe to assume that after compilation artifact deployed bytecode will not decrease its size, and in most of the cases, artifact bytecode length exactly matches the deployed on-chain bytecode.

Thus, the new impl iterates over artifacts with bytecode length less than or equal in descending order. Artifact with exact same length as the on-chain code will always be checked first, and if it's diff_score < 0.1, we will exit early.

Not sure about 0.1 magic constant, but we are using it in `find_by_code` and it seems fine

I've tested it on several codebase and haven't noticed any regression, some contracts even got identified more correctly