### PR TITLE
Bump evm-disassembler dependency to support Cancun opcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "evm-disassembler"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fc9c732a3210153e6aa26746f0abd8773dbf204c64ae3e824309b32b384c5"
+checksum = "ded685d9f07315ff689ba56e7d84e6f1e782db19b531a46c34061a733bba7258"
 dependencies = [
  "eyre",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 color-eyre = "0.6"
 derive_more = "0.99"
-evm-disassembler = "0.4"
+evm-disassembler = "0.5"
 eyre = "0.6"
 hex = { package = "const-hex", version = "1.6", features = ["hex"] }
 itertools = "0.12"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Cancun adds three new opcodes (MCOPY, TLOAD, TSTORE) that we want to support when disassembling smart contract code from binary to human readable opcodes. 

## Solution

Add new opcodes to the `evm-disassembler` library (see [pr](https://github.com/ckoopmann/evm-disassembler/pull/11)) and bump dependency (this pr)
