### PR TITLE
feat: allow including libraries into coverage report

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -64,6 +64,10 @@ pub struct CoverageArgs {
     )]
     report_file: Option<PathBuf>,
 
+    /// Whether to include libraries in the coverage report.
+    #[arg(long)]
+    include_libs: bool,
+
     #[command(flatten)]
     filter: FilterArgs,
 
@@ -162,7 +166,8 @@ impl CoverageArgs {
             report.add_source(version.clone(), source_file.id as usize, path.clone());
 
             // Filter out dependencies
-            if project_paths.has_library_ancestor(std::path::Path::new(&path)) {
+            if !self.include_libs && project_paths.has_library_ancestor(std::path::Path::new(&path))
+            {
                 continue
             }
 


### PR DESCRIPTION
## Motivation

Closes #6853

## Solution

Add `--include-libs` flag to `forge coverage` which results in command also collecting coverage data for libraries.
