### PR TITLE
Make batch size as a option

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -321,7 +321,8 @@ impl BundledState {
 
                 // We send transactions and wait for receipts in batches of 100, since some networks
                 // cannot handle more than that.
-                let batch_size = if sequential_broadcast { 1 } else { 100 };
+                let valid_batch_size = if self.args.batch_size > 100 { 100 } else { self.args.batch_size };
+                let batch_size = if sequential_broadcast { 1 } else { valid_batch_size as usize };
                 let mut index = already_broadcasted;
 
                 for (batch_number, batch) in

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -322,7 +322,7 @@ impl BundledState {
                 // We send transactions and wait for receipts in batches of 100, since some networks
                 // cannot handle more than that.
                 let valid_batch_size = if self.args.batch_size > 100 { 100 } else { self.args.batch_size };
-                let batch_size = if sequential_broadcast { 1 } else { valid_batch_size as usize };
+                let batch_size = if sequential_broadcast { 1 } else { valid_batch_size };
                 let mut index = already_broadcasted;
 
                 for (batch_number, batch) in

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -321,7 +321,7 @@ impl BundledState {
 
                 // We send transactions and wait for receipts in batches of 100, since some networks
                 // cannot handle more than that.
-                let valid_batch_size = if self.args.batch_size > 100 { 100 } else { self.args.batch_size };
+                let valid_batch_size = self.args.batch_size.min(100);
                 let batch_size = if sequential_broadcast { 1 } else { valid_batch_size };
                 let mut index = already_broadcasted;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -105,7 +105,13 @@ pub struct ScriptArgs {
 
     /// Broadcasts the transactions.
     #[arg(long)]
+
     pub broadcast: bool,
+
+    /// Batch size of transactions.
+    /// --batch-size
+    #[arg(long, default_value = "100")]
+    pub batch_size: i32,
 
     /// Skips on-chain simulation.
     #[arg(long)]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -108,7 +108,6 @@ pub struct ScriptArgs {
     pub broadcast: bool,
 
     /// Batch size of transactions.
-    /// --batch-size
     #[arg(long, default_value = "100")]
     pub batch_size: usize,
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -110,7 +110,7 @@ pub struct ScriptArgs {
     /// Batch size of transactions.
     /// --batch-size
     #[arg(long, default_value = "100")]
-    pub batch_size: i32,
+    pub batch_size: usize,
 
     /// Skips on-chain simulation.
     #[arg(long)]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -105,7 +105,6 @@ pub struct ScriptArgs {
 
     /// Broadcasts the transactions.
     #[arg(long)]
-
     pub broadcast: bool,
 
     /// Batch size of transactions.


### PR DESCRIPTION
Make batch size as a option.

## Motivation

We are developing a network based on zkevm - a new evm platform. We are trying to increase compatibility of MUD Framework and zkevm. We found that with the default batch size of 100, zkevm may not be able to handle it, with the --slow option the waiting time is too long. 

## Solution

So we added batch size as an option to increase customization compatibility with many chains.
