### PR TITLE
feat(anvil): Add memery limit to anvil node

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -172,6 +172,7 @@ pub struct NodeArgs {
     #[command(flatten)]
     pub server_config: ServerConfig,
     /// customize the memory limit layer of the anvil  node
+    #[arg(long, visible_alias = "memory-limit")]
     pub memory_limit: Option<u64>,
 }
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -171,8 +171,8 @@ pub struct NodeArgs {
 
     #[command(flatten)]
     pub server_config: ServerConfig,
-    /// customize the memory limit layer of the anvil  node
-    #[arg(long, visible_alias = "memory-limit")]
+    /// The memory limit per EVM execution in bytes.
+    #[arg(long)]
     pub memory_limit: Option<u64>,
 }
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -171,6 +171,8 @@ pub struct NodeArgs {
 
     #[command(flatten)]
     pub server_config: ServerConfig,
+    /// customize the memory limit layer of the anvil  node
+    pub memory_limit: Option<u64>,
 }
 
 #[cfg(windows)]
@@ -235,6 +237,7 @@ impl NodeArgs {
             .with_optimism(self.evm_opts.optimism)
             .with_disable_default_create2_deployer(self.evm_opts.disable_default_create2_deployer)
             .with_slots_in_an_epoch(self.slots_in_an_epoch)
+            .with_memory_limit(self.memory_limit)
     }
 
     fn account_generator(&self) -> AccountGenerator {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -839,7 +839,7 @@ impl NodeConfig {
         cfg.disable_eip3607 = true;
         cfg.disable_block_gas_limit = self.disable_block_gas_limit;
         cfg.handler_cfg.is_optimism = self.enable_optimism;
-        cfg.memory_limit = self.memory_limit.unwrap();
+        cfg.memory_limit = self.memory_limit.unwrap_or_default();
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -409,7 +409,7 @@ impl Default for NodeConfig {
             disable_default_create2_deployer: false,
             enable_optimism: false,
             slots_in_an_epoch: 32,
-            memory_limit: None,
+            memory_limit: Some(100),
         }
     }
 }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -843,7 +843,7 @@ impl NodeConfig {
         if let Some(value) = self.memory_limit {
             cfg.memory_limit = value;
         }
-        
+        // cfg.memory_limit = self.memory_limit.unwrap_or_default();
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -843,7 +843,6 @@ impl NodeConfig {
         if let Some(value) = self.memory_limit {
             cfg.memory_limit = value;
         }
-        // cfg.memory_limit = self.memory_limit.unwrap_or_default();
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -172,6 +172,8 @@ pub struct NodeConfig {
     pub enable_optimism: bool,
     /// Slots in an epoch
     pub slots_in_an_epoch: u64,
+    /// Memory configuration layer
+    pub memory_limit: Option<u64>,
 }
 
 impl NodeConfig {
@@ -407,11 +409,18 @@ impl Default for NodeConfig {
             disable_default_create2_deployer: false,
             enable_optimism: false,
             slots_in_an_epoch: 32,
+            memory_limit: None,
         }
     }
 }
 
 impl NodeConfig {
+    /// Returns the memory limit of the node
+    #[must_use]
+    pub fn with_memory_limit(mut self, mems_value: Option<u64>) -> Self {
+        self.memory_limit = mems_value;
+        self
+    }
     /// Returns the base fee to use
     pub fn get_base_fee(&self) -> U256 {
         self.base_fee
@@ -830,6 +839,7 @@ impl NodeConfig {
         cfg.disable_eip3607 = true;
         cfg.disable_block_gas_limit = self.disable_block_gas_limit;
         cfg.handler_cfg.is_optimism = self.enable_optimism;
+        cfg.memory_limit = self.memory_limit.unwrap();
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -409,7 +409,7 @@ impl Default for NodeConfig {
             disable_default_create2_deployer: false,
             enable_optimism: false,
             slots_in_an_epoch: 32,
-            memory_limit: Some(100),
+            memory_limit: Some(10000),
         }
     }
 }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -843,7 +843,7 @@ impl NodeConfig {
         if let Some(value) = self.memory_limit {
             cfg.memory_limit = value;
         }
-        // cfg.memory_limit = self.memory_limit.unwrap_or_default();
+        
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -409,7 +409,7 @@ impl Default for NodeConfig {
             disable_default_create2_deployer: false,
             enable_optimism: false,
             slots_in_an_epoch: 32,
-            memory_limit: Some(10000),
+            memory_limit: None,
         }
     }
 }
@@ -839,7 +839,11 @@ impl NodeConfig {
         cfg.disable_eip3607 = true;
         cfg.disable_block_gas_limit = self.disable_block_gas_limit;
         cfg.handler_cfg.is_optimism = self.enable_optimism;
-        cfg.memory_limit = self.memory_limit.unwrap_or_default();
+
+        if let Some(value) = self.memory_limit {
+            cfg.memory_limit = value;
+        }
+        // cfg.memory_limit = self.memory_limit.unwrap_or_default();
 
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,


### PR DESCRIPTION
Currently anvil can running into error "EVM error MemoryLimitOOG"  closes https://github.com/foundry-rs/foundry/issues/7478

We add here a way to custom the memory limit for anvil node.

The default assigned here is 100 and can be changed if it's not the right default number.


EDIT: changed default value for memory-limit to 10000 after seeing all test related to anvil failling
