### PR TITLE
fix: handle rpc error response

### DIFF
--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -117,7 +117,7 @@ pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// **Note**: override this function if the expected `Request` deviates from `{ "method" :
     /// "<name>", "params": "<params>" }`
     async fn on_call(&self, call: RpcMethodCall) -> RpcResponse {
-        trace!(target: "rpc",  id = ?call.id , method = ?call.method, "received method call");
+        trace!(target: "rpc",  id = ?call.id , method = ?call.method, params = ?call.params, "received method call");
         let RpcMethodCall { method, params, id, .. } = call;
 
         let params: serde_json::Value = params.into();

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -602,10 +602,7 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
-                    return fork
-                        .get_balance(address, number)
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.get_balance(address, number).await?)
                 }
             }
         }
@@ -630,9 +627,7 @@ impl EthApi {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
                     return Ok(B256::from(
-                        fork.storage_at(address, index, Some(BlockNumber::Number(number)))
-                            .await
-                            .map_err(|_| BlockchainError::DataUnavailable)?,
+                        fork.storage_at(address, index, Some(BlockNumber::Number(number))).await?,
                     ));
                 }
             }
@@ -764,10 +759,7 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
-                    return fork
-                        .get_code(address, number)
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.get_code(address, number).await?)
                 }
             }
         }
@@ -792,10 +784,7 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork_inclusive(number) {
-                    return fork
-                        .get_proof(address, keys, Some(number.into()))
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.get_proof(address, keys, Some(number.into())).await?)
                 }
             }
         }
@@ -990,10 +979,7 @@ impl EthApi {
                             "not available on past forked blocks".to_string(),
                         ));
                     }
-                    return fork
-                        .call(&request, Some(number.into()))
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.call(&request, Some(number.into())).await?)
                 }
             }
         }
@@ -1040,10 +1026,7 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork(number) {
-                    return fork
-                        .create_access_list(&request, Some(number.into()))
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.create_access_list(&request, Some(number.into())).await?)
                 }
             }
         }
@@ -1185,10 +1168,7 @@ impl EthApi {
             self.backend.ensure_block_number(Some(BlockId::Hash(block_hash.into()))).await?;
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork_inclusive(number) {
-                return fork
-                    .uncle_by_block_hash_and_index(block_hash, idx.into())
-                    .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                return Ok(fork.uncle_by_block_hash_and_index(block_hash, idx.into()).await?)
             }
         }
         // It's impossible to have uncles outside of fork mode
@@ -1207,10 +1187,7 @@ impl EthApi {
         let number = self.backend.ensure_block_number(Some(BlockId::Number(block_number))).await?;
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork_inclusive(number) {
-                return fork
-                    .uncle_by_block_number_and_index(number, idx.into())
-                    .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                return Ok(fork.uncle_by_block_number_and_index(number, idx.into()).await?);
             }
         }
         // It's impossible to have uncles outside of fork mode
@@ -2174,10 +2151,7 @@ impl EthApi {
                             "not available on past forked blocks".to_string(),
                         ));
                     }
-                    return fork
-                        .estimate_gas(&request, Some(number.into()))
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.estimate_gas(&request, Some(number.into())).await?)
                 }
             }
         }
