### PR TITLE
chore: fix race condition on test project initialization

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -246,7 +246,7 @@ pub fn initialize(target: &Path) {
             write.set_len(0).unwrap();
             write.seek(std::io::SeekFrom::Start(0)).unwrap();
             write.write_all(b"1").unwrap();
-            
+
             // Initialize and build.
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
             eprintln!("- initializing template dir in {}", prj.root().display());


### PR DESCRIPTION
## Motivation

We often occur ci failures like that one: https://github.com/foundry-rs/foundry/actions/runs/8256390549/job/22584995567#step:12:362

basically, for some reason we are missing data from template project.

I think it might happen because of the race condition we have in `initialize` function which this PR addresses