### PR TITLE
perf(fuzz): use default std hasher for fuzz dict states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,7 +3477,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "revm",
- "rustc-hash",
  "serde",
  "thiserror",
  "tracing",

--- a/crates/evm/fuzz/Cargo.toml
+++ b/crates/evm/fuzz/Cargo.toml
@@ -39,5 +39,4 @@ rand.workspace = true
 serde = "1"
 thiserror = "1"
 tracing = "0.1"
-rustc-hash.workspace = true
 indexmap.workspace = true

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -17,8 +17,7 @@ use std::{fmt, sync::Arc};
 
 // We're using `IndexSet` to have a stable element order when restoring persisted state, as well as
 // for performance when iterating over the sets.
-type FxIndexSet<T> =
-    indexmap::set::IndexSet<T, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+type FxIndexSet<T> = indexmap::set::IndexSet<T>;
 
 /// A set of arbitrary 32 byte data from the VM used to generate values for the strategy.
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #7503 


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

see https://github.com/foundry-rs/foundry/issues/7503#issuecomment-2022143142