### PR TITLE
fix(anvil): evaluate environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "flate2",
+ "foundry-cli",
  "foundry-common",
  "foundry-config",
  "foundry-evm",

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -16,13 +16,18 @@ path = "src/anvil.rs"
 required-features = ["cli"]
 
 [build-dependencies]
-vergen = { workspace = true, default-features = false, features = ["build", "git", "gitcl"] }
+vergen = { workspace = true, default-features = false, features = [
+    "build",
+    "git",
+    "gitcl",
+] }
 
 [dependencies]
 # foundry internal
 anvil-core = { path = "core", features = ["serde", "impersonated-tx"] }
 anvil-rpc = { path = "rpc" }
 anvil-server = { path = "server" }
+foundry-cli.workspace = true
 foundry-common.workspace = true
 foundry-config.workspace = true
 foundry-evm.workspace = true
@@ -76,7 +81,11 @@ rand = "0.8"
 eyre.workspace = true
 
 # cli
-clap = { version = "4", features = ["derive", "env", "wrap_help"], optional = true }
+clap = { version = "4", features = [
+    "derive",
+    "env",
+    "wrap_help",
+], optional = true }
 clap_complete = { version = "4", optional = true }
 chrono.workspace = true
 auto_impl = "1"

--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -1,6 +1,8 @@
 //! The `anvil` cli
+
 use anvil::cmd::NodeArgs;
 use clap::{CommandFactory, Parser, Subcommand};
+use foundry_cli::utils;
 
 /// A fast local Ethereum development node.
 #[derive(Parser)]
@@ -29,6 +31,8 @@ pub enum AnvilSubcommand {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    utils::load_dotenv();
+
     let mut app = Anvil::parse();
     app.node.evm_opts.resolve_rpc_alias();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #7220

Currently implementation lacks evaluation of environment variables inside of `foundry.toml`, see thread.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implements `load_dotenv` from `foundry-cli`, as we do in `cast`, `chisel` and `foundry`. This uses `dotenvy` to evaluate the environment variables.