### PR TITLE
feat(cast): abi-encode-packed 

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -160,8 +160,12 @@ async fn main() -> Result<()> {
             let tokens = format_tokens(&tokens);
             tokens.for_each(|t| println!("{t}"));
         }
-        CastSubcommand::AbiEncode { sig, args } => {
-            println!("{}", SimpleCast::abi_encode(&sig, &args)?);
+        CastSubcommand::AbiEncode { sig, packed, args } => {
+            if !packed {
+                println!("{}", SimpleCast::abi_encode(&sig, &args)?);
+            } else {
+                println!("{}", SimpleCast::abi_encode_packed(&sig, &args)?);
+            }
         }
         CastSubcommand::CalldataDecode { sig, calldata } => {
             let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -491,6 +491,10 @@ pub enum CastSubcommand {
         /// The function signature.
         sig: String,
 
+        /// Whether to use packed encoding.
+        #[clap(long)]
+        packed: bool,
+
         /// The arguments of the function.
         #[clap(allow_hyphen_values = true)]
         args: Vec<String>,

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -21,6 +21,23 @@ where
     func.abi_encode_input(params.as_slice()).map_err(Into::into)
 }
 
+/// Given a function and a vector of string arguments, it proceeds to convert the args to alloy
+/// [DynSolValue]s and encode them using the packed encoding.
+pub fn encode_function_args_packed<I, S>(func: &Function, args: I) -> Result<Vec<u8>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let params: Vec<Vec<u8>> = std::iter::zip(&func.inputs, args)
+        .map(|(input, arg)| coerce_value(&input.selector_type(), arg.as_ref()))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .map(|v| v.abi_encode_packed())
+        .collect();
+
+    Ok(params.concat())
+}
+
 /// Decodes the calldata of the function
 pub fn abi_decode_calldata(
     sig: &str,


### PR DESCRIPTION

Blocked by #7149 

## Motivation

Useful to calculate `abi.encodePacked` without `chisel`.

## Solution

Update `alloy-dyn-abi` to make use of fixed `abi_encode_packed` https://github.com/alloy-rs/core/pull/517



