### PR TITLE
fix(script): decode custom error in script fail message

### DIFF
--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -23,7 +23,7 @@ use foundry_compilers::artifacts::ContractBytecodeSome;
 use foundry_config::{Config, NamedChain};
 use foundry_debugger::Debugger;
 use foundry_evm::{
-    decode::{decode_console_logs, RevertDecoder},
+    decode::decode_console_logs,
     inspectors::cheatcodes::{BroadcastableTransaction, BroadcastableTransactions},
     traces::{
         identifier::{SignaturesIdentifier, TraceIdentifiers},
@@ -423,7 +423,7 @@ impl PreSimulationState {
         if !self.execution_result.success {
             return Err(eyre::eyre!(
                 "script failed: {}",
-                RevertDecoder::new().decode(&self.execution_result.returned[..], None)
+                &self.execution_artifacts.decoder.revert_decoder.decode(&result.returned[..], None)
             ));
         }
 
@@ -504,7 +504,7 @@ impl PreSimulationState {
         if !result.success {
             return Err(eyre::eyre!(
                 "script failed: {}",
-                RevertDecoder::new().decode(&result.returned[..], None)
+                &self.execution_artifacts.decoder.revert_decoder.decode(&result.returned[..], None)
             ));
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Similar with https://github.com/foundry-rs/foundry/pull/7559 but for scripts
```
Error: 
script failed: custom error 31fec19b:
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- use execution_artifacts revert decoder to decode result / show proper message