### PR TITLE
feat: optimize compilation by reading AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,8 +3781,6 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1990477446ea72d80da26951cf7ba68652f9e5b481e3a469f09c4b120f647f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "semver 1.0.22",
  "serde",
  "serde_json",
+ "solang-parser",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,7 +3767,6 @@ dependencies = [
  "semver 1.0.22",
  "serde",
  "serde_json",
- "solang-parser",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3780,7 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.3.15"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8caca67f174741b05c2f4188d3ee93420342130eb2a768abb9b885bb8b918df2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,3 +219,6 @@ axum = "0.6"
 hyper = "0.14"
 tower = "0.4"
 tower-http = "0.4"
+
+[patch.crates-io]
+foundry-compilers = { path = "../compilers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.5", default-features = false }
-foundry-compilers = { version = "0.3.15", default-features = false }
+foundry-compilers = { version = "0.3.17", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg
@@ -219,6 +219,3 @@ axum = "0.6"
 hyper = "0.14"
 tower = "0.4"
 tower-http = "0.4"
-
-[patch.crates-io]
-foundry-compilers = { path = "../compilers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.2.5", default-features = false }
-foundry-compilers = { version = "0.3.14", default-features = false }
+foundry-compilers = { version = "0.3.15", default-features = false }
 
 ## revm
 # no default features to avoid c-kzg

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -39,7 +39,7 @@ pub fn remove_contract(
     } else {
         let mut err = format!("could not find artifact: `{}`", name);
         if let Some(suggestion) =
-            super::did_you_mean(&name, output.artifacts().map(|(name, _)| name)).pop()
+            super::did_you_mean(name, output.artifacts().map(|(name, _)| name)).pop()
         {
             if suggestion != name {
                 err = format!(

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -5,7 +5,6 @@ use foundry_common::{cli_warn, fs, TestFunctionExt};
 use foundry_compilers::{
     artifacts::{CompactBytecode, CompactDeployedBytecode},
     cache::{CacheEntry, SolFilesCache},
-    info::ContractInfo,
     utils::read_json_file,
     Artifact, ProjectCompileOutput,
 };
@@ -20,7 +19,11 @@ use foundry_evm::{
         render_trace_arena, CallTraceDecoder, CallTraceDecoderBuilder, TraceKind, Traces,
     },
 };
-use std::{fmt::Write, path::PathBuf, str::FromStr};
+use std::{
+    fmt::Write,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use yansi::Paint;
 
 /// Given a `Project`'s output, removes the matching ABI, Bytecode and
@@ -28,16 +31,17 @@ use yansi::Paint;
 #[track_caller]
 pub fn remove_contract(
     output: &mut ProjectCompileOutput,
-    info: &ContractInfo,
+    path: &Path,
+    name: &str,
 ) -> Result<(JsonAbi, CompactBytecode, CompactDeployedBytecode)> {
-    let contract = if let Some(contract) = output.remove_contract(info) {
+    let contract = if let Some(contract) = output.remove(path.to_string_lossy(), name) {
         contract
     } else {
-        let mut err = format!("could not find artifact: `{}`", info.name);
+        let mut err = format!("could not find artifact: `{}`", name);
         if let Some(suggestion) =
-            super::did_you_mean(&info.name, output.artifacts().map(|(name, _)| name)).pop()
+            super::did_you_mean(&name, output.artifacts().map(|(name, _)| name)).pop()
         {
-            if suggestion != info.name {
+            if suggestion != name {
                 err = format!(
                     r#"{err}
 
@@ -50,17 +54,17 @@ pub fn remove_contract(
 
     let abi = contract
         .get_abi()
-        .ok_or_else(|| eyre::eyre!("contract {} does not contain abi", info))?
+        .ok_or_else(|| eyre::eyre!("contract {} does not contain abi", name))?
         .into_owned();
 
     let bin = contract
         .get_bytecode()
-        .ok_or_else(|| eyre::eyre!("contract {} does not contain bytecode", info))?
+        .ok_or_else(|| eyre::eyre!("contract {} does not contain bytecode", name))?
         .into_owned();
 
     let runtime = contract
         .get_deployed_bytecode()
-        .ok_or_else(|| eyre::eyre!("contract {} does not contain deployed bytecode", info))?
+        .ok_or_else(|| eyre::eyre!("contract {} does not contain deployed bytecode", name))?
         .into_owned();
 
     Ok((abi, bin, runtime))

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -69,6 +69,7 @@ walkdir = "2"
 yansi = "0.5"
 rustc-hash.workspace = true
 num-format.workspace = true
+solang-parser.workspace = true
 
 [dev-dependencies]
 foundry-macros.workspace = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -69,7 +69,6 @@ walkdir = "2"
 yansi = "0.5"
 rustc-hash.workspace = true
 num-format.workspace = true
-solang-parser.workspace = true
 
 [dev-dependencies]
 foundry-macros.workspace = true

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -13,13 +13,12 @@ use foundry_compilers::{
     },
     remappings::Remapping,
     report::{BasicStdoutReporter, NoReporter, Report},
-    Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig,
+    Artifact, ArtifactId, FileFilter, Project, ProjectCompileOutput, ProjectPathsConfig,
     Solc, SolcConfig,
 };
 use foundry_linking::Linker;
 use num_format::{Locale, ToFormattedString};
 use rustc_hash::FxHashMap;
-use solang_parser::pt::SourceUnitPart;
 use std::{
     collections::{BTreeMap, HashMap},
     convert::Infallible,

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -1,20 +1,15 @@
 //! Support for compiling [foundry_compilers::Project]
 
-use crate::{
-    compact_to_contract, glob::GlobMatcher, term::SpinnerReporter,
-    TestFunctionExt,
-};
+use crate::{compact_to_contract, glob::GlobMatcher, term::SpinnerReporter, TestFunctionExt};
 use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, CellAlignment, Color, Table};
 use eyre::{Context, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    artifacts::{
-        BytecodeObject, ContractBytecodeSome, Libraries,
-    },
+    artifacts::{BytecodeObject, ContractBytecodeSome, Libraries},
     remappings::Remapping,
     report::{BasicStdoutReporter, NoReporter, Report},
-    Artifact, ArtifactId, FileFilter, Project, ProjectCompileOutput, ProjectPathsConfig,
-    Solc, SolcConfig,
+    Artifact, ArtifactId, FileFilter, Project, ProjectCompileOutput, ProjectPathsConfig, Solc,
+    SolcConfig,
 };
 use foundry_linking::Linker;
 use num_format::{Locale, ToFormattedString};

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -525,7 +525,7 @@ fn collect_contract_names(project: &Project) -> Result<HashMap<String, Vec<PathB
 pub fn find_contract_path(target_name: &str, project: &Project) -> Result<PathBuf> {
     let mut contracts = collect_contract_names(project)?;
 
-    if contracts.get(target_name).map_or(true, |paths| paths.len() == 0) {
+    if contracts.get(target_name).map_or(true, |paths| paths.is_empty()) {
         eyre::bail!("No contract found with the name `{}`", target_name);
     }
     let mut paths = contracts.remove(target_name).unwrap();

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -476,21 +476,18 @@ pub fn find_contract_path(target_name: &str, project: &Project) -> Result<PathBu
             .map_err(|_| eyre::eyre!("Failed to parse {}.", file.display()))?;
 
         for part in parsed.0 {
-            match part {
-                SourceUnitPart::ContractDefinition(contract) => {
-                    if let Some(name) = contract.name {
-                        if name.name == target_name {
-                            if target.is_some() {
-                                eyre::bail!(
-                                    "Found multiple matching contracts with the name `{}`",
-                                    target_name
-                                );
-                            }
-                            target = Some(file);
+            if let SourceUnitPart::ContractDefinition(contract) = part {
+                if let Some(name) = contract.name {
+                    if name.name == target_name {
+                        if target.is_some() {
+                            eyre::bail!(
+                                "Found multiple matching contracts with the name `{}`",
+                                target_name
+                            );
                         }
+                        target = Some(file);
                     }
                 }
-                _ => {}
             }
         }
     }

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -1,11 +1,16 @@
 //! Support for compiling [foundry_compilers::Project]
 
-use crate::{compact_to_contract, glob::GlobMatcher, term::SpinnerReporter, TestFunctionExt};
 use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, CellAlignment, Color, Table};
+use crate::{
+    compact_to_contract, fs::read_to_string, glob::GlobMatcher, term::SpinnerReporter,
+    TestFunctionExt,
+};
 use eyre::{Context, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    artifacts::{BytecodeObject, ContractBytecodeSome, Libraries},
+    artifacts::{
+        output_selection::OutputSelection, BytecodeObject, ContractBytecodeSome, Libraries,
+    },
     remappings::Remapping,
     report::{BasicStdoutReporter, NoReporter, Report},
     Artifact, ArtifactId, FileFilter, Graph, Project, ProjectCompileOutput, ProjectPathsConfig,
@@ -464,35 +469,71 @@ pub struct ContractInfo {
     pub is_dev_contract: bool,
 }
 
-/// Finds the path of the contract with the given name.
-/// Throws error if multiple or no contracts with the same name are found.
-pub fn find_contract_path(target_name: &str, project: &Project) -> Result<PathBuf> {
+/// Runs solc compiler without requesting any output and collects a mapping from contract names to
+/// source files containing artifact with given name.
+fn collect_contract_names_solc(project: &Project) -> Result<HashMap<String, Vec<PathBuf>>> {
+    let mut temp_project = (*project).clone();
+    temp_project.no_artifacts = true;
+    temp_project.solc_config.settings.output_selection =
+        OutputSelection::common_output_selection([]);
+
+    let output = temp_project.compile()?;
+
+    if output.has_compiler_errors() {
+        println!("{}", output);
+        eyre::bail!("Compilation failed");
+    }
+
+    let contracts = output.into_artifacts().fold(
+        HashMap::new(),
+        |mut contracts: HashMap<_, Vec<_>>, (id, _)| {
+            contracts.entry(id.name).or_default().push(id.source);
+            contracts
+        },
+    );
+
+    Ok(contracts)
+}
+
+/// Parses project sources via solang parser, collecting mapping from contract name to source files
+/// containing artifact with given name. On parser failure, fallbacks to
+/// [collect_contract_names_solc].
+fn collect_contract_names(project: &Project) -> Result<HashMap<String, Vec<PathBuf>>> {
     let graph = Graph::resolve(&project.paths)?;
-    let mut target = None;
+    let mut contracts: HashMap<String, Vec<PathBuf>> = HashMap::new();
 
     for file in graph.files().keys() {
-        let src = std::fs::read_to_string(file)?;
-        let (parsed, _) = solang_parser::parse(&src, 0)
-            .map_err(|_| eyre::eyre!("Failed to parse {}.", file.display()))?;
+        let src = read_to_string(file)?;
+        let Ok((parsed, _)) = solang_parser::parse(&src, 0) else {
+            return collect_contract_names_solc(project);
+        };
 
         for part in parsed.0 {
             if let SourceUnitPart::ContractDefinition(contract) = part {
                 if let Some(name) = contract.name {
-                    if name.name == target_name {
-                        if target.is_some() {
-                            eyre::bail!(
-                                "Found multiple matching contracts with the name `{}`",
-                                target_name
-                            );
-                        }
-                        target = Some(file);
-                    }
+                    contracts.entry(name.name).or_default().push(file.clone());
                 }
             }
         }
     }
 
-    target.cloned().ok_or_else(|| eyre::eyre!("No contract found with the name `{}`", target_name))
+    Ok(contracts)
+}
+
+/// Finds the path of the contract with the given name.
+/// Throws error if multiple or no contracts with the same name are found.
+pub fn find_contract_path(target_name: &str, project: &Project) -> Result<PathBuf> {
+    let mut contracts = collect_contract_names(project)?;
+
+    if contracts.get(target_name).map_or(true, |paths| paths.len() == 0) {
+        eyre::bail!("No contract found with the name `{}`", target_name);
+    }
+    let mut paths = contracts.remove(target_name).unwrap();
+    if paths.len() > 1 {
+        eyre::bail!("Multiple contracts found with the name `{}`", target_name);
+    }
+
+    Ok(paths.remove(0))
 }
 
 /// Compiles target file path.

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -1,10 +1,10 @@
 //! Support for compiling [foundry_compilers::Project]
 
-use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, CellAlignment, Color, Table};
 use crate::{
     compact_to_contract, fs::read_to_string, glob::GlobMatcher, term::SpinnerReporter,
     TestFunctionExt,
 };
+use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, CellAlignment, Color, Table};
 use eyre::{Context, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4553,6 +4553,7 @@ mod tests {
                     stack_allocation: None,
                     optimizer_steps: Some("dhfoDgvulfnTUtnIf".to_string()),
                 }),
+                simple_counter_for_loop_unchecked_increment: None,
             }),
             ..Default::default()
         };

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -19,7 +19,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::alloy::estimate_eip1559_fees,
 };
-use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo};
+use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize};
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
 
@@ -88,7 +88,7 @@ impl CreateArgs {
         let project = self.opts.project()?;
 
         let target_path = if let Some(ref mut path) = self.contract.path {
-            dunce::canonicalize(path)?
+            canonicalize(project.root().join(&path))?
         } else {
             find_contract_path(&self.contract.name, &project)?
         };

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -88,7 +88,7 @@ impl CreateArgs {
         let project = self.opts.project()?;
 
         let target_path = if let Some(ref mut path) = self.contract.path {
-            canonicalize(project.root().join(&path))?
+            canonicalize(project.root().join(path))?
         } else {
             project.find_contract_path(&self.contract.name)?
         };

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -19,7 +19,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::alloy::estimate_eip1559_fees,
 };
-use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize, utils::find_contract_path};
+use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize};
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
 
@@ -90,7 +90,7 @@ impl CreateArgs {
         let target_path = if let Some(ref mut path) = self.contract.path {
             canonicalize(project.root().join(&path))?
         } else {
-            find_contract_path(&project, &self.contract.name)?
+            project.find_contract_path(&self.contract.name)?
         };
 
         let mut output =

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -15,11 +15,11 @@ use foundry_cli::{
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
 use foundry_common::{
-    compile::{self, find_contract_path},
+    compile::{self},
     fmt::parse_tokens,
     provider::alloy::estimate_eip1559_fees,
 };
-use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize};
+use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize, utils::find_contract_path};
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
 
@@ -90,7 +90,7 @@ impl CreateArgs {
         let target_path = if let Some(ref mut path) = self.contract.path {
             canonicalize(project.root().join(&path))?
         } else {
-            find_contract_path(&self.contract.name, &project)?
+            find_contract_path(&project, &self.contract.name)?
         };
 
         let mut output =

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -15,8 +15,9 @@ use foundry_cli::{
     utils::{self, read_constructor_args_file, remove_contract, LoadConfig},
 };
 use foundry_common::{
-    fmt::parse_tokens, provider::alloy::estimate_eip1559_fees,
     compile::{self, find_contract_path},
+    fmt::parse_tokens,
+    provider::alloy::estimate_eip1559_fees,
 };
 use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo};
 use serde_json::json;

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -4,7 +4,7 @@ use foundry_cli::{
     opts::{CoreBuildArgs, ProjectPathsArgs},
     utils::LoadConfig,
 };
-use foundry_common::{compile::ProjectCompiler, fs};
+use foundry_common::{compile::compile_target, fs};
 use foundry_compilers::{error::SolcError, flatten::Flattener};
 use std::path::PathBuf;
 
@@ -42,7 +42,7 @@ impl FlattenArgs {
         let project = config.ephemeral_no_artifacts_project()?;
 
         let target_path = dunce::canonicalize(target_path)?;
-        let compiler_output = ProjectCompiler::new().files([target_path.clone()]).compile(&project);
+        let compiler_output = compile_target(&target_path, &project, false);
 
         let flattened = match compiler_output {
             Ok(compiler_output) => {

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -6,7 +6,7 @@ use foundry_cli::{
     utils::FoundryPathExt,
 };
 use foundry_common::{
-    compile::ProjectCompiler,
+    compile::{compile_target, find_contract_path, ProjectCompiler},
     selectors::{import_selectors, SelectorImportData},
 };
 use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
@@ -71,7 +71,12 @@ impl SelectorsSubcommands {
                 };
 
                 let project = build_args.project()?;
-                let output = ProjectCompiler::new().quiet(true).compile(&project)?;
+                let output = if let Some(name) = &contract {
+                    let target_path = find_contract_path(name, &project)?;
+                    compile_target(&target_path, &project, false)?
+                } else {
+                    ProjectCompiler::new().compile(&project)?
+                };
                 let artifacts = if all {
                     output
                         .into_artifacts_with_files()

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -9,7 +9,7 @@ use foundry_common::{
     compile::{compile_target, ProjectCompiler},
     selectors::{import_selectors, SelectorImportData},
 };
-use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo, utils::find_contract_path};
+use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
 use std::fs::canonicalize;
 
 /// CLI arguments for `forge selectors`.
@@ -72,7 +72,7 @@ impl SelectorsSubcommands {
 
                 let project = build_args.project()?;
                 let output = if let Some(name) = &contract {
-                    let target_path = find_contract_path(&project, name)?;
+                    let target_path = project.find_contract_path(name)?;
                     compile_target(&target_path, &project, false)?
                 } else {
                     ProjectCompiler::new().compile(&project)?

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -6,10 +6,10 @@ use foundry_cli::{
     utils::FoundryPathExt,
 };
 use foundry_common::{
-    compile::{compile_target, find_contract_path, ProjectCompiler},
+    compile::{compile_target, ProjectCompiler},
     selectors::{import_selectors, SelectorImportData},
 };
-use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
+use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo, utils::find_contract_path};
 use std::fs::canonicalize;
 
 /// CLI arguments for `forge selectors`.
@@ -72,7 +72,7 @@ impl SelectorsSubcommands {
 
                 let project = build_args.project()?;
                 let output = if let Some(name) = &contract {
-                    let target_path = find_contract_path(name, &project)?;
+                    let target_path = find_contract_path(&project, name)?;
                     compile_target(&target_path, &project, false)?
                 } else {
                     ProjectCompiler::new().compile(&project)?

--- a/crates/forge/tests/fixtures/can_create_template_contract.stdout
+++ b/crates/forge/tests/fixtures/can_create_template_contract.stdout
@@ -1,4 +1,4 @@
-Compiling 27 files with 0.8.23
+Compiling 1 files with 0.8.23
 Solc 0.8.23 finished in 2.27s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
+++ b/crates/forge/tests/fixtures/can_create_using_unlocked.stdout
@@ -1,4 +1,4 @@
-Compiling 27 files with 0.8.23
+Compiling 1 files with 0.8.23
 Solc 0.8.23 finished in 1.95s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
+++ b/crates/forge/tests/fixtures/can_create_with_constructor_args.stdout
@@ -1,4 +1,4 @@
-Compiling 28 files with 0.8.23
+Compiling 1 files with 0.8.23
 Solc 0.8.23 finished in 2.82s
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -174,7 +174,7 @@ impl PreprocessedState {
             if let Some(path) = contract.path {
                 dunce::canonicalize(path)?
             } else {
-                foundry_compilers::utils::find_contract_path(&project, contract.name.as_str())?
+                project.find_contract_path(contract.name.as_str())?
             }
         };
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -174,7 +174,7 @@ impl PreprocessedState {
             if let Some(path) = contract.path {
                 dunce::canonicalize(path)?
             } else {
-                compile::find_contract_path(contract.name.as_str(), &project)?
+                foundry_compilers::utils::find_contract_path(&project, contract.name.as_str())?
             }
         };
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -17,7 +17,6 @@ use foundry_common::{
 };
 use foundry_compilers::{
     artifacts::{BytecodeObject, Libraries},
-    cache::SolFilesCache,
     info::ContractInfo,
     ArtifactId, ProjectCompileOutput,
 };

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -8,17 +8,15 @@ use crate::{
 
 use alloy_primitives::{Address, Bytes};
 use alloy_provider::Provider;
-use eyre::{Context, OptionExt, Result};
+use eyre::{OptionExt, Result};
 use foundry_cheatcodes::ScriptWallets;
-use foundry_cli::utils::get_cached_entry_by_name;
 use foundry_common::{
-    compile::{self, ContractSources, ProjectCompiler},
+    compile::{self, ContractSources},
     provider::alloy::try_get_http_provider,
     ContractsByArtifact,
 };
 use foundry_compilers::{
     artifacts::{BytecodeObject, ContractBytecode, ContractBytecodeSome, Libraries},
-    cache::SolFilesCache,
     contracts::ArtifactContracts,
     info::ContractInfo,
     ArtifactId, ProjectCompileOutput,
@@ -162,7 +160,6 @@ impl PreprocessedState {
     pub fn compile(self) -> Result<CompiledState> {
         let Self { args, script_config, script_wallets } = self;
         let project = script_config.config.project()?;
-        let filters = args.skip.clone().unwrap_or_default();
 
         let mut target_name = args.target_contract.clone();
 
@@ -170,46 +167,18 @@ impl PreprocessedState {
         // Otherwise, parse input as <path>:<name> and use the path from the contract info, if
         // present.
         let target_path = if let Ok(path) = dunce::canonicalize(&args.path) {
-            Some(path)
+            path
         } else {
             let contract = ContractInfo::from_str(&args.path)?;
             target_name = Some(contract.name.clone());
             if let Some(path) = contract.path {
-                Some(dunce::canonicalize(path)?)
+                dunce::canonicalize(path)?
             } else {
-                None
+                compile::find_contract_path(contract.name.as_str(), &project)?
             }
         };
 
-        // If we've found target path above, only compile it.
-        // Otherwise, compile everything to match contract by name later.
-        let output = if let Some(target_path) = target_path.clone() {
-            compile::compile_target_with_filter(
-                &target_path,
-                &project,
-                args.opts.silent,
-                args.verify,
-                filters,
-            )
-        } else if !project.paths.has_input_files() {
-            Err(eyre::eyre!("The project doesn't have any input files. Make sure the `script` directory is configured properly in foundry.toml. Otherwise, provide the path to the file."))
-        } else {
-            ProjectCompiler::new().compile(&project)
-        }?;
-
-        // If we still don't have target path, find it by name in the compilation cache.
-        let target_path = if let Some(target_path) = target_path {
-            target_path
-        } else {
-            let target_name = target_name.clone().expect("was set above");
-            let cache = SolFilesCache::read_joined(&project.paths)
-                .wrap_err("Could not open compiler cache")?;
-            let (path, _) = get_cached_entry_by_name(&cache, &target_name)
-                .wrap_err("Could not find target contract in cache")?;
-            path
-        };
-
-        let target_path = project.root().join(target_path);
+        let output = compile::compile_target(&target_path, &project, args.opts.silent)?;
 
         let mut target_id: Option<ArtifactId> = None;
 


### PR DESCRIPTION
## Motivation

Currently when running `forge script <contract_name>` or `forge script <contract_path>` we will recompile entire project, this is true for `forge create` and `forge selectors` as well.

## Solution

Use already existing files filter on `ProjectCompiler` when path is provided, use solang AST to find source file when only contract name is provided.
