### PR TITLE
fix(forge): prefer --from if specified for `cast call`

### DIFF
--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -130,8 +130,8 @@ of the unlocked account you want to use, or provide the --from flag with the add
         Ok(signer)
     }
 
-    /// This function prefers the `from` field and may return a different address from the configured
-    /// signer
+    /// This function prefers the `from` field and may return a different address from the
+    /// configured signer
     /// If from is specified, returns it
     /// If from is not specified, but there is a signer configured, returns the signer's address
     /// If from is not specified and there is no signer configured, returns zero address


### PR DESCRIPTION
## Motivation

Seems like expected behavior is to always use `--from` or `ETH_FROM` if its specified, even if there are any wallet options specified in environment or via CLI args.

## Solution

Change order of things