### PR TITLE
chore: remove `cast bind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,6 @@ dependencies = [
  "const-hex",
  "criterion",
  "dunce",
- "ethers-contract-abigen",
  "evm-disassembler",
  "evmole",
  "eyre",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -42,8 +42,6 @@ alloy-network.workspace = true
 alloy-sol-types.workspace = true
 alloy-chains.workspace = true
 
-ethers-contract-abigen.workspace = true
-
 chrono.workspace = true
 evm-disassembler.workspace = true
 eyre.workspace = true

--- a/crates/cast/bin/cmd/bind.rs
+++ b/crates/cast/bin/cmd/bind.rs
@@ -1,13 +1,10 @@
 use clap::{Parser, ValueHint};
-use ethers_contract_abigen::{Abigen, MultiAbigen};
 use eyre::Result;
-use foundry_block_explorers::{errors::EtherscanError, Client};
 use foundry_cli::opts::EtherscanOpts;
-use foundry_config::Config;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-static DEFAULT_CRATE_NAME: &str = "foundry-contracts";
-static DEFAULT_CRATE_VERSION: &str = "0.0.1";
+const DEFAULT_CRATE_NAME: &str = "foundry-contracts";
+const DEFAULT_CRATE_VERSION: &str = "0.0.1";
 
 /// CLI arguments for `cast bind`.
 #[derive(Clone, Debug, Parser)]
@@ -58,50 +55,10 @@ pub struct BindArgs {
 
 impl BindArgs {
     pub async fn run(self) -> Result<()> {
-        let path = Path::new(&self.path_or_address);
-        let multi = if path.exists() {
-            MultiAbigen::from_json_files(path)
-        } else {
-            self.abigen_etherscan().await
-        }?;
-
-        println!("Generating bindings for {} contracts", multi.len());
-        let bindings = multi.build()?;
-
-        let out = self
-            .output_dir
-            .clone()
-            .unwrap_or_else(|| std::env::current_dir().unwrap().join("bindings"));
-        bindings.write_to_crate(self.crate_name, self.crate_version, out, !self.separate_files)?;
-        Ok(())
-    }
-
-    async fn abigen_etherscan(&self) -> Result<MultiAbigen> {
-        let config = Config::from(&self.etherscan);
-
-        let chain = config.chain.unwrap_or_default();
-        let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-
-        let client = Client::new(chain, api_key)?;
-        let address = self.path_or_address.parse()?;
-        let source = match client.contract_source_code(address).await {
-            Ok(source) => source,
-            Err(EtherscanError::InvalidApiKey) => {
-                eyre::bail!("Invalid Etherscan API key. Did you set it correctly? You may be using an API key for another Etherscan API chain (e.g. Etherscan API key for Polygonscan).")
-            }
-            Err(EtherscanError::ContractCodeNotVerified(address)) => {
-                eyre::bail!("Contract source code at {:?} on {} not verified. Maybe you have selected the wrong chain?", address, chain)
-            }
-            Err(err) => {
-                eyre::bail!(err)
-            }
-        };
-        let abigens = source
-            .items
-            .into_iter()
-            .map(|item| Abigen::new(item.contract_name, item.abi).unwrap())
-            .collect::<Vec<Abigen>>();
-
-        Ok(MultiAbigen::from_abigens(abigens))
+        Err(eyre::eyre!(
+            "`cast bind` has been removed.\n\
+             Please use `cast etherscan-source` to create a Forge project from an Etherscan source\n\
+             and `forge bind` to generate the bindings to it instead."
+        ))
     }
 }

--- a/crates/wallets/src/utils.rs
+++ b/crates/wallets/src/utils.rs
@@ -5,6 +5,7 @@ use alloy_signer_trezor::HDPath as TrezorHDPath;
 use alloy_signer_wallet::LocalWallet;
 use eyre::{Context, Result};
 use foundry_config::Config;
+use hex::FromHex;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -18,20 +19,15 @@ fn ensure_pk_not_env(pk: &str) -> Result<()> {
 }
 
 /// Validates and sanitizes user inputs, returning configured [WalletSigner].
-pub fn create_private_key_signer(private_key: &str) -> Result<WalletSigner> {
-    let privk = private_key.trim().strip_prefix("0x").unwrap_or(private_key);
-
-    let Ok(private_key) = hex::decode(privk) else {
-        ensure_pk_not_env(privk)?;
+pub fn create_private_key_signer(private_key_str: &str) -> Result<WalletSigner> {
+    let Ok(private_key) = B256::from_hex(private_key_str) else {
+        ensure_pk_not_env(private_key_str)?;
         eyre::bail!("Failed to decode private key")
     };
-
-    match LocalWallet::from_bytes(
-        &B256::try_from(private_key.as_slice()).wrap_err("Failed to decode private key")?,
-    ) {
+    match LocalWallet::from_bytes(&private_key) {
         Ok(pk) => Ok(WalletSigner::Local(pk)),
         Err(err) => {
-            ensure_pk_not_env(privk)?;
+            ensure_pk_not_env(private_key_str)?;
             eyre::bail!("Failed to create wallet from private key: {err}")
         }
     }


### PR DESCRIPTION
Can already be replicated using two different commands: `cast etherscan-source` and `forge bind`.