### PR TITLE
Remove --offline flag from cargo install command

### DIFF
--- a/crates/anvil/README.md
+++ b/crates/anvil/README.md
@@ -20,7 +20,7 @@ A local Ethereum node, akin to Ganache, designed for development with [**Forge**
 ```sh
 git clone https://github.com/foundry-rs/foundry
 cd foundry
-cargo install --path ./crates/anvil --profile local --locked --offline --force
+cargo install --path ./crates/anvil --profile local --locked --force
 ```
 
 ## Getting started


### PR DESCRIPTION
Otherwise cargo throws error when installing on a clean Rust installation 

```
error: failed to load source for dependency `ethers`

Caused by:
  Unable to update https://github.com/gakonst/ethers-rs?rev=73e5de211c32a1f5777eb5194205bdb31f6a3502#73e5de21

Caused by:
  can't checkout from 'https://github.com/gakonst/ethers-rs': you are in the offline mode (--offline)
```
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
