### PR TITLE
fix: exclude empty artifacts from `ContractsByArtifact`

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -355,11 +355,14 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
                 }
             }?;
 
-            if deployed {
-                return Ok(artifact.1.deployed_bytecode.clone())
+            let maybe_bytecode = if deployed {
+                artifact.1.deployed_bytecode.clone()
             } else {
-                return Ok(artifact.1.bytecode.clone())
-            }
+                artifact.1.bytecode.clone()
+            };
+
+            return maybe_bytecode
+                .ok_or_else(|| fmt_err!("No bytecode for contract. Is it abstract or unlinked?"));
         } else {
             match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
                 (Some(file), Some(contract_name)) => {

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -20,9 +20,9 @@ pub struct ContractData {
     /// Contract ABI.
     pub abi: JsonAbi,
     /// Contract creation code.
-    pub bytecode: Bytes,
+    pub bytecode: Option<Bytes>,
     /// Contract runtime code.
-    pub deployed_bytecode: Bytes,
+    pub deployed_bytecode: Option<Bytes>,
 }
 
 type ArtifactWithContractRef<'a> = (&'a ArtifactId, &'a ContractData);
@@ -48,9 +48,9 @@ impl ContractsByArtifact {
 
                     // Exclude artifacts with present but empty bytecode. Such artifacts are usually
                     // interfaces and abstract contracts.
-                    if bytecode.is_empty() || deployed_bytecode.is_empty() {
-                        return None;
-                    }
+                    let bytecode = (bytecode.len() > 0).then_some(bytecode);
+                    let deployed_bytecode =
+                        (deployed_bytecode.len() > 0).then_some(deployed_bytecode);
                     let abi = artifact.abi?;
 
                     Some((id, ContractData { name, abi, bytecode, deployed_bytecode }))
@@ -61,14 +61,23 @@ impl ContractsByArtifact {
 
     /// Finds a contract which has a similar bytecode as `code`.
     pub fn find_by_creation_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef> {
-        self.iter()
-            .find(|(_, contract)| bytecode_diff_score(contract.bytecode.as_ref(), code) <= 0.1)
+        self.iter().find(|(_, contract)| {
+            if let Some(bytecode) = &contract.bytecode {
+                bytecode_diff_score(bytecode.as_ref(), code) <= 0.1
+            } else {
+                false
+            }
+        })
     }
 
     /// Finds a contract which has a similar deployed bytecode as `code`.
     pub fn find_by_deployed_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef> {
         self.iter().find(|(_, contract)| {
-            bytecode_diff_score(contract.deployed_bytecode.as_ref(), code) <= 0.1
+            if let Some(deployed_bytecode) = &contract.deployed_bytecode {
+                bytecode_diff_score(deployed_bytecode.as_ref(), code) <= 0.1
+            } else {
+                false
+            }
         })
     }
 

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -46,10 +46,9 @@ impl ContractsByArtifact {
                     let deployed_bytecode =
                         artifact.deployed_bytecode.and_then(|b| b.into_bytes())?;
 
-                    if bytecode.is_empty() {
-                        return None;
-                    }
-                    if deployed_bytecode.is_empty() {
+                    // Exclude artifacts with present but empty bytecode. Such artifacts are usually
+                    // interfaces and abstract contracts.
+                    if bytecode.is_empty() || deployed_bytecode.is_empty() {
                         return None;
                     }
                     let abi = artifact.abi?;

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -45,6 +45,13 @@ impl ContractsByArtifact {
                     let bytecode = artifact.bytecode.and_then(|b| b.into_bytes())?;
                     let deployed_bytecode =
                         artifact.deployed_bytecode.and_then(|b| b.into_bytes())?;
+                    
+                    if bytecode.is_empty() {
+                        return None;
+                    }
+                    if deployed_bytecode.is_empty() {
+                        return None;
+                    }
                     let abi = artifact.abi?;
 
                     Some((id, ContractData { name, abi, bytecode, deployed_bytecode }))

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -45,7 +45,7 @@ impl ContractsByArtifact {
                     let bytecode = artifact.bytecode.and_then(|b| b.into_bytes())?;
                     let deployed_bytecode =
                         artifact.deployed_bytecode.and_then(|b| b.into_bytes())?;
-                    
+
                     if bytecode.is_empty() {
                         return None;
                     }

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{Address, Bytes};
 use alloy_provider::Provider;
 use alloy_rpc_types::request::TransactionRequest;
 use async_recursion::async_recursion;
-use eyre::Result;
+use eyre::{OptionExt, Result};
 use foundry_cheatcodes::ScriptWallets;
 use foundry_cli::utils::{ensure_clean_constructor, needs_setup};
 use foundry_common::{
@@ -62,6 +62,8 @@ impl LinkedState {
         let Self { args, script_config, script_wallets, build_data } = self;
 
         let ContractData { abi, bytecode, .. } = build_data.get_target_contract()?;
+
+        let bytecode = bytecode.ok_or_eyre("target contract has no bytecode")?;
 
         let (func, calldata) = args.get_method_and_calldata(&abi)?;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -362,11 +362,9 @@ impl ScriptArgs {
 
         // From artifacts
         for (artifact, contract) in known_contracts.iter() {
-            bytecodes.push((
-                artifact.name.clone(),
-                &contract.bytecode,
-                &contract.deployed_bytecode,
-            ));
+            let Some(bytecode) = &contract.bytecode else { continue };
+            let Some(deployed_bytecode) = &contract.deployed_bytecode else { continue };
+            bytecodes.push((artifact.name.clone(), bytecode, deployed_bytecode));
         }
 
         // From traces

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -131,6 +131,7 @@ impl TransactionWithMetadata {
 
         let Some(data) = self.transaction.input.input() else { return Ok(()) };
         let Some(info) = info else { return Ok(()) };
+        let Some(bytecode) = info.bytecode.as_ref() else { return Ok(()) };
 
         // `create2` transactions are prefixed by a 32 byte salt.
         let creation_code = if is_create2 {
@@ -143,11 +144,11 @@ impl TransactionWithMetadata {
         };
 
         // The constructor args start after bytecode.
-        let contains_constructor_args = creation_code.len() > info.bytecode.len();
+        let contains_constructor_args = creation_code.len() > bytecode.len();
         if !contains_constructor_args {
             return Ok(());
         }
-        let constructor_args = &creation_code[info.bytecode.len()..];
+        let constructor_args = &creation_code[bytecode.len()..];
 
         let Some(constructor) = info.abi.constructor() else { return Ok(()) };
         let values = constructor.abi_decode_input(constructor_args, false).map_err(|e| {

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -106,15 +106,11 @@ impl VerifyBundle {
         libraries: &[String],
     ) -> Option<VerifyArgs> {
         for (artifact, contract) in self.known_contracts.iter() {
-            // Avoid comparing to empty bytecode.
-            if contract.bytecode.is_empty() {
-                continue;
-            }
+            let Some(bytecode) = contract.bytecode.as_ref() else { continue };
             // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
             // of the transaction
-            if data.split_at(create2_offset).1.starts_with(&contract.bytecode) {
-                let constructor_args =
-                    data.split_at(create2_offset + contract.bytecode.len()).1.to_vec();
+            if data.split_at(create2_offset).1.starts_with(bytecode) {
+                let constructor_args = data.split_at(create2_offset + bytecode.len()).1.to_vec();
 
                 let contract = ContractInfo {
                     path: Some(

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -106,6 +106,10 @@ impl VerifyBundle {
         libraries: &[String],
     ) -> Option<VerifyArgs> {
         for (artifact, contract) in self.known_contracts.iter() {
+            // Avoid comparing to empty bytecode.
+            if contract.bytecode.is_empty() {
+                continue;
+            }
             // If it's a CREATE2, the tx.data comes with a 32-byte salt in the beginning
             // of the transaction
             if data.split_at(create2_offset).1.starts_with(&contract.bytecode) {


### PR DESCRIPTION
## Motivation

Closes #7702

## Solution

Exclude artifacts with present but empty bytecode from `ContractsByArtifact`. Such contracts are usually abstract contracts or interfaces. Also adds additional safety check to `VerifyArgs`