### PR TITLE
feat: temporarily re-introduce custom trace printer

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -30,8 +30,7 @@ pub struct RunArgs {
     debug: bool,
 
     /// Print out opcode traces.
-    #[deprecated]
-    #[arg(long, short, hide = true)]
+    #[arg(long, short)]
     trace_printer: bool,
 
     /// Executes the transaction only with the state from the previous block.
@@ -83,11 +82,6 @@ impl RunArgs {
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
     pub async fn run(self) -> Result<()> {
-        #[allow(deprecated)]
-        if self.trace_printer {
-            eprintln!("WARNING: --trace-printer is deprecated and has no effect\n");
-        }
-
         let figment =
             Config::figment_with_root(find_project_root_path(None).unwrap()).merge(self.rpc);
         let evm_opts = figment.extract::<EvmOpts>()?;
@@ -214,6 +208,8 @@ impl RunArgs {
 
         // Execute our transaction
         let result = {
+            executor.set_trace_printer(self.trace_printer);
+
             configure_tx_env(&mut env, &tx);
 
             if let Some(to) = tx.to {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -172,6 +172,12 @@ impl Executor {
     }
 
     #[inline]
+    pub fn set_trace_printer(&mut self, trace_printer: bool) -> &mut Self {
+        self.inspector.print(trace_printer);
+        self
+    }
+
+    #[inline]
     pub fn set_gas_limit(&mut self, gas_limit: U256) -> &mut Self {
         self.gas_limit = gas_limit;
         self


### PR DESCRIPTION
Partially reverts https://github.com/foundry-rs/foundry/pull/7437
Use revm's printer which looks an expanded version of the one we had before