### PR TITLE
chore(invariant): remove persist_state config, commit by default

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -196,7 +196,6 @@ dictionary_weight = 80
 include_storage = true
 include_push_bytes = true
 shrink_sequence = true
-preserve_state = false
 
 [fmt]
 line_length = 100

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -29,10 +29,6 @@ pub struct InvariantConfig {
     pub shrink_sequence: bool,
     /// The maximum number of attempts to shrink the sequence
     pub shrink_run_limit: usize,
-    /// If set to true then VM state is committed and available for next call
-    /// Useful for handlers that use cheatcodes as roll or warp
-    /// Use it with caution, introduces performance penalty.
-    pub preserve_state: bool,
     /// The maximum number of rejects via `vm.assume` which can be encountered during a single
     /// invariant run.
     pub max_assume_rejects: u32,
@@ -50,7 +46,6 @@ impl Default for InvariantConfig {
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },
             shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18_u32),
-            preserve_state: false,
             max_assume_rejects: 65536,
             gas_report_samples: 256,
         }
@@ -81,7 +76,6 @@ impl InlineConfigParser for InvariantConfig {
                 "fail-on-revert" => conf_clone.fail_on_revert = parse_config_bool(key, value)?,
                 "call-override" => conf_clone.call_override = parse_config_bool(key, value)?,
                 "shrink-sequence" => conf_clone.shrink_sequence = parse_config_bool(key, value)?,
-                "preserve-state" => conf_clone.preserve_state = parse_config_bool(key, value)?,
                 _ => Err(InlineConfigParserError::InvalidConfigProperty(key.to_string()))?,
             }
         }

--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -81,7 +81,7 @@ fn lil_web3() {
 #[test]
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn snekmate() {
-    ExtTester::new("pcaversaccio", "snekmate", "ed49a0454393673cdf9a4250dd7051c28e6ac35f")
+    ExtTester::new("pcaversaccio", "snekmate", "1151a2653171863184c418f3313f1a944320f418")
         .install_command(&["pnpm", "install", "--prefer-offline"])
         // Try npm if pnpm fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])

--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -81,7 +81,7 @@ fn lil_web3() {
 #[test]
 #[cfg_attr(windows, ignore = "Windows cannot find installed programs")]
 fn snekmate() {
-    ExtTester::new("pcaversaccio", "snekmate", "1151a2653171863184c418f3313f1a944320f418")
+    ExtTester::new("pcaversaccio", "snekmate", "1aa50098720d49e04b257a4aa5138b3d737a0667")
         .install_command(&["pnpm", "install", "--prefer-offline"])
         // Try npm if pnpm fails / is not installed.
         .install_command(&["npm", "install", "--prefer-offline"])

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -418,20 +418,7 @@ async fn test_shrink_fail_on_revert() {
 async fn test_invariant_preserve_state() {
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantPreserveState.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    // Should not fail with default options.
     runner.test_options.invariant.fail_on_revert = true;
-    let results = runner.test_collect(&filter);
-    assert_multiple(
-        &results,
-        BTreeMap::from([(
-            "default/fuzz/invariant/common/InvariantPreserveState.t.sol:InvariantPreserveState",
-            vec![("invariant_preserve_state()", true, None, None, None)],
-        )]),
-    );
-
-    // same test should revert when preserve state enabled
-    runner.test_options.invariant.fail_on_revert = true;
-    runner.test_options.invariant.preserve_state = true;
     let results = runner.test_collect(&filter);
     assert_multiple(
         &results,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -106,7 +106,6 @@ impl ForgeTestProfile {
                 },
                 shrink_sequence: true,
                 shrink_run_limit: 2usize.pow(18u32),
-                preserve_state: false,
                 max_assume_rejects: 65536,
                 gas_report_samples: 256,
             })


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7268 
Closes #4994 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Remove `preserve_state` config and commit call by default - this will enable using `vm.warp` and `vm.roll` in invariants tests without any additional config (which is expected behavior)
From test result it can be seen there is a slightly penalty from persisting cheatcode state (not something to worry about IMO).

## Tests

Results were collected by performing different number of runs and depth on a test contract with:
- handler that advance block timestamp by 100 and increments block number on each call by using `vm.warp` and `vm.roll`  (worst case scenario as persisting cheatcode states is now done by default)
- target contract with single selector that makes several state updates

<details>
<summary>Test contract</summary>

```solidity
contract CommitState {
    uint256 state;
    mapping(address => uint256) public state1;
    mapping(address => mapping(address => bool)) public state2;

    function saveState(uint256 x, address y, address z) public {
        state = x;
        state1[y] = x;
        state2[y][z] = true;
    }
}

contract CommitStateHandler is Test {
    CommitState target;

    constructor() {
        target = new CommitState();
    }

    function fuzzTarget(uint256 x, address y, address z) public {
        vm.warp(block.timestamp + 100);
        vm.roll(block.number + 1);
        target.saveState(x, y, z);
    }
}

contract CommitStateTest is Test {
    function setUp() public {
        CommitStateHandler handler = new CommitStateHandler();
        targetContract(address(handler));
    }

    function invariant_commit_state() public view {}
}
```
</details>


| Runs/Depth | time with Master | time with PR |
| --- | --- | --- |
| 100/1000 | 0m18.601s | 0m19.587s |
| 1000/1000 | 2m54.369s | 3m12.411s |
| 1000/5000 | 15m21.012s | 15m55.039s |
| 1/10000 | 0m10.528s | 0m10.827s |
| 10/10000 | 0m27.174s | 0m29.075s |
| 100/10000 | 3m18.966s | 3m26.910s |
| 10000/100 | 2m55.770s | 3m1.623s |

* time contains test contract compile time too