### PR TITLE
chore: enable rustls for foundry-common

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -74,3 +74,7 @@ num-format.workspace = true
 foundry-macros.workspace = true
 pretty_assertions.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[features]
+default = ["rustls"]
+rustls = ["reqwest_ethers/rustls-tls-native-roots"]


### PR DESCRIPTION
## Motivation

Fixes crate-checks job which is failing after https://github.com/foundry-rs/foundry/pull/7655

## Solution
