### PR TITLE
Fix `eth_signTransaction` request and response

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -142,7 +142,7 @@ pub enum EthRequest {
     #[cfg_attr(feature = "serde", serde(rename = "eth_sign", alias = "personal_sign"))]
     EthSign(Address, Bytes),
 
-    #[cfg_attr(feature = "serde", serde(rename = "eth_signTransaction"))]
+    #[cfg_attr(feature = "serde", serde(rename = "eth_signTransaction", with = "sequence"))]
     EthSignTransaction(Box<WithOtherFields<TransactionRequest>>),
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -863,9 +863,8 @@ impl EthApi {
 
         let request = self.build_typed_tx_request(request, nonce)?;
 
-        let signed_transaction =
-            alloy_primitives::hex::encode(self.sign_request(&from, request)?.encoded_2718());
-        Ok(format!("0x{signed_transaction}"))
+        let signed_transaction = self.sign_request(&from, request)?.encoded_2718();
+        Ok(alloy_primitives::hex::encode_prefixed(signed_transaction))
     }
 
     /// Sends a transaction

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -32,6 +32,7 @@ use crate::{
     ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
 };
 use alloy_dyn_abi::TypedData;
+use alloy_eips::eip2718::Encodable2718;
 use alloy_network::eip2718::Decodable2718;
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, B64, U256, U64};
 use alloy_rpc_types::{
@@ -862,10 +863,9 @@ impl EthApi {
 
         let request = self.build_typed_tx_request(request, nonce)?;
 
-        let signer = self.get_signer(from).ok_or(BlockchainError::NoSignerAvailable)?;
-        let signature =
-            alloy_primitives::hex::encode(signer.sign_transaction(request, &from)?.as_bytes());
-        Ok(format!("0x{signature}"))
+        let signed_transaction =
+            alloy_primitives::hex::encode(self.sign_request(&from, request)?.encoded_2718());
+        Ok(format!("0x{signed_transaction}"))
     }
 
     /// Sends a transaction

--- a/crates/anvil/tests/it/sign.rs
+++ b/crates/anvil/tests/it/sign.rs
@@ -283,6 +283,24 @@ async fn can_sign_typed_data_os() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_sign_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+
+    // craft the tx
+    // specify the `from` field so that the client knows which account to use
+    let tx = TransactionRequest::default().to(to).value(U256::from(1001u64)).from(from);
+    let tx = WithOtherFields::new(tx);
+    // sign it via the eth_signTransaction API
+    let signed_tx = api.sign_transaction(tx).await.unwrap();
+
+    assert_eq!(signed_tx, "0x02f86c827a69808084773594008252089470997970c51812dc3a010c7d01b50e0d17dc79c88203e980c082f4f6a05b8c3e67a3cecdad35d8be49df75c6bb07f720dbd9742a4240d3cdee97653e36a02c946c4a6ce6e66803ff22af7b7d1c39307339ca122fa16a0ef63ace382e8d56");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn rejects_different_chain_id() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap().with_chain_id(Some(1));

--- a/crates/anvil/tests/it/sign.rs
+++ b/crates/anvil/tests/it/sign.rs
@@ -303,7 +303,7 @@ async fn can_sign_transaction() {
     // sign it via the eth_signTransaction API
     let signed_tx = api.sign_transaction(tx).await.unwrap();
 
-    assert_eq!(signed_tx, "0x02f868827a690a65648252089470997970c51812dc3a010c7d01b50e0d17dc79c88203e980c001a0e4de88aefcf87ccb04466e60de66a83192e46aa26177d5ea35efbfd43fd0ecdca00e3148e0e8e0b9a6f9b329efd6e30c4a461920f3a27497be3dbefaba996601da");
+    assert_eq!(signed_tx, "0x02f868827a690a65648252089470997970c51812dc3a010c7d01b50e0d17dc79c88203e980c082f4f6a0e4de88aefcf87ccb04466e60de66a83192e46aa26177d5ea35efbfd43fd0ecdca00e3148e0e8e0b9a6f9b329efd6e30c4a461920f3a27497be3dbefaba996601da");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/sign.rs
+++ b/crates/anvil/tests/it/sign.rs
@@ -292,12 +292,18 @@ async fn can_sign_transaction() {
 
     // craft the tx
     // specify the `from` field so that the client knows which account to use
-    let tx = TransactionRequest::default().to(to).value(U256::from(1001u64)).from(from);
+    let tx = TransactionRequest::default()
+        .nonce(10)
+        .max_fee_per_gas(100)
+        .max_priority_fee_per_gas(101)
+        .to(to)
+        .value(U256::from(1001u64))
+        .from(from);
     let tx = WithOtherFields::new(tx);
     // sign it via the eth_signTransaction API
     let signed_tx = api.sign_transaction(tx).await.unwrap();
 
-    assert_eq!(signed_tx, "0x02f86c827a69808084773594008252089470997970c51812dc3a010c7d01b50e0d17dc79c88203e980c082f4f6a05b8c3e67a3cecdad35d8be49df75c6bb07f720dbd9742a4240d3cdee97653e36a02c946c4a6ce6e66803ff22af7b7d1c39307339ca122fa16a0ef63ace382e8d56");
+    assert_eq!(signed_tx, "0x02f868827a690a65648252089470997970c51812dc3a010c7d01b50e0d17dc79c88203e980c001a0e4de88aefcf87ccb04466e60de66a83192e46aa26177d5ea35efbfd43fd0ecdca00e3148e0e8e0b9a6f9b329efd6e30c4a461920f3a27497be3dbefaba996601da");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As per [Ethereum JSON-RPC API Specification](https://ethereum.github.io/execution-apis/api-documentation), the `eth_signTransaction` method should return an RLP encoded transaction payload. Anvil is just returning the signature.

Also the parameters of the transaction MUST be part of a sequence.

## Solution

This PR returns the signed payload in `eth_signTransaction` request and also configures the deserializer to deserialize params using a sequence.

A happy path test was also added in `tests/it/sign.rs` (Was not sure if I should put the test there or in `tests/it/transaction.rs`)

Thank you!
