### PR TITLE
fix: debugger doesn't work with external libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "foundry-block-explorers",
  "foundry-compilers",
  "foundry-config",
+ "foundry-linking",
  "foundry-macros",
  "glob",
  "globset",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 foundry-block-explorers = { workspace = true, features = ["foundry-compilers"] }
 foundry-compilers.workspace = true
 foundry-config.workspace = true
+foundry-linking.workspace = true
 
 ethers-core.workspace = true
 ethers-middleware.workspace = true

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -5,7 +5,11 @@ use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Table};
 use eyre::{Context, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    artifacts::{BytecodeObject, ContractBytecodeSome, Libraries}, remappings::Remapping, report::{BasicStdoutReporter, NoReporter, Report}, Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig, Solc, SolcConfig
+    artifacts::{BytecodeObject, ContractBytecodeSome, Libraries},
+    remappings::Remapping,
+    report::{BasicStdoutReporter, NoReporter, Report},
+    Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig,
+    Solc, SolcConfig,
 };
 use foundry_linking::Linker;
 use rustc_hash::FxHashMap;

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -5,12 +5,9 @@ use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Table};
 use eyre::{Context, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    artifacts::{BytecodeObject, CompactContractBytecode, ContractBytecodeSome},
-    remappings::Remapping,
-    report::{BasicStdoutReporter, NoReporter, Report},
-    Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig,
-    Solc, SolcConfig,
+    artifacts::{BytecodeObject, ContractBytecodeSome, Libraries}, remappings::Remapping, report::{BasicStdoutReporter, NoReporter, Report}, Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig, Solc, SolcConfig
 };
