### PR TITLE
feat(anvil): expose --disable-default-create2-deployer CLI flag

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -229,6 +229,7 @@ impl NodeArgs {
             .with_init_state(self.load_state.or_else(|| self.state.and_then(|s| s.state)))
             .with_transaction_block_keeper(self.transaction_block_keeper)
             .with_optimism(self.evm_opts.optimism)
+            .with_disable_default_create2_deployer(self.evm_opts.disable_default_create2_deployer)
     }
 
     fn account_generator(&self) -> AccountGenerator {
@@ -493,6 +494,10 @@ pub struct AnvilEvmArgs {
     /// Run an Optimism chain
     #[arg(long, visible_alias = "optimism")]
     pub optimism: bool,
+
+    /// Disable the default create2 deployer
+    #[arg(long, visible_alias = "no-create2")]
+    pub disable_default_create2_deployer: bool,
 }
 
 /// Resolves an alias passed as fork-url to the matching url defined in the rpc_endpoints section

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -796,6 +796,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets whether to disable the default create2 deployer
+    #[must_use]
+    pub fn with_disable_default_create2_deployer(mut self, yes: bool) -> Self {
+        self.disable_default_create2_deployer = yes;
+        self
+    }
+
     /// Configures everything related to env, backend and database and returns the
     /// [Backend](mem::Backend)
     ///


### PR DESCRIPTION
## Motivation

It seems that we've added it to `NodeConfig` but never exposed through CLI
