### PR TITLE
fix(forge): correctly write build info

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -679,7 +679,7 @@ impl Config {
             .set_auto_detect(self.is_auto_detect())
             .set_offline(self.offline)
             .set_cached(cached)
-            .set_build_info(cached && self.build_info)
+            .set_build_info(!no_artifacts && self.build_info)
             .set_no_artifacts(no_artifacts)
             .build()?;
 


### PR DESCRIPTION
## Motivation

Closes #6859

## Solution

Not sure why it was `cached && build_info`, probably was meant to only write build info if we are writing any artifacts
