### PR TITLE
feat(`foundry-common`): NameOrAddress ENS util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -101,7 +101,7 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -168,7 +168,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -303,7 +303,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -374,7 +374,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.7",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+source = "git+https://github.com/alloy-rs/alloy#d0fb78ac708a9bd15f3964fc3006dcae2992489d"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -99,10 +99,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-contract"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-providers",
+ "alloy-rpc-types",
+ "alloy-sol-types",
+ "alloy-transport",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-dyn-abi"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7265ac54c88a78604cea8444addfa9dfdad08d3098f153484cb4ee66fc202cc"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -122,7 +136,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -133,7 +147,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -143,8 +157,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c5aecfe87e06da0e760840974c6e3cc19d4247be17a3172825fbbe759c8e60"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -155,7 +168,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -166,7 +179,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -178,8 +191,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b6fb2b432ff223d513db7f908937f63c252bee0af9b82bfd25b0a5dd1eb0d8"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -205,7 +217,7 @@ dependencies = [
 [[package]]
 name = "alloy-providers"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -224,7 +236,7 @@ dependencies = [
 [[package]]
 name = "alloy-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -263,7 +275,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -280,7 +292,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-trace-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -291,7 +303,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -304,7 +316,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -323,8 +335,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0b5ab0cb07c21adf9d72e988b34e8200ce648c2bba8d009183bb1c50fb1216"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -343,8 +354,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd124ec0a456ec5e9dcca5b6e8b011bc723cc410d4d9a66bf032770feaeef4b"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "winnow 0.5.40",
 ]
@@ -352,8 +362,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c08f62ded7ce03513bfb60ef5cad4fff5d4f67eac6feb4df80426b7b9ffb06e"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -365,7 +374,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.21.7",
@@ -381,7 +390,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -394,7 +403,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -412,7 +421,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy#a4453d42ffb755a46bace2ceca3baa454e0cd807"
+source = "git+https://github.com/alloy-rs/alloy#b9dd518b12efd27ab706ae6ffa9ad6b05df451c7"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1248,6 +1257,7 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 name = "cast"
 version = "0.2.0"
 dependencies = [
+ "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
@@ -3039,6 +3049,7 @@ dependencies = [
 name = "foundry-common"
 version = "0.2.0"
 dependencies = [
+ "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -3152,7 +3163,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml 0.8.10",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.5",
  "tracing",
  "walkdir",
 ]
@@ -7240,8 +7251,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63bef2e2c735acbc06874eca3a8506f02a3c4700e6e748afc92cc2e4220e8a03"
+source = "git+https://github.com/alloy-rs/core?rev=18b0509950c90d9ec38f25913b692ae4cdd6f227#18b0509950c90d9ec38f25913b692ae4cdd6f227"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ ethers-solc = { version = "2.0", default-features = false }
 
 ## alloy
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy" }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy" }
 alloy-genesis = { git = "https://github.com/alloy-rs/alloy" }
 alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy" }
@@ -164,9 +165,9 @@ alloy-transport-http = { git = "https://github.com/alloy-rs/alloy" }
 alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy" }
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy" }
 alloy-primitives = { version = "0.6.2", features = ["getrandom"] }
-alloy-dyn-abi = "0.6.2"
-alloy-json-abi = "0.6.2"
-alloy-sol-types = "0.6.2"
+alloy-dyn-abi = "0.6"
+alloy-json-abi = "0.6"
+alloy-sol-types = "0.6"
 syn-solidity = "0.6.0"
 alloy-chains = "0.1"
 
@@ -226,6 +227,11 @@ ethers-providers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b1
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
 ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
 ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "18b0509950c90d9ec38f25913b692ae4cdd6f227" }
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "18b0509950c90d9ec38f25913b692ae4cdd6f227" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "18b0509950c90d9ec38f25913b692ae4cdd6f227" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "18b0509950c90d9ec38f25913b692ae4cdd6f227" }
 
 revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -268,7 +268,7 @@ impl ClientFork {
 
         let block_id = BlockId::Number(blocknumber.into());
 
-        let code = self.provider().get_code_at(address, block_id).await?;
+        let code = self.provider().get_code_at(address, Some(block_id)).await?;
 
         let mut storage = self.storage_write();
         storage.code_at.insert((address, blocknumber), code.clone().0.into());

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -33,6 +33,7 @@ alloy-transport-ipc.workspace = true
 alloy-json-rpc.workspace = true
 alloy-pubsub.workspace = true
 alloy-sol-types.workspace = true
+alloy-contract.workspace = true
 
 tower.workspace = true
 

--- a/crates/common/src/ens.rs
+++ b/crates/common/src/ens.rs
@@ -1,6 +1,6 @@
 //! ENS Name resolving utilities.
 #![allow(missing_docs)]
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use alloy_primitives::{address, keccak256, Address, B256};
 use alloy_providers::provider::TempProvider;
@@ -39,21 +39,21 @@ impl NameOrAddress {
     /// Resolves the name to an Ethereum Address.
     pub async fn resolve<P: TempProvider>(
         &self,
-        provider: Arc<P>,
+        provider: &P,
     ) -> Result<Address, EnsResolutionError> {
         let name = match self {
             NameOrAddress::Name(name) => name.clone(),
             NameOrAddress::Address(addr) => return Ok(*addr),
         };
         let node = namehash(&name);
-        let registry = EnsRegistry::new(ENS_ADDRESS, provider.clone());
+        let registry = EnsRegistry::new(ENS_ADDRESS, provider);
         let resolver = registry
             .resolver(node)
             .call()
             .await
             .map_err(|err| EnsResolutionError::EnsRegistryResolutionFailed(err.to_string()))?
             ._0;
-        let resolver = EnsResolver::new(resolver, provider.clone());
+        let resolver = EnsResolver::new(resolver, provider);
         let addr = resolver
             .addr(node)
             .call()
@@ -79,12 +79,6 @@ impl From<&String> for NameOrAddress {
 impl From<Address> for NameOrAddress {
     fn from(addr: Address) -> Self {
         NameOrAddress::Address(addr)
-    }
-}
-
-impl From<&str> for NameOrAddress {
-    fn from(name: &str) -> Self {
-        Self::from_str(name).unwrap()
     }
 }
 

--- a/crates/common/src/ens.rs
+++ b/crates/common/src/ens.rs
@@ -1,10 +1,9 @@
 //! ENS Name resolving utilities.
 #![allow(missing_docs)]
-use std::str::FromStr;
-
 use alloy_primitives::{address, keccak256, Address, B256};
 use alloy_providers::provider::TempProvider;
 use alloy_sol_types::sol;
+use std::str::FromStr;
 
 // ENS Registry and Resolver contracts.
 sol! {

--- a/crates/common/src/ens.rs
+++ b/crates/common/src/ens.rs
@@ -1,0 +1,146 @@
+//! ENS Name resolving utilities.
+#![allow(missing_docs)]
+use std::{str::FromStr, sync::Arc};
+
+use alloy_primitives::{address, keccak256, Address, B256};
+use alloy_providers::provider::TempProvider;
+use alloy_sol_types::sol;
+
+// ENS Registry and Resolver contracts.
+sol! {
+    #[sol(rpc)]
+    // ENS Registry contract.
+    contract EnsRegistry {
+        /// Returns the resolver for the specified node.
+        function resolver(bytes32 node) view returns (address);
+    }
+
+    #[sol(rpc)]
+    // ENS Resolver interface.
+    contract EnsResolver {
+        // Returns the address associated with the specified node.
+        function addr(bytes32 node) view returns (address);
+    }
+}
+
+/// ENS registry address (`0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`)
+pub const ENS_ADDRESS: Address = address!("00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+
+/// ENS name or Ethereum Address.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NameOrAddress {
+    /// An ENS Name (format does not get checked)
+    Name(String),
+    /// An Ethereum Address
+    Address(Address),
+}
+
+impl NameOrAddress {
+    /// Resolves the name to an Ethereum Address.
+    pub async fn resolve<P: TempProvider>(
+        &self,
+        provider: Arc<P>,
+    ) -> Result<Address, ResolveError> {
+        let name = match self {
+            NameOrAddress::Name(name) => name.clone(),
+            NameOrAddress::Address(addr) => return Ok(*addr),
+        };
+        let node = namehash(&name);
+        let registry = EnsRegistry::new(ENS_ADDRESS, provider.clone());
+        let resolver = registry
+            .resolver(node)
+            .call()
+            .await
+            .map_err(|err| ResolveError::EnsResolutionFailed(err.to_string()))?
+            ._0;
+        let resolver = EnsResolver::new(resolver, provider.clone());
+        let addr = resolver
+            .addr(node)
+            .call()
+            .await
+            .map_err(|err| ResolveError::EnsResolutionFailed(err.to_string()))?
+            ._0;
+        Ok(addr)
+    }
+}
+
+impl From<String> for NameOrAddress {
+    fn from(name: String) -> Self {
+        NameOrAddress::Name(name)
+    }
+}
+
+impl From<&String> for NameOrAddress {
+    fn from(name: &String) -> Self {
+        NameOrAddress::Name(name.clone())
+    }
+}
+
+impl From<Address> for NameOrAddress {
+    fn from(addr: Address) -> Self {
+        NameOrAddress::Address(addr)
+    }
+}
+
+impl From<&str> for NameOrAddress {
+    fn from(name: &str) -> Self {
+        Self::from_str(name).unwrap()
+    }
+}
+
+impl FromStr for NameOrAddress {
+    type Err = <Address as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(addr) = Address::from_str(s) {
+            Ok(NameOrAddress::Address(addr))
+        } else {
+            Ok(NameOrAddress::Name(s.to_string()))
+        }
+    }
+}
+
+/// Error type for ENS resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    /// ENS resolution failed.
+    #[error("ENS resolution failed: {0}")]
+    EnsResolutionFailed(String),
+}
+
+/// Returns the ENS namehash as specified in [EIP-137](https://eips.ethereum.org/EIPS/eip-137)
+pub fn namehash(name: &str) -> B256 {
+    if name.is_empty() {
+        return B256::ZERO
+    }
+
+    // Remove the variation selector U+FE0F
+    let name = name.replace('\u{fe0f}', "");
+
+    // Generate the node starting from the right
+    name.rsplit('.')
+        .fold([0u8; 32], |node, label| *keccak256([node, *keccak256(label.as_bytes())].concat()))
+        .into()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn assert_hex(hash: B256, val: &str) {
+        assert_eq!(hash.0.to_vec(), hex::decode(val).unwrap());
+    }
+
+    #[test]
+    fn test_namehash() {
+        for (name, expected) in &[
+            ("", "0000000000000000000000000000000000000000000000000000000000000000"),
+            ("foo.eth", "de9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"),
+            ("eth", "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"),
+            ("alice.eth", "0x787192fc5378cc32aa956ddfdedbf26b24e8d78e40109add0eea2c1a012c3dec"),
+            ("ret↩️rn.eth", "0x3de5f4c02db61b221e7de7f1c40e29b6e2f07eb48d65bf7e304715cd9ed33b24"),
+        ] {
+            assert_hex(namehash(name), expected);
+        }
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod calc;
 pub mod compile;
 pub mod constants;
 pub mod contracts;
+pub mod ens;
 pub mod errors;
 pub mod evm;
 pub mod fmt;

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -34,7 +34,7 @@ serde_regex = "1"
 serde.workspace = true
 thiserror = "1"
 toml = { version = "0.8", features = ["preserve_order"] }
-toml_edit = "0.21"
+toml_edit = "0.22.4"
 tracing.workspace = true
 walkdir = "2"
 

--- a/crates/evm/core/src/fork/backend.rs
+++ b/crates/evm/core/src/fork/backend.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_providers::provider::TempProvider;
-use alloy_rpc_types::{Block, BlockId, BlockNumberOrTag, Transaction};
+use alloy_rpc_types::{Block, BlockId, Transaction};
 use eyre::WrapErr;
 use foundry_common::NON_ARCHIVE_NODE_WARNING;
 use futures::{
@@ -196,8 +196,7 @@ where
         let fut = Box::pin(async move {
             let balance = provider.get_balance(address, block_id);
             let nonce = provider.get_transaction_count(address, block_id);
-            let code =
-                provider.get_code_at(address, block_id.unwrap_or(BlockNumberOrTag::Latest.into()));
+            let code = provider.get_code_at(address, block_id);
             let resp = tokio::try_join!(balance, nonce, code).map_err(Into::into);
             (resp, address)
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We need a foundry-specific utility to resolve ens names at the CLI level.

## Solution

Adds `NameOrAddress` for CLI use, which can resolve itself to an address, or error.

Part of #7106 