### PR TITLE
chore: use Bytes to store calldata

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -503,9 +503,9 @@ impl DebuggerContext<'_> {
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
         let step = self.current_step();
         let buf = match self.active_buffer {
-            BufferKind::Memory => &step.memory,
-            BufferKind::Calldata => &step.calldata,
-            BufferKind::Returndata => &step.returndata,
+            BufferKind::Memory => step.memory.as_ref(),
+            BufferKind::Calldata => step.calldata.as_ref(),
+            BufferKind::Returndata => step.returndata.as_ref(),
         };
 
         let min_len = hex_digits(buf.len());

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use revm::interpreter::OpCode;
 use revm_inspectors::tracing::types::CallKind;
 use serde::{Deserialize, Serialize};
@@ -170,7 +170,7 @@ pub struct DebugStep {
     /// Memory *prior* to running the associated opcode
     pub memory: Vec<u8>,
     /// Calldata *prior* to running the associated opcode
-    pub calldata: Vec<u8>,
+    pub calldata: Bytes,
     /// Returndata *prior* to running the associated opcode
     pub returndata: Vec<u8>,
     /// Opcode to be executed

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -76,7 +76,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             pc,
             stack: interp.stack().data().clone(),
             memory: interp.shared_memory.context_memory().to_vec(),
-            calldata: interp.contract().input.to_vec(),
+            calldata: interp.contract().input.clone(),
             returndata: interp.return_data_buffer.to_vec(),
             instruction: Instruction::OpCode(op),
             push_bytes,


### PR DESCRIPTION
ref #7382

use Bytes.clone to store calldata for opcode