### PR TITLE
[wip] `ArbSys` precompile support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8caca67f174741b05c2f4188d3ee93420342130eb2a768abb9b885bb8b918df2"
+checksum = "10a73252c7753488cf7779e2788e05088b3b3d9198fbbc5d4da94b5afd0f751d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3851,7 +3851,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
- "yansi 0.5.1",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -3939,6 +3939,7 @@ dependencies = [
 name = "foundry-evm-core"
 version = "0.2.0"
 dependencies = [
+ "alloy-chains",
  "alloy-dyn-abi",
  "alloy-genesis",
  "alloy-json-abi",

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -301,7 +301,7 @@ impl Cheatcode for rollCall {
 impl Cheatcode for getBlockNumberCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
-        Ok(ccx.db.get_block_number(&ccx.env))
+        Ok(ccx.db.get_block_number(&ccx.env)?.abi_encode())
     }
 }
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -301,7 +301,7 @@ impl Cheatcode for rollCall {
 impl Cheatcode for getBlockNumberCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
-        Ok(ccx.ecx.env.block.number.abi_encode())
+        Ok(ccx.db.get_block_number(&ccx.env))
     }
 }
 

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -122,7 +122,12 @@ impl Cheatcode for selectForkCall {
         // fork.
         ccx.state.corrected_nonce = true;
 
-        ccx.ecx.db.select_fork(*forkId, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
+        ccx.ecx.db.select_fork(
+            *forkId,
+            &mut ccx.ecx.env,
+            &mut ccx.precompiles,
+            &mut ccx.ecx.journaled_state,
+        )?;
         Ok(Default::default())
     }
 }
@@ -306,7 +311,12 @@ fn create_select_fork<DB: DatabaseExt>(
     ccx.state.corrected_nonce = true;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    let id = ccx.ecx.db.create_select_fork(fork, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
+    let id = ccx.ecx.db.create_select_fork(
+        fork,
+        &mut ccx.ecx.env,
+        &mut ccx.precompiles,
+        &mut ccx.ecx.journaled_state,
+    )?;
     Ok(id.abi_encode())
 }
 
@@ -337,6 +347,7 @@ fn create_select_fork_at_transaction<DB: DatabaseExt>(
         fork,
         &mut ccx.ecx.env,
         &mut ccx.ecx.journaled_state,
+        &mut ccx.precompiles,
         *transaction,
     )?;
     Ok(id.abi_encode())

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -125,7 +125,7 @@ impl Cheatcode for selectForkCall {
         ccx.ecx.db.select_fork(
             *forkId,
             &mut ccx.ecx.env,
-            &mut ccx.precompiles,
+            ccx.precompiles,
             &mut ccx.ecx.journaled_state,
         )?;
         Ok(Default::default())
@@ -314,7 +314,7 @@ fn create_select_fork<DB: DatabaseExt>(
     let id = ccx.ecx.db.create_select_fork(
         fork,
         &mut ccx.ecx.env,
-        &mut ccx.precompiles,
+        ccx.precompiles,
         &mut ccx.ecx.journaled_state,
     )?;
     Ok(id.abi_encode())
@@ -347,7 +347,7 @@ fn create_select_fork_at_transaction<DB: DatabaseExt>(
         fork,
         &mut ccx.ecx.env,
         &mut ccx.ecx.journaled_state,
-        &mut ccx.precompiles,
+        ccx.precompiles,
         *transaction,
     )?;
     Ok(id.abi_encode())

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -25,6 +25,7 @@ alloy-provider.workspace = true
 alloy-transport.workspace = true
 alloy-rpc-types.workspace = true
 alloy-sol-types.workspace = true
+alloy-chains.workspace = true
 
 revm = { workspace = true, default-features = false, features = [
     "std",

--- a/crates/evm/core/src/arbitrum.rs
+++ b/crates/evm/core/src/arbitrum.rs
@@ -1,0 +1,73 @@
+use self::ArbSys::ArbSysCalls;
+use crate::backend::{DatabaseError, ForkDB};
+use alloy_chains::{Chain, NamedChain};
+use alloy_primitives::{address, Address, Bytes, U256};
+use alloy_sol_types::{sol, SolInterface, SolValue};
+use revm::{
+    primitives::{Env, PrecompileResult},
+    ContextStatefulPrecompile,
+};
+
+pub const ARB_SYS_ADDRESS: Address = address!("0000000000000000000000000000000000000064");
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArbitrumError {
+    #[error("missing L1 block field in L2 block data")]
+    MissingL1BlockField,
+
+    #[error(transparent)]
+    Database(#[from] DatabaseError),
+
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+sol! {
+    interface ArbSys {
+        function arbBlockNumber() external view returns (uint);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ArbSysPrecompile;
+
+impl<DB: revm::Database> ContextStatefulPrecompile<DB> for ArbSysPrecompile {
+    fn call(
+        &self,
+        bytes: &Bytes,
+        _: u64,
+        evmctx: &mut revm::InnerEvmContext<DB>,
+    ) -> PrecompileResult {
+        match ArbSysCalls::abi_decode(bytes.as_ref(), false).map_err(|_| {
+            revm::precompile::Error::other("failed to decode ArbSys precompile call")
+        })? {
+            ArbSysCalls::arbBlockNumber(_) => {
+                Ok((0, U256::from(evmctx.env.block.number).abi_encode().into()))
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub fn get_block_number(active_fork_db: &ForkDB, env: &Env) -> Result<U256, ArbitrumError> {
+    let block = active_fork_db.db.get_full_block(env.block.number.to::<u64>())?;
+    let l1_block_number = block
+        .other
+        .get_deserialized::<U256>("l1BlockNumber")
+        .ok_or(ArbitrumError::MissingL1BlockField)??;
+
+    Ok(l1_block_number)
+}
+
+pub fn is_arbitrum(chain_id: u64) -> bool {
+    let chain = Chain::from(chain_id);
+    matches!(
+        chain.named(),
+        Some(
+            NamedChain::Arbitrum |
+                NamedChain::ArbitrumGoerli |
+                NamedChain::ArbitrumNova |
+                NamedChain::ArbitrumTestnet
+        )
+    )
+}

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -14,6 +14,7 @@ extern crate tracing;
 mod ic;
 
 pub mod abi;
+pub mod arbitrum;
 pub mod backend;
 pub mod constants;
 pub mod debug;

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -467,7 +467,8 @@ impl InspectorStack {
 
         let env = EnvWithHandlerCfg::new_with_spec_id(ecx.env.clone(), ecx.spec_id());
         let res = {
-            let mut evm = crate::utils::new_evm_with_inspector(&mut *ecx.db, env, &mut *self);
+            let mut evm =
+                crate::utils::new_extended_evm_with_inspector(&mut *ecx.db, env, &mut *self);
             let res = evm.transact();
 
             // need to reset the env in case it was modified via cheatcodes during execution


### PR DESCRIPTION
## Motivation

Draft PR implementing support for chain-specific precompiles

## Solution

1. Add `DatabaseExt::get_block_number` method handling NUMBER opcode invocations. Currently it overrides it via l1BlockNumber if we are on arbitrum network.
2. Add `ArbSys` precompile impl (currently only `arbBlockNumber` method).
3. Keep track of precompiles for each fork via `ForkSpecificPrecompiles` which injects and removes precompiles on fork switches.

Impl is not ideal as we'd have to duplicate logic for other chains. This can be made better by only using `Ordinary` precompiles which do not require `DB` generic and thus it will be possible to put custom network logic into some kind of object-safe trait which can be then stored on `Fork`