### PR TITLE
fix(anvil): `ots_getTransactionError` default return

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -62,16 +62,16 @@ impl EthApi {
     }
 
     /// Given a transaction hash, returns its raw revert reason.
-    pub async fn ots_get_transaction_error(&self, hash: B256) -> Result<Option<Bytes>> {
+    pub async fn ots_get_transaction_error(&self, hash: B256) -> Result<Bytes> {
         node_info!("ots_getTransactionError");
 
         if let Some(receipt) = self.backend.mined_transaction_receipt(hash) {
             if !receipt.inner.inner.as_receipt_with_bloom().receipt.status {
-                return Ok(receipt.out.map(|b| b.0.into()))
+                return Ok(receipt.out.map(|b| b.0.into()).unwrap_or(Bytes::default()))
             }
         }
 
-        Ok(Default::default())
+        Ok(Bytes::default())
     }
 
     /// For simplicity purposes, we return the entire block instead of emptying the values that

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -466,6 +466,26 @@ contract Contract {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn ots_get_transaction_error_no_error() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let signer: EthereumSigner = wallets[0].clone().into();
+    let sender = wallets[0].address();
+
+    let provider = ws_provider_with_signer(&handle.ws_endpoint(), signer);
+
+    // Send a successful transaction
+    let tx =
+        TransactionRequest::default().from(sender).to(Address::random()).value(U256::from(100));
+    let tx = WithOtherFields::new(tx);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+
+    let res = api.ots_get_transaction_error(receipt.transaction_hash).await;
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap().to_string(), "0x");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_call_ots_get_block_details() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Closes #7836 

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes `ots_getTransactionError` behavior in the case where there is no transaction error or one can't be found (e.g., out of gas). API reference: https://github.com/otterscan/otterscan/blob/develop/docs/custom-jsonrpc.md#ots_gettransactionerror

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Return `0x` (an empty Bytes object) instead of null.