### PR TITLE
feat: bump k256 to 0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -5065,7 +5065,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.50",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,9 +200,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 evm-disassembler = "0.4"
 vergen = { version = "8", default-features = false }
-# TODO: bumping to >=0.13.2 breaks ecrecover: https://github.com/foundry-rs/foundry/pull/6969
-# TODO: unpin on next revm release: https://github.com/bluealloy/revm/pull/870
-k256 = "=0.13.1"
+k256 = "0.13.3"
 
 axum = "0.6"
 hyper = "0.14"


### PR DESCRIPTION
As https://github.com/bluealloy/revm/pull/870 is merged, the k256 version can be upgraded to v0.13.3 and unpinned from v0.13.1

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
