### PR TITLE
feat: write instruction result when displaying call traces

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -122,23 +122,20 @@ pub async fn render_trace_arena(
 
             // Display trace return data
             let color = trace_color(&node.trace);
-            write!(s, "{child}{EDGE}{}", color.paint(RETURN))?;
-            if node.trace.kind.is_any_create() {
-                match &return_data {
-                    None => {
-                        writeln!(s, "{} bytes of code", node.trace.output.len())?;
-                    }
-                    Some(val) => {
-                        writeln!(s, "{val}")?;
-                    }
+            write!(
+                s,
+                "{child}{EDGE}{}{}",
+                color.paint(RETURN),
+                color.paint(format!("[{:?}] ", node.trace.status))
+            )?;
+            match return_data {
+                Some(val) => writeln!(s, "{val}"),
+                None if node.trace.kind.is_any_create() => {
+                    writeln!(s, "{} bytes of code", node.trace.output.len())
                 }
-            } else {
-                match &return_data {
-                    None if node.trace.output.is_empty() => writeln!(s, "()")?,
-                    None => writeln!(s, "{}", node.trace.output)?,
-                    Some(val) => writeln!(s, "{val}")?,
-                }
-            }
+                None if node.trace.output.is_empty() => Ok(()),
+                None => writeln!(s, "{}", node.trace.output),
+            }?;
 
             Ok(())
         }

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -129,13 +129,14 @@ pub async fn render_trace_arena(
                 color.paint(format!("[{:?}] ", node.trace.status))
             )?;
             match return_data {
-                Some(val) => writeln!(s, "{val}"),
+                Some(val) => write!(s, "{val}"),
                 None if node.trace.kind.is_any_create() => {
-                    writeln!(s, "{} bytes of code", node.trace.output.len())
+                    write!(s, "{} bytes of code", node.trace.output.len())
                 }
                 None if node.trace.output.is_empty() => Ok(()),
-                None => writeln!(s, "{}", node.trace.output),
+                None => write!(s, "{}", node.trace.output),
             }?;
+            writeln!(s)?;
 
             Ok(())
         }

--- a/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
+++ b/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
@@ -6,13 +6,13 @@ Ran 2 tests for test/Contract.t.sol:CustomTypesTest
 [FAIL. Reason: PoolNotInitialized()] testErr() (gas: 231)
 Traces:
   [231] CustomTypesTest::testErr()
-    └─ ← PoolNotInitialized()
+    └─ ← [Revert] PoolNotInitialized()
 
 [PASS] testEvent() (gas: 1312)
 Traces:
   [1312] CustomTypesTest::testEvent()
     ├─ emit MyEvent(a: 100)
-    └─ ← ()
+    └─ ← [Stop] 
 
 Suite result: FAILED. 1 passed; 1 failed; 0 skipped; finished in 3.88ms
 

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -10,7 +10,7 @@ Traces:
     │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
     │   └─ ← [Return] "Tether USD"
-    └─ ← [Stop]
+    └─ ← [Stop] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.43s
 

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -7,10 +7,10 @@ Ran 1 test for test/Contract.t.sol:USDTCallingTest
 Traces:
   [9559] USDTCallingTest::test()
     ├─ [0] VM::createSelectFork("<url>")
-    │   └─ ← 0
+    │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
-    │   └─ ← "Tether USD"
-    └─ ← ()
+    │   └─ ← [Return] "Tether USD"
+    └─ ← [Stop]
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 3.43s
 


### PR DESCRIPTION
Displays the instruction result (AKA `EvmError: <...>`) alongside the return value in call traces. Example from https://github.com/foundry-rs/foundry/issues/7463:

### Before

![image](https://github.com/foundry-rs/foundry/assets/57450786/bbf7db42-f775-4099-9615-67a4682da3d1)

### After

![image](https://github.com/foundry-rs/foundry/assets/57450786/c20f993c-de1d-4e13-b5fb-5cfa950fe4c8)

---

See companion PR in evm-inspectors for more examples: https://github.com/paradigmxyz/evm-inspectors/pull/75