### PR TITLE
fix: coverage for libraries

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -1,4 +1,5 @@
 use super::{ContractId, CoverageItem, CoverageItemKind, SourceLocation};
+use foundry_common::TestFunctionExt;
 use foundry_compilers::artifacts::ast::{self, Ast, Node, NodeType};
 use rustc_hash::FxHashMap;
 use semver::Version;
@@ -485,7 +486,17 @@ impl SourceAnalyzer {
                     .clone(),
             )?;
 
-            self.items.extend(items);
+            let is_test = items.iter().any(|item| {
+                if let CoverageItemKind::Function { name } = &item.kind {
+                    name.is_test()
+                } else {
+                    false
+                }
+            });
+
+            if !is_test {
+                self.items.extend(items);
+            }
         }
 
         Ok(SourceAnalysis { items: self.items })

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -296,16 +296,13 @@ impl<'a> ContractVisitor<'a> {
                 });
 
                 let expr: Option<Node> = node.attribute("expression");
-                match expr.as_ref().map(|expr| &expr.node_type) {
+                if let Some(NodeType::Identifier) = expr.as_ref().map(|expr| &expr.node_type) {
                     // Might be a require/assert call
-                    Some(NodeType::Identifier) => {
-                        let name: Option<String> = expr.and_then(|expr| expr.attribute("name"));
-                        if let Some("assert" | "require") = name.as_deref() {
-                            self.push_branches(&node.src, self.branch_id);
-                            self.branch_id += 1;
-                        }
+                    let name: Option<String> = expr.and_then(|expr| expr.attribute("name"));
+                    if let Some("assert" | "require") = name.as_deref() {
+                        self.push_branches(&node.src, self.branch_id);
+                        self.branch_id += 1;
                     }
-                    _ => (),
                 }
 
                 Ok(())

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -1,9 +1,8 @@
 use super::{ContractId, CoverageItem, CoverageItemKind, SourceLocation};
-use foundry_common::TestFunctionExt;
 use foundry_compilers::artifacts::ast::{self, Ast, Node, NodeType};
 use rustc_hash::FxHashMap;
 use semver::Version;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// A visitor that walks the AST of a single contract and finds coverage items.
 #[derive(Clone, Debug)]
@@ -23,36 +22,14 @@ pub struct ContractVisitor<'a> {
 
     /// Coverage items
     pub items: Vec<CoverageItem>,
-
-    /// Node IDs of this contract's base contracts, as well as IDs for referenced contracts such as
-    /// libraries
-    pub base_contract_node_ids: HashSet<usize>,
 }
 
 impl<'a> ContractVisitor<'a> {
     pub fn new(source_id: usize, source: &'a str, contract_name: String) -> Self {
-        Self {
-            source_id,
-            source,
-            contract_name,
-            branch_id: 0,
-            last_line: 0,
-            items: Vec::new(),
-            base_contract_node_ids: HashSet::new(),
-        }
+        Self { source_id, source, contract_name, branch_id: 0, last_line: 0, items: Vec::new() }
     }
 
     pub fn visit(mut self, contract_ast: Node) -> eyre::Result<Self> {
-        let linearized_base_contracts: Vec<usize> =
-            contract_ast.attribute("linearizedBaseContracts").ok_or_else(|| {
-                eyre::eyre!(
-                    "The contract's AST node is missing a list of linearized base contracts"
-                )
-            })?;
-
-        // We skip the first ID because that's the ID of the contract itself
-        self.base_contract_node_ids.extend(&linearized_base_contracts[1..]);
-
         // Find all functions and walk their AST
         for node in contract_ast.nodes {
             if node.node_type == NodeType::FunctionDefinition {
@@ -327,15 +304,6 @@ impl<'a> ContractVisitor<'a> {
                             self.branch_id += 1;
                         }
                     }
-                    // Might be a call to a library
-                    Some(NodeType::MemberAccess) => {
-                        let referenced_declaration_id = expr
-                            .and_then(|expr| expr.attribute("expression"))
-                            .and_then(|subexpr: Node| subexpr.attribute("referencedDeclaration"));
-                        if let Some(id) = referenced_declaration_id {
-                            self.base_contract_node_ids.insert(id);
-                        }
-                    }
                     _ => (),
                 }
 
@@ -435,9 +403,6 @@ impl<'a> ContractVisitor<'a> {
 pub struct SourceAnalysis {
     /// A collection of coverage items.
     pub items: Vec<CoverageItem>,
-    /// A mapping of contract IDs to item IDs relevant to the contract (including items in base
-    /// contracts).
-    pub contract_items: HashMap<ContractId, Vec<usize>>,
 }
 
 /// Analyzes a set of sources to find coverage items.
@@ -451,10 +416,6 @@ pub struct SourceAnalyzer {
     contracts: HashMap<ContractId, Node>,
     /// A collection of coverage items.
     items: Vec<CoverageItem>,
-    /// A map of contract IDs to item IDs.
-    contract_items: HashMap<ContractId, Vec<usize>>,
-    /// A map of contracts to their base contracts
-    contract_bases: HashMap<ContractId, Vec<ContractId>>,
 }
 
 impl SourceAnalyzer {
@@ -497,11 +458,7 @@ impl SourceAnalyzer {
     ///
     /// Coverage items are found by:
     /// - Walking the AST of each contract (except interfaces)
-    /// - Recording the items and base contracts of each contract
-    ///
-    /// Finally, the item IDs of each contract and its base contracts are flattened, and the return
-    /// value represents all coverage items in the project, along with a mapping of contract IDs to
-    /// item IDs.
+    /// - Recording the items of each contract
     ///
     /// Each coverage item contains relevant information to find opcodes corresponding to them: the
     /// source ID the item is in, the source code range of the item, and the contract name the item
@@ -511,127 +468,26 @@ impl SourceAnalyzer {
     /// two different solc versions will produce overlapping source IDs if the compiler version is
     /// not taken into account.
     pub fn analyze(mut self) -> eyre::Result<SourceAnalysis> {
-        // Analyze the contracts
-        self.analyze_contracts()?;
-
-        // Flatten the data
-        let mut flattened: HashMap<ContractId, Vec<usize>> = HashMap::new();
-        for contract_id in self.contract_items.keys() {
-            let mut item_ids: Vec<usize> = Vec::new();
-
-            //
-            // for a specific contract (id == contract_id):
-            //
-            // self.contract_bases.get(contract_id) includes the following contracts:
-            //   1. all the ancestors of this contract (including parent, grandparent, ...
-            //      contracts)
-            //   2. the libraries **directly** used by this contract
-            //
-            // The missing contracts are:
-            //   1. libraries used in ancestors of this contracts
-            //   2. libraries used in libraries (i.e libs indirectly used by this contract)
-            //
-            // We want to find out all the above contracts and libraries related to this contract.
-
-            for contract_or_lib in {
-                // A set of contracts and libraries related to this contract (will include "this"
-                // contract itself)
-                let mut contracts_libraries: HashSet<&ContractId> = HashSet::new();
-
-                // we use a stack for depth-first search.
-                let mut stack: Vec<&ContractId> = Vec::new();
-
-                // push "this" contract onto the stack
-                stack.push(contract_id);
-
-                while let Some(contract_or_lib) = stack.pop() {
-                    // whenever a contract_or_lib is removed from the stack, it is added to the set
-                    contracts_libraries.insert(contract_or_lib);
-
-                    // push all ancestors of contract_or_lib and libraries used by contract_or_lib
-                    // onto the stack
-                    if let Some(bases) = self.contract_bases.get(contract_or_lib) {
-                        stack.extend(
-                            bases.iter().filter(|base| !contracts_libraries.contains(base)),
-                        );
-                    }
-                }
-
-                contracts_libraries
-            } {
-                // get items of each contract or library
-                if let Some(items) = self.contract_items.get(contract_or_lib) {
-                    item_ids.extend(items.iter());
-                }
-            }
-
-            // If there are no items for this contract, then it was most likely filtered
-            if !item_ids.is_empty() {
-                flattened.insert(contract_id.clone(), item_ids);
-            }
-        }
-
-        Ok(SourceAnalysis { items: self.items.clone(), contract_items: flattened })
-    }
-
-    fn analyze_contracts(&mut self) -> eyre::Result<()> {
         for contract_id in self.contracts.keys() {
-            // Find this contract's coverage items if we haven't already
-            if !self.contract_items.contains_key(contract_id) {
-                let ContractVisitor { items, base_contract_node_ids, .. } = ContractVisitor::new(
-                    contract_id.source_id,
-                    self.sources.get(&contract_id.source_id).unwrap_or_else(|| {
-                        panic!(
-                            "We should have the source code for source ID {}",
-                            contract_id.source_id
-                        )
-                    }),
-                    contract_id.contract_name.clone(),
-                )
-                .visit(
-                    self.contracts
-                        .get(contract_id)
-                        .unwrap_or_else(|| {
-                            panic!("We should have the AST of contract: {contract_id:?}")
-                        })
-                        .clone(),
-                )?;
+            let ContractVisitor { items, .. } = ContractVisitor::new(
+                contract_id.source_id,
+                self.sources.get(&contract_id.source_id).unwrap_or_else(|| {
+                    panic!("We should have the source code for source ID {}", contract_id.source_id)
+                }),
+                contract_id.contract_name.clone(),
+            )
+            .visit(
+                self.contracts
+                    .get(contract_id)
+                    .unwrap_or_else(|| {
+                        panic!("We should have the AST of contract: {contract_id:?}")
+                    })
+                    .clone(),
+            )?;
 
-                let is_test = items.iter().any(|item| {
-                    if let CoverageItemKind::Function { name } = &item.kind {
-                        name.is_test()
-                    } else {
-                        false
-                    }
-                });
-
-                // Record this contract's base contracts
-                // We don't do this for test contracts because we don't care about them
-                if !is_test {
-                    self.contract_bases.insert(
-                        contract_id.clone(),
-                        base_contract_node_ids
-                            .iter()
-                            .filter_map(|base_contract_node_id| {
-                                self.contract_ids.get(base_contract_node_id).cloned()
-                            })
-                            .collect(),
-                    );
-                }
-
-                // For tests and contracts with no items we still record an empty Vec so we don't
-                // end up here again
-                if items.is_empty() || is_test {
-                    self.contract_items.insert(contract_id.clone(), Vec::new());
-                } else {
-                    let item_ids: Vec<usize> =
-                        (self.items.len()..self.items.len() + items.len()).collect();
-                    self.items.extend(items);
-                    self.contract_items.insert(contract_id.clone(), item_ids.clone());
-                }
-            }
+            self.items.extend(items);
         }
 
-        Ok(())
+        Ok(SourceAnalysis { items: self.items })
     }
 }

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -20,7 +20,7 @@ pub fn find_anchors(
     // Prepare coverage items from all sources referenced in the source map
     let potential_item_ids = source_map
         .iter()
-        .filter_map(|element| Some(items_by_source_id.get(&(element.index? as usize))?))
+        .filter_map(|element| items_by_source_id.get(&(element.index? as usize)))
         .flatten()
         .collect::<HashSet<_>>();
 

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -15,22 +15,12 @@ pub fn find_anchors(
     source_map: &SourceMap,
     ic_pc_map: &IcPcMap,
     items: &[CoverageItem],
+    items_by_source_id: &HashMap<usize, Vec<usize>>,
 ) -> Vec<ItemAnchor> {
-    // Build helper mapping
-    // source_id -> [item_id]
-    let items_map = items
-        .iter()
-        .enumerate()
-        .map(|(item_id, item)| (item.loc.source_id, item_id))
-        .fold(HashMap::new(), |mut map, (source_id, item_id)| {
-            map.entry(source_id).or_insert_with(Vec::new).push(item_id);
-            map
-        });
-
     // Prepare coverage items from all sources referenced in the source map
     let potential_item_ids = source_map
         .iter()
-        .filter_map(|element| Some(items_map.get(&(element.index? as usize))?))
+        .filter_map(|element| Some(items_by_source_id.get(&(element.index? as usize))?))
         .flatten()
         .collect::<HashSet<_>>();
 

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -257,18 +257,16 @@ impl CoverageArgs {
                 })?,
             )?
             .analyze()?;
-            let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_analysis
-                .contract_items
+            let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()
-                .filter_map(|(contract_id, item_ids)| {
+                .filter_map(|(contract_id, (_, deployed_source_map))| {
                     // TODO: Creation source map/bytecode as well
                     Some((
                         contract_id.clone(),
                         find_anchors(
                             &bytecodes.get(contract_id)?.1,
-                            &source_maps.get(contract_id)?.1,
+                            deployed_source_map,
                             &ic_pc_maps.get(contract_id)?.1,
-                            item_ids,
                             &source_analysis.items,
                         ),
                     ))

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -264,8 +264,8 @@ impl CoverageArgs {
                 .iter()
                 .enumerate()
                 .map(|(item_id, item)| (item.loc.source_id, item_id))
-                .fold(HashMap::new(), |mut map, (source_id, item_id)| {
-                    map.entry(source_id).or_insert_with(Vec::new).push(item_id);
+                .fold(HashMap::new(), |mut map: HashMap<usize, Vec<usize>>, (source_id, item_id)| {
+                    map.entry(source_id).or_default().push(item_id);
                     map
                 });
 

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -258,8 +258,7 @@ impl CoverageArgs {
             )?
             .analyze()?;
 
-            // Build helper mapping
-            // source_id -> [item_id]
+            // Build helper mapping used by `find_anchors`
             let items_by_source_id = source_analysis
                 .items
                 .iter()

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -258,6 +258,18 @@ impl CoverageArgs {
             )?
             .analyze()?;
 
+            // Build helper mapping
+            // source_id -> [item_id]
+            let items_by_source_id = source_analysis
+                .items
+                .iter()
+                .enumerate()
+                .map(|(item_id, item)| (item.loc.source_id, item_id))
+                .fold(HashMap::new(), |mut map, (source_id, item_id)| {
+                    map.entry(source_id).or_insert_with(Vec::new).push(item_id);
+                    map
+                });
+
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()
                 .filter_map(|(contract_id, (_, deployed_source_map))| {
@@ -269,6 +281,7 @@ impl CoverageArgs {
                             deployed_source_map,
                             &ic_pc_maps.get(contract_id)?.1,
                             &source_analysis.items,
+                            &items_by_source_id,
                         ),
                     ))
                 })

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -257,6 +257,7 @@ impl CoverageArgs {
                 })?,
             )?
             .analyze()?;
+
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()
                 .filter_map(|(contract_id, (_, deployed_source_map))| {

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -264,10 +264,13 @@ impl CoverageArgs {
                 .iter()
                 .enumerate()
                 .map(|(item_id, item)| (item.loc.source_id, item_id))
-                .fold(HashMap::new(), |mut map: HashMap<usize, Vec<usize>>, (source_id, item_id)| {
-                    map.entry(source_id).or_default().push(item_id);
-                    map
-                });
+                .fold(
+                    HashMap::new(),
+                    |mut map: HashMap<usize, Vec<usize>>, (source_id, item_id)| {
+                        map.entry(source_id).or_default().push(item_id);
+                        map
+                    },
+                );
 
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -259,10 +259,11 @@ impl CoverageArgs {
             .analyze()?;
 
             // Build helper mapping used by `find_anchors`
-            let mut items_by_source_id = HashMap::new();
+            let mut items_by_source_id: HashMap<_, Vec<_>> =
+                HashMap::with_capacity(source_analysis.items.len());
 
             for (item_id, item) in source_analysis.items.iter().enumerate() {
-                items_by_source_id.entry(item.loc.source_id).or_insert_with(Vec::new).push(item_id);
+                items_by_source_id.entry(item.loc.source_id).or_default().push(item_id);
             }
 
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -259,18 +259,11 @@ impl CoverageArgs {
             .analyze()?;
 
             // Build helper mapping used by `find_anchors`
-            let items_by_source_id = source_analysis
-                .items
-                .iter()
-                .enumerate()
-                .map(|(item_id, item)| (item.loc.source_id, item_id))
-                .fold(
-                    HashMap::new(),
-                    |mut map: HashMap<usize, Vec<usize>>, (source_id, item_id)| {
-                        map.entry(source_id).or_default().push(item_id);
-                        map
-                    },
-                );
+            let mut items_by_source_id = HashMap::new();
+
+            for (item_id, item) in source_analysis.items.iter().enumerate() {
+                items_by_source_id.entry(item.loc.source_id).or_insert_with(Vec::new).push(item_id);
+            }
 
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()


### PR DESCRIPTION
## Motivation

Closes #7054
Closes #2567
Closes #4854
Closes #4654

## Solution

Currently we're collecting anchors via the following steps:
1. Walk the AST for each contract definition to find coverage items contained in it along with its base contracts and potentially libraries.
2. Collect mapping from contract_id to coverage items contained in it itself or its base contracts/libraries.
3. Try to find anchors for each coverage item found in step 2.

This approach requires us to be able to reliably find libraries used by a contract which turned out to be non-trivial.

One possible approach could be to reuse some of #6936 code to walk through typed AST and find all contracts/libs used by a given contract. However, this might be breaking due to typed AST not working for some solc versions and this approach is also [not perfect](https://github.com/foundry-rs/foundry/pull/6936#issuecomment-1921443885).

Instead, we now just collect all coverage items and then create a mapping from `source_id` to all coverage items given source contains.

After that, when looking for anchors, we only try finding anchors for items from source ids appearing in source map. This allows us to get rid of dependency resolution through AST.

## Example

I was mainly testing those on Uniswap/v4-core contracts.

Report via latest nightly: [report_nightly.txt](https://github.com/foundry-rs/foundry/files/14783218/report_nightly.txt)
Report via this PR: [report_pr.txt](https://github.com/foundry-rs/foundry/files/14783219/report_pr.txt)

diff:
```diff
9,11c9,11
< | src/libraries/BitMath.sol                  | 0.00% (0/47)      | 0.00% (0/57)       | 0.00% (0/36)     | 0.00% (0/2)      |
< | src/libraries/FullMath.sol                 | 0.00% (0/29)      | 0.00% (0/33)       | 0.00% (0/8)      | 0.00% (0/2)      |
< | src/libraries/Hooks.sol                    | 0.00% (0/41)      | 0.00% (0/76)       | 0.00% (0/28)     | 0.00% (0/14)     |
---
> | src/libraries/BitMath.sol                  | 100.00% (47/47)   | 100.00% (57/57)    | 100.00% (36/36)  | 100.00% (2/2)    |
> | src/libraries/FullMath.sol                 | 100.00% (29/29)   | 100.00% (33/33)    | 100.00% (8/8)    | 100.00% (2/2)    |
> | src/libraries/Hooks.sol                    | 100.00% (41/41)   | 98.68% (75/76)     | 96.43% (27/28)   | 100.00% (14/14)  |
14,23c14,23
< | src/libraries/Pool.sol                     | 0.00% (0/130)     | 0.00% (0/141)      | 0.00% (0/86)     | 0.00% (0/13)     |
< | src/libraries/PoolGetters.sol              | 0.00% (0/2)       | 0.00% (0/2)        | 100.00% (0/0)    | 0.00% (0/2)      |
< | src/libraries/Position.sol                 | 0.00% (0/12)      | 0.00% (0/14)       | 0.00% (0/6)      | 0.00% (0/2)      |
< | src/libraries/SafeCast.sol                 | 0.00% (0/8)       | 0.00% (0/14)       | 0.00% (0/8)      | 0.00% (0/4)      |
< | src/libraries/SqrtPriceMath.sol            | 0.00% (0/32)      | 0.00% (0/66)       | 0.00% (0/24)     | 0.00% (0/8)      |
< | src/libraries/SwapFeeLibrary.sol           | 0.00% (0/5)       | 0.00% (0/9)        | 0.00% (0/4)      | 0.00% (0/3)      |
< | src/libraries/SwapMath.sol                 | 0.00% (0/23)      | 0.00% (0/30)       | 0.00% (0/12)     | 0.00% (0/1)      |
< | src/libraries/TickBitmap.sol               | 0.00% (0/19)      | 0.00% (0/34)       | 0.00% (0/6)      | 0.00% (0/3)      |
< | src/libraries/TickMath.sol                 | 97.87% (92/94)    | 92.57% (137/148)   | 82.61% (38/46)   | 50.00% (2/4)     |
< | src/libraries/UnsafeMath.sol               | 0.00% (0/1)       | 0.00% (0/1)        | 100.00% (0/0)    | 0.00% (0/1)      |
---
> | src/libraries/Pool.sol                     | 96.92% (126/130)  | 94.33% (133/141)   | 89.53% (77/86)   | 100.00% (13/13)  |
> | src/libraries/PoolGetters.sol              | 100.00% (2/2)     | 100.00% (2/2)      | 100.00% (0/0)    | 100.00% (2/2)    |
> | src/libraries/Position.sol                 | 100.00% (12/12)   | 100.00% (14/14)    | 100.00% (6/6)    | 100.00% (2/2)    |
> | src/libraries/SafeCast.sol                 | 100.00% (8/8)     | 100.00% (14/14)    | 100.00% (8/8)    | 100.00% (4/4)    |
> | src/libraries/SqrtPriceMath.sol            | 100.00% (32/32)   | 98.48% (65/66)     | 83.33% (20/24)   | 100.00% (8/8)    |
> | src/libraries/SwapFeeLibrary.sol           | 100.00% (5/5)     | 100.00% (9/9)      | 100.00% (4/4)    | 100.00% (3/3)    |
> | src/libraries/SwapMath.sol                 | 100.00% (23/23)   | 100.00% (30/30)    | 100.00% (12/12)  | 100.00% (1/1)    |
> | src/libraries/TickBitmap.sol               | 100.00% (19/19)   | 100.00% (34/34)    | 100.00% (6/6)    | 100.00% (3/3)    |
> | src/libraries/TickMath.sol                 | 97.87% (92/94)    | 97.30% (144/148)   | 97.83% (45/46)   | 50.00% (2/4)     |
> | src/libraries/UnsafeMath.sol               | 100.00% (1/1)     | 100.00% (1/1)      | 100.00% (0/0)    | 100.00% (1/1)    |
51,53c51,53
< | src/types/BalanceDelta.sol                 | 0.00% (0/2)       | 0.00% (0/2)        | 100.00% (0/0)    | 0.00% (0/2)      |
< | src/types/Currency.sol                     | 0.00% (0/15)      | 0.00% (0/24)       | 0.00% (0/10)     | 0.00% (0/6)      |
< | src/types/PoolId.sol                       | 0.00% (0/1)       | 0.00% (0/2)        | 100.00% (0/0)    | 0.00% (0/1)      |
---
> | src/types/BalanceDelta.sol                 | 100.00% (2/2)     | 100.00% (2/2)      | 100.00% (0/0)    | 100.00% (2/2)    |
> | src/types/Currency.sol                     | 100.00% (15/15)   | 91.67% (22/24)     | 80.00% (8/10)    | 100.00% (6/6)    |
> | src/types/PoolId.sol                       | 100.00% (1/1)     | 100.00% (2/2)      | 100.00% (0/0)    | 100.00% (1/1)    |
55c55
< | test/utils/Deployers.sol                   | 0.00% (0/50)      | 0.00% (0/63)       | 0.00% (0/10)     | 0.00% (0/11)     |
---
> | test/utils/Deployers.sol                   | 96.00% (48/50)    | 93.65% (59/63)     | 80.00% (8/10)    | 90.91% (10/11)   |
58,59c58,59
< | test/utils/SortTokens.sol                  | 0.00% (0/3)       | 0.00% (0/5)        | 0.00% (0/2)      | 0.00% (0/1)      |
< | Total                                      | 43.42% (554/1276) | 42.89% (745/1737)  | 22.24% (153/688) | 40.35% (115/285) |
---
> | test/utils/SortTokens.sol                  | 66.67% (2/3)      | 80.00% (4/5)       | 50.00% (1/2)     | 100.00% (1/1)    |
> | Total                                      | 75.78% (967/1276) | 75.30% (1308/1737) | 55.38% (381/688) | 66.67% (190/285) |
```

cc @onbjerg 