### PR TITLE
feat(forge): prompt address and uint cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6080,6 +6080,26 @@
     },
     {
       "func": {
+        "id": "promptAddress",
+        "description": "Prompts the user for an address in the terminal.",
+        "declaration": "function promptAddress(string calldata promptText) external returns (address);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "promptAddress(string)",
+        "selector": "0x62ee05f4",
+        "selectorBytes": [
+          98,
+          238,
+          5,
+          244
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "promptSecret",
         "description": "Prompts the user for a hidden string value in the terminal.",
         "declaration": "function promptSecret(string calldata promptText) external returns (string memory input);",
@@ -6092,6 +6112,26 @@
           39,
           157,
           65
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "promptUint",
+        "description": "Prompts the user for uint256 in the terminal.",
+        "declaration": "function promptUint(string calldata promptText) external returns (uint256);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "promptUint(string)",
+        "selector": "0x652fd489",
+        "selectorBytes": [
+          101,
+          47,
+          212,
+          137
         ]
       },
       "group": "filesystem",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1427,6 +1427,14 @@ interface Vm {
     #[cheatcode(group = Filesystem)]
     function promptSecret(string calldata promptText) external returns (string memory input);
 
+    /// Prompts the user for an address in the terminal.
+    #[cheatcode(group = Filesystem)]
+    function promptAddress(string calldata promptText) external returns (address);
+
+    /// Prompts the user for uint256 in the terminal.
+    #[cheatcode(group = Filesystem)]
+    function promptUint(string calldata promptText) external returns (uint256);
+
     // ======== Environment Variables ========
 
     /// Sets environment variables.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -379,14 +379,14 @@ impl Cheatcode for promptSecretCall {
 impl Cheatcode for promptAddressCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
-        parse(prompt(state, text, prompt_input).unwrap().as_str(), &DynSolType::Address)
+        parse(&prompt(state, text, prompt_input)?, &DynSolType::Address)
     }
 }
 
 impl Cheatcode for promptUintCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
-        parse(prompt(state, text, prompt_input).unwrap().as_str(), &DynSolType::Uint(256))
+        parse(&prompt(state, text, prompt_input)?, &DynSolType::Uint(256))
     }
 }
 

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -1,6 +1,8 @@
 //! Implementations of [`Filesystem`](crate::Group::Filesystem) cheatcodes.
 
+use super::string::parse;
 use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_dyn_abi::DynSolType;
 use alloy_json_abi::ContractObject;
 use alloy_primitives::U256;
 use alloy_sol_types::SolValue;
@@ -371,6 +373,20 @@ impl Cheatcode for promptSecretCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;
         prompt(state, text, prompt_password).map(|res| res.abi_encode())
+    }
+}
+
+impl Cheatcode for promptAddressCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { promptText: text } = self;
+        parse(prompt(state, text, prompt_input).unwrap().as_str(), &DynSolType::Address)
+    }
+}
+
+impl Cheatcode for promptUintCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { promptText: text } = self;
+        parse(prompt(state, text, prompt_input).unwrap().as_str(), &DynSolType::Uint(256))
     }
 }
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -301,7 +301,9 @@ interface Vm {
     function prevrandao(bytes32 newPrevrandao) external;
     function projectRoot() external view returns (string memory path);
     function prompt(string calldata promptText) external returns (string memory input);
+    function promptAddress(string calldata promptText) external returns (address);
     function promptSecret(string calldata promptText) external returns (string memory input);
+    function promptUint(string calldata promptText) external returns (uint256);
     function readCallers() external returns (CallerMode callerMode, address msgSender, address txOrigin);
     function readDir(string calldata path) external view returns (DirEntry[] memory entries);
     function readDir(string calldata path, uint64 maxDepth) external view returns (DirEntry[] memory entries);

--- a/testdata/default/cheats/Prompt.t.sol
+++ b/testdata/default/cheats/Prompt.t.sol
@@ -19,11 +19,11 @@ contract PromptTest is DSTest {
 
     function testPrompt_Address() public {
         address test = vm.promptAddress("test");
-        console.log(test);
+        assertEq(test, 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
     }
 
     function testPrompt_Uint() public {
         uint256 test = vm.promptUint("test");
-        console.log(test);
+        assertEq(test, 6969);
     }
 }

--- a/testdata/default/cheats/Prompt.t.sol
+++ b/testdata/default/cheats/Prompt.t.sol
@@ -18,12 +18,12 @@ contract PromptTest is DSTest {
     }
 
     function testPrompt_Address() public {
+        vm._expectCheatcodeRevert();
         address test = vm.promptAddress("test");
-        assertEq(test, 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
     }
 
     function testPrompt_Uint() public {
+        vm._expectCheatcodeRevert();
         uint256 test = vm.promptUint("test");
-        assertEq(test, 6969);
     }
 }

--- a/testdata/default/cheats/Prompt.t.sol
+++ b/testdata/default/cheats/Prompt.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.18;
 
 import "ds-test/test.sol";
 import "cheats/Vm.sol";
+import "../logs/console.sol";
 
 contract PromptTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
@@ -14,5 +15,15 @@ contract PromptTest is DSTest {
 
         vm._expectCheatcodeRevert();
         vm.promptSecret("test");
+    }
+
+    function testPrompt_Address() public {
+        address test = vm.promptAddress("test");
+        console.log(test);
+    }
+
+    function testPrompt_Uint() public {
+        uint256 test = vm.promptUint("test");
+        console.log(test);
     }
 }


### PR DESCRIPTION
Closes #5509 

cc @mattsse 

In case of parse failure, it fails with these errors:

```bash
[FAIL. Reason: failed parsing "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293B" as type `address`: parser error:
0x3C44CdDdB6a900fa2b585dd299e03d12FA4293B
^
Odd number of digits] testPrompt_Address() (gas: 2948)
```
```bash 
[FAIL. Reason: failed parsing "-1" as type `uint256`: parser error:
-1
^
expected at least one digit] testPrompt_Uint() (gas: 3008)
```