### PR TITLE
chore: don't create a backend unnecessarily in ensure_success

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -18,7 +18,7 @@ use foundry_evm_fuzz::{
 };
 use foundry_evm_traces::CallTraceArena;
 use proptest::test_runner::{TestCaseError, TestError, TestRunner};
-use std::cell::RefCell;
+use std::{borrow::Cow, cell::RefCell};
 
 mod types;
 pub use types::{CaseOutcome, CounterExampleOutcome, FuzzOutcome};
@@ -208,19 +208,16 @@ impl FuzzedExecutor {
         should_fail: bool,
         calldata: alloy_primitives::Bytes,
     ) -> Result<FuzzOutcome, TestCaseError> {
-        let call = self
+        let mut call = self
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|_| TestCaseError::fail(FuzzError::FailedContractCall))?;
-        let state_changeset = call
-            .state_changeset
-            .as_ref()
-            .ok_or_else(|| TestCaseError::fail(FuzzError::EmptyChangeset))?;
+        let state_changeset = call.state_changeset.take().unwrap();
 
         // Build fuzzer state
         collect_state_from_call(
             &call.logs,
-            state_changeset,
+            &state_changeset,
             state.clone(),
             &self.config.dictionary,
         );
@@ -235,8 +232,12 @@ impl FuzzedExecutor {
             .as_ref()
             .map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
-        let success =
-            self.executor.is_raw_call_success(address, state_changeset.clone(), &call, should_fail);
+        let success = self.executor.is_raw_call_success(
+            address,
+            Cow::Owned(state_changeset),
+            &call,
+            should_fail,
+        );
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -13,7 +13,7 @@ use proptest::test_runner::TestError;
 use rand::{seq, thread_rng, Rng};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use revm::primitives::U256;
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 /// Stores information about failures and reverts of the invariant tests.
 #[derive(Clone, Default)]
@@ -244,7 +244,7 @@ impl FailedInvariantCaseData {
                     .expect("bad call to evm");
                 let is_success = executor.is_raw_call_success(
                     self.addr,
-                    call_result.state_changeset.take().unwrap(),
+                    Cow::Owned(call_result.state_changeset.take().unwrap()),
                     &call_result,
                     false,
                 );

--- a/crates/evm/evm/src/executors/invariant/funcs.rs
+++ b/crates/evm/evm/src/executors/invariant/funcs.rs
@@ -9,6 +9,7 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::invariant::{BasicTxDetails, InvariantContract};
 use foundry_evm_traces::{load_contracts, TraceKind, Traces};
 use revm::primitives::U256;
+use std::borrow::Cow;
 
 /// Given the executor state, asserts that no invariant has been broken. Otherwise, it fills the
 /// external `invariant_failures.failed_invariant` map and returns a generic error.
@@ -39,14 +40,12 @@ pub fn assert_invariants(
         )
         .expect("EVM error");
 
-    // This will panic and get caught by the executor
-    let is_err = call_result.reverted ||
-        !executor.is_raw_call_success(
-            invariant_contract.address,
-            call_result.state_changeset.take().expect("we should have a state changeset"),
-            &call_result,
-            false,
-        );
+    let is_err = !executor.is_raw_call_success(
+        invariant_contract.address,
+        Cow::Owned(call_result.state_changeset.take().unwrap()),
+        &call_result,
+        false,
+    );
     if is_err {
         // We only care about invariants which we haven't broken yet.
         if invariant_failures.error.is_none() {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -32,7 +32,7 @@ use revm::{
         SpecId, TransactTo, TxEnv,
     },
 };
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 mod builder;
 pub use builder::ExecutorBuilder;
@@ -197,7 +197,7 @@ impl Executor {
         match res.state_changeset.as_ref() {
             Some(changeset) => {
                 let success = self
-                    .ensure_success(to, res.reverted, changeset.clone(), false)
+                    .ensure_success(to, res.reverted, Cow::Borrowed(changeset), false)
                     .map_err(|err| EvmError::Eyre(eyre::eyre!(err.to_string())))?;
                 if success {
                     Ok(res)
@@ -472,7 +472,7 @@ impl Executor {
         &self,
         address: Address,
         reverted: bool,
-        state_changeset: StateChangeset,
+        state_changeset: Cow<'_, StateChangeset>,
         should_fail: bool,
     ) -> bool {
         self.ensure_success(address, reverted, state_changeset, should_fail).unwrap_or_default()
@@ -496,7 +496,7 @@ impl Executor {
     pub fn is_raw_call_success(
         &self,
         address: Address,
-        state_changeset: StateChangeset,
+        state_changeset: Cow<'_, StateChangeset>,
         call_result: &RawCallResult,
         should_fail: bool,
     ) -> bool {
@@ -511,7 +511,7 @@ impl Executor {
         &self,
         address: Address,
         reverted: bool,
-        state_changeset: StateChangeset,
+        state_changeset: Cow<'_, StateChangeset>,
         should_fail: bool,
     ) -> Result<bool, DatabaseError> {
         if self.backend.has_snapshot_failure() {
@@ -521,21 +521,21 @@ impl Executor {
 
         let mut success = !reverted;
         if success {
-            // Construct a new VM with the state changeset
+            // Construct a new bare-bones backend to evaluate success.
             let mut backend = self.backend.clone_empty();
 
-            // we only clone the test contract and cheatcode accounts, that's all we need to
-            // evaluate success
+            // We only clone the test contract and cheatcode accounts,
+            // that's all we need to evaluate success.
             for addr in [address, CHEATCODE_ADDRESS] {
                 let acc = self.backend.basic_ref(addr)?.unwrap_or_default();
                 backend.insert_account_info(addr, acc);
             }
 
-            // If this test failed any asserts, then this changeset will contain changes `false ->
-            // true` for the contract's `failed` variable and the `globalFailure` flag
-            // in the state of the cheatcode address which are both read when we call
-            // `"failed()(bool)"` in the next step
-            backend.commit(state_changeset);
+            // If this test failed any asserts, then this changeset will contain changes
+            // `false -> true` for the contract's `failed` variable and the `globalFailure` flag
+            // in the state of the cheatcode address,
+            // which are both read when we call `"failed()(bool)"` in the next step.
+            backend.commit(state_changeset.into_owned());
 
             // Check if a DSTest assertion failed
             let executor =

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -519,23 +519,24 @@ impl Executor {
             return Ok(should_fail)
         }
 
-        // Construct a new VM with the state changeset
-        let mut backend = self.backend.clone_empty();
-
-        // we only clone the test contract and cheatcode accounts, that's all we need to evaluate
-        // success
-        for addr in [address, CHEATCODE_ADDRESS] {
-            let acc = self.backend.basic_ref(addr)?.unwrap_or_default();
-            backend.insert_account_info(addr, acc);
-        }
-
-        // If this test failed any asserts, then this changeset will contain changes `false -> true`
-        // for the contract's `failed` variable and the `globalFailure` flag in the state of the
-        // cheatcode address which are both read when we call `"failed()(bool)"` in the next step
-        backend.commit(state_changeset);
-
         let mut success = !reverted;
         if success {
+            // Construct a new VM with the state changeset
+            let mut backend = self.backend.clone_empty();
+
+            // we only clone the test contract and cheatcode accounts, that's all we need to
+            // evaluate success
+            for addr in [address, CHEATCODE_ADDRESS] {
+                let acc = self.backend.basic_ref(addr)?.unwrap_or_default();
+                backend.insert_account_info(addr, acc);
+            }
+
+            // If this test failed any asserts, then this changeset will contain changes `false ->
+            // true` for the contract's `failed` variable and the `globalFailure` flag
+            // in the state of the cheatcode address which are both read when we call
+            // `"failed()(bool)"` in the next step
+            backend.commit(state_changeset);
+
             // Check if a DSTest assertion failed
             let executor =
                 Executor::new(backend, self.env.clone(), self.inspector.clone(), self.gas_limit);

--- a/crates/evm/fuzz/src/error.rs
+++ b/crates/evm/fuzz/src/error.rs
@@ -8,8 +8,6 @@ pub enum FuzzError {
     UnknownContract,
     #[error("Failed contract call")]
     FailedContractCall,
-    #[error("Empty state changeset")]
-    EmptyChangeset,
     #[error("`vm.assume` reject")]
     AssumeReject,
     #[error("The `vm.assume` cheatcode rejected too many inputs ({0} allowed)")]

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -28,6 +28,7 @@ use foundry_evm::{
 use proptest::test_runner::TestRunner;
 use rayon::prelude::*;
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashMap},
     time::Instant,
 };
@@ -415,7 +416,7 @@ impl<'a> ContractRunner<'a> {
         let success = executor.is_success(
             setup.address,
             reverted,
-            state_changeset.expect("we should have a state changeset"),
+            Cow::Owned(state_changeset.unwrap()),
             should_fail,
         );
 


### PR DESCRIPTION
This should be valid because db commit on a new empty db with no forks has no side effects