### PR TITLE
feat(test): include data from fuzz/invariant runs in gas reports

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -22,6 +22,8 @@ pub struct FuzzConfig {
     /// The fuzz dictionary configuration
     #[serde(flatten)]
     pub dictionary: FuzzDictionaryConfig,
+    /// Number of runs to execute and include in the gas report.
+    pub gas_report_samples: u32,
 }
 
 impl Default for FuzzConfig {
@@ -31,6 +33,7 @@ impl Default for FuzzConfig {
             max_test_rejects: 65536,
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
+            gas_report_samples: 256,
         }
     }
 }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -35,6 +35,8 @@ pub struct InvariantConfig {
     /// The maximum number of rejects via `vm.assume` which can be encountered during a single
     /// invariant run.
     pub max_assume_rejects: u32,
+    /// Number of runs to execute and include in the gas report.
+    pub gas_report_samples: u32,
 }
 
 impl Default for InvariantConfig {
@@ -49,6 +51,7 @@ impl Default for InvariantConfig {
             shrink_run_limit: 2usize.pow(18_u32),
             preserve_state: false,
             max_assume_rejects: 65536,
+            gas_report_samples: 256,
         }
     }
 }

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -50,6 +50,9 @@ pub struct InvariantFuzzTestResult {
     /// The entire inputs of the last run of the invariant campaign, used for
     /// replaying the run for collecting traces.
     pub last_run_inputs: Vec<BasicTxDetails>,
+
+    /// Additional traces used for gas report construction.
+    pub gas_report_traces: Vec<Vec<CallTraceArena>>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -150,6 +150,10 @@ pub struct FuzzTestResult {
     /// `num(fuzz_cases)` traces, one for each run, which is neither helpful nor performant.
     pub traces: Option<CallTraceArena>,
 
+    /// Additional traces used for gas report construction.
+    /// Those traces should not be displayed.
+    pub gas_report_traces: Vec<CallTraceArena>,
+
     /// Raw coverage info
     pub coverage: Option<HitMaps>,
 }

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -3,7 +3,7 @@
 use crate::{
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS},
     hashbrown::HashSet,
-    traces::{CallTraceArena, CallTraceDecoder, CallTraceNode, DecodedCallData, TraceKind},
+    traces::{CallTraceArena, CallTraceDecoder, CallTraceNode, DecodedCallData},
 };
 use comfy_table::{presets::ASCII_MARKDOWN, *};
 use foundry_common::{calc, TestFunctionExt};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Display};
 
 /// Represents the gas report for a set of contracts.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct GasReport {
     /// Whether to report any contracts.
     report_any: bool,
