### PR TITLE
fix(cheatcodes): add repro test for once reported issues around empty JSON arrays

### DIFF
--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -176,6 +176,9 @@ test_repro!(3753);
 // https://github.com/foundry-rs/foundry/issues/3792
 test_repro!(3792);
 
+// https://github.com/foundry-rs/foundry/issues/4402
+test_repro!(4402);
+
 // https://github.com/foundry-rs/foundry/issues/4586
 test_repro!(4586);
 

--- a/testdata/fixtures/Json/Issue4402.json
+++ b/testdata/fixtures/Json/Issue4402.json
@@ -1,0 +1,4 @@
+{
+  "tokens": ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+  "empty": []
+}

--- a/testdata/fixtures/Toml/Issue4402.toml
+++ b/testdata/fixtures/Toml/Issue4402.toml
@@ -1,0 +1,2 @@
+tokens = ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
+empty = []

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = "0.8.18"
+# solc = "0.8.18"
 block_base_fee_per_gas = 0
 block_coinbase = "0x0000000000000000000000000000000000000000"
 block_difficulty = 0

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-# solc = "0.8.18"
+solc = "0.8.18"
 block_base_fee_per_gas = 0
 block_coinbase = "0x0000000000000000000000000000000000000000"
 block_difficulty = 0

--- a/testdata/repros/Issue4402.t.sol
+++ b/testdata/repros/Issue4402.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "../cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/4402
+contract Issue4402Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testReadNonEmptyArray() public {
+        string memory path = "fixtures/Json/Issue4402.json";
+        string memory json = vm.readFile(path);
+        address[] memory tokens = vm.parseJsonAddressArray(json, ".tokens");
+        assertEq(tokens.length, 1);
+
+        path = "fixtures/Toml/Issue4402.toml";
+        string memory toml = vm.readFile(path);
+        tokens = vm.parseTomlAddressArray(toml, ".tokens");
+        assertEq(tokens.length, 1);
+    }
+
+    function testReadEmptyArray() public {
+        string memory path = "fixtures/Json/Issue4402.json";
+        string memory json = vm.readFile(path);
+
+        // Every one of these used to causes panic
+        address[] memory emptyAddressArray = vm.parseJsonAddressArray(json, ".empty");
+        bool[] memory emptyBoolArray = vm.parseJsonBoolArray(json, ".empty");
+        bytes[] memory emptyBytesArray = vm.parseJsonBytesArray(json, ".empty");
+        bytes32[] memory emptyBytes32Array = vm.parseJsonBytes32Array(json, ".empty");
+        string[] memory emptyStringArray = vm.parseJsonStringArray(json, ".empty");
+        int256[] memory emptyIntArray = vm.parseJsonIntArray(json, ".empty");
+        uint256[] memory emptyUintArray = vm.parseJsonUintArray(json, ".empty");
+
+        assertEq(emptyAddressArray.length, 0);
+        assertEq(emptyBoolArray.length, 0);
+        assertEq(emptyBytesArray.length, 0);
+        assertEq(emptyBytes32Array.length, 0);
+        assertEq(emptyStringArray.length, 0);
+        assertEq(emptyIntArray.length, 0);
+        assertEq(emptyUintArray.length, 0);
+
+        path = "fixtures/Toml/Issue4402.toml";
+        string memory toml = vm.readFile(path);
+
+        // Every one of these used to causes panic
+        emptyAddressArray = vm.parseTomlAddressArray(toml, ".empty");
+        emptyBoolArray = vm.parseTomlBoolArray(toml, ".empty");
+        emptyBytesArray = vm.parseTomlBytesArray(toml, ".empty");
+        emptyBytes32Array = vm.parseTomlBytes32Array(toml, ".empty");
+        emptyStringArray = vm.parseTomlStringArray(toml, ".empty");
+        emptyIntArray = vm.parseTomlIntArray(toml, ".empty");
+        emptyUintArray = vm.parseTomlUintArray(toml, ".empty");
+
+        assertEq(emptyAddressArray.length, 0);
+        assertEq(emptyBoolArray.length, 0);
+        assertEq(emptyBytesArray.length, 0);
+        assertEq(emptyBytes32Array.length, 0);
+        assertEq(emptyStringArray.length, 0);
+        assertEq(emptyIntArray.length, 0);
+        assertEq(emptyUintArray.length, 0);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Closes #4402, no longer an issue, no changes required.

## Motivation

To make sure recent TOML cheatcodes work correctly on empty arrays, given that #4402 reportedly had issues at one time.

## Solution

Adds a reproduction test to make sure this issue was indeed fixed and won't arise again.