### PR TITLE
fix: transfer check

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2196,8 +2196,7 @@ impl EthApi {
         // check certain fields to see if the request could be a simple transfer
         let maybe_transfer = request.input.input().is_none() &&
             request.access_list.is_none() &&
-            request.blob_versioned_hashes.is_none() &&
-            request.value.is_some();
+            request.blob_versioned_hashes.is_none();
 
         if maybe_transfer {
             if let Some(to) = to {


### PR DESCRIPTION
I think a transfer w/ an empty value is still technically valid? Viem's tests are failing with the latest foundry and reporting `21001` gas instead of `21000` for empty value transfer.

Ref: https://github.com/wevm/viem/actions/runs/8946647082/job/24580052493#step:5:2857