### PR TITLE
feat(forge): add calldata and returndata views to debugger

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -219,7 +219,6 @@ impl DebuggerContext<'_> {
             }
             KeyCode::Char('b') => {
                 self.active_buffer = self.active_buffer.next();
-                // todo: keep track of last scroll position?
                 self.draw_memory.current_buf_startline = 0;
             }
             // Go to top of file

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -21,46 +21,46 @@ pub(crate) struct DrawMemory {
 #[derive(Debug, PartialEq, Default)]
 pub(crate) enum ActiveBuffer {
     #[default]
-    MEMORY,
-    CALLDATA,
-    RETURNDATA,
+    Memory,
+    Calldata,
+    Returndata,
 }
 
 /// Used to note which buffer is being read from by an opcode, if any.
 #[derive(Debug, Default)]
 pub(crate) enum BufferReadAccess {
     #[default]
-    NONE,
-    MEMORY,
-    CALLDATA,
-    RETURNDATA,
+    None,
+    Memory,
+    Calldata,
+    Returndata,
 }
 
 impl ActiveBuffer {
     /// Helper to cycle through the active buffers.
     pub(crate) fn next(&self) -> Self {
         match self {
-            ActiveBuffer::MEMORY => ActiveBuffer::CALLDATA,
-            ActiveBuffer::CALLDATA => ActiveBuffer::RETURNDATA,
-            ActiveBuffer::RETURNDATA => ActiveBuffer::MEMORY,
+            ActiveBuffer::Memory => ActiveBuffer::Calldata,
+            ActiveBuffer::Calldata => ActiveBuffer::Returndata,
+            ActiveBuffer::Returndata => ActiveBuffer::Memory,
         }
     }
 
     /// Helper to compare the active buffer with a buffer read access.
     pub(crate) fn compare(&self, other: &BufferReadAccess) -> bool {
         match self {
-            ActiveBuffer::MEMORY => matches!(other, BufferReadAccess::MEMORY),
-            ActiveBuffer::CALLDATA => matches!(other, BufferReadAccess::CALLDATA),
-            ActiveBuffer::RETURNDATA => matches!(other, BufferReadAccess::RETURNDATA),
+            ActiveBuffer::Memory => matches!(other, BufferReadAccess::Memory),
+            ActiveBuffer::Calldata => matches!(other, BufferReadAccess::Calldata),
+            ActiveBuffer::Returndata => matches!(other, BufferReadAccess::Returndata),
         }
     }
 
     /// Helper to format the title of the active buffer pane
     pub(crate) fn title(&self, size: usize) -> String {
         match self {
-            ActiveBuffer::MEMORY => format!("Memory (max expansion: {} bytes)", size),
-            ActiveBuffer::CALLDATA => format!("Calldata (size: {} bytes)", size),
-            ActiveBuffer::RETURNDATA => format!("Returndata (size: {} bytes)", size),
+            ActiveBuffer::Memory => format!("Memory (max expansion: {} bytes)", size),
+            ActiveBuffer::Calldata => format!("Calldata (size: {} bytes)", size),
+            ActiveBuffer::Returndata => format!("Returndata (size: {} bytes)", size),
         }
     }
 }
@@ -98,7 +98,7 @@ impl<'a> DebuggerContext<'a> {
             stack_labels: false,
             buf_utf: false,
             show_shortcuts: true,
-            active_buffer: ActiveBuffer::MEMORY,
+            active_buffer: ActiveBuffer::Memory,
         }
     }
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -18,49 +18,29 @@ pub(crate) struct DrawMemory {
 }
 
 /// Used to keep track of which buffer is currently active to be drawn by the debugger.
