### PR TITLE
Add transient storage warning to default `ignored_error_codes`

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -134,6 +134,8 @@ pub enum SolidityErrorCode {
     Unreachable,
     /// Missing pragma solidity
     PragmaSolidity,
+    /// Uses transient opcodes
+    TransientStorageUsed,
     /// All other error codes
     Other(u64),
 }
@@ -162,6 +164,7 @@ impl SolidityErrorCode {
             SolidityErrorCode::PragmaSolidity => "pragma-solidity",
             SolidityErrorCode::Other(code) => return Err(*code),
             SolidityErrorCode::VisibilityForConstructorIsIgnored => "constructor-visibility",
+            SolidityErrorCode::TransientStorageUsed => "transient-storage",
         };
         Ok(s)
     }
@@ -185,6 +188,7 @@ impl From<SolidityErrorCode> for u64 {
             SolidityErrorCode::PragmaSolidity => 3420,
             SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes => 3860,
             SolidityErrorCode::VisibilityForConstructorIsIgnored => 2462,
+            SolidityErrorCode::TransientStorageUsed => 2394,
             SolidityErrorCode::Other(code) => code,
         }
     }

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -222,6 +222,7 @@ impl FromStr for SolidityErrorCode {
             "missing-receive-ether" => SolidityErrorCode::PayableNoReceiveEther,
             "same-varname" => SolidityErrorCode::DeclarationSameNameAsAnother,
             "constructor-visibility" => SolidityErrorCode::VisibilityForConstructorIsIgnored,
+            "transient-storage" => SolidityErrorCode::TransientStorageUsed,
             _ => return Err(format!("Unknown variant {s}")),
         };
 
@@ -247,6 +248,7 @@ impl From<u64> for SolidityErrorCode {
             3420 => SolidityErrorCode::PragmaSolidity,
             5740 => SolidityErrorCode::Unreachable,
             2462 => SolidityErrorCode::VisibilityForConstructorIsIgnored,
+            2394 => SolidityErrorCode::TransientStorageUsed,
             other => SolidityErrorCode::Other(other),
         }
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1901,6 +1901,7 @@ impl Default for Config {
                 SolidityErrorCode::SpdxLicenseNotProvided,
                 SolidityErrorCode::ContractExceeds24576Bytes,
                 SolidityErrorCode::ContractInitCodeSizeExceeds49152Bytes,
+                SolidityErrorCode::TransientStorageUsed,
             ],
             ignored_file_paths: vec![],
             deny_warnings: false,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The warning generated by solc when compiling code that uses the new `tstore/tload` opcodes is not particularly useful or productive. The solc team has shown [no interest in removing the warning from the compiler](https://github.com/ethereum/solidity/pull/14819).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Default Forge behavior should be to ignore this warning, as no other (non-deprecated) opcodes get this treatment.
