### PR TITLE
fix: `eth_feeHistory`

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1286,7 +1286,7 @@ impl EthApi {
         let mut rewards = Vec::new();
 
         {
-        let fee_history = self.fee_history_cache.lock();
+            let fee_history = self.fee_history_cache.lock();
 
             // iter over the requested block range
             for n in lowest..=highest {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1286,7 +1286,7 @@ impl EthApi {
         let mut rewards = Vec::new();
 
         {
-            let fee_history = self.fee_history_cache.lock();
+        let fee_history = self.fee_history_cache.lock();
 
             // iter over the requested block range
             for n in lowest..=highest {
@@ -1313,30 +1313,11 @@ impl EthApi {
 
         response.reward = Some(rewards);
 
-        // calculate next base fee
+        // add the next block's base fee to the response
         // The spec states that `base_fee_per_gas` "[..] includes the next block after the
         // newest of the returned range, because this value can be derived from the
         // newest block"
-        if let (Some(last_gas_used), Some(last_fee_per_gas)) =
-            (response.gas_used_ratio.last(), response.base_fee_per_gas.last())
-        {
-            let elasticity = self.backend.elasticity();
-            let last_fee_per_gas = *last_fee_per_gas as f64;
-            if last_gas_used > &0.5 {
-                // increase base gas
-                let increase = ((last_gas_used - 0.5) * 2f64) * elasticity;
-                let new_base_fee = (last_fee_per_gas + (last_fee_per_gas * increase)) as u128;
-                response.base_fee_per_gas.push(new_base_fee);
-            } else if last_gas_used < &0.5 {
-                // decrease gas
-                let increase = ((0.5 - last_gas_used) * 2f64) * elasticity;
-                let new_base_fee = (last_fee_per_gas - (last_fee_per_gas * increase)) as u128;
-                response.base_fee_per_gas.push(new_base_fee);
-            } else {
-                // same base gas
-                response.base_fee_per_gas.push(last_fee_per_gas as u128);
-            }
-        }
+        response.base_fee_per_gas.push(self.backend.fees().base_fee());
 
         Ok(response)
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1054,12 +1054,12 @@ impl Backend {
             header.gas_limit,
             header.base_fee_per_gas.unwrap_or_default(),
         );
-
-        // notify all listeners
-        self.notify_on_new_block(header, block_hash);
-
+        
         // update next base fee
         self.fees.set_base_fee(next_block_base_fee);
+        
+        // notify all listeners
+        self.notify_on_new_block(header, block_hash);
 
         outcome
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1054,10 +1054,10 @@ impl Backend {
             header.gas_limit,
             header.base_fee_per_gas.unwrap_or_default(),
         );
-        
+
         // update next base fee
         self.fees.set_base_fee(next_block_base_fee);
-        
+
         // notify all listeners
         self.notify_on_new_block(header, block_hash);
 

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -174,7 +174,6 @@ impl FeeHistoryService {
 
     /// Create a new history entry for the block
     fn create_cache_entry(&self, hash: B256) -> (FeeHistoryCacheItem, Option<u64>) {
-        let elasticity = self.fees.elasticity();
         // percentile list from 0.0 to 100.0 with a 0.5 resolution.
         // this will create 200 percentile points
         let reward_percentiles: Vec<f64> = {
@@ -199,10 +198,7 @@ impl FeeHistoryService {
             block_number = Some(block.header.number);
 
             let gas_used = block.header.gas_used as f64;
-            let gas_limit = block.header.gas_limit as f64;
-
-            let gas_target = gas_limit / elasticity;
-            item.gas_used_ratio = gas_used / (gas_target * elasticity);
+            item.gas_used_ratio = gas_used / block.header.gas_limit as f64;
 
             // extract useful tx info (gas_used, effective_reward)
             let mut transactions: Vec<(u128, u128)> = receipts


### PR DESCRIPTION
## Motivation

Closes #7769 

Logic for determining pending block base fee is currently different in `eth_feeHistory` handler and miner itself. Thus, using value for pending block base fee returned by `feeHistory` will result in errors as it will be lower than actual base fee

This PR contains 2 changes:
1. Correctly process empty genesis block, thus base fee for 1st block is `87500000000` by default as genesis block is always empty.
2. Use alloy calculation fn in `eth_feeHistory`.