### PR TITLE
fix(anvil): Return transaction hash in ots_getTransactionBySenderAndNonce

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -8,9 +8,7 @@ use crate::eth::{
     EthApi,
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_rpc_types::{
-    Block, BlockId, BlockNumberOrTag as BlockNumber, Transaction, WithOtherFields,
-};
+use alloy_rpc_types::{Block, BlockId, BlockNumberOrTag as BlockNumber};
 use alloy_rpc_types_trace::parity::{
     Action, CallAction, CreateAction, CreateOutput, RewardAction, TraceOutput,
 };
@@ -240,7 +238,7 @@ impl EthApi {
         &self,
         address: Address,
         nonce: U256,
-    ) -> Result<Option<WithOtherFields<Transaction>>> {
+    ) -> Result<Option<B256>> {
         node_info!("ots_getTransactionBySenderAndNonce");
 
         let from = self.get_fork().map(|f| f.block_number() + 1).unwrap_or_default();
@@ -250,7 +248,7 @@ impl EthApi {
             if let Some(txs) = self.backend.mined_transactions_by_block_number(n.into()).await {
                 for tx in txs {
                     if U256::from(tx.nonce) == nonce && tx.from == address {
-                        return Ok(Some(tx))
+                        return Ok(Some(tx.hash))
                     }
                 }
             }

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -594,8 +594,8 @@ async fn can_call_ots_get_transaction_by_sender_and_nonce() {
         .await
         .unwrap();
 
-    assert_eq!(result1.unwrap().hash, receipt1.transaction_hash.to_alloy());
-    assert_eq!(result2.unwrap().hash, receipt2.transaction_hash.to_alloy());
+    assert_eq!(result1.unwrap(), receipt1.transaction_hash.to_alloy());
+    assert_eq!(result2.unwrap(), receipt2.transaction_hash.to_alloy());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Anvil currently returns a transaction object from `ots_getTransactionBySenderAndNonce`, but both the Otterscan execution specs (https://otterscan.github.io/execution-apis/api-documentation/) and the Foundry Book itself (https://book.getfoundry.sh/reference/anvil/) say it should return the transaction hash. Users can't navigate by sender nonce in Anvil-backed Otterscan instances because if this mistake.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Simply return the transaction hash rather than the complete transaction object.

Fixes #7740 


## First-time contributing feedback
I wasn't aware of some extra requirements to run the tests, namely:

Setup:
* Install `gcc`
* Install `make`
* Install `solc`
* Install `libopenssl-dev`

And for formatting:
```
rustup toolchain install nightly
```

It would be helpful if these instructions were added to or linked from the contributing guidelines.

Also, there were some git commit related tests that always failed when running: `cmd::clone::tests::test_clone_single_file_contract` failed with `called `Result::unwrap()` on an `Err` value: Project init error: failed to commit (code=Some(128), stdout="", stderr="Author identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: unable to auto-detect email address (got 'username@rustup.(none)')")`