### PR TITLE
chore: reuse unmodified step memory

### DIFF
--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -1,9 +1,9 @@
+use crate::opcodes;
 use alloy_primitives::{Address, Bytes, U256};
 use revm::interpreter::OpCode;
 use revm_inspectors::tracing::types::CallKind;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
-use crate::opcodes;
 
 /// An arena of [DebugNode]s
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -169,11 +169,11 @@ pub struct DebugStep {
     /// Stack *prior* to running the associated opcode
     pub stack: Vec<U256>,
     /// Memory *prior* to running the associated opcode
-    pub memory: Vec<u8>,
+    pub memory: Bytes,
     /// Calldata *prior* to running the associated opcode
     pub calldata: Bytes,
     /// Returndata *prior* to running the associated opcode
-    pub returndata: Vec<u8>,
+    pub returndata: Bytes,
     /// Opcode to be executed
     pub instruction: Instruction,
     /// Optional bytes that are being pushed onto the stack
@@ -214,9 +214,11 @@ impl DebugStep {
 
     /// Returns `true` if the opcode modifies memory.
     pub fn opcode_modifies_memory(&self) -> bool {
-        self.instruction.opcode().and_then(|opcode| OpCode::new(opcode)).map_or(false, |opcode| opcodes::modifies_memory(opcode))
+        self.instruction
+            .opcode()
+            .and_then(|opcode| OpCode::new(opcode))
+            .map_or(false, |opcode| opcodes::modifies_memory(opcode))
     }
-
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -258,7 +260,6 @@ impl Display for Instruction {
 }
 
 impl Instruction {
-
     /// Returns the opcode of the instruction, if it is an opcode.
     #[inline]
     pub fn opcode(&self) -> Option<u8> {

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -214,10 +214,7 @@ impl DebugStep {
 
     /// Returns `true` if the opcode modifies memory.
     pub fn opcode_modifies_memory(&self) -> bool {
-        self.instruction
-            .opcode()
-            .and_then(|opcode| OpCode::new(opcode))
-            .map_or(false, |opcode| opcodes::modifies_memory(opcode))
+        self.instruction.opcode().and_then(OpCode::new).map_or(false, opcodes::modifies_memory)
     }
 }
 

--- a/crates/evm/core/src/debug.rs
+++ b/crates/evm/core/src/debug.rs
@@ -3,6 +3,7 @@ use revm::interpreter::OpCode;
 use revm_inspectors::tracing::types::CallKind;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use crate::opcodes;
 
 /// An arena of [DebugNode]s
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -210,6 +211,12 @@ impl DebugStep {
             self.instruction.to_string()
         }
     }
+
+    /// Returns `true` if the opcode modifies memory.
+    pub fn opcode_modifies_memory(&self) -> bool {
+        self.instruction.opcode().and_then(|opcode| OpCode::new(opcode)).map_or(false, |opcode| opcodes::modifies_memory(opcode))
+    }
+
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -246,6 +253,18 @@ impl Display for Instruction {
                     .id
                     .to_uppercase()
             ),
+        }
+    }
+}
+
+impl Instruction {
+
+    /// Returns the opcode of the instruction, if it is an opcode.
+    #[inline]
+    pub fn opcode(&self) -> Option<u8> {
+        match self {
+            Instruction::OpCode(op) => Some(*op),
+            _ => None,
         }
     }
 }

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod constants;
 pub mod debug;
 pub mod decode;
 pub mod fork;
+pub mod opcodes;
 pub mod opts;
 pub mod snapshot;
 pub mod utils;

--- a/crates/evm/core/src/opcodes.rs
+++ b/crates/evm/core/src/opcodes.rs
@@ -5,20 +5,21 @@ use revm::interpreter::OpCode;
 /// Returns true if the opcode modifies memory.
 /// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>
 /// <https://github.com/crytic/evm-opcodes>
