### PR TITLE
fix(traces): Etherscan traces are only resolved for first instance of test run

### DIFF
--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -104,6 +104,7 @@ impl TraceIdentifier for EtherscanIdentifier {
             return Vec::new()
         }
 
+        let mut resolved = Vec::new();
         let mut fetcher = EtherscanFetcher::new(
             self.client.clone(),
             Duration::from_secs(1),
@@ -112,10 +113,29 @@ impl TraceIdentifier for EtherscanIdentifier {
         );
 
         for (addr, _) in addresses {
-            if !self.contracts.contains_key(addr) {
+            if self.contracts.contains_key(addr) {
+                resolved.push(*addr);
+            } else {
                 fetcher.push(*addr);
             }
         }
+
+        let resolved = resolved
+            .into_iter()
+            .map(|addr| {
+                let metadata = self.contracts.get(&addr).unwrap();
+                let label = metadata.contract_name.clone();
+                let abi = metadata.abi().ok().map(Cow::Owned);
+
+                AddressIdentity {
+                    address: addr,
+                    label: Some(label.clone()),
+                    contract: Some(label),
+                    abi,
+                    artifact_id: None,
+                }
+            })
+            .collect::<Vec<AddressIdentity<'_>>>();
 
         let fut = fetcher
             .map(|(address, metadata)| {
@@ -131,9 +151,9 @@ impl TraceIdentifier for EtherscanIdentifier {
                     artifact_id: None,
                 }
             })
-            .collect();
+            .collect::<Vec<AddressIdentity<'_>>>();
 
-        RuntimeOrHandle::new().block_on(fut)
+        RuntimeOrHandle::new().block_on(fut).into_iter().chain(resolved).collect()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #7558 

Currently the resolved Etherscan traces are only applied to the first occurrence of an address due to the resolved addresses not being captured and returned, see:

https://github.com/foundry-rs/foundry/blob/ee47bb01ee8aa042639cc9ae86a2a3cf6ab9d037/crates/evm/traces/src/identifier/etherscan.rs#L114-L118

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Reproducible by running minimal repro: https://github.com/zerosnacks/foundry-repro-7558

Implementation is largely pragmatic, emphasis on minimal changes - open to feedback