### PR TITLE
fix(`forge`): correctly find script artifact when compiling with multiple versions

### DIFF
--- a/crates/forge/bin/cmd/script/build.rs
+++ b/crates/forge/bin/cmd/script/build.rs
@@ -104,7 +104,7 @@ impl ScriptArgs {
             true
         };
 
-        let mut target = None;
+        let mut target: Option<&ArtifactId> = None;
 
         for (id, contract) in contracts.iter() {
             if no_target_name {
@@ -112,8 +112,15 @@ impl ScriptArgs {
                 if id.source == std::path::Path::new(&target_fname) &&
                     contract.bytecode.as_ref().map_or(false, |b| b.object.bytes_len() > 0)
                 {
-                    if target.is_some() {
-                        eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`")
+                    if let Some(target) = target {
+                        // We might have multiple artifacts for the same contract but with different
+                        // solc versions. Their names will have form of {name}.0.X.Y, so we are
+                        // stripping versions off before comparing them.
+                        let target_name = target.name.split('.').next().unwrap();
+                        let id_name = id.name.split('.').next().unwrap();
+                        if target_name != id_name {
+                            eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`")
+                        }
                     }
                     target = Some(id);
                 }


### PR DESCRIPTION
## Motivation

Ref #7120

Currently we are exiting with error if we've found more than one artifact for provided contract path, however, we may have several artifacts for the same contract compiled with different solc versions.

## Solution

Only exit early if we've found contract with different name

It's not a regression as this issue existed long before recent linking updates, so not sure if #7120 will get closed by this
