### PR TITLE
Revert "fix: fuzz console log (#7781)"

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -1,7 +1,7 @@
 use crate::executors::{Executor, RawCallResult};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, Log, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_config::FuzzConfig;
 use foundry_evm_core::{
@@ -87,9 +87,6 @@ impl FuzzedExecutor {
             dictionary_weight => fuzz_calldata_from_state(func.clone(), &state),
         ];
 
-        //Stores logs for all fuzz cases
-        let logs: RefCell<Vec<Log>> = RefCell::default();
-
         debug!(func=?func.name, should_fail, "fuzzing");
         let run_result = self.runner.clone().run(&strat, |calldata| {
             let fuzz_res = self.single_fuzz(address, should_fail, calldata)?;
@@ -107,7 +104,6 @@ impl FuzzedExecutor {
                         }
                         traces.borrow_mut().push(call_traces);
                     }
-                    logs.borrow_mut().extend(case.logs);
 
                     if let Some(prev) = coverage.take() {
                         // Safety: If `Option::or` evaluates to `Some`, then `call.coverage` must
@@ -131,7 +127,6 @@ impl FuzzedExecutor {
                     // to run at least one more case to find a minimal failure
                     // case.
                     let call_res = _counterexample.1.result.clone();
-                    logs.borrow_mut().extend(_counterexample.1.logs.clone());
                     *counterexample.borrow_mut() = _counterexample;
                     // HACK: we have to use an empty string here to denote `None`
                     let reason = rd.maybe_decode(&call_res, Some(status));
@@ -145,16 +140,14 @@ impl FuzzedExecutor {
         let mut traces = traces.into_inner();
         let last_run_traces = if run_result.is_ok() { traces.pop() } else { call.traces.clone() };
 
-        let inner_logs = logs.into_inner();
-
         let mut result = FuzzTestResult {
             first_case: first_case.take().unwrap_or_default(),
             gas_by_case: gas_by_case.take(),
             success: run_result.is_ok(),
             reason: None,
             counterexample: None,
-            decoded_logs: decode_console_logs(&inner_logs),
-            logs: inner_logs,
+            decoded_logs: decode_console_logs(&call.logs),
+            logs: call.logs,
             labeled_addresses: call.labels,
             traces: last_run_traces,
             gas_report_traces: traces,
@@ -214,7 +207,7 @@ impl FuzzedExecutor {
 
         // When the `assume` cheatcode is called it returns a special string
         if call.result.as_ref() == MAGIC_ASSUME {
-            return Err(TestCaseError::reject(FuzzError::AssumeReject));
+            return Err(TestCaseError::reject(FuzzError::AssumeReject))
         }
 
         let breakpoints = call
@@ -236,7 +229,6 @@ impl FuzzedExecutor {
                 coverage: call.coverage,
                 debug: call.debug,
                 breakpoints,
-                logs: call.logs,
             }))
         } else {
             Ok(FuzzOutcome::CounterExample(CounterExampleOutcome {

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -1,5 +1,5 @@
 use crate::executors::RawCallResult;
-use alloy_primitives::{Bytes, Log};
+use alloy_primitives::Bytes;
 use foundry_common::evm::Breakpoints;
 use foundry_evm_core::debug::DebugArena;
 use foundry_evm_coverage::HitMaps;
@@ -20,8 +20,6 @@ pub struct CaseOutcome {
     pub debug: Option<DebugArena>,
     /// Breakpoints char pc map
     pub breakpoints: Breakpoints,
-    /// logs of a single fuzz test case
-    pub logs: Vec<Log>,
 }
 
 /// Returned by a single fuzz when a counterexample has been discovered

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1,6 +1,6 @@
 //! Contains various tests for `forge test`.
 
-use foundry_config::{Config, FuzzConfig};
+use foundry_config::Config;
 use foundry_test_utils::{
     rpc,
     util::{OutputExt, OTHER_SOLC_VERSION, SOLC_VERSION},
@@ -543,33 +543,4 @@ contract Dummy {
 
     cmd.args(["test", "--match-path", "src/dummy.sol"]);
     cmd.assert_success()
-});
-
-// tests that `forge test` for fuzz tests will display `console.log` info
-forgetest_init!(can_test_fuzz_with_console_log, |prj, cmd| {
-    prj.wipe_contracts();
-
-    // run fuzz test 3 times
-    let config =
-        Config { fuzz: { FuzzConfig { runs: 3, ..Default::default() } }, ..Default::default() };
-    prj.write_config(config);
-    let config = cmd.config();
-    assert_eq!(config.fuzz.runs, 3);
-
-    prj.add_test(
-        "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-
-    contract ContractFuzz is Test {
-      function testFuzzConsoleLog(uint256 x) public {
-        console2.log("inside fuzz test, x is:", x);
-      }
-    }
-     "#,
-    )
-    .unwrap();
-    cmd.args(["test", "-vv"]);
-    let stdout = cmd.stdout_lossy();
-    assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });


### PR DESCRIPTION
This reverts commit a470d635cfcdce68609e9dc5762a3584351bacc1.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
https://github.com/foundry-rs/foundry/pull/7781 adds ability to log during all fuzz runs, but it introduces unexpected behavior due to the bound result being logged in forge-std, see 
https://github.com/foundry-rs/foundry/pull/7781#issuecomment-2115828404

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- revert commit and check if any special reason for forge-std logging bound results before adding back