### PR TITLE
fix(forge): do not error when artifact does not have an abi

### DIFF
--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
-use eyre::{OptionExt, Result};
+use eyre::Result;
 use foundry_common::{get_contract_name, ContractsByArtifact, TestFunctionExt};
 use foundry_compilers::{contracts::ArtifactContracts, Artifact, ArtifactId, ProjectCompileOutput};
 use foundry_evm::{

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -332,7 +332,9 @@ impl MultiContractRunnerBuilder {
         let mut known_contracts = ContractsByArtifact::default();
 
         for (id, contract) in &linker.contracts.0 {
-            let abi = contract.abi.as_ref().ok_or_eyre("we should have an abi by now")?;
+            let Some(abi) = contract.abi.as_ref() else {
+                continue;
+            };
 
             let LinkOutput { libs_to_deploy, libraries } =
                 linker.link_with_nonce_or_address(Default::default(), evm_opts.sender, 1, id)?;


### PR DESCRIPTION
## Motivation

Closes #7182
Previous linker impl filtered out artifacts without abi during linking https://github.com/foundry-rs/foundry/blob/7116e2429434ecb1b8ea71fd1dc90a5ab6e0968c/crates/forge/src/link.rs#L182

## Solution

I don't known in which cases solc emits artifacts without an abi, would be nice to get a repro and add a test case for this
