### PR TITLE
foundry: make ForkDB public

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -43,7 +43,7 @@ mod snapshot;
 pub use snapshot::{BackendSnapshot, RevertSnapshotAction, StateSnapshot};
 
 // A `revm::Database` that is used in forking mode
-type ForkDB = CacheDB<SharedBackend>;
+pub type ForkDB = CacheDB<SharedBackend>;
 
 /// Represents a numeric `ForkId` valid only for the existence of the `Backend`.
 /// The difference between `ForkId` and `LocalForkId` is that `ForkId` tracks pairs of `endpoint +


### PR DESCRIPTION
## Motivation

This commit simply makes the `ForkDB` public so that it can be imported into other projects. The intention is to use it directly with `revm` itself without needing to go through the foundry EVM tooling which also sets up things like cheatcodes and manages multiple forks simultaneously.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

