### PR TITLE
fix(anvil): take block count limit in fee history into account

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1264,7 +1264,7 @@ impl EthApi {
         }
 
         const MAX_BLOCK_COUNT: u64 = 1024u64;
-        let block_count = block_count.to::<u64>().max(MAX_BLOCK_COUNT);
+        let block_count = block_count.to::<u64>().min(MAX_BLOCK_COUNT);
 
         // highest and lowest block num in the requested range
         let highest = number;


### PR DESCRIPTION
## Motivation

We wrongly compare specified limit with MAX_BLOCK_COUNT, it is even possible to specify 2000 and receive huge response.
Fixes https://github.com/foundry-rs/foundry/issues/7778

## Solution

Change max to min
