### PR TITLE
[cast] Fix cast wallet verify

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -1,16 +1,13 @@
-use alloy_primitives::Address;
+use alloy_primitives::{Address, Signature};
 use alloy_signer::{
     coins_bip39::{English, Mnemonic},
     LocalWallet, MnemonicBuilder, Signer as AlloySigner,
 };
 use clap::Parser;
-use ethers_core::types::{transaction::eip712::TypedData, Signature};
+use ethers_core::types::transaction::eip712::TypedData;
 use ethers_signers::Signer;
 use eyre::{Context, Result};
-use foundry_common::{
-    fs,
-    types::{ToAlloy, ToEthers},
-};
+use foundry_common::{fs, types::ToAlloy};
 use foundry_config::Config;
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
 use rand::thread_rng;
@@ -276,13 +273,11 @@ impl WalletSubcommands {
                 println!("0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
-                match signature.verify(Self::hex_str_to_bytes(&message)?, address.to_ethers()) {
-                    Ok(_) => {
-                        println!("Validation succeeded. Address {address} signed this message.")
-                    }
-                    Err(_) => {
-                        println!("Validation failed. Address {address} did not sign this message.")
-                    }
+                let recovered_address = signature.recover_address_from_msg(message)?;
+                if recovered_address == address {
+                    println!("Validation succeeded. Address {address} signed this message.");
+                } else {
+                    println!("Validation failed. Address {address} did not sign this message.");
                 }
             }
             WalletSubcommands::Import { account_name, keystore_dir, raw_wallet_options } => {

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -1,12 +1,10 @@
-use alloy_primitives::{Address};
+use alloy_primitives::Address;
 use alloy_signer::{
     coins_bip39::{English, Mnemonic},
     LocalWallet, MnemonicBuilder, Signer as AlloySigner,
 };
 use clap::Parser;
-use ethers_core::{
-    types::{transaction::eip712::TypedData, Signature},
-};
+use ethers_core::types::{transaction::eip712::TypedData, Signature};
 use ethers_signers::Signer;
 use eyre::{Context, Result};
 use foundry_common::{

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -273,8 +273,8 @@ impl WalletSubcommands {
                 println!("0x{sig}");
             }
             WalletSubcommands::Verify { message, signature, address } => {
-                let recovered_address = signature.recover_address_from_msg(message)?;
-                if recovered_address == address {
+                let recovered_address = Self::recover_address_from_message(&message, &signature)?;
+                if address == recovered_address {
                     println!("Validation succeeded. Address {address} signed this message.");
                 } else {
                     println!("Validation failed. Address {address} did not sign this message.");
@@ -354,6 +354,11 @@ flag to set your key via:
         Ok(())
     }
 
+    /// Recovers an address from the specified message and signature
+    fn recover_address_from_message(message: &str, signature: &Signature) -> Result<Address> {
+        Ok(signature.recover_address_from_msg(message)?)
+    }
+
     fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>> {
         Ok(match s.strip_prefix("0x") {
             Some(data) => hex::decode(data).wrap_err("Could not decode 0x-prefixed string.")?,
@@ -364,6 +369,10 @@ flag to set your key via:
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::address;
+
     use super::*;
 
     #[test]
@@ -390,6 +399,17 @@ mod tests {
             }
             _ => panic!("expected WalletSubcommands::Sign"),
         }
+    }
+
+    #[test]
+    fn can_verify_signed_hex_message() {
+        let message = "hello";
+        let signature = Signature::from_str("f2dd00eac33840c04b6fc8a5ec8c4a47eff63575c2bc7312ecb269383de0c668045309c423484c8d097df306e690c653f8e1ec92f7f6f45d1f517027771c3e801c").unwrap();
+        let address = address!("28A4F420a619974a2393365BCe5a7b560078Cc13");
+        let recovered_address =
+            WalletSubcommands::recover_address_from_message(message, &signature);
+        assert!(recovered_address.is_ok());
+        assert_eq!(address, recovered_address.unwrap());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

#7088 broke `cast wallet verify`. The following worked previously and no longer works:
```
cast wallet verify --address 0x28A4F420a619974a2393365BCe5a7b560078Cc13 hello $(cast wallet sign --private-key 0x678d52cc9fdedbf5be1cd9b479725aab5ed8b9fbfbfeff9b660dff8b5766bf2a hello)
```

Error:
```
Odd number of digits
```

## Solution

This PR reverts a subset of the PR above which fixes the issue. Happy to take suggestions on alternative paths. Thanks!

Closes #7088 
