### PR TITLE
Use artifact_id instead of file_id

### DIFF
--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -84,8 +84,8 @@ impl EtherscanIdentifier {
         // construct the map
         for (results, (_, metadata)) in artifacts.into_iter().zip(contracts_iter) {
             // get the inner type
-            let (artifact_id, file_id, bytecode) = results?;
-            sources.insert(&artifact_id, file_id, metadata.source_code(), bytecode);
+            let (artifact_id, _, bytecode) = results?;
+            sources.insert(&artifact_id, metadata.source_code(), bytecode);
         }
 
         Ok(sources)


### PR DESCRIPTION
## Motivation

There is a design flaw with `ContractSources`, that always assumes 1 file_id only has 1 artifact. However, It can often happen like:

```
interface A {}
contract T {
    A a ...
}
```

In this case, 1 file_id would have two artifacts. As a result, the `sourcemap` of `T` would be overwritten by `A` if `T` is iterated earlier in this loop:

https://github.com/foundry-rs/foundry/blob/bd56eef59fff9d9597ab0aff4bf4fd6f0a9e399e/crates/common/src/compile.rs#L296-L319

This currently breaks my `forge test --debug` by showing `no source map from contract xxxx`. 

## Solution

This PR fixes it by using `artifact_id` instead of `file_id`. I carefully checked the API exposed by `ContractSources`, and I think currently no other component seems to be using it so it should be safe to make this change. I'm not very sure if this is the best solution but I'm open to discussion.
