### PR TITLE
feat: Add call depth to `vm.stopAndReturnStateDiff()` results

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -375,7 +375,7 @@
         },
         {
           "name": "depth",
-          "ty": "uint256",
+          "ty": "uint64",
           "description": "Call depth traversed during the recording of state differences"
         }
       ]

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -372,6 +372,11 @@
           "name": "storageAccesses",
           "ty": "StorageAccess[]",
           "description": "An ordered list of storage accesses made during an account access operation."
+        },
+        {
+          "name": "depth",
+          "ty": "uint256",
+          "description": "Call depth traversed during the recording of state differences"
         }
       ]
     },

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -203,6 +203,8 @@ interface Vm {
         bool reverted;
         /// An ordered list of storage accesses made during an account access operation.
         StorageAccess[] storageAccesses;
+        /// Call depth traversed during the recording of state differences
+        uint256 depth;
     }
 
     /// The storage accessed during an `AccountAccess`.

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -204,7 +204,7 @@ interface Vm {
         /// An ordered list of storage accesses made during an account access operation.
         StorageAccess[] storageAccesses;
         /// Call depth traversed during the recording of state differences
-        uint256 depth;
+        uint64 depth;
     }
 
     /// The storage accessed during an `AccountAccess`.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -536,8 +536,6 @@ pub(super) fn journaled_account<'a, DB: DatabaseExt>(
 /// In the case where `stopAndReturnStateDiff` is called at a lower
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
-///
-/// Depth value will be preserved in each AccountAccess member depth
 fn get_state_diff(state: &mut Cheatcodes) -> Result {
     let res = state
         .recorded_account_diffs_stack
@@ -545,10 +543,6 @@ fn get_state_diff(state: &mut Cheatcodes) -> Result {
         .unwrap_or_default()
         .into_iter()
         .flatten()
-        .map(|mut record| {
-            record.access.depth = U256::from(record.depth);
-            record.access
-        })
         .collect::<Vec<_>>();
     Ok(res.abi_encode())
 }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -536,6 +536,8 @@ pub(super) fn journaled_account<'a, DB: DatabaseExt>(
 /// In the case where `stopAndReturnStateDiff` is called at a lower
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
+///
+/// Depth value will be preserved in each AccountAccess member depth
 fn get_state_diff(state: &mut Cheatcodes) -> Result {
     let res = state
         .recorded_account_diffs_stack
@@ -543,7 +545,10 @@ fn get_state_diff(state: &mut Cheatcodes) -> Result {
         .unwrap_or_default()
         .into_iter()
         .flatten()
-        .map(|record| record.access)
+        .map(|mut record| {
+            record.access.depth = U256::from(record.depth);
+            record.access
+        })
         .collect::<Vec<_>>();
     Ok(res.abi_encode())
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -434,6 +434,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],
                     storageAccesses: vec![],
+                    depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                 };
                 // Ensure that we're not selfdestructing a context recording was initiated on
                 if let Some(last) = account_accesses.last_mut() {
@@ -541,6 +542,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         reverted: false,
                         deployedCode: vec![],
                         storageAccesses: vec![],
+                        depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                     };
                     let access = AccountAccess {
                         access: account_access,
@@ -899,6 +901,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],
                     storageAccesses: vec![], // updated on step
+                    depth: U256::from(0),    // updated on cheatcodes::evm::get_state_diff
                 },
                 depth: data.journaled_state.depth(),
             }]);
@@ -1283,6 +1286,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     reverted: false,
                     deployedCode: vec![],    // updated on create_end
                     storageAccesses: vec![], // updated on create_end
+                    depth: U256::from(0),    // updated on cheatcodes::evm::get_state_diff
                 },
                 depth,
             }]);
@@ -1613,6 +1617,7 @@ fn append_storage_access(
                         value: U256::ZERO,
                         data: vec![],
                         deployedCode: vec![],
+                        depth: U256::from(0), // updated on cheatcodes::evm::get_state_diff
                     };
                     last.push(AccountAccess { access: resume_record, depth: entry.depth });
                 }

--- a/testdata/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/cheats/RecordAccountAccesses.t.sol
@@ -348,7 +348,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             })
         );
 
@@ -366,7 +367,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -383,7 +385,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "hello world",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
         assertEq(
@@ -400,7 +403,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -417,7 +421,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 2 ether,
                 data: abi.encodePacked(type(SelfCaller).creationCode, abi.encode("hello2 world2")),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -434,7 +439,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.2 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
     }
