### PR TITLE
fix: coverage bug

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -268,6 +268,7 @@ impl CoverageArgs {
 
             let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
                 .iter()
+                .filter(|(contract_id, _)| contract_id.version == version)
                 .filter_map(|(contract_id, (_, deployed_source_map))| {
                     // TODO: Creation source map/bytecode as well
                     Some((


### PR DESCRIPTION
## Motivation

Ref https://github.com/foundry-rs/foundry/pull/7510#issuecomment-2028893064

#7510 introduced bug which resulted in broken coverage reports for projects with multiple solc versions used.

We were collecting coverage items separately for each version, however, anchors search was done for each artifact, thus we were always overriding anchors data for all artifacts with data from last seen version.