### PR TITLE
chore: update tests after new forge-std

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -393,7 +393,7 @@ forgetest!(can_init_vscode, |prj, cmd| {
     let remappings = prj.root().join("remappings.txt");
     assert!(remappings.is_file());
     let content = std::fs::read_to_string(remappings).unwrap();
-    assert_eq!(content, "ds-test/=lib/forge-std/lib/ds-test/src/\nforge-std/=lib/forge-std/src/",);
+    assert_eq!(content, "forge-std/=lib/forge-std/src/",);
 });
 
 // checks that forge can init with template

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -150,14 +150,14 @@ forgetest_init!(can_override_config, |prj, cmd| {
 
     let profile = Config::load_with_root(prj.root());
     // ensure that the auto-generated internal remapping for forge-std's ds-test exists
-    assert_eq!(profile.remappings.len(), 2);
-    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());
+    assert_eq!(profile.remappings.len(), 1);
+    assert_eq!("forge-std/=lib/forge-std/src/", profile.remappings[0].to_string());
 
     // ensure remappings contain test
-    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", profile.remappings[0].to_string());
+    assert_eq!("forge-std/=lib/forge-std/src/", profile.remappings[0].to_string());
     // the loaded config has resolved, absolute paths
     assert_eq!(
-        "ds-test/=lib/forge-std/lib/ds-test/src/",
+        "forge-std/=lib/forge-std/src/",
         Remapping::from(profile.remappings[0].clone()).to_string()
     );
 
@@ -221,12 +221,12 @@ forgetest_init!(can_parse_remappings_correctly, |prj, cmd| {
 
     let profile = Config::load_with_root(prj.root());
     // ensure that the auto-generated internal remapping for forge-std's ds-test exists
-    assert_eq!(profile.remappings.len(), 2);
-    let [r, _] = &profile.remappings[..] else { unreachable!() };
-    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", r.to_string());
+    assert_eq!(profile.remappings.len(), 1);
+    let r = &profile.remappings[0];
+    assert_eq!("forge-std/=lib/forge-std/src/", r.to_string());
 
     // the loaded config has resolved, absolute paths
-    assert_eq!("ds-test/=lib/forge-std/lib/ds-test/src/", Remapping::from(r.clone()).to_string());
+    assert_eq!("forge-std/=lib/forge-std/src/", Remapping::from(r.clone()).to_string());
 
     cmd.arg("config");
     let expected = profile.to_string_pretty().unwrap();
@@ -432,11 +432,11 @@ forgetest!(can_set_gas_price, |prj, cmd| {
 forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
     let config = cmd.config();
     let remappings = config.remappings.iter().cloned().map(Remapping::from).collect::<Vec<_>>();
+    dbg!(&remappings);
     pretty_assertions::assert_eq!(
         remappings,
         vec![
             // global
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
         ]
     );
@@ -455,7 +455,6 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
         remappings,
         vec![
             // default
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             // remapping is local to the lib
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
@@ -481,7 +480,6 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
             // local to the lib
             "another-lib/=lib/nested-lib/lib/another-lib/src/".parse().unwrap(),
             // global
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib
@@ -500,7 +498,6 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
             // local to the lib
             "another-lib/=lib/nested-lib/lib/another-lib/custom-source-dir/".parse().unwrap(),
             // global
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap(),
             "nested-lib/=lib/nested-lib/src/".parse().unwrap(),
             // remappings local to the lib
@@ -529,7 +526,6 @@ forgetest_init!(can_prioritise_closer_lib_remappings, |prj, cmd| {
         remappings,
         vec![
             "dep1/=lib/dep1/src/".parse().unwrap(),
-            "ds-test/=lib/forge-std/lib/ds-test/src/".parse().unwrap(),
             "forge-std/=lib/forge-std/src/".parse().unwrap()
         ]
     );

--- a/crates/forge/tests/fixtures/can_create_template_contract.stdout
+++ b/crates/forge/tests/fixtures/can_create_template_contract.stdout
@@ -1,4 +1,4 @@
-Compiling 24 files with 0.8.23
+Compiling 27 files with 0.8.23
 Solc 0.8.23 finished in 2.27s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
+++ b/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
@@ -1,4 +1,4 @@
-Compiling 24 files with 0.8.23
+Compiling 27 files with 0.8.23
 Solc 0.8.23 finished in 1.95s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
+++ b/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
@@ -1,4 +1,4 @@
-Compiling 25 files with 0.8.23
+Compiling 28 files with 0.8.23
 Solc 0.8.23 finished in 2.82s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/forge/tests/fixtures/can_test_repeatedly.stdout
+++ b/crates/forge/tests/fixtures/can_test_repeatedly.stdout
@@ -2,7 +2,7 @@ No files changed, compilation skipped
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
 [PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: 26521, ~: 28387)
-[PASS] test_Increment() (gas: 28379)
+[PASS] test_Increment() (gas: 31225)
 Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 9.42ms
 
 Ran 1 test suite: 2 tests passed, 0 failed, 0 skipped (2 total tests)

--- a/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
+++ b/crates/forge/tests/fixtures/can_use_libs_in_multi_fork.stdout
@@ -3,7 +3,7 @@ Solc 0.8.23 finished in 1.95s
 Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:ContractTest
-[PASS] test() (gas: 70360)
+[PASS] test() (gas: 70404)
 Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.21s
 
 Ran 1 test suite: 1 tests passed, 0 failed, 0 skipped (1 total tests)

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -3,9 +3,9 @@ Compiling 1 files with 0.8.23
 Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:USDCCallingTest
-[PASS] test() (gas: 16799)
+[PASS] test() (gas: 16821)
 Traces:
-  [16799] USDCCallingTest::test()
+  [16821] USDCCallingTest::test()
     ├─ [0] VM::createSelectFork("<url>")
     │   └─ ← 0
     ├─ [10350] 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48::name() [staticcall]


### PR DESCRIPTION
new forge-std release broke some tests+fixtures