### PR TITLE
fix(anvil): return correct block number for Arbitrum fork

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1013,9 +1013,6 @@ latest block number: {latest_block}"
             ..Default::default()
         };
 
-        // apply changes such as difficulty -> prevrandao
-        apply_chain_and_block_specific_env_changes(env, &block);
-
         // if not set explicitly we use the base fee of the latest block
         if self.base_fee.is_none() {
             if let Some(base_fee) = block.header.base_fee_per_gas {
@@ -1059,6 +1056,8 @@ latest block number: {latest_block}"
             chain_id
         };
         let override_chain_id = self.chain_id;
+        // apply changes such as difficulty -> prevrandao and chain specifics for current chain id
+        apply_chain_and_block_specific_env_changes(env, &block);
 
         let meta = BlockchainDbMeta::new(env.clone(), eth_rpc_url.clone());
         let block_chain_db = if self.fork_chain_id.is_some() {

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     revm::primitives::AccountInfo,
 };
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256, U64};
 use alloy_rpc_types::BlockId;
 use foundry_evm::{
     backend::{DatabaseResult, RevertSnapshotAction, StateSnapshot},
@@ -32,7 +32,11 @@ impl Db for ForkedDatabase {
         self.inner().block_hashes().write().insert(number, hash);
     }
 
-    fn dump_state(&self, at: BlockEnv) -> DatabaseResult<Option<SerializableState>> {
+    fn dump_state(
+        &self,
+        at: BlockEnv,
+        best_number: U64,
+    ) -> DatabaseResult<Option<SerializableState>> {
         let mut db = self.database().clone();
         let accounts = self
             .database()
@@ -57,7 +61,11 @@ impl Db for ForkedDatabase {
                 ))
             })
             .collect::<Result<_, _>>()?;
-        Ok(Some(SerializableState { block: Some(at), accounts }))
+        Ok(Some(SerializableState {
+            block: Some(at),
+            accounts,
+            best_block_number: Some(best_number),
+        }))
     }
 
     fn snapshot(&mut self) -> U256 {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -486,7 +486,7 @@ impl Backend {
 
     /// Returns the current best number of the chain
     pub fn best_number(&self) -> u64 {
-        self.env.read().block.number.try_into().unwrap_or(u64::MAX)
+        self.blockchain.storage.read().best_number.try_into().unwrap_or(u64::MAX)
     }
 
     /// Sets the block number
@@ -712,7 +712,8 @@ impl Backend {
     /// Get the current state.
     pub async fn serialized_state(&self) -> Result<SerializableState, BlockchainError> {
         let at = self.env.read().block.clone();
-        let state = self.db.read().await.dump_state(at)?;
+        let best_number = self.blockchain.storage.read().best_number;
+        let state = self.db.read().await.dump_state(at, best_number)?;
         state.ok_or_else(|| {
             RpcError::invalid_params("Dumping state not supported with the current configuration")
                 .into()
@@ -734,6 +735,11 @@ impl Backend {
         // reset the block env
         if let Some(block) = state.block.clone() {
             self.env.write().block = block;
+        }
+
+        // set the current best block number
+        if let Some(best_number) = state.best_block_number {
+            self.blockchain.storage.write().best_number = best_number;
         }
 
         if !self.db.write().await.load_state(state)? {
@@ -920,8 +926,9 @@ impl Backend {
             let ExecutedTransactions { block, included, invalid } = executed_tx;
             let BlockInfo { block, transactions, receipts } = block;
 
+            let mut storage = self.blockchain.storage.write();
             let header = block.header.clone();
-            let block_number: U64 = env.block.number.to::<U64>();
+            let block_number = storage.best_number.saturating_add(U64::from(1));
 
             trace!(
                 target: "backend",
@@ -931,7 +938,6 @@ impl Backend {
                 transactions.iter().map(|tx| tx.transaction_hash).collect::<Vec<_>>()
             );
 
-            let mut storage = self.blockchain.storage.write();
             // update block metadata
             storage.best_number = block_number;
             storage.best_hash = block_hash;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -734,12 +734,12 @@ impl Backend {
     pub async fn load_state(&self, state: SerializableState) -> Result<bool, BlockchainError> {
         // reset the block env
         if let Some(block) = state.block.clone() {
-            self.env.write().block = block;
-        }
+            self.env.write().block = block.clone();
 
-        // set the current best block number
-        if let Some(best_number) = state.best_block_number {
-            self.blockchain.storage.write().best_number = best_number;
+            // Set the current best block number.
+            // Defaults to block number for compatibility with existing state files.
+            self.blockchain.storage.write().best_number =
+                state.best_block_number.unwrap_or(block.number.to::<U64>());
         }
 
         if !self.db.write().await.load_state(state)? {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1123,6 +1123,55 @@ async fn test_arbitrum_fork_dev_balance() {
     }
 }
 
+// <https://github.com/foundry-rs/foundry/issues/6749>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arbitrum_fork_block_number() {
+    // fork to get initial block for test
+    let (_, handle) = spawn(
+        fork_config()
+            .with_fork_block_number(None::<u64>)
+            .with_eth_rpc_url(Some("https://arb1.arbitrum.io/rpc".to_string())),
+    )
+    .await;
+    let provider = ethers_http_provider(&handle.http_endpoint());
+    let initial_block_number = provider.get_block_number().await.unwrap().as_u64();
+
+    // fork again at block number returned by `eth_blockNumber`
+    // if wrong block number returned (e.g. L1) then fork will fail with error code -32000: missing
+    // trie node
+    let (api, _) = spawn(
+        fork_config()
+            .with_fork_block_number(Some(initial_block_number))
+            .with_eth_rpc_url(Some("https://arb1.arbitrum.io/rpc".to_string())),
+    )
+    .await;
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, initial_block_number);
+
+    // take snapshot at initial block number
+    let snapshot = api.evm_snapshot().await.unwrap();
+
+    // mine new block and check block number returned by `eth_blockNumber`
+    api.mine_one().await;
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, initial_block_number + 1);
+
+    // revert to recorded snapshot and check block number
+    assert!(api.evm_revert(snapshot).await.unwrap());
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, initial_block_number);
+
+    // reset fork to different block number and compare with block returned by `eth_blockNumber`
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some("https://arb1.arbitrum.io/rpc".to_string()),
+        block_number: Some(initial_block_number - 2),
+    }))
+    .await
+    .unwrap();
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, initial_block_number - 2);
+}
+
 // <https://github.com/foundry-rs/foundry/issues/7023>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_execution_reverted() {

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -52,8 +52,9 @@ pub fn halt_to_instruction_result(halt: Halt) -> InstructionResult {
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///
-/// This checks for:
-///    - prevrandao mixhash after merge
+/// - checks for prevrandao mixhash after merge
+/// - applies chain specifics: on Arbitrum `block.number` is the L1 block
+/// Should be called with proper chain id (retrieved from provider if not provided).
 pub fn apply_chain_and_block_specific_env_changes(env: &mut revm::primitives::Env, block: &Block) {
     if let Ok(chain) = NamedChain::try_from(env.cfg.chain_id) {
         let block_number = block.header.number.unwrap_or_default();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #6749 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- use `storage.best_number` for `eth_blockNumber` call
- make sure best number is not overwritten when new blocks are mined
- dump and load `best_number` from state file
- fix issue reported with Arbitrum chain specifics not applied if `--chain-id` missing https://github.com/foundry-rs/foundry/issues/6749#issuecomment-1986961842 by calling `apply_chain_and_block_specific_env_changes` after chain id fetched from provider