### PR TITLE
chore: remove Instruction enum in debug steps

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -4,7 +4,6 @@ use super::context::{BufferKind, DebuggerContext};
 use crate::op::OpcodeParam;
 use alloy_primitives::U256;
 use foundry_compilers::sourcemap::SourceElement;
-use foundry_evm_core::debug::Instruction;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -456,8 +455,7 @@ impl DebuggerContext<'_> {
 
         let min_len = decimal_digits(stack.len()).max(2);
 
-        let params =
-            if let Instruction::OpCode(op) = step.instruction { OpcodeParam::of(op) } else { &[] };
+        let params = OpcodeParam::of(step.instruction);
 
         let text: Vec<Line> = stack
             .iter()
@@ -516,20 +514,18 @@ impl DebuggerContext<'_> {
         let mut write_offset = None;
         let mut write_size = None;
         let mut color = None;
-        if let Instruction::OpCode(op) = step.instruction {
-            let stack_len = step.stack.len();
-            if stack_len > 0 {
-                if let Some(accesses) = get_buffer_accesses(op, &step.stack) {
-                    if let Some(read_access) = accesses.read {
-                        offset = Some(read_access.1.offset);
-                        size = Some(read_access.1.size);
-                        color = Some(Color::Cyan);
-                    }
-                    if let Some(write_access) = accesses.write {
-                        if self.active_buffer == BufferKind::Memory {
-                            write_offset = Some(write_access.offset);
-                            write_size = Some(write_access.size);
-                        }
+        let stack_len = step.stack.len();
+        if stack_len > 0 {
+            if let Some(accesses) = get_buffer_accesses(step.instruction, &step.stack) {
+                if let Some(read_access) = accesses.read {
+                    offset = Some(read_access.1.offset);
+                    size = Some(read_access.1.size);
+                    color = Some(Color::Cyan);
+                }
+                if let Some(write_access) = accesses.write {
+                    if self.active_buffer == BufferKind::Memory {
+                        write_offset = Some(write_access.offset);
+                        write_size = Some(write_access.size);
                     }
                 }
             }
@@ -542,15 +538,13 @@ impl DebuggerContext<'_> {
         if self.current_step > 0 {
             let prev_step = self.current_step - 1;
             let prev_step = &self.debug_steps()[prev_step];
-            if let Instruction::OpCode(op) = prev_step.instruction {
-                if let Some(write_access) =
-                    get_buffer_accesses(op, &prev_step.stack).and_then(|a| a.write)
-                {
-                    if self.active_buffer == BufferKind::Memory {
-                        offset = Some(write_access.offset);
-                        size = Some(write_access.size);
-                        color = Some(Color::Green);
-                    }
+            if let Some(write_access) =
+                get_buffer_accesses(prev_step.instruction, &prev_step.stack).and_then(|a| a.write)
+            {
+                if self.active_buffer == BufferKind::Memory {
+                    offset = Some(write_access.offset);
+                    size = Some(write_access.size);
+                    color = Some(Color::Green);
                 }
             }
         }

--- a/crates/evm/evm/src/inspectors/debugger.rs
+++ b/crates/evm/evm/src/inspectors/debugger.rs
@@ -1,10 +1,9 @@
 use alloy_primitives::Address;
 use arrayvec::ArrayVec;
-use foundry_common::{ErrorExt, SELECTOR_LEN};
+use foundry_common::ErrorExt;
 use foundry_evm_core::{
     backend::DatabaseExt,
-    constants::CHEATCODE_ADDRESS,
-    debug::{DebugArena, DebugNode, DebugStep, Instruction},
+    debug::{DebugArena, DebugNode, DebugStep},
     utils::gas_used,
 };
 use revm::{
@@ -47,7 +46,6 @@ impl Debugger {
 }
 
 impl<DB: DatabaseExt> Inspector<DB> for Debugger {
-    #[inline]
     fn step(&mut self, interp: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         let pc = interp.program_counter();
         let op = interp.current_opcode();
@@ -88,13 +86,12 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             memory,
             calldata: interp.contract().input.clone(),
             returndata: interp.return_data_buffer.clone(),
-            instruction: Instruction::OpCode(op),
+            instruction: op,
             push_bytes: push_bytes.unwrap_or_default(),
             total_gas_used,
         });
     }
 
-    #[inline]
     fn call(&mut self, ecx: &mut EvmContext<DB>, inputs: &mut CallInputs) -> Option<CallOutcome> {
         self.enter(
             ecx.journaled_state.depth() as usize,
@@ -102,19 +99,9 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
             inputs.context.scheme.into(),
         );
 
-        if inputs.contract == CHEATCODE_ADDRESS {
-            if let Some(selector) = inputs.input.get(..SELECTOR_LEN) {
-                self.arena.arena[self.head].steps.push(DebugStep {
-                    instruction: Instruction::Cheatcode(selector.try_into().unwrap()),
-                    ..Default::default()
-                });
-            }
-        }
-
         None
     }
 
-    #[inline]
     fn call_end(
         &mut self,
         _context: &mut EvmContext<DB>,
@@ -126,7 +113,6 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
         outcome
     }
 
-    #[inline]
     fn create(
         &mut self,
         ecx: &mut EvmContext<DB>,
@@ -154,7 +140,6 @@ impl<DB: DatabaseExt> Inspector<DB> for Debugger {
         None
     }
 
-    #[inline]
     fn create_end(
         &mut self,
         _context: &mut EvmContext<DB>,


### PR DESCRIPTION
I don't find this particularly useful and it complicates any potential upstreaming or code anywhere else