### PR TITLE
chore: stop using RuntimeOrHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,6 @@ dependencies = [
  "eyre",
  "foundry-cheatcodes-spec",
  "foundry-common",
- "foundry-compilers",
  "foundry-config",
  "foundry-macros",
  "foundry-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ tikv-jemallocator = "0.5.4"
 num-format = "0.4.4"
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 tempfile = "3.10"
+tokio = "1"
 
 axum = "0.7"
 hyper = "1.0"

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 # async
-tokio = { version = "1", features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 parking_lot = "0.12"
 futures = "0.3"
 async-trait = "0.1"
@@ -99,7 +99,7 @@ alloy-json-rpc.workspace = true
 alloy-pubsub.workspace = true
 foundry-test-utils.workspace = true
 similar-asserts.workspace = true
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["cli"]

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -71,7 +71,7 @@ regex = { version = "1", default-features = false }
 rpassword = "7"
 semver = "1"
 tempfile.workspace = true
-tokio = { version = "1", features = ["macros", "signal"] }
+tokio = { workspace = true, features = ["macros", "signal"] }
 tracing.workspace = true
 yansi.workspace = true
 evmole = "0.3.1"

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -3,9 +3,7 @@ use alloy_primitives::{B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
-use eyre::WrapErr;
 use foundry_common::provider::ProviderBuilder;
-use foundry_compilers::utils::RuntimeOrHandle;
 use foundry_evm_core::fork::CreateFork;
 
 impl Cheatcode for activeForkCall {
@@ -227,11 +225,10 @@ impl Cheatcode for rpcCall {
         let url =
             ccx.ecx.db.active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let provider = ProviderBuilder::new(&url).build()?;
-        let method: &'static str = Box::new(method.clone()).leak();
         let params_json: serde_json::Value = serde_json::from_str(params)?;
-        let result = RuntimeOrHandle::new()
-            .block_on(provider.raw_request(method.into(), params_json))
-            .map_err(|err| fmt_err!("{method:?}: {err}"))?;
+        let result =
+            foundry_common::block_on(provider.raw_request(method.clone().into(), params_json))
+                .map_err(|err| fmt_err!("{method:?}: {err}"))?;
 
         let result_as_tokens = crate::json::json_value_to_token(&result)
             .map_err(|err| fmt_err!("failed to parse result: {err}"))?;
@@ -256,24 +253,12 @@ impl Cheatcode for eth_getLogsCall {
             ccx.ecx.db.active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
         let provider = ProviderBuilder::new(&url).build()?;
         let mut filter = Filter::new().address(*target).from_block(from_block).to_block(to_block);
-        for (i, topic) in topics.iter().enumerate() {
-            // todo: needed because rust wants to convert FixedBytes<32> to U256 to convert it back
-            // to FixedBytes<32> and then to Topic for some reason removing the
-            // From<U256> impl in alloy does not fix the situation, and it is not possible to impl
-            // From<FixedBytes<32>> either because of a conflicting impl
-            match i {
-                0 => filter = filter.event_signature(*topic),
-                1 => filter = filter.topic1(*topic),
-                2 => filter = filter.topic2(*topic),
-                3 => filter = filter.topic3(*topic),
-                _ => unreachable!(),
-            };
+        for (i, &topic) in topics.iter().enumerate() {
+            filter.topics[i] = topic.into();
         }
 
-        // todo: handle the errors somehow
-        let logs = RuntimeOrHandle::new()
-            .block_on(provider.get_logs(&filter))
-            .wrap_err("failed to get logs")?;
+        let logs = foundry_common::block_on(provider.get_logs(&filter))
+            .map_err(|e| fmt_err!("failed to get logs: {e}"))?;
 
         let eth_logs = logs
             .into_iter()

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -11,7 +11,7 @@ use alloy_signer_wallet::{
     LocalWallet, MnemonicBuilder,
 };
 use alloy_sol_types::SolValue;
-use foundry_evm_core::{constants::DEFAULT_CREATE2_DEPLOYER, utils::RuntimeOrHandle};
+use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
 use k256::{
     ecdsa::SigningKey,
     elliptic_curve::{sec1::ToEncodedPoint, Curve},
@@ -202,9 +202,8 @@ pub(super) fn sign_with_wallet<DB: DatabaseExt>(
         .get(&signer)
         .ok_or_else(|| fmt_err!("signer with address {signer} is not available"))?;
 
-    let sig = RuntimeOrHandle::new()
-        .block_on(wallet.sign_hash(digest))
-        .map_err(|err| fmt_err!("{err}"))?;
+    let sig =
+        foundry_common::block_on(wallet.sign_hash(digest)).map_err(|err| fmt_err!("{err}"))?;
 
     let recovered = sig.recover_address_from_prehash(digest).map_err(|err| fmt_err!("{err}"))?;
     assert_eq!(recovered, signer);

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -46,7 +46,7 @@ serde.workspace = true
 solang-parser.workspace = true
 strum = { workspace = true, features = ["derive"] }
 time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 yansi.workspace = true
 tracing.workspace = true
 

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -689,7 +689,7 @@ impl ChiselDispatcher {
                         let failed = !res.success;
                         if new_session_source.config.traces || failed {
                             if let Ok(decoder) =
-                                Self::decode_traces(&new_session_source.config, &mut res)
+                                Self::decode_traces(&new_session_source.config, &mut res).await
                             {
                                 if let Err(e) = Self::show_traces(&decoder, &mut res).await {
                                     return DispatchResult::CommandFailed(e.to_string())
@@ -834,7 +834,8 @@ impl ChiselDispatcher {
                     // If traces are enabled or there was an error in execution, show the execution
                     // traces.
                     if new_source.config.traces || failed {
-                        if let Ok(decoder) = Self::decode_traces(&new_source.config, &mut res) {
+                        if let Ok(decoder) = Self::decode_traces(&new_source.config, &mut res).await
+                        {
                             if let Err(e) = Self::show_traces(&decoder, &mut res).await {
                                 return DispatchResult::CommandFailed(e.to_string())
                             };
@@ -888,7 +889,7 @@ impl ChiselDispatcher {
     /// ### Returns
     ///
     /// Optionally, a [CallTraceDecoder]
-    pub fn decode_traces(
+    pub async fn decode_traces(
         session_config: &SessionSourceConfig,
         result: &mut ChiselResult,
         // known_contracts: &ContractsByArtifact,
@@ -903,7 +904,7 @@ impl ChiselDispatcher {
 
         let mut identifier = TraceIdentifiers::new().with_etherscan(
             &session_config.foundry_config,
-            session_config.evm_opts.get_remote_chain_id(),
+            session_config.evm_opts.get_remote_chain_id().await,
         )?;
         if !identifier.is_empty() {
             for (_, trace) in &mut result.traces {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -189,7 +189,7 @@ impl SessionSource {
 
         let Some((stack, memory, _)) = &res.state else {
             // Show traces and logs, if there are any, and return an error
-            if let Ok(decoder) = ChiselDispatcher::decode_traces(&source.config, &mut res) {
+            if let Ok(decoder) = ChiselDispatcher::decode_traces(&source.config, &mut res).await {
                 ChiselDispatcher::show_traces(&decoder, &mut res).await?;
             }
             let decoded_logs = decode_console_logs(&res.logs);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ regex = { version = "1", default-features = false }
 serde.workspace = true
 strsim = "0.10"
 strum = { workspace = true, features = ["derive"] }
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 tracing-error = "0.2"
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter", "fmt"] }
 tracing.workspace = true

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -158,7 +158,6 @@ pub fn now() -> Duration {
 }
 
 /// Runs the `future` in a new [`tokio::runtime::Runtime`]
-#[allow(unused)]
 pub fn block_on<F: Future>(future: F) -> F::Output {
     let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
     rt.block_on(future)

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -48,7 +48,7 @@ serde_json.workspace = true
 serde.workspace = true
 tempfile.workspace = true
 thiserror = "1"
-tokio = "1"
+tokio.workspace = true
 tracing.workspace = true
 url = "2"
 walkdir = "2"
@@ -59,4 +59,4 @@ num-format.workspace = true
 [dev-dependencies]
 foundry-macros.workspace = true
 similar-asserts.workspace = true
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -31,3 +31,16 @@ pub use constants::*;
 pub use contracts::*;
 pub use traits::*;
 pub use transactions::*;
+
+/// Block on a future using the current tokio runtime on the current thread.
+pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    block_on_handle(&tokio::runtime::Handle::current(), future)
+}
+
+/// Block on a future using the current tokio runtime on the current thread with the given handle.
+pub fn block_on_handle<F: std::future::Future>(
+    handle: &tokio::runtime::Handle,
+    future: F,
+) -> F::Output {
+    tokio::task::block_in_place(|| handle.block_on(future))
+}

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -13,7 +13,6 @@ repository.workspace = true
 [dependencies]
 foundry-cheatcodes-spec.workspace = true
 foundry-common.workspace = true
-foundry-compilers.workspace = true
 foundry-config.workspace = true
 foundry-macros.workspace = true
 
@@ -52,7 +51,7 @@ rustc-hash.workspace = true
 serde = "1"
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["time", "macros"] }
+tokio = { workspace = true, features = ["time", "macros"] }
 tracing = "0.1"
 url = "2"
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -5,7 +5,6 @@ use alloy_provider::Provider;
 use alloy_rpc_types::Block;
 use eyre::WrapErr;
 use foundry_common::{provider::ProviderBuilder, ALCHEMY_FREE_TIER_CUPS};
-use foundry_compilers::utils::RuntimeOrHandle;
 use foundry_config::{Chain, Config};
 use revm::primitives::{BlockEnv, CfgEnv, TxEnv};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -166,11 +165,11 @@ impl EvmOpts {
     ///   - mainnet if `fork_url` contains "mainnet"
     ///   - the chain if `fork_url` is set and the endpoints returned its chain id successfully
     ///   - mainnet otherwise
-    pub fn get_chain_id(&self) -> u64 {
+    pub async fn get_chain_id(&self) -> u64 {
         if let Some(id) = self.env.chain_id {
             return id;
         }
-        self.get_remote_chain_id().unwrap_or(Chain::mainnet()).id()
+        self.get_remote_chain_id().await.unwrap_or(Chain::mainnet()).id()
     }
 
     /// Returns the available compute units per second, which will be
@@ -188,7 +187,7 @@ impl EvmOpts {
     }
 
     /// Returns the chain ID from the RPC, if any.
-    pub fn get_remote_chain_id(&self) -> Option<Chain> {
+    pub async fn get_remote_chain_id(&self) -> Option<Chain> {
         if let Some(ref url) = self.fork_url {
             if url.contains("mainnet") {
                 trace!(?url, "auto detected mainnet chain");
@@ -201,7 +200,7 @@ impl EvmOpts {
                 .ok()
                 .unwrap_or_else(|| panic!("Failed to establish provider to {url}"));
 
-            if let Ok(id) = RuntimeOrHandle::new().block_on(provider.get_chain_id()) {
+            if let Ok(id) = provider.get_chain_id().await {
                 return Some(Chain::from(id));
             }
         }

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -4,9 +4,7 @@ use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, FixedBytes, U256};
 use alloy_rpc_types::{Block, Transaction};
 use eyre::ContextCompat;
-pub use foundry_compilers::utils::RuntimeOrHandle;
 use foundry_config::NamedChain;
-pub use revm::primitives::State as StateChangeset;
 use revm::{
     db::WrapDatabaseRef,
     handler::register::EvmHandler,
@@ -18,6 +16,8 @@ use revm::{
     FrameOrResult, FrameResult,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+pub use revm::primitives::State as StateChangeset;
 
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///

--- a/crates/evm/evm/src/executors/tracing.rs
+++ b/crates/evm/evm/src/executors/tracing.rs
@@ -45,7 +45,7 @@ impl TracingExecutor {
 
         let fork = evm_opts.get_fork(config, env.clone());
 
-        Ok((env, fork, evm_opts.get_remote_chain_id()))
+        Ok((env, fork, evm_opts.get_remote_chain_id().await))
     }
 }
 

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -29,7 +29,7 @@ hex.workspace = true
 itertools.workspace = true
 once_cell = "1"
 serde = "1"
-tokio = { version = "1", features = ["time", "macros"] }
+tokio = { workspace = true, features = ["time", "macros"] }
 tracing = "0.1"
 yansi.workspace = true
 

--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -6,7 +6,6 @@ use foundry_block_explorers::{
 };
 use foundry_common::compile::{self, ContractSources};
 use foundry_config::{Chain, Config};
-use foundry_evm_core::utils::RuntimeOrHandle;
 use futures::{
     future::{join_all, Future},
     stream::{FuturesUnordered, Stream, StreamExt},
@@ -129,7 +128,7 @@ impl TraceIdentifier for EtherscanIdentifier {
             }
         }
 
-        let fetched_identities = RuntimeOrHandle::new().block_on(
+        let fetched_identities = foundry_common::block_on(
             fetcher
                 .map(|(address, metadata)| {
                     let label = metadata.contract_name.clone();

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -79,7 +79,7 @@ similar = { version = "2", features = ["inline"] }
 solang-parser.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 toml = { version = "0.8", features = ["preserve_order"] }
 toml_edit = "0.22.4"
 watchexec = "2.3.2"

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -361,7 +361,7 @@ impl TestArgs {
             return Ok(TestOutcome::new(results, self.allow_failure));
         }
 
-        let remote_chain_id = runner.evm_opts.get_remote_chain_id();
+        let remote_chain_id = runner.evm_opts.get_remote_chain_id().await;
 
         // Run tests.
         let (tx, rx) = channel::<(String, SuiteResult)>();

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
             if cmd.is_watch() {
                 utils::block_on(watch::watch_build(cmd))
             } else {
-                cmd.run().map(|_| ())
+                cmd.run().map(drop)
             }
         }
         ForgeSubcommand::Debug(cmd) => utils::block_on(cmd.run()),

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -254,6 +254,7 @@ impl<'a> ContractRunner<'a> {
         filter: &dyn TestFilter,
         test_options: &TestOptions,
         known_contracts: Arc<ContractsByArtifact>,
+        handle: &tokio::runtime::Handle,
     ) -> SuiteResult {
         info!("starting tests");
         let start = Instant::now();
@@ -346,6 +347,8 @@ impl<'a> ContractRunner<'a> {
         let test_results = functions
             .par_iter()
             .map(|&func| {
+                let _guard = handle.enter();
+
                 let sig = func.signature();
 
                 let setup = setup.clone();

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -298,7 +298,7 @@ impl ExecutedState {
     pub async fn prepare_simulation(self) -> Result<PreSimulationState> {
         let returns = self.get_returns()?;
 
-        let decoder = self.build_trace_decoder(&self.build_data.known_contracts)?;
+        let decoder = self.build_trace_decoder(&self.build_data.known_contracts).await?;
 
         let txs = self.execution_result.transactions.clone().unwrap_or_default();
         let rpc_data = RpcData::from_transactions(&txs);
@@ -328,7 +328,7 @@ impl ExecutedState {
     }
 
     /// Builds [CallTraceDecoder] from the execution result and known contracts.
-    fn build_trace_decoder(
+    async fn build_trace_decoder(
         &self,
         known_contracts: &ContractsByArtifact,
     ) -> Result<CallTraceDecoder> {
@@ -344,7 +344,7 @@ impl ExecutedState {
 
         let mut identifier = TraceIdentifiers::new().with_local(known_contracts).with_etherscan(
             &self.script_config.config,
-            self.script_config.evm_opts.get_remote_chain_id(),
+            self.script_config.evm_opts.get_remote_chain_id().await,
         )?;
 
         // Decoding traces using etherscan is costly as we run into rate limits,

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -38,6 +38,6 @@ once_cell = "1"
 yansi.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 foundry-test-utils.workspace = true
 tempfile.workspace = true

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -39,7 +39,7 @@ thiserror = "1"
 tracing.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
Not necessary, we're always in a tokio runtime, and even if we weren't, we don't want to create and destroy a runtime on every call.