### PR TITLE
feat: add envExists cheatcode to check if a environment variable exists

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3813,6 +3813,26 @@
     },
     {
       "func": {
+        "id": "envExists",
+        "description": "Gets the environment variable `name` and returns true if it exists, else returns false.",
+        "declaration": "function envExists(string calldata name) external view returns (bool exists);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "envExists(string)",
+        "selector": "0xce8365f9",
+        "selectorBytes": [
+          206,
+          131,
+          101,
+          249
+        ]
+      },
+      "group": "environment",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "envInt_0",
         "description": "Gets the environment variable `name` and parses it as `int256`.\nReverts if the variable was not found or could not be parsed.",
         "declaration": "function envInt(string calldata name) external view returns (int256 value);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1501,6 +1501,10 @@ interface Vm {
     #[cheatcode(group = Environment)]
     function setEnv(string calldata name, string calldata value) external;
 
+    /// Gets the environment variable `name` and returns true if it exists, else returns false.
+    #[cheatcode(group = Environment)]
+    function envExists(string calldata name) external view returns (bool exists);
+
     /// Gets the environment variable `name` and parses it as `bool`.
     /// Reverts if the variable was not found or could not be parsed.
     #[cheatcode(group = Environment)]

--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -26,6 +26,13 @@ impl Cheatcode for setEnvCall {
     }
 }
 
+impl Cheatcode for envExistsCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { name } = self;
+        Ok(env::var(name).is_ok().abi_encode())
+    }
+}
+
 impl Cheatcode for envBool_0Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name } = self;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -186,6 +186,7 @@ interface Vm {
     function envBytes32(string calldata name, string calldata delim) external view returns (bytes32[] memory value);
     function envBytes(string calldata name) external view returns (bytes memory value);
     function envBytes(string calldata name, string calldata delim) external view returns (bytes[] memory value);
+    function envExists(string calldata name) external view returns (bool exists);
     function envInt(string calldata name) external view returns (int256 value);
     function envInt(string calldata name, string calldata delim) external view returns (int256[] memory value);
     function envOr(string calldata name, bool defaultValue) external view returns (bool value);

--- a/testdata/default/cheats/Env.t.sol
+++ b/testdata/default/cheats/Env.t.sol
@@ -13,6 +13,14 @@ contract EnvTest is DSTest {
         vm.setEnv(key, val);
     }
 
+    function testEnvExists() public {
+        string memory key = "_foundryCheatcodeEnvExistsTestKey";
+        string memory val = "_foundryCheatcodeEnvExistsTestVal";
+        vm.setEnv(key, val);
+        require(vm.envExists(key), "envExists failed");
+        require(!vm.envExists("nonexistent"), "envExists failed");
+    }
+
     uint256 constant numEnvBoolTests = 2;
 
     function testEnvBool() public {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Inside some of my tests I need to have a pretty advanced environment configuration with potential forks yet I cannot just do it in a clean way as if I load a environment variable that doesn't exists it will reverts. So currently I am using a vm.ffi to bypass this problem and use bash instead to check if the environment variable exists.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a cheatcode that can tell if a environment variable exists or not
