### PR TITLE
Fix: anonymous events without topics are not handled

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -434,9 +434,14 @@ pub(crate) fn handle_expect_emit(state: &mut Cheatcodes, log: &alloy_primitives:
     let expected_topic_0 = expected.topics().first();
     let log_topic_0 = log.topics().first();
 
+    // If the event is marked as anonymous, we don't expect topic 0 to be generated.
+    // We will still match the rest of the topics and data.
+    let is_anonymous_event = expected_topic_0.is_none() && log_topic_0.is_none();
+
     if expected_topic_0
         .zip(log_topic_0)
-        .map_or(false, |(a, b)| a == b && expected.topics().len() == log.topics().len())
+        .map_or(false, |(a, b)| a == b && expected.topics().len() == log.topics().len()) ||
+        is_anonymous_event
     {
         // Match topics
         event_to_fill_or_check.found = log

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -437,11 +437,11 @@ pub(crate) fn handle_expect_emit(state: &mut Cheatcodes, log: &alloy_primitives:
     if expected_topic_0
         .zip(log_topic_0)
         .map_or(false, |(a, b)| a == b && expected.topics().len() == log.topics().len()) ||
-        // If the event is anonymous and has no topics we will still attempt to match the source
-        // address and data if requested.
+        // Anonymous events are a special case where topic 0 is not generated.
+        // If the anonymous event has no other topics we will still attempt to match the source address and data if requested.
         (expected_topic_0.is_none() && log_topic_0.is_none())
     {
-        // Match topics
+        // Match topics, in case no topics are present true is returned.
         event_to_fill_or_check.found = log
             .topics()
             .iter()
@@ -450,12 +450,12 @@ pub(crate) fn handle_expect_emit(state: &mut Cheatcodes, log: &alloy_primitives:
             .filter(|(i, _)| event_to_fill_or_check.checks[*i])
             .all(|(i, topic)| topic == &expected.topics()[i + 1]);
 
-        // Maybe match source address
+        // Maybe match source address.
         if let Some(addr) = event_to_fill_or_check.address {
             event_to_fill_or_check.found &= addr == log.address;
         }
 
-        // Maybe match data
+        // Maybe match data.
         if event_to_fill_or_check.checks[3] {
             event_to_fill_or_check.found &= expected.data.as_ref() == log.data.data.as_ref();
         }

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -434,14 +434,12 @@ pub(crate) fn handle_expect_emit(state: &mut Cheatcodes, log: &alloy_primitives:
     let expected_topic_0 = expected.topics().first();
     let log_topic_0 = log.topics().first();
 
-    // If the event is marked as anonymous, we don't expect topic 0 to be generated.
-    // We will still match the rest of the topics and data.
-    let is_anonymous_event = expected_topic_0.is_none() && log_topic_0.is_none();
-
     if expected_topic_0
         .zip(log_topic_0)
         .map_or(false, |(a, b)| a == b && expected.topics().len() == log.topics().len()) ||
-        is_anonymous_event
+        // If the event is anonymous and has no topics we will still attempt to match the source
+        // address and data if requested.
+        (expected_topic_0.is_none() && log_topic_0.is_none())
     {
         // Match topics
         event_to_fill_or_check.found = log

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -434,13 +434,15 @@ pub(crate) fn handle_expect_emit(state: &mut Cheatcodes, log: &alloy_primitives:
     let expected_topic_0 = expected.topics().first();
     let log_topic_0 = log.topics().first();
 
-    if expected_topic_0
-        .zip(log_topic_0)
-        .map_or(false, |(a, b)| a == b && expected.topics().len() == log.topics().len()) ||
+    if expected_topic_0.zip(log_topic_0).map_or(
         // Anonymous events are a special case where topic 0 is not generated.
-        // If the anonymous event has no other topics we will still attempt to match the source address and data if requested.
-        (expected_topic_0.is_none() && log_topic_0.is_none())
-    {
+        // If the anonymous event has no other topics we will still attempt to match the source
+        // address and data if requested.
+        expected_topic_0.is_none() && log_topic_0.is_none(),
+        // If the topics match and the length of the topic list is the same, we can proceed to
+        // check.
+        |(a, b)| a == b && expected.topics().len() == log.topics().len(),
+    ) {
         // Match topics, in case no topics are present true is returned.
         event_to_fill_or_check.found = log
             .topics()

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -328,3 +328,6 @@ test_repro!(6634; |config| {
   cheats_config.always_use_create_2_factory = true;
   config.runner.cheats_config = std::sync::Arc::new(cheats_config);
 });
+
+// https://github.com/foundry-rs/foundry/issues/7457
+test_repro!(7457);

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -5,65 +5,40 @@ import "ds-test/test.sol";
 import "cheats/Vm.sol";
 
 interface ITarget {
-    event Event0Empty();
-    event Event0WithData(uint256 a);
+    event AnonymousEventEmpty() anonymous;
+    event AnonymousEventWithData(uint256 a) anonymous;
 
-    event Event1(uint256 indexed a);
-    event Event2(uint256 indexed a, uint256 indexed b);
-    event Event3(uint256 indexed a, uint256 indexed b, uint256 indexed c);
-
-    event AnonymousEvent0Empty() anonymous;
-    event AnonymousEvent0WithData(uint256 a) anonymous;
-
-    event AnonymousEvent1(uint256 indexed a) anonymous;
-    event AnonymousEvent2(uint256 indexed a, uint256 indexed b) anonymous;
-    event AnonymousEvent3(uint256 indexed a, uint256 indexed b, uint256 indexed c) anonymous;
-    event AnonymousEvent4(uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 indexed d) anonymous;
+    event AnonymousEventWith1Topic(uint256 indexed a, uint256 b) anonymous;
+    event AnonymousEventWith2Topics(uint256 indexed a, uint256 indexed b, uint256 c) anonymous;
+    event AnonymousEventWith3Topics(uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 d) anonymous;
+    event AnonymousEventWith4Topics(
+        uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 indexed d, uint256 e
+    ) anonymous;
 }
 
 contract Target is ITarget {
-    function emitEvent0Empty() external {
-        emit Event0Empty();
+    function emitAnonymousEventEmpty() external {
+        emit AnonymousEventEmpty();
     }
 
-    function emitEvent0WithData(uint256 a) external {
-        emit Event0WithData(a);
+    function emitAnonymousEventWithData(uint256 a) external {
+        emit AnonymousEventWithData(a);
     }
 
-    function emitEvent1(uint256 a) external {
-        emit Event1(a);
+    function emitAnonymousEventWith1Topic(uint256 a, uint256 b) external {
+        emit AnonymousEventWith1Topic(a, b);
     }
 
-    function emitEvent2(uint256 a, uint256 b) external {
-        emit Event2(a, b);
+    function emitAnonymousEventWith2Topics(uint256 a, uint256 b, uint256 c) external {
+        emit AnonymousEventWith2Topics(a, b, c);
     }
 
-    function emitEvent3(uint256 a, uint256 b, uint256 c) external {
-        emit Event3(a, b, c);
+    function emitAnonymousEventWith3Topics(uint256 a, uint256 b, uint256 c, uint256 d) external {
+        emit AnonymousEventWith3Topics(a, b, c, d);
     }
 
-    function emitAnonymousEvent0Empty() external {
-        emit AnonymousEvent0Empty();
-    }
-
-    function emitAnonymousEvent0WithData(uint256 a) external {
-        emit AnonymousEvent0WithData(a);
-    }
-
-    function emitAnonymousEvent1(uint256 a) external {
-        emit AnonymousEvent1(a);
-    }
-
-    function emitAnonymousEvent2(uint256 a, uint256 b) external {
-        emit AnonymousEvent2(a, b);
-    }
-
-    function emitAnonymousEvent3(uint256 a, uint256 b, uint256 c) external {
-        emit AnonymousEvent3(a, b, c);
-    }
-
-    function emitAnonymousEvent4(uint256 a, uint256 b, uint256 c, uint256 d) external {
-        emit AnonymousEvent4(a, b, c, d);
+    function emitAnonymousEventWith4Topics(uint256 a, uint256 b, uint256 c, uint256 d, uint256 e) external {
+        emit AnonymousEventWith4Topics(a, b, c, d, e);
     }
 }
 
@@ -77,57 +52,39 @@ contract Issue7457Test is DSTest, ITarget {
         target = new Target();
     }
 
-    function testEmitEvent0() public {
+    function testEmitEvent() public {
         vm.expectEmit(false, false, false, true);
-        emit Event0Empty();
-        target.emitEvent0Empty();
-
-        vm.expectEmit(false, false, false, true);
-        emit AnonymousEvent0Empty();
-        target.emitAnonymousEvent0Empty();
-
-        vm.expectEmit(false, false, false, true);
-        emit Event0WithData(1);
-        target.emitEvent0WithData(1);
-
-        vm.expectEmit(false, false, false, true);
-        emit AnonymousEvent0WithData(1);
-        target.emitAnonymousEvent0WithData(1);
+        emit AnonymousEventEmpty();
+        target.emitAnonymousEventEmpty();
     }
 
-    function testEmitEvent1() public {
+    function testEmitEventWithData() public {
+        vm.expectEmit(false, false, false, true);
+        emit AnonymousEventWithData(1);
+        target.emitAnonymousEventWithData(1);
+    }
+
+    function testEmitEventWith1Topic() public {
         vm.expectEmit(true, false, false, true);
-        emit Event1(1);
-        target.emitEvent1(1);
-
-        vm.expectEmit(true, false, false, true);
-        emit AnonymousEvent1(1);
-        target.emitAnonymousEvent1(1);
+        emit AnonymousEventWith1Topic(1, 2);
+        target.emitAnonymousEventWith1Topic(1, 2);
     }
 
-    function testEmitEvent2() public {
+    function testEmitEventWith2Topics() public {
         vm.expectEmit(true, true, false, true);
-        emit Event2(1, 2);
-        target.emitEvent2(1, 2);
-
-        vm.expectEmit(true, true, false, true);
-        emit AnonymousEvent2(1, 2);
-        target.emitAnonymousEvent2(1, 2);
+        emit AnonymousEventWith2Topics(1, 2, 3);
+        target.emitAnonymousEventWith2Topics(1, 2, 3);
     }
 
-    function testEmitEvent3() public {
+    function testEmitEventWith3Topics() public {
         vm.expectEmit(true, true, true, true);
-        emit Event3(1, 2, 3);
-        target.emitEvent3(1, 2, 3);
-
-        vm.expectEmit(true, true, true, true);
-        emit AnonymousEvent3(1, 2, 3);
-        target.emitAnonymousEvent3(1, 2, 3);
+        emit AnonymousEventWith3Topics(1, 2, 3, 4);
+        target.emitAnonymousEventWith3Topics(1, 2, 3, 4);
     }
 
-    function testEmitEvent4() public {
+    function testEmitEventWith4Topics() public {
         vm.expectEmit(true, true, true, true);
-        emit AnonymousEvent4(1, 2, 3, 4);
-        target.emitAnonymousEvent4(1, 2, 3, 4);
+        emit AnonymousEventWith4Topics(1, 2, 3, 4, 5);
+        target.emitAnonymousEventWith4Topics(1, 2, 3, 4, 5);
     }
 }

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+interface ITarget {
+    event Foo(address emitter) anonymous;
+}
+
+contract Target is ITarget {
+    function doEmit() external {
+        emit Foo(address(this));
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/7457
+contract Issue7457Test is DSTest, ITarget {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Target public target;
+
+    function setUp() external {
+        target = new Target();
+    }
+
+    function testEmit0() external {
+        vm.expectEmit(address(target));
+        emit Foo(address(target));
+        target.doEmit();
+    }
+
+    function testEmit1() external {
+        vm.expectEmit(true, true, true, true, address(target));
+        emit Foo(address(target));
+        target.doEmit();
+    }
+
+    function testEmit2() external {
+        vm.expectEmit(true, true, true, true);
+        emit Foo(address(target));
+        target.doEmit();
+    }
+
+    function testEmit3() external {
+        vm.expectEmit(false, false, false, true);
+        emit Foo(address(target));
+        target.doEmit();
+    }
+}

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -6,7 +6,10 @@ import "cheats/Vm.sol";
 
 interface ITarget {
     event AnonymousEventEmpty() anonymous;
-    event AnonymousEventWithData(uint256 a) anonymous;
+    event AnonymousEventNonIndexed(uint256 a) anonymous;
+
+    event DifferentAnonymousEventEmpty() anonymous;
+    event DifferentAnonymousEventNonIndexed(string a) anonymous;
 
     event AnonymousEventWith1Topic(uint256 indexed a, uint256 b) anonymous;
     event AnonymousEventWith2Topics(uint256 indexed a, uint256 indexed b, uint256 c) anonymous;
@@ -21,8 +24,8 @@ contract Target is ITarget {
         emit AnonymousEventEmpty();
     }
 
-    function emitAnonymousEventWithData(uint256 a) external {
-        emit AnonymousEventWithData(a);
+    function emitAnonymousEventNonIndexed(uint256 a) external {
+        emit AnonymousEventNonIndexed(a);
     }
 
     function emitAnonymousEventWith1Topic(uint256 a, uint256 b) external {
@@ -58,10 +61,22 @@ contract Issue7457Test is DSTest, ITarget {
         target.emitAnonymousEventEmpty();
     }
 
-    function testEmitEventWithData() public {
+    function testEmitEventNonIndexed() public {
         vm.expectEmit(false, false, false, true);
-        emit AnonymousEventWithData(1);
-        target.emitAnonymousEventWithData(1);
+        emit AnonymousEventNonIndexed(1);
+        target.emitAnonymousEventNonIndexed(1);
+    }
+
+    // function testFailEmitDifferentEvent() public {
+    //     vm.expectEmit(false, false, false, true);
+    //     emit DifferentAnonymousEventEmpty();
+    //     target.emitAnonymousEventEmpty();
+    // }
+
+    function testFailEmitDifferentEventNonIndexed() public {
+        vm.expectEmit(false, false, false, true);
+        emit DifferentAnonymousEventNonIndexed("1");
+        target.emitAnonymousEventNonIndexed(1);
     }
 
     function testEmitEventWith1Topic() public {

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -5,12 +5,65 @@ import "ds-test/test.sol";
 import "cheats/Vm.sol";
 
 interface ITarget {
-    event Foo(address emitter) anonymous;
+    event Event0Empty();
+    event Event0WithData(uint256 a);
+
+    event Event1(uint256 indexed a);
+    event Event2(uint256 indexed a, uint256 indexed b);
+    event Event3(uint256 indexed a, uint256 indexed b, uint256 indexed c);
+
+    event AnonymousEvent0Empty() anonymous;
+    event AnonymousEvent0WithData(uint256 a) anonymous;
+
+    event AnonymousEvent1(uint256 indexed a) anonymous;
+    event AnonymousEvent2(uint256 indexed a, uint256 indexed b) anonymous;
+    event AnonymousEvent3(uint256 indexed a, uint256 indexed b, uint256 indexed c) anonymous;
+    event AnonymousEvent4(uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 indexed d) anonymous;
 }
 
 contract Target is ITarget {
-    function doEmit() external {
-        emit Foo(address(this));
+    function emitEvent0Empty() external {
+        emit Event0Empty();
+    }
+
+    function emitEvent0WithData(uint256 a) external {
+        emit Event0WithData(a);
+    }
+
+    function emitEvent1(uint256 a) external {
+        emit Event1(a);
+    }
+
+    function emitEvent2(uint256 a, uint256 b) external {
+        emit Event2(a, b);
+    }
+
+    function emitEvent3(uint256 a, uint256 b, uint256 c) external {
+        emit Event3(a, b, c);
+    }
+
+    function emitAnonymousEvent0Empty() external {
+        emit AnonymousEvent0Empty();
+    }
+
+    function emitAnonymousEvent0WithData(uint256 a) external {
+        emit AnonymousEvent0WithData(a);
+    }
+
+    function emitAnonymousEvent1(uint256 a) external {
+        emit AnonymousEvent1(a);
+    }
+
+    function emitAnonymousEvent2(uint256 a, uint256 b) external {
+        emit AnonymousEvent2(a, b);
+    }
+
+    function emitAnonymousEvent3(uint256 a, uint256 b, uint256 c) external {
+        emit AnonymousEvent3(a, b, c);
+    }
+
+    function emitAnonymousEvent4(uint256 a, uint256 b, uint256 c, uint256 d) external {
+        emit AnonymousEvent4(a, b, c, d);
     }
 }
 
@@ -24,27 +77,57 @@ contract Issue7457Test is DSTest, ITarget {
         target = new Target();
     }
 
-    function testEmit0() external {
-        vm.expectEmit(address(target));
-        emit Foo(address(target));
-        target.doEmit();
-    }
-
-    function testEmit1() external {
-        vm.expectEmit(true, true, true, true, address(target));
-        emit Foo(address(target));
-        target.doEmit();
-    }
-
-    function testEmit2() external {
-        vm.expectEmit(true, true, true, true);
-        emit Foo(address(target));
-        target.doEmit();
-    }
-
-    function testEmit3() external {
+    function testEmitEvent0() public {
         vm.expectEmit(false, false, false, true);
-        emit Foo(address(target));
-        target.doEmit();
+        emit Event0Empty();
+        target.emitEvent0Empty();
+
+        vm.expectEmit(false, false, false, true);
+        emit AnonymousEvent0Empty();
+        target.emitAnonymousEvent0Empty();
+
+        vm.expectEmit(false, false, false, true);
+        emit Event0WithData(1);
+        target.emitEvent0WithData(1);
+
+        vm.expectEmit(false, false, false, true);
+        emit AnonymousEvent0WithData(1);
+        target.emitAnonymousEvent0WithData(1);
+    }
+
+    function testEmitEvent1() public {
+        vm.expectEmit(true, false, false, true);
+        emit Event1(1);
+        target.emitEvent1(1);
+
+        vm.expectEmit(true, false, false, true);
+        emit AnonymousEvent1(1);
+        target.emitAnonymousEvent1(1);
+    }
+
+    function testEmitEvent2() public {
+        vm.expectEmit(true, true, false, true);
+        emit Event2(1, 2);
+        target.emitEvent2(1, 2);
+
+        vm.expectEmit(true, true, false, true);
+        emit AnonymousEvent2(1, 2);
+        target.emitAnonymousEvent2(1, 2);
+    }
+
+    function testEmitEvent3() public {
+        vm.expectEmit(true, true, true, true);
+        emit Event3(1, 2, 3);
+        target.emitEvent3(1, 2, 3);
+
+        vm.expectEmit(true, true, true, true);
+        emit AnonymousEvent3(1, 2, 3);
+        target.emitAnonymousEvent3(1, 2, 3);
+    }
+
+    function testEmitEvent4() public {
+        vm.expectEmit(true, true, true, true);
+        emit AnonymousEvent4(1, 2, 3, 4);
+        target.emitAnonymousEvent4(1, 2, 3, 4);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #7457 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds an extra case for anonymous events without topics and a repro test testing the handling of anonymous events.

Because anonymous events do not contain a hash of the event it is only possible to match against data and possibly the address metadata. Whilst the proposed implementation fixes the reported bug I'm not sure if it is actually desirable to introduce ambiguity, consider:

- `event Foo(uint256 a) anonymous`
- `event Bar(uint256 b) anonymous`

These would both match against each other. Perhaps it is more reasonable to document the limitation. In the existing implementation it rejects both cases.

To prevent code duplication it abuses the fact that `.all()` on an empty iterator returns true.