### PR TITLE
fix(forge): total duration is not the sum of individual runs

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -32,7 +32,7 @@ use foundry_config::{
 };
 use foundry_debugger::Debugger;
 use regex::Regex;
-use std::{collections::BTreeMap, fs, sync::mpsc::channel, time::Instant};
+use std::{sync::mpsc::channel, time::Instant};
 use watchexec::config::{InitConfig, RuntimeConfig};
 use yansi::Paint;
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -42,7 +42,7 @@ impl TestOutcome {
 
     /// Creates a new empty test outcome.
     pub fn empty(allow_failure: bool) -> Self {
-        Self { results: BTreeMap::new(), allow_failure, decoder: None }
+        Self::new(BTreeMap::new(), allow_failure)
     }
 
     /// Returns an iterator over all individual succeeding tests and their names.
@@ -112,13 +112,15 @@ impl TestOutcome {
         self.failures().count()
     }
 
-    /// Calculates the total duration of all test suites.
-    pub fn duration(&self) -> Duration {
+    /// Sums up all the durations of all individual test suites.
+    ///
+    /// Note that this is not necessarily the wall clock time of the entire test run.
+    pub fn total_time(&self) -> Duration {
         self.results.values().map(|suite| suite.duration).sum()
     }
 
     /// Formats the aggregated summary of all test suites into a string (for printing).
-    pub fn summary(&self) -> String {
+    pub fn summary(&self, wall_clock_time: Duration) -> String {
         let num_test_suites = self.results.len();
         let suites = if num_test_suites == 1 { "suite" } else { "suites" };
         let total_passed = self.passed();
@@ -126,10 +128,11 @@ impl TestOutcome {
         let total_skipped = self.skipped();
         let total_tests = total_passed + total_failed + total_skipped;
         format!(
-            "\nRan {} test {} in {:.2?}: {} tests passed, {} failed, {} skipped ({} total tests)",
+            "\nRan {} test {} in {:.2?} ({:.2?} user time): {} tests passed, {} failed, {} skipped ({} total tests)",
             num_test_suites,
             suites,
-            self.duration(),
+            wall_clock_time,
+            self.total_time(),
             Paint::green(total_passed),
             Paint::red(total_failed),
             Paint::yellow(total_skipped),
@@ -180,7 +183,7 @@ impl TestOutcome {
 /// A set of test results for a single test suite, which is all the tests in a single contract.
 #[derive(Clone, Debug, Serialize)]
 pub struct SuiteResult {
-    /// Total duration of the test run for this block of tests.
+    /// Wall clock time it took to execute all tests in this suite.
     pub duration: Duration,
     /// Individual test results: `test fn signature -> TestResult`.
     pub test_results: BTreeMap<String, TestResult>,
@@ -242,17 +245,25 @@ impl SuiteResult {
         self.test_results.len()
     }
 
+    /// Sums up all the durations of all individual tests in this suite.
+    ///
+    /// Note that this is not necessarily the wall clock time of the entire test suite.
+    pub fn total_time(&self) -> Duration {
+        self.test_results.values().map(|result| result.duration).sum()
+    }
+
     /// Returns the summary of a single test suite.
     pub fn summary(&self) -> String {
         let failed = self.failed();
         let result = if failed == 0 { Paint::green("ok") } else { Paint::red("FAILED") };
         format!(
-            "Test result: {}. {} passed; {} failed; {} skipped; finished in {:.2?}",
+            "Suite result: {}. {} passed; {} failed; {} skipped; finished in {:.2?} ({:.2?} user time)",
             result,
             Paint::green(self.passed()),
             Paint::red(failed),
             Paint::yellow(self.skipped()),
             self.duration,
+            self.total_time(),
         )
     }
 }
@@ -356,6 +367,8 @@ pub struct TestResult {
 
     /// The debug nodes of the call
     pub debug: Option<DebugArena>,
+
+    pub duration: Duration,
 
     /// pc breakpoint char map
     pub breakpoints: Breakpoints,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -128,7 +128,7 @@ impl TestOutcome {
         let total_skipped = self.skipped();
         let total_tests = total_passed + total_failed + total_skipped;
         format!(
-            "\nRan {} test {} in {:.2?} ({:.2?} user time): {} tests passed, {} failed, {} skipped ({} total tests)",
+            "\nRan {} test {} in {:.2?} ({:.2?} CPU time): {} tests passed, {} failed, {} skipped ({} total tests)",
             num_test_suites,
             suites,
             wall_clock_time,
@@ -257,7 +257,7 @@ impl SuiteResult {
         let failed = self.failed();
         let result = if failed == 0 { Paint::green("ok") } else { Paint::red("FAILED") };
         format!(
-            "Suite result: {}. {} passed; {} failed; {} skipped; finished in {:.2?} ({:.2?} user time)",
+            "Suite result: {}. {} passed; {} failed; {} skipped; finished in {:.2?} ({:.2?} CPU time)",
             result,
             Paint::green(self.passed()),
             Paint::red(failed),

--- a/crates/forge/tests/fixtures/can_check_snapshot.stdout
+++ b/crates/forge/tests/fixtures/can_check_snapshot.stdout
@@ -4,6 +4,6 @@ Compiler run successful!
 
 Ran 1 test for src/ATest.t.sol:ATest
 [PASS] testExample() (gas: 168)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 4.42ms
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_run_test_in_custom_test_folder.stdout
+++ b/crates/forge/tests/fixtures/can_run_test_in_custom_test_folder.stdout
@@ -4,6 +4,6 @@ Compiler run successful!
 
 Ran 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
 [PASS] testTrue() (gas: 168)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.93ms
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/can_test_repeatedly.stdout
+++ b/crates/forge/tests/fixtures/can_test_repeatedly.stdout
@@ -3,6 +3,6 @@ No files changed, compilation skipped
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
 [PASS] test_Increment() (gas: 28379)
-Test result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
+Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
 
 Ran 1 test suite: 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -4,6 +4,6 @@ Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:ContractTest
 [PASS] test() (gas: 70360)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
+++ b/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
@@ -14,7 +14,7 @@ Traces:
     ├─ emit MyEvent(a: 100)
     └─ ← ()
 
-Test result: FAILED. 1 passed; 1 failed; 0 skipped; finished in 3.88ms
+Suite result: FAILED. 1 passed; 1 failed; 0 skipped; finished in 3.88ms
 
 Ran 1 test suite: 1 tests passed, 1 failed, 0 skipped (2 total tests)
 

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -14,6 +14,6 @@ Traces:
     │   └─ ← "USD Coin"
     └─ ← ()
 
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.43s
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.43s
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.1.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.1.stdout
@@ -4,6 +4,6 @@ Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.2.stdout
+++ b/crates/forge/tests/fixtures/runs_tests_exactly_once_with_changed_versions.2.stdout
@@ -4,6 +4,6 @@ Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
 [PASS] testExample() (gas: 190)
-Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
+Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 1.89ms
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -1054,7 +1054,7 @@ static IGNORE_IN_FIXTURES: Lazy<Regex> = Lazy::new(|| {
         // solc runs
         r"runs: \d+, μ: \d+, ~: \d+",
         // elapsed time
-        "(?:finished)? ?in .*?s",
+        r"(?:finished)? ?in .*?s(?: \(.*?s CPU time\))?",
         // file paths
         r"-->.*\.sol",
         r"Location(.|\n)*\.rs(.|\n)*Backtrace",


### PR DESCRIPTION
Since both individual suites (contracts) and tests can run in parallel, the sum of their individual durations can be different from the actual wall clock time taken executing them