### PR TITLE
feat: allow supplying function name via `forge script --sig`

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1179,3 +1179,21 @@ forgetest_async!(can_sign_with_script_wallet_multiple, |prj, cmd| {
         .await
         .simulate(ScriptOutcome::OkRun);
 });
+
+forgetest_async!(fails_with_function_name_and_overloads, |prj, cmd| {
+    let script = prj
+        .add_script(
+            "Sctipt.s.sol",
+            r#"
+contract Script {
+    function run() external {}
+
+    function run(address,uint256) external {}
+}
+            "#,
+        )
+        .unwrap();
+
+    cmd.arg("script").args([&script.to_string_lossy(), "--sig", "run"]);
+    assert!(cmd.stderr_lossy().contains("Multiple functions with the same name"));
+});

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -340,7 +340,7 @@ impl ScriptArgs {
                 ),
             }
         };
-        let data = encode_function_args(&func, &self.args)?;
+        let data = encode_function_args(func, &self.args)?;
 
         Ok((func.clone(), data.into()))
     }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -313,10 +313,8 @@ impl ScriptArgs {
     fn get_method_and_calldata(&self, abi: &JsonAbi) -> Result<(Function, Bytes)> {
         if let Ok(decoded) = hex::decode(&self.sig) {
             let selector = &decoded[..SELECTOR_LEN];
-            let func = abi
-                .functions()
-                .find(|func| selector == &func.selector()[..])
-                .ok_or_else(|| {
+            let func =
+                abi.functions().find(|func| selector == &func.selector()[..]).ok_or_else(|| {
                     eyre::eyre!(
                         "Function selector `{}` not found in the ABI",
                         hex::encode(selector)
@@ -324,7 +322,7 @@ impl ScriptArgs {
                 })?;
             return Ok((func.clone(), decoded.into()));
         }
-        
+
         let func = if self.sig.contains('(') {
             let func = get_func(&self.sig)?;
             abi.functions()


### PR DESCRIPTION
## Motivation

Having script function with many arguments can be annoying as you have to write stuff like `forge script --sig run(address,uint256,(address,uint256)...`

With this PR if only function name is provided as `--sig` argument and there is exactly one function with such name in the script ABI, then it will be used. Example above becomes just `forge script --sig 'run' 'ARG 1' 'ARG 2'`

cc @mds1 I remember we had discussion related to script UX and you mentioned that such UX improvements might result in footguns, so curious to know what you think about this
