### PR TITLE
fix: smarter `getCode` validation

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -8,6 +8,7 @@ use foundry_config::{
     ResolvedRpcEndpoints,
 };
 use foundry_evm_core::opts::EvmOpts;
+use semver::Version;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -47,6 +48,8 @@ pub struct CheatsConfig {
     /// If Some, `vm.getDeployedCode` invocations are validated to be in scope of this list.
     /// If None, no validation is performed.
     pub available_artifacts: Option<Vec<ArtifactId>>,
+    /// Version of the script/test contract which is currently running.
+    pub running_version: Option<Version>,
 }
 
 impl CheatsConfig {
@@ -56,6 +59,7 @@ impl CheatsConfig {
         evm_opts: EvmOpts,
         available_artifacts: Option<Vec<ArtifactId>>,
         script_wallets: Option<ScriptWallets>,
+        running_version: Option<Version>,
     ) -> Self {
         let mut allowed_paths = vec![config.__root.0.clone()];
         allowed_paths.extend(config.libs.clone());
@@ -82,6 +86,7 @@ impl CheatsConfig {
             labels: config.labels.clone(),
             script_wallets,
             available_artifacts,
+            running_version,
         }
     }
 
@@ -200,6 +205,7 @@ impl Default for CheatsConfig {
             labels: Default::default(),
             script_wallets: None,
             available_artifacts: Default::default(),
+            running_version: Default::default(),
         }
     }
 }

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -221,6 +221,7 @@ mod tests {
             Default::default(),
             None,
             None,
+            None,
         )
     }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -271,7 +271,7 @@ impl Cheatcode for getDeployedCodeCall {
 }
 
 /// Returns the path to the json artifact depending on the input
-/// 
+///
 /// Can parse following input formats:
 /// - `path/to/artifact.json`
 /// - `path/to/contract.sol`
@@ -294,7 +294,7 @@ fn get_artifact_path(state: &Cheatcodes, path: &str) -> Result<PathBuf> {
         if path_or_name.ends_with(".sol") {
             file = Some(PathBuf::from(path_or_name));
             if let Some(name_or_version) = parts.next() {
-                if name_or_version.contains(".") {
+                if name_or_version.contains('.') {
                     version = Some(name_or_version);
                 } else {
                     contract_name = Some(name_or_version);
@@ -365,19 +365,18 @@ fn get_artifact_path(state: &Cheatcodes, path: &str) -> Result<PathBuf> {
 
             Ok(artifact.path.clone())
         } else {
-            let path_in_artifacts = match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
-                (Some(file), Some(contract_name)) => {
-                    Ok(format!("{file}/{contract_name}.json"))
-                }
-                (None, Some(contract_name)) => {
-                    Ok(format!("{contract_name}.sol/{contract_name}.json"))
-                }
-                (Some(file), None) => {
-                    let name = file.replace(".sol", "");
-                    Ok(format!("{file}/{name}.json"))
-                }
-                _ => Err(fmt_err!("Invalid artifact path")),
-            }?;
+            let path_in_artifacts =
+                match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
+                    (Some(file), Some(contract_name)) => Ok(format!("{file}/{contract_name}.json")),
+                    (None, Some(contract_name)) => {
+                        Ok(format!("{contract_name}.sol/{contract_name}.json"))
+                    }
+                    (Some(file), None) => {
+                        let name = file.replace(".sol", "");
+                        Ok(format!("{file}/{name}.json"))
+                    }
+                    _ => Err(fmt_err!("Invalid artifact path")),
+                }?;
             Ok(state.config.paths.artifacts.join(path_in_artifacts))
         }
     }

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -310,7 +310,7 @@ fn get_artifact_path(state: &Cheatcodes, path: &str) -> Result<PathBuf> {
                             return false;
                         }
                     }
-                    return true;
+                    true
                 })
                 .collect::<Vec<_>>();
 
