### PR TITLE
fix(foundryup): use fish_add_path in fish shell

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -45,7 +45,12 @@ esac
 # Only add foundryup if it isn't already in PATH.
 if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
     # Add the foundryup directory to the path and ensure the old PATH variables remain.
-    echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
+    # If the shell is fish, echo fish_add_path instead of export.
+    if [[ "$PREF_SHELL" == "fish" ]]; then
+        echo >> "$PROFILE" && echo "fish_add_path -a $FOUNDRY_BIN_DIR" >> "$PROFILE"
+    else
+        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
+    fi
 fi
 
 # Warn MacOS users that they may need to manually install libusb via Homebrew:


### PR DESCRIPTION
## Motivation

Addresses #6487 .

## Solution

Use `fish_add_path` - more idiomatic way to add to path for fish shell.
