### PR TITLE
fix(forge): list cache files that are saved as block numbers for `cache ls`

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1526,15 +1526,14 @@ impl Config {
             let file_name = block.file_name();
             let filepath = if file_type.is_dir() {
                 block.path().join("storage.json")
-            } else if file_type.is_file() && file_name.to_string_lossy().chars().all(char::is_numeric) {
+            } else if file_type.is_file() &&
+                file_name.to_string_lossy().chars().all(char::is_numeric)
+            {
                 block.path()
             } else {
                 continue
             };
-            blocks.push((
-                file_name.to_string_lossy().into_owned(),
-                fs::metadata(filepath)?.len(),
-            ));
+            blocks.push((file_name.to_string_lossy().into_owned(), fs::metadata(filepath)?.len()));
         }
         Ok(blocks)
     }
@@ -4567,7 +4566,11 @@ mod tests {
             writeln!(file, "{}", vec![' '; size_bytes - 1].iter().collect::<String>()).unwrap();
         }
 
-        fn fake_block_cache_block_path_as_file(chain_path: &Path, block_number: &str, size_bytes: usize) {
+        fn fake_block_cache_block_path_as_file(
+            chain_path: &Path,
+            block_number: &str,
+            size_bytes: usize,
+        ) {
             let block_path = chain_path.join(block_number);
             let mut file = File::create(block_path).unwrap();
             writeln!(file, "{}", vec![' '; size_bytes - 1].iter().collect::<String>()).unwrap();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1521,8 +1521,12 @@ impl Config {
         if !chain_path.exists() {
             return Ok(blocks)
         }
-        for block in chain_path.read_dir()?.flatten().filter(|x| x.file_type().unwrap().is_dir()) {
-            let filepath = block.path().join("storage.json");
+        for block in chain_path.read_dir()?.flatten() {
+            let filepath = if block.file_type()?.is_dir() {
+                block.path().join("storage.json")
+            } else {
+                block.path()
+            };
             blocks.push((
                 block.file_name().to_string_lossy().into_owned(),
                 fs::metadata(filepath)?.len(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Some time ago, after this PR https://github.com/foundry-rs/foundry/commit/4ae40da76e9a1dbb56c136db509dc3e7eab703c8#diff-61de971a1475be0209ee9896ce71d6b3424904b26eb2ea0227d1ff23ee4e6e6bL585-L587

the rpc cache location was changed from 
`~/.foundry/cache/rpc/[chain]/[blockNumber]/storage.json` 
to 
`~/.foundry/cache/rpc/[chain]/[blockNumber]`

However the `cache ls` function was not updated with this change.
This resulted `forge cache ls` listing very old caches that are not used anymore, but ignoring the newer caches as they are not directories.


Example:
Running `forge cache ls` with forge 0.2.0 (43b4e23 2024-02-25T00:21:15.546682000Z)

<img width="335" alt="image" src="https://github.com/foundry-rs/foundry/assets/4276174/8a69364e-b69b-4f59-a9a3-26a53ad10182">

Note that the RPC caches are ignored in above output and the total sizes are do not include them.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Don't ignore files that are numeric only in their names when listing caches.

<img width="327" alt="image" src="https://github.com/foundry-rs/foundry/assets/4276174/ff7bc57a-140c-4a29-92a1-e03cfda94c14">

RPC caches are included and the total size of the cache is correctly displayed as well.