@@ -461,7 +467,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodeCall(this.revertingCall, (address(1234), "")),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             })
         );
         assertEq(
@@ -478,7 +485,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: "",
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
     }
@@ -519,7 +527,8 @@ contract RecordAccountAccessesTest is DSTest {
                     value: 0,
                     data: "",
                     reverted: false,
-                    storageAccesses: new Vm.StorageAccess[](0)
+                    storageAccesses: new Vm.StorageAccess[](0),
+		    depth: startingIndex
                 })
             );
         }
@@ -551,7 +560,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodeCall(NestedRunner.run, (shouldRevert)),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex
             }),
             false
         );
@@ -583,7 +593,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: abi.encodeCall(Reverter.run, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 1
             }),
             false
         );
@@ -615,7 +626,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.01 ether,
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 2
             }),
             false
         );
@@ -647,7 +659,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.001 ether,
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: true,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 3
             }),
             false
         );
@@ -679,7 +692,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.1 ether,
                 data: abi.encodeCall(Succeeder.run, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 4
             }),
             false
         );
@@ -711,7 +725,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.01 ether,
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 5
             }),
             false
         );
@@ -743,7 +758,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0.001 ether,
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: shouldRevert,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: startingIndex + 6
             }),
             false
         );
@@ -782,7 +798,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodeCall(NestedStorer.run, ()),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             }),
             false
         );
@@ -826,7 +843,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodeCall(NestedStorer.run2, ()),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             }),
             false
         );
@@ -858,7 +876,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             }),
             false
         );
@@ -903,7 +922,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(false)),
                 reverted: false,
-                storageAccesses: storageAccesses
+                storageAccesses: storageAccesses,
+		depth: 0
             })
         );
 
@@ -925,7 +945,8 @@ contract RecordAccountAccessesTest is DSTest {
                     (bytes32(0), abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(true)))
                     ),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
 
@@ -953,7 +974,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: creationCode,
                 reverted: true,
-                storageAccesses: storageAccesses
+                storageAccesses: storageAccesses,
+		depth: 2
             })
         );
     }
@@ -998,7 +1020,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: creationCode,
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -1015,7 +1038,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
     }
@@ -1044,7 +1068,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(this))),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 1
             })
         );
         assertEq(
@@ -1061,7 +1086,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 2
             })
         );
         assertEq(
@@ -1078,7 +1104,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(bytes20("doesn't exist yet")))),
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 3
             })
         );
         assertEq(
@@ -1095,7 +1122,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 1 ether,
                 data: "",
                 reverted: false,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 4
             })
         );
     }
@@ -1190,7 +1218,8 @@ contract RecordAccountAccessesTest is DSTest {
                 value: 0,
                 data: "",
                 reverted: expected.reverted,
-                storageAccesses: new Vm.StorageAccess[](0)
+                storageAccesses: new Vm.StorageAccess[](0),
+		depth: 0
             }),
             false
         );

--- a/testdata/cheats/RecordAccountAccesses.t.sol
+++ b/testdata/cheats/RecordAccountAccesses.t.sol
@@ -349,7 +349,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 0
+                depth: 0
             })
         );
 
@@ -368,7 +368,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             })
         );
         assertEq(
@@ -386,7 +386,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "hello world",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 2
+                depth: 2
             })
         );
         assertEq(
@@ -404,7 +404,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 3
+                depth: 3
             })
         );
         assertEq(
@@ -422,7 +422,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodePacked(type(SelfCaller).creationCode, abi.encode("hello2 world2")),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 3
+                depth: 3
             })
         );
         assertEq(
@@ -440,7 +440,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 3
+                depth: 3
             })
         );
     }
@@ -468,7 +468,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(this.revertingCall, (address(1234), "")),
                 reverted: true,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 0
+                depth: 0
             })
         );
         assertEq(
@@ -486,7 +486,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: true,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             })
         );
     }
@@ -511,7 +511,7 @@ contract RecordAccountAccessesTest is DSTest {
         Vm.AccountAccess[] memory called = filterExtcodesizeForLegacyTests(cheats.stopAndReturnStateDiff());
         assertEq(called.length, 7 + toUint(expectFirstCall), "incorrect length");
 
-        uint256 startingIndex = toUint(expectFirstCall);
+        uint64 startingIndex = uint64(toUint(expectFirstCall));
         if (expectFirstCall) {
             assertEq(
                 called[0],
@@ -528,7 +528,7 @@ contract RecordAccountAccessesTest is DSTest {
                     data: "",
                     reverted: false,
                     storageAccesses: new Vm.StorageAccess[](0),
-		    depth: startingIndex
+                    depth: startingIndex
                 })
             );
         }