@@ -331,7 +331,7 @@ fn get_artifact_path(state: &Cheatcodes, path: &str) -> Result<PathBuf> {
 
                             (filtered.len() == 1).then_some(filtered[0])
                         })
-                        .ok_or_else(|| fmt_err!("Multiple artifacts found for the same version"))
+                        .ok_or_else(|| fmt_err!("Multiple matching artifacts found"))
                 }
             }?;
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -308,6 +308,7 @@ impl SessionSource {
                         self.config.evm_opts.clone(),
                         None,
                         None,
+                        self.solc.version().ok(),
                     )
                     .into(),
                 )

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -317,6 +317,7 @@ impl CoverageArgs {
                 evm_opts.clone(),
                 Some(artifact_ids),
                 None,
+                None,
             ))
             .with_test_options(TestOptions {
                 fuzz: config.fuzz,

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -287,6 +287,7 @@ impl TestArgs {
                 evm_opts.clone(),
                 Some(artifact_ids),
                 None,
+                None, // populated separately for each test contract
             ))
             .with_test_options(test_options)
             .enable_isolation(evm_opts.isolate)

--- a/crates/forge/tests/it/cheats.rs
+++ b/crates/forge/tests/it/cheats.rs
@@ -2,14 +2,13 @@
 
 use crate::{
     config::*,
-    test_helpers::{RE_PATH_SEPARATOR, TEST_DATA_DEFAULT},
+    test_helpers::{ForgeTestData, RE_PATH_SEPARATOR, TEST_DATA_DEFAULT, TEST_DATA_MULTI_VERSION},
 };
 use foundry_config::{fs_permissions::PathPermission, FsPermissions};
 use foundry_test_utils::Filter;
 
 /// Executes all cheat code tests but not fork cheat codes
-#[tokio::test(flavor = "multi_thread")]
-async fn test_cheats_local() {
+async fn test_cheats_local(test_data: &ForgeTestData) {
     let mut filter =
         Filter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}*")).exclude_paths("Fork");
 
@@ -18,9 +17,19 @@ async fn test_cheats_local() {
         filter = filter.exclude_tests("(Ffi|File|Line|Root)");
     }
 
-    let mut config = TEST_DATA_DEFAULT.config.clone();
+    let mut config = test_data.config.clone();
     config.fs_permissions = FsPermissions::new(vec![PathPermission::read_write("./")]);
-    let runner = TEST_DATA_DEFAULT.runner_with_config(config);
+    let runner = test_data.runner_with_config(config);
 
     TestConfig::with_filter(runner, filter).run().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cheats_local_default() {
+    test_cheats_local(&TEST_DATA_DEFAULT).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cheats_local_multi_version() {
+    test_cheats_local(&TEST_DATA_MULTI_VERSION).await
 }

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -32,6 +32,7 @@ const TESTDATA: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata");
 pub enum ForgeTestProfile {
     Default,
     Cancun,
+    MultiVersion,
 }
 
 impl fmt::Display for ForgeTestProfile {
@@ -39,6 +40,7 @@ impl fmt::Display for ForgeTestProfile {
         match self {
             ForgeTestProfile::Default => write!(f, "default"),
             ForgeTestProfile::Cancun => write!(f, "cancun"),
+            ForgeTestProfile::MultiVersion => write!(f, "multi-version"),
         }
     }
 }
@@ -279,6 +281,10 @@ pub static TEST_DATA_DEFAULT: Lazy<ForgeTestData> =
 /// Data for tests requiring Cancun support on Solc and EVM level.
 pub static TEST_DATA_CANCUN: Lazy<ForgeTestData> =
     Lazy::new(|| ForgeTestData::new(ForgeTestProfile::Cancun));
+
+/// Data for tests requiring Cancun support on Solc and EVM level.
+pub static TEST_DATA_MULTI_VERSION: Lazy<ForgeTestData> =
+    Lazy::new(|| ForgeTestData::new(ForgeTestProfile::MultiVersion));
 
 pub fn manifest_root() -> &'static Path {
     let mut root = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -206,7 +206,13 @@ impl ForgeTestData {
         let output = self.output.clone();
         let artifact_ids = output.artifact_ids().map(|(id, _)| id).collect();
         self.base_runner()
-            .with_cheats_config(CheatsConfig::new(&config, opts.clone(), Some(artifact_ids), None))
+            .with_cheats_config(CheatsConfig::new(
+                &config,
+                opts.clone(),
+                Some(artifact_ids),
+                None,
+                None,
+            ))
             .sender(config.sender)
             .with_test_options(self.test_opts.clone())
             .build(root, output, env, opts.clone())

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -102,6 +102,7 @@ impl PreExecutionState {
                 self.build_data.build_data.artifact_ids.clone(),
                 self.script_wallets.clone(),
                 self.args.debug,
+                self.build_data.build_data.target.clone(),
             )
             .await?;
         let mut result = self.execute_with_runner(&mut runner).await?;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -559,13 +559,14 @@ impl ScriptConfig {
         artifact_ids: Vec<ArtifactId>,
         script_wallets: ScriptWallets,
         debug: bool,
+        target: ArtifactId,
     ) -> Result<ScriptRunner> {
-        self._get_runner(Some((artifact_ids, script_wallets)), debug).await
+        self._get_runner(Some((artifact_ids, script_wallets, target)), debug).await
     }
 
     async fn _get_runner(
         &mut self,
-        cheats_data: Option<(Vec<ArtifactId>, ScriptWallets)>,
+        cheats_data: Option<(Vec<ArtifactId>, ScriptWallets, ArtifactId)>,
         debug: bool,
     ) -> Result<ScriptRunner> {
         trace!("preparing script runner");
@@ -594,7 +595,7 @@ impl ScriptConfig {
             .spec(self.config.evm_spec_id())
             .gas_limit(self.evm_opts.gas_limit());
 
-        if let Some((artifact_ids, script_wallets)) = cheats_data {
+        if let Some((artifact_ids, script_wallets, target)) = cheats_data {
             builder = builder.inspectors(|stack| {
                 stack
                     .debug(debug)
@@ -604,6 +605,7 @@ impl ScriptConfig {
                             self.evm_opts.clone(),
                             Some(artifact_ids),
                             Some(script_wallets),
+                            Some(target.version),
                         )
                         .into(),
                     )

--- a/testdata/default/cheats/GetCode.t.sol
+++ b/testdata/default/cheats/GetCode.t.sol
@@ -6,6 +6,8 @@ import "cheats/Vm.sol";
 
 contract TestContract {}
 
+contract TestContractGetCode {}
+
 contract GetCodeTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
@@ -79,5 +81,15 @@ contract GetCodeTest is DSTest {
 
         vm._expectCheatcodeRevert("No matching artifact found");
         vm.getCode("cheats/GetCode.t.sol:TestContract:0.8.19");
+    }
+
+    function testByName() public {
+        bytes memory code = vm.getCode("TestContractGetCode");
+        assertEq(type(TestContractGetCode).creationCode, code);
+    }
+
+    function testByNameAndVersion() public {
+        bytes memory code = vm.getCode("TestContractGetCode:0.8.18");
+        assertEq(type(TestContractGetCode).creationCode, code);
     }
 }

--- a/testdata/multi-version/Counter.sol
+++ b/testdata/multi-version/Counter.sol
@@ -1,0 +1,11 @@
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/testdata/multi-version/Importer.sol
+++ b/testdata/multi-version/Importer.sol
@@ -3,5 +3,5 @@ pragma solidity 0.8.17;
 import "./Counter.sol";
 
 // Please do not remove or change version pragma for this file.
-// If you need to ensure that some of the files are compiled with 
+// If you need to ensure that some of the files are compiled with
 // solc 0.8.17, you should add imports of them to this file.

--- a/testdata/multi-version/Importer.sol
+++ b/testdata/multi-version/Importer.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.8.17;
+
+import "./Counter.sol";
+
+// Please do not remove or change version pragma for this file.
+// If you need to ensure that some of the files are compiled with 
+// solc 0.8.17, you should add imports of them to this file.

--- a/testdata/multi-version/cheats/GetCode.t.sol
+++ b/testdata/multi-version/cheats/GetCode.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+import "../Counter.sol";
+
+contract GetCodeTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testGetCodeMultiVersion() public {
+        assertEq(vm.getCode("Counter.sol"), type(Counter).creationCode);
+        require(keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.17")), "Invalid artifact");
+        assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.18"));
+    }
+}

--- a/testdata/multi-version/cheats/GetCode.t.sol
+++ b/testdata/multi-version/cheats/GetCode.t.sol
@@ -10,7 +10,10 @@ contract GetCodeTest is DSTest {
 
     function testGetCodeMultiVersion() public {
         assertEq(vm.getCode("Counter.sol"), type(Counter).creationCode);
-        require(keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.17")), "Invalid artifact");
+        require(
+            keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.17")),
+            "Invalid artifact"
+        );
         assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.18"));
     }
 }

--- a/testdata/multi-version/cheats/GetCode.t.sol
+++ b/testdata/multi-version/cheats/GetCode.t.sol
@@ -16,4 +16,10 @@ contract GetCodeTest is DSTest {
         );
         assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.18"));
     }
+
+    function testGetCodeByNameMultiVersion() public {
+        assertEq(vm.getCode("Counter"), type(Counter).creationCode);
+        require(keccak256(vm.getCode("Counter")) != keccak256(vm.getCode("Counter:0.8.17")), "Invalid artifact");
+        assertEq(vm.getCode("Counter"), vm.getCode("Counter:0.8.18"));
+    }
 }

--- a/testdata/multi-version/cheats/GetCode17.t.sol
+++ b/testdata/multi-version/cheats/GetCode17.t.sol
@@ -11,7 +11,10 @@ contract GetCodeTest17 is DSTest {
 
     function testGetCodeMultiVersion() public {
         assertEq(vm.getCode("Counter.sol"), type(Counter).creationCode);
-        require(keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.18")), "Invalid artifact");
+        require(
+            keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.18")),
+            "Invalid artifact"
+        );
         assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.17"));
     }
 }

--- a/testdata/multi-version/cheats/GetCode17.t.sol
+++ b/testdata/multi-version/cheats/GetCode17.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.17;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+import "../Counter.sol";
+
+// Same as GetCode.t.sol but for 0.8.17 version
+contract GetCodeTest17 is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testGetCodeMultiVersion() public {
+        assertEq(vm.getCode("Counter.sol"), type(Counter).creationCode);
+        require(keccak256(vm.getCode("Counter.sol")) != keccak256(vm.getCode("Counter.sol:Counter:0.8.18")), "Invalid artifact");
+        assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.17"));
+    }
+}

--- a/testdata/multi-version/cheats/GetCode17.t.sol
+++ b/testdata/multi-version/cheats/GetCode17.t.sol
@@ -17,4 +17,10 @@ contract GetCodeTest17 is DSTest {
         );
         assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter.sol:Counter:0.8.17"));
     }
+
+    function testGetCodeByNameMultiVersion() public {
+        assertEq(vm.getCode("Counter"), type(Counter).creationCode);
+        require(keccak256(vm.getCode("Counter")) != keccak256(vm.getCode("Counter:0.8.18")), "Invalid artifact");
+        assertEq(vm.getCode("Counter.sol"), vm.getCode("Counter:0.8.17"));
+    }
 }


### PR DESCRIPTION
## Motivation

One more fix after #7334 

If we've found multiple matching artifacts for `vm.getCode` and exactly one of them matches version of the currently running test/script source, return that.

Ref https://t.me/foundry_support/52016

## Solution

This changes test runner flow a bit so we now create executor for each `ContractRunner` to alter cheatcodes config with running contract version
