### PR TITLE
fix: nonce correction logic

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -553,7 +553,6 @@ impl Cheatcode for stopAndReturnStateDiffCall {
 }
 
 pub(super) fn get_nonce<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>, address: &Address) -> Result {
-    super::script::correct_sender_nonce(ccx)?;
     let (account, _) = ccx.ecx.journaled_state.load_account(*address, &mut ccx.ecx.db)?;
     Ok(account.info.nonce.abi_encode())
 }

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -116,10 +116,6 @@ impl Cheatcode for selectForkCall {
         let Self { forkId } = self;
         check_broadcast(ccx.state)?;
 
-        // No need to correct since the sender's nonce does not get incremented when selecting a
-        // fork.
-        ccx.state.corrected_nonce = true;
-
         ccx.ecx.db.select_fork(*forkId, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
         Ok(Default::default())
     }
@@ -287,9 +283,6 @@ fn create_select_fork<DB: DatabaseExt>(
 ) -> Result {
     check_broadcast(ccx.state)?;
 
-    // No need to correct since the sender's nonce does not get incremented when selecting a fork.
-    ccx.state.corrected_nonce = true;
-
     let fork = create_fork_request(ccx, url_or_alias, block)?;
     let id = ccx.ecx.db.create_select_fork(fork, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
     Ok(id.abi_encode())
@@ -313,9 +306,6 @@ fn create_select_fork_at_transaction<DB: DatabaseExt>(
     transaction: &B256,
 ) -> Result {
     check_broadcast(ccx.state)?;
-
-    // No need to correct since the sender's nonce does not get incremented when selecting a fork.
-    ccx.state.corrected_nonce = true;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
     let id = ccx.ecx.db.create_select_fork_at_transaction(

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -764,8 +764,9 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
     fn call(&mut self, ecx: &mut EvmContext<DB>, call: &mut CallInputs) -> Option<CallOutcome> {
         let gas = Gas::new(call.gas_limit);
 
-        // At the root call to test function or script `run()`/`setUp()` functions, we are decrease
-        // sender nonce to ensure that it matches on-chain nonce once we start broadcasting.
+        // At the root call to test function or script `run()`/`setUp()` functions, we are
+        // decreasing sender nonce to ensure that it matches on-chain nonce once we start
+        // broadcasting.
         if ecx.journaled_state.depth == 0 {
             let sender = ecx.env.tx.caller;
             if sender != Config::DEFAULT_SENDER {

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -101,8 +101,6 @@ impl ScriptRunner {
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
 
-                    self.maybe_correct_nonce(sender_nonce, libraries.len())?;
-
                     (
                         !reverted,
                         gas_used,
@@ -124,8 +122,6 @@ impl ScriptRunner {
                     } = err.raw;
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
-
-                    self.maybe_correct_nonce(sender_nonce, libraries.len())?;
 
                     (
                         !reverted,
@@ -154,24 +150,6 @@ impl ScriptRunner {
                 ..Default::default()
             },
         ))
-    }
-
-    /// We call the `setUp()` function with self.sender, and if there haven't been
-    /// any broadcasts, then the EVM cheatcode module hasn't corrected the nonce.
-    /// So we have to.
-    fn maybe_correct_nonce(
-        &mut self,
-        sender_initial_nonce: u64,
-        libraries_len: usize,
-    ) -> Result<()> {
-        if let Some(cheatcodes) = &self.executor.inspector.cheatcodes {
-            if !cheatcodes.corrected_nonce {
-                self.executor
-                    .set_nonce(self.sender, sender_initial_nonce + libraries_len as u64)?;
-            }
-            self.executor.inspector.cheatcodes.as_mut().unwrap().corrected_nonce = false;
-        }
-        Ok(())
     }
 
     /// Executes the method that will collect all broadcastable transactions.


### PR DESCRIPTION
## Motivation

Current approach with nonce correction is not really straightforward as nonce is getting corrected only when invoking certain cheats.

Currently this results in issues when executing the following example:
```solidity
contract SimpleScript is Script {
    function setUp() external {
        uint256 initialFork = vm.activeFork();
        vm.createSelectFork("<url>");
        vm.selectFork(initialFork);
    }

    function run() external {
        assert(vm.getNonce(msg.sender) == 0);
    }
}
```

Specifically, the issue is in this line:
https://github.com/foundry-rs/foundry/blob/503792a1dbadd901a4c02f6fcd1de1caff1573ff/crates/cheatcodes/src/evm/fork.rs#L119-L122

We assume here that we've either corrected nonce on the current fork or will not come back to it. This could've been fixed by adding `correct_sender_nonce` invocation but imo having invocations of it in a lot of random places is not great and clean.

What we are trying to do here is to prevent `run()` and `setUp()` from increasing `--sender` nonce. Technically this is as simple as avoiding call with depth 0 increasing `tx.origin` nonce.

## Solution

This PR changes flow for nonce correction by always applying it in `call` hook for top-level call seen by cheatcodes inspector.

This results in `sender` nonce being corrected regardless of the script logic and allows us to remove the `corrected_nonce` flag.
