### PR TITLE
feat invariant (#5868) - configure calldata fuzzed addresses dictionary

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -88,6 +88,7 @@ pub struct FuzzDictionaryConfig {
     pub max_fuzz_dictionary_values: usize,
     /// How many random addresses to use and to recycle when fuzzing calldata.
     /// If not specified then `max_fuzz_dictionary_addresses` value applies.
+    #[serde(deserialize_with = "crate::deserialize_usize_or_max")]
     pub max_calldata_fuzz_dictionary_addresses: usize,
 }
 

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -86,6 +86,9 @@ pub struct FuzzDictionaryConfig {
     /// Once the fuzzer exceeds this limit, it will start evicting random entries
     #[serde(deserialize_with = "crate::deserialize_usize_or_max")]
     pub max_fuzz_dictionary_values: usize,
+    /// How many random addresses to use and to recycle when fuzzing calldata.
+    /// If not specified then `max_fuzz_dictionary_addresses` value applies.
+    pub max_calldata_fuzz_dictionary_addresses: Option<usize>,
 }
 
 impl Default for FuzzDictionaryConfig {
@@ -98,6 +101,7 @@ impl Default for FuzzDictionaryConfig {
             max_fuzz_dictionary_addresses: (300 * 1024 * 1024) / 20,
             // limit this to 200MB
             max_fuzz_dictionary_values: (200 * 1024 * 1024) / 32,
+            max_calldata_fuzz_dictionary_addresses: None,
         }
     }
 }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -88,7 +88,7 @@ pub struct FuzzDictionaryConfig {
     pub max_fuzz_dictionary_values: usize,
     /// How many random addresses to use and to recycle when fuzzing calldata.
     /// If not specified then `max_fuzz_dictionary_addresses` value applies.
-    pub max_calldata_fuzz_dictionary_addresses: Option<usize>,
+    pub max_calldata_fuzz_dictionary_addresses: usize,
 }
 
 impl Default for FuzzDictionaryConfig {
@@ -101,7 +101,7 @@ impl Default for FuzzDictionaryConfig {
             max_fuzz_dictionary_addresses: (300 * 1024 * 1024) / 20,
             // limit this to 200MB
             max_fuzz_dictionary_values: (200 * 1024 * 1024) / 32,
-            max_calldata_fuzz_dictionary_addresses: None,
+            max_calldata_fuzz_dictionary_addresses: 0,
         }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -33,7 +33,7 @@ use std::{cell::RefCell, collections::BTreeMap, sync::Arc};
 
 mod error;
 pub use error::{InvariantFailures, InvariantFuzzError, InvariantFuzzTestResult};
-use foundry_evm_fuzz::strategies::{CalldataFuzzDictionary, CalldataFuzzDictionaryConfig};
+use foundry_evm_fuzz::strategies::CalldataFuzzDictionary;
 
 mod funcs;
 pub use funcs::{assert_invariants, replay_run};
@@ -251,7 +251,7 @@ impl<'a> InvariantExecutor<'a> {
             Ok(())
         });
 
-        trace!(target: "forge::test::invariant::calldata_address_fuzz_dictionary", "{:?}", calldata_fuzz_dictionary.clone().addresses);
+        trace!(target: "forge::test::invariant::calldata_address_fuzz_dictionary", "{:?}", calldata_fuzz_dictionary.inner.addresses);
         trace!(target: "forge::test::invariant::dictionary", "{:?}", fuzz_state.read().values().iter().map(hex::encode).collect::<Vec<_>>());
 
         let (reverts, error) = failures.into_inner().into_inner();