@@ -561,7 +561,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(NestedRunner.run, (shouldRevert)),
                 reverted: shouldRevert,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex
+                depth: startingIndex
             }),
             false
         );
@@ -594,7 +594,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Reverter.run, ()),
                 reverted: true,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 1
+                depth: startingIndex + 1
             }),
             false
         );
@@ -627,7 +627,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: true,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 2
+                depth: startingIndex + 2
             }),
             false
         );
@@ -660,7 +660,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: true,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 3
+                depth: startingIndex + 3
             }),
             false
         );
@@ -693,7 +693,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Succeeder.run, ()),
                 reverted: shouldRevert,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 4
+                depth: startingIndex + 4
             }),
             false
         );
@@ -726,7 +726,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Doer.run, ()),
                 reverted: shouldRevert,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 5
+                depth: startingIndex + 5
             }),
             false
         );
@@ -759,7 +759,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(Doer.doStuff, ()),
                 reverted: shouldRevert,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: startingIndex + 6
+                depth: startingIndex + 6
             }),
             false
         );
@@ -799,7 +799,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(NestedStorer.run, ()),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 0
+                depth: 0
             }),
             false
         );
@@ -844,7 +844,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodeCall(NestedStorer.run2, ()),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             }),
             false
         );
@@ -877,7 +877,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 2
+                depth: 2
             }),
             false
         );
@@ -923,7 +923,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodePacked(type(ConstructorStorer).creationCode, abi.encode(false)),
                 reverted: false,
                 storageAccesses: storageAccesses,
-		depth: 0
+                depth: 0
             })
         );
 
@@ -946,7 +946,7 @@ contract RecordAccountAccessesTest is DSTest {
                     ),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             })
         );
 
@@ -975,7 +975,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: creationCode,
                 reverted: true,
                 storageAccesses: storageAccesses,
-		depth: 2
+                depth: 2
             })
         );
     }
@@ -1021,7 +1021,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: creationCode,
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             })
         );
         assertEq(
@@ -1039,7 +1039,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 2
+                depth: 2
             })
         );
     }
@@ -1069,7 +1069,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(this))),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 1
+                depth: 1
             })
         );
         assertEq(
@@ -1087,7 +1087,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 2
+                depth: 2
             })
         );
         assertEq(
@@ -1105,7 +1105,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: abi.encodePacked(type(SelfDestructor).creationCode, abi.encode(address(bytes20("doesn't exist yet")))),
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 3
+                depth: 3
             })
         );
         assertEq(
@@ -1123,7 +1123,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: false,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 4
+                depth: 4
             })
         );
     }
@@ -1219,7 +1219,7 @@ contract RecordAccountAccessesTest is DSTest {
                 data: "",
                 reverted: expected.reverted,
                 storageAccesses: new Vm.StorageAccess[](0),
-		depth: 0
+                depth: 0
             }),
             false
         );

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -16,7 +16,7 @@ interface Vm {
     struct Wallet { address addr; uint256 publicKeyX; uint256 publicKeyY; uint256 privateKey; }
     struct FfiResult { int32 exitCode; bytes stdout; bytes stderr; }
     struct ChainInfo { uint256 forkId; uint256 chainId; }
-    struct AccountAccess { ChainInfo chainInfo; AccountAccessKind kind; address account; address accessor; bool initialized; uint256 oldBalance; uint256 newBalance; bytes deployedCode; uint256 value; bytes data; bool reverted; StorageAccess[] storageAccesses; }
+    struct AccountAccess { ChainInfo chainInfo; AccountAccessKind kind; address account; address accessor; bool initialized; uint256 oldBalance; uint256 newBalance; bytes deployedCode; uint256 value; bytes data; bool reverted; StorageAccess[] storageAccesses; uint64 depth; }
     struct StorageAccess { address account; bytes32 slot; bool isWrite; bytes32 previousValue; bytes32 newValue; bool reverted; }
     function _expectCheatcodeRevert() external;
     function _expectCheatcodeRevert(bytes4 revertData) external;


### PR DESCRIPTION
## Motivation
Closes #6632 

## Solution 
The call depth was already recorded in the `cheatcodes::inspector::AccountAccess` wrapper. This PR removes that wrapper type in favor of only using `cheatcodes::vm::AccountAccess`, which now has a depth field.

Credit to ercembu in #6667 for the initial implementation. I decided to pick this up since it's important to us at Sphinx, and that PR appears to be abandoned. I recommend closing that once this is merged.
