### PR TITLE
[wip] feat(forge): add buffer dump to debugger

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -299,7 +299,6 @@ impl DebuggerContext<'_> {
             // dump memory+calldata+returndata to timestamped file
             KeyCode::Char('w') => {
                 use std::time::SystemTime;
-                let address_str = self.address().to_string();
                 // create a json file with the current memory, calldata, and returndata
                 // and write it to the current directory
                 // the file should be named with the current timestamp
@@ -328,17 +327,17 @@ impl DebuggerContext<'_> {
                         .map(|byte| format!("{:02x}", byte))
                         .collect::<String>()
                 );
-                let filename: PathBuf = format!(
-                    "debug/debug_dump_{}_{}.json",
-                    address_str,
-                    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
-                )
-                .into();
                 let mapping: HashMap<&str, &String> = [
                     ("memory", &memory_ascii),
                     ("calldata", &calldata_ascii),
                     ("returndata", &returndata_ascii),
                 ]
+                .into();
+                let filename: PathBuf = format!(
+                    "debug/debug_dump_{}_{}.json",
+                    self.address().to_string(),
+                    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
+                )
                 .into();
                 create_dir("debug").err();
                 write_json_file(&filename, &mapping).unwrap();

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -3,7 +3,7 @@
 use crate::{Debugger, ExitReason};
 use alloy_primitives::Address;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use foundry_common::fs::write_json_file;
+use foundry_common::fs::{create_dir, write_json_file};
 use foundry_evm_core::debug::{DebugNodeFlat, DebugStep};
 use revm_inspectors::tracing::types::CallKind;
 use std::{cell::RefCell, collections::HashMap, ops::ControlFlow, path::PathBuf};
@@ -299,6 +299,7 @@ impl DebuggerContext<'_> {
             // dump memory+calldata+returndata to timestamped file
             KeyCode::Char('w') => {
                 use std::time::SystemTime;
+                let address_str = self.address().to_string();
                 // create a json file with the current memory, calldata, and returndata
                 // and write it to the current directory
                 // the file should be named with the current timestamp
@@ -328,7 +329,8 @@ impl DebuggerContext<'_> {
                         .collect::<String>()
                 );
                 let filename: PathBuf = format!(
-                    "debug_dump_{}.json",
+                    "debug/debug_dump_{}_{}.json",
+                    address_str,
                     SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs()
                 )
                 .into();
@@ -338,6 +340,7 @@ impl DebuggerContext<'_> {
                     ("returndata", &returndata_ascii),
                 ]
                 .into();
+                create_dir("debug").err();
                 write_json_file(&filename, &mapping).unwrap();
             }
             KeyCode::Char(

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -185,7 +185,7 @@ impl DebuggerContext<'_> {
 
     fn draw_footer(&self, f: &mut Frame<'_>, area: Rect) {
         let l1 = "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [b]: cycle memory/calldata/returndata buffers";
-        let l2 = "[t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
+        let l2 = "[t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help | [w] dump buffers to json file";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         let lines =
             vec![Line::from(Span::styled(l1, dimmed)), Line::from(Span::styled(l2, dimmed))];

--- a/crates/forge/assets/.gitignoreTemplate
+++ b/crates/forge/assets/.gitignoreTemplate
@@ -2,6 +2,9 @@
 cache/
 out/
 
+# Debug files
+debug/
+
 # Ignores development broadcast logs
 !/broadcast
 /broadcast/*/31337/


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Since the debugger doesn't allow copy/paste, and buffers can be large, it can be useful to dump buffers to disk for further manual debugging.

Closes #7112 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- add a dump action `w` ("write") to the debugger and update help string
- write to `{cwd}/debug/debug_dump_{contract name}_{address}_{timestamp}.json`
- update `.gitignoreTemplate` to ignore `debug/`

Thoughts:
- it might be nice to dump more than just buffers
- maybe `d` makes more sense as a key? but `w` feels more aligned with vim-esque keybindings and writing to disk
- not sure if there are read/write concerns
- maybe folder path logic could be more robust to always write to `{project root}/debug/x.json`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