+use foundry_linking::Linker;
 use rustc_hash::FxHashMap;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -296,7 +293,10 @@ impl ContractSources {
     pub fn from_project_output(
         output: &ProjectCompileOutput,
         root: &Path,
+        libraries: &Libraries,
     ) -> Result<ContractSources> {
+        let linker = Linker::new(root, output.artifact_ids().collect());
+
         let mut sources = ContractSources::default();
         for (id, artifact) in output.artifact_ids() {
             if let Some(file_id) = artifact.id {
@@ -304,12 +304,8 @@ impl ContractSources {
                 let source_code = std::fs::read_to_string(abs_path).wrap_err_with(|| {
                     format!("failed to read artifact source file for `{}`", id.identifier())
                 })?;
-                let compact = CompactContractBytecode {
-                    abi: artifact.abi.clone(),
-                    bytecode: artifact.bytecode.clone(),
-                    deployed_bytecode: artifact.deployed_bytecode.clone(),
-                };
-                let contract = compact_to_contract(compact)?;
+                let linked = linker.link(&id, libraries)?;
+                let contract = compact_to_contract(linked)?;
                 sources.insert(&id, file_id, source_code, contract);
             } else {
                 warn!(id = id.identifier(), "source not found");

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -231,7 +231,7 @@ impl TestArgs {
                 .find(|(_, r)| !r.test_results.is_empty())
                 .map(|(_, r)| (r, r.test_results.values().next().unwrap()))
             else {
-                eyre::bail!("No tests found to debug");
+                return Err(eyre::eyre!("no tests were executed"));
             };
 
             let sources = ContractSources::from_project_output(

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -224,6 +224,7 @@ impl TestArgs {
         let outcome = self.run_tests(runner, config, verbosity, &filter).await?;
 
         if should_debug {
+            // Get first non-empty suite result. We will have only one such entry
             let Some((suite_result, test_result)) = outcome.results.iter().filter(|(_, r)| {
                 !r.test_results.is_empty()
             }).next().map(|(_, r)| (r, r.test_results.values().next().unwrap())) else {
@@ -235,9 +236,7 @@ impl TestArgs {
                 project.root(),
                 &suite_result.libraries,
             )?;
-
-            println!("{:?}", sources);
-
+            
             // Run the debugger.
             let mut builder = Debugger::builder()
                 .debug_arenas(test_result.debug.as_slice())

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -225,9 +225,12 @@ impl TestArgs {
 
         if should_debug {
             // Get first non-empty suite result. We will have only one such entry
-            let Some((suite_result, test_result)) = outcome.results.iter().filter(|(_, r)| {
-                !r.test_results.is_empty()
-            }).next().map(|(_, r)| (r, r.test_results.values().next().unwrap())) else {
+            let Some((suite_result, test_result)) = outcome
+                .results
+                .iter()
+                .find(|(_, r)| !r.test_results.is_empty())
+                .map(|(_, r)| (r, r.test_results.values().next().unwrap()))
+            else {
                 eyre::bail!("No tests found to debug");
             };
 
@@ -236,7 +239,7 @@ impl TestArgs {
                 project.root(),
                 &suite_result.libraries,
             )?;
-            
+
             // Run the debugger.
             let mut builder = Debugger::builder()
                 .debug_arenas(test_result.debug.as_slice())

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -26,6 +26,7 @@ use std::{
     time::Instant,
 };
 
+#[derive(Debug, Clone)]
 pub struct TestContract {
     pub abi: JsonAbi,
     pub bytecode: Bytes,
@@ -74,7 +75,9 @@ impl MultiContractRunner {
         &'a self,
         filter: &'a dyn TestFilter,
     ) -> impl Iterator<Item = (&ArtifactId, &TestContract)> {
-        self.contracts.iter().filter(|&(id, TestContract { abi, ..})| matches_contract(id, abi, filter))
+        self.contracts
+            .iter()
+            .filter(|&(id, TestContract { abi, .. })| matches_contract(id, abi, filter))
     }
 
     /// Returns an iterator over all test functions that match the filter.
@@ -83,7 +86,7 @@ impl MultiContractRunner {
         filter: &'a dyn TestFilter,
     ) -> impl Iterator<Item = &Function> {
         self.matching_contracts(filter)
-            .flat_map(|(_, TestContract { abi, ..})| abi.functions())
+            .flat_map(|(_, TestContract { abi, .. })| abi.functions())
             .filter(|func| is_matching_test(func, filter))
     }
 
@@ -95,14 +98,14 @@ impl MultiContractRunner {
         self.contracts
             .iter()
             .filter(|(id, _)| filter.matches_path(&id.source) && filter.matches_contract(&id.name))
-            .flat_map(|(_, TestContract { abi, ..})| abi.functions())
+            .flat_map(|(_, TestContract { abi, .. })| abi.functions())
             .filter(|func| func.is_test() || func.is_invariant_test())
     }
 
     /// Returns all matching tests grouped by contract grouped by file (file -> (contract -> tests))
     pub fn list(&self, filter: &dyn TestFilter) -> BTreeMap<String, BTreeMap<String, Vec<String>>> {
         self.matching_contracts(filter)
-            .map(|(id, TestContract { abi, ..})| {
+            .map(|(id, TestContract { abi, .. })| {
                 let source = id.source.as_path().display().to_string();
                 let name = id.name.clone();
                 let tests = abi
@@ -175,22 +178,19 @@ impl MultiContractRunner {
             find_time,
         );
 
-        contracts.par_iter().for_each_with(tx, |tx, &(id, TestContract { abi, bytecode, libs_to_deploy })| {
+        contracts.par_iter().for_each_with(tx, |tx, &(id, contract)| {
             let identifier = id.identifier();
             let executor = executor.clone();
-            let result = self.run_tests(&identifier, abi, executor, bytecode, libs_to_deploy, filter);
+            let result = self.run_tests(&identifier, contract, executor, filter);
             let _ = tx.send((identifier, result));
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn run_tests(
         &self,
         name: &str,
-        contract: &JsonAbi,
+        contract: &TestContract,
         executor: Executor,
-        deploy_code: &Bytes,
-        libs: &[Bytes],
         filter: &dyn TestFilter,
     ) -> SuiteResult {
         let mut span_name = name;
@@ -205,11 +205,9 @@ impl MultiContractRunner {
             name,
             executor,
             contract,
-            deploy_code,
             self.evm_opts.initial_balance,
             self.sender,
             &self.revert_decoder,
-            libs,
             self.debug,
         );
         let r = runner.run_tests(filter, &self.test_options, Some(&self.known_contracts));
@@ -347,7 +345,10 @@ impl MultiContractRunnerBuilder {
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                 abi.functions().any(|func| func.name.is_test() || func.name.is_invariant_test())
             {
-                deployable_contracts.insert(id.clone(), TestContract { abi: abi.clone(), bytecode, libs_to_deploy });
+                deployable_contracts.insert(
+                    id.clone(),
+                    TestContract { abi: abi.clone(), bytecode, libs_to_deploy },
+                );
             }
 
             if let Some(bytes) = linked_contract.get_deployed_bytecode_bytes() {

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -5,7 +5,9 @@ use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_common::{get_contract_name, ContractsByArtifact, TestFunctionExt};
-use foundry_compilers::{artifacts::Libraries, contracts::ArtifactContracts, Artifact, ArtifactId, ProjectCompileOutput};
+use foundry_compilers::{
+    artifacts::Libraries, contracts::ArtifactContracts, Artifact, ArtifactId, ProjectCompileOutput,
+};
 use foundry_evm::{
     backend::Backend,
     decode::RevertDecoder,
@@ -312,7 +314,10 @@ impl MultiContractRunnerBuilder {
             .map(|(i, _)| (i.identifier(), root.join(&i.source).to_string_lossy().into()))
             .collect::<BTreeMap<String, String>>();
 
-        let linker = Linker::new(root, contracts.iter().map(|(id, artifact)| (id.clone(), artifact)).collect());
+        let linker = Linker::new(
+            root,
+            contracts.iter().map(|(id, artifact)| (id.clone(), artifact)).collect(),
+        );
 
         // Create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
@@ -325,9 +330,9 @@ impl MultiContractRunnerBuilder {
             };
 
             let LinkOutput { libs_to_deploy, libraries } =
-                linker.link_with_nonce_or_address(Default::default(), evm_opts.sender, 1, &id)?;
+                linker.link_with_nonce_or_address(Default::default(), evm_opts.sender, 1, id)?;
 
-            let linked_contract = linker.link(&id, &libraries)?;
+            let linked_contract = linker.link(id, &libraries)?;
 
             // get bytes if deployable, else add to known contracts and continue.
             // interfaces and abstract contracts should be known to enable fuzzing of their ABI

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::{Address, Log};
 use foundry_common::{evm::Breakpoints, get_contract_name, get_file_name, shell};
+use foundry_compilers::artifacts::Libraries;
 use foundry_evm::{
     coverage::HitMaps,
     debug::DebugArena,
@@ -193,6 +194,8 @@ pub struct SuiteResult {
     pub test_results: BTreeMap<String, TestResult>,
     /// Generated warnings.
     pub warnings: Vec<String>,
+    /// Libraries used to link test contract.
+    pub libraries: Libraries,
 }
 
 impl SuiteResult {
@@ -200,8 +203,9 @@ impl SuiteResult {
         duration: Duration,
         test_results: BTreeMap<String, TestResult>,
         warnings: Vec<String>,
+        libraries: Libraries,
     ) -> Self {
-        Self { duration, test_results, warnings }
+        Self { duration, test_results, warnings, libraries }
     }
 
     /// Returns an iterator over all individual succeeding tests and their names.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -206,7 +206,7 @@ impl<'a> ContractRunner<'a> {
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
                     .into(),
                 warnings,
-                self.contract.libraries.clone()
+                self.contract.libraries.clone(),
             )
         }
 
@@ -243,7 +243,7 @@ impl<'a> ContractRunner<'a> {
                 )]
                 .into(),
                 warnings,
-                self.contract.libraries.clone()
+                self.contract.libraries.clone(),
             )
         }
 
@@ -299,7 +299,8 @@ impl<'a> ContractRunner<'a> {
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(duration, test_results, warnings, self.contract.libraries.clone());
+        let suite_result =
+            SuiteResult::new(duration, test_results, warnings, self.contract.libraries.clone());
         info!(
             duration=?suite_result.duration,
             "done. {}/{} successful",

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -52,7 +52,6 @@ pub struct ContractRunner<'a> {
 }
 
 impl<'a> ContractRunner<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &'a str,
         executor: Executor,
@@ -207,6 +206,7 @@ impl<'a> ContractRunner<'a> {
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
                     .into(),
                 warnings,
+                self.contract.libraries.clone()
             )
         }
 
@@ -243,6 +243,7 @@ impl<'a> ContractRunner<'a> {
                 )]
                 .into(),
                 warnings,
+                self.contract.libraries.clone()
             )
         }
 
@@ -298,7 +299,7 @@ impl<'a> ContractRunner<'a> {
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(duration, test_results, warnings);
+        let suite_result = SuiteResult::new(duration, test_results, warnings, self.contract.libraries.clone());
         info!(
             duration=?suite_result.duration,
             "done. {}/{} successful",

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -50,8 +50,12 @@ impl BuildData {
         sender: Address,
         nonce: u64,
     ) -> Result<LinkedBuildData> {
-        let link_output =
-            self.get_linker().link_with_nonce_or_address(known_libraries, sender, nonce, &self.target)?;
+        let link_output = self.get_linker().link_with_nonce_or_address(
+            known_libraries,
+            sender,
+            nonce,
+            &self.target,
+        )?;
 
         LinkedBuildData::new(link_output, self)
     }
@@ -59,7 +63,12 @@ impl BuildData {
     /// Links the build data with the given libraries. Expects supplied libraries set being enough
     /// to fully link target contract.
     pub fn link_with_libraries(self, libraries: Libraries) -> Result<LinkedBuildData> {
-        let link_output = self.get_linker().link_with_nonce_or_address(libraries, Address::ZERO, 0, &self.target)?;
+        let link_output = self.get_linker().link_with_nonce_or_address(
+            libraries,
+            Address::ZERO,
+            0,
+            &self.target,
+        )?;
 
         if !link_output.libs_to_deploy.is_empty() {
             eyre::bail!("incomplete libraries set");
@@ -85,7 +94,11 @@ pub struct LinkedBuildData {
 
 impl LinkedBuildData {
     pub fn new(link_output: LinkOutput, build_data: BuildData) -> Result<Self> {
-        let sources = ContractSources::from_project_output(&build_data.output, &build_data.project_root, &link_output.libraries)?;
+        let sources = ContractSources::from_project_output(
+            &build_data.output,
+            &build_data.project_root,
+            &link_output.libraries,
+        )?;
 
         let highlevel_known_contracts = build_data
             .get_linker()

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -22,22 +22,26 @@ use foundry_compilers::{
     cache::SolFilesCache,
     contracts::ArtifactContracts,
     info::ContractInfo,
-    ArtifactId,
+    ArtifactId, ProjectCompileOutput,
 };
 use foundry_linking::{LinkOutput, Linker};
-use std::{str::FromStr, sync::Arc};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 /// Container for the compiled contracts.
 pub struct BuildData {
+    /// Root of the project
+    pub project_root: PathBuf,
     /// Linker which can be used to link contracts, owns [ArtifactContracts] map.
-    pub linker: Linker,
+    pub output: ProjectCompileOutput,
     /// Id of target contract artifact.
     pub target: ArtifactId,
-    /// Source files of the contracts. Used by debugger.
-    pub sources: ContractSources,
 }
 
 impl BuildData {
+    pub fn get_linker(&self) -> Linker {
+        Linker::new(self.project_root.clone(), self.output.artifact_ids().collect())
+    }
+
     /// Links the build data with given libraries, using sender and nonce to compute addresses of
     /// missing libraries.
     pub fn link(
@@ -47,7 +51,7 @@ impl BuildData {
         nonce: u64,
     ) -> Result<LinkedBuildData> {
         let link_output =
-            self.linker.link_with_nonce_or_address(known_libraries, sender, nonce, &self.target)?;
+            self.get_linker().link_with_nonce_or_address(known_libraries, sender, nonce, &self.target)?;
 
         LinkedBuildData::new(link_output, self)
     }
@@ -55,8 +59,7 @@ impl BuildData {
     /// Links the build data with the given libraries. Expects supplied libraries set being enough
     /// to fully link target contract.
     pub fn link_with_libraries(self, libraries: Libraries) -> Result<LinkedBuildData> {
-        let link_output =
-            self.linker.link_with_nonce_or_address(libraries, Address::ZERO, 0, &self.target)?;
+        let link_output = self.get_linker().link_with_nonce_or_address(libraries, Address::ZERO, 0, &self.target)?;
 
         if !link_output.libs_to_deploy.is_empty() {
             eyre::bail!("incomplete libraries set");
@@ -76,12 +79,16 @@ pub struct LinkedBuildData {
     pub libraries: Libraries,
     /// Libraries that need to be deployed by sender before script execution.
     pub predeploy_libraries: Vec<Bytes>,
+    /// Source files of the contracts. Used by debugger.
+    pub sources: ContractSources,
 }
 
 impl LinkedBuildData {
     pub fn new(link_output: LinkOutput, build_data: BuildData) -> Result<Self> {
+        let sources = ContractSources::from_project_output(&build_data.output, &build_data.project_root, &link_output.libraries)?;
+
         let highlevel_known_contracts = build_data
-            .linker
+            .get_linker()
             .get_linked_artifacts(&link_output.libraries)?
             .iter()
             .filter_map(|(id, contract)| {
@@ -97,6 +104,7 @@ impl LinkedBuildData {
             highlevel_known_contracts,
             libraries: link_output.libraries,
             predeploy_libraries: link_output.libs_to_deploy,
+            sources,
         })
     }
 
@@ -220,16 +228,13 @@ impl PreprocessedState {
             target_id = Some(id);
         }
 
-        let sources = ContractSources::from_project_output(&output, project.root())?;
-        let contracts = output.into_artifacts().collect();
         let target = target_id.ok_or_eyre("Could not find target contract")?;
-        let linker = Linker::new(project.root(), contracts);
 
         Ok(CompiledState {
             args,
             script_config,
             script_wallets,
-            build_data: BuildData { linker, target, sources },
+            build_data: BuildData { output, target, project_root: project.root().clone() },
         })
     }
 }

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -511,7 +511,7 @@ impl PreSimulationState {
         let mut debugger = Debugger::builder()
             .debug_arenas(self.execution_result.debug.as_deref().unwrap_or_default())
             .decoder(&self.execution_artifacts.decoder)
-            .sources(self.build_data.build_data.sources.clone())
+            .sources(self.build_data.sources.clone())
             .breakpoints(self.execution_result.breakpoints.clone())
             .build();
         debugger.try_run()?;


### PR DESCRIPTION
## Motivation

Closes #7038

## Solution

Rewrite `Linker` a bit to use `CompactContractBytecodeCow` as there is actually no need for linker to own artifacts in most of the cases

Changes test runner flow to keep library addresses used for the test run and link contracts before running the debugger.
