### PR TITLE
fix: use 2718 encoding for transactions trie root calculation

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -48,7 +48,7 @@ impl Block {
         let ommers_hash =
             B256::from_slice(alloy_primitives::utils::keccak256(encoded_ommers).as_slice());
         let transactions_root =
-            trie::ordered_trie_root(transactions.iter().map(|r| r.transaction.encoded_2718()));
+            trie::ordered_trie_root(transactions.iter().map(|r| r.encoded_2718()));
 
         Self {
             header: Header {

--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -5,6 +5,7 @@ use super::{
 use alloy_consensus::Header;
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
+use alloy_eips::eip2718::Encodable2718;
 
 // Type alias to optionally support impersonated transactions
 #[cfg(not(feature = "impersonated-tx"))]
@@ -47,7 +48,7 @@ impl Block {
         let ommers_hash =
             B256::from_slice(alloy_primitives::utils::keccak256(encoded_ommers).as_slice());
         let transactions_root =
-            trie::ordered_trie_root(transactions.iter().map(|r| Bytes::from(alloy_rlp::encode(r))));
+            trie::ordered_trie_root(transactions.iter().map(|r| r.transaction.encoded_2718()));
 
         Self {
             header: Header {

--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -3,9 +3,9 @@ use super::{
     trie,
 };
 use alloy_consensus::Header;
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, Bloom, Bytes, B256, B64, U256};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use alloy_eips::eip2718::Encodable2718;
 
 // Type alias to optionally support impersonated transactions
 #[cfg(not(feature = "impersonated-tx"))]

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -941,7 +941,6 @@ impl Encodable2718 for TypedTransaction {
 
     fn encode_2718(&self, out: &mut dyn BufMut) {
         match self {
-            // Legacy transactions have no difference between network and 2718
             TypedTransaction::Legacy(tx) => TxEnvelope::from(tx.clone()).encode_2718(out),
             TypedTransaction::EIP2930(tx) => TxEnvelope::from(tx.clone()).encode_2718(out),
             TypedTransaction::EIP1559(tx) => TxEnvelope::from(tx.clone()).encode_2718(out),


### PR DESCRIPTION
## Motivation

Closes #7698

## Solution

Implement `Encodable2718` for `TypedTransaction` and use correct encoding for transactions root calculation.

alloy does not expose methods for encoding transaction types other than `TxEnvelope::encode_2718`, so currently this impl clones txs to construct `TxEnvelope`. We should probably expose `encode_with_signature` methods used [here](https://github.com/alloy-rs/alloy/blob/09241dc647def90423210a89f896b967cb2aa890/crates/consensus/src/transaction/envelope.rs#L252) to avoid this
