### PR TITLE
fix(invariants): support `vm.assume` in invariant tests

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -33,6 +33,9 @@ pub struct InvariantConfig {
     /// Applies only when `fail_on_revert` set to true. Use it with caution, introduces performance
     /// penalty.
     pub preserve_state: bool,
+    /// The maximum number of rejects via `vm.assume` which can be encountered during a single
+    /// invariant run.
+    pub max_assume_rejects: u32,
 }
 
 impl Default for InvariantConfig {
@@ -46,6 +49,7 @@ impl Default for InvariantConfig {
             shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18_u32),
             preserve_state: false,
+            max_assume_rejects: 65536,
         }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/funcs.rs
+++ b/crates/evm/evm/src/executors/invariant/funcs.rs
@@ -1,4 +1,4 @@
-use super::{InvariantFailures, InvariantFuzzError};
+use super::{error::FailedInvariantCaseData, InvariantFailures, InvariantFuzzError};
 use crate::executors::{Executor, RawCallResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
@@ -50,7 +50,7 @@ pub fn assert_invariants(
     if is_err {
         // We only care about invariants which we haven't broken yet.
         if invariant_failures.error.is_none() {
-            invariant_failures.error = Some(InvariantFuzzError::new(
+            let case_data = FailedInvariantCaseData::new(
                 invariant_contract,
                 Some(func),
                 calldata,
@@ -58,7 +58,8 @@ pub fn assert_invariants(
                 &inner_sequence,
                 shrink_sequence,
                 shrink_run_limit,
-            ));
+            );
+            invariant_failures.error = Some(InvariantFuzzError::BrokenInvariant(case_data));
             return None
         }
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -44,7 +44,7 @@ use self::error::FailedInvariantCaseData;
 type InvariantPreparation = (
     EvmFuzzState,
     FuzzRunIdentifiedContracts,
-    BoxedStrategy<Vec<BasicTxDetails>>,
+    BoxedStrategy<BasicTxDetails>,
     CalldataFuzzDictionary,
 );
 

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -51,10 +51,10 @@ pub fn invariant_strat(
     senders: SenderFilters,
     contracts: FuzzRunIdentifiedContracts,
     dictionary_weight: u32,
-) -> impl Strategy<Value = Vec<BasicTxDetails>> {
+) -> impl Strategy<Value = BasicTxDetails> {
     // We only want to seed the first value, since we want to generate the rest as we mutate the
     // state
-    generate_call(fuzz_state, senders, contracts, dictionary_weight).prop_map(|x| vec![x])
+    generate_call(fuzz_state, senders, contracts, dictionary_weight)
 }
 
 /// Strategy to generate a transaction where the `sender`, `target` and `calldata` are all generated

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -533,7 +533,7 @@ impl<'a> ContractRunner<'a> {
                         }
                     };
                 }
-                _ => {}
+                InvariantFuzzError::MaxAssumeRejects(_) => {}
             },
 
             // If invariants ran successfully, replay the last run to collect logs and

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -109,6 +109,7 @@ pub static TEST_OPTS: Lazy<TestOptions> = Lazy::new(|| {
             shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18u32),
             preserve_state: false,
+            max_assume_rejects: 65536,
         })
         .build(&COMPILED, &PROJECT.paths.root)
         .expect("Config loaded")

--- a/testdata/fuzz/invariant/common/InvariantAssume.t.sol
+++ b/testdata/fuzz/invariant/common/InvariantAssume.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+import "../../../cheats/Vm.sol";
+
+contract Handler is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    
+    function doSomething(uint256 param) public {
+        vm.assume(param != 0);
+    }
+}
+
+contract InvariantAssume is DSTest {
+    Handler handler;
+
+    function setUp() public {
+        handler = new Handler();
+    }
+
+    function invariant_dummy() public {}
+}


### PR DESCRIPTION
## Motivation

Closes #4190 

## Solution

Catch reverts with `MAGIC_ASSUME`, regenerate latest calldata and increase `assume_rejects_counter`. Once counter goes beyond configured `max_assume_rejects`, test fails.

I've changed `InvariantFuzzError` to be an enum, because we don't need data it holds right now for `MaxAssumeRejects` failures.

Also changed `invariant_strat` a bit, currently it always returns Vec with one element, it seemed a bit confusing at first glance, so I changed it to return just a single input.