### PR TITLE
feat(debugger): update ratatui, use `List`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "40646aa7f01e396139cf0d6c3a7475eeb8094a0f41d8199f10860c8aef09d2f1"
 dependencies = [
  "num_enum",
  "serde",
- "strum 0.26.2",
+ "strum",
 ]
 
 [[package]]
@@ -1816,6 +1816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,7 +1875,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "solang-parser",
- "strum 0.26.2",
+ "strum",
  "tikv-jemallocator",
  "time",
  "tokio",
@@ -2135,8 +2144,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -2150,6 +2159,19 @@ dependencies = [
  "nix 0.26.4",
  "tokio",
  "winapi",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3042,7 +3064,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum 0.26.2",
+ "strum",
  "syn 2.0.58",
  "tempfile",
  "thiserror",
@@ -3476,7 +3498,7 @@ dependencies = [
  "serde_json",
  "similar",
  "solang-parser",
- "strum 0.26.2",
+ "strum",
  "svm-rs 0.4.1",
  "tempfile",
  "thiserror",
@@ -3711,7 +3733,7 @@ dependencies = [
  "regex",
  "serde",
  "strsim 0.10.0",
- "strum 0.26.2",
+ "strum",
  "tempfile",
  "tokio",
  "tracing",
@@ -6702,18 +6724,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
+checksum = "a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80"
 dependencies = [
  "bitflags 2.5.0",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lru",
  "paste",
- "strum 0.25.0",
+ "stability",
+ "strum",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -7831,6 +7855,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
+dependencies = [
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7882,33 +7916,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.26.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.58",
+ "strum_macros",
 ]
 
 [[package]]

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -20,6 +20,6 @@ alloy-primitives.workspace = true
 
 crossterm = "0.27"
 eyre.workspace = true
-ratatui = { version = "0.24.0", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.26", default-features = false, features = ["crossterm"] }
 revm.workspace = true
 tracing.workspace = true

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -118,6 +118,13 @@ impl<'a> DebuggerContext<'a> {
         self.opcode_list.extend(debug_steps.iter().map(DebugStep::pretty_opcode));
     }
 
+    fn gen_opcode_list_if_necessary(&mut self) {
+        if self.last_index != self.draw_memory.inner_call_index {
+            self.gen_opcode_list();
+            self.last_index = self.draw_memory.inner_call_index;
+        }
+    }
+
     fn active_buffer(&self) -> &[u8] {
         match self.active_buffer {
             BufferKind::Memory => &self.current_step().memory,
@@ -129,19 +136,18 @@ impl<'a> DebuggerContext<'a> {
 
 impl DebuggerContext<'_> {
     pub(crate) fn handle_event(&mut self, event: Event) -> ControlFlow<ExitReason> {
-        if self.last_index != self.draw_memory.inner_call_index {
-            self.gen_opcode_list();
-            self.last_index = self.draw_memory.inner_call_index;
-        }
-
-        match event {
+        let ret = match event {
             Event::Key(event) => self.handle_key_event(event),
             Event::Mouse(event) => self.handle_mouse_event(event),
             _ => ControlFlow::Continue(()),
-        }
+        };
+        // Generate the list after the event has been handled.
+        self.gen_opcode_list_if_necessary();
+        ret
     }
 
     fn handle_key_event(&mut self, event: KeyEvent) -> ControlFlow<ExitReason> {
+        // Breakpoints
         if let KeyCode::Char(c) = event.code {
             if c.is_alphabetic() && self.key_buffer.starts_with('\'') {
                 self.handle_breakpoint(c);
@@ -149,154 +155,130 @@ impl DebuggerContext<'_> {
             }
         }
 
+        let control = event.modifiers.contains(KeyModifiers::CONTROL);
+
         match event.code {
             // Exit
             KeyCode::Char('q') => return ControlFlow::Break(ExitReason::CharExit),
-            // Move down
-            KeyCode::Char('j') | KeyCode::Down => {
-                // Grab number of times to do it
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    if event.modifiers.contains(KeyModifiers::CONTROL) {
-                        let max_buf = (self.active_buffer().len() / 32).saturating_sub(1);
-                        if self.draw_memory.current_buf_startline < max_buf {
-                            self.draw_memory.current_buf_startline += 1;
-                        }
-                    } else if self.current_step < self.opcode_list.len() - 1 {
-                        self.current_step += 1;
-                    } else if self.draw_memory.inner_call_index < self.debug_arena().len() - 1 {
-                        self.draw_memory.inner_call_index += 1;
-                        self.current_step = 0;
-                    }
+
+            // Scroll up the memory buffer
+            KeyCode::Char('k') | KeyCode::Up if control => self.repeat(|this| {
+                this.draw_memory.current_buf_startline =
+                    this.draw_memory.current_buf_startline.saturating_sub(1);
+            }),
+            // Scroll down the memory buffer
+            KeyCode::Char('j') | KeyCode::Down if control => self.repeat(|this| {
+                let max_buf = (this.active_buffer().len() / 32).saturating_sub(1);
+                if this.draw_memory.current_buf_startline < max_buf {
+                    this.draw_memory.current_buf_startline += 1;
                 }
-                self.key_buffer.clear();
-            }
-            KeyCode::Char('J') => {
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    let max_stack = self.current_step().stack.len().saturating_sub(1);
-                    if self.draw_memory.current_stack_startline < max_stack {
-                        self.draw_memory.current_stack_startline += 1;
-                    }
-                }
-                self.key_buffer.clear();
-            }
+            }),
+
             // Move up
-            KeyCode::Char('k') | KeyCode::Up => {
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    if event.modifiers.contains(KeyModifiers::CONTROL) {
-                        self.draw_memory.current_buf_startline =
-                            self.draw_memory.current_buf_startline.saturating_sub(1);
-                    } else if self.current_step > 0 {
-                        self.current_step -= 1;
-                    } else if self.draw_memory.inner_call_index > 0 {
-                        self.draw_memory.inner_call_index -= 1;
-                        self.current_step = self.debug_steps().len() - 1;
-                    }
+            KeyCode::Char('k') | KeyCode::Up => self.repeat(Self::step_back),
+            // Move down
+            KeyCode::Char('j') | KeyCode::Down => self.repeat(Self::step),
+
+            // Scroll up the stack
+            KeyCode::Char('K') => self.repeat(|this| {
+                this.draw_memory.current_stack_startline =
+                    this.draw_memory.current_stack_startline.saturating_sub(1);
+            }),
+            // Scroll down the stack
+            KeyCode::Char('J') => self.repeat(|this| {
+                let max_stack = this.current_step().stack.len().saturating_sub(1);
+                if this.draw_memory.current_stack_startline < max_stack {
+                    this.draw_memory.current_stack_startline += 1;
                 }
-                self.key_buffer.clear();
-            }
-            KeyCode::Char('K') => {
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    self.draw_memory.current_stack_startline =
-                        self.draw_memory.current_stack_startline.saturating_sub(1);
-                }
-                self.key_buffer.clear();
-            }
+            }),
+
+            // Cycle buffers
             KeyCode::Char('b') => {
                 self.active_buffer = self.active_buffer.next();
                 self.draw_memory.current_buf_startline = 0;
             }
+
             // Go to top of file
             KeyCode::Char('g') => {
                 self.draw_memory.inner_call_index = 0;
                 self.current_step = 0;
-                self.key_buffer.clear();
             }
+
             // Go to bottom of file
             KeyCode::Char('G') => {
                 self.draw_memory.inner_call_index = self.debug_arena().len() - 1;
-                self.current_step = self.debug_steps().len() - 1;
-                self.key_buffer.clear();
+                self.current_step = self.n_steps() - 1;
             }
+
             // Go to previous call
             KeyCode::Char('c') => {
                 self.draw_memory.inner_call_index =
                     self.draw_memory.inner_call_index.saturating_sub(1);
-                self.current_step = self.debug_steps().len() - 1;
-                self.key_buffer.clear();
+                self.current_step = self.n_steps() - 1;
             }
+
             // Go to next call
             KeyCode::Char('C') => {
                 if self.debug_arena().len() > self.draw_memory.inner_call_index + 1 {
                     self.draw_memory.inner_call_index += 1;
                     self.current_step = 0;
                 }
-                self.key_buffer.clear();
             }
+
             // Step forward
-            KeyCode::Char('s') => {
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    let remaining_ops = self.opcode_list[self.current_step..].to_vec();
-                    self.current_step += remaining_ops
-                        .iter()
-                        .enumerate()
-                        .find_map(|(i, op)| {
-                            if i < remaining_ops.len() - 1 {
-                                match (
-                                    op.contains("JUMP") && op != "JUMPDEST",
-                                    &*remaining_ops[i + 1],
-                                ) {
-                                    (true, "JUMPDEST") => Some(i + 1),
-                                    _ => None,
-                                }
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or(self.opcode_list.len() - 1);
-                    if self.current_step > self.opcode_list.len() {
-                        self.current_step = self.opcode_list.len() - 1
-                    };
+            KeyCode::Char('s') => self.repeat(|this| {
+                let remaining_ops = &this.opcode_list[this.current_step..];
+                if let Some((i, _)) = remaining_ops.iter().enumerate().skip(1).find(|&(i, op)| {
+                    let prev = &remaining_ops[i - 1];
+                    let prev_is_jump = prev.contains("JUMP") && prev != "JUMPDEST";
+                    let is_jumpdest = op == "JUMPDEST";
+                    prev_is_jump && is_jumpdest
+                }) {
+                    this.current_step += i;
                 }
-                self.key_buffer.clear();
-            }
+            }),
+
             // Step backwards
-            KeyCode::Char('a') => {
-                for _ in 0..buffer_as_number(&self.key_buffer, 1) {
-                    let prev_ops = self.opcode_list[..self.current_step].to_vec();
-                    self.current_step = prev_ops
-                        .iter()
-                        .enumerate()
-                        .rev()
-                        .find_map(|(i, op)| {
-                            if i > 0 {
-                                match (
-                                    prev_ops[i - 1].contains("JUMP") &&
-                                        prev_ops[i - 1] != "JUMPDEST",
-                                    &**op,
-                                ) {
-                                    (true, "JUMPDEST") => Some(i - 1),
-                                    _ => None,
-                                }
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or_default();
-                }
-                self.key_buffer.clear();
-            }
-            // toggle stack labels
+            KeyCode::Char('a') => self.repeat(|this| {
+                let ops = &this.opcode_list[..this.current_step];
+                this.current_step = ops
+                    .iter()
+                    .enumerate()
+                    .skip(1)
+                    .rev()
+                    .find(|&(i, op)| {
+                        let prev = &ops[i - 1];
+                        let prev_is_jump = prev.contains("JUMP") && prev != "JUMPDEST";
+                        let is_jumpdest = op == "JUMPDEST";
+                        prev_is_jump && is_jumpdest
+                    })
+                    .map(|(i, _)| i)
+                    .unwrap_or_default();
+            }),
+
+            // Toggle stack labels
             KeyCode::Char('t') => self.stack_labels = !self.stack_labels,
-            // toggle memory utf8 decoding
+
+            // Toggle memory UTF-8 decoding
             KeyCode::Char('m') => self.buf_utf = !self.buf_utf,
-            // toggle help notice
+
+            // Toggle help notice
             KeyCode::Char('h') => self.show_shortcuts = !self.show_shortcuts,
+
+            // Numbers for repeating commands or breakpoints
             KeyCode::Char(
                 other @ ('0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '\''),
-            ) => self.key_buffer.push(other),
-            _ => self.key_buffer.clear(),
+            ) => {
+                // Early return to not clear the buffer.
+                self.key_buffer.push(other);
+                return ControlFlow::Continue(());
+            }
+
+            // Unknown/unhandled key code
+            _ => {}
         };
 
+        self.key_buffer.clear();
         ControlFlow::Continue(())
     }
 
@@ -319,37 +301,47 @@ impl DebuggerContext<'_> {
 
     fn handle_mouse_event(&mut self, event: MouseEvent) -> ControlFlow<ExitReason> {
         match event.kind {
-            MouseEventKind::ScrollUp => {
-                if self.current_step > 0 {
-                    self.current_step -= 1;
-                } else if self.draw_memory.inner_call_index > 0 {
-                    self.draw_memory.inner_call_index -= 1;
-                    self.draw_memory.current_buf_startline = 0;
-                    self.draw_memory.current_stack_startline = 0;
-                    self.current_step = self.debug_steps().len() - 1;
-                }
-            }
-            MouseEventKind::ScrollDown => {
-                if self.current_step < self.opcode_list.len() - 1 {
-                    self.current_step += 1;
-                } else if self.draw_memory.inner_call_index < self.debug_arena().len() - 1 {
-                    self.draw_memory.inner_call_index += 1;
-                    self.draw_memory.current_buf_startline = 0;
-                    self.draw_memory.current_stack_startline = 0;
-                    self.current_step = 0;
-                }
-            }
+            MouseEventKind::ScrollUp => self.step_back(),
+            MouseEventKind::ScrollDown => self.step(),
             _ => {}
         }
 
         ControlFlow::Continue(())
     }
+
+    fn step_back(&mut self) {
+        if self.current_step > 0 {
+            self.current_step -= 1;
+        } else if self.draw_memory.inner_call_index > 0 {
+            self.draw_memory.inner_call_index -= 1;
+            self.current_step = self.n_steps() - 1;
+        }
+    }
+
+    fn step(&mut self) {
+        if self.current_step < self.n_steps() - 1 {
+            self.current_step += 1;
+        } else if self.draw_memory.inner_call_index < self.debug_arena().len() - 1 {
+            self.draw_memory.inner_call_index += 1;
+            self.current_step = 0;
+        }
+    }
+
+    /// Calls a closure `f` the number of times specified in the key buffer, and at least once.
+    fn repeat(&mut self, mut f: impl FnMut(&mut Self)) {
+        for _ in 0..buffer_as_number(&self.key_buffer) {
+            f(self);
+        }
+    }
+
+    fn n_steps(&self) -> usize {
+        self.debug_steps().len()
+    }
 }
 
 /// Grab number from buffer. Used for something like '10k' to move up 10 operations
-fn buffer_as_number(s: &str, default_value: usize) -> usize {
-    match s.parse() {
-        Ok(num) if num >= 1 => num,
-        _ => default_value,
-    }
+fn buffer_as_number(s: &str) -> usize {
+    const MIN: usize = 1;
+    const MAX: usize = 100_000;
+    s.parse().unwrap_or(MIN).clamp(MIN, MAX)
 }

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -5,13 +5,11 @@ use alloy_primitives::Address;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::debug::{DebugNodeFlat, DebugStep};
 use revm_inspectors::tracing::types::CallKind;
-use std::{cell::RefCell, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 /// This is currently used to remember last scroll position so screen doesn't wiggle as much.
 #[derive(Default)]
 pub(crate) struct DrawMemory {
-    // TODO
-    pub(crate) current_startline: RefCell<usize>,
     pub(crate) inner_call_index: usize,
     pub(crate) current_buf_startline: usize,
     pub(crate) current_stack_startline: usize,

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -401,11 +401,10 @@ impl DebuggerContext<'_> {
             self.current_step().total_gas_used,
         );
         let block = Block::default().title(title).borders(Borders::ALL);
-        let hl_style = Style::new().fg(Color::White).bg(Color::DarkGray);
         let list = List::new(items)
             .block(block)
             .highlight_symbol("▶")
-            .highlight_style(hl_style)
+            .highlight_style(Style::new().fg(Color::White).bg(Color::DarkGray))
             .scroll_padding(1);
         let mut state = ListState::default().with_selected(Some(self.current_step));
         f.render_stateful_widget(list, area, &mut state);

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -115,16 +115,13 @@ impl Debugger {
             .spawn(move || Self::event_listener(tx))
             .expect("failed to spawn thread");
 
-        // Draw the initial state.
-        cx.draw(terminal)?;
-
         // Start the event loop.
         loop {
+            cx.draw(terminal)?;
             match cx.handle_event(rx.recv()?) {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(reason) => return Ok(reason),
             }
-            cx.draw(terminal)?;
         }
     }
 


### PR DESCRIPTION
Update ratatui from 0.24 to 0.26, the only observable breaking change is Layout builder method params were moved to the `new` method.

Use builtin `List` widget to handle printing opcodes. This fixes a bunch of logic errors with that code that nobody wants to debug by removing it.
Differences:
- the highlight symbol is before the index instead of the opcode name
- 1 opcode padding instead of whatever that code did, meaning the highlight will stop 1 before the end
  - this would just go off screen if the box was too small
- the highlight spans across the entire box rather than just behind the text

Some other misc fixes:
- generate the opcode list after the event has been handled. Fixes a small bug when changing call context as the opcode list would be the wrong one until another event was handled
- clamp repeat number (e.g. `1000k`) to 1..=100_000
- sync mouse wheel step and keyboard step logic
- don't reset memory view when stepping

---

## Before

![Peek 2024-04-16 00-57](https://github.com/foundry-rs/foundry/assets/57450786/c6a045b6-0978-42ea-88cb-2288c58a5db9)


## After

![Peek 2024-04-16 00-56](https://github.com/foundry-rs/foundry/assets/57450786/9cbc72bd-2101-4a4c-b791-6806fa217639)
