### PR TITLE
fix(invariant): panic when decoding logs with None value

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -261,18 +261,20 @@ impl FuzzDictionary {
     /// If collected samples limit is reached then values are inserted as regular values.
     pub fn insert_sample_values(&mut self, sample_values: Vec<DynSolValue>, limit: u32) {
         for sample in sample_values {
-            let sample_type = sample.as_type().unwrap();
-            let sample_value = sample.as_word().unwrap().into();
-
-            if let Some(values) = self.sample_values.get_mut(&sample_type) {
-                if values.len() < limit as usize {
-                    values.insert(sample_value);
-                } else {
-                    // Insert as state value (will be removed at the end of the run).
-                    self.insert_value(sample_value, true);
+            if let Some(sample_type) = sample.as_type() {
+                if let Some(sample_value) = sample.as_word() {
+                    let sample_value = sample_value.into();
+                    if let Some(values) = self.sample_values.get_mut(&sample_type) {
+                        if values.len() < limit as usize {
+                            values.insert(sample_value);
+                        } else {
+                            // Insert as state value (will be removed at the end of the run).
+                            self.insert_value(sample_value, true);
+                        }
+                    } else {
+                        self.sample_values.entry(sample_type).or_default().insert(sample_value);
+                    }
                 }
-            } else {
-                self.sample_values.entry(sample_type).or_default().insert(sample_value);
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

some logs (console) are decoded without value and producing panic when creating samples

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- check if type and values are not None before unwrap and insert sample values 
