### PR TITLE
fix(fuzz): prevent int strategy to overflow when complicate

### DIFF
--- a/crates/evm/fuzz/src/strategies/int.rs
+++ b/crates/evm/fuzz/src/strategies/int.rs
@@ -67,7 +67,11 @@ impl ValueTree for IntValueTree {
             return false
         }
 
-        self.lo = self.curr + if self.hi.is_negative() { I256::MINUS_ONE } else { I256::ONE };
+        self.lo = if self.curr != I256::MIN && self.curr != I256::MAX {
+            self.curr + if self.hi.is_negative() { I256::MINUS_ONE } else { I256::ONE }
+        } else {
+            self.curr
+        };
 
         self.reposition()
     }
@@ -190,5 +194,27 @@ impl Strategy for IntStrategy {
             x if x < self.edge_weight + self.fixtures_weight => self.generate_fixtures_tree(runner),
             _ => self.generate_random_tree(runner),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::strategies::int::IntValueTree;
+    use alloy_primitives::I256;
+    use proptest::strategy::ValueTree;
+
+    #[test]
+    fn test_int_tree_complicate_should_not_overflow() {
+        let mut int_tree = IntValueTree::new(I256::MAX, false);
+        assert_eq!(int_tree.hi, I256::MAX);
+        assert_eq!(int_tree.curr, I256::MAX);
+        int_tree.complicate();
+        assert_eq!(int_tree.lo, I256::MAX);
+
+        let mut int_tree = IntValueTree::new(I256::MIN, false);
+        assert_eq!(int_tree.hi, I256::MIN);
+        assert_eq!(int_tree.curr, I256::MIN);
+        int_tree.complicate();
+        assert_eq!(int_tree.lo, I256::MIN);
     }
 }

--- a/crates/evm/fuzz/src/strategies/uint.rs
+++ b/crates/evm/fuzz/src/strategies/uint.rs
@@ -167,3 +167,19 @@ impl Strategy for UintStrategy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::strategies::uint::UintValueTree;
+    use alloy_primitives::U256;
+    use proptest::strategy::ValueTree;
+
+    #[test]
+    fn test_uint_tree_complicate_max() {
+        let mut uint_tree = UintValueTree::new(U256::MAX, false);
+        assert_eq!(uint_tree.hi, U256::MAX);
+        assert_eq!(uint_tree.curr, U256::MAX);
+        uint_tree.complicate();
+        assert_eq!(uint_tree.lo, U256::MIN);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
 int strategy complicate can overflow
```
The application panicked (crashed).
Message:  overflow
Location: crates/evm/fuzz/src/strategies/int.rs:71

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: <foundry_evm_fuzz::strategies::int::IntValueTree as proptest::strategy::traits::ValueTree>::complicate::h8a9032e00b3a6ca5
      at <unknown source file>:<unknown line>
   9: <proptest::strategy::unions::TupleUnionValueTree<(proptest::strategy::lazy::LazyValueTree<A>,core::option::Option<proptest::strategy::lazy::LazyValueTree<B>>)> as proptest::strategy::traits::ValueTree>::complicate::hdc78563564ff1e33
      at <unknown source file>:<unknown line>
  10: proptest::test_runner::runner::TestRunner::shrink::h189a0410aaa9c28a
      at <unknown source file>:<unknown line>
  11: proptest::test_runner::runner::TestRunner::run_one_with_replay::hcf865adda789fe4a
      at <unknown source file>:<unknown line>
  12: proptest::test_runner::runner::TestRunner::run_in_process_with_replay::he634a8132578406c
      at <unknown source file>:<unknown line>
  13: foundry_evm::executors::fuzz::FuzzedExecutor::fuzz::hf3b9de2094877486
  
  
  
self.curr: -57896044618658097711785492504343953926634992332820282019728792003956564819968, self.hi:-57896044618658097711785492504343953926634992332820282019728792003956564819968
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
 ensure complicate lo is set to curr value if min or max