### PR TITLE
fix(providers): remove locks on requests

### DIFF
--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -215,15 +215,12 @@ impl RuntimeTransport {
                 let mut inner = this.inner.write().await;
                 *inner = Some(this.connect().await.map_err(TransportErrorKind::custom)?)
             }
-
-            let mut inner = this.inner.write().await;
+            
             // SAFETY: We just checked that the inner transport exists.
-            let inner_mut = inner.as_mut().expect("We should have an inner transport.");
-
-            match inner_mut {
-                InnerTransport::Http(http) => http.call(req),
-                InnerTransport::Ws(ws) => ws.call(req),
-                InnerTransport::Ipc(ipc) => ipc.call(req),
+            match this.inner.read().await.as_ref().unwrap().clone() {
+                InnerTransport::Http(mut http) => http.call(req),
+                InnerTransport::Ws(mut ws) => ws.call(req),
+                InnerTransport::Ipc(mut ipc) => ipc.call(req),
             }
             .await
         })

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -211,16 +211,31 @@ impl RuntimeTransport {
     pub fn request(&self, req: RequestPacket) -> TransportFut<'static> {
         let this = self.clone();
         Box::pin(async move {
-            if this.inner.read().await.is_none() {
-                let mut inner = this.inner.write().await;
-                *inner = Some(this.connect().await.map_err(TransportErrorKind::custom)?)
+            let mut inner = this.inner.read().await;
+            if inner.is_none() {
+                drop(inner);
+                let mut inner_mut = this.inner.write().await;
+                if inner_mut.is_none() {
+                    *inner_mut = Some(this.connect().await.map_err(TransportErrorKind::custom)?);
+                }
+                drop(inner_mut);
+                inner = this.inner.read().await;
             }
 
             // SAFETY: We just checked that the inner transport exists.
-            match this.inner.read().await.as_ref().unwrap().clone() {
-                InnerTransport::Http(mut http) => http.call(req),
-                InnerTransport::Ws(mut ws) => ws.call(req),
-                InnerTransport::Ipc(mut ipc) => ipc.call(req),
+            match inner.as_ref().unwrap() {
+                InnerTransport::Http(http) => {
+                    let mut http = http;
+                    http.call(req)
+                }
+                InnerTransport::Ws(ws) => {
+                    let mut ws = ws;
+                    ws.call(req)
+                }
+                InnerTransport::Ipc(ipc) => {
+                    let mut ipc = ipc;
+                    ipc.call(req)
+                }
             }
             .await
         })

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -215,7 +215,7 @@ impl RuntimeTransport {
                 let mut inner = this.inner.write().await;
                 *inner = Some(this.connect().await.map_err(TransportErrorKind::custom)?)
             }
-            
+
             // SAFETY: We just checked that the inner transport exists.
             match this.inner.read().await.as_ref().unwrap().clone() {
                 InnerTransport::Http(mut http) => http.call(req),

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -217,7 +217,8 @@ impl RuntimeTransport {
                 {
                     let mut inner_mut = this.inner.write().await;
                     if inner_mut.is_none() {
-                        *inner_mut = Some(this.connect().await.map_err(TransportErrorKind::custom)?);
+                        *inner_mut =
+                            Some(this.connect().await.map_err(TransportErrorKind::custom)?);
                     }
                 }
                 inner = this.inner.read().await;


### PR DESCRIPTION
## Motivation

Closes #7131 

We are basically blocking all async requests through provider rn by aquiring write lock before making a request.

## Solution

Use read lock