-#[derive(Debug, PartialEq, Default)]
-pub(crate) enum ActiveBuffer {
-    #[default]
+#[derive(Debug, PartialEq)]
+pub(crate) enum BufferKind {
     Memory,
     Calldata,
     Returndata,
 }
 
-/// Used to note which buffer is being read from by an opcode, if any.
-#[derive(Debug, Default)]
-pub(crate) enum BufferReadAccess {
-    #[default]
-    None,
-    Memory,
-    Calldata,
-    Returndata,
-}
-
-impl ActiveBuffer {
+impl BufferKind {
     /// Helper to cycle through the active buffers.
     pub(crate) fn next(&self) -> Self {
         match self {
-            ActiveBuffer::Memory => ActiveBuffer::Calldata,
-            ActiveBuffer::Calldata => ActiveBuffer::Returndata,
-            ActiveBuffer::Returndata => ActiveBuffer::Memory,
-        }
-    }
-
-    /// Helper to compare the active buffer with a buffer read access.
-    pub(crate) fn compare(&self, other: &BufferReadAccess) -> bool {
-        match self {
-            ActiveBuffer::Memory => matches!(other, BufferReadAccess::Memory),
-            ActiveBuffer::Calldata => matches!(other, BufferReadAccess::Calldata),
-            ActiveBuffer::Returndata => matches!(other, BufferReadAccess::Returndata),
+            BufferKind::Memory => BufferKind::Calldata,
+            BufferKind::Calldata => BufferKind::Returndata,
+            BufferKind::Returndata => BufferKind::Memory,
         }
     }
 
     /// Helper to format the title of the active buffer pane
     pub(crate) fn title(&self, size: usize) -> String {
         match self {
-            ActiveBuffer::Memory => format!("Memory (max expansion: {} bytes)", size),
-            ActiveBuffer::Calldata => format!("Calldata (size: {} bytes)", size),
-            ActiveBuffer::Returndata => format!("Returndata (size: {} bytes)", size),
+            BufferKind::Memory => format!("Memory (max expansion: {} bytes)", size),
+            BufferKind::Calldata => format!("Calldata (size: {} bytes)", size),
+            BufferKind::Returndata => format!("Returndata (size: {} bytes)", size),
         }
     }
 }
@@ -81,7 +61,7 @@ pub(crate) struct DebuggerContext<'a> {
     pub(crate) buf_utf: bool,
     pub(crate) show_shortcuts: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
-    pub(crate) active_buffer: ActiveBuffer,
+    pub(crate) active_buffer: BufferKind,
 }
 
 impl<'a> DebuggerContext<'a> {
@@ -98,7 +78,7 @@ impl<'a> DebuggerContext<'a> {
             stack_labels: false,
             buf_utf: false,
             show_shortcuts: true,
-            active_buffer: ActiveBuffer::Memory,
+            active_buffer: BufferKind::Memory,
         }
     }
 
@@ -144,9 +124,9 @@ impl<'a> DebuggerContext<'a> {
 
     fn active_buffer(&self) -> &[u8] {
         match self.active_buffer {
-            ActiveBuffer::Memory => &self.current_step().memory,
-            ActiveBuffer::Calldata => &self.current_step().calldata,
-            ActiveBuffer::Returndata => &self.current_step().returndata,
+            BufferKind::Memory => &self.current_step().memory,
+            BufferKind::Calldata => &self.current_step().calldata,
+            BufferKind::Returndata => &self.current_step().returndata,
         }
     }
 }

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -141,6 +141,14 @@ impl<'a> DebuggerContext<'a> {
     fn opcode_list(&self) -> Vec<String> {
         self.debug_steps().iter().map(DebugStep::pretty_opcode).collect()
     }
+
+    fn active_buffer(&self) -> &[u8] {
+        match self.active_buffer {
+            ActiveBuffer::Memory => &self.current_step().memory,
+            ActiveBuffer::Calldata => &self.current_step().calldata,
+            ActiveBuffer::Returndata => &self.current_step().returndata,
+        }
+    }
 }
 
 impl DebuggerContext<'_> {
@@ -173,8 +181,8 @@ impl DebuggerContext<'_> {
                 // Grab number of times to do it
                 for _ in 0..buffer_as_number(&self.key_buffer, 1) {
                     if event.modifiers.contains(KeyModifiers::CONTROL) {
-                        let max_mem = (self.current_step().memory.len() / 32).saturating_sub(1);
-                        if self.draw_memory.current_buf_startline < max_mem {
+                        let max_buf = (self.active_buffer().len() / 32).saturating_sub(1);
+                        if self.draw_memory.current_buf_startline < max_buf {
                             self.draw_memory.current_buf_startline += 1;
                         }
                     } else if self.current_step < self.opcode_list.len() - 1 {

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -667,24 +667,22 @@ struct BufferAccesses {
 fn get_buffer_accesses(op: u8, stack: &[U256]) -> Option<BufferAccesses> {
     let buffer_access = match op {
         opcode::KECCAK256 | opcode::RETURN | opcode::REVERT => {
-            (Some((BufferKind::Memory, 1, 2)), Some((0, 0)))
+            (Some((BufferKind::Memory, 1, 2)), None)
         }
         opcode::CALLDATACOPY => (Some((BufferKind::Calldata, 2, 3)), Some((1, 3))),
         opcode::RETURNDATACOPY => (Some((BufferKind::Returndata, 2, 3)), Some((1, 3))),
-        opcode::CALLDATALOAD => (Some((BufferKind::Calldata, 1, -1)), Some((0, 0))),
-        opcode::CODECOPY => (Some((BufferKind::Memory, 0, 0)), Some((1, 3))),
-        opcode::EXTCODECOPY => (Some((BufferKind::Memory, 0, 0)), Some((2, 4))),
-        opcode::MLOAD => (Some((BufferKind::Memory, 1, -1)), Some((0, 0))),
-        opcode::MSTORE => (Some((BufferKind::Memory, 0, 0)), Some((1, -1))),
-        opcode::MSTORE8 => (Some((BufferKind::Memory, 0, 0)), Some((1, -2))),
+        opcode::CALLDATALOAD => (Some((BufferKind::Calldata, 1, -1)), None),
+        opcode::CODECOPY => (None, Some((1, 3))),
+        opcode::EXTCODECOPY => (None, Some((2, 4))),
+        opcode::MLOAD => (Some((BufferKind::Memory, 1, -1)), None),
+        opcode::MSTORE => (None, Some((1, -1))),
+        opcode::MSTORE8 => (None, Some((1, -2))),
         opcode::LOG0 | opcode::LOG1 | opcode::LOG2 | opcode::LOG3 | opcode::LOG4 => {
-            (Some((BufferKind::Memory, 1, 2)), Some((0, 0)))
+            (Some((BufferKind::Memory, 1, 2)), None)
         }
-        opcode::CREATE | opcode::CREATE2 => (Some((BufferKind::Memory, 2, 3)), Some((0, 0))),
-        opcode::CALL | opcode::CALLCODE => (Some((BufferKind::Memory, 4, 5)), Some((0, 0))),
-        opcode::DELEGATECALL | opcode::STATICCALL => {
-            (Some((BufferKind::Memory, 3, 4)), Some((0, 0)))
-        }
+        opcode::CREATE | opcode::CREATE2 => (Some((BufferKind::Memory, 2, 3)), None),
+        opcode::CALL | opcode::CALLCODE => (Some((BufferKind::Memory, 4, 5)), None),
+        opcode::DELEGATECALL | opcode::STATICCALL => (Some((BufferKind::Memory, 3, 4)), None),
         _ => Default::default(),
     };
 

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -503,9 +503,9 @@ impl DebuggerContext<'_> {
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
         let step = self.current_step();
         let buf = match self.active_buffer {
-            ActiveBuffer::MEMORY => &step.memory,
-            ActiveBuffer::CALLDATA => &step.calldata,
-            ActiveBuffer::RETURNDATA => &step.returndata,
+            ActiveBuffer::Memory => &step.memory,
+            ActiveBuffer::Calldata => &step.calldata,
+            ActiveBuffer::Returndata => &step.returndata,
         };
 
         let min_len = hex_digits(buf.len());
@@ -523,7 +523,7 @@ impl DebuggerContext<'_> {
                     offset = read_offset;
                     size = read_size;
                     color = Some(Color::Cyan);
-                } else if write_offset.is_some() && self.active_buffer == ActiveBuffer::MEMORY {
+                } else if write_offset.is_some() && self.active_buffer == ActiveBuffer::Memory {
                     // memory is the only volatile buffer, so hardcode memory check
                     offset = write_offset;
                     size = write_size;
@@ -538,7 +538,7 @@ impl DebuggerContext<'_> {
             let prev_step = &self.debug_steps()[prev_step];
             if let Instruction::OpCode(op) = prev_step.instruction {
                 let (_, _, _, write_offset, write_size) = get_buffer_access(op, &prev_step.stack);
-                if write_offset.is_some() && self.active_buffer == ActiveBuffer::MEMORY {
+                if write_offset.is_some() && self.active_buffer == ActiveBuffer::Memory {
                     // memory is the only volatile buffer, so hardcode memory check
                     offset = write_offset;
                     size = write_size;
@@ -649,22 +649,22 @@ fn get_buffer_access(
 ) -> (BufferReadAccess, Option<usize>, Option<usize>, Option<usize>, Option<usize>) {
     let buffer_access = match op {
         opcode::KECCAK256 | opcode::RETURN | opcode::REVERT => {
-            (BufferReadAccess::MEMORY, 1, 2, 0, 0)
+            (BufferReadAccess::Memory, 1, 2, 0, 0)
         }
-        opcode::CALLDATACOPY => (BufferReadAccess::CALLDATA, 2, 3, 1, 3),
-        opcode::RETURNDATACOPY => (BufferReadAccess::RETURNDATA, 2, 3, 1, 3),
-        opcode::CALLDATALOAD => (BufferReadAccess::CALLDATA, 1, -1, 0, 0),
-        opcode::CODECOPY => (BufferReadAccess::MEMORY, 0, 0, 1, 3),
-        opcode::EXTCODECOPY => (BufferReadAccess::MEMORY, 0, 0, 2, 4),
-        opcode::MLOAD => (BufferReadAccess::MEMORY, 1, -1, 0, 0),
-        opcode::MSTORE => (BufferReadAccess::MEMORY, 0, 0, 1, -1),
-        opcode::MSTORE8 => (BufferReadAccess::MEMORY, 0, 0, 1, -2),
+        opcode::CALLDATACOPY => (BufferReadAccess::Calldata, 2, 3, 1, 3),
+        opcode::RETURNDATACOPY => (BufferReadAccess::Returndata, 2, 3, 1, 3),
+        opcode::CALLDATALOAD => (BufferReadAccess::Calldata, 1, -1, 0, 0),
+        opcode::CODECOPY => (BufferReadAccess::Memory, 0, 0, 1, 3),
+        opcode::EXTCODECOPY => (BufferReadAccess::Memory, 0, 0, 2, 4),
+        opcode::MLOAD => (BufferReadAccess::Memory, 1, -1, 0, 0),
+        opcode::MSTORE => (BufferReadAccess::Memory, 0, 0, 1, -1),
+        opcode::MSTORE8 => (BufferReadAccess::Memory, 0, 0, 1, -2),
         opcode::LOG0 | opcode::LOG1 | opcode::LOG2 | opcode::LOG3 | opcode::LOG4 => {
-            (BufferReadAccess::MEMORY, 1, 2, 0, 0)
+            (BufferReadAccess::Memory, 1, 2, 0, 0)
         }
-        opcode::CREATE | opcode::CREATE2 => (BufferReadAccess::MEMORY, 2, 3, 0, 0),
-        opcode::CALL | opcode::CALLCODE => (BufferReadAccess::MEMORY, 4, 5, 0, 0),
-        opcode::DELEGATECALL | opcode::STATICCALL => (BufferReadAccess::MEMORY, 3, 4, 0, 0),
+        opcode::CREATE | opcode::CREATE2 => (BufferReadAccess::Memory, 2, 3, 0, 0),
+        opcode::CALL | opcode::CALLCODE => (BufferReadAccess::Memory, 4, 5, 0, 0),
+        opcode::DELEGATECALL | opcode::STATICCALL => (BufferReadAccess::Memory, 3, 4, 0, 0),
         _ => Default::default(),
     };
 

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -520,8 +520,6 @@ impl DebuggerContext<'_> {
                 let (read_buffer_accessed, read_offset, read_size, write_offset, write_size) =
                     get_buffer_access(op, &step.stack);
 
-                // if (let Some(buffer) = read_buffer_accessed) == self.active_buffer &&
-                // read_offset.is_some() {
                 if read_offset.is_some() &&
                     read_buffer_accessed.is_some_and(|b| b == self.active_buffer)
                 {

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -169,6 +169,10 @@ pub struct DebugStep {
     pub stack: Vec<U256>,
     /// Memory *prior* to running the associated opcode
     pub memory: Vec<u8>,
+    /// Calldata *prior* to running the associated opcode
+    pub calldata: Vec<u8>,
+    /// Returndata *prior* to running the associated opcode
+    pub returndata: Vec<u8>,
     /// Opcode to be executed
     pub instruction: Instruction,
     /// Optional bytes that are being pushed onto the stack
@@ -187,6 +191,8 @@ impl Default for DebugStep {
         Self {
             stack: vec![],
             memory: Default::default(),
+            calldata: Default::default(),
+            returndata: Default::default(),
             instruction: Instruction::OpCode(revm::interpreter::opcode::INVALID),
             push_bytes: None,
             pc: 0,

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -75,6 +75,8 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             pc,
             stack: interpreter.stack().data().clone(),
             memory: interpreter.shared_memory.context_memory().to_vec(),
+            calldata: interpreter.contract().input.to_vec(),
+            returndata: interpreter.return_data_buffer.to_vec(),
             instruction: Instruction::OpCode(op),
             push_bytes,
             total_gas_used,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

It's often useful to see what data is actually in calldata/returndata, as well as see which regions are being operated on.

Closes #5492.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add calldata and returndata to `DebugStep`
- Add `active_buffer` to `DebuggerContext`
- `get_memory_access` -> `get_buffer_accesses`; note which buffer is being read from, if any; simplify return type
- `draw_memory` -> `draw_buffer`; compare read/writes to current active buffer 
- add `b` ("buffer") operator to debugger to cycle Memory -> Calldata -> Returndata buffers in the "buffer" panel view
- add `b` to help string; update references of "memory" to "buffer"

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Unsure of where debugger tests live (if anywhere), but draw logic seems to handle edge cases well; I'd be most concerned about potential performance issues or highlighting regions in the wrong buffer.

Screenshots:

Calldata access:
<img width="1171" alt="Screenshot 2024-02-13 at 2 10 15 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/2df93b84-23ea-41e9-befe-001ac67fc5bf">
Memory overwrite from calldatacopy:
<img width="1172" alt="Screenshot 2024-02-13 at 2 11 32 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/8515a440-bd5b-4876-add9-48da8a1c052e">
Returndata access:
<img width="1169" alt="Screenshot 2024-02-13 at 2 10 42 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/13debb84-1c27-4b76-a483-2459d58678ac">
Memory overwrite from returndatacopy:
<img width="1171" alt="Screenshot 2024-02-13 at 2 10 55 PM" src="https://github.com/foundry-rs/foundry/assets/6371847/a7349066-bd9d-4531-8a34-484a902e997e">
