### PR TITLE
fix(bench): avoid panic if test benchmark execution not success

### DIFF
--- a/crates/forge/benches/test.rs
+++ b/crates/forge/benches/test.rs
@@ -15,7 +15,7 @@ fn forge_test_benchmark(c: &mut Criterion) {
         let mut cmd = prj.forge_command();
         cmd.arg("test");
         b.iter(|| {
-            cmd.ensure_execute_success().unwrap();
+            cmd.print_output();
         });
     });
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7531

see https://github.com/foundry-rs/foundry/issues/7531#issuecomment-2029209895 tests of project used could fail but it shouldn't panic test benchmark

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

use `cmd.print_output()` when benchmark (to also give an insight re tests execution outcome) instead assuming tests are executed with success