### PR TITLE
fix(forge): fix debugger buffer-write highlight else-if fallthrough

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -518,12 +518,11 @@ impl DebuggerContext<'_> {
             let stack_len = step.stack.len();
             if stack_len > 0 {
                 if let Some(accesses) = get_buffer_accesses(op, &step.stack) {
-                    if let Some(read_access) = accesses.read {
-                        if read_access.0 == self.active_buffer {
-                            offset = Some(read_access.1.offset);
-                            size = Some(read_access.1.size);
-                            color = Some(Color::Cyan);
-                        }
+                    if accesses.read.as_ref().is_some_and(|a| a.0 == self.active_buffer) {
+                        let read_access = accesses.read.unwrap();
+                        offset = Some(read_access.1.offset);
+                        size = Some(read_access.1.size);
+                        color = Some(Color::Cyan);
                     } else if let Some(write_access) = accesses.write {
                         // TODO: with MCOPY, it will be possible to both read from and write to the
                         // memory buffer with the same opcode


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Was a bit late pushing my last commit to #7110, apologies cc @DaniPopes 

The check on `read_accesses` should check both that it's Some and that the active buffer matches, else writes to the memory buffer won't get highlighted.

This doesn't feel particularly elegant, so let me know if there's a better way to check if a member is Some and check against a member of _that_ member in the same conditional.

As noted in a comment in the previous PR, behavior should be tweaked in the future to allow simultaneous read+write highlights for MCOPY

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