@@ -290,9 +290,8 @@ impl<'a> InvariantExecutor<'a> {
         let targeted_contracts: FuzzRunIdentifiedContracts =
             Arc::new(Mutex::new(targeted_contracts));
 
-        let calldata_fuzz_config: CalldataFuzzDictionary = Arc::new(
-            CalldataFuzzDictionaryConfig::new(&self.config.dictionary, fuzz_state.clone()),
-        );
+        let calldata_fuzz_config =
+            CalldataFuzzDictionary::new(&self.config.dictionary, fuzz_state.clone());
 
         // Creates the invariant strategy.
         let strat = invariant_strat(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -33,13 +33,18 @@ use std::{cell::RefCell, collections::BTreeMap, sync::Arc};
 
 mod error;
 pub use error::{InvariantFailures, InvariantFuzzError, InvariantFuzzTestResult};
+use foundry_evm_fuzz::strategies::{CalldataFuzzDictionary, CalldataFuzzDictionaryConfig};
 
 mod funcs;
 pub use funcs::{assert_invariants, replay_run};
 
 /// Alias for (Dictionary for fuzzing, initial contracts to fuzz and an InvariantStrategy).
-type InvariantPreparation =
-    (EvmFuzzState, FuzzRunIdentifiedContracts, BoxedStrategy<Vec<BasicTxDetails>>);
+type InvariantPreparation = (
+    EvmFuzzState,
+    FuzzRunIdentifiedContracts,
+    BoxedStrategy<Vec<BasicTxDetails>>,
+    CalldataFuzzDictionary,
+);
 
 /// Enriched results of an invariant run check.
 ///
@@ -104,7 +109,8 @@ impl<'a> InvariantExecutor<'a> {
             return Err(eyre!("Invariant test function should have no inputs"))
         }
 
-        let (fuzz_state, targeted_contracts, strat) = self.prepare_fuzzing(&invariant_contract)?;
+        let (fuzz_state, targeted_contracts, strat, calldata_fuzz_dictionary) =
+            self.prepare_fuzzing(&invariant_contract)?;
 
         // Stores the consumed gas and calldata of every successful fuzz call.
         let fuzz_cases: RefCell<Vec<FuzzedCases>> = RefCell::new(Default::default());
@@ -239,6 +245,7 @@ impl<'a> InvariantExecutor<'a> {
             Ok(())
         });
 
+        trace!(target: "forge::test::invariant::calldata_address_fuzz_dictionary", "{:?}", calldata_fuzz_dictionary.clone().addresses);
         trace!(target: "forge::test::invariant::dictionary", "{:?}", fuzz_state.read().values().iter().map(hex::encode).collect::<Vec<_>>());
 
         let (reverts, error) = failures.into_inner().into_inner();
@@ -277,12 +284,17 @@ impl<'a> InvariantExecutor<'a> {
         let targeted_contracts: FuzzRunIdentifiedContracts =
             Arc::new(Mutex::new(targeted_contracts));
 
+        let calldata_fuzz_config: CalldataFuzzDictionary = Arc::new(
+            CalldataFuzzDictionaryConfig::new(&self.config.dictionary, fuzz_state.clone()),
+        );
+
         // Creates the invariant strategy.
         let strat = invariant_strat(
             fuzz_state.clone(),
             targeted_senders,
             targeted_contracts.clone(),
             self.config.dictionary.dictionary_weight,
+            calldata_fuzz_config.clone(),
         )
         .no_shrink()
         .boxed();
@@ -300,6 +312,7 @@ impl<'a> InvariantExecutor<'a> {
                     fuzz_state.clone(),
                     targeted_contracts.clone(),
                     target_contract_ref.clone(),
+                    calldata_fuzz_config.clone(),
                 ),
                 target_contract_ref,
             ));
@@ -308,7 +321,7 @@ impl<'a> InvariantExecutor<'a> {
         self.executor.inspector.fuzzer =
             Some(Fuzzer { call_generator, fuzz_state: fuzz_state.clone(), collect: true });
 
-        Ok((fuzz_state, targeted_contracts, strat))
+        Ok((fuzz_state, targeted_contracts, strat, calldata_fuzz_config))
     }
 
     /// Fills the `InvariantExecutor` with the artifact identifier filters (in `path:name` string

--- a/crates/evm/fuzz/src/strategies/calldata.rs
+++ b/crates/evm/fuzz/src/strategies/calldata.rs
@@ -1,18 +1,64 @@
-use super::fuzz_param;
+use crate::strategies::{fuzz_param, EvmFuzzState};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
+use foundry_config::FuzzDictionaryConfig;
+use hashbrown::HashSet;
 use proptest::prelude::{BoxedStrategy, Strategy};
