### PR TITLE
refactor(forge/test): cache initial executor, don't clone options

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -19,6 +19,7 @@ use std::{
     path::{Path, PathBuf},
     result,
     str::FromStr,
+    time::Instant,
 };
 
 /// Builder type to configure how to compile a project.
@@ -185,7 +186,7 @@ impl ProjectCompiler {
         let output = foundry_compilers::report::with_scoped(&reporter, || {
             tracing::debug!("compiling project");
 
-            let timer = std::time::Instant::now();
+            let timer = Instant::now();
             let r = f();
             let elapsed = timer.elapsed();
 

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -10,7 +10,7 @@ use revm::primitives::{Env, SpecId};
 ///
 /// [`Cheatcodes`]: super::inspector::Cheatcodes
 /// [`InspectorStack`]: super::inspector::InspectorStack
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[must_use = "builders do nothing unless you call `build` on them"]
 pub struct ExecutorBuilder {
     /// The configuration used to build an [InspectorStack].

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -313,9 +313,7 @@ impl CoverageArgs {
         let known_contracts = runner.known_contracts.clone();
         let filter = self.filter;
         let (tx, rx) = channel::<(String, SuiteResult)>();
-        let handle = tokio::task::spawn(async move {
-            runner.test(&filter, tx, runner.test_options.clone()).await
-        });
+        let handle = tokio::task::spawn(async move { runner.test(&filter, tx).await });
 
         // Add hit data to the coverage report
         let data = rx

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -20,7 +20,7 @@ use foundry_cli::{
 use foundry_common::{
     compile::{ContractSources, ProjectCompiler},
     evm::EvmArgs,
-    shell, TestFunctionExt,
+    shell,
 };
 use foundry_config::{
     figment,
@@ -273,11 +273,7 @@ impl TestArgs {
                 if let Some(test_pattern) = &filter.args().test_pattern {
                     let test_name = test_pattern.as_str();
                     // Filter contracts but not test functions.
-                    let candidates = runner
-                        .matching_contracts(filter)
-                        .flat_map(|(_, (abi, _, _))| abi.functions())
-                        .filter(|func| func.is_test() || func.is_invariant_test())
-                        .map(|f| &f.name);
+                    let candidates = runner.all_test_functions(filter).map(|f| &f.name);
                     if let Some(suggestion) = utils::did_you_mean(test_name, candidates).pop() {
                         println!("\nDid you mean `{suggestion}`?");
                     }

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -1,13 +1,11 @@
 #[macro_use]
 extern crate tracing;
 
-use alloy_primitives::B256;
 use foundry_compilers::ProjectCompileOutput;
 use foundry_config::{
     validate_profiles, Config, FuzzConfig, InlineConfig, InlineConfigError, InlineConfigParser,
     InvariantConfig, NatSpec,
 };
-
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
 use std::path::Path;
 
@@ -146,20 +144,20 @@ impl TestOptions {
 
     pub fn fuzzer_with_cases(&self, cases: u32) -> TestRunner {
         // TODO: Add Options to modify the persistence
-        let cfg = proptest::test_runner::Config {
+        let config = proptest::test_runner::Config {
             failure_persistence: None,
             cases,
             max_global_rejects: self.fuzz.max_test_rejects,
             ..Default::default()
         };
 
-        if let Some(ref fuzz_seed) = self.fuzz.seed {
-            trace!(target: "forge::test", "building deterministic fuzzer with seed {}", fuzz_seed);
-            let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &B256::from(*fuzz_seed).0);
-            TestRunner::new_with_rng(cfg, rng)
+        if let Some(seed) = &self.fuzz.seed {
+            trace!(target: "forge::test", %seed, "building deterministic fuzzer");
+            let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &seed.to_be_bytes::<32>());
+            TestRunner::new_with_rng(config, rng)
         } else {
             trace!(target: "forge::test", "building stochastic fuzzer");
-            TestRunner::new(cfg)
+            TestRunner::new(config)
         }
     }
 }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -147,7 +147,7 @@ impl MultiContractRunner {
     pub async fn test(&mut self, filter: &dyn TestFilter, tx: mpsc::Sender<(String, SuiteResult)>) {
         trace!("running all tests");
 
-        // The DB backend that serves all the data, each test must get its own instance.
+        // The DB backend that serves all the data.
         let db = Backend::spawn(self.fork.take()).await;
         let executor = ExecutorBuilder::new()
             .inspectors(|stack| {

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -74,7 +74,7 @@ impl MultiContractRunner {
         self.contracts.iter().filter(|&(id, (abi, _, _))| matches_contract(id, abi, filter))
     }
 
-    /// Returns all test functions matching the filter
+    /// Returns an iterator over all test functions that match the filter.
     pub fn matching_test_functions<'a>(
         &'a self,
         filter: &'a dyn TestFilter,
@@ -82,6 +82,18 @@ impl MultiContractRunner {
         self.matching_contracts(filter)
             .flat_map(|(_, (abi, _, _))| abi.functions())
             .filter(|func| is_matching_test(func, filter))
+    }
+
+    /// Returns an iterator over all test functions in contracts that match the filter.
+    pub fn all_test_functions<'a>(
+        &'a self,
+        filter: &'a dyn TestFilter,
+    ) -> impl Iterator<Item = &Function> {
+        self.contracts
+            .iter()
+            .filter(|(id, _)| filter.matches_path(&id.source) && filter.matches_contract(&id.name))
+            .flat_map(|(_, (abi, _, _))| abi.functions())
+            .filter(|func| func.is_test() || func.is_invariant_test())
     }
 
     /// Returns all matching tests grouped by contract grouped by file (file -> (contract -> tests))

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -159,18 +159,20 @@ impl MultiContractRunner {
 
         // The DB backend that serves all the data, each test must get its own instance.
         let db = Backend::spawn(self.fork.take()).await;
-        let executor_builder = ExecutorBuilder::new()
-            .inspectors(|stack| {
-                stack
-                    .cheatcodes(self.cheats_config.clone())
-                    .trace(self.evm_opts.verbosity >= 3 || self.debug)
-                    .debug(self.debug)
-                    .coverage(self.coverage)
-                    .enable_isolation(self.isolation)
-            })
-            .spec(self.evm_spec)
-            .gas_limit(self.evm_opts.gas_limit());
-        let make_executor = || executor_builder.clone().build(self.env.clone(), db.clone());
+        let make_executor = || {
+            ExecutorBuilder::new()
+                .inspectors(|stack| {
+                    stack
+                        .cheatcodes(self.cheats_config.clone())
+                        .trace(self.evm_opts.verbosity >= 3 || self.debug)
+                        .debug(self.debug)
+                        .coverage(self.coverage)
+                        .enable_isolation(self.isolation)
+                })
+                .spec(self.evm_spec)
+                .gas_limit(self.evm_opts.gas_limit())
+                .build(self.env.clone(), db.clone())
+        };
 
         let find_timer = Instant::now();
         let contracts = self

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -380,7 +380,5 @@ fn matches_contract(id: &ArtifactId, abi: &JsonAbi, filter: &dyn TestFilter) -> 
 
 /// Returns `true` if the function is a test function that matches the given filter.
 pub(crate) fn is_matching_test(func: &Function, filter: &dyn TestFilter) -> bool {
-    // Avoid calculating the signature if possible.
-    (func.is_test() || func.is_invariant_test()) &&
-        (filter.matches_test(&func.name) || filter.matches_test(&func.signature()))
+    (func.is_test() || func.is_invariant_test()) && filter.matches_test(&func.signature())
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -261,7 +261,7 @@ impl<'a> ContractRunner<'a> {
             .contract
             .functions()
             .map(|func| (func.signature(), func))
-            .filter(|(sig, func)| is_matching_test(func, || filter.matches_test(&sig)))
+            .filter(|(sig, func)| is_matching_test(func, || filter.matches_test(sig)))
             .collect::<Vec<_>>();
         let find_time = find_timer.elapsed();
         debug!(

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -421,7 +421,7 @@ impl<'a> ContractRunner<'a> {
 
         // Record test execution time
         let duration = start.elapsed();
-        debug!(?duration, gas, reverted, should_fail, success);
+        trace!(?duration, gas, reverted, should_fail, success);
 
         TestResult {
             status: match success {
@@ -678,7 +678,7 @@ impl<'a> ContractRunner<'a> {
 
         // Record test execution time
         let duration = start.elapsed();
-        debug!(?duration, success = %result.success);
+        trace!(?duration, success = %result.success);
 
         TestResult {
             status: match result.success {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -290,10 +290,12 @@ impl<'a> ContractRunner<'a> {
                         identified_contracts.as_ref().unwrap(),
                     )
                 } else if func.is_fuzz_test() {
+                    debug_assert!(func.is_test());
                     let runner = test_options.fuzz_runner(self.name, &func.name);
                     let fuzz_config = test_options.fuzz_config(self.name, &func.name);
                     self.run_fuzz_test(func, should_fail, runner, setup, *fuzz_config)
                 } else {
+                    debug_assert!(func.is_test());
                     self.run_test(func, should_fail, setup)
                 };
                 (sig, res)

--- a/crates/forge/tests/it/cheats.rs
+++ b/crates/forge/tests/it/cheats.rs
@@ -10,15 +10,17 @@ use foundry_test_utils::Filter;
 /// Executes all cheat code tests but not fork cheat codes
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_local() {
-    let mut config = Config::with_root(PROJECT.root());
-    config.fs_permissions = FsPermissions::new(vec![PathPermission::read_write("./")]);
-    let runner = runner_with_config(config);
-    let filter =
+    let mut filter =
         Filter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}*")).exclude_paths("Fork");
 
-    // on windows exclude ffi tests since no echo and file test that expect a certain file path
-    #[cfg(windows)]
-    let filter = filter.exclude_tests("(Ffi|File|Line|Root)");
+    // Exclude FFI tests on Windows because no `echo`, and file tests that expect certain file paths
+    if cfg!(windows) {
+        filter = filter.exclude_tests("(Ffi|File|Line|Root)");
+    }
 
-    TestConfig::with_filter(runner.await, filter).run().await;
+    let mut config = Config::with_root(PROJECT.root());
+    config.fs_permissions = FsPermissions::new(vec![PathPermission::read_write("./")]);
+    let runner = runner_with_config(config).await;
+
+    TestConfig::with_filter(runner, filter).run().await;
 }

--- a/crates/forge/tests/it/core.rs
+++ b/crates/forge/tests/it/core.rs
@@ -8,8 +8,9 @@ use std::{collections::BTreeMap, env};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_core() {
+    let filter = Filter::new(".*", ".*", ".*core");
     let mut runner = runner().await;
-    let results = runner.test_collect(&Filter::new(".*", ".*", ".*core"), test_opts()).await;
+    let results = runner.test_collect(&filter).await;
 
     assert_multiple(
         &results,
@@ -77,8 +78,9 @@ async fn test_core() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_linking() {
+    let filter = Filter::new(".*", ".*", ".*linking");
     let mut runner = runner().await;
-    let results = runner.test_collect(&Filter::new(".*", ".*", ".*linking"), test_opts()).await;
+    let results = runner.test_collect(&filter).await;
 
     assert_multiple(
         &results,
@@ -110,8 +112,9 @@ async fn test_linking() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_logs() {
+    let filter = Filter::new(".*", ".*", ".*logs");
     let mut runner = runner().await;
-    let results = runner.test_collect(&Filter::new(".*", ".*", ".*logs"), test_opts()).await;
+    let results = runner.test_collect(&filter).await;
 
     assert_multiple(
         &results,
@@ -670,38 +673,31 @@ async fn test_logs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_env_vars() {
-    let mut runner = runner().await;
-
-    // test `setEnv` first, and confirm that it can correctly set environment variables,
-    // so that we can use it in subsequent `env*` tests
-    let _ = runner.test_collect(&Filter::new("testSetEnv", ".*", ".*"), test_opts()).await;
     let env_var_key = "_foundryCheatcodeSetEnvTestKey";
     let env_var_val = "_foundryCheatcodeSetEnvTestVal";
-    let res = env::var(env_var_key);
-    assert!(
-        res.is_ok() && res.unwrap() == env_var_val,
-        "Test `testSetEnv` did not pass as expected.
-Reason: `setEnv` failed to set an environment variable `{env_var_key}={env_var_val}`"
-    );
+    env::remove_var(env_var_key);
+
+    let filter = Filter::new("testSetEnv", ".*", ".*");
+    let mut runner = runner().await;
+    let _ = runner.test_collect(&filter).await;
+
+    assert_eq!(env::var(env_var_key).unwrap(), env_var_val);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_doesnt_run_abstract_contract() {
+    let filter = Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str());
     let mut runner = runner().await;
-    let results = runner
-        .test_collect(
-            &Filter::new(".*", ".*", ".*Abstract.t.sol".to_string().as_str()),
-            test_opts(),
-        )
-        .await;
+    let results = runner.test_collect(&filter).await;
     assert!(results.get("core/Abstract.t.sol:AbstractTestBase").is_none());
     assert!(results.get("core/Abstract.t.sol:AbstractTest").is_some());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_trace() {
+    let filter = Filter::new(".*", ".*", ".*trace");
     let mut runner = tracing_runner().await;
-    let suite_result = runner.test_collect(&Filter::new(".*", ".*", ".*trace"), test_opts()).await;
+    let suite_result = runner.test_collect(&filter).await;
 
     // TODO: This trace test is very basic - it is probably a good candidate for snapshot
     // testing.

--- a/crates/forge/tests/it/fork.rs
+++ b/crates/forge/tests/it/fork.rs
@@ -11,17 +11,13 @@ use foundry_test_utils::Filter;
 /// Executes reverting fork test
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_fork_revert() {
+    let filter = Filter::new(
+        "testNonExistingContractRevert",
+        ".*",
+        &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
+    );
     let mut runner = runner().await;
-    let suite_result = runner
-        .test_collect(
-            &Filter::new(
-                "testNonExistingContractRevert",
-                ".*",
-                &format!(".*cheats{RE_PATH_SEPARATOR}Fork"),
-            ),
-            test_opts(),
-        )
-        .await;
+    let suite_result = runner.test_collect(&filter).await;
     assert_eq!(suite_result.len(), 1);
 
     for (_, SuiteResult { test_results, .. }) in suite_result {

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -8,16 +8,11 @@ use std::collections::BTreeMap;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fuzz() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/")
+        .exclude_tests(r"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)|testSuccessChecker\(uint256\)|testSuccessChecker2\(int256\)|testSuccessChecker3\(uint32\)")
+        .exclude_paths("invariant");
     let mut runner = runner().await;
-
-    let suite_result = runner
-        .test_collect(
-            &Filter::new(".*", ".*", ".*fuzz/")
-                .exclude_tests(r"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)|testSuccessChecker\(uint256\)|testSuccessChecker2\(int256\)|testSuccessChecker3\(uint32\)")
-                .exclude_paths("invariant"),
-            test_opts(),
-        )
-        .await;
+    let suite_result = runner.test_collect(&filter).await;
 
     assert!(!suite_result.is_empty());
 
@@ -27,15 +22,17 @@ async fn test_fuzz() {
                 "testPositive(uint256)" |
                 "testPositive(int256)" |
                 "testSuccessfulFuzz(uint128,uint128)" |
-                "testToStringFuzz(bytes32)" => assert!(
-                    result.status == TestStatus::Success,
+                "testToStringFuzz(bytes32)" => assert_eq!(
+                    result.status,
+                    TestStatus::Success,
                     "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
                     result.decoded_logs.join("\n")
                 ),
-                _ => assert!(
-                    result.status == TestStatus::Failure,
+                _ => assert_eq!(
+                    result.status,
+                    TestStatus::Failure,
                     "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
@@ -48,16 +45,11 @@ async fn test_fuzz() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_successful_fuzz_cases() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/FuzzPositive")
+        .exclude_tests(r"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)")
+        .exclude_paths("invariant");
     let mut runner = runner().await;
-
-    let suite_result = runner
-        .test_collect(
-            &Filter::new(".*", ".*", ".*fuzz/FuzzPositive")
-                .exclude_tests(r"invariantCounter|testIncrement\(address\)|testNeedle\(uint256\)")
-                .exclude_paths("invariant"),
-            test_opts(),
-        )
-        .await;
+    let suite_result = runner.test_collect(&filter).await;
 
     assert!(!suite_result.is_empty());
 
@@ -66,8 +58,9 @@ async fn test_successful_fuzz_cases() {
             match test_name.as_str() {
                 "testSuccessChecker(uint256)" |
                 "testSuccessChecker2(int256)" |
-                "testSuccessChecker3(uint32)" => assert!(
-                    result.status == TestStatus::Success,
+                "testSuccessChecker3(uint32)" => assert_eq!(
+                    result.status,
+                    TestStatus::Success,
                     "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
@@ -84,17 +77,13 @@ async fn test_successful_fuzz_cases() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_fuzz_collection() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol");
     let mut runner = runner().await;
-
-    let mut opts = test_opts();
-    opts.invariant.depth = 100;
-    opts.invariant.runs = 1000;
-    opts.fuzz.runs = 1000;
-    opts.fuzz.seed = Some(U256::from(6u32));
-    runner.test_options = opts.clone();
-
-    let results =
-        runner.test_collect(&Filter::new(".*", ".*", ".*fuzz/FuzzCollection.t.sol"), opts).await;
+    runner.test_options.invariant.depth = 100;
+    runner.test_options.invariant.runs = 1000;
+    runner.test_options.fuzz.runs = 1000;
+    runner.test_options.fuzz.seed = Some(U256::from(6u32));
+    let results = runner.test_collect(&filter).await;
 
     assert_multiple(
         &results,

--- a/crates/forge/tests/it/inline.rs
+++ b/crates/forge/tests/it/inline.rs
@@ -13,14 +13,9 @@ use foundry_test_utils::Filter;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn inline_config_run_fuzz() {
-    let opts = default_test_options();
-
     let filter = Filter::new(".*", ".*", ".*inline/FuzzInlineConf.t.sol");
-
     let mut runner = runner().await;
-    runner.test_options = opts.clone();
-
-    let result = runner.test_collect(&filter, opts).await;
+    let result = runner.test_collect(&filter).await;
     let suite_result: &SuiteResult =
         result.get("inline/FuzzInlineConf.t.sol:FuzzInlineConf").unwrap();
     let test_result: &TestResult =
@@ -39,12 +34,10 @@ async fn inline_config_run_fuzz() {
 async fn inline_config_run_invariant() {
     const ROOT: &str = "inline/InvariantInlineConf.t.sol";
 
-    let opts = default_test_options();
     let filter = Filter::new(".*", ".*", ".*inline/InvariantInlineConf.t.sol");
     let mut runner = runner().await;
-    runner.test_options = opts.clone();
-
-    let result = runner.test_collect(&filter, opts).await;
+    runner.test_options = default_test_options();
+    let result = runner.test_collect(&filter).await;
 
     let suite_result_1 = result.get(&format!("{ROOT}:InvariantInlineConf")).expect("Result exists");
     let suite_result_2 =


### PR DESCRIPTION
Same as https://github.com/foundry-rs/foundry/pull/7283 plus more refactors