### PR TITLE
fix: remove constructor when generating interface

### DIFF
--- a/crates/cast/tests/fixtures/interface.json
+++ b/crates/cast/tests/fixtures/interface.json
@@ -1,0 +1,141 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_integrationManager",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_addressListRegistry",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_aTokenListId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_pool",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_referralCode",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getIntegrationManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "integrationManager_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lend",
+    "inputs": [
+      {
+        "name": "_vaultProxy",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "_assetData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "parseAssetsForAction",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_selector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      },
+      {
+        "name": "_actionData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "spendAssetsHandleType_",
+        "type": "uint8",
+        "internalType": "enum IIntegrationManager.SpendAssetsHandleType"
+      },
+      {
+        "name": "spendAssets_",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "spendAssetAmounts_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "incomingAssets_",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "minIncomingAssetAmounts_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "redeem",
+    "inputs": [
+      {
+        "name": "_vaultProxy",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "_assetData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  }
+]


### PR DESCRIPTION
closes https://github.com/alloy-rs/core/issues/555

remove constructor from the abi before generating the interface