### PR TITLE
feat: add a revert decoder to eagerly hash error selectors

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -67,7 +67,7 @@ use anvil_rpc::{error::RpcError, response::ResponseResult};
 use foundry_common::provider::alloy::ProviderBuilder;
 use foundry_evm::{
     backend::DatabaseError,
-    decode::maybe_decode_revert,
+    decode::RevertDecoder,
     revm::{
         db::DatabaseRef,
         interpreter::{return_ok, return_revert, InstructionResult},
@@ -1917,7 +1917,9 @@ impl EthApi {
                         if let Some(output) = receipt.out {
                             // insert revert reason if failure
                             if receipt.inner.status_code.unwrap_or_default().to::<u64>() == 0 {
-                                if let Some(reason) = maybe_decode_revert(&output, None, None) {
+                                if let Some(reason) =
+                                    RevertDecoder::new().maybe_decode(&output, None)
+                                {
                                     tx.other.insert(
                                         "revertReason".to_string(),
                                         serde_json::to_value(reason).expect("Infallible"),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -62,7 +62,7 @@ use foundry_common::types::ToAlloy;
 use foundry_evm::{
     backend::{DatabaseError, DatabaseResult, RevertSnapshotAction},
     constants::DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE,
-    decode::decode_revert,
+    decode::RevertDecoder,
     inspectors::AccessListTracer,
     revm::{
         self,
@@ -956,9 +956,8 @@ impl Backend {
                 }
                 node_info!("    Gas used: {}", receipt.gas_used());
                 if !info.exit.is_ok() {
-                    let r = decode_revert(
-                        info.out.clone().unwrap_or_default().as_ref(),
-                        None,
+                    let r = RevertDecoder::new().decode(
+                        info.out.as_ref().map(|b| &b[..]).unwrap_or_default(),
                         Some(info.exit),
                     );
                     node_info!("    Error: reverted with: {r}");

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -10,7 +10,7 @@ use anvil_rpc::{
 };
 use foundry_evm::{
     backend::DatabaseError,
-    decode::maybe_decode_revert,
+    decode::RevertDecoder,
     revm::{
         self,
         interpreter::InstructionResult,
@@ -302,8 +302,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                     InvalidTransactionError::Revert(data) => {
                         // this mimics geth revert error
                         let mut msg = "execution reverted".to_string();
-                        if let Some(reason) =
-                            data.as_ref().and_then(|data| maybe_decode_revert(data, None, None))
+                        if let Some(reason) = data
+                            .as_ref()
+                            .and_then(|data| RevertDecoder::new().maybe_decode(data, None))
                         {
                             msg = format!("{msg}: {reason}");
                         }

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -69,17 +69,6 @@ impl ContractsByArtifact {
         }
         (funcs, events, errors_abi)
     }
-
-    /// Flattens the errors into a single JsonAbi.
-    pub fn flatten_errors(&self) -> JsonAbi {
-        let mut errors_abi = JsonAbi::new();
-        for (_name, (abi, _code)) in self.iter() {
-            for error in abi.errors() {
-                errors_abi.errors.entry(error.name.clone()).or_default().push(error.clone());
-            }
-        }
-        errors_abi
-    }
 }
 
 impl Deref for ContractsByArtifact {

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -2,12 +2,13 @@
 
 use crate::abi::{Console, Vm};
 use alloy_dyn_abi::JsonAbiExt;
-use alloy_json_abi::JsonAbi;
-use alloy_primitives::Log;
+use alloy_json_abi::{Error, JsonAbi};
+use alloy_primitives::{Log, Selector};
 use alloy_sol_types::{SolCall, SolError, SolEventInterface, SolInterface, SolValue};
 use foundry_common::SELECTOR_LEN;
 use itertools::Itertools;
 use revm::interpreter::InstructionResult;
+use std::{collections::HashMap, sync::OnceLock};
 
 /// Decode a set of logs, only returning logs from DSTest logging events and Hardhat's `console.log`
 pub fn decode_console_logs(logs: &[Log]) -> Vec<String> {
@@ -23,107 +24,165 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
     Console::ConsoleEvents::decode_log(log, false).ok().map(|decoded| decoded.to_string())
 }
 
-/// Tries to decode an error message from the given revert bytes.
-///
-/// Note that this is just a best-effort guess, and should not be relied upon for anything other
-/// than user output.
-pub fn decode_revert(
-    err: &[u8],
-    maybe_abi: Option<&JsonAbi>,
-    status: Option<InstructionResult>,
-) -> String {
-    maybe_decode_revert(err, maybe_abi, status).unwrap_or_else(|| {
-        if err.is_empty() {
-            "<empty revert data>".to_string()
-        } else {
-            trimmed_hex(err)
-        }
-    })
+/// Decodes revert data.
+#[derive(Clone, Debug, Default)]
+pub struct RevertDecoder {
+    /// The custom errors to use for decoding.
+    pub errors: HashMap<Selector, Vec<Error>>,
 }
 
-/// Tries to decode an error message from the given revert bytes.
-///
-/// See [`decode_revert`] for more information.
-pub fn maybe_decode_revert(
-    err: &[u8],
-    maybe_abi: Option<&JsonAbi>,
-    status: Option<InstructionResult>,
-) -> Option<String> {
-    if err.len() < SELECTOR_LEN {
-        if let Some(status) = status {
-            if !status.is_ok() {
-                return Some(format!("EvmError: {status:?}"));
+impl Default for &RevertDecoder {
+    fn default() -> Self {
+        static EMPTY: OnceLock<RevertDecoder> = OnceLock::new();
+        EMPTY.get_or_init(RevertDecoder::new)
+    }
+}
+
+impl RevertDecoder {
+    /// Creates a new, empty revert decoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the ABIs to use for error decoding.
+    ///
+    /// Note that this is decently expensive as it will hash all errors for faster indexing.
+    pub fn with_abis<'a>(mut self, abi: impl IntoIterator<Item = &'a JsonAbi>) -> Self {
+        self.extend_from_abis(abi);
+        self
+    }
+
+    /// Sets the ABI to use for error decoding.
+    ///
+    /// Note that this is decently expensive as it will hash all errors for faster indexing.
+    pub fn with_abi(mut self, abi: &JsonAbi) -> Self {
+        self.extend_from_abi(abi);
+        self
+    }
+
+    /// Sets the ABI to use for error decoding, if it is present.
+    ///
+    /// Note that this is decently expensive as it will hash all errors for faster indexing.
+    pub fn with_abi_opt(mut self, abi: Option<&JsonAbi>) -> Self {
+        if let Some(abi) = abi {
+            self.extend_from_abi(abi);
+        }
+        self
+    }
+
+    /// Extends the decoder with the given ABI's custom errors.
+    pub fn extend_from_abis<'a>(&mut self, abi: impl IntoIterator<Item = &'a JsonAbi>) {
+        for abi in abi {
+            self.extend_from_abi(abi);
+        }
+    }
+
+    /// Extends the decoder with the given ABI's custom errors.
+    pub fn extend_from_abi(&mut self, abi: &JsonAbi) {
+        for error in abi.errors() {
+            self.push_error(error.clone());
+        }
+    }
+
+    /// Adds a custom error to use for decoding.
+    pub fn push_error(&mut self, error: Error) {
+        self.errors.entry(error.selector()).or_default().push(error);
+    }
+
+    /// Tries to decode an error message from the given revert bytes.
+    ///
+    /// Note that this is just a best-effort guess, and should not be relied upon for anything other
+    /// than user output.
+    pub fn decode(&self, err: &[u8], status: Option<InstructionResult>) -> String {
+        self.maybe_decode(err, status).unwrap_or_else(|| {
+            if err.is_empty() {
+                "<empty revert data>".to_string()
+            } else {
+                trimmed_hex(err)
+            }
+        })
+    }
+
+    /// Tries to decode an error message from the given revert bytes.
+    ///
+    /// See [`decode_revert`] for more information.
+    pub fn maybe_decode(&self, err: &[u8], status: Option<InstructionResult>) -> Option<String> {
+        if err.len() < SELECTOR_LEN {
+            if let Some(status) = status {
+                if !status.is_ok() {
+                    return Some(format!("EvmError: {status:?}"));
+                }
+            }
+            return if err.is_empty() {
+                None
+            } else {
+                Some(format!("custom error bytes {}", hex::encode_prefixed(err)))
+            };
+        }
+
+        if err == crate::constants::MAGIC_SKIP {
+            // Also used in forge fuzz runner
+            return Some("SKIPPED".to_string());
+        }
+
+        // Solidity's `Error(string)` or `Panic(uint256)`
+        if let Ok(e) = alloy_sol_types::GenericContractError::abi_decode(err, false) {
+            return Some(e.to_string());
+        }
+
+        let (selector, data) = err.split_at(SELECTOR_LEN);
+        let selector: &[u8; 4] = selector.try_into().unwrap();
+
+        match *selector {
+            // `CheatcodeError(string)`
+            Vm::CheatcodeError::SELECTOR => {
+                let e = Vm::CheatcodeError::abi_decode_raw(data, false).ok()?;
+                return Some(e.message);
+            }
+            // `expectRevert(bytes)`
+            Vm::expectRevert_2Call::SELECTOR => {
+                let e = Vm::expectRevert_2Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
+            // `expectRevert(bytes4)`
+            Vm::expectRevert_1Call::SELECTOR => {
+                let e = Vm::expectRevert_1Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
+            _ => {}
+        }
+
+        // Custom errors.
+        if let Some(errors) = self.errors.get(selector) {
+            for error in errors {
+                // If we don't decode, don't return an error, try to decode as a string later.
+                if let Ok(decoded) = error.abi_decode_input(data, false) {
+                    return Some(format!(
+                        "{}({})",
+                        error.name,
+                        decoded.iter().map(foundry_common::fmt::format_token).format(", ")
+                    ));
+                }
             }
         }
-        return if err.is_empty() {
-            None
-        } else {
-            Some(format!("custom error bytes {}", hex::encode_prefixed(err)))
-        };
-    }
 
-    if err == crate::constants::MAGIC_SKIP {
-        // Also used in forge fuzz runner
-        return Some("SKIPPED".to_string());
-    }
-
-    // Solidity's `Error(string)` or `Panic(uint256)`
-    if let Ok(e) = alloy_sol_types::GenericContractError::abi_decode(err, false) {
-        return Some(e.to_string());
-    }
-
-    let (selector, data) = err.split_at(SELECTOR_LEN);
-    let selector: &[u8; 4] = selector.try_into().unwrap();
-
-    match *selector {
-        // `CheatcodeError(string)`
-        Vm::CheatcodeError::SELECTOR => {
-            let e = Vm::CheatcodeError::abi_decode_raw(data, false).ok()?;
-            return Some(e.message);
+        // ABI-encoded `string`.
+        if let Ok(s) = String::abi_decode(err, false) {
+            return Some(s);
         }
-        // `expectRevert(bytes)`
-        Vm::expectRevert_2Call::SELECTOR => {
-            let e = Vm::expectRevert_2Call::abi_decode_raw(data, false).ok()?;
-            return maybe_decode_revert(&e.revertData[..], maybe_abi, status);
+
+        // UTF-8-encoded string.
+        if let Ok(s) = std::str::from_utf8(err) {
+            return Some(s.to_string());
         }
-        // `expectRevert(bytes4)`
-        Vm::expectRevert_1Call::SELECTOR => {
-            let e = Vm::expectRevert_1Call::abi_decode_raw(data, false).ok()?;
-            return maybe_decode_revert(&e.revertData[..], maybe_abi, status);
-        }
-        _ => {}
-    }
 
-    // Custom error from the given ABI
-    if let Some(abi) = maybe_abi {
-        if let Some(abi_error) = abi.errors().find(|e| selector == e.selector()) {
-            // if we don't decode, don't return an error, try to decode as a string later
-            if let Ok(decoded) = abi_error.abi_decode_input(data, false) {
-                return Some(format!(
-                    "{}({})",
-                    abi_error.name,
-                    decoded.iter().map(foundry_common::fmt::format_token).format(", ")
-                ));
-            }
-        }
+        // Generic custom error.
+        Some(format!(
+            "custom error {}:{}",
+            hex::encode(selector),
+            std::str::from_utf8(data).map_or_else(|_| trimmed_hex(data), String::from)
+        ))
     }
-
-    // ABI-encoded `string`
-    if let Ok(s) = String::abi_decode(err, false) {
-        return Some(s);
-    }
-
-    // UTF-8-encoded string
-    if let Ok(s) = std::str::from_utf8(err) {
-        return Some(s.to_string());
-    }
-
-    // Generic custom error
-    Some(format!(
-        "custom error {}:{}",
-        hex::encode(selector),
-        std::str::from_utf8(data).map_or_else(|_| trimmed_hex(data), String::from)
-    ))
 }
 
 fn trimmed_hex(s: &[u8]) -> String {
@@ -147,8 +206,8 @@ mod tests {
     fn test_trimmed_hex() {
         assert_eq!(trimmed_hex(&hex::decode("1234567890").unwrap()), "1234567890");
         assert_eq!(
-        trimmed_hex(&hex::decode("492077697368207275737420737570706F72746564206869676865722D6B696E646564207479706573").unwrap()),
-        "49207769736820727573742073757070…6865722d6b696e646564207479706573 (41 bytes)"
-    );
+            trimmed_hex(&hex::decode("492077697368207275737420737570706F72746564206869676865722D6B696E646564207479706573").unwrap()),
+            "49207769736820727573742073757070…6865722d6b696e646564207479706573 (41 bytes)"
+        );
     }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -666,14 +666,9 @@ impl<'a> InvariantExecutor<'a> {
         f: fn(DynSolValue) -> Vec<T>,
     ) -> Vec<T> {
         if let Some(func) = abi.functions().find(|func| func.name == method_name) {
-            if let Ok(call_result) = self.executor.call::<_, _>(
-                CALLER,
-                address,
-                func.clone(),
-                vec![],
-                U256::ZERO,
-                Some(abi),
-            ) {
+            if let Ok(call_result) =
+                self.executor.call::<_, _>(CALLER, address, func.clone(), vec![], U256::ZERO, None)
+            {
                 return f(call_result.result)
             } else {
                 warn!(

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -43,7 +43,7 @@ use foundry_config::{
 };
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
-    decode,
+    decode::RevertDecoder,
     inspectors::cheatcodes::{BroadcastableTransaction, BroadcastableTransactions},
 };
 use foundry_wallets::MultiWallet;
@@ -349,7 +349,7 @@ impl ScriptArgs {
         if !result.success {
             return Err(eyre::eyre!(
                 "script failed: {}",
-                decode::decode_revert(&result.returned[..], None, None)
+                RevertDecoder::new().decode(&result.returned[..], None)
             ));
         }
 
@@ -367,7 +367,7 @@ impl ScriptArgs {
         if !result.success {
             return Err(eyre::eyre!(
                 "script failed: {}",
-                decode::decode_revert(&result.returned[..], None, None)
+                RevertDecoder::new().decode(&result.returned[..], None)
             ));
         }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -15,7 +15,7 @@ use foundry_config::{FuzzConfig, InvariantConfig};
 use foundry_evm::{
     constants::CALLER,
     coverage::HitMaps,
-    decode::decode_console_logs,
+    decode::{decode_console_logs, RevertDecoder},
     executors::{
         fuzz::{CaseOutcome, CounterExampleOutcome, FuzzOutcome, FuzzedExecutor},
         invariant::{replay_run, InvariantExecutor, InvariantFuzzError, InvariantFuzzTestResult},
@@ -43,8 +43,8 @@ pub struct ContractRunner<'a> {
     pub code: Bytes,
     /// The test contract's ABI
     pub contract: &'a JsonAbi,
-    /// All known errors, used to decode reverts
-    pub errors: Option<&'a JsonAbi>,
+    /// Revert decoder. Contains all known errors.
+    pub revert_decoder: &'a RevertDecoder,
     /// The initial balance of the test contract
     pub initial_balance: U256,
     /// The address which will be used as the `from` field in all EVM calls
@@ -62,7 +62,7 @@ impl<'a> ContractRunner<'a> {
         code: Bytes,
         initial_balance: U256,
         sender: Option<Address>,
-        errors: Option<&'a JsonAbi>,
+        revert_decoder: &'a RevertDecoder,
         predeploy_libs: &'a [Bytes],
         debug: bool,
     ) -> Self {
@@ -73,7 +73,7 @@ impl<'a> ContractRunner<'a> {
             code,
             initial_balance,
             sender: sender.unwrap_or_default(),
-            errors,
+            revert_decoder,
             predeploy_libs,
             debug,
         }
@@ -104,7 +104,12 @@ impl<'a> ContractRunner<'a> {
         let mut logs = Vec::new();
         let mut traces = Vec::with_capacity(self.predeploy_libs.len());
         for code in self.predeploy_libs.iter() {
-            match self.executor.deploy(self.sender, code.clone(), U256::ZERO, self.errors) {
+            match self.executor.deploy(
+                self.sender,
+                code.clone(),
+                U256::ZERO,
+                Some(self.revert_decoder),
+            ) {
                 Ok(d) => {
                     logs.extend(d.logs);
                     traces.extend(d.traces.map(|traces| (TraceKind::Deployment, traces)));
@@ -122,7 +127,12 @@ impl<'a> ContractRunner<'a> {
         self.executor.set_balance(address, self.initial_balance)?;
 
         // Deploy the test contract
-        match self.executor.deploy(self.sender, self.code.clone(), U256::ZERO, self.errors) {
+        match self.executor.deploy(
+            self.sender,
+            self.code.clone(),
+            U256::ZERO,
+            Some(self.revert_decoder),
+        ) {
             Ok(d) => {
                 logs.extend(d.logs);
                 traces.extend(d.traces.map(|traces| (TraceKind::Deployment, traces)));
@@ -320,7 +330,7 @@ impl<'a> ContractRunner<'a> {
                 func.clone(),
                 vec![],
                 U256::ZERO,
-                self.errors,
+                Some(self.revert_decoder),
             ) {
                 Ok(CallResult {
                     reverted,
@@ -438,7 +448,7 @@ impl<'a> ContractRunner<'a> {
             func.clone(),
             vec![],
             U256::ZERO,
-            self.errors,
+            Some(self.revert_decoder),
         ) {
             return TestResult {
                 status: TestStatus::Skipped,
@@ -563,7 +573,7 @@ impl<'a> ContractRunner<'a> {
         let fuzzed_executor =
             FuzzedExecutor::new(self.executor.clone(), runner.clone(), self.sender, fuzz_config);
         let state = fuzzed_executor.build_fuzz_state();
-        let result = fuzzed_executor.fuzz(func, address, should_fail, self.errors);
+        let result = fuzzed_executor.fuzz(func, address, should_fail, self.revert_decoder);
 
         let mut debug = Default::default();
         let mut breakpoints = Default::default();


### PR DESCRIPTION
Eagerly hash selectors once instead of on every call to `decode_revert`. This improves performance when decoding lots of traces with lots of contracts as decoding custom errors is now trivial.

Diff is kinda bad but the decoding logic is unchanged (review with "hide whitespace").

Closes https://github.com/foundry-rs/foundry/issues/7119

See `render_trace_arena`, from ~2000 to ~750 samples for the same task (`FOUNDRY_PROFILE=lite forge t -vvvvv --nmc Fork` in [sablier/v2-core](https://github.com/sablier-labs/v2-core)):
- before https://share.firefox.dev/3UG8Mq3
- after https://share.firefox.dev/4bAwwBV