### PR TITLE
fix: ignore forge-std artifacts in build --sizes

### DIFF
--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -31,3 +31,12 @@ forgetest_init!(exact_build_output, |prj, cmd| {
     let stdout = cmd.stdout_lossy();
     assert!(stdout.contains("Compiling"), "\n{stdout}");
 });
+
+// tests build output is as expected
+forgetest_init!(build_sizes_no_forge_std, |prj, cmd| {
+    cmd.args(["build", "--sizes"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(!stdout.contains("console"), "\n{stdout}");
+    assert!(!stdout.contains("std"), "\n{stdout}");
+    assert!(stdout.contains("Counter"), "\n{stdout}");
+});


### PR DESCRIPTION
ref https://github.com/foundry-rs/forge-std/issues/522
ref https://github.com/foundry-rs/forge-std/pull/523

ignores all forge-std artifacts when `--build --sizes`