### PR TITLE
fix: allow fork related cli args without forkurl

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -118,13 +118,7 @@ pub struct EvmArgs {
     /// default value: 330
     ///
     /// See also --fork-url and https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
-    #[arg(
-        long,
-        requires = "fork_url",
-        alias = "cups",
-        value_name = "CUPS",
-        help_heading = "Fork config"
-    )]
+    #[arg(long, alias = "cups", value_name = "CUPS", help_heading = "Fork config")]
     pub compute_units_per_second: Option<u64>,
 
     /// Disables rate limiting for this node's provider.
@@ -132,7 +126,6 @@ pub struct EvmArgs {
     /// See also --fork-url and https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second
     #[arg(
         long,
-        requires = "fork_url",
         value_name = "NO_RATE_LIMITS",
         help_heading = "Fork config",
         visible_alias = "no-rate-limit"


### PR DESCRIPTION
we want to allow this because these settings can be used during cheatcode forking:


https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/src/evm/fork.rs#L361-L366