### PR TITLE
forge(verify): OKLink support

### DIFF
--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -84,9 +84,7 @@ impl VerificationProviderType {
             VerificationProviderType::Blockscout => {
                 Ok(Box::<EtherscanVerificationProvider>::default())
             }
-            VerificationProviderType::Oklink => {
-                Ok(Box::<EtherscanVerificationProvider>::default())
-            }
+            VerificationProviderType::Oklink => Ok(Box::<EtherscanVerificationProvider>::default()),
         }
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -85,9 +85,6 @@ impl VerificationProviderType {
                 Ok(Box::<EtherscanVerificationProvider>::default())
             }
             VerificationProviderType::Oklink => {
-                if key.as_ref().map_or(true, |key| key.is_empty()) {
-                    eyre::bail!("OKLINK_API_KEY must be set")
-                }
                 Ok(Box::<EtherscanVerificationProvider>::default())
             }
         }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -33,6 +33,7 @@ impl FromStr for VerificationProviderType {
             "e" | "etherscan" => Ok(VerificationProviderType::Etherscan),
             "s" | "sourcify" => Ok(VerificationProviderType::Sourcify),
             "b" | "blockscout" => Ok(VerificationProviderType::Blockscout),
+            "o" | "oklink" => Ok(VerificationProviderType::Oklink),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }
@@ -50,6 +51,9 @@ impl fmt::Display for VerificationProviderType {
             VerificationProviderType::Blockscout => {
                 write!(f, "blockscout")?;
             }
+            VerificationProviderType::Oklink => {
+                write!(f, "oklink")?;
+            }
         };
         Ok(())
     }
@@ -61,6 +65,7 @@ pub enum VerificationProviderType {
     Etherscan,
     Sourcify,
     Blockscout,
+    Oklink,
 }
 
 impl VerificationProviderType {
@@ -77,6 +82,12 @@ impl VerificationProviderType {
                 Ok(Box::<SourcifyVerificationProvider>::default())
             }
             VerificationProviderType::Blockscout => {
+                Ok(Box::<EtherscanVerificationProvider>::default())
+            }
+            VerificationProviderType::Oklink => {
+                if key.as_ref().map_or(true, |key| key.is_empty()) {
+                    eyre::bail!("OKLINK_API_KEY must be set")
+                }
                 Ok(Box::<EtherscanVerificationProvider>::default())
             }
         }


### PR DESCRIPTION
## Motivation
To add support for the OKLink explorer contract verification. since the OKLink use almost the same API as the etherscan does for the contract verification part. the only difference is that the OKLink requires the Ok-Access-Key pass in the header, while etherscan requires the x-apiKey pass in the header. 

## Solution
To make the OKLink API more similar to the Etherscan API, the oklink backend decide to handle the API_KEY the same as etherscan does. so, we basically only add an entry point as blockscout does. 

Reference
- https://www.oklink.com/docs/zh/#explorer-rpc-api-contract-verifysourcecode
Closes https://github.com/foundry-rs/foundry/issues/7724
closes https://github.com/foundry-rs/foundry/pull/7586 