### PR TITLE
chore(invariant) - rename TargetAbiSelector

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -53,7 +53,7 @@ sol! {
         }
 
         #[derive(Default)]
-        struct FuzzAbiSelector {
+        struct FuzzArtifactSelector {
             string contract_abi;
             bytes4[] selectors;
         }
@@ -77,7 +77,7 @@ sol! {
         function targetArtifacts() public view returns (string[] memory targetedArtifacts);
 
         #[derive(Default)]
-        function targetArtifactSelectors() public view returns (FuzzAbiSelector[] memory targetedArtifactSelectors);
+        function targetArtifactSelectors() public view returns (FuzzArtifactSelector[] memory targetedArtifactSelectors);
 
         #[derive(Default)]
         function targetContracts() public view returns (address[] memory targetedContracts);
@@ -400,7 +400,7 @@ impl<'a> InvariantExecutor<'a> {
             .call_sol_default(invariant_address, &IInvariantTest::targetArtifactSelectorsCall {});
 
         // Insert them into the executor `targeted_abi`.
-        for IInvariantTest::FuzzAbiSelector { contract_abi, selectors } in
+        for IInvariantTest::FuzzArtifactSelector { contract_abi, selectors } in
             result.targetedArtifactSelectors
         {
             let identifier = self.validate_selected_contract(contract_abi, &selectors)?;

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -54,7 +54,7 @@ sol! {
 
         #[derive(Default)]
         struct FuzzArtifactSelector {
-            string contract_abi;
+            string artifact;
             bytes4[] selectors;
         }
 
@@ -400,10 +400,10 @@ impl<'a> InvariantExecutor<'a> {
             .call_sol_default(invariant_address, &IInvariantTest::targetArtifactSelectorsCall {});
 
         // Insert them into the executor `targeted_abi`.
-        for IInvariantTest::FuzzArtifactSelector { contract_abi, selectors } in
+        for IInvariantTest::FuzzArtifactSelector { artifact, selectors } in
             result.targetedArtifactSelectors
         {
-            let identifier = self.validate_selected_contract(contract_abi, &selectors)?;
+            let identifier = self.validate_selected_contract(artifact, &selectors)?;
             self.artifact_filters.targeted.entry(identifier).or_default().extend(selectors);
         }
 

--- a/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol
+++ b/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.18;
 
 import "ds-test/test.sol";
 
-struct FuzzAbiSelector {
+struct FuzzArtifactSelector {
     string contract_abi;
     bytes4[] selectors;
 }
@@ -27,11 +27,12 @@ contract TargetArtifactSelectors is DSTest {
         hello = new Hi();
     }
 
-    function targetArtifactSelectors() public returns (FuzzAbiSelector[] memory) {
-        FuzzAbiSelector[] memory targets = new FuzzAbiSelector[](1);
+    function targetArtifactSelectors() public returns (FuzzArtifactSelector[] memory) {
+        FuzzArtifactSelector[] memory targets = new FuzzArtifactSelector[](1);
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = Hi.no_change.selector;
-        targets[0] = FuzzAbiSelector("default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol:Hi", selectors);
+        targets[0] =
+            FuzzArtifactSelector("default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol:Hi", selectors);
         return targets;
     }
 

--- a/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol
+++ b/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import "ds-test/test.sol";
 
 struct FuzzArtifactSelector {
-    string contract_abi;
+    string artifact;
     bytes4[] selectors;
 }
 

--- a/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol
+++ b/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.18;
 
 import "ds-test/test.sol";
 
-struct FuzzAbiSelector {
+struct FuzzArtifactSelector {
     string contract_abi;
     bytes4[] selectors;
 }
@@ -46,18 +46,20 @@ contract TargetArtifactSelectors2 is DSTest {
         parent = new Parent();
     }
 
-    function targetArtifactSelectors() public returns (FuzzAbiSelector[] memory) {
-        FuzzAbiSelector[] memory targets = new FuzzAbiSelector[](2);
+    function targetArtifactSelectors() public returns (FuzzArtifactSelector[] memory) {
+        FuzzArtifactSelector[] memory targets = new FuzzArtifactSelector[](2);
         bytes4[] memory selectors_child = new bytes4[](1);
 
         selectors_child[0] = Child.change_parent.selector;
-        targets[0] =
-            FuzzAbiSelector("default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol:Child", selectors_child);
+        targets[0] = FuzzArtifactSelector(
+            "default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol:Child", selectors_child
+        );
 
         bytes4[] memory selectors_parent = new bytes4[](1);
         selectors_parent[0] = Parent.create.selector;
-        targets[1] =
-            FuzzAbiSelector("default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol:Parent", selectors_parent);
+        targets[1] = FuzzArtifactSelector(
+            "default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol:Parent", selectors_parent
+        );
         return targets;
     }
 

--- a/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol
+++ b/testdata/default/fuzz/invariant/targetAbi/TargetArtifactSelectors2.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import "ds-test/test.sol";
 
 struct FuzzArtifactSelector {
-    string contract_abi;
+    string artifact;
     bytes4[] selectors;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- consistent naming `FuzzArtifactSelector` instead `FuzzAbiSelector`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
