### PR TITLE
fix(`anvil`): properly set deposit nonce key on mined tx receipt

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2072,7 +2072,7 @@ impl Backend {
         };
 
         inner.other.insert(
-            "deposit_nonce".to_string(),
+            "depositNonce".to_string(),
             serde_json::to_value(deposit_nonce).expect("Infallible"),
         );
 

--- a/crates/anvil/tests/it/optimism.rs
+++ b/crates/anvil/tests/it/optimism.rs
@@ -138,6 +138,7 @@ async fn test_send_value_raw_deposit_transaction() {
     let receipt = provider.get_transaction_receipt(pending.tx_hash()).await.unwrap().unwrap();
     assert_eq!(receipt.from, from_addr);
     assert_eq!(receipt.to, Some(to_addr));
+    assert_eq!(receipt.other.get_deserialized::<u64>("depositNonce").unwrap().unwrap(), 0);
 
     // the recipient should have received the value
     let balance = provider.get_balance(to_addr, None).await.unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This should be camelcase rather than snake case. A quirk when using other fields. Closes #7026 

## Solution

use camelcase.
