### PR TITLE
fix: correctly process relative paths as `--skip` values

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -573,10 +573,9 @@ impl FileFilter for SkipBuildFilters {
         self.matchers.iter().all(|matcher| {
             if !is_match_exclude(matcher, file) {
                 false
-            } else if let Ok(stripped) = file.strip_prefix(&self.project_root) {
-                is_match_exclude(matcher, stripped)
             } else {
-                true
+                file.strip_prefix(&self.project_root)
+                    .map_or(true, |stripped| is_match_exclude(matcher, stripped))
             }
         })
     }

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -572,9 +572,9 @@ impl FileFilter for SkipBuildFilters {
     fn is_match(&self, file: &Path) -> bool {
         self.matchers.iter().all(|matcher| {
             if !is_match_exclude(matcher, file) {
-                return false;
+                false
             } else if let Ok(stripped) = file.strip_prefix(&self.project_root) {
-                return is_match_exclude(matcher, stripped);
+                is_match_exclude(matcher, stripped)
             } else {
                 true
             }

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -560,19 +560,36 @@ pub fn etherscan_project(metadata: &Metadata, target_path: impl AsRef<Path>) -> 
 
 /// Bundles multiple `SkipBuildFilter` into a single `FileFilter`
 #[derive(Clone, Debug)]
-pub struct SkipBuildFilters(Vec<GlobMatcher>);
+pub struct SkipBuildFilters {
+    /// All provided filters.
+    pub matchers: Vec<GlobMatcher>,
+    /// Root of the project.
+    pub project_root: PathBuf,
+}
 
 impl FileFilter for SkipBuildFilters {
     /// Only returns a match if _no_  exclusion filter matches
     fn is_match(&self, file: &Path) -> bool {
-        self.0.iter().all(|matcher| is_match_exclude(matcher, file))
+        self.matchers.iter().all(|matcher| {
+            if !is_match_exclude(matcher, file) {
+                return false;
+            } else if let Ok(stripped) = file.strip_prefix(&self.project_root) {
+                return is_match_exclude(matcher, stripped);
+            } else {
+                true
+            }
+        })
     }
 }
 
 impl SkipBuildFilters {
     /// Creates a new `SkipBuildFilters` from multiple `SkipBuildFilter`.
-    pub fn new(matchers: impl IntoIterator<Item = SkipBuildFilter>) -> Result<Self> {
-        matchers.into_iter().map(|m| m.compile()).collect::<Result<_>>().map(Self)
+    pub fn new(
+        filters: impl IntoIterator<Item = SkipBuildFilter>,
+        project_root: PathBuf,
+    ) -> Result<Self> {
+        let matchers = filters.into_iter().map(|m| m.compile()).collect::<Result<_>>();
+        matchers.map(|filters| Self { matchers: filters, project_root })
     }
 }
 

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -94,7 +94,8 @@ impl BuildArgs {
             .bail(!self.format_json);
         if let Some(skip) = self.skip {
             if !skip.is_empty() {
-                compiler = compiler.filter(Box::new(SkipBuildFilters::new(skip)?));
+                compiler = compiler
+                    .filter(Box::new(SkipBuildFilters::new(skip, project.root().to_path_buf())?));
             }
         }
         let output = compiler.compile(&project)?;

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1620,7 +1620,12 @@ function test_run() external {}
 
     // only builds the single template contract `src/*` even if `*.t.sol` or `.s.sol` is absent
     prj.clear();
-    cmd.args(["build", "--skip", "*/test/**", "--skip", "*/script/**"]);
+    cmd.args(["build", "--skip", "*/test/**", "--skip", "*/script/**", "--force"]);
+    cmd.unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/can_build_skip_glob.stdout"),
+    );
+
+    cmd.forge_fuse().args(["build", "--skip", "./test/**", "--skip", "./script/**", "--force"]);
     cmd.unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/can_build_skip_glob.stdout"),
     );

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -373,7 +373,10 @@ impl VerifyBytecodeArgs {
 
         if let Some(skip) = &self.skip {
             if !skip.is_empty() {
-                compiler = compiler.filter(Box::new(SkipBuildFilters::new(skip.to_owned())?));
+                compiler = compiler.filter(Box::new(SkipBuildFilters::new(
+                    skip.to_owned(),
+                    project.root().to_path_buf(),
+                )?));
             }
         }
         let output = compiler.compile(&project)?;


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/7730

## Solution

keep root path and try matching stripped path as well
