### PR TITLE
perf: use `jemalloc` as the global allocator on unix (try 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,10 @@ jobs:
                 target="${{ matrix.target }}"
                 flags=()
 
-                # `keccak-asm` does not support MSVC or aarch64 Linux.
-                [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]] && flags+=(--features=asm-keccak)
+                # `jemalloc` and `keccak-asm` are not supported on MSVC or aarch64 Linux.
+                if [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]]; then
+                  flags+=(--features asm-keccak,jemalloc)
+                fi
 
                 [[ "$target" == *windows* ]] && exe=".exe"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "serde_repr",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tracing",
@@ -1338,6 +1339,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "vergen",
@@ -1402,6 +1404,7 @@ dependencies = [
  "serial_test",
  "solang-parser",
  "strum 0.26.2",
+ "tikv-jemallocator",
  "time",
  "tokio",
  "tracing",
@@ -3006,6 +3009,7 @@ dependencies = [
  "svm-rs 0.4.0",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tower-http",
  "tracing",
@@ -7622,6 +7626,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ ruint.opt-level = 3
 sha2.opt-level = 3
 sha3.opt-level = 3
 tiny-keccak.opt-level = 3
+bitvec.opt-level = 3
 
 # fuzzing
 proptest.opt-level = 3
@@ -208,6 +209,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 vergen = { version = "8", default-features = false }
 indexmap = "2.2"
+tikv-jemallocator = "0.5.4"
 
 axum = "0.6"
 hyper = "0.14"

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -16,11 +16,7 @@ path = "src/anvil.rs"
 required-features = ["cli"]
 
 [build-dependencies]
-vergen = { workspace = true, default-features = false, features = [
-    "build",
-    "git",
-    "gitcl",
-] }
+vergen = { workspace = true, default-features = false, features = ["build", "git", "gitcl"] }
 
 [dependencies]
 # foundry internal
@@ -81,11 +77,7 @@ rand = "0.8"
 eyre.workspace = true
 
 # cli
-clap = { version = "4", features = [
-    "derive",
-    "env",
-    "wrap_help",
-], optional = true }
+clap = { version = "4", features = ["derive", "env", "wrap_help"], optional = true }
 clap_complete = { version = "4", optional = true }
 chrono.workspace = true
 auto_impl = "1"
@@ -93,6 +85,9 @@ ctrlc = { version = "3", optional = true }
 fdlimit = { version = "0.3", optional = true }
 clap_complete_fig = "4"
 ethereum-forkid = "0.12"
+
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-json-abi.workspace = true
@@ -109,3 +104,6 @@ default = ["cli"]
 cmd = ["clap", "clap_complete", "ctrlc", "anvil-server/clap"]
 cli = ["tokio/full", "cmd", "fdlimit"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+# TODO: parity dependencies are not compatible with a different global allocator.
+# jemalloc = ["dep:tikv-jemallocator"]
+jemalloc = []

--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -4,6 +4,12 @@ use anvil::cmd::NodeArgs;
 use clap::{CommandFactory, Parser, Subcommand};
 use foundry_cli::utils;
 
+// TODO: parity dependencies are not compatible with a different global allocator.
+#[cfg(any())]
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// A fast local Ethereum development node.
 #[derive(Parser)]
 #[command(name = "anvil", version = anvil::VERSION_MESSAGE, next_display_order = None)]

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -75,6 +75,9 @@ tracing.workspace = true
 yansi = "0.5"
 evmole = "0.3.1"
 
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+
 [dev-dependencies]
 foundry-test-utils.workspace = true
 async-trait = "0.1"
@@ -85,6 +88,7 @@ default = ["rustls"]
 rustls = ["foundry-cli/rustls", "foundry-wallets/rustls"]
 openssl = ["foundry-cli/openssl", "foundry-wallets/openssl"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[bench]]
 name = "vanity"

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -30,6 +30,10 @@ pub mod tx;
 
 use opts::{Cast as Opts, CastSubcommand, ToBaseArgs};
 
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     handler::install();

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -50,6 +50,9 @@ tokio = { version = "1", features = ["full"] }
 yansi = "0.5"
 tracing.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }
 once_cell = "1"
@@ -61,6 +64,7 @@ default = ["rustls"]
 rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
 openssl = ["foundry-compilers/openssl", "reqwest/default-tls"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[bench]]
 name = "session_source"

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -27,6 +27,10 @@ use std::path::PathBuf;
 use tracing::debug;
 use yansi::Paint;
 
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(Chisel, opts, evm_opts);
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -87,6 +87,9 @@ hyper.workspace = true
 tower-http = { workspace = true, features = ["fs"] }
 opener = "0.6"
 
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+
 [dev-dependencies]
 anvil.workspace = true
 foundry-test-utils.workspace = true
@@ -110,6 +113,7 @@ rustls = [
 ]
 openssl = ["foundry-cli/openssl", "reqwest/default-tls", "foundry-wallets/openssl"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[bench]]
 name = "test"

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -7,10 +7,14 @@ use eyre::Result;
 use foundry_cli::{handler, utils};
 
 mod cmd;
-mod opts;
-
 use cmd::{cache::CacheSubcommands, generate::GenerateSubcommands, watch};
+
+mod opts;
 use opts::{Forge, ForgeSubcommand};
+
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() -> Result<()> {
     handler::install();


### PR DESCRIPTION
We should be able to enable this on unix and x64. Cannot enable on:
- anvil: parity dependencies have something cursed going on that depend on the global allocator being the system one, otherwise it segfaults
  - https://github.com/foundry-rs/foundry/issues/5754
  - https://github.com/foundry-rs/foundry/issues/5756
- linux arm: incompatible page sizes, macos arm should be fine
  - https://github.com/foundry-rs/foundry/issues/5832