### PR TITLE
use correct deserializer for `ots_getBlockDetails`

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -676,7 +676,7 @@ pub enum EthRequest {
     OtsGetBlockDetails(
         #[cfg_attr(
             feature = "serde",
-            serde(deserialize_with = "lenient_block_number::lenient_block_number", default)
+            serde(deserialize_with = "lenient_block_number::lenient_block_number_seq", default)
         )]
         BlockNumber,
     ),


### PR DESCRIPTION

## Motivation

fixes: https://github.com/foundry-rs/foundry/issues/7433

## Solution

* block_number in ots_getBlockDetails is a list so appropriate deserializer would be `lenient_block_number_seq`.