### PR TITLE
feat: `vm.sign` for scripts

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -2941,7 +2941,7 @@
     {
       "func": {
         "id": "broadcast_0",
-        "description": "Using the address that calls the test contract, has the next call (at this call depth only)\ncreate a transaction that can later be signed and sent onchain.",
+        "description": "Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
         "declaration": "function broadcast() external;",
         "visibility": "external",
         "mutability": "",
@@ -7041,6 +7041,46 @@
     {
       "func": {
         "id": "sign_1",
+        "description": "Signs `digest` with signer provided to script using the secp256k1 curve.\nIf `--sender` is provided, the signer with provided address is used, otherwise,\nif exactly one signer is provided to the script, that signer is used.\nRaises error if signer passed through `--sender` does not match any unlocked signers or\nif `--sender` is not provided and not exactly one signer is passed to the script.",
+        "declaration": "function sign(bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "sign(bytes32)",
+        "selector": "0x799cd333",
+        "selectorBytes": [
+          121,
+          156,
+          211,
+          51
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "sign_2",
+        "description": "Signs `digest` with signer provided to script using the secp256k1 curve.\nRaises error if none of the signers passed into the script have provided address.",
+        "declaration": "function sign(address signer, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "sign(address,bytes32)",
+        "selector": "0x8c1aa205",
+        "selectorBytes": [
+          140,
+          26,
+          162,
+          5
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "sign_3",
         "description": "Signs data with a `Wallet`.",
         "declaration": "function sign(Wallet calldata wallet, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);",
         "visibility": "external",
@@ -7141,7 +7181,7 @@
     {
       "func": {
         "id": "startBroadcast_0",
-        "description": "Using the address that calls the test contract, has all subsequent calls\n(at this call depth only) create transactions that can later be signed and sent onchain.",
+        "description": "Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.\nBroadcasting address is determined by checking the following in order:\n1. If `--sender` argument was provided, that address is used.\n2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.\n3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.",
         "declaration": "function startBroadcast() external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -249,6 +249,22 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Safe)]
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
 
+    /// Signs `digest` with signer provided to script using the secp256k1 curve.
+    ///
+    /// If `--sender` is provided, the signer with provided address is used, otherwise,
+    /// if exactly one signer is provided to the script, that signer is used.
+    ///
+    /// Raises error if signer passed through `--sender` does not match any unlocked signers or
+    /// if `--sender` is not provided and not exactly one signer is passed to the script.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function sign(bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+
+    /// Signs `digest` with signer provided to script using the secp256k1 curve.
+    ///
+    /// Raises error if none of the signers passed into the script have provided address.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function sign(address signer, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+
     /// Signs `digest` with `privateKey` using the secp256r1 curve.
     #[cheatcode(group = Evm, safety = Safe)]
     function signP256(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 s);
@@ -1553,8 +1569,12 @@ interface Vm {
 
     // -------- Broadcasting Transactions --------
 
-    /// Using the address that calls the test contract, has the next call (at this call depth only)
-    /// create a transaction that can later be signed and sent onchain.
+    /// Has the next call (at this call depth only) create transactions that can later be signed and sent onchain.
+    ///
+    /// Broadcasting address is determined by checking the following in order:
+    /// 1. If `--sender` argument was provided, that address is used.
+    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
+    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
     #[cheatcode(group = Scripting)]
     function broadcast() external;
 
@@ -1568,8 +1588,12 @@ interface Vm {
     #[cheatcode(group = Scripting)]
     function broadcast(uint256 privateKey) external;
 
-    /// Using the address that calls the test contract, has all subsequent calls
-    /// (at this call depth only) create transactions that can later be signed and sent onchain.
+    /// Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain.
+    ///
+    /// Broadcasting address is determined by checking the following in order:
+    /// 1. If `--sender` argument was provided, that address is used.
+    /// 2. If exactly one signer (e.g. private key, hw wallet, keystore) is set when `forge broadcast` is invoked, that signer is used.
+    /// 3. Otherwise, default foundry sender (1804c8AB1F12E6bbf3894d4083f33e07309d1f38) is used.
     #[cheatcode(group = Scripting)]
     function startBroadcast() external;
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -145,6 +145,20 @@ impl Cheatcode for sign_0Call {
     }
 }
 
+impl Cheatcode for sign_1Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { digest } = self;
+        super::utils::sign_with_wallet(ccx, None, digest)
+    }
+}
+
+impl Cheatcode for sign_2Call {
+    fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { signer, digest } = self;
+        super::utils::sign_with_wallet(ccx, Some(*signer), digest)
+    }
+}
+
 impl Cheatcode for signP256Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { privateKey, digest } = self;

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -198,7 +198,7 @@ pub(super) fn sign_with_wallet<DB: DatabaseExt>(
             .ok_or_else(|| fmt_err!("signer with address {signer} is not available"))?;
 
         let sig = RuntimeOrHandle::new()
-            .block_on(wallet.sign_hash(&digest))
+            .block_on(wallet.sign_hash(digest))
             .map_err(|err| fmt_err!("{err}"))?;
 
         let recovered = sig.recover(digest.to_ethers()).map_err(|err| fmt_err!("{err}"))?;

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1157,3 +1157,25 @@ contract ScriptC {}
     tester.cmd.forge_fuse().args(["script", "script/B.sol"]);
     tester.simulate(ScriptOutcome::OkNoEndpoint);
 });
+
+forgetest_async!(can_sign_with_script_wallet_single, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    tester
+        .add_sig("ScriptSign", "run()")
+        .load_private_keys(&[0])
+        .await
+        .simulate(ScriptOutcome::OkNoEndpoint);
+});
+
+forgetest_async!(can_sign_with_script_wallet_multiple, |prj, cmd| {
+    let mut tester = ScriptTester::new_broadcast_without_endpoint(cmd, prj.root());
+    let acc = tester.accounts_pub[0].to_checksum(None);
+    tester
+        .add_sig("ScriptSign", "run(address)")
+        .arg(&acc)
+        .load_private_keys(&[0, 1, 2])
+        .await
+        .simulate(ScriptOutcome::OkRun);
+});

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -264,6 +264,7 @@ pub enum ScriptOutcome {
     ScriptFailed,
     UnsupportedLibraries,
     ErrorSelectForkOnBroadcast,
+    OkRun,
 }
 
 impl ScriptOutcome {
@@ -279,6 +280,7 @@ impl ScriptOutcome {
             Self::ScriptFailed => "script failed: ",
             Self::UnsupportedLibraries => "Multi chain deployment does not support library linking at the moment.",
             Self::ErrorSelectForkOnBroadcast => "cannot select forks during a broadcast",
+            Self::OkRun => "Script ran successfully",
         }
     }
 
@@ -287,7 +289,8 @@ impl ScriptOutcome {
             ScriptOutcome::OkNoEndpoint |
             ScriptOutcome::OkSimulation |
             ScriptOutcome::OkBroadcast |
-            ScriptOutcome::WarnSpecifyDeployer => false,
+            ScriptOutcome::WarnSpecifyDeployer |
+            ScriptOutcome::OkRun => false,
             ScriptOutcome::MissingSender |
             ScriptOutcome::MissingWallet |
             ScriptOutcome::StaticCallNotAllowed |

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -349,6 +349,8 @@ interface Vm {
     function setNonceUnsafe(address account, uint64 newNonce) external;
     function signP256(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 s);
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+    function sign(bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+    function sign(address signer, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function sign(Wallet calldata wallet, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
     function skip(bool skipTest) external;
     function sleep(uint256 duration) external;

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -549,6 +549,11 @@ contract ScriptSign is DSTest {
         vm.startBroadcast();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(digest);
 
+        vm._expectCheatcodeRevert(
+            bytes(string.concat("signer with address ", vm.toString(address(this)), " is not available"))
+        );
+        vm.sign(address(this), digest);
+
         SignatureTester tester = new SignatureTester();
         (, address caller,) = vm.readCallers();
         assertEq(tester.owner(), caller);
@@ -556,6 +561,9 @@ contract ScriptSign is DSTest {
     }
 
     function run(address sender) external {
+        vm._expectCheatcodeRevert(bytes("could not determine signer"));
+        vm.sign(digest);
+
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(sender, digest);
         address actual = ecrecover(digest, v, r, s);
 

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -528,3 +528,37 @@ contract ScriptAdditionalContracts is DSTest {
         new Parent();
     }
 }
+
+contract SignatureTester {
+    address public immutable owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function verifySignature(bytes32 digest, uint8 v, bytes32 r, bytes32 s) public view returns (bool) {
+        require(ecrecover(digest, v, r, s) == owner, "Invalid signature");
+    }
+}
+
+contract ScriptSign is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    bytes32 digest = keccak256("something");
+
+    function run() external {
+        vm.startBroadcast();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(digest);
+
+        SignatureTester tester = new SignatureTester();
+        (, address caller,) = vm.readCallers();
+        assertEq(tester.owner(), caller);
+        tester.verifySignature(digest, v, r, s);
+    }
+
+    function run(address sender) external {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(sender, digest);
+        address actual = ecrecover(digest, v, r, s);
+
+        assertEq(actual, sender);
+    }
+}


### PR DESCRIPTION
## Motivation

Closes #7446

## Solution

Adds `vm.sign(bytes32 digest)` determining signer in a similar way `vm.broadcast()` and `vm.startBroadcast()` do.
Adds `vm.sign(address signer, bytes32 digest)` similar to `vm.broadcast(address)`

Also added more docs to explain the way we choose signer for `vm.broadcast()` and it seems pretty complicated tbh. Afaik we still don't even have a reliable way to fetch signer address besides `vm.broadcast()` -> `vm.readCallers()`, perhaps we should reconsider and document that?

Also those cheatcodes are not compatible with tests right now. We can probably allow that by running tests with empty `ScriptWallets`. That way tests will be able to inject private keys via `vm.rememberKey`