### PR TITLE
feat: library deployments though CREATE2

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -28,7 +28,7 @@ use foundry_compilers::{
 };
 use inflector::Inflector;
 use regex::Regex;
-use revm_primitives::{fixed_bytes, FixedBytes, SpecId};
+use revm_primitives::{FixedBytes, SpecId};
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -454,10 +454,7 @@ impl Config {
     pub const DEFAULT_SENDER: Address = address!("1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
 
     /// Default salt for create2 library deployments
-    ///
-    /// cast keccak 'foundry create2'
-    pub const DEFAULT_CREATE2_LIBRARY_SALT: FixedBytes<32> =
-        fixed_bytes!("19bf59b7b67ae8edcbc6e53616080f61fa99285c061450ad601b0bc40c9adfc9");
+    pub const DEFAULT_CREATE2_LIBRARY_SALT: FixedBytes<32> = FixedBytes::<32>::ZERO;
 
     /// Returns the current `Config`
     ///

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -28,7 +28,7 @@ use foundry_compilers::{
 };
 use inflector::Inflector;
 use regex::Regex;
-use revm_primitives::SpecId;
+use revm_primitives::{fixed_bytes, FixedBytes, SpecId};
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -394,6 +394,9 @@ pub struct Config {
     /// If disabled, it is possible to access artifacts which were not recompiled or cached.
     pub unchecked_cheatcode_artifacts: bool,
 
+    /// CREATE2 salt to use for the library deployment in scripts.
+    pub create2_library_salt: B256,
+
     /// The root path where the config detection started from, `Config::with_root`
     #[doc(hidden)]
     //  We're skipping serialization here, so it won't be included in the [`Config::to_string()`]
@@ -449,6 +452,12 @@ impl Config {
     ///
     /// `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`
     pub const DEFAULT_SENDER: Address = address!("1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
+
+    /// Default salt for create2 library deployments
+    ///
+    /// cast keccak 'foundry create2'
+    pub const DEFAULT_CREATE2_LIBRARY_SALT: FixedBytes<32> =
+        fixed_bytes!("19bf59b7b67ae8edcbc6e53616080f61fa99285c061450ad601b0bc40c9adfc9");
 
     /// Returns the current `Config`
     ///
@@ -2006,6 +2015,7 @@ impl Default for Config {
             doc: Default::default(),
             labels: Default::default(),
             unchecked_cheatcode_artifacts: false,
+            create2_library_salt: Config::DEFAULT_CREATE2_LIBRARY_SALT,
             __non_exhaustive: (),
             __warnings: vec![],
         }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -159,7 +159,7 @@ impl Executor {
         Ok(self.backend.basic_ref(address)?.map(|acc| acc.nonce).unwrap_or_default())
     }
 
-    /// Gets the nonce of an account
+    /// Returns true if account has no code.
     pub fn is_empty_code(&self, address: Address) -> DatabaseResult<bool> {
         Ok(self.backend.basic_ref(address)?.map(|acc| acc.is_empty_code_hash()).unwrap_or_default())
     }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -159,6 +159,11 @@ impl Executor {
         Ok(self.backend.basic_ref(address)?.map(|acc| acc.nonce).unwrap_or_default())
     }
 
+    /// Gets the nonce of an account
+    pub fn is_empty_code(&self, address: Address) -> DatabaseResult<bool> {
+        Ok(self.backend.basic_ref(address)?.map(|acc| acc.is_empty_code_hash()).unwrap_or_default())
+    }
+
     #[inline]
     pub fn set_tracing(&mut self, tracing: bool) -> &mut Self {
         self.inspector.tracing(tracing);

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -161,7 +161,7 @@ impl Executor {
 
     /// Returns true if account has no code.
     pub fn is_empty_code(&self, address: Address) -> DatabaseResult<bool> {
-        Ok(self.backend.basic_ref(address)?.map(|acc| acc.is_empty_code_hash()).unwrap_or_default())
+        Ok(self.backend.basic_ref(address)?.map(|acc| acc.is_empty_code_hash()).unwrap_or(true))
     }
 
     #[inline]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -130,6 +130,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         cancun: true,
         isolate: true,
         unchecked_cheatcode_artifacts: false,
+        create2_library_salt: Config::DEFAULT_CREATE2_LIBRARY_SALT,
         __non_exhaustive: (),
         __warnings: vec![],
     };

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1395,3 +1395,30 @@ contract SimpleScript is Script {
 
     cmd.stdout_lossy();
 });
+
+// Asserts that running the same script twice only deploys library once.
+forgetest_async!(can_deploy_library_create2, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+
+    tester
+        .load_private_keys(&[0, 1])
+        .await
+        .add_sig("BroadcastTest", "deploy()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(&[(0, 2), (1, 1)])
+        .await;
+
+    tester.clear();
+
+    tester
+        .load_private_keys(&[0, 1])
+        .await
+        .add_sig("BroadcastTest", "deploy()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(&[(0, 1), (1, 1)])
+        .await;
+});

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1422,3 +1422,32 @@ forgetest_async!(can_deploy_library_create2, |prj, cmd| {
         .assert_nonce_increment(&[(0, 1), (1, 1)])
         .await;
 });
+
+// Asserts that running the same script twice only deploys library once when using different
+// senders.
+forgetest_async!(can_deploy_library_create2_different_sender, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+
+    tester
+        .load_private_keys(&[0, 1])
+        .await
+        .add_sig("BroadcastTest", "deploy()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(&[(0, 2), (1, 1)])
+        .await;
+
+    tester.clear();
+
+    // Run different script from the same contract (which requires the same library).
+    tester
+        .load_private_keys(&[2])
+        .await
+        .add_sig("BroadcastTest", "deployNoArgs()")
+        .simulate(ScriptOutcome::OkSimulation)
+        .broadcast(ScriptOutcome::OkBroadcast)
+        .assert_nonce_increment(&[(2, 2)])
+        .await;
+});

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -275,10 +275,7 @@ impl<'a> Linker<'a> {
 mod tests {
     use super::*;
     use alloy_primitives::fixed_bytes;
-    use foundry_compilers::{
-        artifacts::output_selection::{ContractOutputSelection, OutputSelection},
-        ConfigurableArtifacts, Project, ProjectCompileOutput, ProjectPathsConfig,
-    };
+    use foundry_compilers::{Project, ProjectCompileOutput, ProjectPathsConfig};
     use std::collections::HashMap;
 
     struct LinkerTest {

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -5,7 +5,6 @@ use crate::{
     sequence::{ScriptSequence, ScriptSequenceKind},
     ScriptArgs, ScriptConfig,
 };
-
 use alloy_primitives::{Bytes, B256};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -6,7 +6,7 @@ use crate::{
     ScriptArgs, ScriptConfig,
 };
 
-use alloy_primitives::{Address, Bytes, B256};
+use alloy_primitives::{Bytes, B256};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use foundry_cheatcodes::ScriptWallets;
@@ -21,7 +21,6 @@ use foundry_compilers::{
     utils::source_files_iter,
     ArtifactId, ProjectCompileOutput, SOLC_EXTENSIONS,
 };
-use foundry_config::Config;
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use foundry_linking::Linker;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
@@ -42,28 +41,48 @@ impl BuildData {
         Linker::new(self.project_root.clone(), self.output.artifact_ids().collect())
     }
 
-    /// Links the build data with given libraries, using sender and nonce to compute addresses of
-    /// missing libraries.
-    pub fn link(self, config: &Config, sender: Address, nonce: u64) -> Result<LinkedBuildData> {
-        let known_libraries = config.libraries_with_remappings()?;
-        let (libraries, predeploy_libs) = if let Ok(output) = self.get_linker().link_with_create2(
-            known_libraries.clone(),
-            DEFAULT_CREATE2_DEPLOYER,
-            config.create2_library_salt,
-            &self.target,
-        ) {
+    /// Links contracts. Uses CREATE2 linking when possible, otherwise falls back to
+    /// default linking with sender nonce and address.
+    pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
+        let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
+            let provider = try_get_http_provider(fork_url)?;
+            let deployer_code =
+                provider.get_code_at(DEFAULT_CREATE2_DEPLOYER, Default::default()).await?;
+
+            !deployer_code.is_empty()
+        } else {
+            // If --fork-url is not provided, we are just simulating the script.
+            true
+        };
+
+        let known_libraries = script_config.config.libraries_with_remappings()?;
+
+        let maybe_create2_link_output = can_use_create2
+            .then(|| {
+                self.get_linker()
+                    .link_with_create2(
+                        known_libraries.clone(),
+                        DEFAULT_CREATE2_DEPLOYER,
+                        script_config.config.create2_library_salt,
+                        &self.target,
+                    )
+                    .ok()
+            })
+            .flatten();
+
+        let (libraries, predeploy_libs) = if let Some(output) = maybe_create2_link_output {
             (
                 output.libraries,
                 ScriptPredeployLibraries::Create2(
                     output.libs_to_deploy,
-                    config.create2_library_salt,
+                    script_config.config.create2_library_salt,
                 ),
             )
         } else {
             let output = self.get_linker().link_with_nonce_or_address(
                 known_libraries,
-                sender,
-                nonce,
+                script_config.evm_opts.sender,
+                script_config.sender_nonce,
                 &self.target,
             )?;
 
@@ -230,12 +249,10 @@ pub struct CompiledState {
 
 impl CompiledState {
     /// Uses provided sender address to compute library addresses and link contracts with them.
-    pub fn link(self) -> Result<LinkedState> {
+    pub async fn link(self) -> Result<LinkedState> {
         let Self { args, script_config, script_wallets, build_data } = self;
 
-        let sender = script_config.evm_opts.sender;
-        let nonce = script_config.sender_nonce;
-        let build_data = build_data.link(&script_config.config, sender, nonce)?;
+        let build_data = build_data.link(&script_config).await?;
 
         Ok(LinkedState { args, script_config, script_wallets, build_data })
     }
@@ -286,7 +303,7 @@ impl CompiledState {
             if !froms.all(|from| available_signers.contains(&from)) {
                 // IF we are missing required signers, execute script as we might need to collect
                 // private keys from the execution.
-                let executed = self.link()?.prepare_execution().await?.execute().await?;
+                let executed = self.link().await?.prepare_execution().await?.execute().await?;
                 (
                     executed.args,
                     executed.build_data.build_data,

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -118,7 +118,7 @@ impl PreExecutionState {
                 build_data: self.build_data.build_data,
             };
 
-            return state.link()?.prepare_execution().await?.execute().await;
+            return state.link().await?.prepare_execution().await?.execute().await;
         }
 
         Ok(ExecutedState {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -228,7 +228,8 @@ impl ScriptArgs {
         } else {
             // Drive state machine to point at which we have everything needed for simulation.
             let pre_simulation = compiled
-                .link()?
+                .link()
+                .await?
                 .prepare_execution()
                 .await?
                 .execute()

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -600,11 +600,7 @@ impl ScriptConfig {
             });
         }
 
-        Ok(ScriptRunner::new(
-            builder.build(env, db),
-            self.evm_opts.initial_balance,
-            self.evm_opts.sender,
-        ))
+        Ok(ScriptRunner::new(builder.build(env, db), self.evm_opts.clone()))
     }
 }
 

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -1,7 +1,6 @@
-use std::collections::VecDeque;
-use crate::build::ScriptPredeployLibraries;
 use super::ScriptResult;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
+use crate::build::ScriptPredeployLibraries;
 use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
@@ -13,6 +12,7 @@ use foundry_evm::{
     revm::interpreter::{return_ok, InstructionResult},
     traces::{TraceKind, Traces},
 };
+use std::collections::VecDeque;
 use yansi::Paint;
 
 /// Drives script execution

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -1,6 +1,6 @@
 use super::ScriptResult;
-use alloy_primitives::{Address, Bytes, TxKind, U256};
 use crate::build::ScriptPredeployLibraries;
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use crate::build::ScriptPredeployLibraries;
 
 use super::ScriptResult;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
@@ -112,7 +112,7 @@ impl ScriptRunner {
                             from: Some(self.evm_opts.sender),
                             input: Some(calldata.into()).into(),
                             nonce: Some(sender_nonce + library_transactions.len() as u64),
-                            to: Some(DEFAULT_CREATE2_DEPLOYER),
+                            to: Some(TxKind::Call(DEFAULT_CREATE2_DEPLOYER)),
                             ..Default::default()
                         },
                     });

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -1,7 +1,5 @@
 use std::collections::VecDeque;
-
 use crate::build::ScriptPredeployLibraries;
-
 use super::ScriptResult;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_rpc_types::TransactionRequest;

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -1,10 +1,17 @@
+use std::collections::VecDeque;
+
+use crate::build::ScriptPredeployLibraries;
+
 use super::ScriptResult;
 use alloy_primitives::{Address, Bytes, U256};
+use alloy_rpc_types::TransactionRequest;
 use eyre::Result;
+use foundry_cheatcodes::BroadcastableTransaction;
 use foundry_config::Config;
 use foundry_evm::{
-    constants::CALLER,
+    constants::{CALLER, DEFAULT_CREATE2_DEPLOYER},
     executors::{DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
+    opts::EvmOpts,
     revm::interpreter::{return_ok, InstructionResult},
     traces::{TraceKind, Traces},
 };
@@ -14,19 +21,18 @@ use yansi::Paint;
 #[derive(Debug)]
 pub struct ScriptRunner {
     pub executor: Executor,
-    pub initial_balance: U256,
-    pub sender: Address,
+    pub evm_opts: EvmOpts,
 }
 
 impl ScriptRunner {
-    pub fn new(executor: Executor, initial_balance: U256, sender: Address) -> Self {
-        Self { executor, initial_balance, sender }
+    pub fn new(executor: Executor, evm_opts: EvmOpts) -> Self {
+        Self { executor, evm_opts }
     }
 
     /// Deploys the libraries and broadcast contract. Calls setUp method if requested.
     pub fn setup(
         &mut self,
-        libraries: &[Bytes],
+        libraries: &ScriptPredeployLibraries,
         code: Bytes,
         setup: bool,
         sender_nonce: u64,
@@ -36,9 +42,9 @@ impl ScriptRunner {
         trace!(target: "script", "executing setUP()");
 
         if !is_broadcast {
-            if self.sender == Config::DEFAULT_SENDER {
+            if self.evm_opts.sender == Config::DEFAULT_SENDER {
                 // We max out their balance so that they can deploy and make calls.
-                self.executor.set_balance(self.sender, U256::MAX)?;
+                self.executor.set_balance(self.evm_opts.sender, U256::MAX)?;
             }
 
             if need_create2_deployer {
@@ -46,29 +52,79 @@ impl ScriptRunner {
             }
         }
 
-        self.executor.set_nonce(self.sender, sender_nonce)?;
+        self.executor.set_nonce(self.evm_opts.sender, sender_nonce)?;
 
         // We max out their balance so that they can deploy and make calls.
         self.executor.set_balance(CALLER, U256::MAX)?;
 
+        let mut library_transactions = VecDeque::new();
+        let mut traces = Traces::default();
+
         // Deploy libraries
-        let mut traces: Traces = libraries
-            .iter()
-            .filter_map(|code| {
-                self.executor
-                    .deploy(self.sender, code.clone(), U256::ZERO, None)
+        match libraries {
+            ScriptPredeployLibraries::Default(libraries) => libraries.iter().for_each(|code| {
+                let result = self
+                    .executor
+                    .deploy(self.evm_opts.sender, code.clone(), U256::ZERO, None)
                     .expect("couldn't deploy library")
-                    .raw
-                    .traces
-            })
-            .map(|traces| (TraceKind::Deployment, traces))
-            .collect();
+                    .raw;
+
+                if let Some(deploy_traces) = result.traces {
+                    traces.push((TraceKind::Deployment, deploy_traces));
+                }
+
+                library_transactions.push_back(BroadcastableTransaction {
+                    rpc: self.evm_opts.fork_url.clone(),
+                    transaction: TransactionRequest {
+                        from: Some(self.evm_opts.sender),
+                        input: Some(code.clone()).into(),
+                        nonce: Some(sender_nonce + library_transactions.len() as u64),
+                        ..Default::default()
+                    },
+                })
+            }),
+            ScriptPredeployLibraries::Create2(libraries, salt) => {
+                for library in libraries {
+                    let address =
+                        DEFAULT_CREATE2_DEPLOYER.create2_from_code(salt, library.as_ref());
+                    // Skip if already deployed
+                    if !self.executor.is_empty_code(address)? {
+                        continue;
+                    }
+                    let calldata = [salt.as_ref(), library.as_ref()].concat();
+                    let result = self
+                        .executor
+                        .call_raw_committing(
+                            self.evm_opts.sender,
+                            DEFAULT_CREATE2_DEPLOYER,
+                            calldata.clone().into(),
+                            U256::from(0),
+                        )
+                        .expect("couldn't deploy library");
+
+                    if let Some(deploy_traces) = result.traces {
+                        traces.push((TraceKind::Deployment, deploy_traces));
+                    }
+
+                    library_transactions.push_back(BroadcastableTransaction {
+                        rpc: self.evm_opts.fork_url.clone(),
+                        transaction: TransactionRequest {
+                            from: Some(self.evm_opts.sender),
+                            input: Some(calldata.into()).into(),
+                            nonce: Some(sender_nonce + library_transactions.len() as u64),
+                            to: Some(DEFAULT_CREATE2_DEPLOYER),
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+        };
 
         let address = CALLER.create(self.executor.get_nonce(CALLER)?);
 
         // Set the contracts initial balance before deployment, so it is available during the
         // construction
-        self.executor.set_balance(address, self.initial_balance)?;
+        self.executor.set_balance(address, self.evm_opts.initial_balance)?;
 
         // Deploy an instance of the contract
         let DeployResult {
@@ -85,9 +141,15 @@ impl ScriptRunner {
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions, debug) = if !setup {
             self.executor.backend.set_test_contract(address);
-            (true, 0, Default::default(), None, vec![constructor_debug].into_iter().collect())
+            (
+                true,
+                0,
+                Default::default(),
+                Some(library_transactions),
+                vec![constructor_debug].into_iter().collect(),
+            )
         } else {
-            match self.executor.setup(Some(self.sender), address, None) {
+            match self.executor.setup(Some(self.evm_opts.sender), address, None) {
                 Ok(RawCallResult {
                     reverted,
                     traces: setup_traces,
@@ -95,17 +157,21 @@ impl ScriptRunner {
                     logs: setup_logs,
                     debug,
                     gas_used,
-                    transactions,
+                    transactions: setup_transactions,
                     ..
                 }) => {
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
+                    if let Some(txs) = setup_transactions {
+                        library_transactions.extend(txs);
+                    }
+
                     (
                         !reverted,
                         gas_used,
                         labels,
-                        transactions,
+                        Some(library_transactions),
                         vec![constructor_debug, debug].into_iter().collect(),
                     )
                 }
@@ -123,11 +189,15 @@ impl ScriptRunner {
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
+                    if let Some(txs) = transactions {
+                        library_transactions.extend(txs);
+                    }
+
                     (
                         !reverted,
                         gas_used,
                         labels,
-                        transactions,
+                        Some(library_transactions),
                         vec![constructor_debug, debug].into_iter().collect(),
                     )
                 }
@@ -154,7 +224,7 @@ impl ScriptRunner {
 
     /// Executes the method that will collect all broadcastable transactions.
     pub fn script(&mut self, address: Address, calldata: Bytes) -> Result<ScriptResult> {
-        self.call(self.sender, address, calldata, U256::ZERO, false)
+        self.call(self.evm_opts.sender, address, calldata, U256::ZERO, false)
     }
 
     /// Runs a broadcastable transaction locally and persists its state.

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -115,6 +115,13 @@ impl ScriptRunner {
                         },
                     });
                 }
+
+                // Sender nonce is not incremented when performing CALLs. We need to manually
+                // increase it.
+                self.executor.set_nonce(
+                    self.evm_opts.sender,
+                    sender_nonce + library_transactions.len() as u64,
+                )?;
             }
         };
 


### PR DESCRIPTION
## Motivation

Closes #4810
ref https://github.com/foundry-rs/foundry/pull/7027#discussion_r1481556804

## Solution

This PR introduces a new approach to library linking for scripts. If CREATE2 deployer is present on target chain, ibraries are deployed through it, and only if they have not been deployed before. This makes it possible for users to run scripts without ever thinking about library deployment and need to provide addresses in `foundry.toml` or via `--libraries` args.

Salt for deployments can be configured through `create2_library_salt`.

It is not possible to link libraries with cyclic dependencies in such way, so we are still falling back to default linking algo if error occurs.