### PR TITLE
chore: solc 0.8.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc03b422b28e49d6dd61b8442bcee16c22edd975be1764de5a39c4037ecb478"
+checksum = "21eea332056d354044d94dee89e5885061199746046a3c9f61db0eead7bfbf69"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3318,7 +3318,7 @@ dependencies = [
  "sha2 0.10.8",
  "solang-parser",
  "svm-rs",
- "svm-rs-builds 0.3.5",
+ "svm-rs-builds 0.3.6",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3580,13 +3580,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7404,13 +7404,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
+checksum = "f9b34cc1af809be8d20575428638da2c6a1eb12b1da06dae79c1b82a4ddf83ac"
 dependencies = [
+ "const-hex",
  "dirs 5.0.1",
- "fs2",
- "hex",
+ "fs4",
  "once_cell",
  "reqwest",
  "semver 1.0.22",
@@ -7437,12 +7437,12 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8d3c94c4d3337336f58493471b98d712c267c66977b0fbe48efd6cbf69ffd0"
+checksum = "0d482af665b54264c23571bba709b9e50ecc0639e10b88bdfd019839473846f9"
 dependencies = [
  "build_const",
- "hex",
+ "const-hex",
  "semver 1.0.22",
  "serde_json",
  "svm-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-genesis",
+ "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-providers",
@@ -553,12 +554,12 @@ dependencies = [
  "ethereum-forkid",
  "ethers",
  "ethers-core",
- "ethers-solc",
  "eyre",
  "fdlimit",
  "flate2",
  "foundry-cli",
  "foundry-common",
+ "foundry-compilers",
  "foundry-config",
  "foundry-evm",
  "futures",
@@ -2691,25 +2692,19 @@ dependencies = [
  "dirs 5.0.1",
  "dunce",
  "ethers-core",
- "fs_extra",
- "futures-util",
  "glob",
  "home",
  "md-5 0.10.6",
  "num_cpus",
  "once_cell",
  "path-slash",
- "rand 0.8.5",
  "rayon",
  "regex",
  "semver 1.0.22",
  "serde",
  "serde_json",
- "sha2 0.10.8",
  "solang-parser",
- "svm-rs",
- "svm-rs-builds 0.2.3",
- "tempfile",
+ "svm-rs 0.3.6",
  "thiserror",
  "tiny-keccak",
  "tokio",
@@ -3008,7 +3003,7 @@ dependencies = [
  "similar",
  "solang-parser",
  "strum 0.26.2",
- "svm-rs",
+ "svm-rs 0.4.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3292,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eea332056d354044d94dee89e5885061199746046a3c9f61db0eead7bfbf69"
+checksum = "079ada1a2093e0fec67caa15ccf018a2d1b5747c16ba1c11a28df53530eb1a5f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3317,8 +3312,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "solang-parser",
- "svm-rs",
- "svm-rs-builds 0.3.6",
+ "svm-rs 0.4.0",
+ "svm-rs-builds",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7423,29 +7418,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "svm-rs-builds"
-version = "0.2.3"
+name = "svm-rs"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa64b5e8eecd3a8af7cfc311e29db31a268a62d5953233d3e8243ec77a71c4e3"
+checksum = "cde88464d5718a437e9f6be54cf3771837a111bed305c4f4f9d3497471e96249"
 dependencies = [
- "build_const",
- "hex",
+ "const-hex",
+ "dirs 5.0.1",
+ "fs4",
+ "once_cell",
+ "reqwest",
  "semver 1.0.22",
+ "serde",
  "serde_json",
- "svm-rs",
+ "sha2 0.10.8",
+ "thiserror",
+ "url",
+ "zip",
 ]
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d482af665b54264c23571bba709b9e50ecc0639e10b88bdfd019839473846f9"
+checksum = "2ff43323737122457c266fe28a454635edd9cd15f8b6277251eb4703ef54f829"
 dependencies = [
  "build_const",
  "const-hex",
  "semver 1.0.22",
  "serde_json",
- "svm-rs",
+ "svm-rs 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.3", default-features = false }
-foundry-compilers = { version = "0.3.9", default-features = false }
+foundry-compilers = { version = "0.3.12", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.3", default-features = false }
-foundry-compilers = { version = "0.3.12", default-features = false }
+foundry-compilers = { version = "0.3.13", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg
@@ -156,7 +156,6 @@ ethers-contract-abigen = { version = "2.0.14", default-features = false }
 ethers-providers = { version = "2.0.14", default-features = false }
 ethers-signers = { version = "2.0.14", default-features = false }
 ethers-middleware = { version = "2.0.14", default-features = false }
-ethers-solc = { version = "2.0.14", default-features = false }
 
 ## alloy
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "9ac2c90", default-features = false }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -95,9 +95,11 @@ clap_complete_fig = "4"
 ethereum-forkid = "0.12"
 
 [dev-dependencies]
+alloy-json-abi.workspace = true
 ethers = { workspace = true, features = ["abigen"] }
 ethers-core = { workspace = true, features = ["optimism"] }
-ethers-solc = { workspace = true, features = ["project-util", "full"] }
+foundry-compilers = { workspace = true, features = ["project-util", "full"] }
+
 pretty_assertions = "1.3.0"
 tokio = { version = "1", features = ["full"] }
 crc = "3.0.1"

--- a/crates/anvil/tests/it/ganache.rs
+++ b/crates/anvil/tests/it/ganache.rs
@@ -1,6 +1,9 @@
 //! tests against local ganache for local debug purposes
 #![allow(unused)]
-use crate::init_tracing;
+use crate::{
+    init_tracing,
+    utils::{ContractInstanceCompat, DeploymentTxFactoryCompat},
+};
 use ethers::{
     abi::Address,
     contract::{Contract, ContractFactory, ContractInstance},
@@ -11,7 +14,7 @@ use ethers::{
     types::{BlockNumber, U256},
     utils::hex,
 };
-use ethers_solc::{project_util::TempProject, Artifact};
+use foundry_compilers::{project_util::TempProject, Artifact};
 use std::sync::Arc;
 
 // the mnemonic used to start the local ganache instance
@@ -115,7 +118,7 @@ contract Contract {
 
     let (abi, bytecode, _) = contract.into_contract_bytecode().into_parts();
 
-    let factory = ContractFactory::new(abi.unwrap(), bytecode.unwrap(), Arc::clone(&client));
+    let factory = ContractFactory::new_compat(abi.unwrap(), bytecode.unwrap(), Arc::clone(&client));
     let contract = factory.deploy(()).unwrap().legacy().send().await;
     contract.unwrap_err();
 }
@@ -153,13 +156,13 @@ contract Contract {
     let client = Arc::new(http_client());
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().legacy().send().await.unwrap();
     let provider = SignerMiddleware::new(
         Provider::<Http>::try_from("http://127.0.0.1:8545").unwrap(),
         ganache_wallet2(),
     );
-    let contract = ContractInstance::new(contract.address(), abi.unwrap(), provider);
+    let contract = ContractInstance::new_compat(contract.address(), abi.unwrap(), provider);
     let resp = contract.method::<_, U256>("getSecret", ()).unwrap().legacy().call().await;
     resp.unwrap_err();
 

--- a/crates/anvil/tests/it/geth.rs
+++ b/crates/anvil/tests/it/geth.rs
@@ -1,6 +1,9 @@
 //! tests against local geth for local debug purposes
 
-use crate::abi::VENDING_MACHINE_CONTRACT;
+use crate::{
+    abi::VENDING_MACHINE_CONTRACT,
+    utils::{ContractInstanceCompat, DeploymentTxFactoryCompat},
+};
 use ethers::{
     abi::Address,
     contract::{Contract, ContractFactory},
@@ -9,7 +12,7 @@ use ethers::{
     types::U256,
     utils::WEI_IN_ETHER,
 };
-use ethers_solc::{project_util::TempProject, Artifact};
+use foundry_compilers::{project_util::TempProject, Artifact};
 use futures::StreamExt;
 use std::sync::Arc;
 use tokio::time::timeout;
@@ -52,7 +55,7 @@ async fn test_geth_revert_transaction() {
 
     // deploy successfully
     let factory =
-        ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), Arc::clone(&client));
+        ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), Arc::clone(&client));
 
     let mut tx = factory.deploy(()).unwrap().tx;
     tx.set_from(account);
@@ -60,7 +63,7 @@ async fn test_geth_revert_transaction() {
     let resp = client.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap();
 
     let contract =
-        Contract::<Provider<_>>::new(resp.contract_address.unwrap(), abi.unwrap(), client);
+        Contract::<Provider<_>>::new_compat(resp.contract_address.unwrap(), abi.unwrap(), client);
 
     let ten = WEI_IN_ETHER.saturating_mul(10u64.into());
     let call = contract.method::<_, ()>("buyRevert", ten).unwrap().value(ten).from(account);

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -1,7 +1,9 @@
 //! tests for otterscan endpoints
 use crate::{
     abi::MulticallContract,
-    utils::{ethers_http_provider, ethers_ws_provider},
+    utils::{
+        ethers_http_provider, ethers_ws_provider, ContractInstanceCompat, DeploymentTxFactoryCompat,
+    },
 };
 use alloy_primitives::U256 as rU256;
 use alloy_rpc_types::{BlockNumberOrTag, BlockTransactions};
@@ -19,8 +21,8 @@ use ethers::{
     types::{Bytes, TransactionRequest},
     utils::get_contract_address,
 };
-use ethers_solc::{project_util::TempProject, Artifact};
 use foundry_common::types::{ToAlloy, ToEthers};
+use foundry_compilers::{project_util::TempProject, Artifact};
 use std::{collections::VecDeque, str::FromStr, sync::Arc};
 
 #[tokio::test(flavor = "multi_thread")]
@@ -136,10 +138,10 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
-    let contract = ContractInstance::new(
+    let contract = ContractInstance::new_compat(
         contract.address(),
         abi.unwrap(),
         SignerMiddleware::new(ethers_http_provider(&handle.http_endpoint()), wallets[1].clone()),
@@ -194,10 +196,10 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
-    let contract = ContractInstance::new(
+    let contract = ContractInstance::new_compat(
         contract.address(),
         abi.unwrap(),
         SignerMiddleware::new(ethers_http_provider(&handle.http_endpoint()), wallets[1].clone()),
@@ -307,10 +309,10 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
-    let contract = ContractInstance::new(
+    let contract = ContractInstance::new_compat(
         contract.address(),
         abi.unwrap(),
         SignerMiddleware::new(ethers_http_provider(&handle.http_endpoint()), wallets[1].clone()),
@@ -397,7 +399,7 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallet));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
     let call = contract.method::<_, ()>("trigger_revert", ()).unwrap().gas(150_000u64);

--- a/crates/anvil/tests/it/revert.rs
+++ b/crates/anvil/tests/it/revert.rs
@@ -6,7 +6,7 @@ use ethers::{
     types::U256,
     utils::WEI_IN_ETHER,
 };
-use ethers_solc::{project_util::TempProject, Artifact};
+use foundry_compilers::{project_util::TempProject, Artifact};
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -1,6 +1,8 @@
 use crate::{
     fork::fork_config,
-    utils::{ethers_http_provider, ethers_ws_provider},
+    utils::{
+        ethers_http_provider, ethers_ws_provider, ContractInstanceCompat, DeploymentTxFactoryCompat,
+    },
 };
 use alloy_primitives::U256;
 use anvil::{spawn, Hardfork, NodeConfig};
@@ -13,8 +15,8 @@ use ethers::{
     types::{ActionType, Address, GethDebugTracingCallOptions, Trace},
     utils::hex,
 };
-use ethers_solc::{project_util::TempProject, Artifact};
 use foundry_common::types::{ToAlloy, ToEthers};
+use foundry_compilers::{project_util::TempProject, Artifact};
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -82,10 +84,10 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
-    let contract = ContractInstance::new(
+    let contract = ContractInstance::new_compat(
         contract.address(),
         abi.unwrap(),
         SignerMiddleware::new(ethers_http_provider(&handle.http_endpoint()), wallets[1].clone()),
@@ -132,10 +134,10 @@ contract Contract {
     let client = Arc::new(SignerMiddleware::new(provider, wallets[0].clone()));
 
     // deploy successfully
-    let factory = ContractFactory::new(abi.clone().unwrap(), bytecode.unwrap(), client);
+    let factory = ContractFactory::new_compat(abi.clone().unwrap(), bytecode.unwrap(), client);
     let contract = factory.deploy(()).unwrap().send().await.unwrap();
 
-    let contract = ContractInstance::new(
+    let contract = ContractInstance::new_compat(
         contract.address(),
         abi.unwrap(),
         SignerMiddleware::new(ethers_http_provider(&handle.http_endpoint()), wallets[1].clone()),

--- a/crates/anvil/tests/it/utils.rs
+++ b/crates/anvil/tests/it/utils.rs
@@ -1,8 +1,14 @@
+use alloy_json_abi::JsonAbi;
+use alloy_primitives::Bytes;
 use ethers::{
     addressbook::contract,
+    contract::ContractInstance,
+    middleware::Middleware,
+    prelude::DeploymentTxFactory,
     types::{Address, Chain},
 };
 use foundry_common::provider::ethers::{ProviderBuilder, RetryProvider};
+use std::borrow::Borrow;
 
 /// Returns a set of various contract addresses
 pub fn contract_addresses(chain: Chain) -> Vec<Address> {
@@ -28,4 +34,51 @@ pub fn ethers_ws_provider(ws_endpoint: &str) -> RetryProvider {
 /// Builds an ethers ws [RetryProvider]
 pub fn ethers_ipc_provider(ipc_endpoint: Option<String>) -> Option<RetryProvider> {
     ProviderBuilder::new(&ipc_endpoint?).build().ok()
+}
+
+/// Temporary helper trait for compatibility with ethers
+pub trait ContractInstanceCompat<B, M>
+where
+    B: Borrow<M>,
+    M: Middleware,
+{
+    fn new_compat(address: Address, abi: JsonAbi, client: B) -> Self;
+}
+
+impl<B, M> ContractInstanceCompat<B, M> for ContractInstance<B, M>
+where
+    B: Borrow<M>,
+    M: Middleware,
+{
+    fn new_compat(address: Address, abi: JsonAbi, client: B) -> Self {
+        let json = serde_json::to_string(&abi).unwrap();
+        ContractInstance::new(
+            address,
+            serde_json::from_str::<ethers::abi::Abi>(&json).unwrap(),
+            client,
+        )
+    }
+}
+
+pub trait DeploymentTxFactoryCompat<B, M>
+where
+    B: Borrow<M> + Clone,
+    M: Middleware,
+{
+    fn new_compat(abi: JsonAbi, bytecode: Bytes, client: B) -> Self;
+}
+
+impl<B, M> DeploymentTxFactoryCompat<B, M> for DeploymentTxFactory<B, M>
+where
+    B: Borrow<M> + Clone,
+    M: Middleware,
+{
+    fn new_compat(abi: JsonAbi, bytecode: Bytes, client: B) -> Self {
+        let json = serde_json::to_string(&abi).unwrap();
+        DeploymentTxFactory::new(
+            serde_json::from_str::<ethers::abi::Abi>(&json).unwrap(),
+            bytecode.as_ref().to_vec().into(),
+            client,
+        )
+    }
 }

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -96,7 +96,7 @@ globset = "0.4"
 paste = "1.0"
 path-slash = "0.2"
 pretty_assertions.workspace = true
-svm = { package = "svm-rs", version = "0.3", default-features = false, features = ["rustls"] }
+svm = { package = "svm-rs", version = "0.4", default-features = false, features = ["rustls"] }
 tempfile = "3"
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -11,7 +11,7 @@ use svm::Platform;
 /// 3. svm bumped in foundry-compilers
 /// 4. foundry-compilers update with any breaking changes
 /// 5. upgrade the `LATEST_SOLC`
-const LATEST_SOLC: Version = Version::new(0, 8, 24);
+const LATEST_SOLC: Version = Version::new(0, 8, 25);
 
 macro_rules! ensure_svm_releases {
     ($($test:ident => $platform:ident),* $(,)?) => {$(


### PR DESCRIPTION
closes #7405

becuase of breaking changes in svm, this replaces ethers-solc with foundry-compilers and adds some (temp) compat helpers until we fully migrate to alloy