### PR TITLE
chore: retry 429 errors

### DIFF
--- a/crates/common/src/provider/retry.rs
+++ b/crates/common/src/provider/retry.rs
@@ -79,6 +79,12 @@ fn should_retry_transport_level_error(error: &TransportErrorKind) -> bool {
     match error {
         // Missing batch response errors can be retried.
         TransportErrorKind::MissingBatchResponse(_) => true,
+        TransportErrorKind::Custom(err) => {
+            // currently http error responses are not standard in alloy
+            let msg = err.to_string();
+            msg.contains("429 Too Many Requests")
+        }
+
         // If the backend is gone, or there's a completely custom error, we should assume it's not
         // retryable.
         _ => false,


### PR DESCRIPTION
ref https://github.com/alloy-rs/alloy/blob/09e90e8a76542aaffb3ac0c551a678f2e4fa2890/crates/transport-http/src/hyper.rs#L43-L47

ensures we can retry 429 errors

https://github.com/foundry-rs/foundry/actions/runs/8256007930/job/22583747756?pr=7383