### PR TITLE
feat: coverage for constructors

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -1,7 +1,7 @@
 //! Commonly used contract types and functions.
 
 use alloy_json_abi::{Event, Function, JsonAbi};
-use alloy_primitives::{hex, Address, Selector, B256};
+use alloy_primitives::{Address, Bytes, Selector, B256};
 use eyre::Result;
 use foundry_compilers::{
     artifacts::{CompactContractBytecode, ContractBytecodeSome},
@@ -9,26 +9,40 @@ use foundry_compilers::{
 };
 use std::{
     collections::BTreeMap,
-    fmt,
     ops::{Deref, DerefMut},
 };
 
-type ArtifactWithContractRef<'a> = (&'a ArtifactId, &'a (JsonAbi, Vec<u8>));
+/// Container for commonly used contract data.
+#[derive(Debug, Clone)]
+pub struct ContractData {
+    /// Contract name.
+    pub name: String,
+    /// Contract ABI.
+    pub abi: JsonAbi,
+    /// Contract creation code.
+    pub bytecode: Bytes,
+    /// Contract runtime code.
+    pub deployed_bytecode: Bytes,
+}
+
+type ArtifactWithContractRef<'a> = (&'a ArtifactId, &'a ContractData);
 
 /// Wrapper type that maps an artifact to a contract ABI and bytecode.
-#[derive(Clone, Default)]
-pub struct ContractsByArtifact(pub BTreeMap<ArtifactId, (JsonAbi, Vec<u8>)>);
-
-impl fmt::Debug for ContractsByArtifact {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map().entries(self.iter().map(|(k, (v1, v2))| (k, (v1, hex::encode(v2))))).finish()
-    }
-}
+#[derive(Clone, Default, Debug)]
+pub struct ContractsByArtifact(pub BTreeMap<ArtifactId, ContractData>);
 
 impl ContractsByArtifact {
     /// Finds a contract which has a similar bytecode as `code`.
-    pub fn find_by_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef> {
-        self.iter().find(|(_, (_, known_code))| bytecode_diff_score(known_code, code) <= 0.1)
+    pub fn find_by_creation_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef> {
+        self.iter()
+            .find(|(_, contract)| bytecode_diff_score(contract.bytecode.as_ref(), code) <= 0.1)
+    }
+
+    /// Finds a contract which has a similar deployed bytecode as `code`.
+    pub fn find_by_deployed_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef> {
+        self.iter().find(|(_, contract)| {
+            bytecode_diff_score(contract.deployed_bytecode.as_ref(), code) <= 0.1
+        })
     }
 
     /// Finds a contract which has the same contract name or identifier as `id`. If more than one is
@@ -51,14 +65,14 @@ impl ContractsByArtifact {
         let mut funcs = BTreeMap::new();
         let mut events = BTreeMap::new();
         let mut errors_abi = JsonAbi::new();
-        for (_name, (abi, _code)) in self.iter() {
-            for func in abi.functions() {
+        for (_name, contract) in self.iter() {
+            for func in contract.abi.functions() {
                 funcs.insert(func.selector(), func.clone());
             }
-            for event in abi.events() {
+            for event in contract.abi.events() {
                 events.insert(event.selector(), event.clone());
             }
-            for error in abi.errors() {
+            for error in contract.abi.errors() {
                 errors_abi.errors.entry(error.name.clone()).or_default().push(error.clone());
             }
         }
@@ -67,7 +81,7 @@ impl ContractsByArtifact {
 }
 
 impl Deref for ContractsByArtifact {
-    type Target = BTreeMap<ArtifactId, (JsonAbi, Vec<u8>)>;
+    type Target = BTreeMap<ArtifactId, ContractData>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -45,13 +45,10 @@ impl<'a> ContractVisitor<'a> {
         let name: String =
             node.attribute("name").ok_or_else(|| eyre::eyre!("Function has no name"))?;
 
-        // TODO(onbjerg): Re-enable constructor parsing when we walk both the deployment and runtime
-        // sourcemaps. Currently this fails because we are trying to look for anchors in the runtime
-        // sourcemap.
         // TODO(onbjerg): Figure out why we cannot find anchors for the receive function
         let kind: String =
             node.attribute("kind").ok_or_else(|| eyre::eyre!("Function has no kind"))?;
-        if kind == "constructor" || kind == "receive" {
+        if kind == "receive" {
             return Ok(())
         }
 

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -131,7 +131,7 @@ impl CoverageReport {
         &mut self,
         contract_id: &ContractId,
         hit_map: &HitMap,
-        deployed_code: bool,
+        is_deployed_code: bool,
     ) -> Result<()> {
         // Add bytecode level hits
         let e = self
@@ -147,7 +147,7 @@ impl CoverageReport {
 
         // Add source level hits
         if let Some(anchors) = self.anchors.get(contract_id) {
-            let anchors = if deployed_code { &anchors.1 } else { &anchors.0 };
+            let anchors = if is_deployed_code { &anchors.1 } else { &anchors.0 };
             for anchor in anchors {
                 if let Some(hits) = hit_map.hits.get(&anchor.instruction) {
                     self.items

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -316,15 +316,17 @@ pub fn collect_created_contracts(
         if !setup_contracts.contains_key(address) {
             if let (true, Some(code)) = (&account.is_touched(), &account.info.code) {
                 if !code.is_empty() {
-                    if let Some((artifact, (abi, _))) =
-                        project_contracts.find_by_code(&code.original_bytes())
+                    if let Some((artifact, contract)) =
+                        project_contracts.find_by_deployed_code(&code.original_bytes())
                     {
                         if let Some(functions) =
-                            artifact_filters.get_targeted_functions(artifact, abi)?
+                            artifact_filters.get_targeted_functions(artifact, &contract.abi)?
                         {
                             created_contracts.push(*address);
-                            writable_targeted
-                                .insert(*address, (artifact.name.clone(), abi.clone(), functions));
+                            writable_targeted.insert(
+                                *address,
+                                (artifact.name.clone(), contract.abi.clone(), functions),
+                            );
                         }
                     }
                 }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -56,8 +56,8 @@ impl CallTraceDecoderBuilder {
     #[inline]
     pub fn with_known_contracts(mut self, contracts: &ContractsByArtifact) -> Self {
         trace!(target: "evm::traces", len=contracts.len(), "collecting known contract ABIs");
-        for (abi, _) in contracts.values() {
-            self.decoder.collect_abi(abi, None);
+        for contract in contracts.values() {
+            self.decoder.collect_abi(&contract.abi, None);
         }
         self
     }

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 pub struct LocalTraceIdentifier<'a> {
     /// Known contracts to search through.
     known_contracts: &'a ContractsByArtifact,
-    /// Vector of pairs of artifact ID and the code length of the given artifact.
+    /// Vector of pairs of artifact ID and the runtime code length of the given artifact.
     ordered_ids: Vec<(&'a ArtifactId, usize)>,
 }
 
@@ -17,8 +17,10 @@ impl<'a> LocalTraceIdentifier<'a> {
     /// Creates a new local trace identifier.
     #[inline]
     pub fn new(known_contracts: &'a ContractsByArtifact) -> Self {
-        let mut ordered_ids =
-            known_contracts.iter().map(|(id, contract)| (id, contract.1.len())).collect::<Vec<_>>();
+        let mut ordered_ids = known_contracts
+            .iter()
+            .map(|(id, contract)| (id, contract.deployed_bytecode.len()))
+            .collect::<Vec<_>>();
         ordered_ids.sort_by_key(|(_, len)| *len);
         Self { known_contracts, ordered_ids }
     }
@@ -37,15 +39,15 @@ impl<'a> LocalTraceIdentifier<'a> {
         let mut min_score_id = None;
 
         let mut check = |id| {
-            let (abi, known_code) = self.known_contracts.get(id)?;
-            let score = bytecode_diff_score(known_code, code);
+            let contract = self.known_contracts.get(id)?;
+            let score = bytecode_diff_score(&contract.deployed_bytecode, code);
             if score == 0.0 {
                 trace!(target: "evm::traces", "found exact match");
-                return Some((id, abi));
+                return Some((id, &contract.abi));
             }
             if score < min_score {
                 min_score = score;
-                min_score_id = Some((id, abi));
+                min_score_id = Some((id, &contract.abi));
             }
             None
         };

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -308,8 +308,8 @@ pub fn load_contracts(
         .contracts
         .iter()
         .filter_map(|(addr, name)| {
-            if let Ok(Some((_, (abi, _)))) = contracts.find_by_name_or_identifier(name) {
-                return Some((*addr, (name.clone(), abi.clone())));
+            if let Ok(Some((_, contract))) = contracts.find_by_name_or_identifier(name) {
+                return Some((*addr, (name.clone(), contract.abi.clone())));
             }
             None
         })

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -358,7 +358,7 @@ impl CoverageArgs {
                     }
                 })
             });
-        for (artifact_id, hits, deployed_code) in data {
+        for (artifact_id, hits, is_deployed_code) in data {
             // TODO: Note down failing tests
             if let Some(source_id) = report.get_source_id(
                 artifact_id.version.clone(),
@@ -372,7 +372,7 @@ impl CoverageArgs {
                         contract_name: artifact_id.name.clone(),
                     },
                     &hits,
-                    deployed_code,
+                    is_deployed_code,
                 )?;
             }
         }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -5,7 +5,7 @@ use eyre::{Context, Result};
 use forge::{
     coverage::{
         analysis::SourceAnalyzer, anchors::find_anchors, BytecodeReporter, ContractId,
-        CoverageReport, CoverageReporter, DebugReporter, ItemAnchor, LcovReporter, SummaryReporter,
+        CoverageReport, CoverageReporter, DebugReporter, LcovReporter, SummaryReporter,
     },
     inspectors::CheatsConfig,
     opts::EvmOpts,
@@ -266,21 +266,26 @@ impl CoverageArgs {
                 items_by_source_id.entry(item.loc.source_id).or_default().push(item_id);
             }
 
-            let anchors: HashMap<ContractId, Vec<ItemAnchor>> = source_maps
+            let anchors = source_maps
                 .iter()
                 .filter(|(contract_id, _)| contract_id.version == version)
-                .filter_map(|(contract_id, (_, deployed_source_map))| {
+                .filter_map(|(contract_id, (creation_source_map, deployed_source_map))| {
+                    let creation_code_anchors = find_anchors(
+                        &bytecodes.get(contract_id)?.0,
+                        creation_source_map,
+                        &ic_pc_maps.get(contract_id)?.0,
+                        &source_analysis.items,
+                        &items_by_source_id,
+                    );
+                    let deployed_code_anchors = find_anchors(
+                        &bytecodes.get(contract_id)?.1,
+                        deployed_source_map,
+                        &ic_pc_maps.get(contract_id)?.1,
+                        &source_analysis.items,
+                        &items_by_source_id,
+                    );
                     // TODO: Creation source map/bytecode as well
-                    Some((
-                        contract_id.clone(),
-                        find_anchors(
-                            &bytecodes.get(contract_id)?.1,
-                            deployed_source_map,
-                            &ic_pc_maps.get(contract_id)?.1,
-                            &source_analysis.items,
-                            &items_by_source_id,
-                        ),
-                    ))
+                    Some((contract_id.clone(), (creation_code_anchors, deployed_code_anchors)))
                 })
                 .collect();
             report.add_items(version, source_analysis.items);
@@ -340,17 +345,26 @@ impl CoverageArgs {
             .filter_map(|mut result| result.coverage.take())
             .flat_map(|hit_maps| {
                 hit_maps.0.into_values().filter_map(|map| {
-                    Some((known_contracts.find_by_code(map.bytecode.as_ref())?.0, map))
+                    if let Some((id, _)) =
+                        known_contracts.find_by_deployed_code(map.bytecode.as_ref())
+                    {
+                        Some((id, map, true))
+                    } else if let Some((id, _)) =
+                        known_contracts.find_by_creation_code(map.bytecode.as_ref())
+                    {
+                        Some((id, map, false))
+                    } else {
+                        None
+                    }
                 })
             });
-        for (artifact_id, hits) in data {
+        for (artifact_id, hits, deployed_code) in data {
             // TODO: Note down failing tests
             if let Some(source_id) = report.get_source_id(
                 artifact_id.version.clone(),
                 artifact_id.source.to_string_lossy().to_string(),
             ) {
                 let source_id = *source_id;
-                // TODO: Distinguish between creation/runtime in a smart way
                 report.add_hit_map(
                     &ContractId {
                         version: artifact_id.version.clone(),
@@ -358,6 +372,7 @@ impl CoverageArgs {
                         contract_name: artifact_id.name.clone(),
                     },
                     &hits,
+                    deployed_code,
                 )?;
             }
         }

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -161,17 +161,27 @@ impl CoverageReporter for DebugReporter {
 
         for (contract_id, anchors) in &report.anchors {
             println!("Anchors for {contract_id}:");
-            anchors.iter().for_each(|anchor| {
-                println!("- {anchor}");
-                println!(
-                    "  - Refers to item: {}",
-                    report
-                        .items
-                        .get(&contract_id.version)
-                        .and_then(|items| items.get(anchor.item_id))
-                        .map_or("None".to_owned(), |item| item.to_string())
-                );
-            });
+            anchors
+                .0
+                .iter()
+                .map(|anchor| (false, anchor))
+                .chain(anchors.1.iter().map(|anchor| (true, anchor)))
+                .for_each(|(is_deployed, anchor)| {
+                    println!("- {anchor}");
+                    if is_deployed {
+                        println!("- Creation code");
+                    } else {
+                        println!("- Runtime code");
+                    }
+                    println!(
+                        "  - Refers to item: {}",
+                        report
+                            .items
+                            .get(&contract_id.version)
+                            .and_then(|items| items.get(anchor.item_id))
+                            .map_or("None".to_owned(), |item| item.to_string())
+                    );
+                });
             println!();
         }
 

--- a/crates/script/src/artifacts.rs
+++ b/crates/script/src/artifacts.rs
@@ -1,8 +1,0 @@
-use alloy_json_abi::JsonAbi;
-
-/// Bundles info of an artifact
-pub struct ArtifactInfo<'a> {
-    pub contract_name: String,
-    pub abi: &'a JsonAbi,
-    pub code: &'a Vec<u8>,
-}

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -26,7 +26,7 @@ impl BroadcastedState {
         let verify = VerifyBundle::new(
             &script_config.config.project()?,
             &script_config.config,
-            build_data.get_flattened_contracts(false),
+            build_data.known_contracts,
             args.retry,
             args.verifier,
         );
@@ -105,11 +105,12 @@ impl VerifyBundle {
         data: &[u8],
         libraries: &[String],
     ) -> Option<VerifyArgs> {
-        for (artifact, (_contract, bytecode)) in self.known_contracts.iter() {
+        for (artifact, contract) in self.known_contracts.iter() {
             // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
             // of the transaction
-            if data.split_at(create2_offset).1.starts_with(bytecode) {
-                let constructor_args = data.split_at(create2_offset + bytecode.len()).1.to_vec();
+            if data.split_at(create2_offset).1.starts_with(&contract.bytecode) {
+                let constructor_args =
+                    data.split_at(create2_offset + contract.bytecode.len()).1.to_vec();
 
                 let contract = ContractInfo {
                     path: Some(


### PR DESCRIPTION
## Motivation

Closes #3453
Closes #1963

## Solution

This PR includes general refactor of code using `ContractsByArtifacts` extending it to contain both creation and runtime code. Currently it can only fit one bytecode type thus resulting in script code generating different `ContractsByArtifacts` object for different purposes making code a bit harder to navigate. This allowed to add more context to `MultiContractRunner::known_contracts` and simplify scripting code a bit by storing `ContractsByArtifacts` directly instead of generating each time.

Added creation code to `ContractsByArtifacts` allowed us to map collected hitmaps for creation codes to artifacts via `find_by_creation_code` fn, thus extending coverage to also process creation code just required duplicating anchors discovery and processing logic