### PR TITLE
chore: fix test project initialization

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -243,10 +243,6 @@ pub fn initialize(target: &Path) {
         write.read_to_string(&mut data).unwrap();
 
         if data != "1" {
-            write.set_len(0).unwrap();
-            write.seek(std::io::SeekFrom::Start(0)).unwrap();
-            write.write_all(b"1").unwrap();
-
             // Initialize and build.
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
             eprintln!("- initializing template dir in {}", prj.root().display());
@@ -259,6 +255,11 @@ pub fn initialize(target: &Path) {
 
             // Copy the template to the global template path.
             pretty_err(tpath, copy_dir(prj.root(), tpath));
+
+            // Update lockfile to mark that template is initialized.
+            write.set_len(0).unwrap();
+            write.seek(std::io::SeekFrom::Start(0)).unwrap();
+            write.write_all(b"1").unwrap();
         }
 
         // Release the write lock and acquire a new read lock.


### PR DESCRIPTION
## Motivation

CI for #7415 failed with this error again, it seems that the issue in fact is happening because process initializing template might fail, but will write "1" to lock file anyway: https://github.com/foundry-rs/foundry/actions/runs/8315673331/job/22754269551#step:12:127 - here it failed while running `forge build` with "Text file busy (os error 26)", not sure why exactly.

We should only write "1" to lockfile after we've successfuly copied template to its location, thus this PR just changes order of things.