### PR TITLE
chore(fuzz): delete fuzz dir relative to proj root

### DIFF
--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -81,11 +81,12 @@ fn main() -> Result<()> {
         }
         ForgeSubcommand::Clean { root } => {
             let config = utils::load_config_with_root(root);
-            config.project()?.cleanup()?;
+            let proj = config.project()?;
+            proj.cleanup()?;
 
             // Remove fuzz cache directory.
             if let Some(fuzz_cache) = config.fuzz.failure_persist_dir {
-                let _ = std::fs::remove_dir_all(fuzz_cache);
+                let _ = std::fs::remove_dir_all(proj.root().join(fuzz_cache));
             }
             Ok(())
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
continuation of https://github.com/foundry-rs/foundry/pull/7809 
Realized that we allow configuring fuzz cache dir to point to a dir outside of proj root, it is safer to delete only paths relative to proj root to avoid any confusion / unexpected behavior.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
