### PR TITLE
fix(chisel): min and max for all types

### DIFF
--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -387,8 +387,6 @@ impl MultiWalletOpts {
 
 #[cfg(test)]
 mod tests {
-    use ethers_signers::Signer;
-
     use super::*;
     use std::path::Path;
 


### PR DESCRIPTION
Follow-up fix for https://github.com/foundry-rs/foundry/pull/7173

max and min are of the input type, we should only default for enums

Also add msg.gas and block.blobbasefee

Ref also https://github.com/foundry-rs/foundry/issues/5705