### PR TITLE
fix: disable cache if build-info is requested

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -678,7 +678,7 @@ impl Config {
             })
             .set_auto_detect(self.is_auto_detect())
             .set_offline(self.offline)
-            .set_cached(cached)
+            .set_cached(cached && !self.build_info)
             .set_build_info(!no_artifacts && self.build_info)
             .set_no_artifacts(no_artifacts)
             .build()?;


### PR DESCRIPTION
## Motivation

Closes #4981

## Solution

It seems that build-info is expected to always contain build info for all artifacts, and we can't aquire it from cached artifacts, so we enforce recompilation of all sources
