### PR TITLE
fix(anvil): correctly use `BlobVersionNotSupported`

### DIFF
--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -280,7 +280,7 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
                 InvalidTransactionError::BlobCreateTransaction
             }
             InvalidTransaction::BlobVersionNotSupported => {
-                InvalidTransactionError::BlobVersionedHashesNotSupported
+                InvalidTransactionError::BlobVersionNotSupported
             }
             InvalidTransaction::EmptyBlobs => InvalidTransactionError::EmptyBlobs,
             InvalidTransaction::TooManyBlobs => InvalidTransactionError::TooManyBlobs,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently mapping to `revm::InvalidTransaction::BlobVersionNotSupported` to `BlobVersionedHashesNotSupported`, which is wrong.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Should be mapped to `BlobVersionNotSupported`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
