### PR TITLE
chore: rename `FuzzBackendWrapper` to `CowBackend`

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -31,16 +31,16 @@ use std::{borrow::Cow, collections::HashMap};
 /// function via immutable raw (no state changes) calls.
 ///
 /// **N.B.**: we're assuming cheatcodes that alter the state (like multi fork swapping) are niche.
-/// If they executed during fuzzing, it will require a clone of the initial input database. This way
-/// we can support these cheatcodes in fuzzing cheaply without adding overhead for fuzz tests that
+/// If they executed, it will require a clone of the initial input database.
+/// This way we can support these cheatcodes cheaply without adding overhead for tests that
 /// don't make use of them. Alternatively each test case would require its own `Backend` clone,
 /// which would add significant overhead for large fuzz sets even if the Database is not big after
 /// setup.
 #[derive(Clone, Debug)]
-pub struct FuzzBackendWrapper<'a> {
-    /// The underlying immutable `Backend`
+pub struct CowBackend<'a> {
+    /// The underlying `Backend`.
     ///
-    /// No calls on the `FuzzBackendWrapper` will ever persistently modify the `backend`'s state.
+    /// No calls on the `CowBackend` will ever persistently modify the `backend`'s state.
     pub backend: Cow<'a, Backend>,
     /// Keeps track of whether the backed is already initialized
     is_initialized: bool,
@@ -48,7 +48,8 @@ pub struct FuzzBackendWrapper<'a> {
     spec_id: SpecId,
 }
 
-impl<'a> FuzzBackendWrapper<'a> {
+impl<'a> CowBackend<'a> {
+    /// Creates a new `CowBackend` with the given `Backend`.
     pub fn new(backend: &'a Backend) -> Self {
         Self { backend: Cow::Borrowed(backend), is_initialized: false, spec_id: SpecId::LATEST }
     }
@@ -75,7 +76,7 @@ impl<'a> FuzzBackendWrapper<'a> {
         Ok(res)
     }
 
-    /// Returns whether there was a snapshot failure in the fuzz backend.
+    /// Returns whether there was a snapshot failure in the backend.
     ///
     /// This is bubbled up from the underlying Copy-On-Write backend when a revert occurs.
     pub fn has_snapshot_failure(&self) -> bool {
@@ -105,9 +106,8 @@ impl<'a> FuzzBackendWrapper<'a> {
     }
 }
 
-impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
+impl<'a> DatabaseExt for CowBackend<'a> {
     fn snapshot(&mut self, journaled_state: &JournaledState, env: &Env) -> U256 {
-        trace!("fuzz: create snapshot");
         self.backend_mut(env).snapshot(journaled_state, env)
     }
 
@@ -118,7 +118,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         current: &mut Env,
         action: RevertSnapshotAction,
     ) -> Option<JournaledState> {
-        trace!(?id, "fuzz: revert snapshot");
         self.backend_mut(current).revert(id, journaled_state, current, action)
     }
 
@@ -137,7 +136,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     }
 
     fn create_fork(&mut self, fork: CreateFork) -> eyre::Result<LocalForkId> {
-        trace!("fuzz: create fork");
         self.backend.to_mut().create_fork(fork)
     }
 
@@ -146,7 +144,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         fork: CreateFork,
         transaction: B256,
     ) -> eyre::Result<LocalForkId> {
-        trace!(?transaction, "fuzz: create fork at");
         self.backend.to_mut().create_fork_at_transaction(fork, transaction)
     }
 
@@ -156,7 +153,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        trace!(?id, "fuzz: select fork");
         self.backend_mut(env).select_fork(id, env, journaled_state)
     }
 
@@ -167,7 +163,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        trace!(?id, ?block_number, "fuzz: roll fork");
         self.backend_mut(env).roll_fork(id, block_number, env, journaled_state)
     }
 
@@ -178,7 +173,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         env: &mut Env,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<()> {
-        trace!(?id, ?transaction, "fuzz: roll fork to transaction");
         self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
     }
 
@@ -190,7 +184,6 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
         journaled_state: &mut JournaledState,
         inspector: &mut I,
     ) -> eyre::Result<()> {
-        trace!(?id, ?transaction, "fuzz: execute transaction");
         self.backend_mut(env).transact(id, transaction, env, journaled_state, inspector)
     }
 
@@ -251,7 +244,7 @@ impl<'a> DatabaseExt for FuzzBackendWrapper<'a> {
     }
 }
 
-impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {
+impl<'a> DatabaseRef for CowBackend<'a> {
     type Error = DatabaseError;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -271,7 +264,7 @@ impl<'a> DatabaseRef for FuzzBackendWrapper<'a> {
     }
 }
 
-impl<'a> Database for FuzzBackendWrapper<'a> {
+impl<'a> Database for CowBackend<'a> {
     type Error = DatabaseError;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -291,7 +284,7 @@ impl<'a> Database for FuzzBackendWrapper<'a> {
     }
 }
 
-impl<'a> DatabaseCommit for FuzzBackendWrapper<'a> {
+impl<'a> DatabaseCommit for CowBackend<'a> {
     fn commit(&mut self, changes: Map<Address, Account>) {
         self.backend.to_mut().commit(changes)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -32,8 +32,8 @@ pub use diagnostic::RevertDiagnostic;
 mod error;
 pub use error::{DatabaseError, DatabaseResult};
 
-mod fuzz;
-pub use fuzz::FuzzBackendWrapper;
+mod cow;
+pub use cow::CowBackend;
 
 mod in_memory_db;
 pub use in_memory_db::{EmptyDBWrapper, FoundryEvmInMemoryDB, MemDb};

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -345,7 +345,7 @@ impl MultiContractRunnerBuilder {
             }
 
             if let Some(bytes) = linked_contract.get_deployed_bytecode_bytes() {
-                known_contracts.insert(id.clone(), (abi.clone(), bytes.to_vec()));
+                known_contracts.insert(id.clone(), (abi.clone(), bytes.into_owned().into()));
             }
         }
 


### PR DESCRIPTION
Name what it is not what it's used for, or something like that
