### PR TITLE
invariant (bug): inconsistent shrinked call sequence sometimes

### DIFF
--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -253,14 +253,18 @@ impl InvariantFuzzError {
 
         let shrunk_call_indices = self.try_shrinking_recurse(calls, executor, 0, 0);
 
-        // Filter the calls by if the call index is present in `shrunk_call_indices`
-        calls
-            .iter()
-            .enumerate()
-            .filter_map(
-                |(i, call)| if shrunk_call_indices.contains(&i) { Some(call) } else { None },
-            )
-            .collect()
+        // we recreate the call sequence in the same order as they reproduce the failure
+        // otherwise we could end up with inverted sequence
+        // e.g. in a sequence of:
+        // 1. Alice calls acceptOwnership and reverts
+        // 2. Bob calls transferOwnership to Alice
+        // 3. Alice calls acceptOwnership and test fails
+        // we shrink to indices of [2, 1] and we recreate call sequence in same order
+        let mut new_calls_sequence = Vec::with_capacity(shrunk_call_indices.len());
+        shrunk_call_indices.iter().for_each(|call_index| {
+            new_calls_sequence.push(calls.get(*call_index).unwrap());
+        });
+        new_calls_sequence
     }
 
     /// We try to construct a [powerset](https://en.wikipedia.org/wiki/Power_set) of the sequence if


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

while testing fix for https://github.com/foundry-rs/foundry/issues/5868 noticed that sometimes the shrinked sequence comes inverted, e.g.

```
        [Sequence]
                sender=0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 addr=[test/Owned.t.sol:Handler]0x2e234DAe75C793f67A35089C9d99245E1C58470b calldata=acceptOwnership(address) args=[0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f]
                sender=0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 addr=[test/Owned.t.sol:Handler]0x2e234DAe75C793f67A35089C9d99245E1C58470b calldata=transferOwnership(address,address) args=[0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496, 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f]
```
instead
```
        [Sequence]
                sender=0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 addr=[test/Owned.t.sol:Handler]0x2e234DAe75C793f67A35089C9d99245E1C58470b calldata=transferOwnership(address,address) args=[0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496, 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f]
                sender=0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 addr=[test/Owned.t.sol:Handler]0x2e234DAe75C793f67A35089C9d99245E1C58470b calldata=acceptOwnership(address) args=[0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f]
```
this happens when the same `acceptOwnership` call that breaks invariant is also performed before `transferOwnership` prereq, that is in a sequence of:
1. Alice calls acceptOwnership and reverts
2. Bob calls transferOwnership to Alice
3. Alice calls acceptOwnership and breaks invariant
in this case shrinked indices are [2, 1] but we recreate call sequence as 1 and 2

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Recreate new shrinked call sequence by respecting the order from shrunk call indices
