### PR TITLE
chore(cli): fix clap deprecated warnings

### DIFF
--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -13,7 +13,6 @@ pub struct ServerConfig {
             long,
             help = "Set the CORS allow_origin",
             default_value = "*",
-            name = "allow-origin",
             value_name = "ALLOW_ORIGIN"
         )
     )]

--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -20,7 +20,7 @@ pub struct ServerConfig {
     /// Whether to enable CORS
     #[cfg_attr(
         feature = "clap",
-        arg(long, help = "Disable CORS", conflicts_with = "allow-origin")
+        arg(long, help = "Disable CORS", conflicts_with = "allow_origin")
     )]
     pub no_cors: bool,
 }

--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -4,12 +4,12 @@ use std::str::FromStr;
 
 /// Additional server options.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::Parser), clap(next_help_heading = "Server options"))]
+#[cfg_attr(feature = "clap", derive(clap::Parser), command(next_help_heading = "Server options"))]
 pub struct ServerConfig {
     /// The cors `allow_origin` header
     #[cfg_attr(
         feature = "clap",
-        clap(
+        arg(
             long,
             help = "Set the CORS allow_origin",
             default_value = "*",
@@ -21,7 +21,7 @@ pub struct ServerConfig {
     /// Whether to enable CORS
     #[cfg_attr(
         feature = "clap",
-        clap(long, help = "Disable CORS", conflicts_with = "allow-origin")
+        arg(long, help = "Disable CORS", conflicts_with = "allow-origin")
     )]
     pub no_cors: bool,
 }

--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -4,26 +4,26 @@ use clap::{CommandFactory, Parser, Subcommand};
 
 /// A fast local Ethereum development node.
 #[derive(Parser)]
-#[clap(name = "anvil", version = anvil::VERSION_MESSAGE, next_display_order = None)]
+#[command(name = "anvil", version = anvil::VERSION_MESSAGE, next_display_order = None)]
 pub struct Anvil {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub node: NodeArgs,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub cmd: Option<AnvilSubcommand>,
 }
 
 #[derive(Subcommand)]
 pub enum AnvilSubcommand {
     /// Generate shell completions script.
-    #[clap(visible_alias = "com")]
+    #[command(visible_alias = "com")]
     Completions {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
 
     /// Generate Fig autocompletion spec.
-    #[clap(visible_alias = "fig")]
+    #[command(visible_alias = "fig")]
     GenerateFigSpec,
 }
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -91,7 +91,7 @@ pub struct NodeArgs {
     pub config_out: Option<String>,
 
     /// Disable auto and interval mining, and mine on demand instead.
-    #[arg(long, visible_alias = "no-mine", conflicts_with = "block-time")]
+    #[arg(long, visible_alias = "no-mine", conflicts_with = "block_time")]
     pub no_mining: bool,
 
     /// The hosts the server will listen on.

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -30,31 +30,31 @@ use tokio::time::{Instant, Interval};
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {
     /// Port number to listen on.
-    #[clap(long, short, default_value = "8545", value_name = "NUM")]
+    #[arg(long, short, default_value = "8545", value_name = "NUM")]
     pub port: u16,
 
     /// Number of dev accounts to generate and configure.
-    #[clap(long, short, default_value = "10", value_name = "NUM")]
+    #[arg(long, short, default_value = "10", value_name = "NUM")]
     pub accounts: u64,
 
     /// The balance of every dev account in Ether.
-    #[clap(long, default_value = "10000", value_name = "NUM")]
+    #[arg(long, default_value = "10000", value_name = "NUM")]
     pub balance: u64,
 
     /// The timestamp of the genesis block.
-    #[clap(long, value_name = "NUM")]
+    #[arg(long, value_name = "NUM")]
     pub timestamp: Option<u64>,
 
     /// BIP39 mnemonic phrase used for generating accounts.
     /// Cannot be used if `mnemonic_random` or `mnemonic_seed` are used
-    #[clap(long, short, conflicts_with_all = &["mnemonic_seed", "mnemonic_random"])]
+    #[arg(long, short, conflicts_with_all = &["mnemonic_seed", "mnemonic_random"])]
     pub mnemonic: Option<String>,
 
     /// Automatically generates a BIP39 mnemonic phrase, and derives accounts from it.
     /// Cannot be used with other `mnemonic` options
     /// You can specify the number of words you want in the mnemonic.
     /// [default: 12]
-    #[clap(long, conflicts_with_all = &["mnemonic", "mnemonic_seed"], default_missing_value = "12", num_args(0..=1))]
+    #[arg(long, conflicts_with_all = &["mnemonic", "mnemonic_seed"], default_missing_value = "12", num_args(0..=1))]
     pub mnemonic_random: Option<usize>,
 
     /// Generates a BIP39 mnemonic phrase from a given seed
@@ -62,40 +62,40 @@ pub struct NodeArgs {
     ///
     /// CAREFUL: this is NOT SAFE and should only be used for testing.
     /// Never use the private keys generated in production.
-    #[clap(long = "mnemonic-seed-unsafe", conflicts_with_all = &["mnemonic", "mnemonic_random"])]
+    #[arg(long = "mnemonic-seed-unsafe", conflicts_with_all = &["mnemonic", "mnemonic_random"])]
     pub mnemonic_seed: Option<u64>,
 
     /// Sets the derivation path of the child key to be derived.
     ///
     /// [default: m/44'/60'/0'/0/]
-    #[clap(long)]
+    #[arg(long)]
     pub derivation_path: Option<String>,
 
     /// Don't print anything on startup and don't print logs
-    #[clap(long)]
+    #[arg(long)]
     pub silent: bool,
 
     /// The EVM hardfork to use.
     ///
     /// Choose the hardfork by name, e.g. `shanghai`, `paris`, `london`, etc...
     /// [default: latest]
-    #[clap(long, value_parser = Hardfork::from_str)]
+    #[arg(long, value_parser = Hardfork::from_str)]
     pub hardfork: Option<Hardfork>,
 
     /// Block time in seconds for interval mining.
-    #[clap(short, long, visible_alias = "blockTime", name = "block-time", value_name = "SECONDS")]
+    #[arg(short, long, visible_alias = "blockTime", name = "block-time", value_name = "SECONDS")]
     pub block_time: Option<u64>,
 
     /// Writes output of `anvil` as json to user-specified file.
-    #[clap(long, value_name = "OUT_FILE")]
+    #[arg(long, value_name = "OUT_FILE")]
     pub config_out: Option<String>,
 
     /// Disable auto and interval mining, and mine on demand instead.
-    #[clap(long, visible_alias = "no-mine", conflicts_with = "block-time")]
+    #[arg(long, visible_alias = "no-mine", conflicts_with = "block-time")]
     pub no_mining: bool,
 
     /// The hosts the server will listen on.
-    #[clap(
+    #[arg(
         long,
         value_name = "IP_ADDR",
         env = "ANVIL_IP_ADDR",
@@ -106,18 +106,18 @@ pub struct NodeArgs {
     pub host: Vec<IpAddr>,
 
     /// How transactions are sorted in the mempool.
-    #[clap(long, default_value = "fees")]
+    #[arg(long, default_value = "fees")]
     pub order: TransactionOrder,
 
     /// Initialize the genesis block with the given `genesis.json` file.
-    #[clap(long, value_name = "PATH", value_parser= read_genesis_file)]
+    #[arg(long, value_name = "PATH", value_parser= read_genesis_file)]
     pub init: Option<Genesis>,
 
     /// This is an alias for both --load-state and --dump-state.
     ///
     /// It initializes the chain with the state and block environment stored at the file, if it
     /// exists, and dumps the chain's state on exit.
-    #[clap(
+    #[arg(
         long,
         value_name = "PATH",
         value_parser = StateFile::parse,
@@ -132,17 +132,17 @@ pub struct NodeArgs {
     /// Interval in seconds at which the state and block environment is to be dumped to disk.
     ///
     /// See --state and --dump-state
-    #[clap(short, long, value_name = "SECONDS")]
+    #[arg(short, long, value_name = "SECONDS")]
     pub state_interval: Option<u64>,
 
     /// Dump the state and block environment of chain on exit to the given file.
     ///
     /// If the value is a directory, the state will be written to `<VALUE>/state.json`.
-    #[clap(long, value_name = "PATH", conflicts_with = "init")]
+    #[arg(long, value_name = "PATH", conflicts_with = "init")]
     pub dump_state: Option<PathBuf>,
 
     /// Initialize the chain from a previously saved state snapshot.
-    #[clap(
+    #[arg(
         long,
         value_name = "PATH",
         value_parser = SerializableState::parse,
@@ -150,22 +150,22 @@ pub struct NodeArgs {
     )]
     pub load_state: Option<SerializableState>,
 
-    #[clap(long, help = IPC_HELP, value_name = "PATH", visible_alias = "ipcpath")]
+    #[arg(long, help = IPC_HELP, value_name = "PATH", visible_alias = "ipcpath")]
     pub ipc: Option<Option<String>>,
 
     /// Don't keep full chain history.
     /// If a number argument is specified, at most this number of states is kept in memory.
-    #[clap(long)]
+    #[arg(long)]
     pub prune_history: Option<Option<usize>>,
 
     /// Number of blocks with transactions to keep in memory.
-    #[clap(long)]
+    #[arg(long)]
     pub transaction_block_keeper: Option<usize>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub evm_opts: AnvilEvmArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub server_config: ServerConfig,
 }
 
@@ -344,12 +344,12 @@ impl NodeArgs {
 
 /// Anvil's EVM related arguments.
 #[derive(Clone, Debug, Parser)]
-#[clap(next_help_heading = "EVM options")]
+#[command(next_help_heading = "EVM options")]
 pub struct AnvilEvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
     /// If you want to fetch state from a specific block number, add a block number like `http://localhost:8545@1400000` or use the `--fork-block-number` argument.
-    #[clap(
+    #[arg(
         long,
         short,
         visible_alias = "rpc-url",
@@ -361,7 +361,7 @@ pub struct AnvilEvmArgs {
     /// Headers to use for the rpc client, e.g. "User-Agent: test-agent"
     ///
     /// See --fork-url.
-    #[clap(
+    #[arg(
         long = "fork-header",
         value_name = "HEADERS",
         help_heading = "Fork config",
@@ -372,35 +372,25 @@ pub struct AnvilEvmArgs {
     /// Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
     ///
     /// Default value 45000
-    #[clap(
-        long = "timeout",
-        name = "timeout",
-        help_heading = "Fork config",
-        requires = "fork_url"
-    )]
+    #[arg(long = "timeout", name = "timeout", help_heading = "Fork config", requires = "fork_url")]
     pub fork_request_timeout: Option<u64>,
 
     /// Number of retry requests for spurious networks (timed out requests)
     ///
     /// Default value 5
-    #[clap(
-        long = "retries",
-        name = "retries",
-        help_heading = "Fork config",
-        requires = "fork_url"
-    )]
+    #[arg(long = "retries", name = "retries", help_heading = "Fork config", requires = "fork_url")]
     pub fork_request_retries: Option<u32>,
 
     /// Fetch state from a specific block number over a remote endpoint.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BLOCK", help_heading = "Fork config")]
+    #[arg(long, requires = "fork_url", value_name = "BLOCK", help_heading = "Fork config")]
     pub fork_block_number: Option<u64>,
 
     /// Initial retry backoff on encountering errors.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "Fork config")]
+    #[arg(long, requires = "fork_url", value_name = "BACKOFF", help_heading = "Fork config")]
     pub fork_retry_backoff: Option<u64>,
 
     /// Specify chain id to skip fetching it from remote endpoint. This enables offline-start mode.
@@ -408,7 +398,7 @@ pub struct AnvilEvmArgs {
     /// You still must pass both `--fork-url` and `--fork-block-number`, and already have your
     /// required state cached on disk, anything missing locally would be fetched from the
     /// remote.
-    #[clap(
+    #[arg(
         long,
         help_heading = "Fork config",
         value_name = "CHAIN",
@@ -422,7 +412,7 @@ pub struct AnvilEvmArgs {
     ///
     /// See --fork-url.
     /// See also, https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(
+    #[arg(
         long,
         requires = "fork_url",
         alias = "cups",
@@ -437,7 +427,7 @@ pub struct AnvilEvmArgs {
     ///
     /// See --fork-url.
     /// See also, https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(
+    #[arg(
         long,
         requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
@@ -453,15 +443,15 @@ pub struct AnvilEvmArgs {
     /// This flag overrides the project's configuration file.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", help_heading = "Fork config")]
+    #[arg(long, requires = "fork_url", help_heading = "Fork config")]
     pub no_storage_caching: bool,
 
     /// The block gas limit.
-    #[clap(long, alias = "block-gas-limit", help_heading = "Environment config")]
+    #[arg(long, alias = "block-gas-limit", help_heading = "Environment config")]
     pub gas_limit: Option<u64>,
 
     /// Disable the `call.gas_limit <= block.gas_limit` constraint.
-    #[clap(
+    #[arg(
         long,
         value_name = "DISABLE_GAS_LIMIT",
         help_heading = "Environment config",
@@ -472,15 +462,15 @@ pub struct AnvilEvmArgs {
 
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
     /// default, it is 0x6000 (~25kb).
-    #[clap(long, value_name = "CODE_SIZE", help_heading = "Environment config")]
+    #[arg(long, value_name = "CODE_SIZE", help_heading = "Environment config")]
     pub code_size_limit: Option<usize>,
 
     /// The gas price.
-    #[clap(long, help_heading = "Environment config")]
+    #[arg(long, help_heading = "Environment config")]
     pub gas_price: Option<u64>,
 
     /// The base fee in a block.
-    #[clap(
+    #[arg(
         long,
         visible_alias = "base-fee",
         value_name = "FEE",
@@ -489,19 +479,19 @@ pub struct AnvilEvmArgs {
     pub block_base_fee_per_gas: Option<u64>,
 
     /// The chain ID.
-    #[clap(long, alias = "chain", help_heading = "Environment config")]
+    #[arg(long, alias = "chain", help_heading = "Environment config")]
     pub chain_id: Option<Chain>,
 
     /// Enable steps tracing used for debug calls returning geth-style traces
-    #[clap(long, visible_alias = "tracing")]
+    #[arg(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
 
     /// Enable autoImpersonate on startup
-    #[clap(long, visible_alias = "auto-impersonate")]
+    #[arg(long, visible_alias = "auto-impersonate")]
     pub auto_impersonate: bool,
 
     /// Run an Optimism chain
-    #[clap(long, visible_alias = "optimism")]
+    #[arg(long, visible_alias = "optimism")]
     pub optimism: bool,
 }
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -83,7 +83,7 @@ pub struct NodeArgs {
     pub hardfork: Option<Hardfork>,
 
     /// Block time in seconds for interval mining.
-    #[arg(short, long, visible_alias = "blockTime", name = "block-time", value_name = "SECONDS")]
+    #[arg(short, long, visible_alias = "blockTime", value_name = "SECONDS")]
     pub block_time: Option<u64>,
 
     /// Writes output of `anvil` as json to user-specified file.
@@ -372,13 +372,13 @@ pub struct AnvilEvmArgs {
     /// Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
     ///
     /// Default value 45000
-    #[arg(long = "timeout", name = "timeout", help_heading = "Fork config", requires = "fork_url")]
+    #[arg(id = "timeout", long = "timeout", help_heading = "Fork config", requires = "fork_url")]
     pub fork_request_timeout: Option<u64>,
 
     /// Number of retry requests for spurious networks (timed out requests)
     ///
     /// Default value 5
-    #[arg(long = "retries", name = "retries", help_heading = "Fork config", requires = "fork_url")]
+    #[arg(id = "retries", long = "retries", help_heading = "Fork config", requires = "fork_url")]
     pub fork_request_retries: Option<u32>,
 
     /// Fetch state from a specific block number over a remote endpoint.

--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -15,22 +15,22 @@ use std::str::FromStr;
 #[derive(Debug, Parser)]
 pub struct AccessListArgs {
     /// The destination of the transaction.
-    #[clap(
+    #[arg(
         value_name = "TO",
         value_parser = NameOrAddress::from_str
     )]
     to: Option<NameOrAddress>,
 
     /// The signature of the function to call.
-    #[clap(value_name = "SIG")]
+    #[arg(value_name = "SIG")]
     sig: Option<String>,
 
     /// The arguments of the function to call.
-    #[clap(value_name = "ARGS")]
+    #[arg(value_name = "ARGS")]
     args: Vec<String>,
 
     /// The data for the transaction.
-    #[clap(
+    #[arg(
         long,
         value_name = "DATA",
         conflicts_with_all = &["sig", "args"]
@@ -40,17 +40,17 @@ pub struct AccessListArgs {
     /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
-    #[clap(long, short = 'B')]
+    #[arg(long, short = 'B')]
     block: Option<BlockId>,
 
     /// Print the access list as JSON.
-    #[clap(long, short, help_heading = "Display options")]
+    #[arg(long, short, help_heading = "Display options")]
     json: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     tx: TransactionOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     eth: EthereumOpts,
 }
 

--- a/crates/cast/bin/cmd/bind.rs
+++ b/crates/cast/bin/cmd/bind.rs
@@ -18,7 +18,7 @@ pub struct BindArgs {
     path_or_address: String,
 
     /// Path to where bindings will be stored
-    #[clap(
+    #[arg(
         short,
         long,
         value_hint = ValueHint::DirPath,
@@ -30,7 +30,7 @@ pub struct BindArgs {
     ///
     /// This should be a valid crates.io crate name. However, this is currently not validated by
     /// this command.
-    #[clap(
+    #[arg(
         long,
         default_value = DEFAULT_CRATE_NAME,
         value_name = "NAME"
@@ -41,7 +41,7 @@ pub struct BindArgs {
     ///
     /// This should be a standard semver version string. However, it is not currently validated by
     /// this command.
-    #[clap(
+    #[arg(
         long,
         default_value = DEFAULT_CRATE_VERSION,
         value_name = "VERSION"
@@ -49,10 +49,10 @@ pub struct BindArgs {
     crate_version: String,
 
     /// Generate bindings as separate files.
-    #[clap(long)]
+    #[arg(long)]
     separate_files: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     etherscan: EtherscanOpts,
 }
 

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -22,7 +22,7 @@ type Provider = ethers_providers::Provider<RuntimeClient>;
 #[derive(Debug, Parser)]
 pub struct CallArgs {
     /// The destination of the transaction.
-    #[clap(value_parser = NameOrAddress::from_str)]
+    #[arg(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
     /// The signature of the function to call.
@@ -32,51 +32,51 @@ pub struct CallArgs {
     args: Vec<String>,
 
     /// Data for the transaction.
-    #[clap(
+    #[arg(
         long,
         conflicts_with_all = &["sig", "args"]
     )]
     data: Option<String>,
 
     /// Forks the remote rpc, executes the transaction locally and prints a trace
-    #[clap(long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     trace: bool,
 
     /// Opens an interactive debugger.
     /// Can only be used with `--trace`.
-    #[clap(long, requires = "trace")]
+    #[arg(long, requires = "trace")]
     debug: bool,
 
     /// Labels to apply to the traces; format: `address:label`.
     /// Can only be used with `--trace`.
-    #[clap(long, requires = "trace")]
+    #[arg(long, requires = "trace")]
     labels: Vec<String>,
 
     /// The EVM Version to use.
     /// Can only be used with `--trace`.
-    #[clap(long, requires = "trace")]
+    #[arg(long, requires = "trace")]
     evm_version: Option<EvmVersion>,
 
     /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
-    #[clap(long, short)]
+    #[arg(long, short)]
     block: Option<BlockId>,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<CallSubcommands>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     tx: TransactionOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     eth: EthereumOpts,
 }
 
 #[derive(Debug, Parser)]
 pub enum CallSubcommands {
     /// ignores the address field and simulates creating a contract
-    #[clap(name = "--create")]
+    #[command(name = "--create")]
     Create {
         /// Bytecode of contract.
         code: String,
@@ -92,7 +92,7 @@ pub enum CallSubcommands {
         /// Either specified in wei, or as a string with a unit type.
         ///
         /// Examples: 1ether, 10gwei, 0.01ether
-        #[clap(long, value_parser = parse_ether_value)]
+        #[arg(long, value_parser = parse_ether_value)]
         value: Option<U256>,
     },
 }

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -19,7 +19,7 @@ const DEPLOYER: &str = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
 #[derive(Clone, Debug, Parser)]
 pub struct Create2Args {
     /// Prefix for the contract address.
-    #[clap(
+    #[arg(
         long,
         short,
         required_unless_present_any = &["ends_with", "matching"],
@@ -28,19 +28,19 @@ pub struct Create2Args {
     starts_with: Option<String>,
 
     /// Suffix for the contract address.
-    #[clap(long, short, value_name = "HEX")]
+    #[arg(long, short, value_name = "HEX")]
     ends_with: Option<String>,
 
     /// Sequence that the address has to match.
-    #[clap(long, short, value_name = "HEX")]
+    #[arg(long, short, value_name = "HEX")]
     matching: Option<String>,
 
     /// Case sensitive matching.
-    #[clap(short, long)]
+    #[arg(short, long)]
     case_sensitive: bool,
 
     /// Address of the contract deployer.
-    #[clap(
+    #[arg(
         short,
         long,
         default_value = DEPLOYER,
@@ -49,27 +49,27 @@ pub struct Create2Args {
     deployer: Address,
 
     /// Init code of the contract to be deployed.
-    #[clap(short, long, value_name = "HEX")]
+    #[arg(short, long, value_name = "HEX")]
     init_code: Option<String>,
 
     /// Init code hash of the contract to be deployed.
-    #[clap(alias = "ch", long, value_name = "HASH", required_unless_present = "init_code")]
+    #[arg(alias = "ch", long, value_name = "HASH", required_unless_present = "init_code")]
     init_code_hash: Option<String>,
 
     /// Number of threads to use. Defaults to and caps at the number of logical cores.
-    #[clap(short, long)]
+    #[arg(short, long)]
     jobs: Option<NonZeroUsize>,
 
     /// Address of the caller. Used for the first 20 bytes of the salt.
-    #[clap(long, value_name = "ADDRESS")]
+    #[arg(long, value_name = "ADDRESS")]
     caller: Option<Address>,
 
     /// The random number generator's seed, used to initialize the salt.
-    #[clap(long, value_name = "HEX")]
+    #[arg(long, value_name = "HEX")]
     seed: Option<B256>,
 
     /// Don't initialize the salt with a random value, and instead use the default value of 0.
-    #[clap(long, conflicts_with = "seed")]
+    #[arg(long, conflicts_with = "seed")]
     no_random: bool,
 }
 

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 #[derive(Debug, Parser)]
 pub struct EstimateArgs {
     /// The destination of the transaction.
-    #[clap(value_parser = NameOrAddress::from_str)]
+    #[arg(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
     /// The signature of the function to call.
@@ -24,7 +24,7 @@ pub struct EstimateArgs {
     args: Vec<String>,
 
     /// The sender account.
-    #[clap(
+    #[arg(
         short,
         long,
         value_parser = NameOrAddress::from_str,
@@ -38,23 +38,23 @@ pub struct EstimateArgs {
     /// Either specified in wei, or as a string with a unit type:
     ///
     /// Examples: 1ether, 10gwei, 0.01ether
-    #[clap(long, value_parser = parse_ether_value)]
+    #[arg(long, value_parser = parse_ether_value)]
     value: Option<U256>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc: RpcOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     etherscan: EtherscanOpts,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<EstimateSubcommands>,
 }
 
 #[derive(Debug, Parser)]
 pub enum EstimateSubcommands {
     /// Estimate gas cost to deploy a smart contract
-    #[clap(name = "--create")]
+    #[command(name = "--create")]
     Create {
         /// The bytecode of contract
         code: String,
@@ -70,7 +70,7 @@ pub enum EstimateSubcommands {
         /// Either specified in wei, or as a string with a unit type:
         ///
         /// Examples: 1ether, 10gwei, 0.01ether
-        #[clap(long, value_parser = parse_ether_value)]
+        #[arg(long, value_parser = parse_ether_value)]
         value: Option<U256>,
     },
 }

--- a/crates/cast/bin/cmd/find_block.rs
+++ b/crates/cast/bin/cmd/find_block.rs
@@ -14,7 +14,7 @@ pub struct FindBlockArgs {
     /// The UNIX timestamp to search for, in seconds.
     timestamp: u64,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc: RpcOpts,
 }
 

--- a/crates/cast/bin/cmd/interface.rs
+++ b/crates/cast/bin/cmd/interface.rs
@@ -16,17 +16,17 @@ pub struct InterfaceArgs {
     path_or_address: String,
 
     /// The name to use for the generated interface.
-    #[clap(long, short)]
+    #[arg(long, short)]
     name: Option<String>,
 
     /// Solidity pragma version.
-    #[clap(long, short, default_value = "^0.8.4", value_name = "VERSION")]
+    #[arg(long, short, default_value = "^0.8.4", value_name = "VERSION")]
     pragma: String,
 
     /// The path to the output file.
     ///
     /// If not specified, the interface will be output to stdout.
-    #[clap(
+    #[arg(
         short,
         long,
         value_hint = clap::ValueHint::FilePath,
@@ -35,10 +35,10 @@ pub struct InterfaceArgs {
     output: Option<PathBuf>,
 
     /// If specified, the interface will be output as JSON rather than Solidity.
-    #[clap(long, short)]
+    #[arg(long, short)]
     json: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     etherscan: EtherscanOpts,
 }
 

--- a/crates/cast/bin/cmd/logs.rs
+++ b/crates/cast/bin/cmd/logs.rs
@@ -22,17 +22,17 @@ pub struct LogsArgs {
     /// The block height to start query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
-    #[clap(long)]
+    #[arg(long)]
     from_block: Option<BlockId>,
 
     /// The block height to stop query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
-    #[clap(long)]
+    #[arg(long)]
     to_block: Option<BlockId>,
 
     /// The contract address to filter on.
-    #[clap(
+    #[arg(
         long,
         value_parser = NameOrAddress::from_str
     )]
@@ -40,24 +40,24 @@ pub struct LogsArgs {
 
     /// The signature of the event to filter logs by which will be converted to the first topic or
     /// a topic to filter on.
-    #[clap(value_name = "SIG_OR_TOPIC")]
+    #[arg(value_name = "SIG_OR_TOPIC")]
     sig_or_topic: Option<String>,
 
     /// If used with a signature, the indexed fields of the event to filter by. Otherwise, the
     /// remaining topics of the filter.
-    #[clap(value_name = "TOPICS_OR_ARGS")]
+    #[arg(value_name = "TOPICS_OR_ARGS")]
     topics_or_args: Vec<String>,
 
     /// If the RPC type and endpoints supports `eth_subscribe` stream logs instead of printing and
     /// exiting. Will continue until interrupted or TO_BLOCK is reached.
-    #[clap(long)]
+    #[arg(long)]
     subscribe: bool,
 
     /// Print the logs as JSON.s
-    #[clap(long, short, help_heading = "Display options")]
+    #[arg(long, short, help_heading = "Display options")]
     json: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     eth: EthereumOpts,
 }
 

--- a/crates/cast/bin/cmd/rpc.rs
+++ b/crates/cast/bin/cmd/rpc.rs
@@ -26,10 +26,10 @@ pub struct RpcArgs {
     ///
     /// cast rpc eth_getBlockByNumber '["0x123", false]' --raw
     ///     => {"method": "eth_getBlockByNumber", "params": ["0x123", false] ... }
-    #[clap(long, short = 'w')]
+    #[arg(long, short = 'w')]
     raw: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc: RpcOpts,
 }
 

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -25,36 +25,36 @@ pub struct RunArgs {
     tx_hash: String,
 
     /// Opens the transaction in the debugger.
-    #[clap(long, short)]
+    #[arg(long, short)]
     debug: bool,
 
     /// Print out opcode traces.
-    #[clap(long, short)]
+    #[arg(long, short)]
     trace_printer: bool,
 
     /// Executes the transaction only with the state from the previous block.
     ///
     /// May result in different results than the live execution!
-    #[clap(long, short)]
+    #[arg(long, short)]
     quick: bool,
 
     /// Prints the full address of the contract.
-    #[clap(long, short)]
+    #[arg(long, short)]
     verbose: bool,
 
     /// Label addresses in the trace.
     ///
     /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
-    #[clap(long, short)]
+    #[arg(long, short)]
     label: Vec<String>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc: RpcOpts,
 
     /// The EVM version to use.
     ///
     /// Overrides the version specified in the config.
-    #[clap(long, short)]
+    #[arg(long, short)]
     evm_version: Option<EvmVersion>,
 
     /// Sets the number of assumed available compute units per second for this provider
@@ -62,7 +62,7 @@ pub struct RunArgs {
     /// default value: 330
     ///
     /// See also, https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(long, alias = "cups", value_name = "CUPS")]
+    #[arg(long, alias = "cups", value_name = "CUPS")]
     pub compute_units_per_second: Option<u64>,
 
     /// Disables rate limiting for this node's provider.
@@ -70,7 +70,7 @@ pub struct RunArgs {
     /// default value: false
     ///
     /// See also, https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(long, value_name = "NO_RATE_LIMITS", visible_alias = "no-rpc-rate-limit")]
+    #[arg(long, value_name = "NO_RATE_LIMITS", visible_alias = "no-rpc-rate-limit")]
     pub no_rate_limit: bool,
 }
 

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -22,7 +22,7 @@ pub struct SendTxArgs {
     /// The destination of the transaction.
     ///
     /// If not provided, you must use cast send --create.
-    #[clap(value_parser = NameOrAddress::from_str)]
+    #[arg(value_parser = NameOrAddress::from_str)]
     to: Option<NameOrAddress>,
 
     /// The signature of the function to call.
@@ -32,39 +32,39 @@ pub struct SendTxArgs {
     args: Vec<String>,
 
     /// Only print the transaction hash and exit immediately.
-    #[clap(name = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
+    #[arg(name = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
     cast_async: bool,
 
     /// The number of confirmations until the receipt is fetched.
-    #[clap(long, default_value = "1")]
+    #[arg(long, default_value = "1")]
     confirmations: usize,
 
     /// Print the transaction receipt as JSON.
-    #[clap(long, short, help_heading = "Display options")]
+    #[arg(long, short, help_heading = "Display options")]
     json: bool,
 
     /// Reuse the latest nonce for the sender account.
-    #[clap(long, conflicts_with = "nonce")]
+    #[arg(long, conflicts_with = "nonce")]
     resend: bool,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<SendTxSubcommands>,
 
     /// Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM as sender
-    #[clap(long, requires = "from")]
+    #[arg(long, requires = "from")]
     unlocked: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     tx: TransactionOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     eth: EthereumOpts,
 }
 
 #[derive(Debug, Parser)]
 pub enum SendTxSubcommands {
     /// Use to deploy raw contract bytecode.
-    #[clap(name = "--create")]
+    #[command(name = "--create")]
     Create {
         /// The bytecode of the contract to deploy.
         code: String,

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -32,7 +32,7 @@ pub struct SendTxArgs {
     args: Vec<String>,
 
     /// Only print the transaction hash and exit immediately.
-    #[arg(name = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
+    #[arg(id = "async", long = "async", alias = "cast-async", env = "CAST_ASYNC")]
     cast_async: bool,
 
     /// The number of confirmations until the receipt is fetched.

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -36,26 +36,26 @@ const MIN_SOLC: Version = Version::new(0, 6, 5);
 #[derive(Clone, Debug, Parser)]
 pub struct StorageArgs {
     /// The contract address.
-    #[clap(value_parser = NameOrAddress::from_str)]
+    #[arg(value_parser = NameOrAddress::from_str)]
     address: NameOrAddress,
 
     /// The storage slot number.
-    #[clap(value_parser = parse_slot)]
+    #[arg(value_parser = parse_slot)]
     slot: Option<B256>,
 
     /// The block height to query at.
     ///
     /// Can also be the tags earliest, finalized, safe, latest, or pending.
-    #[clap(long, short)]
+    #[arg(long, short)]
     block: Option<BlockId>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc: RpcOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     etherscan: EtherscanOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     build: CoreBuildArgs,
 }
 

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -10,27 +10,27 @@ use foundry_wallets::multi_wallet::MultiWalletOptsBuilder;
 pub struct ListArgs {
     /// List all the accounts in the keystore directory.
     /// Default keystore directory is used if no path provided.
-    #[clap(long, default_missing_value = "", num_args(0..=1))]
+    #[arg(long, default_missing_value = "", num_args(0..=1))]
     dir: Option<String>,
 
     /// List accounts from a Ledger hardware wallet.
-    #[clap(long, short, group = "hw-wallets")]
+    #[arg(long, short, group = "hw-wallets")]
     ledger: bool,
 
     /// List accounts from a Trezor hardware wallet.
-    #[clap(long, short, group = "hw-wallets")]
+    #[arg(long, short, group = "hw-wallets")]
     trezor: bool,
 
     /// List accounts from AWS KMS.
-    #[clap(long)]
+    #[arg(long)]
     aws: bool,
 
     /// List all configured accounts.
-    #[clap(long, group = "hw-wallets")]
+    #[arg(long, group = "hw-wallets")]
     all: bool,
 
     /// Max number of addresses to display from hardware wallets.
-    #[clap(long, short, default_value = "3", requires = "hw-wallets")]
+    #[arg(long, short, default_value = "3", requires = "hw-wallets")]
     max_senders: Option<usize>,
 }
 

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -25,7 +25,7 @@ use list::ListArgs;
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {
     /// Create a new random keypair.
-    #[clap(visible_alias = "n")]
+    #[command(visible_alias = "n")]
     New {
         /// If provided, then keypair will be written to an encrypted JSON keystore.
         path: Option<String>,
@@ -33,53 +33,53 @@ pub enum WalletSubcommands {
         /// Triggers a hidden password prompt for the JSON keystore.
         ///
         /// Deprecated: prompting for a hidden password is now the default.
-        #[clap(long, short, requires = "path", conflicts_with = "unsafe_password")]
+        #[arg(long, short, requires = "path", conflicts_with = "unsafe_password")]
         password: bool,
 
         /// Password for the JSON keystore in cleartext.
         ///
         /// This is UNSAFE to use and we recommend using the --password.
-        #[clap(long, requires = "path", env = "CAST_PASSWORD", value_name = "PASSWORD")]
+        #[arg(long, requires = "path", env = "CAST_PASSWORD", value_name = "PASSWORD")]
         unsafe_password: Option<String>,
 
         /// Number of wallets to generate.
-        #[clap(long, short, default_value = "1")]
+        #[arg(long, short, default_value = "1")]
         number: u32,
 
         /// Output generated wallets as JSON.
-        #[clap(long, short, default_value = "false")]
+        #[arg(long, short, default_value = "false")]
         json: bool,
     },
 
     /// Generates a random BIP39 mnemonic phrase
-    #[clap(visible_alias = "nm")]
+    #[command(visible_alias = "nm")]
     NewMnemonic {
         /// Number of words for the mnemonic
-        #[clap(long, short, default_value = "12")]
+        #[arg(long, short, default_value = "12")]
         words: usize,
 
         /// Number of accounts to display
-        #[clap(long, short, default_value = "1")]
+        #[arg(long, short, default_value = "1")]
         accounts: u8,
     },
 
     /// Generate a vanity address.
-    #[clap(visible_alias = "va")]
+    #[command(visible_alias = "va")]
     Vanity(VanityArgs),
 
     /// Convert a private key to an address.
-    #[clap(visible_aliases = &["a", "addr"])]
+    #[command(visible_aliases = &["a", "addr"])]
     Address {
         /// If provided, the address will be derived from the specified private key.
-        #[clap(value_name = "PRIVATE_KEY")]
+        #[arg(value_name = "PRIVATE_KEY")]
         private_key_override: Option<String>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         wallet: WalletOpts,
     },
 
     /// Sign a message or typed data.
-    #[clap(visible_alias = "s")]
+    #[command(visible_alias = "s")]
     Sign {
         /// The message, typed data, or hash to sign.
         ///
@@ -97,23 +97,23 @@ pub enum WalletSubcommands {
         message: String,
 
         /// Treat the message as JSON typed data.
-        #[clap(long)]
+        #[arg(long)]
         data: bool,
 
         /// Treat the message as a file containing JSON typed data. Requires `--data`.
-        #[clap(long, requires = "data")]
+        #[arg(long, requires = "data")]
         from_file: bool,
 
         /// Treat the message as a raw 32-byte hash and sign it directly without hashing it again.
-        #[clap(long, conflicts_with = "data")]
+        #[arg(long, conflicts_with = "data")]
         no_hash: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         wallet: WalletOpts,
     },
 
     /// Verify the signature of a message.
-    #[clap(visible_alias = "v")]
+    #[command(visible_alias = "v")]
     Verify {
         /// The original message.
         message: String,
@@ -122,28 +122,30 @@ pub enum WalletSubcommands {
         signature: Signature,
 
         /// The address of the message signer.
-        #[clap(long, short)]
+        #[arg(long, short)]
         address: Address,
     },
+
     /// Import a private key into an encrypted keystore.
-    #[clap(visible_alias = "i")]
+    #[command(visible_alias = "i")]
     Import {
         /// The name for the account in the keystore.
-        #[clap(value_name = "ACCOUNT_NAME")]
+        #[arg(value_name = "ACCOUNT_NAME")]
         account_name: String,
         /// If provided, keystore will be saved here instead of the default keystores directory
         /// (~/.foundry/keystores)
-        #[clap(long, short)]
+        #[arg(long, short)]
         keystore_dir: Option<String>,
-        #[clap(flatten)]
+        #[command(flatten)]
         raw_wallet_options: RawWalletOpts,
     },
+
     /// List all the accounts in the keystore default directory
-    #[clap(visible_alias = "ls")]
+    #[command(visible_alias = "ls")]
     List(ListArgs),
 
     /// Derives private key from mnemonic
-    #[clap(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
+    #[command(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
     DerivePrivateKey { mnemonic: String, mnemonic_index: Option<u8> },
 }
 

--- a/crates/cast/bin/cmd/wallet/vanity.rs
+++ b/crates/cast/bin/cmd/wallet/vanity.rs
@@ -18,7 +18,7 @@ pub type GeneratedWallet = (SigningKey, Address);
 #[derive(Clone, Debug, Parser)]
 pub struct VanityArgs {
     /// Prefix for the vanity address.
-    #[clap(
+    #[arg(
         long,
         required_unless_present = "ends_with",
         value_parser = HexAddressValidator,
@@ -27,20 +27,20 @@ pub struct VanityArgs {
     pub starts_with: Option<String>,
 
     /// Suffix for the vanity address.
-    #[clap(long, value_parser = HexAddressValidator, value_name = "HEX")]
+    #[arg(long, value_parser = HexAddressValidator, value_name = "HEX")]
     pub ends_with: Option<String>,
 
     // 2^64-1 is max possible nonce per [eip-2681](https://eips.ethereum.org/EIPS/eip-2681).
     /// Generate a vanity contract address created by the generated keypair with the specified
     /// nonce.
-    #[clap(long)]
+    #[arg(long)]
     pub nonce: Option<u64>,
 
     /// Path to save the generated vanity contract address to.
     ///
     /// If provided, the generated vanity addresses will appended to a JSON array in the specified
     /// file.
-    #[clap(
+    #[arg(
         long,
         value_hint = clap::ValueHint::FilePath,
         value_name = "PATH",

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -421,7 +421,7 @@ pub enum CastSubcommand {
         confirmations: usize,
 
         /// Exit immediately if the transaction was not found.
-        #[arg(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
+        #[arg(id = "async", long = "async", env = "CAST_ASYNC", alias = "cast-async")]
         cast_async: bool,
 
         /// Print as JSON.
@@ -443,7 +443,7 @@ pub enum CastSubcommand {
         raw_tx: String,
 
         /// Only print the transaction hash and exit immediately.
-        #[arg(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
+        #[arg(id = "async", long = "async", env = "CAST_ASYNC", alias = "cast-async")]
         cast_async: bool,
 
         #[command(flatten)]

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -21,53 +21,53 @@ const VERSION_MESSAGE: &str = concat!(
 
 /// Perform Ethereum RPC calls from the comfort of your command line.
 #[derive(Parser)]
-#[clap(
+#[command(
     name = "cast",
     version = VERSION_MESSAGE,
     after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html",
     next_display_order = None,
 )]
 pub struct Cast {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub cmd: CastSubcommand,
 }
 
 #[derive(Subcommand)]
 pub enum CastSubcommand {
     /// Prints the maximum value of the given integer type.
-    #[clap(visible_aliases = &["--max-int", "maxi"])]
+    #[command(visible_aliases = &["--max-int", "maxi"])]
     MaxInt {
         /// The integer type to get the maximum value of.
-        #[clap(default_value = "int256")]
+        #[arg(default_value = "int256")]
         r#type: String,
     },
 
     /// Prints the minimum value of the given integer type.
-    #[clap(visible_aliases = &["--min-int", "mini"])]
+    #[command(visible_aliases = &["--min-int", "mini"])]
     MinInt {
         /// The integer type to get the minimum value of.
-        #[clap(default_value = "int256")]
+        #[arg(default_value = "int256")]
         r#type: String,
     },
 
     /// Prints the maximum value of the given integer type.
-    #[clap(visible_aliases = &["--max-uint", "maxu"])]
+    #[command(visible_aliases = &["--max-uint", "maxu"])]
     MaxUint {
         /// The unsigned integer type to get the maximum value of.
-        #[clap(default_value = "uint256")]
+        #[arg(default_value = "uint256")]
         r#type: String,
     },
 
     /// Prints the zero address.
-    #[clap(visible_aliases = &["--address-zero", "az"])]
+    #[command(visible_aliases = &["--address-zero", "az"])]
     AddressZero,
 
     /// Prints the zero hash.
-    #[clap(visible_aliases = &["--hash-zero", "hz"])]
+    #[command(visible_aliases = &["--hash-zero", "hz"])]
     HashZero,
 
     /// Convert UTF8 text to hex.
-    #[clap(
+    #[command(
         visible_aliases = &[
         "--from-ascii",
         "--from-utf8",
@@ -81,14 +81,14 @@ pub enum CastSubcommand {
     },
 
     /// Concatenate hex strings.
-    #[clap(visible_aliases = &["--concat-hex", "ch"])]
+    #[command(visible_aliases = &["--concat-hex", "ch"])]
     ConcatHex {
         /// The data to concatenate.
         data: Vec<String>,
     },
 
     /// Convert binary data into hex data.
-    #[clap(visible_aliases = &["--from-bin", "from-binx", "fb"])]
+    #[command(visible_aliases = &["--from-bin", "from-binx", "fb"])]
     FromBin,
 
     /// Normalize the input to lowercase, 0x-prefixed hex.
@@ -98,14 +98,14 @@ pub enum CastSubcommand {
     /// - 0x prefixed hex, concatenated with a ':'
     /// - an absolute path to file
     /// - @tag, where the tag is defined in an environment variable
-    #[clap(visible_aliases = &["--to-hexdata", "thd", "2hd"])]
+    #[command(visible_aliases = &["--to-hexdata", "thd", "2hd"])]
     ToHexdata {
         /// The input to normalize.
         input: Option<String>,
     },
 
     /// Convert an address to a checksummed format (EIP-55).
-    #[clap(
+    #[command(
         visible_aliases = &["--to-checksum-address",
         "--to-checksum",
         "to-checksum",
@@ -118,57 +118,57 @@ pub enum CastSubcommand {
     },
 
     /// Convert hex data to an ASCII string.
-    #[clap(visible_aliases = &["--to-ascii", "tas", "2as"])]
+    #[command(visible_aliases = &["--to-ascii", "tas", "2as"])]
     ToAscii {
         /// The hex data to convert.
         hexdata: Option<String>,
     },
 
     /// Convert a fixed point number into an integer.
-    #[clap(visible_aliases = &["--from-fix", "ff"])]
+    #[command(visible_aliases = &["--from-fix", "ff"])]
     FromFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
 
         /// The value to convert.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         value: Option<String>,
     },
 
     /// Right-pads hex data to 32 bytes.
-    #[clap(visible_aliases = &["--to-bytes32", "tb", "2b"])]
+    #[command(visible_aliases = &["--to-bytes32", "tb", "2b"])]
     ToBytes32 {
         /// The hex data to convert.
         bytes: Option<String>,
     },
 
     /// Convert an integer into a fixed point number.
-    #[clap(visible_aliases = &["--to-fix", "tf", "2f"])]
+    #[command(visible_aliases = &["--to-fix", "tf", "2f"])]
     ToFixedPoint {
         /// The number of decimals to use.
         decimals: Option<String>,
 
         /// The value to convert.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         value: Option<String>,
     },
 
     /// Convert a number to a hex-encoded uint256.
-    #[clap(name = "to-uint256", visible_aliases = &["--to-uint256", "tu", "2u"])]
+    #[command(name = "to-uint256", visible_aliases = &["--to-uint256", "tu", "2u"])]
     ToUint256 {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Convert a number to a hex-encoded int256.
-    #[clap(name = "to-int256", visible_aliases = &["--to-int256", "ti", "2i"])]
+    #[command(name = "to-int256", visible_aliases = &["--to-int256", "ti", "2i"])]
     ToInt256 {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Perform a left shifting operation
-    #[clap(name = "shl")]
+    #[command(name = "shl")]
     LeftShift {
         /// The value to shift.
         value: String,
@@ -177,16 +177,16 @@ pub enum CastSubcommand {
         bits: String,
 
         /// The input base.
-        #[clap(long)]
+        #[arg(long)]
         base_in: Option<String>,
 
         /// The output base.
-        #[clap(long, default_value = "16")]
+        #[arg(long, default_value = "16")]
         base_out: String,
     },
 
     /// Perform a right shifting operation
-    #[clap(name = "shr")]
+    #[command(name = "shr")]
     RightShift {
         /// The value to shift.
         value: String,
@@ -195,11 +195,11 @@ pub enum CastSubcommand {
         bits: String,
 
         /// The input base,
-        #[clap(long)]
+        #[arg(long)]
         base_in: Option<String>,
 
         /// The output base,
-        #[clap(long, default_value = "16")]
+        #[arg(long, default_value = "16")]
         base_out: String,
     },
 
@@ -211,46 +211,46 @@ pub enum CastSubcommand {
     /// - 1ether
     /// - 1 gwei
     /// - 1gwei ether
-    #[clap(visible_aliases = &["--to-unit", "tun", "2un"])]
+    #[command(visible_aliases = &["--to-unit", "tun", "2un"])]
     ToUnit {
         /// The value to convert.
         value: Option<String>,
 
         /// The unit to convert to (ether, gwei, wei).
-        #[clap(default_value = "wei")]
+        #[arg(default_value = "wei")]
         unit: String,
     },
 
     /// Convert an ETH amount to wei.
     ///
     /// Consider using --to-unit.
-    #[clap(visible_aliases = &["--to-wei", "tw", "2w"])]
+    #[command(visible_aliases = &["--to-wei", "tw", "2w"])]
     ToWei {
         /// The value to convert.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         value: Option<String>,
 
         /// The unit to convert from (ether, gwei, wei).
-        #[clap(default_value = "eth")]
+        #[arg(default_value = "eth")]
         unit: String,
     },
 
     /// Convert wei into an ETH amount.
     ///
     /// Consider using --to-unit.
-    #[clap(visible_aliases = &["--from-wei", "fw"])]
+    #[command(visible_aliases = &["--from-wei", "fw"])]
     FromWei {
         /// The value to convert.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         value: Option<String>,
 
         /// The unit to convert from (ether, gwei, wei).
-        #[clap(default_value = "eth")]
+        #[arg(default_value = "eth")]
         unit: String,
     },
 
-    /// RLP encodes hex data, or an array of hex data
-    #[clap(visible_aliases = &["--to-rlp"])]
+    /// RLP encodes hex data, or an array of hex data.
+    #[command(visible_aliases = &["--to-rlp"])]
     ToRlp {
         /// The value to convert.
         value: Option<String>,
@@ -259,22 +259,22 @@ pub enum CastSubcommand {
     /// Decodes RLP encoded data.
     ///
     /// Input must be hexadecimal.
-    #[clap(visible_aliases = &["--from-rlp"])]
+    #[command(visible_aliases = &["--from-rlp"])]
     FromRlp {
         /// The value to convert.
         value: Option<String>,
     },
 
     /// Converts a number of one base to another
-    #[clap(visible_aliases = &["--to-hex", "th", "2h"])]
+    #[command(visible_aliases = &["--to-hex", "th", "2h"])]
     ToHex(ToBaseArgs),
 
     /// Converts a number of one base to decimal
-    #[clap(visible_aliases = &["--to-dec", "td", "2d"])]
+    #[command(visible_aliases = &["--to-dec", "td", "2d"])]
     ToDec(ToBaseArgs),
 
     /// Converts a number of one base to another
-    #[clap(
+    #[command(
         visible_aliases = &["--to-base",
         "--to-radix",
         "to-radix",
@@ -282,21 +282,21 @@ pub enum CastSubcommand {
         "2r"]
     )]
     ToBase {
-        #[clap(flatten)]
+        #[command(flatten)]
         base: ToBaseArgs,
 
         /// The output base.
-        #[clap(value_name = "BASE")]
+        #[arg(value_name = "BASE")]
         base_out: Option<String>,
     },
     /// Create an access list for a transaction.
-    #[clap(visible_aliases = &["ac", "acl"])]
+    #[command(visible_aliases = &["ac", "acl"])]
     AccessList(AccessListArgs),
     /// Get logs by signature or topic.
-    #[clap(visible_alias = "l")]
+    #[command(visible_alias = "l")]
     Logs(LogsArgs),
     /// Get information about a block.
-    #[clap(visible_alias = "bl")]
+    #[command(visible_alias = "bl")]
     Block {
         /// The block height to query at.
         ///
@@ -304,89 +304,89 @@ pub enum CastSubcommand {
         block: Option<BlockId>,
 
         /// If specified, only get the given field of the block.
-        #[clap(long, short)]
+        #[arg(long, short)]
         field: Option<String>,
 
-        #[clap(long, env = "CAST_FULL_BLOCK")]
+        #[arg(long, env = "CAST_FULL_BLOCK")]
         full: bool,
 
         /// Print the block as JSON.
-        #[clap(long, short, help_heading = "Display options")]
+        #[arg(long, short, help_heading = "Display options")]
         json: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the latest block number.
-    #[clap(visible_alias = "bn")]
+    #[command(visible_alias = "bn")]
     BlockNumber {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Perform a call on an account without publishing a transaction.
-    #[clap(visible_alias = "c")]
+    #[command(visible_alias = "c")]
     Call(CallArgs),
 
     /// ABI-encode a function with arguments.
-    #[clap(name = "calldata", visible_alias = "cd")]
+    #[command(name = "calldata", visible_alias = "cd")]
     CalldataEncode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`
         sig: String,
 
         /// The arguments to encode.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
     /// Get the symbolic name of the current chain.
     Chain {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the Ethereum chain ID.
-    #[clap(visible_aliases = &["ci", "cid"])]
+    #[command(visible_aliases = &["ci", "cid"])]
     ChainId {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the current client version.
-    #[clap(visible_alias = "cl")]
+    #[command(visible_alias = "cl")]
     Client {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Compute the contract address from a given nonce and deployer address.
-    #[clap(visible_alias = "ca")]
+    #[command(visible_alias = "ca")]
     ComputeAddress {
         /// The deployer address.
         address: Option<String>,
 
         /// The nonce of the deployer address.
-        #[clap(long)]
+        #[arg(long)]
         nonce: Option<u64>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Disassembles hex encoded bytecode into individual / human readable opcodes
-    #[clap(visible_alias = "da")]
+    #[command(visible_alias = "da")]
     Disassemble {
         /// The hex encoded bytecode.
         bytecode: String,
     },
 
     /// Calculate the ENS namehash of a name.
-    #[clap(visible_aliases = &["na", "nh"])]
+    #[command(visible_aliases = &["na", "nh"])]
     Namehash { name: Option<String> },
 
     /// Get information about a transaction.
-    #[clap(visible_alias = "t")]
+    #[command(visible_alias = "t")]
     Tx {
         /// The transaction hash.
         tx_hash: String,
@@ -396,19 +396,19 @@ pub enum CastSubcommand {
         field: Option<String>,
 
         /// Print the raw RLP encoded transaction.
-        #[clap(long, conflicts_with = "field")]
+        #[arg(long, conflicts_with = "field")]
         raw: bool,
 
         /// Print as JSON.
-        #[clap(long, short, help_heading = "Display options")]
+        #[arg(long, short, help_heading = "Display options")]
         json: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the transaction receipt for a transaction.
-    #[clap(visible_alias = "re")]
+    #[command(visible_alias = "re")]
     Receipt {
         /// The transaction hash.
         tx_hash: String,
@@ -417,48 +417,48 @@ pub enum CastSubcommand {
         field: Option<String>,
 
         /// The number of confirmations until the receipt is fetched
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         confirmations: usize,
 
         /// Exit immediately if the transaction was not found.
-        #[clap(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
+        #[arg(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
         cast_async: bool,
 
         /// Print as JSON.
-        #[clap(long, short, help_heading = "Display options")]
+        #[arg(long, short, help_heading = "Display options")]
         json: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Sign and publish a transaction.
-    #[clap(name = "send", visible_alias = "s")]
+    #[command(name = "send", visible_alias = "s")]
     SendTx(SendTxArgs),
 
     /// Publish a raw transaction to the network.
-    #[clap(name = "publish", visible_alias = "p")]
+    #[command(name = "publish", visible_alias = "p")]
     PublishTx {
         /// The raw transaction
         raw_tx: String,
 
         /// Only print the transaction hash and exit immediately.
-        #[clap(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
+        #[arg(long = "async", env = "CAST_ASYNC", name = "async", alias = "cast-async")]
         cast_async: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Estimate the gas cost of a transaction.
-    #[clap(visible_alias = "e")]
+    #[command(visible_alias = "e")]
     Estimate(EstimateArgs),
 
     /// Decode ABI-encoded input data.
     ///
     /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata`
     /// string
-    #[clap(visible_aliases = &["--calldata-decode","cdd"])]
+    #[command(visible_aliases = &["--calldata-decode","cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -472,7 +472,7 @@ pub enum CastSubcommand {
     /// Defaults to decoding output data. To decode input data pass --input.
     ///
     /// When passing `--input`, function selector must NOT be prefixed in `calldata` string
-    #[clap(name = "abi-decode", visible_aliases = &["ad", "--abi-decode"])]
+    #[command(name = "abi-decode", visible_aliases = &["ad", "--abi-decode"])]
     AbiDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -481,27 +481,27 @@ pub enum CastSubcommand {
         calldata: String,
 
         /// Whether to decode the input or output data.
-        #[clap(long, short, help_heading = "Decode input data instead of output data")]
+        #[arg(long, short, help_heading = "Decode input data instead of output data")]
         input: bool,
     },
 
     /// ABI encode the given function argument, excluding the selector.
-    #[clap(visible_alias = "ae")]
+    #[command(visible_alias = "ae")]
     AbiEncode {
         /// The function signature.
         sig: String,
 
         /// Whether to use packed encoding.
-        #[clap(long)]
+        #[arg(long)]
         packed: bool,
 
         /// The arguments of the function.
-        #[clap(allow_hyphen_values = true)]
+        #[arg(allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
     /// Compute the storage slot for an entry in a mapping.
-    #[clap(visible_alias = "in")]
+    #[command(visible_alias = "in")]
     Index {
         /// The mapping key type.
         key_type: String,
@@ -514,58 +514,58 @@ pub enum CastSubcommand {
     },
 
     /// Fetch the EIP-1967 implementation account
-    #[clap(visible_alias = "impl")]
+    #[command(visible_alias = "impl")]
     Implementation {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The address to get the nonce for.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Fetch the EIP-1967 admin account
-    #[clap(visible_alias = "adm")]
+    #[command(visible_alias = "adm")]
     Admin {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The address to get the nonce for.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the function signatures for the given selector from https://openchain.xyz.
-    #[clap(name = "4byte", visible_aliases = &["4", "4b"])]
+    #[command(name = "4byte", visible_aliases = &["4", "4b"])]
     FourByte {
         /// The function selector.
         selector: Option<String>,
     },
 
     /// Decode ABI-encoded calldata using https://openchain.xyz.
-    #[clap(name = "4byte-decode", visible_aliases = &["4d", "4bd"])]
+    #[command(name = "4byte-decode", visible_aliases = &["4d", "4bd"])]
     FourByteDecode {
         /// The ABI-encoded calldata.
         calldata: Option<String>,
     },
 
     /// Get the event signature for a given topic 0 from https://openchain.xyz.
-    #[clap(name = "4byte-event", visible_aliases = &["4e", "4be", "topic0-event", "t0e"])]
+    #[command(name = "4byte-event", visible_aliases = &["4e", "4be", "topic0-event", "t0e"])]
     FourByteEvent {
         /// Topic 0
-        #[clap(value_name = "TOPIC_0")]
+        #[arg(value_name = "TOPIC_0")]
         topic: Option<String>,
     },
 
@@ -576,7 +576,7 @@ pub enum CastSubcommand {
     /// - "function transfer(address,uint256)"
     /// - "function transfer(address,uint256)" "event Transfer(address,address,uint256)"
     /// - "./out/Contract.sol/Contract.json"
-    #[clap(visible_aliases = &["ups"])]
+    #[command(visible_aliases = &["ups"])]
     UploadSignature {
         /// The signatures to upload.
         ///
@@ -588,228 +588,228 @@ pub enum CastSubcommand {
     /// Pretty print calldata.
     ///
     /// Tries to decode the calldata using https://openchain.xyz unless --offline is passed.
-    #[clap(visible_alias = "pc")]
+    #[command(visible_alias = "pc")]
     PrettyCalldata {
         /// The calldata.
         calldata: Option<String>,
 
         /// Skip the https://openchain.xyz lookup.
-        #[clap(long, short)]
+        #[arg(long, short)]
         offline: bool,
     },
 
     /// Get the timestamp of a block.
-    #[clap(visible_alias = "a")]
+    #[command(visible_alias = "a")]
     Age {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
         block: Option<BlockId>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the balance of an account in wei.
-    #[clap(visible_alias = "b")]
+    #[command(visible_alias = "b")]
     Balance {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The account to query.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
         /// Format the balance in ether.
-        #[clap(long, short)]
+        #[arg(long, short)]
         ether: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
 
         /// erc20 address to query, with the method `balanceOf(address) return (uint256)`, alias
         /// with '--erc721'
-        #[clap(long, alias = "erc721")]
+        #[arg(long, alias = "erc721")]
         erc20: Option<Address>,
     },
 
     /// Get the basefee of a block.
-    #[clap(visible_aliases = &["ba", "fee", "basefee"])]
+    #[command(visible_aliases = &["ba", "fee", "basefee"])]
     BaseFee {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
         block: Option<BlockId>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the runtime bytecode of a contract.
-    #[clap(visible_alias = "co")]
+    #[command(visible_alias = "co")]
     Code {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The contract address.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
         /// Disassemble bytecodes into individual opcodes.
-        #[clap(long, short)]
+        #[arg(long, short)]
         disassemble: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the runtime bytecode size of a contract.
-    #[clap(visible_alias = "cs")]
+    #[command(visible_alias = "cs")]
     Codesize {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The contract address.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the current gas price.
-    #[clap(visible_alias = "g")]
+    #[command(visible_alias = "g")]
     GasPrice {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Generate event signatures from event string.
-    #[clap(visible_alias = "se")]
+    #[command(visible_alias = "se")]
     SigEvent {
         /// The event string.
         event_string: Option<String>,
     },
 
     /// Hash arbitrary data using Keccak-256.
-    #[clap(visible_alias = "k")]
+    #[command(visible_alias = "k")]
     Keccak {
         /// The data to hash.
         data: Option<String>,
     },
 
     /// Perform an ENS lookup.
-    #[clap(visible_alias = "rn")]
+    #[command(visible_alias = "rn")]
     ResolveName {
         /// The name to lookup.
         who: Option<String>,
 
         /// Perform a reverse lookup to verify that the name is correct.
-        #[clap(long, short)]
+        #[arg(long, short)]
         verify: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Perform an ENS reverse lookup.
-    #[clap(visible_alias = "la")]
+    #[command(visible_alias = "la")]
     LookupAddress {
         /// The account to perform the lookup for.
         who: Option<Address>,
 
         /// Perform a normal lookup to verify that the address is correct.
-        #[clap(long, short)]
+        #[arg(long, short)]
         verify: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the raw value of a contract's storage slot.
-    #[clap(visible_alias = "st")]
+    #[command(visible_alias = "st")]
     Storage(StorageArgs),
 
     /// Generate a storage proof for a given storage slot.
-    #[clap(visible_alias = "pr")]
+    #[command(visible_alias = "pr")]
     Proof {
         /// The contract address.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         address: NameOrAddress,
 
         /// The storage slot numbers (hex or decimal).
-        #[clap(value_parser = parse_slot)]
+        #[arg(value_parser = parse_slot)]
         slots: Vec<B256>,
 
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the nonce for an account.
-    #[clap(visible_alias = "n")]
+    #[command(visible_alias = "n")]
     Nonce {
         /// The block height to query at.
         ///
         /// Can also be the tags earliest, finalized, safe, latest, or pending.
-        #[clap(long, short = 'B')]
+        #[arg(long, short = 'B')]
         block: Option<BlockId>,
 
         /// The address to get the nonce for.
-        #[clap(value_parser = NameOrAddress::from_str)]
+        #[arg(value_parser = NameOrAddress::from_str)]
         who: NameOrAddress,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc: RpcOpts,
     },
 
     /// Get the source code of a contract from Etherscan.
-    #[clap(visible_aliases = &["et", "src"])]
+    #[command(visible_aliases = &["et", "src"])]
     EtherscanSource {
         /// The contract's address.
         address: String,
 
         /// The output directory to expand source tree into.
-        #[clap(short, value_hint = ValueHint::DirPath)]
+        #[arg(short, value_hint = ValueHint::DirPath)]
         directory: Option<PathBuf>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         etherscan: EtherscanOpts,
     },
 
     /// Wallet management utilities.
-    #[clap(visible_alias = "w")]
+    #[command(visible_alias = "w")]
     Wallet {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         command: WalletSubcommands,
     },
 
     /// Generate a Solidity interface from a given ABI.
     ///
     /// Currently does not support ABI encoder v2.
-    #[clap(visible_alias = "i")]
+    #[command(visible_alias = "i")]
     Interface(InterfaceArgs),
 
     /// Generate a rust binding from a given ABI.
-    #[clap(visible_alias = "bi")]
+    #[command(visible_alias = "bi")]
     Bind(BindArgs),
 
     /// Get the selector for a function.
-    #[clap(visible_alias = "si")]
+    #[command(visible_alias = "si")]
     Sig {
         /// The function signature, e.g. transfer(address,uint256).
         sig: Option<String>,
@@ -819,64 +819,64 @@ pub enum CastSubcommand {
     },
 
     /// Generate a deterministic contract address using CREATE2.
-    #[clap(visible_alias = "c2")]
+    #[command(visible_alias = "c2")]
     Create2(Create2Args),
 
     /// Get the block number closest to the provided timestamp.
-    #[clap(visible_alias = "f")]
+    #[command(visible_alias = "f")]
     FindBlock(FindBlockArgs),
 
     /// Generate shell completions script.
-    #[clap(visible_alias = "com")]
+    #[command(visible_alias = "com")]
     Completions {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
 
     /// Generate Fig autocompletion spec.
-    #[clap(visible_alias = "fig")]
+    #[command(visible_alias = "fig")]
     GenerateFigSpec,
 
     /// Runs a published transaction in a local environment and prints the trace.
-    #[clap(visible_alias = "r")]
+    #[command(visible_alias = "r")]
     Run(RunArgs),
 
     /// Perform a raw JSON-RPC request.
-    #[clap(visible_alias = "rp")]
+    #[command(visible_alias = "rp")]
     Rpc(RpcArgs),
 
     /// Formats a string into bytes32 encoding.
-    #[clap(name = "format-bytes32-string", visible_aliases = &["--format-bytes32-string"])]
+    #[command(name = "format-bytes32-string", visible_aliases = &["--format-bytes32-string"])]
     FormatBytes32String {
         /// The string to format.
         string: Option<String>,
     },
 
     /// Parses a string from bytes32 encoding.
-    #[clap(name = "parse-bytes32-string", visible_aliases = &["--parse-bytes32-string"])]
+    #[command(name = "parse-bytes32-string", visible_aliases = &["--parse-bytes32-string"])]
     ParseBytes32String {
         /// The string to parse.
         bytes: Option<String>,
     },
-    #[clap(name = "parse-bytes32-address", visible_aliases = &["--parse-bytes32-address"])]
-    #[clap(about = "Parses a checksummed address from bytes32 encoding.")]
+    #[command(name = "parse-bytes32-address", visible_aliases = &["--parse-bytes32-address"])]
+    #[command(about = "Parses a checksummed address from bytes32 encoding.")]
     ParseBytes32Address {
-        #[clap(value_name = "BYTES")]
+        #[arg(value_name = "BYTES")]
         bytes: Option<String>,
     },
 
     /// Decodes a raw signed EIP 2718 typed transaction
-    #[clap(visible_alias = "dt")]
+    #[command(visible_alias = "dt")]
     DecodeTransaction { tx: Option<String> },
 
     /// Extracts function selectors and arguments from bytecode
-    #[clap(visible_alias = "sel")]
+    #[command(visible_alias = "sel")]
     Selectors {
         /// The hex encoded bytecode.
         bytecode: String,
 
         /// Resolve the function signatures for the extracted selectors using https://openchain.xyz
-        #[clap(long, short)]
+        #[arg(long, short)]
         resolve: bool,
     },
 }
@@ -885,11 +885,11 @@ pub enum CastSubcommand {
 #[derive(Debug, Parser)]
 pub struct ToBaseArgs {
     /// The value to convert.
-    #[clap(allow_hyphen_values = true)]
+    #[arg(allow_hyphen_values = true)]
     pub value: Option<String>,
 
     /// The input base.
-    #[clap(long, short = 'i')]
+    #[arg(long, short = 'i')]
     pub base_in: Option<String>,
 }
 

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -41,7 +41,7 @@ const VERSION_MESSAGE: &str = concat!(
 
 /// Fast, utilitarian, and verbose Solidity REPL.
 #[derive(Debug, Parser)]
-#[clap(name = "chisel", version = VERSION_MESSAGE)]
+#[command(name = "chisel", version = VERSION_MESSAGE)]
 pub struct Chisel {
     #[command(subcommand)]
     pub cmd: Option<ChiselSubcommand>,
@@ -50,21 +50,21 @@ pub struct Chisel {
     ///
     /// These files will be evaluated before the top-level of the
     /// REPL, therefore functioning as a prelude
-    #[clap(long, help_heading = "REPL options")]
+    #[arg(long, help_heading = "REPL options")]
     pub prelude: Option<PathBuf>,
 
     /// Disable the default `Vm` import.
-    #[clap(long, help_heading = "REPL options", long_help = format!(
+    #[arg(long, help_heading = "REPL options", long_help = format!(
         "Disable the default `Vm` import.\n\n\
          The import is disabled by default if the Solc version is less than {}.",
         chisel::session_source::MIN_VM_VERSION
     ))]
     pub no_vm: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub opts: CoreBuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub evm_opts: EvmArgs,
 }
 

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -19,59 +19,59 @@ use serde::Serialize;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Build options")]
+#[command(next_help_heading = "Build options")]
 pub struct CoreBuildArgs {
     /// Clear the cache and artifacts folder and recompile.
-    #[clap(long, help_heading = "Cache options")]
+    #[arg(long, help_heading = "Cache options")]
     #[serde(skip)]
     pub force: bool,
 
     /// Disable the cache.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub no_cache: bool,
 
     /// Set pre-linked libraries.
-    #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
+    #[arg(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
     /// Ignore solc warnings by error code.
-    #[clap(long, help_heading = "Compiler options", value_name = "ERROR_CODES")]
+    #[arg(long, help_heading = "Compiler options", value_name = "ERROR_CODES")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignored_error_codes: Vec<u64>,
 
     /// Warnings will trigger a compiler error
-    #[clap(long, help_heading = "Compiler options")]
+    #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub deny_warnings: bool,
 
     /// Do not auto-detect the `solc` version.
-    #[clap(long, help_heading = "Compiler options")]
+    #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub no_auto_detect: bool,
 
     /// Specify the solc version, or a path to a local solc, to build with.
     ///
     /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
-    #[clap(long = "use", help_heading = "Compiler options", value_name = "SOLC_VERSION")]
+    #[arg(long = "use", help_heading = "Compiler options", value_name = "SOLC_VERSION")]
     #[serde(skip)]
     pub use_solc: Option<String>,
 
     /// Do not access the network.
     ///
     /// Missing solc versions will not be installed.
-    #[clap(help_heading = "Compiler options", long)]
+    #[arg(help_heading = "Compiler options", long)]
     #[serde(skip)]
     pub offline: bool,
 
     /// Use the Yul intermediate representation compilation pipeline.
-    #[clap(long, help_heading = "Compiler options")]
+    #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub via_ir: bool,
 
     /// The path to the contract artifacts folder.
-    #[clap(
+    #[arg(
         long = "out",
         short,
         help_heading = "Project options",
@@ -85,22 +85,22 @@ pub struct CoreBuildArgs {
     ///
     /// Possible values are "default", "strip" (remove),
     /// "debug" (Solidity-generated revert strings) and "verboseDebug"
-    #[clap(long, help_heading = "Project options", value_name = "REVERT")]
+    #[arg(long, help_heading = "Project options", value_name = "REVERT")]
     #[serde(skip)]
     pub revert_strings: Option<RevertStrings>,
 
     /// Don't print anything on startup.
-    #[clap(long, help_heading = "Compiler options")]
+    #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub silent: bool,
 
     /// Generate build info files.
-    #[clap(long, help_heading = "Project options")]
+    #[arg(long, help_heading = "Project options")]
     #[serde(skip)]
     pub build_info: bool,
 
     /// Output path to directory that build info files will be written to.
-    #[clap(
+    #[arg(
         long,
         help_heading = "Project options",
         value_hint = ValueHint::DirPath,
@@ -110,11 +110,11 @@ pub struct CoreBuildArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_info_path: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     #[serde(flatten)]
     pub project_paths: ProjectPathsArgs,
 }

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -13,25 +13,25 @@ pub use self::paths::ProjectPathsArgs;
 //
 // See also `BuildArgs`.
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Compiler options")]
+#[command(next_help_heading = "Compiler options")]
 pub struct CompilerArgs {
     /// Includes the AST as JSON in the compiler output.
-    #[clap(long, help_heading = "Compiler options")]
+    #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub ast: bool,
 
     /// The target EVM version.
-    #[clap(long, value_name = "VERSION")]
+    #[arg(long, value_name = "VERSION")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evm_version: Option<EvmVersion>,
 
     /// Activate the Solidity optimizer.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub optimize: bool,
 
     /// The number of optimizer runs.
-    #[clap(long, value_name = "RUNS")]
+    #[arg(long, value_name = "RUNS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimizer_runs: Option<usize>,
 
@@ -40,14 +40,14 @@ pub struct CompilerArgs {
     /// Example keys: evm.assembly, ewasm, ir, irOptimized, metadata
     ///
     /// For a full description, see https://docs.soliditylang.org/en/v0.8.13/using-the-compiler.html#input-description
-    #[clap(long, num_args(1..), value_name = "SELECTOR")]
+    #[arg(long, num_args(1..), value_name = "SELECTOR")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_output: Vec<ContractOutputSelection>,
 
     /// Extra output to write to separate files.
     ///
     /// Valid values: metadata, ir, irOptimized, ewasm, evm.assembly
-    #[clap(long, num_args(1..), value_name = "SELECTOR")]
+    #[arg(long, num_args(1..), value_name = "SELECTOR")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_output_files: Vec<ContractOutputSelection>,
 }

--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -15,50 +15,50 @@ use std::path::PathBuf;
 
 /// Common arguments for a project's paths.
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Project options")]
+#[command(next_help_heading = "Project options")]
 pub struct ProjectPathsArgs {
     /// The project's root path.
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(skip)]
     pub root: Option<PathBuf>,
 
     /// The contracts source directory.
-    #[clap(long, short = 'C', value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, short = 'C', value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(rename = "src", skip_serializing_if = "Option::is_none")]
     pub contracts: Option<PathBuf>,
 
     /// The project's remappings.
-    #[clap(long, short = 'R')]
+    #[arg(long, short = 'R')]
     #[serde(skip)]
     pub remappings: Vec<Remapping>,
 
     /// The project's remappings from the environment.
-    #[clap(long, value_name = "ENV")]
+    #[arg(long, value_name = "ENV")]
     #[serde(skip)]
     pub remappings_env: Option<String>,
 
     /// The path to the compiler cache.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_path: Option<PathBuf>,
 
     /// The path to the library folder.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     #[serde(rename = "libs", skip_serializing_if = "Vec::is_empty")]
     pub lib_paths: Vec<PathBuf>,
 
     /// Use the Hardhat-style project layout.
     ///
     /// This is the same as using: `--contracts contracts --lib-paths node_modules`.
-    #[clap(long, conflicts_with = "contracts", visible_alias = "hh")]
+    #[arg(long, conflicts_with = "contracts", visible_alias = "hh")]
     #[serde(skip)]
     pub hardhat: bool,
 
     /// Path to the config file.
-    #[clap(long, value_hint = ValueHint::FilePath, value_name = "FILE")]
+    #[arg(long, value_hint = ValueHint::FilePath, value_name = "FILE")]
     #[serde(skip)]
     pub config_path: Option<PathBuf>,
 }

--- a/crates/cli/src/opts/ethereum.rs
+++ b/crates/cli/src/opts/ethereum.rs
@@ -18,13 +18,13 @@ const FLASHBOTS_URL: &str = "https://rpc.flashbots.net/fast";
 #[derive(Clone, Debug, Default, Parser)]
 pub struct RpcOpts {
     /// The RPC endpoint.
-    #[clap(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
+    #[arg(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
     pub url: Option<String>,
 
     /// Use the Flashbots RPC URL with fast mode (https://rpc.flashbots.net/fast).
     /// This shares the transaction privately with all registered builders.
     /// https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions
-    #[clap(long)]
+    #[arg(long)]
     pub flashbots: bool,
 
     /// JWT Secret for the RPC endpoint.
@@ -36,7 +36,7 @@ pub struct RpcOpts {
     /// '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
     /// "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
     /// "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-    #[clap(long, env = "ETH_RPC_JWT_SECRET")]
+    #[arg(long, env = "ETH_RPC_JWT_SECRET")]
     pub jwt_secret: Option<String>,
 }
 
@@ -89,12 +89,12 @@ impl RpcOpts {
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 pub struct EtherscanOpts {
     /// The Etherscan (or equivalent) API key.
-    #[clap(short = 'e', long = "etherscan-api-key", alias = "api-key", env = "ETHERSCAN_API_KEY")]
+    #[arg(short = 'e', long = "etherscan-api-key", alias = "api-key", env = "ETHERSCAN_API_KEY")]
     #[serde(rename = "etherscan_api_key", skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 
     /// The chain name or EIP-155 chain ID.
-    #[clap(
+    #[arg(
         short,
         long,
         alias = "chain-id",
@@ -141,15 +141,15 @@ impl EtherscanOpts {
 }
 
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(next_help_heading = "Ethereum options")]
+#[command(next_help_heading = "Ethereum options")]
 pub struct EthereumOpts {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub etherscan: EtherscanOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub wallet: WalletOpts,
 }
 

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -4,14 +4,14 @@ use clap::Parser;
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize, Parser)]
-#[clap(next_help_heading = "Transaction options")]
+#[command(next_help_heading = "Transaction options")]
 pub struct TransactionOpts {
     /// Gas limit for the transaction.
-    #[clap(long, env = "ETH_GAS_LIMIT")]
+    #[arg(long, env = "ETH_GAS_LIMIT")]
     pub gas_limit: Option<U256>,
 
     /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.
-    #[clap(
+    #[arg(
         long,
         env = "ETH_GAS_PRICE",
         value_parser = parse_ether_value,
@@ -20,7 +20,7 @@ pub struct TransactionOpts {
     pub gas_price: Option<U256>,
 
     /// Max priority fee per gas for EIP1559 transactions.
-    #[clap(
+    #[arg(
         long,
         env = "ETH_PRIORITY_GAS_PRICE",
         value_parser = parse_ether_value,
@@ -33,17 +33,17 @@ pub struct TransactionOpts {
     ///
     ///
     /// Examples: 1ether, 10gwei, 0.01ether
-    #[clap(long, value_parser = parse_ether_value)]
+    #[arg(long, value_parser = parse_ether_value)]
     pub value: Option<U256>,
 
     /// Nonce for the transaction.
-    #[clap(long)]
+    #[arg(long)]
     pub nonce: Option<U256>,
 
     /// Send a legacy transaction instead of an EIP1559 transaction.
     ///
     /// This is automatically enabled for common networks without EIP1559.
-    #[clap(long)]
+    #[arg(long)]
     pub legacy: bool,
 }
 

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -39,33 +39,33 @@ pub type Breakpoints = HashMap<char, (Address, usize)>;
 /// # }
 /// ```
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "EVM options", about = None, long_about = None)] // override doc
+#[command(next_help_heading = "EVM options", about = None, long_about = None)] // override doc
 pub struct EvmArgs {
     /// Fetch state over a remote endpoint instead of starting from an empty state.
     ///
     /// If you want to fetch state from a specific block number, see --fork-block-number.
-    #[clap(long, short, visible_alias = "rpc-url", value_name = "URL")]
+    #[arg(long, short, visible_alias = "rpc-url", value_name = "URL")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
     pub fork_url: Option<String>,
 
     /// Fetch state from a specific block number over a remote endpoint.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BLOCK")]
+    #[arg(long, requires = "fork_url", value_name = "BLOCK")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
 
     /// Number of retries.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "RETRIES")]
+    #[arg(long, requires = "fork_url", value_name = "RETRIES")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_retries: Option<u32>,
 
     /// Initial retry backoff on encountering errors.
     ///
     /// See --fork-url.
-    #[clap(long, requires = "fork_url", value_name = "BACKOFF")]
+    #[arg(long, requires = "fork_url", value_name = "BACKOFF")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_retry_backoff: Option<u64>,
 
@@ -76,27 +76,27 @@ pub struct EvmArgs {
     /// This flag overrides the project's configuration file.
     ///
     /// See --fork-url.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub no_storage_caching: bool,
 
     /// The initial balance of deployed test contracts.
-    #[clap(long, value_name = "BALANCE")]
+    #[arg(long, value_name = "BALANCE")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_balance: Option<U256>,
 
     /// The address which will be executing tests.
-    #[clap(long, value_name = "ADDRESS")]
+    #[arg(long, value_name = "ADDRESS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender: Option<Address>,
 
     /// Enable the FFI cheatcode.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub ffi: bool,
 
     /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub always_use_create_2_factory: bool,
 
@@ -109,7 +109,7 @@ pub struct EvmArgs {
     /// - 3: Print execution traces for failing tests
     /// - 4: Print execution traces for all tests, and setup traces for failing tests
     /// - 5: Print execution and setup traces for all tests
-    #[clap(long, short, verbatim_doc_comment, action = ArgAction::Count)]
+    #[arg(long, short, verbatim_doc_comment, action = ArgAction::Count)]
     #[serde(skip)]
     pub verbosity: u8,
 
@@ -118,7 +118,7 @@ pub struct EvmArgs {
     /// default value: 330
     ///
     /// See also --fork-url and https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(
+    #[arg(
         long,
         requires = "fork_url",
         alias = "cups",
@@ -130,7 +130,7 @@ pub struct EvmArgs {
     /// Disables rate limiting for this node's provider.
     ///
     /// See also --fork-url and https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[clap(
+    #[arg(
         long,
         requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
@@ -141,14 +141,14 @@ pub struct EvmArgs {
     pub no_rpc_rate_limit: bool,
 
     /// All ethereum environment related arguments
-    #[clap(flatten)]
+    #[command(flatten)]
     #[serde(flatten)]
     pub env: EnvArgs,
 
     /// Whether to enable isolation of calls.
     /// In isolation mode all top-level calls are executed as a separate transaction in a separate
     /// EVM context, enabling more precise gas accounting and transaction state changes.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub isolate: bool,
 }
@@ -202,66 +202,66 @@ impl Provider for EvmArgs {
 
 /// Configures the executor environment during tests.
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Executor environment config")]
+#[command(next_help_heading = "Executor environment config")]
 pub struct EnvArgs {
     /// The block gas limit.
-    #[clap(long, value_name = "GAS_LIMIT")]
+    #[arg(long, value_name = "GAS_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
 
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
     /// default, it is 0x6000 (~25kb).
-    #[clap(long, value_name = "CODE_SIZE")]
+    #[arg(long, value_name = "CODE_SIZE")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_size_limit: Option<usize>,
 
     /// The chain name or EIP-155 chain ID.
-    #[clap(long, visible_alias = "chain-id", value_name = "CHAIN")]
+    #[arg(long, visible_alias = "chain-id", value_name = "CHAIN")]
     #[serde(rename = "chain_id", skip_serializing_if = "Option::is_none", serialize_with = "id")]
     pub chain: Option<Chain>,
 
     /// The gas price.
-    #[clap(long, value_name = "GAS_PRICE")]
+    #[arg(long, value_name = "GAS_PRICE")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_price: Option<u64>,
 
     /// The base fee in a block.
-    #[clap(long, visible_alias = "base-fee", value_name = "FEE")]
+    #[arg(long, visible_alias = "base-fee", value_name = "FEE")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_base_fee_per_gas: Option<u64>,
 
     /// The transaction origin.
-    #[clap(long, value_name = "ADDRESS")]
+    #[arg(long, value_name = "ADDRESS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_origin: Option<Address>,
 
     /// The coinbase of the block.
-    #[clap(long, value_name = "ADDRESS")]
+    #[arg(long, value_name = "ADDRESS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_coinbase: Option<Address>,
 
     /// The timestamp of the block.
-    #[clap(long, value_name = "TIMESTAMP")]
+    #[arg(long, value_name = "TIMESTAMP")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_timestamp: Option<u64>,
 
     /// The block number.
-    #[clap(long, value_name = "BLOCK")]
+    #[arg(long, value_name = "BLOCK")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,
 
     /// The block difficulty.
-    #[clap(long, value_name = "DIFFICULTY")]
+    #[arg(long, value_name = "DIFFICULTY")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_difficulty: Option<u64>,
 
     /// The block prevrandao value. NOTE: Before merge this field was mix_hash.
-    #[clap(long, value_name = "PREVRANDAO")]
+    #[arg(long, value_name = "PREVRANDAO")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_prevrandao: Option<B256>,
 
     /// The block gas limit.
-    #[clap(long, value_name = "GAS_LIMIT")]
+    #[arg(long, value_name = "GAS_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_gas_limit: Option<u64>,
 
@@ -269,7 +269,7 @@ pub struct EnvArgs {
     /// If this limit is exceeded, a `MemoryLimitOOG` result is thrown.
     ///
     /// The default is 128MiB.
-    #[clap(long, value_name = "MEMORY_LIMIT")]
+    #[arg(long, value_name = "MEMORY_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_limit: Option<u64>,
 }

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -18,7 +18,7 @@ const DEFAULT_CRATE_VERSION: &str = "0.1.0";
 #[derive(Clone, Debug, Parser)]
 pub struct BindArgs {
     /// Path to where the contract artifacts are stored.
-    #[clap(
+    #[arg(
         long = "bindings-path",
         short,
         value_hint = ValueHint::DirPath,
@@ -27,61 +27,61 @@ pub struct BindArgs {
     pub bindings: Option<PathBuf>,
 
     /// Create bindings only for contracts whose names match the specified filter(s)
-    #[clap(long)]
+    #[arg(long)]
     pub select: Vec<regex::Regex>,
 
     /// Create bindings only for contracts whose names do not match the specified filter(s)
-    #[clap(long, conflicts_with = "select")]
+    #[arg(long, conflicts_with = "select")]
     pub skip: Vec<regex::Regex>,
 
     /// Explicitly generate bindings for all contracts
     ///
     /// By default all contracts ending with `Test` or `Script` are excluded.
-    #[clap(long, conflicts_with_all = &["select", "skip"])]
+    #[arg(long, conflicts_with_all = &["select", "skip"])]
     pub select_all: bool,
 
     /// The name of the Rust crate to generate.
     ///
     /// This should be a valid crates.io crate name,
     /// however, this is not currently validated by this command.
-    #[clap(long, default_value = DEFAULT_CRATE_NAME, value_name = "NAME")]
+    #[arg(long, default_value = DEFAULT_CRATE_NAME, value_name = "NAME")]
     crate_name: String,
 
     /// The version of the Rust crate to generate.
     ///
     /// This should be a standard semver version string,
     /// however, this is not currently validated by this command.
-    #[clap(long, default_value = DEFAULT_CRATE_VERSION, value_name = "VERSION")]
+    #[arg(long, default_value = DEFAULT_CRATE_VERSION, value_name = "VERSION")]
     crate_version: String,
 
     /// Generate the bindings as a module instead of a crate.
-    #[clap(long)]
+    #[arg(long)]
     module: bool,
 
     /// Overwrite existing generated bindings.
     ///
     /// By default, the command will check that the bindings are correct, and then exit. If
     /// --overwrite is passed, it will instead delete and overwrite the bindings.
-    #[clap(long)]
+    #[arg(long)]
     overwrite: bool,
 
     /// Generate bindings as a single file.
-    #[clap(long)]
+    #[arg(long)]
     single_file: bool,
 
     /// Skip Cargo.toml consistency checks.
-    #[clap(long)]
+    #[arg(long)]
     skip_cargo_toml: bool,
 
     /// Skips running forge build before generating binding
-    #[clap(long)]
+    #[arg(long)]
     skip_build: bool,
 
     /// Don't add any additional derives to generated bindings
-    #[clap(long)]
+    #[arg(long)]
     skip_extra_derives: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     build_args: CoreBuildArgs,
 }
 

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -40,36 +40,36 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 /// Some arguments are marked as `#[serde(skip)]` and require manual processing in
 /// `figment::Provider` implementation
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Build options", about = None, long_about = None)] // override doc
+#[command(next_help_heading = "Build options", about = None, long_about = None)] // override doc
 pub struct BuildArgs {
     /// Print compiled contract names.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub names: bool,
 
     /// Print compiled contract sizes.
-    #[clap(long)]
+    #[arg(long)]
     #[serde(skip)]
     pub sizes: bool,
 
     /// Skip building files whose names contain the given filter.
     ///
     /// `test` and `script` are aliases for `.t.sol` and `.s.sol`.
-    #[clap(long, num_args(1..))]
+    #[arg(long, num_args(1..))]
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     #[serde(flatten)]
     pub args: CoreBuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     #[serde(skip)]
     pub watch: WatchArgs,
 
     /// Output the compilation errors in the json format.
     /// This is useful when you want to use the output in other tools.
-    #[clap(long, conflicts_with = "silent")]
+    #[arg(long, conflicts_with = "silent")]
     #[serde(skip)]
     pub format_json: bool,
 }

--- a/crates/forge/bin/cmd/cache.rs
+++ b/crates/forge/bin/cmd/cache.rs
@@ -11,7 +11,7 @@ use strum::VariantNames;
 /// CLI arguments for `forge cache`.
 #[derive(Debug, Parser)]
 pub struct CacheArgs {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub sub: CacheSubcommands,
 }
 
@@ -26,12 +26,12 @@ pub enum CacheSubcommands {
 
 /// CLI arguments for `forge clean`.
 #[derive(Debug, Parser)]
-#[clap(group = clap::ArgGroup::new("etherscan-blocks").multiple(false))]
+#[command(group = clap::ArgGroup::new("etherscan-blocks").multiple(false))]
 pub struct CleanArgs {
     /// The chains to clean the cache for.
     ///
     /// Can also be "all" to clean all chains.
-    #[clap(
+    #[arg(
         env = "CHAIN",
         default_value = "all",
         value_parser = ChainOrAllValueParser::default(),
@@ -39,7 +39,7 @@ pub struct CleanArgs {
     chains: Vec<ChainOrAll>,
 
     /// The blocks to clean the cache for.
-    #[clap(
+    #[arg(
         short,
         long,
         num_args(1..),
@@ -50,7 +50,7 @@ pub struct CleanArgs {
     blocks: Vec<u64>,
 
     /// Whether to clean the Etherscan cache.
-    #[clap(long, group = "etherscan-blocks")]
+    #[arg(long, group = "etherscan-blocks")]
     etherscan: bool,
 }
 
@@ -82,7 +82,7 @@ pub struct LsArgs {
     /// The chains to list the cache for.
     ///
     /// Can also be "all" to list all chains.
-    #[clap(
+    #[arg(
         env = "CHAIN",
         default_value = "all",
         value_parser = ChainOrAllValueParser::default(),

--- a/crates/forge/bin/cmd/cache.rs
+++ b/crates/forge/bin/cmd/cache.rs
@@ -43,7 +43,6 @@ pub struct CleanArgs {
         short,
         long,
         num_args(1..),
-        use_value_delimiter(true),
         value_delimiter(','),
         group = "etherscan-blocks"
     )]

--- a/crates/forge/bin/cmd/config.rs
+++ b/crates/forge/bin/cmd/config.rs
@@ -11,22 +11,22 @@ foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
 #[derive(Clone, Debug, Parser)]
 pub struct ConfigArgs {
     /// Print only a basic set of the currently set config values.
-    #[clap(long)]
+    #[arg(long)]
     basic: bool,
 
     /// Print currently set config values as JSON.
-    #[clap(long)]
+    #[arg(long)]
     json: bool,
 
     /// Attempt to fix any configuration warnings.
-    #[clap(long)]
+    #[arg(long)]
     fix: bool,
 
     // support nested build arguments
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: BuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     evm_opts: EvmArgs,
 }
 

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -42,20 +42,20 @@ pub struct CoverageArgs {
     /// The report type to use for coverage.
     ///
     /// This flag can be used multiple times.
-    #[clap(long, value_enum, default_value = "summary")]
+    #[arg(long, value_enum, default_value = "summary")]
     report: Vec<CoverageReportKind>,
 
     /// Enable viaIR with minimum optimization
     ///
     /// This can fix most of the "stack too deep" errors while resulting a
     /// relatively accurate source map.
-    #[clap(long)]
+    #[arg(long)]
     ir_minimum: bool,
 
     /// The path to output the report.
     ///
     /// If not specified, the report will be stored in the root of the project.
-    #[clap(
+    #[arg(
         long,
         short,
         value_hint = ValueHint::FilePath,
@@ -63,13 +63,13 @@ pub struct CoverageArgs {
     )]
     report_file: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     filter: FilterArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     evm_opts: EvmArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: CoreBuildArgs,
 }
 

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -35,7 +35,7 @@ pub struct CreateArgs {
     contract: ContractInfo,
 
     /// The constructor arguments.
-    #[clap(
+    #[arg(
         long,
         num_args(1..),
         conflicts_with = "constructor_args_path",
@@ -44,7 +44,7 @@ pub struct CreateArgs {
     constructor_args: Vec<String>,
 
     /// The path to a file containing the constructor arguments.
-    #[clap(
+    #[arg(
         long,
         value_hint = ValueHint::FilePath,
         value_name = "PATH",
@@ -52,37 +52,37 @@ pub struct CreateArgs {
     constructor_args_path: Option<PathBuf>,
 
     /// Print the deployment information as JSON.
-    #[clap(long, help_heading = "Display options")]
+    #[arg(long, help_heading = "Display options")]
     json: bool,
 
     /// Verify contract after creation.
-    #[clap(long)]
+    #[arg(long)]
     verify: bool,
 
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
-    #[clap(long, requires = "from")]
+    #[arg(long, requires = "from")]
     unlocked: bool,
 
     /// Prints the standard json compiler input if `--verify` is provided.
     ///
     /// The standard json compiler input can be used to manually submit contract verification in
     /// the browser.
-    #[clap(long, requires = "verify")]
+    #[arg(long, requires = "verify")]
     show_standard_json_input: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: CoreBuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     tx: TransactionOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     eth: EthereumOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub verifier: verify::VerifierArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     retry: RetryArgs,
 }
 

--- a/crates/forge/bin/cmd/debug.rs
+++ b/crates/forge/bin/cmd/debug.rs
@@ -14,28 +14,28 @@ pub struct DebugArgs {
     ///
     /// If multiple contracts exist in the same file you must specify the target contract with
     /// --target-contract.
-    #[clap(value_hint = ValueHint::FilePath)]
+    #[arg(value_hint = ValueHint::FilePath)]
     pub path: PathBuf,
 
     /// Arguments to pass to the script function.
     pub args: Vec<String>,
 
     /// The name of the contract you want to run.
-    #[clap(long, visible_alias = "tc", value_name = "CONTRACT_NAME")]
+    #[arg(long, visible_alias = "tc", value_name = "CONTRACT_NAME")]
     pub target_contract: Option<String>,
 
     /// The signature of the function you want to call in the contract, or raw calldata.
-    #[clap(long, short, default_value = "run()", value_name = "SIGNATURE")]
+    #[arg(long, short, default_value = "run()", value_name = "SIGNATURE")]
     pub sig: String,
 
     /// Open the script in the debugger.
-    #[clap(long)]
+    #[arg(long)]
     pub debug: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub opts: CoreBuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub evm_opts: EvmArgs,
 }
 

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -16,13 +16,13 @@ pub struct DocArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
     /// The doc's output path.
     ///
     /// By default, it is the `docs/` in project root.
-    #[clap(
+    #[arg(
         long,
         short,
         value_hint = ValueHint::DirPath,
@@ -31,32 +31,32 @@ pub struct DocArgs {
     out: Option<PathBuf>,
 
     /// Build the `mdbook` from generated files.
-    #[clap(long, short)]
+    #[arg(long, short)]
     build: bool,
 
     /// Serve the documentation.
-    #[clap(long, short)]
+    #[arg(long, short)]
     serve: bool,
 
     /// Open the documentation in a browser after serving.
-    #[clap(long, requires = "serve")]
+    #[arg(long, requires = "serve")]
     open: bool,
 
     /// Hostname for serving documentation.
-    #[clap(long, requires = "serve")]
+    #[arg(long, requires = "serve")]
     hostname: Option<String>,
 
     /// Port for serving documentation.
-    #[clap(long, short, requires = "serve")]
+    #[arg(long, short, requires = "serve")]
     port: Option<usize>,
 
     /// The relative path to the `hardhat-deploy` or `forge-deploy` artifact directory. Leave blank
     /// for default.
-    #[clap(long)]
+    #[arg(long)]
     deployments: Option<Option<PathBuf>>,
 
     /// Whether to create docs for external libraries.
-    #[clap(long, short)]
+    #[arg(long, short)]
     include_libraries: bool,
 }
 

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -12,13 +12,13 @@ use std::path::PathBuf;
 #[derive(Clone, Debug, Parser)]
 pub struct FlattenArgs {
     /// The path to the contract to flatten.
-    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
+    #[arg(value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub target_path: PathBuf,
 
     /// The path to output the flattened contract.
     ///
     /// If not specified, the flattened contract will be output to stdout.
-    #[clap(
+    #[arg(
         long,
         short,
         value_hint = ValueHint::FilePath,
@@ -26,7 +26,7 @@ pub struct FlattenArgs {
     )]
     pub output: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     project_paths: ProjectPathsArgs,
 }
 

--- a/crates/forge/bin/cmd/fmt.rs
+++ b/crates/forge/bin/cmd/fmt.rs
@@ -18,25 +18,25 @@ use yansi::Color;
 #[derive(Clone, Debug, Parser)]
 pub struct FmtArgs {
     /// Path to the file, directory or '-' to read from stdin.
-    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH", num_args(1..))]
+    #[arg(value_hint = ValueHint::FilePath, value_name = "PATH", num_args(1..))]
     paths: Vec<PathBuf>,
 
     /// The project's root path.
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 
     /// Run in 'check' mode.
     ///
     /// Exits with 0 if input is formatted correctly.
     /// Exits with 1 if formatting is required.
-    #[clap(long)]
+    #[arg(long)]
     check: bool,
 
     /// In 'check' and stdin modes, outputs raw formatted code instead of the diff.
-    #[clap(long, short)]
+    #[arg(long, short)]
     raw: bool,
 }
 

--- a/crates/forge/bin/cmd/geiger/mod.rs
+++ b/crates/forge/bin/cmd/geiger/mod.rs
@@ -19,7 +19,7 @@ mod visitor;
 #[derive(Clone, Debug, Parser)]
 pub struct GeigerArgs {
     /// Paths to files or directories to detect.
-    #[clap(
+    #[arg(
         conflicts_with = "root",
         value_hint = ValueHint::FilePath,
         value_name = "PATH",
@@ -31,17 +31,17 @@ pub struct GeigerArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 
     /// Run in "check" mode.
     ///
     /// The exit code of the program will be the number of unsafe cheatcodes found.
-    #[clap(long)]
+    #[arg(long)]
     pub check: bool,
 
     /// Globs to ignore.
-    #[clap(
+    #[arg(
         long,
         value_hint = ValueHint::FilePath,
         value_name = "PATH",
@@ -50,7 +50,7 @@ pub struct GeigerArgs {
     ignore: Vec<PathBuf>,
 
     /// Print a report of all files, even if no unsafe functions are found.
-    #[clap(long)]
+    #[arg(long)]
     full: bool,
 }
 

--- a/crates/forge/bin/cmd/generate/mod.rs
+++ b/crates/forge/bin/cmd/generate/mod.rs
@@ -7,7 +7,7 @@ use yansi::Paint;
 /// CLI arguments for `forge generate`.
 #[derive(Debug, Parser)]
 pub struct GenerateArgs {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub sub: GenerateSubcommands,
 }
 
@@ -20,7 +20,7 @@ pub enum GenerateSubcommands {
 #[derive(Debug, Parser)]
 pub struct GenerateTestArgs {
     /// Contract name for test generation.
-    #[clap(long, short, value_name = "CONTRACT_NAME")]
+    #[arg(long, short, value_name = "CONTRACT_NAME")]
     pub contract_name: String,
 }
 

--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -12,32 +12,32 @@ use yansi::Paint;
 #[derive(Clone, Debug, Parser)]
 pub struct InitArgs {
     /// The root directory of the new project.
-    #[clap(value_hint = ValueHint::DirPath, default_value = ".", value_name = "PATH")]
+    #[arg(value_hint = ValueHint::DirPath, default_value = ".", value_name = "PATH")]
     root: PathBuf,
 
     /// The template to start from.
-    #[clap(long, short)]
+    #[arg(long, short)]
     template: Option<String>,
 
     /// Branch argument that can only be used with template option.
     /// If not specified, the default branch is used.
-    #[clap(long, short, requires = "template")]
+    #[arg(long, short, requires = "template")]
     branch: Option<String>,
 
     /// Do not install dependencies from the network.
-    #[clap(long, conflicts_with = "template", visible_alias = "no-deps")]
+    #[arg(long, conflicts_with = "template", visible_alias = "no-deps")]
     offline: bool,
 
     /// Create the project even if the specified root directory is not empty.
-    #[clap(long, conflicts_with = "template")]
+    #[arg(long, conflicts_with = "template")]
     force: bool,
 
     /// Create a .vscode/settings.json file with Solidity settings, and generate a remappings.txt
     /// file.
-    #[clap(long, conflicts_with = "template")]
+    #[arg(long, conflicts_with = "template")]
     vscode: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: DependencyInstallOpts,
 }
 

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -23,15 +23,15 @@ pub struct InspectArgs {
     pub contract: ContractInfo,
 
     /// The contract artifact field to inspect.
-    #[clap(value_enum)]
+    #[arg(value_enum)]
     pub field: ContractArtifactField,
 
     /// Pretty print the selected field, if supported.
-    #[clap(long)]
+    #[arg(long)]
     pub pretty: bool,
 
     /// All build arguments are supported
-    #[clap(flatten)]
+    #[command(flatten)]
     build: CoreBuildArgs,
 }
 

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -22,7 +22,7 @@ static DEPENDENCY_VERSION_TAG_REGEX: Lazy<Regex> =
 
 /// CLI arguments for `forge install`.
 #[derive(Clone, Debug, Parser)]
-#[clap(override_usage = "forge install [OPTIONS] [DEPENDENCIES]...
+#[command(override_usage = "forge install [OPTIONS] [DEPENDENCIES]...
     forge install [OPTIONS] <github username>/<github project>@<tag>...
     forge install [OPTIONS] <alias>=<github username>/<github project>@<tag>...
     forge install [OPTIONS] <https:// git url>...")]
@@ -46,10 +46,10 @@ pub struct InstallArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: DependencyInstallOpts,
 }
 
@@ -67,19 +67,19 @@ pub struct DependencyInstallOpts {
     /// Perform shallow clones instead of deep ones.
     ///
     /// Improves performance and reduces disk usage, but prevents switching branches or tags.
-    #[clap(long)]
+    #[arg(long)]
     pub shallow: bool,
 
     /// Install without adding the dependency as a submodule.
-    #[clap(long)]
+    #[arg(long)]
     pub no_git: bool,
 
     /// Do not create a commit.
-    #[clap(long)]
+    #[arg(long)]
     pub no_commit: bool,
 
     /// Do not print any messages.
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub quiet: bool,
 }
 

--- a/crates/forge/bin/cmd/mod.rs
+++ b/crates/forge/bin/cmd/mod.rs
@@ -23,9 +23,9 @@
 //! // A new clap subcommand that accepts both `EvmArgs` and `BuildArgs`
 //! #[derive(Clone, Debug, Parser)]
 //! pub struct MyArgs {
-//!     #[clap(flatten)]
+//!     #[command(flatten)]
 //!     evm_opts: EvmArgs,
-//!     #[clap(flatten)]
+//!     #[command(flatten)]
 //!     opts: BuildArgs,
 //! }
 //!

--- a/crates/forge/bin/cmd/remappings.rs
+++ b/crates/forge/bin/cmd/remappings.rs
@@ -12,10 +12,10 @@ pub struct RemappingArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
     /// Pretty-print the remappings, grouping each of them by context.
-    #[clap(long)]
+    #[arg(long)]
     pretty: bool,
 }
 impl_figment_convert_basic!(RemappingArgs);

--- a/crates/forge/bin/cmd/remove.rs
+++ b/crates/forge/bin/cmd/remove.rs
@@ -17,11 +17,11 @@ pub struct RemoveArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 
     /// Override the up-to-date check.
-    #[clap(short, long)]
+    #[arg(short, long)]
     force: bool,
 }
 impl_figment_convert_basic!(RemoveArgs);

--- a/crates/forge/bin/cmd/retry.rs
+++ b/crates/forge/bin/cmd/retry.rs
@@ -10,10 +10,10 @@ pub const RETRY_VERIFY_ON_CREATE: RetryArgs = RetryArgs { retries: 15, delay: 5 
 
 /// Retry arguments for contract verification.
 #[derive(Clone, Copy, Debug, Parser)]
-#[clap(about = "Allows to use retry arguments for contract verification")] // override doc
+#[command(about = "Allows to use retry arguments for contract verification")] // override doc
 pub struct RetryArgs {
     /// Number of attempts for retrying verification.
-    #[clap(
+    #[arg(
         long,
         value_parser = RangedU64ValueParser::<u32>::new().range(1..),
         default_value = "5",
@@ -21,7 +21,7 @@ pub struct RetryArgs {
     pub retries: u32,
 
     /// Optional delay to apply inbetween verification attempts, in seconds.
-    #[clap(
+    #[arg(
         long,
         value_parser = RangedU64ValueParser::<u32>::new().range(0..=30),
         default_value = "5",

--- a/crates/forge/bin/cmd/script/mod.rs
+++ b/crates/forge/bin/cmd/script/mod.rs
@@ -72,22 +72,22 @@ pub struct ScriptArgs {
     ///
     /// If multiple contracts exist in the same file you must specify the target contract with
     /// --target-contract.
-    #[clap(value_hint = ValueHint::FilePath)]
+    #[arg(value_hint = ValueHint::FilePath)]
     pub path: String,
 
     /// Arguments to pass to the script function.
     pub args: Vec<String>,
 
     /// The name of the contract you want to run.
-    #[clap(long, visible_alias = "tc", value_name = "CONTRACT_NAME")]
+    #[arg(long, visible_alias = "tc", value_name = "CONTRACT_NAME")]
     pub target_contract: Option<String>,
 
     /// The signature of the function you want to call in the contract, or raw calldata.
-    #[clap(long, short, default_value = "run()")]
+    #[arg(long, short, default_value = "run()")]
     pub sig: String,
 
     /// Max priority fee per gas for EIP1559 transactions.
-    #[clap(
+    #[arg(
         long,
         env = "ETH_PRIORITY_GAS_PRICE",
         value_parser = foundry_cli::utils::parse_ether_value,
@@ -98,23 +98,23 @@ pub struct ScriptArgs {
     /// Use legacy transactions instead of EIP1559 ones.
     ///
     /// This is auto-enabled for common networks without EIP1559.
-    #[clap(long)]
+    #[arg(long)]
     pub legacy: bool,
 
     /// Broadcasts the transactions.
-    #[clap(long)]
+    #[arg(long)]
     pub broadcast: bool,
 
     /// Skips on-chain simulation.
-    #[clap(long)]
+    #[arg(long)]
     pub skip_simulation: bool,
 
     /// Relative percentage to multiply gas estimates by.
-    #[clap(long, short, default_value = "130")]
+    #[arg(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
 
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
-    #[clap(
+    #[arg(
         long,
         requires = "sender",
         conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"],
@@ -127,44 +127,44 @@ pub struct ScriptArgs {
     ///
     /// Example: If transaction N has a nonce of 22, then the account should have a nonce of 22,
     /// otherwise it fails.
-    #[clap(long)]
+    #[arg(long)]
     pub resume: bool,
 
     /// If present, --resume or --verify will be assumed to be a multi chain deployment.
-    #[clap(long)]
+    #[arg(long)]
     pub multi: bool,
 
     /// Open the script in the debugger.
     ///
     /// Takes precedence over broadcast.
-    #[clap(long)]
+    #[arg(long)]
     pub debug: bool,
 
     /// Makes sure a transaction is sent,
     /// only after its previous one has been confirmed and succeeded.
-    #[clap(long)]
+    #[arg(long)]
     pub slow: bool,
 
     /// Disables interactive prompts that might appear when deploying big contracts.
     ///
     /// For more info on the contract size limit, see EIP-170: <https://eips.ethereum.org/EIPS/eip-170>
-    #[clap(long)]
+    #[arg(long)]
     pub non_interactive: bool,
 
     /// The Etherscan (or equivalent) API key
-    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+    #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,
 
     /// Verifies all the contracts found in the receipts of a script, if any.
-    #[clap(long)]
+    #[arg(long)]
     pub verify: bool,
 
     /// Output results in JSON format.
-    #[clap(long)]
+    #[arg(long)]
     pub json: bool,
 
     /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.
-    #[clap(
+    #[arg(
         long,
         env = "ETH_GAS_PRICE",
         value_parser = foundry_cli::utils::parse_ether_value,
@@ -172,19 +172,19 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub opts: BuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub wallets: MultiWalletOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub evm_opts: EvmArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub verifier: super::verify::VerifierArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub retry: RetryArgs,
 }
 

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -16,7 +16,7 @@ use std::fs::canonicalize;
 #[derive(Clone, Debug, Parser)]
 pub enum SelectorsSubcommands {
     /// Check for selector collisions between contracts
-    #[clap(visible_alias = "co")]
+    #[command(visible_alias = "co")]
     Collision {
         /// The first of the two contracts for which to look selector collisions for, in the form
         /// `(<path>:)?<contractname>`.
@@ -26,33 +26,33 @@ pub enum SelectorsSubcommands {
         /// `(<path>:)?<contractname>`.
         second_contract: ContractInfo,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         build: Box<CoreBuildArgs>,
     },
 
     /// Upload selectors to registry
-    #[clap(visible_alias = "up")]
+    #[command(visible_alias = "up")]
     Upload {
         /// The name of the contract to upload selectors for.
-        #[clap(required_unless_present = "all")]
+        #[arg(required_unless_present = "all")]
         contract: Option<String>,
 
         /// Upload selectors for all contracts in the project.
-        #[clap(long, required_unless_present = "contract")]
+        #[arg(long, required_unless_present = "contract")]
         all: bool,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         project_paths: ProjectPathsArgs,
     },
 
     /// List selectors from current workspace
-    #[clap(visible_alias = "ls")]
+    #[command(visible_alias = "ls")]
     List {
         /// The name of the contract to list selectors for.
-        #[clap(help = "The name of the contract to list selectors for.")]
+        #[arg(help = "The name of the contract to list selectors for.")]
         contract: Option<String>,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         project_paths: ProjectPathsArgs,
     },
 }

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -29,7 +29,7 @@ pub struct SnapshotArgs {
     /// Output a diff against a pre-existing snapshot.
     ///
     /// By default, the comparison is done with .gas-snapshot.
-    #[clap(
+    #[arg(
         conflicts_with = "snap",
         long,
         value_hint = ValueHint::FilePath,
@@ -42,7 +42,7 @@ pub struct SnapshotArgs {
     /// Outputs a diff if the snapshots do not match.
     ///
     /// By default, the comparison is done with .gas-snapshot.
-    #[clap(
+    #[arg(
         conflicts_with = "diff",
         long,
         value_hint = ValueHint::FilePath,
@@ -52,11 +52,11 @@ pub struct SnapshotArgs {
 
     // Hidden because there is only one option
     /// How to format the output.
-    #[clap(long, hide(true))]
+    #[arg(long, hide(true))]
     format: Option<Format>,
 
     /// Output file for the snapshot.
-    #[clap(
+    #[arg(
         long,
         default_value = ".gas-snapshot",
         value_hint = ValueHint::FilePath,
@@ -65,7 +65,7 @@ pub struct SnapshotArgs {
     snap: PathBuf,
 
     /// Tolerates gas deviations up to the specified percentage.
-    #[clap(
+    #[arg(
         long,
         value_parser = RangedU64ValueParser::<u32>::new().range(0..100),
         value_name = "SNAPSHOT_THRESHOLD"
@@ -73,11 +73,11 @@ pub struct SnapshotArgs {
     tolerance: Option<u32>,
 
     /// All test arguments are supported
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) test: test::TestArgs,
 
     /// Additional configs for test results
-    #[clap(flatten)]
+    #[command(flatten)]
     config: SnapshotConfig,
 }
 
@@ -141,19 +141,19 @@ impl FromStr for Format {
 #[derive(Clone, Debug, Default, Parser)]
 struct SnapshotConfig {
     /// Sort results by gas used (ascending).
-    #[clap(long)]
+    #[arg(long)]
     asc: bool,
 
     /// Sort results by gas used (descending).
-    #[clap(conflicts_with = "asc", long)]
+    #[arg(conflicts_with = "asc", long)]
     desc: bool,
 
     /// Only include tests that used more gas that the given amount.
-    #[clap(long, value_name = "MIN_GAS")]
+    #[arg(long, value_name = "MIN_GAS")]
     min: Option<u64>,
 
     /// Only include tests that used less gas that the given amount.
-    #[clap(long, value_name = "MAX_GAS")]
+    #[arg(long, value_name = "MAX_GAS")]
     max: Option<u64>,
 }
 

--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -34,7 +34,7 @@ pub struct FilterArgs {
 
     /// Only run tests in source files that do not match the specified glob pattern.
     #[arg(
-        name = "no-match-path",
+        id = "no-match-path",
         long = "no-match-path",
         visible_alias = "nmp",
         value_name = "GLOB"

--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -10,30 +10,30 @@ use std::{fmt, path::Path};
 ///
 /// See also `FileFilter`.
 #[derive(Clone, Parser)]
-#[clap(next_help_heading = "Test filtering")]
+#[command(next_help_heading = "Test filtering")]
 pub struct FilterArgs {
     /// Only run test functions matching the specified regex pattern.
-    #[clap(long = "match-test", visible_alias = "mt", value_name = "REGEX")]
+    #[arg(long = "match-test", visible_alias = "mt", value_name = "REGEX")]
     pub test_pattern: Option<regex::Regex>,
 
     /// Only run test functions that do not match the specified regex pattern.
-    #[clap(long = "no-match-test", visible_alias = "nmt", value_name = "REGEX")]
+    #[arg(long = "no-match-test", visible_alias = "nmt", value_name = "REGEX")]
     pub test_pattern_inverse: Option<regex::Regex>,
 
     /// Only run tests in contracts matching the specified regex pattern.
-    #[clap(long = "match-contract", visible_alias = "mc", value_name = "REGEX")]
+    #[arg(long = "match-contract", visible_alias = "mc", value_name = "REGEX")]
     pub contract_pattern: Option<regex::Regex>,
 
     /// Only run tests in contracts that do not match the specified regex pattern.
-    #[clap(long = "no-match-contract", visible_alias = "nmc", value_name = "REGEX")]
+    #[arg(long = "no-match-contract", visible_alias = "nmc", value_name = "REGEX")]
     pub contract_pattern_inverse: Option<regex::Regex>,
 
     /// Only run tests in source files matching the specified glob pattern.
-    #[clap(long = "match-path", visible_alias = "mp", value_name = "GLOB")]
+    #[arg(long = "match-path", visible_alias = "mp", value_name = "GLOB")]
     pub path_pattern: Option<GlobMatcher>,
 
     /// Only run tests in source files that do not match the specified glob pattern.
-    #[clap(
+    #[arg(
         name = "no-match-path",
         long = "no-match-path",
         visible_alias = "nmp",

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -48,7 +48,7 @@ foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
 
 /// CLI arguments for `forge test`.
 #[derive(Clone, Debug, Parser)]
-#[clap(next_help_heading = "Test options")]
+#[command(next_help_heading = "Test options")]
 pub struct TestArgs {
     /// Run a test in the debugger.
     ///
@@ -65,58 +65,58 @@ pub struct TestArgs {
     /// If the fuzz test does not fail, it will open the debugger on the last fuzz case.
     ///
     /// For more fine-grained control of which fuzz case is run, see forge run.
-    #[clap(long, value_name = "TEST_FUNCTION")]
+    #[arg(long, value_name = "TEST_FUNCTION")]
     debug: Option<Regex>,
 
     /// Print a gas report.
-    #[clap(long, env = "FORGE_GAS_REPORT")]
+    #[arg(long, env = "FORGE_GAS_REPORT")]
     gas_report: bool,
 
     /// Exit with code 0 even if a test fails.
-    #[clap(long, env = "FORGE_ALLOW_FAILURE")]
+    #[arg(long, env = "FORGE_ALLOW_FAILURE")]
     allow_failure: bool,
 
     /// Output test results in JSON format.
-    #[clap(long, short, help_heading = "Display options")]
+    #[arg(long, short, help_heading = "Display options")]
     json: bool,
 
     /// Stop running tests after the first failure.
-    #[clap(long)]
+    #[arg(long)]
     pub fail_fast: bool,
 
     /// The Etherscan (or equivalent) API key.
-    #[clap(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+    #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     etherscan_api_key: Option<String>,
 
     /// List tests instead of running them.
-    #[clap(long, short, help_heading = "Display options")]
+    #[arg(long, short, help_heading = "Display options")]
     list: bool,
 
     /// Set seed used to generate randomness during your fuzz runs.
-    #[clap(long)]
+    #[arg(long)]
     pub fuzz_seed: Option<U256>,
 
-    #[clap(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]
+    #[arg(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]
     pub fuzz_runs: Option<u64>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     filter: FilterArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     evm_opts: EvmArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: CoreBuildArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub watch: WatchArgs,
 
     /// Print test summary table.
-    #[clap(long, help_heading = "Display options")]
+    #[arg(long, help_heading = "Display options")]
     pub summary: bool,
 
     /// Print detailed test summary table.
-    #[clap(long, help_heading = "Display options", requires = "summary")]
+    #[arg(long, help_heading = "Display options", requires = "summary")]
     pub detailed: bool,
 }
 

--- a/crates/forge/bin/cmd/tree.rs
+++ b/crates/forge/bin/cmd/tree.rs
@@ -10,16 +10,16 @@ use foundry_compilers::{
 #[derive(Clone, Debug, Parser)]
 pub struct TreeArgs {
     /// Do not de-duplicate (repeats all shared dependencies)
-    #[clap(long)]
+    #[arg(long)]
     no_dedupe: bool,
 
     /// Character set to use in output.
     ///
     /// [possible values: utf8, ascii]
-    #[clap(long, default_value = "utf8")]
+    #[arg(long, default_value = "utf8")]
     charset: Charset,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     opts: ProjectPathsArgs,
 }
 

--- a/crates/forge/bin/cmd/update.rs
+++ b/crates/forge/bin/cmd/update.rs
@@ -17,15 +17,15 @@ pub struct UpdateArgs {
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     root: Option<PathBuf>,
 
     /// Override the up-to-date check.
-    #[clap(short, long)]
+    #[arg(short, long)]
     force: bool,
 
     /// Recursively update submodules.
-    #[clap(short, long)]
+    #[arg(short, long)]
     recursive: bool,
 }
 impl_figment_convert_basic!(UpdateArgs);

--- a/crates/forge/bin/cmd/verify/mod.rs
+++ b/crates/forge/bin/cmd/verify/mod.rs
@@ -21,11 +21,11 @@ mod sourcify;
 #[derive(Clone, Debug, Parser)]
 pub struct VerifierArgs {
     /// The contract verification provider to use.
-    #[clap(long, help_heading = "Verifier options", default_value = "etherscan", value_enum)]
+    #[arg(long, help_heading = "Verifier options", default_value = "etherscan", value_enum)]
     pub verifier: VerificationProviderType,
 
     /// The verifier URL, if using a custom provider
-    #[clap(long, help_heading = "Verifier options", env = "VERIFIER_URL")]
+    #[arg(long, help_heading = "Verifier options", env = "VERIFIER_URL")]
     pub verifier_url: Option<String>,
 }
 
@@ -45,7 +45,7 @@ pub struct VerifyArgs {
     pub contract: ContractInfo,
 
     /// The ABI-encoded constructor arguments.
-    #[clap(
+    #[arg(
         long,
         conflicts_with = "constructor_args_path",
         value_name = "ARGS",
@@ -54,68 +54,68 @@ pub struct VerifyArgs {
     pub constructor_args: Option<String>,
 
     /// The path to a file containing the constructor arguments.
-    #[clap(long, value_hint = ValueHint::FilePath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub constructor_args_path: Option<PathBuf>,
 
     /// The `solc` version to use to build the smart contract.
-    #[clap(long, value_name = "VERSION")]
+    #[arg(long, value_name = "VERSION")]
     pub compiler_version: Option<String>,
 
     /// The number of optimization runs used to build the smart contract.
-    #[clap(long, visible_alias = "optimizer-runs", value_name = "NUM")]
+    #[arg(long, visible_alias = "optimizer-runs", value_name = "NUM")]
     pub num_of_optimizations: Option<usize>,
 
     /// Flatten the source code before verifying.
-    #[clap(long)]
+    #[arg(long)]
     pub flatten: bool,
 
     /// Do not compile the flattened smart contract before verifying (if --flatten is passed).
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub force: bool,
 
     /// Do not check if the contract is already verified before verifying.
-    #[clap(long)]
+    #[arg(long)]
     pub skip_is_verified_check: bool,
 
     /// Wait for verification result after submission.
-    #[clap(long)]
+    #[arg(long)]
     pub watch: bool,
 
     /// Set pre-linked libraries.
-    #[clap(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
+    #[arg(long, help_heading = "Linker options", env = "DAPP_LIBRARIES")]
     pub libraries: Vec<String>,
 
     /// The project's root path.
     ///
     /// By default root of the Git repository, if in one,
     /// or the current working directory.
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+    #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
     pub root: Option<PathBuf>,
 
     /// Prints the standard json compiler input.
     ///
     /// The standard json compiler input can be used to manually submit contract verification in
     /// the browser.
-    #[clap(long, conflicts_with = "flatten")]
+    #[arg(long, conflicts_with = "flatten")]
     pub show_standard_json_input: bool,
 
     /// Use the Yul intermediate representation compilation pipeline.
-    #[clap(long)]
+    #[arg(long)]
     pub via_ir: bool,
 
     /// The EVM version to use.
     ///
     /// Overrides the version specified in the config.
-    #[clap(long)]
+    #[arg(long)]
     pub evm_version: Option<EvmVersion>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub etherscan: EtherscanOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub retry: RetryArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub verifier: VerifierArgs,
 }
 
@@ -205,13 +205,13 @@ pub struct VerifyCheckArgs {
     /// For Sourcify - Contract Address.
     id: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     retry: RetryArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     etherscan: EtherscanOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     verifier: VerifierArgs,
 }
 

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -16,12 +16,12 @@ use watchexec::{
 };
 
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(next_help_heading = "Watch options")]
+#[command(next_help_heading = "Watch options")]
 pub struct WatchArgs {
     /// Watch the given files or directories for changes.
     ///
     /// If no paths are provided, the source and test directories of the project are watched.
-    #[clap(
+    #[arg(
         long,
         short,
         num_args(0..),
@@ -30,13 +30,13 @@ pub struct WatchArgs {
     pub watch: Option<Vec<PathBuf>>,
 
     /// Do not restart the command while it's still running.
-    #[clap(long)]
+    #[arg(long)]
     pub no_restart: bool,
 
     /// Explicitly re-run all tests when a change is made.
     ///
     /// By default, only the tests of the last modified test file are executed.
-    #[clap(long)]
+    #[arg(long)]
     pub run_all: bool,
 
     /// File update debounce delay.
@@ -52,7 +52,7 @@ pub struct WatchArgs {
     ///
     /// When using --poll mode, you'll want a larger duration, or risk
     /// overloading disk I/O.
-    #[clap(long, value_name = "DELAY")]
+    #[arg(long, value_name = "DELAY")]
     pub watch_delay: Option<String>,
 }
 

--- a/crates/forge/bin/opts.rs
+++ b/crates/forge/bin/opts.rs
@@ -33,14 +33,14 @@ const VERSION_MESSAGE: &str = concat!(
 
 /// Build, test, fuzz, debug and deploy Solidity contracts.
 #[derive(Parser)]
-#[clap(
+#[command(
     name = "forge",
     version = VERSION_MESSAGE,
     after_help = "Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html",
     next_display_order = None,
 )]
 pub struct Forge {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub cmd: ForgeSubcommand,
 }
 
@@ -48,7 +48,7 @@ pub struct Forge {
 #[allow(clippy::large_enum_variant)]
 pub enum ForgeSubcommand {
     /// Run the project's tests.
-    #[clap(visible_alias = "t")]
+    #[command(visible_alias = "t")]
     Test(test::TestArgs),
 
     /// Run a smart contract as a script, building transactions that can be sent onchain.
@@ -58,71 +58,71 @@ pub enum ForgeSubcommand {
     Coverage(coverage::CoverageArgs),
 
     /// Generate Rust bindings for smart contracts.
-    #[clap(alias = "bi")]
+    #[command(alias = "bi")]
     Bind(BindArgs),
 
     /// Build the project's smart contracts.
-    #[clap(visible_aliases = ["b", "compile"])]
+    #[command(visible_aliases = ["b", "compile"])]
     Build(BuildArgs),
 
     /// Debugs a single smart contract as a script.
-    #[clap(visible_alias = "d")]
+    #[command(visible_alias = "d")]
     Debug(DebugArgs),
 
     /// Update one or multiple dependencies.
     ///
     /// If no arguments are provided, then all dependencies are updated.
-    #[clap(visible_alias = "u")]
+    #[command(visible_alias = "u")]
     Update(update::UpdateArgs),
 
     /// Install one or multiple dependencies.
     ///
     /// If no arguments are provided, then existing dependencies will be installed.
-    #[clap(visible_alias = "i")]
+    #[command(visible_alias = "i")]
     Install(InstallArgs),
 
     /// Remove one or multiple dependencies.
-    #[clap(visible_alias = "rm")]
+    #[command(visible_alias = "rm")]
     Remove(RemoveArgs),
 
     /// Get the automatically inferred remappings for the project.
-    #[clap(visible_alias = "re")]
+    #[command(visible_alias = "re")]
     Remappings(RemappingArgs),
 
     /// Verify smart contracts on Etherscan.
-    #[clap(visible_alias = "v")]
+    #[command(visible_alias = "v")]
     VerifyContract(VerifyArgs),
 
     /// Check verification status on Etherscan.
-    #[clap(visible_alias = "vc")]
+    #[command(visible_alias = "vc")]
     VerifyCheck(VerifyCheckArgs),
 
     /// Deploy a smart contract.
-    #[clap(visible_alias = "c")]
+    #[command(visible_alias = "c")]
     Create(CreateArgs),
 
     /// Create a new Forge project.
     Init(InitArgs),
 
     /// Generate shell completions script.
-    #[clap(visible_alias = "com")]
+    #[command(visible_alias = "com")]
     Completions {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
 
     /// Generate Fig autocompletion spec.
-    #[clap(visible_alias = "fig")]
+    #[command(visible_alias = "fig")]
     GenerateFigSpec,
 
     /// Remove the build artifacts and cache directories.
-    #[clap(visible_alias = "cl")]
+    #[command(visible_alias = "cl")]
     Clean {
         /// The project's root path.
         ///
         /// By default root of the Git repository, if in one,
         /// or the current working directory.
-        #[clap(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
+        #[arg(long, value_hint = ValueHint::DirPath, value_name = "PATH")]
         root: Option<PathBuf>,
     },
 
@@ -130,26 +130,26 @@ pub enum ForgeSubcommand {
     Cache(CacheArgs),
 
     /// Create a snapshot of each test's gas usage.
-    #[clap(visible_alias = "s")]
+    #[command(visible_alias = "s")]
     Snapshot(snapshot::SnapshotArgs),
 
     /// Display the current config.
-    #[clap(visible_alias = "co")]
+    #[command(visible_alias = "co")]
     Config(config::ConfigArgs),
 
     /// Flatten a source file and all of its imports into one file.
-    #[clap(visible_alias = "f")]
+    #[command(visible_alias = "f")]
     Flatten(flatten::FlattenArgs),
 
     /// Format Solidity source files.
     Fmt(FmtArgs),
 
     /// Get specialized information about a smart contract.
-    #[clap(visible_alias = "in")]
+    #[command(visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 
     /// Display a tree visualization of the project's dependency graph.
-    #[clap(visible_alias = "tr")]
+    #[command(visible_alias = "tr")]
     Tree(tree::TreeArgs),
 
     /// Detects usage of unsafe cheat codes in a project and its dependencies.
@@ -159,9 +159,9 @@ pub enum ForgeSubcommand {
     Doc(DocArgs),
 
     /// Function selector utilities
-    #[clap(visible_alias = "se")]
+    #[command(visible_alias = "se")]
     Selectors {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         command: SelectorsSubcommands,
     },
 

--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -89,10 +89,10 @@ macro_rules! create_hw_wallets {
 /// 6. Private Keys (interactively via secure prompt)
 /// 7. AWS KMS
 #[derive(Builder, Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
+#[command(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct MultiWalletOpts {
     /// The sender accounts.
-    #[clap(
+    #[arg(
         long,
         short = 'a',
         help_heading = "Wallet options - raw",
@@ -106,7 +106,7 @@ pub struct MultiWalletOpts {
     /// Open an interactive prompt to enter your private key.
     ///
     /// Takes a value for the number of keys to enter.
-    #[clap(
+    #[arg(
         long,
         short,
         help_heading = "Wallet options - raw",
@@ -116,12 +116,12 @@ pub struct MultiWalletOpts {
     pub interactives: u32,
 
     /// Use the provided private keys.
-    #[clap(long, help_heading = "Wallet options - raw", value_name = "RAW_PRIVATE_KEYS")]
+    #[arg(long, help_heading = "Wallet options - raw", value_name = "RAW_PRIVATE_KEYS")]
     #[builder(default = "None")]
     pub private_keys: Option<Vec<String>>,
 
     /// Use the provided private key.
-    #[clap(
+    #[arg(
         long,
         help_heading = "Wallet options - raw",
         conflicts_with = "private_keys",
@@ -131,19 +131,19 @@ pub struct MultiWalletOpts {
     pub private_key: Option<String>,
 
     /// Use the mnemonic phrases of mnemonic files at the specified paths.
-    #[clap(long, alias = "mnemonic-paths", help_heading = "Wallet options - raw")]
+    #[arg(long, alias = "mnemonic-paths", help_heading = "Wallet options - raw")]
     #[builder(default = "None")]
     pub mnemonics: Option<Vec<String>>,
 
     /// Use a BIP39 passphrases for the mnemonic.
-    #[clap(long, help_heading = "Wallet options - raw", value_name = "PASSPHRASE")]
+    #[arg(long, help_heading = "Wallet options - raw", value_name = "PASSPHRASE")]
     #[builder(default = "None")]
     pub mnemonic_passphrases: Option<Vec<String>>,
 
     /// The wallet derivation path.
     ///
     /// Works with both --mnemonic-path and hardware wallets.
-    #[clap(
+    #[arg(
         long = "mnemonic-derivation-paths",
         alias = "hd-paths",
         help_heading = "Wallet options - raw",
@@ -155,7 +155,7 @@ pub struct MultiWalletOpts {
     /// Use the private key from the given mnemonic index.
     ///
     /// Can be used with --mnemonics, --ledger, --aws and --trezor.
-    #[clap(
+    #[arg(
         long,
         conflicts_with = "hd_paths",
         help_heading = "Wallet options - raw",
@@ -165,7 +165,7 @@ pub struct MultiWalletOpts {
     pub mnemonic_indexes: Option<Vec<u32>>,
 
     /// Use the keystore in the given folder or file.
-    #[clap(
+    #[arg(
         long = "keystore",
         visible_alias = "keystores",
         help_heading = "Wallet options - keystore",
@@ -176,7 +176,7 @@ pub struct MultiWalletOpts {
     pub keystore_paths: Option<Vec<String>>,
 
     /// Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
-    #[clap(
+    #[arg(
         long = "account",
         visible_alias = "accounts",
         help_heading = "Wallet options - keystore",
@@ -190,7 +190,7 @@ pub struct MultiWalletOpts {
     /// The keystore password.
     ///
     /// Used with --keystore.
-    #[clap(
+    #[arg(
         long = "password",
         help_heading = "Wallet options - keystore",
         requires = "keystore_paths",
@@ -202,7 +202,7 @@ pub struct MultiWalletOpts {
     /// The keystore password file path.
     ///
     /// Used with --keystore.
-    #[clap(
+    #[arg(
         long = "password-file",
         help_heading = "Wallet options - keystore",
         requires = "keystore_paths",
@@ -213,15 +213,15 @@ pub struct MultiWalletOpts {
     pub keystore_password_files: Option<Vec<String>>,
 
     /// Use a Ledger hardware wallet.
-    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
+    #[arg(long, short, help_heading = "Wallet options - hardware wallet")]
     pub ledger: bool,
 
     /// Use a Trezor hardware wallet.
-    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
+    #[arg(long, short, help_heading = "Wallet options - hardware wallet")]
     pub trezor: bool,
 
     /// Use AWS Key Management Service.
-    #[clap(long, help_heading = "Wallet options - remote")]
+    #[arg(long, help_heading = "Wallet options - remote")]
     pub aws: bool,
 }
 

--- a/crates/wallets/src/raw_wallet.rs
+++ b/crates/wallets/src/raw_wallet.rs
@@ -9,34 +9,34 @@ use serde::Serialize;
 /// 2. Private Key (interactively via secure prompt)
 /// 3. Mnemonic (via file path)
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Wallet options - raw", about = None, long_about = None)]
+#[command(next_help_heading = "Wallet options - raw", about = None, long_about = None)]
 pub struct RawWalletOpts {
     /// Open an interactive prompt to enter your private key.
-    #[clap(long, short)]
+    #[arg(long, short)]
     pub interactive: bool,
 
     /// Use the provided private key.
-    #[clap(long, value_name = "RAW_PRIVATE_KEY")]
+    #[arg(long, value_name = "RAW_PRIVATE_KEY")]
     pub private_key: Option<String>,
 
     /// Use the mnemonic phrase of mnemonic file at the specified path.
-    #[clap(long, alias = "mnemonic-path")]
+    #[arg(long, alias = "mnemonic-path")]
     pub mnemonic: Option<String>,
 
     /// Use a BIP39 passphrase for the mnemonic.
-    #[clap(long, value_name = "PASSPHRASE")]
+    #[arg(long, value_name = "PASSPHRASE")]
     pub mnemonic_passphrase: Option<String>,
 
     /// The wallet derivation path.
     ///
     /// Works with both --mnemonic-path and hardware wallets.
-    #[clap(long = "mnemonic-derivation-path", alias = "hd-path", value_name = "PATH")]
+    #[arg(long = "mnemonic-derivation-path", alias = "hd-path", value_name = "PATH")]
     pub hd_path: Option<String>,
 
     /// Use the private key from the given mnemonic index.
     ///
     /// Used with --mnemonic-path.
-    #[clap(long, conflicts_with = "hd_path", default_value_t = 0, value_name = "INDEX")]
+    #[arg(long, conflicts_with = "hd_path", default_value_t = 0, value_name = "INDEX")]
     pub mnemonic_index: u32,
 }
 

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -13,10 +13,10 @@ use serde::Serialize;
 /// 4. Keystore (via file path)
 /// 5. AWS KMS
 #[derive(Clone, Debug, Default, Serialize, Parser)]
-#[clap(next_help_heading = "Wallet options", about = None, long_about = None)]
+#[command(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct WalletOpts {
     /// The sender account.
-    #[clap(
+    #[arg(
         long,
         short,
         value_name = "ADDRESS",
@@ -25,11 +25,11 @@ pub struct WalletOpts {
     )]
     pub from: Option<Address>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub raw: RawWalletOpts,
 
     /// Use the keystore in the given folder or file.
-    #[clap(
+    #[arg(
         long = "keystore",
         help_heading = "Wallet options - keystore",
         value_name = "PATH",
@@ -38,7 +38,7 @@ pub struct WalletOpts {
     pub keystore_path: Option<String>,
 
     /// Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
-    #[clap(
+    #[arg(
         long = "account",
         help_heading = "Wallet options - keystore",
         value_name = "ACCOUNT_NAME",
@@ -50,7 +50,7 @@ pub struct WalletOpts {
     /// The keystore password.
     ///
     /// Used with --keystore.
-    #[clap(
+    #[arg(
         long = "password",
         help_heading = "Wallet options - keystore",
         requires = "keystore_path",
@@ -61,7 +61,7 @@ pub struct WalletOpts {
     /// The keystore password file path.
     ///
     /// Used with --keystore.
-    #[clap(
+    #[arg(
         long = "password-file",
         help_heading = "Wallet options - keystore",
         requires = "keystore_path",
@@ -71,15 +71,15 @@ pub struct WalletOpts {
     pub keystore_password_file: Option<String>,
 
     /// Use a Ledger hardware wallet.
-    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
+    #[arg(long, short, help_heading = "Wallet options - hardware wallet")]
     pub ledger: bool,
 
     /// Use a Trezor hardware wallet.
-    #[clap(long, short, help_heading = "Wallet options - hardware wallet")]
+    #[arg(long, short, help_heading = "Wallet options - hardware wallet")]
     pub trezor: bool,
 
     /// Use AWS Key Management Service.
-    #[clap(long, help_heading = "Wallet options - AWS KMS")]
+    #[arg(long, help_heading = "Wallet options - AWS KMS")]
     pub aws: bool,
 }
 


### PR DESCRIPTION
Fix all warnings reported by `cargo check --features clap/deprecated`, see individual commits