### PR TITLE
fix(cheatcodes): `expectSafeMemory` + `stopExpectSafeMemory`

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -18,7 +18,7 @@ use crate::{
 use alloy_primitives::{Address, Bytes, Log, B256, U256};
 use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolInterface, SolValue};
-use foundry_common::{evm::Breakpoints, provider::alloy::RpcUrl};
+use foundry_common::{evm::Breakpoints, provider::alloy::RpcUrl, SELECTOR_LEN};
 use foundry_evm_core::{
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
@@ -608,7 +608,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                                 // execution.
                                 let value = try_or_continue!(interpreter.stack().peek(1)).to_be_bytes::<32>();
                                 let selector = stopExpectSafeMemoryCall {}.cheatcode().func.selector_bytes;
-                                if value[0..4] == selector {
+                                if value[0..SELECTOR_LEN] == selector {
                                     return
                                 }
 
@@ -678,7 +678,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                                     let args_size = try_or_continue!(interpreter.stack().peek(4)).saturating_to::<usize>();
                                     let selector = stopExpectSafeMemoryCall {}.cheatcode().func.selector_bytes;
                                     let memory_word = interpreter.shared_memory.slice(args_offset, args_size);
-                                    if memory_word[0..4] == selector {
+                                    if memory_word[0..SELECTOR_LEN] == selector {
                                         return
                                     }
                                 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -12,7 +12,7 @@ use crate::{
         self, ExpectedCallData, ExpectedCallTracker, ExpectedCallType, ExpectedEmit,
         ExpectedRevert, ExpectedRevertKind,
     },
-    CheatsConfig, CheatsCtxt, Error, Result, Vm,
+    CheatsConfig, CheatsCtxt, DynCheatcode, Error, Result, Vm,
     Vm::AccountAccess,
 };
 use alloy_primitives::{Address, Bytes, Log, B256, U256};
@@ -20,6 +20,7 @@ use alloy_rpc_types::request::{TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolInterface, SolValue};
 use foundry_common::{evm::Breakpoints, provider::alloy::RpcUrl};
 use foundry_evm_core::{
+    abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS},
 };
@@ -601,6 +602,16 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                             if !ranges.iter().any(|range| {
                                 range.contains(&offset) && range.contains(&(offset + 31))
                             }) {
+                                // SPECIAL CASE: When the compiler attempts to store the selector for
+                                // `stopExpectSafeMemory`, this is allowed. It will do so at the current free memory
+                                // pointer, which could have been updated to the exclusive upper bound during
+                                // execution.
+                                let value = try_or_continue!(interpreter.stack().peek(1)).to_be_bytes::<32>();
+                                let selector = stopExpectSafeMemoryCall {}.cheatcode().func.selector_bytes;
+                                if value[0..4] == selector {
+                                    return
+                                }
+
                                 disallowed_mem_write(offset, 32, interpreter, ranges);
                                 return
                             }
@@ -640,11 +651,48 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         //          OPERATIONS WITH OFFSET AND SIZE ON STACK          //
                         ////////////////////////////////////////////////////////////////
 
+                        opcode::CALL => {
+                            // The destination offset of the operation is the fifth element on the stack.
+                            let dest_offset = try_or_continue!(interpreter.stack().peek(5)).saturating_to::<u64>();
+
+                            // The size of the data that will be copied is the sixth element on the stack.
+                            let size = try_or_continue!(interpreter.stack().peek(6)).saturating_to::<u64>();
+
+                            // If none of the allowed ranges contain [dest_offset, dest_offset + size),
+                            // memory outside of the expected ranges has been touched. If the opcode
+                            // only reads from memory, this is okay as long as the memory is not expanded.
+                            let fail_cond = !ranges.iter().any(|range| {
+                                range.contains(&dest_offset) &&
+                                    range.contains(&(dest_offset + size.saturating_sub(1)))
+                            });
+
+                            // If the failure condition is met, set the output buffer to a revert string
+                            // that gives information about the allowed ranges and revert.
+                            if fail_cond {
+                                // SPECIAL CASE: When a call to `stopExpectSafeMemory` is performed, this is allowed.
+                                // It allocated calldata at the current free memory pointer, and will attempt to read
+                                // from this memory region to perform the call.
+                                let to = Address::from_word(try_or_continue!(interpreter.stack().peek(1)).to_be_bytes::<32>().into());
+                                if to == CHEATCODE_ADDRESS {
+                                    let args_offset = try_or_continue!(interpreter.stack().peek(3)).saturating_to::<usize>();
+                                    let args_size = try_or_continue!(interpreter.stack().peek(4)).saturating_to::<usize>();
+                                    let selector = stopExpectSafeMemoryCall {}.cheatcode().func.selector_bytes;
+                                    let memory_word = interpreter.shared_memory.slice(args_offset, args_size);
+                                    if memory_word[0..4] == selector {
+                                        return
+                                    }
+                                }
+
+                                disallowed_mem_write(dest_offset, size, interpreter, ranges);
+                                return
+                            }
+                        }
+
                         $(opcode::$opcode => {
-                            // The destination offset of the operation is at the top of the stack.
+                            // The destination offset of the operation.
                             let dest_offset = try_or_continue!(interpreter.stack().peek($offset_depth)).saturating_to::<u64>();
 
-                            // The size of the data that will be copied is the third item on the stack.
+                            // The size of the data that will be copied.
                             let size = try_or_continue!(interpreter.stack().peek($size_depth)).saturating_to::<u64>();
 
                             // If none of the allowed ranges contain [dest_offset, dest_offset + size),
@@ -678,7 +726,6 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                 (CODECOPY, 0, 2, true),
                 (RETURNDATACOPY, 0, 2, true),
                 (EXTCODECOPY, 1, 3, true),
-                (CALL, 5, 6, true),
                 (CALLCODE, 5, 6, true),
                 (STATICCALL, 4, 5, true),
                 (DELEGATECALL, 4, 5, true),

--- a/testdata/default/cheats/MemSafety.t.sol
+++ b/testdata/default/cheats/MemSafety.t.sol
@@ -738,6 +738,24 @@ contract MemSafetyTest is DSTest {
         vm.stopExpectSafeMemory();
     }
 
+    /// @dev Tests that the `stopExpectSafeMemory` cheatcode can still be called if the free memory pointer was
+    ///      updated to the exclusive upper boundary during execution.
+    function testStopExpectSafeMemory_freeMemUpdate() public {
+        uint64 initPtr;
+        assembly {
+            initPtr := mload(0x40)
+        }
+
+        vm.expectSafeMemory(initPtr, initPtr + 0x20);
+        assembly {
+            // write outside of allowed range, this should revert
+            mstore(initPtr, 0x01)
+            mstore(0x40, add(initPtr, 0x20))
+        }
+
+        vm.stopExpectSafeMemory();
+    }
+
     ////////////////////////////////////////////////////////////////
     //                          HELPERS                           //
     ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Overview

Fixes the `stopExpectSafeMemory` cheatcode by allowing for the memory allocation of the `stopExpectSafeMemory` selector as well as the potentially out-of-bounds read performed in the `CALL` operation to the cheatcode contract.

Currently, forge reports incorrectly that memory safety was violated in a memory safe region of a test, if the free memory pointer was updated to `[exclusiveUpperBound-31, exclusiveUpperBound]` during execution and is followed by a `stopExpectSafeMemory` call.

To fix this, we allow for `MSTORE` operations that store the selector bytes for `stopExpectSafeMemory`, as well as `CALL` operations that are to the cheatcode address and contain the `stopExpectSafeMemory` selector in the first 4 bytes of the call arguments, even if they write/read from outside of the allowed region(s).