### PR TITLE
chore(invariant): remove shrink_sequence config

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -195,7 +195,6 @@ call_override = false
 dictionary_weight = 80
 include_storage = true
 include_push_bytes = true
-shrink_sequence = true
 preserve_state = false
 
 [fmt]

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -24,9 +24,6 @@ pub struct InvariantConfig {
     /// The fuzz dictionary configuration
     #[serde(flatten)]
     pub dictionary: FuzzDictionaryConfig,
-    /// Attempt to shrink the failure case to its smallest sequence of calls
-    /// TODO: remove this setting as it is now redundant with shrink_run_limit = 0
-    pub shrink_sequence: bool,
     /// The maximum number of attempts to shrink the sequence
     pub shrink_run_limit: usize,
     /// If set to true then VM state is committed and available for next call
@@ -48,7 +45,6 @@ impl Default for InvariantConfig {
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },
-            shrink_sequence: true,
             shrink_run_limit: 2usize.pow(18_u32),
             preserve_state: false,
             max_assume_rejects: 65536,
@@ -80,7 +76,6 @@ impl InlineConfigParser for InvariantConfig {
                 "depth" => conf_clone.depth = parse_config_u32(key, value)?,
                 "fail-on-revert" => conf_clone.fail_on_revert = parse_config_bool(key, value)?,
                 "call-override" => conf_clone.call_override = parse_config_bool(key, value)?,
-                "shrink-sequence" => conf_clone.shrink_sequence = parse_config_bool(key, value)?,
                 "preserve-state" => conf_clone.preserve_state = parse_config_bool(key, value)?,
                 _ => Err(InlineConfigParserError::InvalidConfigProperty(key.to_string()))?,
             }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3714,7 +3714,6 @@ mod tests {
                 depth = 15
                 fail_on_revert = false
                 call_override = false
-                shrink_sequence = true
             "#,
             )?;
 

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -63,8 +63,6 @@ pub struct FailedInvariantCaseData {
     pub func: Bytes,
     /// Inner fuzzing Sequence coming from overriding calls.
     pub inner_sequence: Vec<Option<BasicTxDetails>>,
-    /// Shrink the failed test case to the smallest sequence.
-    pub shrink_sequence: bool,
     /// Shrink run limit
     pub shrink_run_limit: usize,
     /// Fail on revert, used to check sequence when shrinking.
@@ -103,7 +101,6 @@ impl FailedInvariantCaseData {
             addr: invariant_contract.address,
             func: func.selector().to_vec().into(),
             inner_sequence: inner_sequence.to_vec(),
-            shrink_sequence: invariant_config.shrink_sequence,
             shrink_run_limit: invariant_config.shrink_run_limit,
             fail_on_revert: invariant_config.fail_on_revert,
         }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -144,10 +144,6 @@ impl<'a> InvariantExecutor<'a> {
             return Err(eyre!("Invariant test function should have no inputs"))
         }
 
-        if !self.config.shrink_sequence {
-            error!(target: "forge::test", "shrink_sequence config is deprecated and will be removed, use shrink_run_limit = 0")
-        }
-
         let (fuzz_state, targeted_contracts, strat) =
             self.prepare_fuzzing(&invariant_contract, fuzz_fixtures)?;
 

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -100,12 +100,7 @@ pub fn replay_error(
         TestError::Abort(_) => Ok(None),
         TestError::Fail(_, ref calls) => {
             // Shrink sequence of failed calls.
-            let calls = if failed_case.shrink_sequence {
-                shrink_sequence(failed_case, calls, &executor)?
-            } else {
-                trace!(target: "forge::test", "Shrinking disabled.");
-                calls.clone()
-            };
+            let calls = shrink_sequence(failed_case, calls, &executor)?;
 
             set_up_inner_replay(&mut executor, &failed_case.inner_sequence);
             // Replay calls to get the counterexample and to collect logs, traces and coverage.

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -84,7 +84,7 @@ pub(crate) fn shrink_sequence(
     calls: &[BasicTxDetails],
     executor: &Executor,
 ) -> eyre::Result<Vec<BasicTxDetails>> {
-    trace!(target: "forge::test", "Shrinking.");
+    trace!(target: "forge::test", "Shrinking sequence of {} calls.", calls.len());
 
     // Special case test: the invariant is *unsatisfiable* - it took 0 calls to
     // break the invariant -- consider emitting a warning.

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -104,7 +104,6 @@ impl ForgeTestProfile {
                     max_fuzz_dictionary_addresses: 10_000,
                     max_fuzz_dictionary_values: 10_000,
                 },
-                shrink_sequence: true,
                 shrink_run_limit: 2usize.pow(18u32),
                 preserve_state: false,
                 max_assume_rejects: 65536,

--- a/testdata/foundry.toml
+++ b/testdata/foundry.toml
@@ -16,7 +16,6 @@ ffi = false
 force = false
 invariant_fail_on_revert = false
 invariant_call_override = false
-invariant_shrink_sequence = true
 invariant_preserve_state = false
 gas_limit = 9223372036854775807
 gas_price = 0


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
-  remove `shrink_sequence` config (same as `shrink_run_limit = 0 `)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
