### PR TITLE
fix(anvil): include blob hashes in call env

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1114,7 +1114,18 @@ impl Backend {
         block_env: BlockEnv,
     ) -> EnvWithHandlerCfg {
         let WithOtherFields::<TransactionRequest> {
-            inner: TransactionRequest { from, to, gas, value, input, nonce, access_list, .. },
+            inner:
+                TransactionRequest {
+                    from,
+                    to,
+                    gas,
+                    value,
+                    input,
+                    nonce,
+                    access_list,
+                    blob_versioned_hashes,
+                    ..
+                },
             ..
         } = request;
 
@@ -1154,8 +1165,8 @@ impl Backend {
             chain_id: None,
             nonce,
             access_list: access_list.unwrap_or_default().flattened(),
+            blob_hashes: blob_versioned_hashes.unwrap_or_default(),
             optimism: OptimismFields { enveloped_tx: Some(Bytes::new()), ..Default::default() },
-            ..Default::default()
         };
 
         if env.block.basefee == revm::primitives::U256::ZERO {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1124,7 +1124,10 @@ impl Backend {
                     nonce,
                     access_list,
                     blob_versioned_hashes,
-                    ..
+                    sidecar: _,
+                    chain_id: _,
+                    transaction_type: _,
+                    .. // Rest of the gas fees related fields are taken from `fee_details`
                 },
             ..
         } = request;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

4844 tx simulation would fail due to `blob_hashes` being set to empty, despite being present in the request. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Include `blob_version_hashes` from tx req into revm `TxEnv`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