-pub fn modifies_memory(opcode: OpCode) -> bool {
-    match opcode {
+#[inline]
+pub const fn modifies_memory(opcode: OpCode) -> bool {
+    matches!(
+        opcode,
         OpCode::EXTCODECOPY |
-        OpCode::MLOAD |
-        OpCode::MSTORE |
-        OpCode::MSTORE8 |
-        OpCode::MCOPY |
-        OpCode::CODECOPY |
-        OpCode::CALLDATACOPY |
-        OpCode::RETURNDATACOPY |
-        OpCode::CALL |
-        OpCode::CALLCODE |
-        OpCode::DELEGATECALL |
-        OpCode::STATICCALL => true,
-        _ => false,
-    }
+            OpCode::MLOAD |
+            OpCode::MSTORE |
+            OpCode::MSTORE8 |
+            OpCode::MCOPY |
+            OpCode::CODECOPY |
+            OpCode::CALLDATACOPY |
+            OpCode::RETURNDATACOPY |
+            OpCode::CALL |
+            OpCode::CALLCODE |
+            OpCode::DELEGATECALL |
+            OpCode::STATICCALL
+    )
 }

--- a/crates/evm/core/src/opcodes.rs
+++ b/crates/evm/core/src/opcodes.rs
@@ -1,0 +1,24 @@
+//! Opcode utils
+
+use revm::interpreter::OpCode;
+
+/// Returns true if the opcode modifies memory.
+/// <https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes>
+/// <https://github.com/crytic/evm-opcodes>
+pub fn modifies_memory(opcode: OpCode) -> bool {
+    match opcode {
+        OpCode::EXTCODECOPY |
+        OpCode::MLOAD |
+        OpCode::MSTORE |
+        OpCode::MSTORE8 |
+        OpCode::MCOPY |
+        OpCode::CODECOPY |
+        OpCode::CALLDATACOPY |
+        OpCode::RETURNDATACOPY |
+        OpCode::CALL |
+        OpCode::CALLCODE |
+        OpCode::DELEGATECALL |
+        OpCode::STATICCALL => true,
+        _ => false,
+    }
+}

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -1,11 +1,6 @@
 use alloy_primitives::Address;
 use foundry_common::{ErrorExt, SELECTOR_LEN};
-use foundry_evm_core::{
-    backend::DatabaseExt,
-    constants::CHEATCODE_ADDRESS,
-    debug::{DebugArena, DebugNode, DebugStep, Instruction},
-    utils::gas_used,
-};
+use foundry_evm_core::{backend::DatabaseExt, constants::CHEATCODE_ADDRESS, debug::{DebugArena, DebugNode, DebugStep, Instruction}, opcodes, utils::gas_used};
 use revm::{
     interpreter::{
         opcode::{self, spec_opcode_gas},
@@ -71,6 +66,12 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             interp.gas.limit().saturating_sub(interp.gas.remaining()),
             interp.gas.refunded() as u64,
         );
+
+
+        let head = self.arena.arena[self.head].steps.last().and_then(|previous| {
+            previous.instruction.opcode().map_or(false, |opcode|  opcodes::modifies_memory(previous));
+
+        })
 
         self.arena.arena[self.head].steps.push(DebugStep {
             pc,

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -1,6 +1,11 @@
 use alloy_primitives::Address;
 use foundry_common::{ErrorExt, SELECTOR_LEN};
-use foundry_evm_core::{backend::DatabaseExt, constants::CHEATCODE_ADDRESS, debug::{DebugArena, DebugNode, DebugStep, Instruction}, opcodes, utils::gas_used};
+use foundry_evm_core::{
+    backend::DatabaseExt,
+    constants::CHEATCODE_ADDRESS,
+    debug::{DebugArena, DebugNode, DebugStep, Instruction},
+    utils::gas_used,
+};
 use revm::{
     interpreter::{
         opcode::{self, spec_opcode_gas},
@@ -67,19 +72,28 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             interp.gas.refunded() as u64,
         );
 
-        // if the previous opcode does __not__ modify memory, we can safely assume the memory of that step
-        self.arena.arena[self.head].steps.last().map(|step|{
-            if !step.opcode_modifies_memory() {
-
-            }
-        });
+        // if the previous opcode does __not__ modify memory, we can reuse the memory of
+        // that step
+        let memory = self.arena.arena[self.head]
+            .steps
+            .last()
+            .and_then(|step| {
+                if !step.opcode_modifies_memory() {
+                    // reuse the memory from the previous step, because its opcode did not modify
+                    // memory
+                    Some(step.memory.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| interp.shared_memory.context_memory().to_vec().into());
 
         self.arena.arena[self.head].steps.push(DebugStep {
             pc,
             stack: interp.stack().data().clone(),
-            memory: interp.shared_memory.context_memory().to_vec(),
+            memory,
             calldata: interp.contract().input.clone(),
-            returndata: interp.return_data_buffer.to_vec(),
+            returndata: interp.return_data_buffer.clone(),
             instruction: Instruction::OpCode(op),
             push_bytes,
             total_gas_used,

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -67,11 +67,12 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             interp.gas.refunded() as u64,
         );
 
+        // if the previous opcode does __not__ modify memory, we can safely assume the memory of that step
+        self.arena.arena[self.head].steps.last().map(|step|{
+            if !step.opcode_modifies_memory() {
 
-        let head = self.arena.arena[self.head].steps.last().and_then(|previous| {
-            previous.instruction.opcode().map_or(false, |opcode|  opcodes::modifies_memory(previous));
-
-        })
+            }
+        });
 
         self.arena.arena[self.head].steps.push(DebugStep {
             pc,


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/7382

checks if the previously recorded step/opcode did not modify the memory, if so reuse the recorded memory from the previous step


https://bluealloy.github.io/revm/crates/interpreter/memory.html#opcodes