### PR TITLE
feat: add tmp prague config value

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -379,6 +379,11 @@ pub struct Config {
     /// Should be removed once EvmVersion Cancun is supported by solc
     pub cancun: bool,
 
+    /// Temporary config to enable [SpecId::PRAGUE]
+    ///
+    /// Should be removed once EvmVersion Prague is supported by solc
+    pub prague: bool,
+
     /// Whether to enable call isolation.
     ///
     /// Useful for more correct gas accounting and EVM behavior in general.
@@ -851,6 +856,9 @@ impl Config {
     pub fn evm_spec_id(&self) -> SpecId {
         if self.cancun {
             return SpecId::CANCUN
+        }
+        if self.prague {
+            return SpecId::PRAGUE
         }
         evm_spec_id(&self.evm_version)
     }
@@ -1928,6 +1936,7 @@ impl Default for Config {
             profile: Self::DEFAULT_PROFILE,
             fs_permissions: FsPermissions::new([PathPermission::read("out")]),
             cancun: false,
+            prague: false,
             isolate: false,
             __root: Default::default(),
             src: "src".into(),
@@ -2883,7 +2892,7 @@ mod tests {
                 test = "defaulttest"
                 src  = "defaultsrc"
                 libs = ['lib', 'node_modules']
-                
+
                 [profile.custom]
                 src = "customsrc"
             "#,
@@ -3705,7 +3714,7 @@ mod tests {
                 tx_origin = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
                 verbosity = 0
                 via_ir = false
-                
+
                 [profile.default.rpc_storage_caching]
                 chains = 'all'
                 endpoints = 'all'
@@ -4173,7 +4182,7 @@ mod tests {
                         './src/SizeAuction.sol:Math:0x902f6cf364b8d9470d5793a9b2b2e86bddd21e0c',
                         './src/test/ChainlinkTWAP.t.sol:ChainlinkTWAP:0xffedba5e171c4f15abaaabc86e8bd01f9b54dae5',
                         './src/SizeAuctionDiscount.sol:Math:0x902f6cf364b8d9470d5793a9b2b2e86bddd21e0c',
-                    ]       
+                    ]
             ",
             )?;
             let config = Config::load();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -132,6 +132,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         fs_permissions: Default::default(),
         labels: Default::default(),
         cancun: true,
+        prague: true,
         isolate: true,
         unchecked_cheatcode_artifacts: false,
         create2_library_salt: Config::DEFAULT_CREATE2_LIBRARY_SALT,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

This adds a `prague = true` option to foundry.toml which enables Prague SpecId.

This is a temp measure that will get phased out once solc recognizes the prague version, until then the solc target and evm can be configured independently

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
