### PR TITLE
fix: compile contracts before generating docs

### DIFF
--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -4,6 +4,7 @@ use forge_doc::{
     ContractInheritance, Deployments, DocBuilder, GitSource, InferInlineHyperlinks, Inheritdoc,
 };
 use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
+use foundry_common::compile::ProjectCompiler;
 use foundry_config::{find_project_root_path, load_config_with_root};
 use std::{path::PathBuf, process::Command};
 
@@ -64,6 +65,9 @@ impl DocArgs {
     pub fn run(self) -> Result<()> {
         let root = self.root.clone().unwrap_or(find_project_root_path(None)?);
         let config = load_config_with_root(Some(root.clone()));
+        let project = config.project()?;
+        let compiler = ProjectCompiler::new();
+        let _output = compiler.compile(&project)?;
 
         let mut doc_config = config.doc.clone();
         if let Some(out) = self.out {

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -66,7 +66,7 @@ impl DocArgs {
         let root = self.root.clone().unwrap_or(find_project_root_path(None)?);
         let config = load_config_with_root(Some(root.clone()));
         let project = config.project()?;
-        let compiler = ProjectCompiler::new();
+        let compiler = ProjectCompiler::new().quiet(true);
         let _output = compiler.compile(&project)?;
 
         let mut doc_config = config.doc.clone();


### PR DESCRIPTION
## Motivation

While solving the issue #7331, I tested the `forge doc` on a sample contract.

Example to reproduce the issue:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.24;

interface IERC20 {
    /**
    * @notice Mints `amount` token to `recipient`.
    * @param  recipient The address of the account receiving minted token.
    * @param  amount    The amount of token to mint.
    */
    function mint(address recipient, uint256 amount) external;
}

contract Test is IERC20 {
    /// @inheritdoc IERC20
    function mint(someType recipient, someType amount) external onlyOwner {}
}
```

Here you can some issues like `someType` is not a valid variable type and also `onlyOwner` isn't defined. But if we run `forge doc` here, it runs successfully without giving any errors and gives an output like this.

```markdown
**Parameters**

|Name|Type|Description|
|----|----|-----------|
|`recipient`|`someType`|The address of the account receiving minted token.|
|`amount`|`someType`|   The amount of token to mint.|
```

You can see in the type `someType` comes which is not a valid solidity type.

## Solution

compile contracts before running `forge doc`.

If we now run the forge doc, it will give an error of something like this:

```bash
[⠒] Compiling...
[⠢] Compiling 1 files with 0.8.24
[⠆] Solc 0.8.24 finished in 25.80ms
Error:
Compiler run failed:
Error (7920): Identifier not found or not unique.
  --> src/Test.sol:15:19:
   |
15 |     function mint(someType recipient, someType amount) external onlyOwner {}
   |                   ^^^^^^^^
```