### PR TITLE
fix: apply `--no-match-test` when invoking compiler

### DIFF
--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -186,7 +186,7 @@ impl ProjectPathsAwareFilter {
 impl FileFilter for ProjectPathsAwareFilter {
     /// Returns true if the file regex pattern match the `file`
     ///
-    /// If no file regex is set this returns true by default 
+    /// If no file regex is set this returns true by default
     fn is_match(&self, mut file: &Path) -> bool {
         file = file.strip_prefix(&self.paths.root).unwrap_or(file);
         self.args_filter.is_match(file)

--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use forge::TestFilter;
-use foundry_cli::utils::FoundryPathExt;
 use foundry_common::glob::GlobMatcher;
 use foundry_compilers::{FileFilter, ProjectPathsConfig};
 use foundry_config::Config;
@@ -96,13 +95,7 @@ impl FileFilter for FilterArgs {
     /// If no file regex is set this returns true if the file ends with `.t.sol`, see
     /// [`FoundryPathExt::is_sol_test()`].
     fn is_match(&self, file: &Path) -> bool {
-        if let Some(glob) = &self.path_pattern {
-            return glob.is_match(file)
-        }
-        if let Some(glob) = &self.path_pattern_inverse {
-            return !glob.is_match(file)
-        }
-        file.is_sol_test()
+        self.matches_path(file)
     }
 }
 
@@ -195,7 +188,7 @@ impl FileFilter for ProjectPathsAwareFilter {
     /// Returns true if the file regex pattern match the `file`
     ///
     /// If no file regex is set this returns true if the file ends with `.t.sol`, see
-    /// [FoundryPathExr::is_sol_test()]
+    /// [FoundryPathExt::is_sol_test()]
     fn is_match(&self, mut file: &Path) -> bool {
         file = file.strip_prefix(&self.paths.root).unwrap_or(file);
         self.args_filter.is_match(file)

--- a/crates/forge/bin/cmd/test/filter.rs
+++ b/crates/forge/bin/cmd/test/filter.rs
@@ -92,8 +92,7 @@ impl fmt::Debug for FilterArgs {
 impl FileFilter for FilterArgs {
     /// Returns true if the file regex pattern match the `file`
     ///
-    /// If no file regex is set this returns true if the file ends with `.t.sol`, see
-    /// [`FoundryPathExt::is_sol_test()`].
+    /// If no file regex is set this returns true by default
     fn is_match(&self, file: &Path) -> bool {
         self.matches_path(file)
     }
@@ -187,8 +186,7 @@ impl ProjectPathsAwareFilter {
 impl FileFilter for ProjectPathsAwareFilter {
     /// Returns true if the file regex pattern match the `file`
     ///
-    /// If no file regex is set this returns true if the file ends with `.t.sol`, see
-    /// [FoundryPathExt::is_sol_test()]
+    /// If no file regex is set this returns true by default 
     fn is_match(&self, mut file: &Path) -> bool {
         file = file.strip_prefix(&self.paths.root).unwrap_or(file);
         self.args_filter.is_match(file)

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -20,7 +20,8 @@ use foundry_common::{
     shell,
 };
 use foundry_compilers::{
-    artifacts::output_selection::OutputSelection, utils::source_files_iter, SOLC_EXTENSIONS,
+    artifacts::output_selection::OutputSelection, utils::source_files_iter, SolcSparseFileFilter,
+    SOLC_EXTENSIONS,
 };
 use foundry_config::{
     figment,
@@ -153,7 +154,8 @@ impl TestArgs {
         let mut project = config.create_project(true, true)?;
         project.settings.output_selection =
             OutputSelection::common_output_selection(["abi".to_string()]);
-        let output = project.compile()?;
+
+        let output = project.compile_sparse(Box::new(SolcSparseFileFilter::new(filter.clone())))?;
 
         if output.has_compiler_errors() {
             println!("{}", output);


### PR DESCRIPTION
## Motivation

Currently when running `forge test` all files under `./test` will be passed to compiler on initial ABI-only run. This might be an issue if files being filtered out can't be compiled for some reason.

## Solution

Apply test filter as sparse output filter in a similar way `forge build --skip` works
