### PR TITLE
closes #7303 - apply `preserve_state` even when `fail_on_revert` is false

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -30,8 +30,7 @@ pub struct InvariantConfig {
     pub shrink_run_limit: usize,
     /// If set to true then VM state is committed and available for next call
     /// Useful for handlers that use cheatcodes as roll or warp
-    /// Applies only when `fail_on_revert` set to true. Use it with caution, introduces performance
-    /// penalty.
+    /// Use it with caution, introduces performance penalty.
     pub preserve_state: bool,
 }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -162,7 +162,7 @@ impl<'a> InvariantExecutor<'a> {
                 let (sender, (address, calldata)) = inputs.last().expect("no input generated");
 
                 // Executes the call from the randomly generated sequence.
-                let call_result = if self.config.fail_on_revert && self.config.preserve_state {
+                let call_result = if self.config.preserve_state {
                     executor
                         .call_raw_committing(*sender, *address, calldata.clone(), U256::ZERO)
                         .expect("could not make raw evm call")


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Not really a meaningful settings dependency, see https://github.com/foundry-rs/foundry/issues/7303#issuecomment-1976466685 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
