### PR TITLE
perf(debugger): don't clone debug info twice

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -115,11 +115,9 @@ impl<'a> DebuggerContext<'a> {
     }
 
     fn gen_opcode_list(&mut self) {
-        self.opcode_list = self.opcode_list();
-    }
-
-    fn opcode_list(&self) -> Vec<String> {
-        self.debug_steps().iter().map(DebugStep::pretty_opcode).collect()
+        self.opcode_list.clear();
+        let debug_steps = &self.debugger.debug_arena[self.draw_memory.inner_call_index].steps;
+        self.opcode_list.extend(debug_steps.iter().map(DebugStep::pretty_opcode));
     }
 
     fn active_buffer(&self) -> &[u8] {

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -225,7 +225,7 @@ impl TestArgs {
 
         if should_debug {
             // There is only one test.
-            let Some(test) = outcome.into_tests_cloned().next() else {
+            let Some((_, test_result)) = outcome.tests().next() else {
                 return Err(eyre::eyre!("no tests were executed"));
             };
 
@@ -236,9 +236,9 @@ impl TestArgs {
 
             // Run the debugger.
             let mut builder = Debugger::builder()
-                .debug_arenas(test.result.debug.as_slice())
+                .debug_arenas(test_result.debug.as_slice())
                 .sources(sources)
-                .breakpoints(test.result.breakpoints);
+                .breakpoints(test_result.breakpoints.clone());
             if let Some(decoder) = &outcome.decoder {
                 builder = builder.decoder(decoder);
             }


### PR DESCRIPTION
Helps with https://github.com/foundry-rs/foundry/issues/7386
We still have to clone it when flattening