### PR TITLE
feat(forge): add labels for precompile addresses

### DIFF
--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -35,3 +35,33 @@ pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920c
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE: &[u8] = &hex!("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
+
+/// The ECRecover precompile address.
+pub const EC_RECOVER_ADDRESS: Address = address!("0000000000000000000000000000000000000001");
+
+/// The SHA-256 precompile address.
+pub const SHA_256_ADDRESS: Address = address!("0000000000000000000000000000000000000002");
+
+/// The RIPEMD-160 precompile address.
+pub const RIPEMD_160_ADDRESS: Address = address!("0000000000000000000000000000000000000003");
+
+/// The Identity precompile address.
+pub const IDENTITY_ADDRESS: Address = address!("0000000000000000000000000000000000000004");
+
+/// The ModExp precompile address.
+pub const MOD_EXP_ADDRESS: Address = address!("0000000000000000000000000000000000000005");
+
+/// The ECAdd precompile address.
+pub const EC_ADD_ADDRESS: Address = address!("0000000000000000000000000000000000000006");
+
+/// The ECMul precompile address.
+pub const EC_MUL_ADDRESS: Address = address!("0000000000000000000000000000000000000007");
+
+/// The ECPairing precompile address.
+pub const EC_PAIRING_ADDRESS: Address = address!("0000000000000000000000000000000000000008");
+
+/// The Blake2F precompile address.
+pub const BLAKE_2F_ADDRESS: Address = address!("0000000000000000000000000000000000000009");
+
+/// The PointEvaluation precompile address.
+pub const POINT_EVALUATION_ADDRESS: Address = address!("000000000000000000000000000000000000000a");

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -13,8 +13,10 @@ use foundry_common::{
 use foundry_evm_core::{
     abi::{Console, HardhatConsole, Vm, HARDHAT_CONSOLE_SELECTOR_PATCHES},
     constants::{
-        CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS,
-        TEST_CONTRACT_ADDRESS,
+        BLAKE_2F_ADDRESS, CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, EC_ADD_ADDRESS,
+        EC_MUL_ADDRESS, EC_PAIRING_ADDRESS, EC_RECOVER_ADDRESS, HARDHAT_CONSOLE_ADDRESS,
+        IDENTITY_ADDRESS, MOD_EXP_ADDRESS, POINT_EVALUATION_ADDRESS, RIPEMD_160_ADDRESS,
+        SHA_256_ADDRESS, TEST_CONTRACT_ADDRESS,
     },
     decode::RevertDecoder,
 };
@@ -158,6 +160,16 @@ impl CallTraceDecoder {
                 (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
                 (CALLER, "DefaultSender".to_string()),
                 (TEST_CONTRACT_ADDRESS, "DefaultTestContract".to_string()),
+                (EC_RECOVER_ADDRESS, "ECRecover".to_string()),
+                (SHA_256_ADDRESS, "SHA-256".to_string()),
+                (RIPEMD_160_ADDRESS, "RIPEMD-160".to_string()),
+                (IDENTITY_ADDRESS, "Identity".to_string()),
+                (MOD_EXP_ADDRESS, "ModExp".to_string()),
+                (EC_ADD_ADDRESS, "ECAdd".to_string()),
+                (EC_MUL_ADDRESS, "ECMul".to_string()),
+                (EC_PAIRING_ADDRESS, "ECPairing".to_string()),
+                (BLAKE_2F_ADDRESS, "Blake2F".to_string()),
+                (POINT_EVALUATION_ADDRESS, "PointEvaluation".to_string()),
             ]
             .into(),
             receive_contracts: Default::default(),

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -526,3 +526,53 @@ contract GasLimitTest is Test {
 
     cmd.args(["test", "-vvvv", "--isolate", "--disable-block-gas-limit"]).assert_success();
 });
+
+// <https://github.com/foundry-rs/foundry/issues/7530>
+forgetest_init!(repro_7530, |prj, cmd| {
+    prj.wipe_contracts();
+
+    prj.add_test(
+        "Contract.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract PrecompileLabelsTest is Test {
+    function testPrecompileLabels() public {
+        vm.deal(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D), 1 ether);
+        vm.deal(address(0x000000000000000000636F6e736F6c652e6c6f67), 1 ether);
+        vm.deal(address(0x4e59b44847b379578588920cA78FbF26c0B4956C), 1 ether);
+        vm.deal(address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38), 1 ether);
+        vm.deal(address(0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84), 1 ether);
+        vm.deal(address(1), 1 ether);
+        vm.deal(address(2), 1 ether);
+        vm.deal(address(3), 1 ether);
+        vm.deal(address(4), 1 ether);
+        vm.deal(address(5), 1 ether);
+        vm.deal(address(6), 1 ether);
+        vm.deal(address(7), 1 ether);
+        vm.deal(address(8), 1 ether);
+        vm.deal(address(9), 1 ether);
+        vm.deal(address(10), 1 ether);
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    let output = cmd.args(["test", "-vvvv"]).stdout_lossy();
+    assert!(output.contains("VM: [0x7109709ECfa91a80626fF3989D68f67F5b1DD12D]"));
+    assert!(output.contains("console: [0x000000000000000000636F6e736F6c652e6c6f67]"));
+    assert!(output.contains("Create2Deployer: [0x4e59b44847b379578588920cA78FbF26c0B4956C]"));
+    assert!(output.contains("DefaultSender: [0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38]"));
+    assert!(output.contains("DefaultTestContract: [0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84]"));
+    assert!(output.contains("ECRecover: [0x0000000000000000000000000000000000000001]"));
+    assert!(output.contains("SHA-256: [0x0000000000000000000000000000000000000002]"));
+    assert!(output.contains("RIPEMD-160: [0x0000000000000000000000000000000000000003]"));
+    assert!(output.contains("Identity: [0x0000000000000000000000000000000000000004]"));
+    assert!(output.contains("ModExp: [0x0000000000000000000000000000000000000005]"));
+    assert!(output.contains("ECAdd: [0x0000000000000000000000000000000000000006]"));
+    assert!(output.contains("ECMul: [0x0000000000000000000000000000000000000007]"));
+    assert!(output.contains("ECPairing: [0x0000000000000000000000000000000000000008]"));
+    assert!(output.contains("Blake2F: [0x0000000000000000000000000000000000000009]"));
+    assert!(output.contains("PointEvaluation: [0x000000000000000000000000000000000000000A]"));
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7530 

Not all precompiles are labeled, this PR add missing labels

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- added precompile addresses in constants
- in precompile decode match on address
- add trace labels to all precompile addresses