### PR TITLE
[anvil] correct log index for getTransactionReceipt

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1011,6 +1011,16 @@ impl TypedReceipt {
             TypedReceipt::Deposit(r) => &r.bloom,
         }
     }
+
+    pub fn logs(&self) -> &Vec<Log> {
+        match self {
+            TypedReceipt::Legacy(r) |
+            TypedReceipt::EIP1559(r) |
+            TypedReceipt::EIP2930(r) |
+            TypedReceipt::EIP4844(r) |
+            TypedReceipt::Deposit(r) => &r.receipt.logs,
+        }
+    }
 }
 
 impl From<TypedReceipt> for ReceiptWithBloom {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2009,8 +2009,9 @@ impl Backend {
                 let mut pre_receipts_log_index = None;
                 if !cumulative_receipts.is_empty() {
                     cumulative_receipts.truncate(cumulative_receipts.len() - 1);
-                    pre_receipts_log_index =
-                        Some(cumulative_receipts.iter().map(|_r| logs.len() as u32).sum::<u32>());
+                    pre_receipts_log_index = Some(
+                        cumulative_receipts.iter().map(|r| r.logs().len() as u32).sum::<u32>(),
+                    );
                 }
                 logs.iter()
                     .enumerate()


### PR DESCRIPTION
## Motivation

Before this PR, `eth_getTransactionReceipt` returns wrong `logIndex` in the logs. `logIndex` is supposed to be the position of the log in the entire block.

## Solution

The fix is very straightforward so please refer to it directly. Also updated a test case to cover this piece.

