### PR TITLE
fix: fuzz console log

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -131,9 +131,8 @@ impl FuzzedExecutor {
                     // to run at least one more case to find a minimal failure
                     // case.
                     let call_res = _counterexample.1.result.clone();
-                    let _logs = _counterexample.1.logs.clone();
+                    logs.borrow_mut().extend(_counterexample.1.logs.clone());
                     *counterexample.borrow_mut() = _counterexample;
-                    logs.borrow_mut().extend(_logs);
                     // HACK: we have to use an empty string here to denote `None`
                     let reason = rd.maybe_decode(&call_res, Some(status));
                     Err(TestCaseError::fail(reason.unwrap_or_default()))

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -145,14 +145,16 @@ impl FuzzedExecutor {
         let mut traces = traces.into_inner();
         let last_run_traces = if run_result.is_ok() { traces.pop() } else { call.traces.clone() };
 
+        let inner_logs = logs.into_inner();
+
         let mut result = FuzzTestResult {
             first_case: first_case.take().unwrap_or_default(),
             gas_by_case: gas_by_case.take(),
             success: run_result.is_ok(),
             reason: None,
             counterexample: None,
-            decoded_logs: decode_console_logs(&logs.clone().into_inner()),
-            logs: logs.into_inner(),
+            decoded_logs: decode_console_logs(&inner_logs),
+            logs: inner_logs,
             labeled_addresses: call.labels,
             traces: last_run_traces,
             gas_report_traces: traces,

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -1,5 +1,5 @@
 use crate::executors::RawCallResult;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, Log};
 use foundry_common::evm::Breakpoints;
 use foundry_evm_core::debug::DebugArena;
 use foundry_evm_coverage::HitMaps;
@@ -20,6 +20,8 @@ pub struct CaseOutcome {
     pub debug: Option<DebugArena>,
     /// Breakpoints char pc map
     pub breakpoints: Breakpoints,
+    /// logs of a single fuzz test case
+    pub logs: Vec<Log>,
 }
 
 /// Returned by a single fuzz when a counterexample has been discovered


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

**Closes #7928  #3843 **
when using fuzz test, `console.log` doesn't work as expected(display console log info). this PR is to fix `console.log` in fuzz test


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
current version of foundry only keep the logs for failed fuzz test case. so in this PR, added `logs` to keep logs in every `CaseOutcome` and display logs for every run case in a fuzz test. 


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
