### PR TITLE
fix: show return data length instead of calldata for CREATE traces

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -126,7 +126,7 @@ pub async fn render_trace_arena(
             if node.trace.kind.is_any_create() {
                 match &return_data {
                     None => {
-                        writeln!(s, "{} bytes of code", node.trace.data.len())?;
+                        writeln!(s, "{} bytes of code", node.trace.output.len())?;
                     }
                     Some(val) => {
                         writeln!(s, "{val}")?;


### PR DESCRIPTION
Fixes https://github.com/foundry-rs/foundry/issues/7041

This is already fixed in [evm-inspectors](https://github.com/paradigmxyz/evm-inspectors/blob/a2a908aeb61318cd7df92b51444755cea338d49c/src/tracing/writer.rs#L219)