### PR TITLE
fix(cast): fix to address reveal problem in cast receipt

### DIFF
--- a/crates/common/src/fmt/ui.rs
+++ b/crates/common/src/fmt/ui.rs
@@ -180,7 +180,7 @@ type                    {}",
         );
 
         if let Some(to) = to {
-            pretty.push_str(&format!("\nto                      {}", to));
+            pretty.push_str(&format!("\nto                      {}", to.pretty()));
         }
 
         // additional captured fields


### PR DESCRIPTION
## Motivation
fix(cast): fix to address reveal problem in cast receipt

cast receipt 

```shell
cast receipt 0xb07ed701975427442edb04dfe576ea145829744f6ce297ead59032b0f150ac13 --rpc-url=https://rpc.ankr.com/eth
```

output: 

```shell
blockHash               0x4869a5890a55c1ae4cdddf43481210b50826bae1d1b40135557f08ff4e8f4420
blockNumber             19323316
contractAddress         
cumulativeGasUsed       859206
effectiveGasPrice       49687020650
from                    0x259F3683692caEA205495742fd2eFE47539857Dc
gasUsed                 54436
logs                    [{"address":"0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe","topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x000000000000000000000000259f3683692caea205495742fd2efe47539857dc","0x0000000000000000000000005c9321e92ba4eb43f2901c4952358e132163a85a"],"data":"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc17","blockHash":"0x4869a5890a55c1ae4cdddf43481210b50826bae1d1b40135557f08ff4e8f4420","blockNumber":"0x126d9b4","transactionHash":"0xb07ed701975427442edb04dfe576ea145829744f6ce297ead59032b0f150ac13","transactionIndex":"0xd","logIndex":"0x15","removed":false}]
logsBloom               0x00000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000800000000000000000200000000000001000000002000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000800000000000000000010000000000000000000000020000000000000000000000000000000000000
root                    
status                  1
transactionHash         0xb07ed701975427442edb04dfe576ea145829744f6ce297ead59032b0f150ac13
transactionIndex        13
type                    2
to                      0x3419…b4fe
```

Where `to` field isn't shown completely. 


After this fix:

```shell
blockHash               0x4869a5890a55c1ae4cdddf43481210b50826bae1d1b40135557f08ff4e8f4420
blockNumber             19323316
contractAddress         
cumulativeGasUsed       859206
effectiveGasPrice       49687020650
from                    0x259F3683692caEA205495742fd2eFE47539857Dc
gasUsed                 54436
logs                    [{"address":"0x3419875b4d3bca7f3fdda2db7a476a79fd31b4fe","topics":["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925","0x000000000000000000000000259f3683692caea205495742fd2efe47539857dc","0x0000000000000000000000005c9321e92ba4eb43f2901c4952358e132163a85a"],"data":"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc17","blockHash":"0x4869a5890a55c1ae4cdddf43481210b50826bae1d1b40135557f08ff4e8f4420","blockNumber":"0x126d9b4","transactionHash":"0xb07ed701975427442edb04dfe576ea145829744f6ce297ead59032b0f150ac13","transactionIndex":"0xd","logIndex":"0x15","removed":false}]
logsBloom               0x00000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000800000000000000000200000000000001000000002000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000800000000000000000010000000000000000000000020000000000000000000000000000000000000
root                    
status                  1
transactionHash         0xb07ed701975427442edb04dfe576ea145829744f6ce297ead59032b0f150ac13
transactionIndex        13
type                    2
to                      0x3419875B4D3Bca7F3FddA2dB7a476A79fD31B4fE
```
