### PR TITLE
feat(cast): support convert hex data to a utf-8 string

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
         }
         CastSubcommand::ToUtf8 { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_utf8(&value));
+            println!("{}", SimpleCast::to_utf8(&value)?);
         }
         CastSubcommand::FromFixedPoint { value, decimals } => {
             let (value, decimals) = stdin::unwrap2(value, decimals)?;

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -68,6 +68,10 @@ async fn main() -> Result<()> {
             let value = stdin::unwrap(hexdata, false)?;
             println!("{}", SimpleCast::to_ascii(&value)?);
         }
+        CastSubcommand::ToUtf8 { hexdata } => {
+            let value = stdin::unwrap(hexdata, false)?;
+            println!("{}", SimpleCast::to_utf8(&value));
+        }
         CastSubcommand::FromFixedPoint { value, decimals } => {
             let (value, decimals) = stdin::unwrap2(value, decimals)?;
             println!("{}", SimpleCast::from_fixed_point(&value, &decimals)?);

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -126,6 +126,13 @@ pub enum CastSubcommand {
         hexdata: Option<String>,
     },
 
+    /// Convert hex data to a utf-8 string.
+    #[command(visible_aliases = &["--to-utf8", "tu8", "2u8"])]
+    ToUtf8 {
+        /// The hex data to convert.
+        hexdata: Option<String>,
+    },
+
     /// Convert a fixed point number into an integer.
     #[command(visible_aliases = &["--from-fix", "ff"])]
     FromFixedPoint {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1053,6 +1053,23 @@ impl SimpleCast {
         hex::encode_prefixed(s)
     }
 
+    /// Converts hex input to UTF-8 text
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// assert_eq!(Cast::to_utf8("0x796f"), "yo");
+    /// assert_eq!(Cast::to_utf8("0x48656c6c6f2c20576f726c6421"), "Hello, World!");
+    /// assert_eq!(Cast::to_utf8("0x547572626f44617070546f6f6c73"), "TurboDappTools");
+    /// assert_eq!(Cast::to_utf8("0xe4bda0e5a5bd"), "你好");
+    /// # Ok::<_, eyre::Report>(())
+    /// ```
+    pub fn to_utf8(s: &str) -> String {
+        String::from_utf8(hex::decode(s).unwrap()).unwrap()
+    }
+
     /// Converts hex data into text data
     ///
     /// # Example

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1060,14 +1060,15 @@ impl SimpleCast {
     /// ```
     /// use cast::SimpleCast as Cast;
     ///
-    /// assert_eq!(Cast::to_utf8("0x796f"), "yo");
-    /// assert_eq!(Cast::to_utf8("0x48656c6c6f2c20576f726c6421"), "Hello, World!");
-    /// assert_eq!(Cast::to_utf8("0x547572626f44617070546f6f6c73"), "TurboDappTools");
-    /// assert_eq!(Cast::to_utf8("0xe4bda0e5a5bd"), "你好");
+    /// assert_eq!(Cast::to_utf8("0x796f")?, "yo");
+    /// assert_eq!(Cast::to_utf8("0x48656c6c6f2c20576f726c6421")?, "Hello, World!");
+    /// assert_eq!(Cast::to_utf8("0x547572626f44617070546f6f6c73")?, "TurboDappTools");
+    /// assert_eq!(Cast::to_utf8("0xe4bda0e5a5bd")?, "你好");
     /// # Ok::<_, eyre::Report>(())
     /// ```
-    pub fn to_utf8(s: &str) -> String {
-        String::from_utf8(hex::decode(s).unwrap()).unwrap()
+    pub fn to_utf8(s: &str) -> Result<String> {
+        let bytes = hex::decode(s)?;
+        Ok(String::from_utf8_lossy(bytes.as_ref()).to_string())
     }
 
     /// Converts hex data into text data


### PR DESCRIPTION
## Motivation
foundry `cast` implements command `cast from-utf8` but no features like `cast to-utf8`. 

This PR aims to provide the function `cast to-utf8`. 

// 你好 means "Hello"

```shell
cast --from-utf8 "你好"
0xe4bda0e5a5bd
```

```shell
cast --to-utf8 0xe4bda0e5a5bd
你好
```




