### PR TITLE
fix: do not require `--sender` with `--unlocked`

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -120,7 +120,6 @@ pub struct ScriptArgs {
     /// Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
     #[arg(
         long,
-        requires = "sender",
         conflicts_with_all = &["private_key", "private_keys", "froms", "ledger", "trezor", "aws"],
     )]
     pub unlocked: bool,


### PR DESCRIPTION
## Motivation

Closes #4822

## Solution

We now do not require users to explicitly provide senders for `--unlocked` and resolve them from collected transactions instead: https://github.com/foundry-rs/foundry/blob/30f145ff677eb01361f7f05c3233c133d1fd0d5b/crates/script/src/broadcast.rs#L207
