### PR TITLE
fix(verify): improve err handling for unset etherscan api key

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -137,11 +137,10 @@ impl VerifyBytecodeArgs {
             config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
 
         // If etherscan key is not set, we can't proceed with etherscan verification
-        let etherscan = if let Some(ref key) = self.etherscan_opts.key {
-            Client::new(chain, key.to_owned())?
-        } else {
+        let Some(key) = self.etherscan_opts.key.clone() else {
             eyre::bail!("Etherscan API key is required for verification");
         };
+        let etherscan = Client::new(chain, key)?;
 
         // Get the constructor args using `source_code` endpoint
         let source_code = etherscan.contract_source_code(self.address).await?;

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -135,6 +135,11 @@ impl VerifyBytecodeArgs {
         self.etherscan_opts.chain = Some(chain);
         self.etherscan_opts.key =
             config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
+
+        // If etherscan key is not set, we can't proceed with etherscan verification
+        if self.etherscan_opts.key.is_none() {
+            eyre::bail!("Etherscan API key is required for verification");
+        }
         // Create etherscan client
         let etherscan = Client::new(chain, self.etherscan_opts.key.clone().unwrap())?;
 
@@ -170,7 +175,7 @@ impl VerifyBytecodeArgs {
         if provided_constructor_args != constructor_args.to_string() && !self.json {
             println!(
                 "{}",
-                Paint::red("The provider constructor args do not match the constructor args from etherscan. This will result in a mismatch - Using the args from etherscan").bold(),
+                Paint::red("The provided constructor args do not match the constructor args from etherscan. This will result in a mismatch - Using the args from etherscan").bold(),
             );
         }
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -137,11 +137,11 @@ impl VerifyBytecodeArgs {
             config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
 
         // If etherscan key is not set, we can't proceed with etherscan verification
-        if self.etherscan_opts.key.is_none() {
+        let etherscan = if let Some(ref key) = self.etherscan_opts.key {
+            Client::new(chain, key.to_owned())?
+        } else {
             eyre::bail!("Etherscan API key is required for verification");
-        }
-        // Create etherscan client
-        let etherscan = Client::new(chain, self.etherscan_opts.key.clone().unwrap())?;
+        };
 
         // Get the constructor args using `source_code` endpoint
         let source_code = etherscan.contract_source_code(self.address).await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref #7667.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Improve error handling for unset etherscan API key. Report error instead of panicking.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
