### PR TITLE
ci: disable debuginfo for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       matrix: ${{ fromJson(needs.matrices.outputs.test-matrix) }}
     env:
       ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/C3JEvfW6VgtqZQa-Qp1E-2srEiIc02sD
+      CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Halves the size of target/, which currently with debug=1, all target, clean build, is 12gb.
Should fix CI issues with out of space.