### PR TITLE
feat: supports socket address as --rpc-url input

### DIFF
--- a/crates/common/src/provider/alloy.rs
+++ b/crates/common/src/provider/alloy.rs
@@ -14,6 +14,8 @@ use reqwest::Url;
 use std::{
     path::{Path, PathBuf},
     time::Duration,
+    net::SocketAddr,
+    str::FromStr,
 };
 use url::ParseError;
 
@@ -93,12 +95,16 @@ impl ProviderBuilder {
         let url = Url::parse(url_str)
             .or_else(|err| match err {
                 ParseError::RelativeUrlWithoutBase => {
-                    let path = Path::new(url_str);
-
-                    if let Ok(path) = resolve_path(path) {
-                        Url::parse(&format!("file://{}", path.display()))
+                    if let Ok(_) = SocketAddr::from_str(url_str) {
+                        Url::parse(&format!("http://{}", url_str))
                     } else {
-                        Err(err)
+                        let path = Path::new(url_str);
+
+                        if let Ok(path) = resolve_path(path) {
+                            Url::parse(&format!("file://{}", path.display()))
+                        } else {
+                            Err(err)
+                        }
                     }
                 }
                 _ => Err(err),

--- a/crates/common/src/provider/alloy.rs
+++ b/crates/common/src/provider/alloy.rs
@@ -12,10 +12,10 @@ use foundry_common::types::ToAlloy;
 use foundry_config::NamedChain;
 use reqwest::Url;
 use std::{
-    path::{Path, PathBuf},
-    time::Duration,
     net::SocketAddr,
+    path::{Path, PathBuf},
     str::FromStr,
+    time::Duration,
 };
 use url::ParseError;
 
@@ -95,7 +95,7 @@ impl ProviderBuilder {
         let url = Url::parse(url_str)
             .or_else(|err| match err {
                 ParseError::RelativeUrlWithoutBase => {
-                    if let Ok(_) = SocketAddr::from_str(url_str) {
+                    if SocketAddr::from_str(url_str).is_ok() {
                         Url::parse(&format!("http://{}", url_str))
                     } else {
                         let path = Path::new(url_str);


### PR DESCRIPTION
## Motivation

Fixes #7381 

On ` ./target/debug/anvil.exe` gives me:

```bash 
Listening on 127.0.0.1:8545
```

And on `./target/debug/anvil.exe --fork-url 127.0.0.1:8545 --port 6969` gives me:

```bash
Fork
==================
Endpoint:       127.0.0.1:8545
Block number:   0
Block hash:     0x579aa11e37a4f00c05e15e9cbdba31cbb3cb6c32e990e510bab1e38635764261
Chain ID:       31337

Listening on 127.0.0.1:6969
```