### PR TITLE
chore(`common`): doc fixes and unused fns removal

### DIFF
--- a/crates/common/src/provider/alloy.rs
+++ b/crates/common/src/provider/alloy.rs
@@ -203,18 +203,6 @@ impl ProviderBuilder {
         self
     }
 
-    /// Same as [`Self:build()`] but also retrieves the `chainId` in order to derive an appropriate
-    /// interval.
-    pub async fn connect(self) -> Result<RetryProvider> {
-        let provider = self.build()?;
-        // todo: port poll interval hint
-        /*if let Some(blocktime) = provider.get_chainid().await.ok().and_then(|id| {
-        }) {
-            provider = provider.interval(blocktime / 2);
-            }*/
-        Ok(provider)
-    }
-
     /// Constructs the `RetryProvider` taking all configs into account.
     pub fn build(self) -> Result<RetryProvider> {
         let ProviderBuilder {

--- a/crates/common/src/provider/retry.rs
+++ b/crates/common/src/provider/retry.rs
@@ -3,7 +3,7 @@ use alloy_json_rpc::ErrorPayload;
 use alloy_transport::{TransportError, TransportErrorKind};
 use serde::Deserialize;
 
-/// [RetryPolicy] defines logic for which [JsonRpcClient::Error] instances should
+/// [RetryPolicy] defines logic for which [TransportError] instances should
 /// the client retry the request and try to recover from.
 pub trait RetryPolicy: Send + Sync + std::fmt::Debug {
     /// Whether to retry the request based on the given `error`
@@ -52,6 +52,7 @@ impl RetryPolicy for RateLimitRetryPolicy {
         }
     }
 
+    /// Provides a backoff hint if the error response contains it
     fn backoff_hint(&self, error: &TransportError) -> Option<std::time::Duration> {
         if let TransportError::ErrorResp(resp) = error {
             let data = resp.try_data_as::<serde_json::Value>();

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -25,7 +25,6 @@ pub enum InnerTransport {
     Http(Http<reqwest::Client>),
     /// WebSocket transport
     Ws(PubSubFrontend),
-    // TODO: IPC
     /// IPC transport
     Ipc(PubSubFrontend),
 }
@@ -177,7 +176,6 @@ impl RuntimeTransport {
         let client =
             client_builder.build().map_err(RuntimeTransportError::HttpConstructionError)?;
 
-        // todo: retry tower layer
         Ok(InnerTransport::Http(Http::with_client(client, self.url.clone())))
     }
 
@@ -271,7 +269,7 @@ impl tower::Service<RequestPacket> for RuntimeTransport {
     }
 }
 
-impl Service<RequestPacket> for &RuntimeTransport {
+impl tower::Service<RequestPacket> for &RuntimeTransport {
     type Response = ResponsePacket;
     type Error = TransportError;
     type Future = TransportFut<'static>;
@@ -297,7 +295,6 @@ fn build_auth(jwt: String) -> eyre::Result<Authorization> {
     let auth = JwtAuth::new(secret, None, None);
     let token = auth.generate_token()?;
 
-    // Essentially unrolled ethers-rs new_with_auth to accommodate the custom timeout
     let auth = Authorization::Bearer(token);
 
     Ok(auth)

--- a/crates/common/src/provider/tower.rs
+++ b/crates/common/src/provider/tower.rs
@@ -10,7 +10,6 @@ use std::{
 
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut};
-use tower::Service;
 
 use super::{
     retry::{RateLimitRetryPolicy, RetryPolicy},
@@ -65,7 +64,7 @@ impl<S> tower::layer::Layer<S> for RetryBackoffLayer {
 }
 
 /// An Alloy Tower Service that is responsible for retrying requests based on the
-/// error type. See [TransportError] and [RetryWithPolicyLayer].
+/// error type. See [TransportError] and [RateLimitRetryPolicy].
 #[derive(Debug, Clone)]
 pub struct RetryBackoffService<S> {
     /// The inner service
@@ -85,7 +84,7 @@ pub struct RetryBackoffService<S> {
 }
 
 // impl tower service
-impl Service<RequestPacket> for RetryBackoffService<RuntimeTransport> {
+impl tower::Service<RequestPacket> for RetryBackoffService<RuntimeTransport> {
     type Response = ResponsePacket;
     type Error = TransportError;
     type Future = TransportFut<'static>;


### PR DESCRIPTION
Fixes up some docs on providers on `foundry-common`.
