### PR TITLE
fix: only early-return if an exact bytecode match is found

### DIFF
--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -29,12 +29,7 @@ impl<'a> LocalTraceIdentifier<'a> {
         self.known_contracts
     }
 
-    /// Iterates over artifacts with code length less than or equal to the given code and tries to
-    /// find a match.
-    ///
-    /// We do not consider artifacts with code length greater than the given code length as it is
-    /// considered that after compilation code can only be extended by additional parameters
-    /// (immutables) and cannot be shortened.
+    /// Tries to the bytecode most similar to the given one.
     pub fn identify_code(&self, code: &[u8]) -> Option<(&'a ArtifactId, &'a JsonAbi)> {
         let len = code.len();
 
@@ -81,7 +76,14 @@ impl<'a> LocalTraceIdentifier<'a> {
         }
 
         trace!(%min_score, "no exact match found");
-        min_score_id
+
+        // Note: the diff score can be inaccurate for small contracts so we're using a relatively
+        // high threshold here to avoid filtering out too many contracts.
+        if min_score < 0.85 {
+            min_score_id
+        } else {
+            None
+        }
     }
 
     /// Returns the index of the artifact with the given code length, or the index of the first

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -44,8 +44,8 @@ impl<'a> LocalTraceIdentifier<'a> {
         let mut check = |id| {
             let (abi, known_code) = self.known_contracts.get(id)?;
             let score = bytecode_diff_score(known_code, code);
-            if score <= 0.1 {
-                trace!(%score, "found close-enough match");
+            if score == 0.0 {
+                trace!("found exact match");
                 return Some((id, abi));
             }
             if score < min_score {
@@ -80,7 +80,7 @@ impl<'a> LocalTraceIdentifier<'a> {
             }
         }
 
-        trace!(%min_score, "no close-enough match found");
+        trace!(%min_score, "no exact match found");
         min_score_id
     }
 


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/7144

Also re-added the threshold present before refactoring: https://github.com/foundry-rs/foundry/blob/e911d2256393190c0ff5e9f72653d5ea359ac40f/crates/evm/traces/src/identifier/local.rs#L41-L49