### PR TITLE
fix(anvil): `tx.gas_price()` return val

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -611,7 +611,7 @@ impl TypedTransaction {
             TypedTransaction::Legacy(tx) => tx.tx().gas_price,
             TypedTransaction::EIP2930(tx) => tx.tx().gas_price,
             TypedTransaction::EIP1559(tx) => tx.tx().max_fee_per_gas,
-            TypedTransaction::EIP4844(tx) => tx.tx().tx().max_fee_per_blob_gas,
+            TypedTransaction::EIP4844(tx) => tx.tx().tx().max_fee_per_gas,
             TypedTransaction::Deposit(_) => 0,
         }
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2359,13 +2359,8 @@ impl TransactionValidator for Backend {
         }
 
         if (env.handler_cfg.spec_id as u8) >= (SpecId::LONDON as u8) {
-            let gas_price = if tx.is_eip4844() {
-                tx.essentials().max_fee_per_gas.ok_or(InvalidTransactionError::FeeCapTooLow)?.to()
-            } else {
-                tx.gas_price()
-            };
-            if gas_price < env.block.basefee.to() && !is_deposit_tx {
-                warn!(target: "backend", "max fee per gas={}, too low, block basefee={}",gas_price,  env.block.basefee);
+            if tx.gas_price() < env.block.basefee.to() && !is_deposit_tx {
+                warn!(target: "backend", "max fee per gas={}, too low, block basefee={}",tx.gas_price(),  env.block.basefee);
                 return Err(InvalidTransactionError::FeeCapTooLow);
             }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When a tx is sent, upon validation we are checking the `tx.gas_price()` against the `block.basefee`. The value returned from `tx.gas_price()` is `max_fee_per_blob_gas` in case of a 4844 tx, which would more often than not be less than that of 1559 basefee, especially on startup. 

This would cause the transaction to be failed with error `InvalidTransactionError::FeeCapTooLow` even though `max_fee_per_gas` would have been set correctly.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Check which type of tx is incoming and associate `gas_price` correctly.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