@@ -22,7 +22,7 @@ pub struct GasReport {
     ignore: HashSet<String>,
     /// All contracts that were analyzed grouped by their identifier
     /// ``test/Counter.t.sol:CounterTest
-    contracts: BTreeMap<String, ContractInfo>,
+    pub contracts: BTreeMap<String, ContractInfo>,
 }
 
 impl GasReport {
@@ -61,10 +61,10 @@ impl GasReport {
     /// Analyzes the given traces and generates a gas report.
     pub async fn analyze(
         &mut self,
-        traces: &[(TraceKind, CallTraceArena)],
+        arenas: impl IntoIterator<Item = &CallTraceArena>,
         decoder: &CallTraceDecoder,
     ) {
-        for node in traces.iter().flat_map(|(_, arena)| arena.nodes()) {
+        for node in arenas.into_iter().flat_map(|arena| arena.nodes()) {
             self.analyze_node(node, decoder).await;
         }
     }
@@ -78,7 +78,7 @@ impl GasReport {
 
         // Only include top-level calls which accout for calldata and base (21.000) cost.
         // Only include Calls and Creates as only these calls are isolated in inspector.
-        if trace.depth != 1 &&
+        if trace.depth > 1 &&
             (trace.kind == CallKind::Call ||
                 trace.kind == CallKind::Create ||
                 trace.kind == CallKind::Create2)
@@ -186,7 +186,7 @@ impl Display for GasReport {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ContractInfo {
     pub gas: u64,
     pub size: usize,
@@ -194,7 +194,7 @@ pub struct ContractInfo {
     pub functions: BTreeMap<String, BTreeMap<String, GasInfo>>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct GasInfo {
     pub calls: Vec<u64>,
     pub min: u64,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -7,7 +7,7 @@ use foundry_evm::{
     debug::DebugArena,
     executors::EvmError,
     fuzz::{CounterExample, FuzzCase},
-    traces::{CallTraceDecoder, TraceKind, Traces},
+    traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -16,6 +16,8 @@ use std::{
     time::Duration,
 };
 use yansi::Paint;
+
+use crate::gas_report::GasReport;
 
 /// The aggregated result of a test run.
 #[derive(Clone, Debug)]
@@ -32,12 +34,14 @@ pub struct TestOutcome {
     ///
     /// Note that `Address` fields only contain the last executed test case's data.
     pub decoder: Option<CallTraceDecoder>,
+    /// The gas report, if requested.
+    pub gas_report: Option<GasReport>,
 }
 
 impl TestOutcome {
     /// Creates a new test outcome with the given results.
     pub fn new(results: BTreeMap<String, SuiteResult>, allow_failure: bool) -> Self {
-        Self { results, allow_failure, decoder: None }
+        Self { results, allow_failure, decoder: None, gas_report: None }
     }
 
     /// Creates a new empty test outcome.
@@ -357,6 +361,10 @@ pub struct TestResult {
     /// Traces
     #[serde(skip)]
     pub traces: Traces,
+
+    /// Additional traces to use for gas report.
+    #[serde(skip)]
+    pub gas_report_traces: Vec<Vec<CallTraceArena>>,
 
     /// Raw coverage info
     #[serde(skip)]

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -439,6 +439,7 @@ impl<'a> ContractRunner<'a> {
             debug: debug_arena,
             breakpoints,
             duration,
+            gas_report_traces: Vec::new(),
         }
     }
 
@@ -491,23 +492,24 @@ impl<'a> ContractRunner<'a> {
         let invariant_contract =
             InvariantContract { address, invariant_function: func, abi: self.contract };
 
-        let InvariantFuzzTestResult { error, cases, reverts, last_run_inputs } = match evm
-            .invariant_fuzz(invariant_contract.clone())
-        {
-            Ok(x) => x,
-            Err(e) => {
-                return TestResult {
-                    status: TestStatus::Failure,
-                    reason: Some(format!("failed to set up invariant testing environment: {e}")),
-                    decoded_logs: decode_console_logs(&logs),
-                    traces,
-                    labeled_addresses,
-                    kind: TestKind::Invariant { runs: 0, calls: 0, reverts: 0 },
-                    duration: start.elapsed(),
-                    ..Default::default()
+        let InvariantFuzzTestResult { error, cases, reverts, last_run_inputs, gas_report_traces } =
+            match evm.invariant_fuzz(invariant_contract.clone()) {
+                Ok(x) => x,
+                Err(e) => {
+                    return TestResult {
+                        status: TestStatus::Failure,
+                        reason: Some(format!(
+                            "failed to set up invariant testing environment: {e}"
+                        )),
+                        decoded_logs: decode_console_logs(&logs),
+                        traces,
+                        labeled_addresses,
+                        kind: TestKind::Invariant { runs: 0, calls: 0, reverts: 0 },
+                        duration: start.elapsed(),
+                        ..Default::default()
+                    }
                 }
-            }
-        };
+            };
 
         let mut counterexample = None;
         let mut logs = logs.clone();
@@ -571,6 +573,7 @@ impl<'a> ContractRunner<'a> {
             traces,
             labeled_addresses: labeled_addresses.clone(),
             duration: start.elapsed(),
+            gas_report_traces,
             ..Default::default() // TODO collect debug traces on the last run or error
         }
     }
@@ -698,6 +701,7 @@ impl<'a> ContractRunner<'a> {
             debug,
             breakpoints,
             duration,
+            gas_report_traces: result.gas_report_traces.into_iter().map(|t| vec![t]).collect(),
         }
     }
 }

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -94,6 +94,7 @@ pub static TEST_OPTS: Lazy<TestOptions> = Lazy::new(|| {
                 max_fuzz_dictionary_values: 10_000,
                 max_calldata_fuzz_dictionary_addresses: 0,
             },
+            gas_report_samples: 256,
         })
         .invariant(InvariantConfig {
             runs: 256,
@@ -112,6 +113,7 @@ pub static TEST_OPTS: Lazy<TestOptions> = Lazy::new(|| {
             shrink_run_limit: 2usize.pow(18u32),
             preserve_state: false,
             max_assume_rejects: 65536,
+            gas_report_samples: 256,
         })
         .build(&COMPILED, &PROJECT.paths.root)
         .expect("Config loaded")


### PR DESCRIPTION
## Motivation

Closes #7313

Now the output of the `test --gas-report` from the [repro](https://github.com/aelmanaa/test-forge-gas-internal-tx/tree/main) is the following:
```
| test/Inv.t.sol:ContractA contract |                 |       |        |        |         |
|-----------------------------------|-----------------|-------|--------|--------|---------|
| Deployment Cost                   | Deployment Size |       |        |        |         |
| 154332                            | 534             |       |        |        |         |
| Function Name                     | min             | avg   | median | max    | # calls |
| increment                         | 48554           | 48554 | 48554  | 48554  | 1       |
| setNumber                         | 48795           | 68117 | 49077  | 103999 | 256     |


| test/Inv.t.sol:Counter contract |                 |     |        |     |         |
|---------------------------------|-----------------|-----|--------|-----|---------|
| Deployment Cost                 | Deployment Size |     |        |     |         |
| 137113                          | 421             |     |        |     |         |
| Function Name                   | min             | avg | median | max | # calls |
| number                          | 305             | 305 | 305    | 305 | 257     |
```

## Solution

We now collect up to `FuzzConfig::gas_report_samples`/`InvariantConfig::gas_report_samples` additional traces of successfull runs of fuzz/invariant tests, then identify and include them into gas report.

Additional samples are not collected when gas report is disabled so there should be no performance overhead for defaut runs.

Not sure if I've chosen the best approach for testing this. Existing --gas-report tests operated on stdout and I needed access to the resulted `GasReport` object to test count of calls.