### PR TITLE
feat(anvil): remove all txs from tx pool by sender origin

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -717,6 +717,13 @@ pub enum EthRequest {
     /// contract.
     #[cfg_attr(feature = "serde", serde(rename = "ots_getContractCreator", with = "sequence"))]
     OtsGetContractCreator(Address),
+
+    /// Removes transactions from the pool by sender origin.
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "anvil_removePoolTransactions", with = "sequence")
+    )]
+    RemovePoolTransactions(Address),
 }
 
 /// Represents ethereum JSON-RPC API
@@ -1503,6 +1510,13 @@ true}]}"#;
     #[test]
     fn test_eth_sign_typed_data() {
         let s = r#"{"method":"eth_signTypedData_v4","params":["0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826", {"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"primaryType":"Mail","domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_remove_pool_transactions() {
+        let s = r#"{"method": "anvil_removePoolTransactions",  "params":["0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -413,6 +413,9 @@ impl EthApi {
             EthRequest::OtsGetContractCreator(address) => {
                 self.ots_get_contract_creator(address).await.to_rpc_result()
             }
+            EthRequest::RemovePoolTransactions(address) => {
+                self.anvil_remove_pool_transactions(address).await.to_rpc_result()
+            }
         }
     }
 
@@ -1779,6 +1782,12 @@ impl EthApi {
             }),
             snapshots,
         })
+    }
+
+    pub async fn anvil_remove_pool_transactions(&self, address: Address) -> Result<()> {
+        node_info!("anvil_removePoolTransactions");
+        self.pool.remove_transactions_by_address(address);
+        Ok(())
     }
 
     /// Snapshot the state of the blockchain at the current block.

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -139,14 +139,6 @@ impl PendingTransactions {
         self.waiting_queue.values().map(|tx| tx.transaction.clone())
     }
 
-    /// Returns an iterator over all transactions in the waiting pool filtered by the sender
-    pub fn transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> impl Iterator<Item = Arc<PoolTransaction>> + '_ {
-        self.transactions().filter(move |tx| tx.pending_transaction.sender().eq(&sender))
-    }
-
     /// Adds a transaction to Pending queue of transactions
     pub fn add_transaction(&mut self, tx: PendingPoolTransaction) -> Result<(), PoolError> {
         assert!(!tx.is_ready(), "transaction must not be ready");
@@ -383,14 +375,6 @@ impl ReadyTransactions {
             awaiting: Default::default(),
             _invalid: Default::default(),
         }
-    }
-
-    /// Returns an iterator over all transactions by the sender
-    pub fn transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> impl Iterator<Item = Arc<PoolTransaction>> + '_ {
-        self.get_transactions().filter(move |tx| tx.pending_transaction.sender().eq(&sender))
     }
 
     /// Returns true if the transaction is part of the queue.

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -139,6 +139,14 @@ impl PendingTransactions {
         self.waiting_queue.values().map(|tx| tx.transaction.clone())
     }
 
+    /// Returns an iterator over all transactions in the waiting pool filtered by the sender
+    pub fn transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> impl Iterator<Item = Arc<PoolTransaction>> + '_ {
+        self.transactions().filter(move |tx| tx.pending_transaction.sender().eq(&sender))
+    }
+
     /// Adds a transaction to Pending queue of transactions
     pub fn add_transaction(&mut self, tx: PendingPoolTransaction) -> Result<(), PoolError> {
         assert!(!tx.is_ready(), "transaction must not be ready");
@@ -375,6 +383,14 @@ impl ReadyTransactions {
             awaiting: Default::default(),
             _invalid: Default::default(),
         }
+    }
+
+    /// Returns an iterator over all transactions by the sender
+    pub fn transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> impl Iterator<Item = Arc<PoolTransaction>> + '_ {
+        self.get_transactions().filter(move |tx| tx.pending_transaction.sender().eq(&sender))
     }
 
     /// Returns true if the transaction is part of the queue.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Context: #7250 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Adds `anvil_removePoolTransactions` method that removes pool transactions by sender origin.
