### PR TITLE
chore(fork): adjust `chain_id` when updating local env with fork

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1774,6 +1774,7 @@ impl Default for BackendInner {
 pub(crate) fn update_current_env_with_fork_env(current: &mut Env, fork: Env) {
     current.block = fork.block;
     current.cfg = fork.cfg;
+    current.tx.chain_id = fork.tx.chain_id;
 }
 
 /// Clones the data of the given `accounts` from the `active` database into the `fork_db`

--- a/testdata/default/cheats/Fork.t.sol
+++ b/testdata/default/cheats/Fork.t.sol
@@ -111,4 +111,10 @@ contract ForkTest is DSTest {
         uint256 expected = block.chainid;
         assertEq(newChainId, expected);
     }
+
+    // ensures forks change chain ids automatically
+    function testCanAutoUpdateChainId() public {
+        vm.createSelectFork("https://polygon-pokt.nodies.app"); // Polygon mainnet RPC URL
+        assertEq(block.chainid, 137);
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Solves #7633

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds the following line to `update_current_env_with_fork_env()`:
```rust
current.tx.chain_id = fork.tx.chain_id;
```
Apologies if this breaks or leads to unforeseen behavior as I'm _relatively_ new to fork testing. 
I'm always happy to hear how this can be improved!