@@ -2556,10 +2530,7 @@ impl EthApi {
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
                 if fork.predates_fork_inclusive(number) {
-                    return fork
-                        .get_nonce(address, number)
-                        .await
-                        .map_err(|_| BlockchainError::DataUnavailable);
+                    return Ok(fork.get_nonce(address, number).await?);
                 }
             }
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -393,8 +393,7 @@ impl Backend {
             let fork_block_number = fork.block_number();
             let fork_block = fork
                 .block_by_number(fork_block_number)
-                .await
-                .map_err(|_| BlockchainError::DataUnavailable)?
+                .await?
                 .ok_or(BlockchainError::BlockNotFound)?;
             // update all settings related to the forked block
             {
@@ -1248,7 +1247,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return fork.logs(&filter).await.map_err(|_| BlockchainError::DataUnavailable);
+            return Ok(fork.logs(&filter).await?);
         }
 
         Ok(Vec::new())
@@ -1335,8 +1334,7 @@ impl Backend {
             if fork.predates_fork(from) {
                 // this data is only available on the forked client
                 let filter = filter.clone().from_block(from).to_block(to_on_fork);
-                all_logs =
-                    fork.logs(&filter).await.map_err(|_| BlockchainError::DataUnavailable)?;
+                all_logs = fork.logs(&filter).await?;
 
                 // update the range
                 from = fork.block_number() + 1;
@@ -1379,7 +1377,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return fork.block_by_hash(hash).await.map_err(|_| BlockchainError::DataUnavailable);
+            return Ok(fork.block_by_hash(hash).await?);
         }
 
         Ok(None)
@@ -1395,10 +1393,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return fork
-                .block_by_hash_full(hash)
-                .await
-                .map_err(|_| BlockchainError::DataUnavailable);
+            return Ok(fork.block_by_hash_full(hash).await?)
         }
 
         Ok(None)
@@ -1452,10 +1447,7 @@ impl Backend {
         if let Some(fork) = self.get_fork() {
             let number = self.convert_block_number(Some(number));
             if fork.predates_fork_inclusive(number) {
-                return fork
-                    .block_by_number(number)
-                    .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                return Ok(fork.block_by_number(number).await?)
             }
         }
 
@@ -1474,10 +1466,7 @@ impl Backend {
         if let Some(fork) = self.get_fork() {
             let number = self.convert_block_number(Some(number));
             if fork.predates_fork_inclusive(number) {
-                return fork
-                    .block_by_number_full(number)
-                    .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                return Ok(fork.block_by_number_full(number).await?)
             }
         }
 
@@ -1891,10 +1880,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return fork.debug_trace_transaction(hash, opts).await.map_err(|err| {
-                warn!(target: "backend", "error delegating debug_traceTransaction: {:?}", err);
-                BlockchainError::DataUnavailable
-            })
+            return Ok(fork.debug_trace_transaction(hash, opts).await?)
         }
 
         Ok(GethTrace::Default(Default::default()))
@@ -1920,10 +1906,7 @@ impl Backend {
 
         if let Some(fork) = self.get_fork() {
             if fork.predates_fork(number) {
-                return fork.trace_block(number).await.map_err(|err| {
-                    warn!(target: "backend", "error delegating trace_block: {:?}", err);
-                    BlockchainError::DataUnavailable
-                })
+                return Ok(fork.trace_block(number).await?)
             }
         }
 
@@ -1939,10 +1922,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            let receipt = fork
-                .transaction_receipt(hash)
-                .await
-                .map_err(|_| BlockchainError::DataUnavailable)?;
+            let receipt = fork.transaction_receipt(hash).await?;
             let number = self.convert_block_number(
                 receipt
                     .clone()
@@ -2116,10 +2096,7 @@ impl Backend {
         if let Some(fork) = self.get_fork() {
             let number = self.convert_block_number(Some(number));
             if fork.predates_fork(number) {
-                return fork
-                    .transaction_by_block_number_and_index(number, index.into())
-                    .await
-                    .map_err(|_| BlockchainError::DataUnavailable);
+                return Ok(fork.transaction_by_block_number_and_index(number, index.into()).await?)
             }
         }
 
@@ -2136,10 +2113,7 @@ impl Backend {
         }
 
         if let Some(fork) = self.get_fork() {
-            return fork
-                .transaction_by_block_hash_and_index(hash, index.into())
-                .await
-                .map_err(|_| BlockchainError::DataUnavailable);
+            return Ok(fork.transaction_by_block_hash_and_index(hash, index.into()).await?)
         }
 
         Ok(None)


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/7023

this converts an error received from the fork properly, by converting it to an rpc err if it is an rpc error