+use std::{fmt, sync::Arc};
+
+pub type CalldataFuzzDictionary = Arc<CalldataFuzzDictionaryConfig>;
+
+#[derive(Clone)]
+pub struct CalldataFuzzDictionaryConfig {
+    /// Addresses that can be used for fuzzing calldata.
+    pub addresses: Vec<Address>,
+}
+
+impl fmt::Debug for CalldataFuzzDictionaryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CalldataFuzzDictionaryConfig").field("addresses", &self.addresses).finish()
+    }
+}
+
+impl CalldataFuzzDictionaryConfig {
+    pub fn new(config: &FuzzDictionaryConfig, state: EvmFuzzState) -> Self {
+        let mut addresses: HashSet<Address> = HashSet::new();
+
+        if let Some(len) = config.max_calldata_fuzz_dictionary_addresses {
+            loop {
+                if addresses.len() == len {
+                    break
+                }
+                addresses.insert(Address::random());
+            }
+
+            // add any state address calldata fuzz dictionary, in addition to random generated
+            // addresses
+            let mut state = state.write();
+            addresses.extend(state.addresses());
+        }
+
+        Self { addresses: Vec::from_iter(addresses) }
+    }
+}
 
 /// Given a function, it returns a strategy which generates valid calldata
 /// for that function's input types.
 pub fn fuzz_calldata(func: Function) -> BoxedStrategy<Bytes> {
+    fuzz_calldata_with_config(func, None)
+}
+
+pub fn fuzz_calldata_with_config(
+    func: Function,
+    config: Option<CalldataFuzzDictionary>,
+) -> BoxedStrategy<Bytes> {
     // We need to compose all the strategies generated for each parameter in all
     // possible combinations
     let strats = func
         .inputs
         .iter()
-        .map(|input| fuzz_param(&input.selector_type().parse().unwrap()))
+        .map(|input| fuzz_param(&input.selector_type().parse().unwrap(), config.clone()))
         .collect::<Vec<_>>();
 
     strats

--- a/crates/evm/fuzz/src/strategies/calldata.rs
+++ b/crates/evm/fuzz/src/strategies/calldata.rs
@@ -24,10 +24,11 @@ impl fmt::Debug for CalldataFuzzDictionaryConfig {
 impl CalldataFuzzDictionaryConfig {
     pub fn new(config: &FuzzDictionaryConfig, state: EvmFuzzState) -> Self {
         let mut addresses: HashSet<Address> = HashSet::new();
+        let dict_size = config.max_calldata_fuzz_dictionary_addresses;
 
-        if let Some(len) = config.max_calldata_fuzz_dictionary_addresses {
+        if dict_size > 0 {
             loop {
-                if addresses.len() == len {
+                if addresses.len() == dict_size {
                     break
                 }
                 addresses.insert(Address::random());

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -1,7 +1,7 @@
-use super::fuzz_param_from_state;
+use super::{fuzz_calldata_with_config, fuzz_param_from_state, CalldataFuzzDictionary};
 use crate::{
     invariant::{BasicTxDetails, FuzzRunIdentifiedContracts, SenderFilters},
-    strategies::{fuzz_calldata, fuzz_calldata_from_state, fuzz_param, EvmFuzzState},
+    strategies::{fuzz_calldata_from_state, fuzz_param, EvmFuzzState},
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes};
@@ -14,6 +14,7 @@ pub fn override_call_strat(
     fuzz_state: EvmFuzzState,
     contracts: FuzzRunIdentifiedContracts,
     target: Arc<RwLock<Address>>,
+    calldata_fuzz_config: CalldataFuzzDictionary,
 ) -> SBoxedStrategy<(Address, Bytes)> {
     let contracts_ref = contracts.clone();
 
@@ -27,10 +28,16 @@ pub fn override_call_strat(
     ])
     .prop_flat_map(move |target_address| {
         let fuzz_state = fuzz_state.clone();
+        let calldata_fuzz_config = calldata_fuzz_config.clone();
         let (_, abi, functions) = contracts.lock().get(&target_address).unwrap().clone();
         let func = select_random_function(abi, functions);
         func.prop_flat_map(move |func| {
-            fuzz_contract_with_calldata(fuzz_state.clone(), target_address, func)
+            fuzz_contract_with_calldata(
+                fuzz_state.clone(),
+                calldata_fuzz_config.clone(),
+                target_address,
+                func,
+            )
         })
     })
     .sboxed()
@@ -51,10 +58,12 @@ pub fn invariant_strat(
     senders: SenderFilters,
     contracts: FuzzRunIdentifiedContracts,
     dictionary_weight: u32,
+    calldata_fuzz_config: CalldataFuzzDictionary,
 ) -> impl Strategy<Value = Vec<BasicTxDetails>> {
     // We only want to seed the first value, since we want to generate the rest as we mutate the
     // state
-    generate_call(fuzz_state, senders, contracts, dictionary_weight).prop_map(|x| vec![x])
+    generate_call(fuzz_state, senders, contracts, dictionary_weight, calldata_fuzz_config)
+        .prop_map(|x| vec![x])
 }
 
 /// Strategy to generate a transaction where the `sender`, `target` and `calldata` are all generated
@@ -64,6 +73,7 @@ fn generate_call(
     senders: SenderFilters,
     contracts: FuzzRunIdentifiedContracts,
     dictionary_weight: u32,
+    calldata_fuzz_config: CalldataFuzzDictionary,
 ) -> BoxedStrategy<BasicTxDetails> {
     let random_contract = select_random_contract(contracts);
     let senders = Rc::new(senders);
@@ -72,10 +82,19 @@ fn generate_call(
             let func = select_random_function(abi, functions);
             let senders = senders.clone();
             let fuzz_state = fuzz_state.clone();
+            let calldata_fuzz_config = calldata_fuzz_config.clone();
             func.prop_flat_map(move |func| {
                 let sender =
                     select_random_sender(fuzz_state.clone(), senders.clone(), dictionary_weight);
-                (sender, fuzz_contract_with_calldata(fuzz_state.clone(), contract, func))
+                (
+                    sender,
+                    fuzz_contract_with_calldata(
+                        fuzz_state.clone(),
+                        calldata_fuzz_config.clone(),
+                        contract,
+                        func,
+                    ),
+                )
             })
         })
         .boxed()
@@ -93,7 +112,7 @@ fn select_random_sender(
     let fuzz_strategy = proptest::strategy::Union::new_weighted(vec![
         (
             100 - dictionary_weight,
-            fuzz_param(&alloy_dyn_abi::DynSolType::Address)
+            fuzz_param(&alloy_dyn_abi::DynSolType::Address, None)
                 .prop_map(move |addr| addr.as_address().unwrap())
                 .boxed(),
         ),
@@ -165,6 +184,7 @@ fn select_random_function(
 /// for that function's input types.
 pub fn fuzz_contract_with_calldata(
     fuzz_state: EvmFuzzState,
+    calldata_fuzz_config: CalldataFuzzDictionary,
     contract: Address,
     func: Function,
 ) -> impl Strategy<Value = (Address, Bytes)> {
@@ -173,7 +193,7 @@ pub fn fuzz_contract_with_calldata(
     // `prop_oneof!` / `TupleUnion` `Arc`s for cheap cloning
     #[allow(clippy::arc_with_non_send_sync)]
     let strats = prop_oneof![
-        60 => fuzz_calldata(func.clone()),
+        60 => fuzz_calldata_with_config(func.clone(), Some(calldata_fuzz_config)),
         40 => fuzz_calldata_from_state(func, fuzz_state),
     ];
     strats.prop_map(move |calldata| {

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -8,7 +8,9 @@ mod param;
 pub use param::{fuzz_param, fuzz_param_from_state};
 
 mod calldata;
-pub use calldata::fuzz_calldata;
+pub use calldata::{
+    fuzz_calldata, fuzz_calldata_with_config, CalldataFuzzDictionary, CalldataFuzzDictionaryConfig,
+};
 
 mod state;
 pub use state::{

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -1,4 +1,5 @@
 use super::state::EvmFuzzState;
+use crate::strategies::calldata::CalldataFuzzDictionary;
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{Address, FixedBytes, I256, U256};
 use arbitrary::Unstructured;
@@ -10,12 +11,30 @@ const MAX_ARRAY_LEN: usize = 256;
 /// Given a parameter type, returns a strategy for generating values for that type.
 ///
 /// Works with ABI Encoder v2 tuples.
-pub fn fuzz_param(param: &DynSolType) -> BoxedStrategy<DynSolValue> {
+pub fn fuzz_param(
+    param: &DynSolType,
+    config: Option<CalldataFuzzDictionary>,
+) -> BoxedStrategy<DynSolValue> {
     let param = param.to_owned();
     match param {
-        DynSolType::Address => any::<[u8; 32]>()
-            .prop_map(|x| DynSolValue::Address(Address::from_word(x.into())))
-            .boxed(),
+        DynSolType::Address => {
+            let cfg = config.clone();
+            if cfg.is_some() && !cfg.unwrap().addresses.is_empty() {
+                let dict_len = config.clone().unwrap().addresses.len();
+                any::<prop::sample::Index>()
+                    .prop_map(move |index| index.index(dict_len))
+                    .prop_map(move |index| {
+                        DynSolValue::Address(
+                            config.clone().unwrap().addresses.get(index).cloned().unwrap(),
+                        )
+                    })
+                    .boxed()
+            } else {
+                any::<[u8; 32]>()
+                    .prop_map(|x| DynSolValue::Address(Address::from_word(x.into())))
+                    .boxed()
+            }
+        }
         DynSolType::Int(n) => {
             let strat = super::IntStrategy::new(n, vec![]);
             let strat = strat.prop_map(move |x| DynSolValue::Int(x, n));
@@ -48,15 +67,22 @@ pub fn fuzz_param(param: &DynSolType) -> BoxedStrategy<DynSolValue> {
                 )
             })
             .boxed(),
-        DynSolType::Tuple(params) => {
-            params.iter().map(fuzz_param).collect::<Vec<_>>().prop_map(DynSolValue::Tuple).boxed()
+        DynSolType::Tuple(params) => params
+            .iter()
+            .map(|p| fuzz_param(p, config.clone()))
+            .collect::<Vec<_>>()
+            .prop_map(DynSolValue::Tuple)
+            .boxed(),
+        DynSolType::FixedArray(param, size) => {
+            proptest::collection::vec(fuzz_param(&param, config), size)
+                .prop_map(DynSolValue::FixedArray)
+                .boxed()
         }
-        DynSolType::FixedArray(param, size) => proptest::collection::vec(fuzz_param(&param), size)
-            .prop_map(DynSolValue::FixedArray)
-            .boxed(),
-        DynSolType::Array(param) => proptest::collection::vec(fuzz_param(&param), 0..MAX_ARRAY_LEN)
-            .prop_map(DynSolValue::Array)
-            .boxed(),
+        DynSolType::Array(param) => {
+            proptest::collection::vec(fuzz_param(&param, config), 0..MAX_ARRAY_LEN)
+                .prop_map(DynSolValue::Array)
+                .boxed()
+        }
         DynSolType::CustomStruct { .. } => panic!("unsupported type"),
     }
 }

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -123,6 +123,7 @@ pub fn test_opts() -> TestOptions {
                 dictionary_weight: 40,
                 max_fuzz_dictionary_addresses: 10_000,
                 max_fuzz_dictionary_values: 10_000,
+                max_calldata_fuzz_dictionary_addresses: None,
             },
         })
         .invariant(InvariantConfig {
@@ -136,6 +137,7 @@ pub fn test_opts() -> TestOptions {
                 include_push_bytes: true,
                 max_fuzz_dictionary_addresses: 10_000,
                 max_fuzz_dictionary_values: 10_000,
+                max_calldata_fuzz_dictionary_addresses: None,
             },
             shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18u32),

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -123,7 +123,7 @@ pub fn test_opts() -> TestOptions {
                 dictionary_weight: 40,
                 max_fuzz_dictionary_addresses: 10_000,
                 max_fuzz_dictionary_values: 10_000,
-                max_calldata_fuzz_dictionary_addresses: None,
+                max_calldata_fuzz_dictionary_addresses: 0,
             },
         })
         .invariant(InvariantConfig {
@@ -137,7 +137,7 @@ pub fn test_opts() -> TestOptions {
                 include_push_bytes: true,
                 max_fuzz_dictionary_addresses: 10_000,
                 max_fuzz_dictionary_values: 10_000,
-                max_calldata_fuzz_dictionary_addresses: None,
+                max_calldata_fuzz_dictionary_addresses: 0,
             },
             shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18u32),

--- a/testdata/fuzz/invariant/common/InvariantCalldataDictionary.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantCalldataDictionary.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../../../cheats/Vm.sol";
+
+struct FuzzSelector {
+    address addr;
+    bytes4[] selectors;
+}
+
+// https://github.com/foundry-rs/foundry/issues/5868
+contract Owned {
+    address public owner;
+    address private ownerCandidate;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    modifier onlyOwnerCandidate() {
+        require(msg.sender == ownerCandidate);
+        _;
+    }
+
+    function transferOwnership(address candidate) external onlyOwner {
+        ownerCandidate = candidate;
+    }
+
+    function acceptOwnership() external onlyOwnerCandidate {
+        owner = ownerCandidate;
+    }
+}
+
+contract Handler is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    Owned owned;
+
+    constructor(Owned _owned) {
+        owned = _owned;
+    }
+
+    function transferOwnership(address sender, address candidate) external {
+        vm.assume(sender != address(0));
+        vm.prank(sender);
+        owned.transferOwnership(candidate);
+    }
+
+    function acceptOwnership(address sender) external {
+        vm.assume(sender != address(0));
+        vm.prank(sender);
+        owned.acceptOwnership();
+    }
+}
+
+contract InvariantCalldataDictionary is DSTest {
+    address owner;
+    Owned owned;
+    Handler handler;
+
+    function setUp() public {
+        owner = address(this);
+        owned = new Owned();
+        handler = new Handler(owned);
+    }
+
+    function targetSelectors() public returns (FuzzSelector[] memory) {
+        FuzzSelector[] memory targets = new FuzzSelector[](1);
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = handler.transferOwnership.selector;
+        selectors[1] = handler.acceptOwnership.selector;
+        targets[0] = FuzzSelector(address(handler), selectors);
+        return targets;
+    }
+
+    function invariant_owner_never_changes() public {
+        assertEq(owned.owner(), owner);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Atm there's no way to configure calldata fuzzed params behavior - this could in particular be an issue when fuzzing addresses as there's little to no chance the same address is reused.
For invariant testing this is a bigger issue as one would often want to randomly reuse addresses when calling different handler selectors (see https://github.com/foundry-rs/foundry/issues/5868). Some projects maintains an array of addresses in handlers and fuzz the indexes / prank with users from array of addresses - that's a little bit hard to mantain and cannot scale for too many addresses.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR introduce an additional config for the dictionary of addresses used in calldata fuzzing.
```
[invariant]
max_calldata_fuzz_dictionary_addresses=100
```

- added `FuzzDictionaryConfig.max_calldata_fuzz_dictionary_addresses` option to specify how many random addresses to generate and to randomly select from when fuzzing calldata. If option is not specified then current behavior applies
- to narrow down number of runs / addresses involved in invariant test the `CalldataFuzzDictionaryConfig` is populated with random addresses plus all accounts from db (from `EvmFuzzState`)
- added `fuzz_calldata_with_config` fn that accepts `Option<CalldataFuzzDictionary>` as param. Non invariants tests use existing `fuzz_calldata` fn and pass None as config arg

Further improvements:
- add other options to generate fuzz dictionary address (like from external csv file, from inline config, etc)
- extend config also for basic (non invariant) tests
- extend calldata fuzz config with rules for other fuzzed param types  

Todo:
- add inline config
- add tests