### PR TITLE
anvil: add `--memory-limit` option

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -12,6 +12,7 @@ use core::fmt;
 use foundry_config::{Chain, Config};
 use futures::FutureExt;
 use rand::{rngs::StdRng, SeedableRng};
+use serde::Serialize;
 use std::{
     future::Future,
     net::IpAddr,
@@ -26,7 +27,6 @@ use std::{
     time::Duration,
 };
 use tokio::time::{Instant, Interval};
-use serde::Serialize;
 
 #[derive(Clone, Debug, Parser)]
 pub struct NodeArgs {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -168,6 +168,8 @@ pub struct NodeConfig {
     pub transaction_block_keeper: Option<usize>,
     /// Disable the default CREATE2 deployer
     pub disable_default_create2_deployer: bool,
+    /// The memory limit for the EVM
+    pub memory_limit: u64,
     /// Enable Optimism deposit transaction
     pub enable_optimism: bool,
     /// Slots in an epoch
@@ -405,6 +407,7 @@ impl Default for NodeConfig {
             init_state: None,
             transaction_block_keeper: None,
             disable_default_create2_deployer: false,
+            memory_limit: 1 << 27, // 2**27 = 128MiB = 134_217_728 bytes
             enable_optimism: false,
             slots_in_an_epoch: 32,
         }
@@ -813,6 +816,14 @@ impl NodeConfig {
         self
     }
 
+    /// Sets custom memory limit for the EVM
+    pub fn with_memory_limit(mut self, memory_limit: Option<u64>) -> Self {
+        if let Some(memory_limit) = memory_limit {
+            self.memory_limit = memory_limit;
+        }
+        self
+    }
+
     /// Configures everything related to env, backend and database and returns the
     /// [Backend](mem::Backend)
     ///
@@ -824,6 +835,7 @@ impl NodeConfig {
             CfgEnvWithHandlerCfg::new_with_spec_id(CfgEnv::default(), self.get_hardfork().into());
         cfg.chain_id = self.get_chain_id();
         cfg.limit_contract_code_size = self.code_size_limit;
+        cfg.memory_limit = self.memory_limit;
         // EIP-3607 rejects transactions from senders with deployed code.
         // If EIP-3607 is enabled it can cause issues during fuzz/invariant tests if the
         // caller is a contract. So we disable the check by default.


### PR DESCRIPTION
## Motivation
Closes #7478 

My first rust/foundry PR so let me know  if I can improve anything.

I saw #7482 was opened (thanks @DoTheBestToGetTheBest) but figured some of the code here might be better (better description of the flag that matches the other modules, adds a test, etc.)

## Solution

This solution still isn't solving my anvil issues with memory limit even after building locally and passing a high number, but figure it's nice to still have configurable. It's hard for me to share a repro case because it requires a complex setup of ~10 txs (balance updates, mint new nfts, approvals, then fulfill them through Seaport) but I hope to find a more simple repro case to share separately as a bug.