### PR TITLE
fix: include base fee per gas for next block

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -145,6 +145,12 @@ pub async fn spawn(mut config: NodeConfig) -> (EthApi, NodeHandle) {
         fees,
         StorageInfo::new(Arc::clone(&backend)),
     );
+    // create an entry for the best block
+    if let Some(best_block) =
+        backend.get_block(backend.best_number()).map(|block| block.header.hash_slow())
+    {
+        fee_history_service.insert_cache_entry_for_block(best_block);
+    }
 
     let filters = Filters::default();
 


### PR DESCRIPTION
closes #7084

This fixes the bug by creating a fee entry to the best block at launch:

```
curl http://localhost:8545 -X POST -H "Content-Type: application/json" -d '{"id": 1, "jsonrpc": "2.0", "method": "eth_feeHistory", "params": ["0x5", "latest", [20,30]]}'
```

```json
{"jsonrpc":"2.0","id":1,"result":{"baseFeePerGas":["0x3b9aca00","0x342770c0"],"gasUsedRatio":[0.0],"oldestBlock":"0x0","reward":[["0x0","0x0"]]}}
```

The baseFeePerGas has two entries because this is supposed to also include the next block's base fee which can be derived from the current block