### PR TITLE
feat(`cast wallet list`) issue #6958: Include HW wallets in cast wallet ls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +1987,37 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.49",
 ]
 
@@ -3349,6 +3415,7 @@ dependencies = [
  "async-trait",
  "clap",
  "const-hex",
+ "derive_builder",
  "ethers-core",
  "ethers-providers",
  "ethers-signers",
@@ -4137,6 +4204,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -1,0 +1,158 @@
+use clap::Parser;
+use eyre::Result;
+
+use foundry_common::{fs, types::ToAlloy};
+use foundry_config::Config;
+use foundry_wallets::{multi_wallet::MultiWalletOptsBuilder, WalletSigner};
+
+/// CLI arguments for `cast wallet list`.
+#[derive(Clone, Debug, Parser)]
+pub struct ListArgs {
+    /// List all the accounts in the keystore directory.
+    /// Default keystore directory is used if no path provided.
+    #[clap(long, default_missing_value = "", num_args(0..=1), help_heading = "List local accounts")]
+    dir: Option<String>,
+
+    /// List accounts from a Ledger hardware wallet.
+    #[clap(long, short, help_heading = "List Ledger hardware wallet accounts")]
+    ledger: bool,
+
+    /// List accounts from a Trezor hardware wallet.
+    #[clap(long, short, help_heading = "List Trezor hardware wallet accounts")]
+    trezor: bool,
+
+    /// List accounts from AWS KMS.
+    #[clap(long, help_heading = "List AWS KMS account")]
+    aws: bool,
+
+    /// List all configured accounts.
+    #[clap(long, help_heading = "List all accounts")]
+    all: bool,
+}
+
+impl ListArgs {
+    pub async fn run(self) -> Result<()> {
+        // list local accounts as files in keystore dir, no need to unlock / provide password
+        if self.dir.is_some() || self.all || !self.ledger && !self.trezor && !self.aws {
+            self.list_local_senders().await?;
+        }
+
+        // Create options for multi wallet - ledger, trezor and AWS
+        let list_opts = MultiWalletOptsBuilder::default()
+            .ledger(self.ledger || self.all)
+            .mnemonic_indexes(Some(vec![0]))
+            .trezor(self.trezor || self.all)
+            .aws(self.aws || self.all)
+            .froms(None)
+            .interactives(0)
+            .private_keys(None)
+            .private_key(None)
+            .mnemonics(None)
+            .mnemonic_passphrases(None)
+            .hd_paths(None)
+            .keystore_paths(None)
+            .keystore_account_names(None)
+            .keystore_passwords(None)
+            .keystore_password_files(None)
+            .build()
+            .expect("build multi wallet");
+
+        // max number of senders to be shown for ledger and trezor signers
+        let max_senders = 3;
+
+        // List ledger accounts
+        match list_opts.ledgers().await {
+            Ok(signers) => {
+                self.list_senders(signers.unwrap_or_default(), max_senders, "Ledger").await?
+            }
+            Err(e) => {
+                if !self.all {
+                    println!("{}", e)
+                }
+            }
+        }
+
+        // List Trezor accounts
+        match list_opts.trezors().await {
+            Ok(signers) => {
+                self.list_senders(signers.unwrap_or_default(), max_senders, "Trezor").await?
+            }
+            Err(e) => {
+                if !self.all {
+                    println!("{}", e)
+                }
+            }
+        }
+
+        // List AWS accounts
+        match list_opts.aws_signers().await {
+            Ok(signers) => {
+                self.list_senders(signers.unwrap_or_default(), max_senders, "AWS").await?
+            }
+            Err(e) => {
+                if !self.all {
+                    println!("{}", e)
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn list_local_senders(&self) -> Result<()> {
+        let keystore_path = self.dir.clone().unwrap_or_default();
+        let keystore_dir = if keystore_path.is_empty() {
+            let default_dir = Config::foundry_keystores_dir()
+                .ok_or_else(|| eyre::eyre!("Could not find the default keystore directory."))?;
+            // Create the keystore directory if it doesn't exist
+            fs::create_dir_all(&default_dir)?;
+            default_dir
+        } else {
+            dunce::canonicalize(keystore_path)?
+        };
+
+        match std::fs::read_dir(keystore_dir) {
+            Ok(entries) => {
+                entries.flatten().for_each(|entry| {
+                    let path = entry.path();
+                    if path.is_file() && path.extension().is_none() {
+                        if let Some(file_name) = path.file_name() {
+                            if let Some(name) = file_name.to_str() {
+                                println!("{} (Local)", name);
+                            }
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                if !self.all {
+                    println!("{}", e)
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn list_senders(
+        &self,
+        signers: Vec<WalletSigner>,
+        max_senders: usize,
+        label: &str,
+    ) -> eyre::Result<()> {
+        for signer in signers.iter() {
+            match signer.available_senders(max_senders).await {
+                Ok(senders) => {
+                    senders.iter().for_each(|sender| println!("{} ({})", sender.to_alloy(), label));
+                }
+                Err(e) => {
+                    if !self.all {
+                        println!("{}", e)
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -33,7 +33,7 @@ pub struct ListArgs {
 impl ListArgs {
     pub async fn run(self) -> Result<()> {
         // list local accounts as files in keystore dir, no need to unlock / provide password
-        if self.dir.is_some() || self.all || !self.ledger && !self.trezor && !self.aws {
+        if self.dir.is_some() || self.all || (!self.ledger && !self.trezor && !self.aws) {
             self.list_local_senders().await?;
         }
 
@@ -43,17 +43,7 @@ impl ListArgs {
             .mnemonic_indexes(Some(vec![0]))
             .trezor(self.trezor || self.all)
             .aws(self.aws || self.all)
-            .froms(None)
             .interactives(0)
-            .private_keys(None)
-            .private_key(None)
-            .mnemonics(None)
-            .mnemonic_passphrases(None)
-            .hd_paths(None)
-            .keystore_paths(None)
-            .keystore_account_names(None)
-            .keystore_passwords(None)
-            .keystore_password_files(None)
             .build()
             .expect("build multi wallet");
 
@@ -102,9 +92,8 @@ impl ListArgs {
     async fn list_local_senders(&self) -> Result<()> {
         let keystore_path = self.dir.clone().unwrap_or_default();
         let keystore_dir = if keystore_path.is_empty() {
-            let default_dir = Config::foundry_keystores_dir()
-                .ok_or_else(|| eyre::eyre!("Could not find the default keystore directory."))?;
-            // Create the keystore directory if it doesn't exist
+            // Create the keystore default directory if it doesn't exist
+            let default_dir = Config::foundry_keystores_dir().unwrap();
             fs::create_dir_all(&default_dir)?;
             default_dir
         } else {

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -56,7 +56,7 @@ impl ListArgs {
                 match $signers.await {
                     Ok(signers) => {
                         self.list_senders(
-                            signers.unwrap_or_default(),
+                            &signers.unwrap_or_default(),
                             self.max_senders.unwrap(),
                             $label,
                         )
@@ -114,10 +114,10 @@ impl ListArgs {
 
     async fn list_senders(
         &self,
-        signers: Vec<WalletSigner>,
+        signers: &[WalletSigner],
         max_senders: usize,
         label: &str,
-    ) -> eyre::Result<()> {
+    ) -> Result<()> {
         for signer in signers.iter() {
             signer
                 .available_senders(max_senders)

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -50,41 +50,32 @@ impl ListArgs {
         // max number of senders to be shown for ledger and trezor signers
         let max_senders = 3;
 
-        // List ledger accounts
-        match list_opts.ledgers().await {
-            Ok(signers) => {
-                self.list_senders(signers.unwrap_or_default(), max_senders, "Ledger").await?
-            }
-            Err(e) => {
-                if !self.all {
-                    println!("{}", e)
+        macro_rules! list_signers {
+            ($signers:ident, $label: ident) => {
+                match $signers.await {
+                    Ok(signers) => {
+                        self.list_senders(signers.unwrap_or_default(), max_senders, $label).await?
+                    }
+                    Err(e) => {
+                        if !self.all {
+                            println!("{}", e)
+                        }
+                    }
                 }
-            }
+            };
         }
 
-        // List Trezor accounts
-        match list_opts.trezors().await {
-            Ok(signers) => {
-                self.list_senders(signers.unwrap_or_default(), max_senders, "Trezor").await?
-            }
-            Err(e) => {
-                if !self.all {
-                    println!("{}", e)
-                }
-            }
-        }
+        let label = "Ledger";
+        let signers = list_opts.ledgers();
+        list_signers!(signers, label);
 
-        // List AWS accounts
-        match list_opts.aws_signers().await {
-            Ok(signers) => {
-                self.list_senders(signers.unwrap_or_default(), max_senders, "AWS").await?
-            }
-            Err(e) => {
-                if !self.all {
-                    println!("{}", e)
-                }
-            }
-        }
+        let label = "Trezor";
+        let signers = list_opts.trezors();
+        list_signers!(signers, label);
+
+        let label = "AWS";
+        let signers = list_opts.aws_signers();
+        list_signers!(signers, label);
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -53,7 +53,7 @@ impl ListArgs {
 
         // macro to print senders for a list of signers
         macro_rules! list_senders {
-            ($signers:ident, $label: ident) => {
+            ($signers:expr, $label:literal) => {
                 match $signers.await {
                     Ok(signers) => {
                         for signer in signers.unwrap_or_default().iter() {
@@ -73,17 +73,9 @@ impl ListArgs {
             };
         }
 
-        let label = "Ledger";
-        let signers = list_opts.ledgers();
-        list_senders!(signers, label);
-
-        let label = "Trezor";
-        let signers = list_opts.trezors();
-        list_senders!(signers, label);
-
-        let label = "AWS";
-        let signers = list_opts.aws_signers();
-        list_senders!(signers, label);
+        list_senders!(list_opts.ledgers(), "Ledger");
+        list_senders!(list_opts.trezors(), "Trezor");
+        list_senders!(list_opts.aws_signers(), "AWS");
 
         Ok(())
     }

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -24,6 +24,7 @@ foundry-common.workspace = true
 
 async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+derive_builder = "0.20.0"
 eyre.workspace = true
 hex = { workspace = true, features = ["serde"] }
 itertools.workspace = true

--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -100,6 +100,7 @@ pub struct MultiWalletOpts {
         env = "ETH_FROM",
         num_args(0..),
     )]
+    #[builder(default = "None")]
     pub froms: Option<Vec<Address>>,
 
     /// Open an interactive prompt to enter your private key.
@@ -116,6 +117,7 @@ pub struct MultiWalletOpts {
 
     /// Use the provided private keys.
     #[clap(long, help_heading = "Wallet options - raw", value_name = "RAW_PRIVATE_KEYS")]
+    #[builder(default = "None")]
     pub private_keys: Option<Vec<String>>,
 
     /// Use the provided private key.
@@ -125,14 +127,17 @@ pub struct MultiWalletOpts {
         conflicts_with = "private_keys",
         value_name = "RAW_PRIVATE_KEY"
     )]
+    #[builder(default = "None")]
     pub private_key: Option<String>,
 
     /// Use the mnemonic phrases of mnemonic files at the specified paths.
     #[clap(long, alias = "mnemonic-paths", help_heading = "Wallet options - raw")]
+    #[builder(default = "None")]
     pub mnemonics: Option<Vec<String>>,
 
     /// Use a BIP39 passphrases for the mnemonic.
     #[clap(long, help_heading = "Wallet options - raw", value_name = "PASSPHRASE")]
+    #[builder(default = "None")]
     pub mnemonic_passphrases: Option<Vec<String>>,
 
     /// The wallet derivation path.
@@ -144,6 +149,7 @@ pub struct MultiWalletOpts {
         help_heading = "Wallet options - raw",
         value_name = "PATH"
     )]
+    #[builder(default = "None")]
     pub hd_paths: Option<Vec<String>>,
 
     /// Use the private key from the given mnemonic index.
@@ -166,6 +172,7 @@ pub struct MultiWalletOpts {
         value_name = "PATHS",
         env = "ETH_KEYSTORE"
     )]
+    #[builder(default = "None")]
     pub keystore_paths: Option<Vec<String>>,
 
     /// Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
@@ -177,6 +184,7 @@ pub struct MultiWalletOpts {
         env = "ETH_KEYSTORE_ACCOUNT",
         conflicts_with = "keystore_paths"
     )]
+    #[builder(default = "None")]
     pub keystore_account_names: Option<Vec<String>>,
 
     /// The keystore password.
@@ -188,6 +196,7 @@ pub struct MultiWalletOpts {
         requires = "keystore_paths",
         value_name = "PASSWORDS"
     )]
+    #[builder(default = "None")]
     pub keystore_passwords: Option<Vec<String>>,
 
     /// The keystore password file path.
@@ -200,6 +209,7 @@ pub struct MultiWalletOpts {
         value_name = "PATHS",
         env = "ETH_PASSWORD"
     )]
+    #[builder(default = "None")]
     pub keystore_password_files: Option<Vec<String>>,
 
     /// Use a Ledger hardware wallet.

--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use alloy_primitives::Address;
 use clap::Parser;
+use derive_builder::Builder;
 use ethers_signers::Signer;
 use eyre::Result;
 use foundry_common::types::ToAlloy;
@@ -87,7 +88,7 @@ macro_rules! create_hw_wallets {
 /// 5. Private Keys (cleartext in CLI)
 /// 6. Private Keys (interactively via secure prompt)
 /// 7. AWS KMS
-#[derive(Clone, Debug, Default, Serialize, Parser)]
+#[derive(Builder, Clone, Debug, Default, Serialize, Parser)]
 #[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct MultiWalletOpts {
     /// The sender accounts.

--- a/crates/wallets/src/wallet_signer.rs
+++ b/crates/wallets/src/wallet_signer.rs
@@ -57,13 +57,30 @@ impl WalletSigner {
         Ok(Self::Local(wallet))
     }
 
+    /// Returns a list of addresses available to use with current signer
+    ///
+    /// - for Ledger and Trezor signers the number of addresses to retrieve is specified as argument
+    /// - the result for Ledger signers includes addresses available for both LedgerLive and Legacy
+    ///   derivation paths
+    /// - for Local and AWS signers the result contains a single address
     pub async fn available_senders(&self, max: usize) -> Result<Vec<ethers_core::types::Address>> {
         let mut senders = Vec::new();
         match self {
+            WalletSigner::Local(local) => {
+                senders.push(local.address());
+                Ok(senders)
+            }
             WalletSigner::Ledger(ledger) => {
                 for i in 0..max {
                     if let Ok(address) =
                         ledger.get_address_with_path(&LedgerHDPath::LedgerLive(i)).await
+                    {
+                        senders.push(address);
+                    }
+                }
+                for i in 0..max {
+                    if let Ok(address) =
+                        ledger.get_address_with_path(&LedgerHDPath::Legacy(i)).await
                     {
                         senders.push(address);
                     }
@@ -84,7 +101,6 @@ impl WalletSigner {
                 senders.push(aws.address());
                 Ok(senders)
             }
-            _ => Ok(senders),
         }
     }
 

--- a/crates/wallets/src/wallet_signer.rs
+++ b/crates/wallets/src/wallet_signer.rs
@@ -57,6 +57,37 @@ impl WalletSigner {
         Ok(Self::Local(wallet))
     }
 
+    pub async fn available_senders(&self, max: usize) -> Result<Vec<ethers_core::types::Address>> {
+        let mut senders = Vec::new();
+        match self {
+            WalletSigner::Ledger(ledger) => {
+                for i in 0..max {
+                    if let Ok(address) =
+                        ledger.get_address_with_path(&LedgerHDPath::LedgerLive(i)).await
+                    {
+                        senders.push(address);
+                    }
+                }
+                Ok(senders)
+            }
+            WalletSigner::Trezor(trezor) => {
+                for i in 0..max {
+                    if let Ok(address) =
+                        trezor.get_address_with_path(&TrezorHDPath::TrezorLive(i)).await
+                    {
+                        senders.push(address);
+                    }
+                }
+                Ok(senders)
+            }
+            WalletSigner::Aws(aws) => {
+                senders.push(aws.address());
+                Ok(senders)
+            }
+            _ => Ok(senders),
+        }
+    }
+
     pub fn from_mnemonic(
         mnemonic: &str,
         passphrase: Option<&str>,

--- a/crates/wallets/src/wallet_signer.rs
+++ b/crates/wallets/src/wallet_signer.rs
@@ -68,7 +68,6 @@ impl WalletSigner {
         match self {
             WalletSigner::Local(local) => {
                 senders.push(local.address());
-                Ok(senders)
             }
             WalletSigner::Ledger(ledger) => {
                 for i in 0..max {
@@ -85,7 +84,6 @@ impl WalletSigner {
                         senders.push(address);
                     }
                 }
-                Ok(senders)
             }
             WalletSigner::Trezor(trezor) => {
                 for i in 0..max {
@@ -95,13 +93,12 @@ impl WalletSigner {
                         senders.push(address);
                     }
                 }
-                Ok(senders)
             }
             WalletSigner::Aws(aws) => {
                 senders.push(aws.address());
-                Ok(senders)
             }
         }
+        Ok(senders)
     }
 
     pub fn from_mnemonic(


### PR DESCRIPTION
- added new options for list command, default list local keystore

```
Options:
      --dir [<DIR>]                List all the accounts in the keystore directory. Default keystore directory is used if no path provided
  -l, --ledger                     List accounts from a Ledger hardware wallet
  -t, --trezor                     List accounts from a Trezor hardware wallet
  -m, --max-senders <MAX_SENDERS>  Max number of addresses to display from hardware wallets [default: 3]
      --aws                        List accounts from AWS KMS
      --all                        List all configured accounts
  -h, --help                       Print help
```

- for ledger display 3 addresses for each ledger live and legacy HD
- for trezor display 3 addresses for trezor live HD path
- for AWS display all keys configured
- for local keystore list files in dir

- unit tests

Note: I don't have Trezor / AWS configured

Things to discuss:
- chain id is hardcoded to 0 and not determined from rpc url, should it be?
- number of accounts to display are hardcoded to 2, should this be configurable?
- for local accounts - rn it creates the keystore directory if it doesn't exist, I'd argue this shouldn't be part of list command? 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
