### PR TITLE
feat(forge): --disable-block-gas-limit flag

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -272,6 +272,10 @@ pub struct EnvArgs {
     #[arg(long, value_name = "MEMORY_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_limit: Option<u64>,
+
+    /// Whether to disable the block gas limit checks.
+    #[arg(long, visible_alias = "no-gas-limit")]
+    pub disable_block_gas_limit: bool,
 }
 
 impl EvmArgs {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -379,6 +379,9 @@ pub struct Config {
     /// Useful for more correct gas accounting and EVM behavior in general.
     pub isolate: bool,
 
+    /// Whether to disable the block gas limit.
+    pub disable_block_gas_limit: bool,
+
     /// Address labels
     pub labels: HashMap<Address, String>,
 
@@ -1889,6 +1892,7 @@ impl Default for Config {
             block_difficulty: 0,
             block_prevrandao: Default::default(),
             block_gas_limit: None,
+            disable_block_gas_limit: false,
             memory_limit: 1 << 27, // 2**27 = 128MiB = 134_217_728 bytes
             eth_rpc_url: None,
             eth_rpc_jwt: None,

--- a/crates/evm/core/src/fork/init.rs
+++ b/crates/evm/core/src/fork/init.rs
@@ -17,6 +17,7 @@ pub async fn environment<P: TempProvider>(
     override_chain_id: Option<u64>,
     pin_block: Option<u64>,
     origin: Address,
+    disable_block_gas_limit: bool,
 ) -> eyre::Result<(Env, Block)> {
     let block_number = if let Some(pin_block) = pin_block {
         pin_block
@@ -55,6 +56,7 @@ pub async fn environment<P: TempProvider>(
     // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the caller
     // is a contract. So we disable the check by default.
     cfg.disable_eip3607 = true;
+    cfg.disable_block_gas_limit = disable_block_gas_limit;
 
     let mut env = Env {
         cfg,

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -64,6 +64,9 @@ pub struct EvmOpts {
 
     /// Whether to enable isolation of calls.
     pub isolate: bool,
+
+    /// Whether to disable block gas limit checks.
+    pub disable_block_gas_limit: bool,
 }
 
 impl EvmOpts {
@@ -96,6 +99,7 @@ impl EvmOpts {
             self.env.chain_id,
             self.fork_block_number,
             self.sender,
+            self.disable_block_gas_limit,
         )
         .await
         .wrap_err_with(|| {
@@ -114,6 +118,7 @@ impl EvmOpts {
         // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
         // caller is a contract. So we disable the check by default.
         cfg.disable_eip3607 = true;
+        cfg.disable_block_gas_limit = self.disable_block_gas_limit;
 
         revm::primitives::Env {
             block: BlockEnv {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -467,9 +467,13 @@ impl InspectorStack {
         data.env.tx.value = value;
         data.env.tx.nonce = Some(nonce);
         // Add 21000 to the gas limit to account for the base cost of transaction.
-        // We might have modified block gas limit earlier and revm will reject tx with gas limit >
-        // block gas limit, so we adjust.
-        data.env.tx.gas_limit = std::cmp::min(gas_limit + 21000, data.env.block.gas_limit.to());
+        data.env.tx.gas_limit = gas_limit + 21000;
+        // If we haven't disabled gas limit checks, ensure that transaction gas limit will not
+        // exceed block gas limit.
+        if !data.env.cfg.disable_block_gas_limit {
+            data.env.tx.gas_limit =
+                std::cmp::min(data.env.tx.gas_limit, data.env.block.gas_limit.to());
+        }
         data.env.tx.gas_price = U256::ZERO;
 
         self.inner_context_data = Some(InnerContextData {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -85,6 +85,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         block_difficulty: 10,
         block_prevrandao: B256::random(),
         block_gas_limit: Some(100u64.into()),
+        disable_block_gas_limit: false,
         memory_limit: 1 << 27,
         eth_rpc_url: Some("localhost".to_string()),
         eth_rpc_jwt: None,

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -494,9 +494,11 @@ contract TransientTest is Test {
 forgetest_init!(can_disable_block_gas_limit, |prj, cmd| {
     prj.wipe_contracts();
 
+    let endpoint = rpc::next_http_archive_rpc_endpoint();
+
     prj.add_test(
         "Contract.t.sol",
-        r#"pragma solidity 0.8.24;
+        &r#"pragma solidity 0.8.24;
 import {Test} from "forge-std/Test.sol";
 
 contract C is Test {}
@@ -511,13 +513,14 @@ contract GasWaster {
 
 contract GasLimitTest is Test {
     function test() public {
-        vm.createSelectFork("mainnet");
+        vm.createSelectFork("<rpc>");
         
         GasWaster waster = new GasWaster();
         waster.waste();
     }
 }
-   "#,
+   "#
+        .replace("<rpc>", &endpoint),
     )
     .unwrap();
 

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -490,3 +490,36 @@ contract TransientTest is Test {
 
     cmd.args(["test", "-vvvv", "--isolate", "--evm-version", "cancun"]).assert_success();
 });
+
+forgetest_init!(can_disable_block_gas_limit, |prj, cmd| {
+    prj.wipe_contracts();
+
+    prj.add_test(
+        "Contract.t.sol",
+        r#"pragma solidity 0.8.24;
+import {Test} from "forge-std/Test.sol";
+
+contract C is Test {}
+
+contract GasWaster {
+    function waste() public {
+        for (uint256 i = 0; i < 100; i++) {
+            new C();
+        }
+    }
+}
+
+contract GasLimitTest is Test {
+    function test() public {
+        vm.createSelectFork("mainnet");
+        
+        GasWaster waster = new GasWaster();
+        waster.waste();
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "-vvvv", "--isolate", "--disable-block-gas-limit"]).assert_success();
+});


### PR DESCRIPTION
## Motivation

ref disscussion in https://github.com/foundry-rs/foundry/pull/7186#issuecomment-1972131061

## Solution

Right now those gas limit reverts will still be breaking for some codebases, because this flag is not enabled by default. And if we want to make it a default, we should probably change API to `--enable-block-gas-limit`. Let's discuss here if we want this to be a breaking change or keep the previous behavior