### PR TITLE
fix: `--match-path` is broken

### DIFF
--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -196,7 +196,8 @@ impl FileFilter for ProjectPathsAwareFilter {
     ///
     /// If no file regex is set this returns true if the file ends with `.t.sol`, see
     /// [FoundryPathExr::is_sol_test()]
-    fn is_match(&self, file: &Path) -> bool {
+    fn is_match(&self, mut file: &Path) -> bool {
+        file = file.strip_prefix(&self.paths.root).unwrap_or(file);
         self.args_filter.is_match(file)
     }
 }
@@ -210,8 +211,9 @@ impl TestFilter for ProjectPathsAwareFilter {
         self.args_filter.matches_contract(contract_name)
     }
 
-    fn matches_path(&self, path: &Path) -> bool {
+    fn matches_path(&self, mut path: &Path) -> bool {
         // we don't want to test files that belong to a library
+        path = path.strip_prefix(&self.paths.root).unwrap_or(path);
         self.args_filter.matches_path(path) && !self.paths.has_library_ancestor(path)
     }
 }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -526,3 +526,22 @@ contract GasLimitTest is Test {
 
     cmd.args(["test", "-vvvv", "--isolate", "--disable-block-gas-limit"]).assert_success();
 });
+
+// tests that warning is displayed with pattern when no tests match
+forgetest!(test_match_path, |prj, cmd| {
+    prj.add_source(
+        "dummy",
+        r"  
+contract Dummy {
+    function testDummy() public {}
+}
+",
+    )
+    .unwrap();
+
+    // set up command
+    cmd.args(["test", "--match-path", "src/dummy.sol"]);
+
+    // run command and assert
+    cmd.assert_success()
+});

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -527,7 +527,6 @@ contract GasLimitTest is Test {
     cmd.args(["test", "-vvvv", "--isolate", "--disable-block-gas-limit"]).assert_success();
 });
 
-// tests that warning is displayed with pattern when no tests match
 forgetest!(test_match_path, |prj, cmd| {
     prj.add_source(
         "dummy",
@@ -539,9 +538,6 @@ contract Dummy {
     )
     .unwrap();
 
-    // set up command
     cmd.args(["test", "--match-path", "src/dummy.sol"]);
-
-    // run command and assert
     cmd.assert_success()
 });


### PR DESCRIPTION
## Motivation

Closes #7578

#7334 moved tests filtering to `TestArgs::get_sources_to_compile` which does not strip project root from paths opposed to `MultiContractRunner` which keeps them stripped. Thus, `--match-path` and `--no-match-path` filters are now broken.

## Solution

Strip project root when filtering in `ProjectPathsAwareFilter`. Also added a test for this flag, it seems that we didn't have any