### PR TITLE
invariant shrink #6683: check if test failed instead revert

### DIFF
--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -214,12 +214,18 @@ impl InvariantFuzzError {
                 .call_raw_committing(*sender, *addr, bytes.clone(), U256::ZERO)
                 .expect("bad call to evm");
 
-            // Checks the invariant. If we exit before the last call, all the better.
+            // Checks the invariant. If we revert or fail before the last call, all the better.
             if let Some(func) = &self.func {
-                let error_call_result = executor
+                let call_result = executor
                     .call_raw(CALLER, self.addr, func.clone(), U256::ZERO)
                     .expect("bad call to evm");
-                if error_call_result.reverted {
+                let is_success = executor.is_raw_call_success(
+                    self.addr,
+                    call_result.state_changeset.clone().unwrap(),
+                    &call_result,
+                    false,
+                );
+                if !is_success {
                     let mut locked = curr_seq.write();
                     if new_sequence[..=seq_idx].len() < locked.len() {
                         // update the curr_sequence if the new sequence is lower than

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -216,12 +216,12 @@ impl InvariantFuzzError {
 
             // Checks the invariant. If we revert or fail before the last call, all the better.
             if let Some(func) = &self.func {
-                let call_result = executor
+                let mut call_result = executor
                     .call_raw(CALLER, self.addr, func.clone(), U256::ZERO)
                     .expect("bad call to evm");
                 let is_success = executor.is_raw_call_success(
                     self.addr,
-                    call_result.state_changeset.clone().unwrap(),
+                    call_result.state_changeset.take().unwrap(),
                     &call_result,
                     false,
                 );

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -286,7 +286,7 @@ async fn test_invariant_assert_shrink() {
     let mut opts = test_opts();
     opts.fuzz.seed = Some(U256::from(119u32));
 
-    // ensure assert and require shrinks to same sequence of 3
+    // ensure assert and require shrinks to same sequence of 3 or less
     test_shrink(opts.clone(), "InvariantShrinkWithAssert").await;
     test_shrink(opts.clone(), "InvariantShrinkWithRequire").await;
 }
@@ -322,7 +322,7 @@ async fn test_shrink(opts: TestOptions, contract_pattern: &str) {
     match counter {
         CounterExample::Single(_) => panic!("CounterExample should be a sequence."),
         CounterExample::Sequence(sequence) => {
-            assert_eq!(sequence.len(), 3);
+            assert!(sequence.len() <= 3);
         }
     };
 }

--- a/testdata/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+import "../../../cheats/Vm.sol";
+
+struct FuzzSelector {
+    address addr;
+    bytes4[] selectors;
+}
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+
+    function decrement() public {
+        number--;
+    }
+
+    function double() public {
+        number *= 2;
+    }
+
+    function half() public {
+        number /= 2;
+    }
+
+    function triple() public {
+        number *= 3;
+    }
+
+    function third() public {
+        number /= 3;
+    }
+
+    function quadruple() public {
+        number *= 4;
+    }
+
+    function quarter() public {
+        number /= 4;
+    }
+}
+
+contract Handler is DSTest {
+    Counter public counter;
+
+    constructor(Counter _counter) {
+        counter = _counter;
+        counter.setNumber(0);
+    }
+
+    function increment() public {
+        counter.increment();
+    }
+
+    function setNumber(uint256 x) public {
+        counter.setNumber(x);
+    }
+}
+
+contract InvariantShrinkWithAssert is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    Counter public counter;
+    Handler handler;
+
+    function setUp() public {
+        counter = new Counter();
+        handler = new Handler(counter);
+    }
+
+    function targetSelectors() public returns (FuzzSelector[] memory) {
+        FuzzSelector[] memory targets = new FuzzSelector[](1);
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = handler.increment.selector;
+        selectors[1] = handler.setNumber.selector;
+        targets[0] = FuzzSelector(address(handler), selectors);
+        return targets;
+    }
+
+    function invariant_with_assert() public {
+        assertTrue(counter.number() != 3);
+    }
+}
+
+contract InvariantShrinkWithRequire is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    Counter public counter;
+    Handler handler;
+
+    function setUp() public {
+        counter = new Counter();
+        handler = new Handler(counter);
+    }
+
+    function targetSelectors() public returns (FuzzSelector[] memory) {
+        FuzzSelector[] memory targets = new FuzzSelector[](1);
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = handler.increment.selector;
+        selectors[1] = handler.setNumber.selector;
+        targets[0] = FuzzSelector(address(handler), selectors);
+        return targets;
+    }
+
+    function invariant_with_require() public {
+        require(counter.number() != 3, "wrong counter");
+    }
+}


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

see https://github.com/foundry-rs/foundry/issues/6683#issuecomment-1966794329
Atm shrinking doesn't apply for invariants using asserts but only for invariants that reverts (require)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- when deciding if a sequence can fail test check if test failed (instead if reverted only)
- added test with assert and require to ensure they shrink at same len
