### PR TITLE
fix(cast): list all files in the keystore directory

### DIFF
--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -91,17 +91,17 @@ impl ListArgs {
             dunce::canonicalize(keystore_path)?
         };
 
-        // list files within keystore dir
-        std::fs::read_dir(keystore_dir)?.flatten().for_each(|entry| {
-            let path = entry.path();
-            if path.is_file() && path.extension().is_none() {
+        // List all files within the keystore directory.
+        for entry in std::fs::read_dir(keystore_dir)? {
+            let path = entry?.path();
+            if path.is_file() {
                 if let Some(file_name) = path.file_name() {
                     if let Some(name) = file_name.to_str() {
-                        println!("{} (Local)", name);
+                        println!("{name} (Local)");
                     }
                 }
             }
-        });
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Don't filter out files with extensions

Fixes https://github.com/foundry-rs/foundry/issues/7520