### PR TITLE
feat(coverage): add statements to `lcov` reports

### DIFF
--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -117,7 +117,9 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
                         )?;
                     }
                     // Statements are not in the LCOV format
-                    CoverageItemKind::Statement => (),
+                    CoverageItemKind::Statement => {
+                        writeln!(self.destination, "DA:{line},{hits}")?;
+                    },
                 }
             }
 


### PR DESCRIPTION
## Motivation

To improve `lcov` coverage reports, by adding `DA` for statements.

closes #6968 

## Solution

I did a little bit of digging for this one, my first guess was an error with the visitor implementation but it was not the case, it looks like `statement`s are omitted while generating `lcov` reports. I am not sure about the reason but there is comment that says statement's are not compatible with `lcov`. I am not very familiar with lcov so not sure about the next statement but, I feel like adding `DA` to lcov report for statements should work. https://github.com/foundry-rs/foundry/blob/e897bd6874312d2c2d9acc7d24081ef721845b29/crates/forge/src/coverage.rs#L119-L120

By changing it to emit `DA` values I obtained following coverage report for the project reported:


<img width="1723" alt="image" src="https://github.com/foundry-rs/foundry/assets/20915464/9d7d2a3c-684e-4997-baba-af6c2073b56c">