### PR TITLE
feat(forge-cli): Add `--no-metadata` as CLI compiler option 

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -70,6 +70,13 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub via_ir: bool,
 
+    /// Whether to append the metadata hash to the bytecode.
+    /// This is equivalent to setting [Config::bytecode_hash] to `none` and
+    /// [Config::cbor_metadata] to `false`.
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub no_metadata: bool,
+
     /// The path to the contract artifacts folder.
     #[arg(
         long = "out",
@@ -204,9 +211,15 @@ impl Provider for CoreBuildArgs {
             dict.insert("via_ir".to_string(), true.into());
         }
 
+        if self.no_metadata {
+            dict.insert("bytecode_hash".to_string(), "none".into());
+            dict.insert("cbor_metadata".to_string(), false.into());
+        }
+
         if self.force {
             dict.insert("force".to_string(), self.force.into());
         }
+
         // we need to ensure no_cache set accordingly
         if self.no_cache {
             dict.insert("cache".to_string(), false.into());

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -70,9 +70,9 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub via_ir: bool,
 
-    /// Whether to append the metadata hash to the bytecode.
-    /// This is equivalent to setting [Config::bytecode_hash] to `none` and
-    /// [Config::cbor_metadata] to `false`.
+    /// Do not append any metadata to the bytecode.
+    ///
+    /// This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
     #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub no_metadata: bool,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256, U256};
 use foundry_cli::utils as forge_utils;
-use foundry_compilers::artifacts::{OptimizerDetails, RevertStrings, YulDetails};
+use foundry_compilers::artifacts::{BytecodeHash, OptimizerDetails, RevertStrings, YulDetails};
 use foundry_config::{
     cache::{CachedChains, CachedEndpoints, StorageCachingConfig},
     fs_permissions::{FsAccessPermission, PathPermission},
@@ -305,8 +305,10 @@ forgetest_init!(can_get_evm_opts, |prj, _cmd| {
 
 // checks that we can set various config values
 forgetest_init!(can_set_config_values, |prj, _cmd| {
-    let config = prj.config_from_output(["--via-ir"]);
+    let config = prj.config_from_output(["--via-ir", "--no-metadata"]);
     assert!(config.via_ir);
+    assert_eq!(config.cbor_metadata, false);
+    assert_eq!(config.bytecode_hash, BytecodeHash::None);
 });
 
 // tests that solc can be explicitly set


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #7488 

Adds `--no-metadata` as CLI option, equivalent to passing `--no-cbor-metadata  --metadata-hash none` to `solc` or defining:

```
bytecode_hash = "none"
cbor_metadata = false
```

in `foundry.toml`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Considering the requirement for deterministic builds is common I think it makes sense to add a CLI option that bundles the two as requested.

For comparison between `forge build` and `forge build --no-metadata`: https://jsoncompare.com/#!/diff/id=f0200fd7445202aefdf057a353664f29/

Open to feedback, it may make more sense to decouple the two, contrary to the proposal, and allow users to pass `--no-cbor-metadata --bytecode-hash="none"`.