### PR TITLE
fix(forge): update submodules after dependency checkout

### DIFF
--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -84,7 +84,7 @@ impl InitArgs {
                 git.submodule_init()?;
             } else {
                 // if not shallow, initialize and clone submodules (without fetching latest)
-                git.submodule_update(false, false, true, true, None::<PathBuf>)?;
+                git.submodule_update(false, false, true, true, std::iter::empty::<PathBuf>())?;
             }
         } else {
             // if target is not empty

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -348,6 +348,10 @@ impl Installer<'_> {
             return Err(e)
         }
 
+        // We might have additional submodules after checkout, load them.
+        trace!("updating dependency submodules recursively");
+        self.git.root(path).submodule_update(false, false, false, true, None::<PathBuf>)?;
+
         if is_branch {
             Ok(tag)
         } else {

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -237,7 +237,13 @@ impl Installer<'_> {
         self.git_checkout(&dep, path, false)?;
 
         trace!("updating dependency submodules recursively");
-        self.git.root(path).submodule_update(false, false, false, true, None::<PathBuf>)?;
+        self.git.root(path).submodule_update(
+            false,
+            false,
+            false,
+            true,
+            std::iter::empty::<PathBuf>(),
+        )?;
 
         // remove git artifacts
         fs::remove_dir_all(path.join(".git"))?;
@@ -263,7 +269,13 @@ impl Installer<'_> {
         self.git_checkout(&dep, path, true)?;
 
         trace!("updating dependency submodules recursively");
-        self.git.root(path).submodule_update(false, false, false, true, None::<PathBuf>)?;
+        self.git.root(path).submodule_update(
+            false,
+            false,
+            false,
+            true,
+            std::iter::empty::<PathBuf>(),
+        )?;
 
         if !self.no_commit {
             self.git.add(Some(path))?;


### PR DESCRIPTION
## Motivation

Currently dependencies are being installed in 3 steps:
1. Clone dependency
2. Clone its submodules
3. Checkout to the given or found tag, if any.

We need to swap 2 and 3 here as checked out commit might have more submodules than master and vice versa.

Because of that our CI failing right now as when installing forge-std, we are firstly cloning master which don't have ds-test dependency, and then checking out v1.7.6, which has it and requires it to compile normally

cc @mds1 

