### PR TITLE
fix(ci): use correct runner label

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
     container:
-        runs-on: Linux-20.04
+        runs-on: ubuntu-20.04
         # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
         permissions:
             id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
     release-docker:
         name: Release Docker
-        uses: ./.github/workflows/docker-publish.yml
+        uses: ./.github/workflows/docker-publish.yml@main
 
     release:
         name: ${{ matrix.target }} (${{ matrix.runner }})
@@ -78,22 +78,22 @@ jobs:
                     # `target`: Rust build target triple
                     # `platform` and `arch`: Used in tarball names
                     # `svm`: target platform to use for the Solc binary: https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-                    - runner: Linux-20.04
+                    - runner: ubuntu-20.04
                       target: x86_64-unknown-linux-gnu
                       svm_target_platform: linux-amd64
                       platform: linux
                       arch: amd64
-                    - runner: Linux-20.04
+                    - runner: ubuntu-20.04
                       target: aarch64-unknown-linux-gnu
                       svm_target_platform: linux-aarch64
                       platform: linux
                       arch: arm64
-                    - runner: macos-latest-large
+                    - runner: macos-latest
                       target: x86_64-apple-darwin
                       svm_target_platform: macosx-amd64
                       platform: darwin
                       arch: amd64
-                    - runner: macos-latest-large
+                    - runner: macos-latest
                       target: aarch64-apple-darwin
                       svm_target_platform: macosx-aarch64
                       platform: darwin


### PR DESCRIPTION
 label "Linux-20.04" is unknown. available labels are "windows-latest", "windows-2022", "windows-2019", "windows-2016", "ubuntu-latest", "ubuntu-20.04", "ubuntu-18.04", "macos-latest", "macos-11", "macos-11.0", "macos-10.15", "self-hosted", "x64", "arm", "arm64", "linux", "macos", "windows". if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file