### PR TITLE
fix(invariant): call override strategy panic

### DIFF
--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -25,7 +25,17 @@ pub fn override_call_strat(
     .prop_flat_map(move |target_address| {
         let fuzz_state = fuzz_state.clone();
         let calldata_fuzz_config = calldata_fuzz_config.clone();
-        let (_, abi, functions) = &contracts.lock()[&target_address];
+
+        let contracts = &contracts.lock();
+        let (_, abi, functions) = contracts.get(&target_address).unwrap_or({
+            // Choose a random contract if target selected by lazy strategy is not in fuzz run
+            // identified contracts. This can happen when contract is created in `setUp` call
+            // but is not included in targetContracts.
+            let rand_index = rand::thread_rng().gen_range(0..contracts.iter().len());
+            let (_, contract_specs) = contracts.iter().nth(rand_index).unwrap();
+            contract_specs
+        });
+
         let func = select_random_function(abi, functions);
         func.prop_flat_map(move |func| {
             fuzz_contract_with_calldata(&fuzz_state, &calldata_fuzz_config, target_address, func)

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -153,6 +153,7 @@ async fn test_invariant() {
 async fn test_invariant_override() {
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantReentrancy.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
+    runner.test_options.invariant.fail_on_revert = false;
     runner.test_options.invariant.call_override = true;
     let results = runner.test_collect(&filter);
 

--- a/testdata/default/fuzz/invariant/common/InvariantReentrancy.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantReentrancy.t.sol
@@ -5,7 +5,9 @@ import "ds-test/test.sol";
 
 contract Malicious {
     function world() public {
-        // Does not matter, since it will get overridden.
+        // add code so contract is accounted as valid sender
+        // see https://github.com/foundry-rs/foundry/issues/4245
+        payable(msg.sender).transfer(1);
     }
 }
 
@@ -37,6 +39,14 @@ contract InvariantReentrancy is DSTest {
     function setUp() public {
         mal = new Malicious();
         vuln = new Vulnerable(address(mal));
+    }
+
+    // do not include `mal` in identified contracts
+    // see https://github.com/foundry-rs/foundry/issues/4245
+    function targetContracts() public view returns (address[] memory) {
+        address[] memory targets = new address[](1);
+        targets[0] = address(vuln);
+        return targets;
     }
 
     function invariantNotStolen() public {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4245 

```
The application panicked (crashed).
Message:  no entry found for key
Location: crates/evm/fuzz/src/strategies/invariants.rs:29

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: core::option::expect_failed::hc85eb6037a3050f7
      at <unknown source file>:<unknown line>
   9: <proptest::strategy::map::Map<S,F> as proptest::strategy::traits::ValueTree>::current::h5c49d6f755e96fbf
      at <unknown source file>:<unknown line>
  10: <proptest::strategy::flatten::Flatten<S> as proptest::strategy::traits::Strategy>::new_tree::hd1899ce2fdb532df
      at <unknown source file>:<unknown line>
  11: <proptest::strategy::traits::BoxedStrategyWrapper<T> as proptest::strategy::traits::Strategy>::new_tree::h21d88ddf93eea8c3
```

- reproducible with repo https://github.com/foundry-rs/foundry/issues/4245#issuecomment-1482032978
- happens when a contract is not added as target contract but it is used to override calls

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- check if target address is in list of fuzzed run identified contracts, if it is not then choose a random one
- updated `InvariantReentrancy` test to cover panic scenario