### PR TITLE
fix(anvil): Otterscan searchTransactions behavior

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -9,9 +9,7 @@ use crate::eth::{
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types::{Block, BlockId, BlockNumberOrTag as BlockNumber};
-use alloy_rpc_types_trace::parity::{
-    Action, CallAction, CreateAction, CreateOutput, RewardAction, TraceOutput,
-};
+use alloy_rpc_types_trace::parity::{Action, CreateAction, CreateOutput, TraceOutput};
 use itertools::Itertools;
 
 impl EthApi {
@@ -134,38 +132,31 @@ impl EthApi {
         let best = self.backend.best_number();
         // we go from given block (defaulting to best) down to first block
         // considering only post-fork
-        let from = if block_number == 0 { best } else { block_number };
+        let from = if block_number == 0 { best } else { block_number - 1 };
         let to = self.get_fork().map(|f| f.block_number() + 1).unwrap_or(1);
 
-        let first_page = from == best;
+        let first_page = from >= best;
         let mut last_page = false;
 
         let mut res: Vec<_> = vec![];
 
         for n in (to..=from).rev() {
-            if n == to {
-                last_page = true;
-            }
-
             if let Some(traces) = self.backend.mined_parity_trace_block(n) {
                 let hashes = traces
                     .into_iter()
                     .rev()
-                    .filter_map(|trace| match trace.trace.action {
-                        Action::Call(CallAction { from, to, .. })
-                            if from == address || to == address =>
-                        {
-                            trace.transaction_hash
-                        }
-                        _ => None,
-                    })
+                    .filter_map(|trace| OtsSearchTransactions::mentions_address(trace, address))
                     .unique();
-
-                res.extend(hashes);
 
                 if res.len() >= page_size {
                     break
                 }
+
+                res.extend(hashes);
+            }
+
+            if n == to {
+                last_page = true;
             }
         }
 
@@ -183,20 +174,17 @@ impl EthApi {
 
         let best = self.backend.best_number();
         // we go from the first post-fork block, up to the tip
-        let from = if block_number == 0 {
-            self.get_fork().map(|f| f.block_number() + 1).unwrap_or(1)
-        } else {
-            block_number
-        };
+        let first_block = self.get_fork().map(|f| f.block_number() + 1).unwrap_or(1);
+        let from = if block_number == 0 { first_block } else { block_number + 1 };
         let to = best;
 
-        let first_page = from == best;
+        let mut first_page = from >= best;
         let mut last_page = false;
 
         let mut res: Vec<_> = vec![];
 
         for n in from..=to {
-            if n == to {
+            if n == first_block {
                 last_page = true;
             }
 
@@ -204,30 +192,23 @@ impl EthApi {
                 let hashes = traces
                     .into_iter()
                     .rev()
-                    .filter_map(|trace| match trace.trace.action {
-                        Action::Call(CallAction { from, to, .. })
-                            if from == address || to == address =>
-                        {
-                            trace.transaction_hash
-                        }
-                        Action::Create(CreateAction { from, .. }) if from == address => {
-                            trace.transaction_hash
-                        }
-                        Action::Reward(RewardAction { author, .. }) if author == address => {
-                            trace.transaction_hash
-                        }
-                        _ => None,
-                    })
+                    .filter_map(|trace| OtsSearchTransactions::mentions_address(trace, address))
                     .unique();
-
-                res.extend(hashes);
 
                 if res.len() >= page_size {
                     break
                 }
+
+                res.extend(hashes);
+            }
+
+            if n == to {
+                first_page = true;
             }
         }
 
+        // Results are always sent in reverse chronological order, according to the Otterscan spec
+        res.reverse();
         OtsSearchTransactions::build(res, &self.backend, first_page, last_page).await
     }
 

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -586,17 +586,18 @@ async fn can_call_ots_search_transactions_before() {
 
     let page_size = 2;
     let mut block = 0;
-    for _ in 0..4 {
+    for i in 0..4 {
         let result = api.ots_search_transactions_before(sender, block, page_size).await.unwrap();
 
-        assert!(result.txs.len() <= page_size);
+        assert_eq!(result.first_page, i == 0);
+        assert_eq!(result.last_page, i == 3);
 
         // check each individual hash
         result.txs.iter().for_each(|tx| {
             assert_eq!(hashes.pop(), Some(tx.hash));
         });
 
-        block = result.txs.last().unwrap().block_number.unwrap() - 1;
+        block = result.txs.last().unwrap().block_number.unwrap();
     }
 
     assert!(hashes.is_empty());
@@ -626,17 +627,18 @@ async fn can_call_ots_search_transactions_after() {
 
     let page_size = 2;
     let mut block = 0;
-    for _ in 0..4 {
+    for i in 0..4 {
         let result = api.ots_search_transactions_after(sender, block, page_size).await.unwrap();
 
-        assert!(result.txs.len() <= page_size);
+        assert_eq!(result.first_page, i == 3);
+        assert_eq!(result.last_page, i == 0);
 
         // check each individual hash
-        result.txs.iter().for_each(|tx| {
+        result.txs.iter().rev().for_each(|tx| {
             assert_eq!(hashes.pop_back(), Some(tx.hash));
         });
 
-        block = result.txs.last().unwrap().block_number.unwrap() + 1;
+        block = result.txs.first().unwrap().block_number.unwrap();
     }
 
     assert!(hashes.is_empty());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
Fixes #7516.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Anvil's `ots_searchTransactionsBefore` and `ots_searchTransactionsAfter` are not compliant to the specification, making transaction navigation in Otterscan buggy when using an Anvil backend.

## Solution

This PR fixes multiple bugs in the `ots_searchTransactionsBefore` and `ots_searchTransactionsAfter` implementations, namely fulfilling that

* Results must be given in reverse chronological order for both functions
* `firstPage` indicates that the results include the most recent transaction
* `lastPage` indicates that the results include the oldest transaction
* Scanning must continue even after the page of results is filled in order to check whether this is the first/last page
* Results should only include transactions before/after the block number provided as a parameter, rather than including transactions inside that block
* Results may include more than `pageSize` transactions if the final block searched extends the list by more than the page size
* Results should include contract creation transactions if the address is the creator
* Results should include the contract creation transaction if the address is the created contract

These changes follow the intricacies of the method as outlined here: https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md#ots_searchtransactionsbefore-and-ots_searchtransactionsafter

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
