### PR TITLE
refactor: clean-up cast send

### DIFF
--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -1,3 +1,4 @@
+use crate::tx::CastTxBuilder;
 use alloy_primitives::TxKind;
 use alloy_rpc_types::BlockId;
 use cast::Cast;
@@ -5,13 +6,11 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::{self},
+    utils,
 };
 use foundry_common::ens::NameOrAddress;
 use foundry_config::Config;
 use std::str::FromStr;
-
-use crate::tx::CastTxBuilder;
 
 /// CLI arguments for `cast access-list`.
 #[derive(Debug, Parser)]

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -1,18 +1,19 @@
-use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, U256};
-use alloy_rpc_types::{BlockId, TransactionRequest, WithOtherFields};
+use alloy_rpc_types::BlockId;
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::{self, handle_traces, parse_ether_value, parse_function_args, TraceResult},
+    utils::{self, handle_traces, parse_ether_value, TraceResult},
 };
 use foundry_common::ens::NameOrAddress;
 use foundry_compilers::EvmVersion;
 use foundry_config::{find_project_root_path, Config};
 use foundry_evm::{executors::TracingExecutor, opts::EvmOpts};
 use std::str::FromStr;
+
+use crate::tx::CastTxBuilder;
 
 /// CLI arguments for `cast call`.
 #[derive(Debug, Parser)]
@@ -97,10 +98,9 @@ impl CallArgs {
     pub async fn run(self) -> Result<()> {
         let CallArgs {
             to,
-            sig,
-            args,
-            data,
-            tx,
+            mut sig,
+            mut args,
+            mut tx,
             eth,
             command,
             block,
@@ -108,132 +108,78 @@ impl CallArgs {
             evm_version,
             debug,
             labels,
+            data,
         } = self;
+
+        if let Some(data) = data {
+            sig = Some(data);
+        }
 
         let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
-        let chain = utils::get_chain(config.chain, &provider).await?;
         let sender = eth.wallet.sender().await;
-        let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
 
-        let to = match to {
-            Some(to) => Some(to.resolve(&provider).await?),
-            None => None,
+        let tx_kind = if let Some(to) = to {
+            TxKind::Call(to.resolve(&provider).await?)
+        } else {
+            TxKind::Create
         };
 
-        let mut req = WithOtherFields::<TransactionRequest>::default()
-            .with_from(sender)
-            .with_value(tx.value.unwrap_or_default());
-
-        if let Some(to) = to {
-            req.set_to(to);
+        let code = if let Some(CallSubcommands::Create {
+            code,
+            sig: create_sig,
+            args: create_args,
+            value,
+        }) = command
+        {
+            sig = create_sig;
+            args = create_args;
+            if let Some(value) = value {
+                tx.value = Some(value);
+            }
+            Some(code)
         } else {
-            req.set_kind(alloy_primitives::TxKind::Create);
-        }
+            None
+        };
 
-        if let Some(nonce) = tx.nonce {
-            req.set_nonce(nonce.to());
-        }
+        let (tx, func) = CastTxBuilder::new(&provider, tx, &config)
+            .await?
+            .with_tx_kind(tx_kind)
+            .with_code_sig_and_args(code, sig, args)
+            .await?
+            .build_raw(sender)
+            .await?;
 
-        let (data, func) = match command {
-            Some(CallSubcommands::Create { code, sig, args, value }) => {
-                if let Some(value) = value {
-                    req.set_value(value);
-                }
+        if trace {
+            let figment =
+                Config::figment_with_root(find_project_root_path(None).unwrap()).merge(eth.rpc);
+            let evm_opts = figment.extract::<EvmOpts>()?;
+            let (env, fork, chain) = TracingExecutor::get_fork_material(&config, evm_opts).await?;
+            let mut executor = TracingExecutor::new(env, fork, evm_version, debug);
 
-                let mut data = hex::decode(code)?;
+            let value = tx.value.unwrap_or_default();
+            let input = tx.inner.input.into_input().unwrap_or_default();
 
-                if let Some(s) = sig {
-                    let (mut constructor_args, _) = parse_function_args(
-                        &s,
-                        args,
-                        None,
-                        chain,
-                        &provider,
-                        etherscan_api_key.as_deref(),
-                    )
-                    .await?;
-                    data.append(&mut constructor_args);
-                }
+            let trace = match tx_kind {
+                TxKind::Create => {
+                    let deploy_result = executor.deploy(sender, input, value, None);
 
-                if trace {
-                    let figment = Config::figment_with_root(find_project_root_path(None).unwrap())
-                        .merge(eth.rpc);
-
-                    let evm_opts = figment.extract::<EvmOpts>()?;
-
-                    let (env, fork, chain) =
-                        TracingExecutor::get_fork_material(&config, evm_opts).await?;
-
-                    let mut executor = TracingExecutor::new(env, fork, evm_version, debug);
-
-                    let trace = match executor.deploy(
-                        sender,
-                        data.into(),
-                        req.value.unwrap_or_default(),
-                        None,
-                    ) {
+                    match deploy_result {
                         Ok(deploy_result) => TraceResult::from(deploy_result),
                         Err(evm_err) => TraceResult::try_from(evm_err)?,
-                    };
-
-                    handle_traces(trace, &config, chain, labels, debug).await?;
-
-                    return Ok(());
+                    }
                 }
-
-                (data, None)
-            }
-            _ => {
-                // fill first here because we need to use the builder in the conditional
-                let (data, func) = if let Some(sig) = sig {
-                    parse_function_args(
-                        &sig,
-                        args,
-                        to,
-                        chain,
-                        &provider,
-                        etherscan_api_key.as_deref(),
-                    )
-                    .await?
-                } else if let Some(data) = data {
-                    // Note: `sig+args` and `data` are mutually exclusive
-                    (hex::decode(data)?, None)
-                } else {
-                    (Vec::new(), None)
-                };
-
-                if trace {
-                    let figment = Config::figment_with_root(find_project_root_path(None).unwrap())
-                        .merge(eth.rpc);
-
-                    let evm_opts = figment.extract::<EvmOpts>()?;
-
-                    let (env, fork, chain) =
-                        TracingExecutor::get_fork_material(&config, evm_opts).await?;
-
-                    let mut executor = TracingExecutor::new(env, fork, evm_version, debug);
-
-                    let to = if let Some(TxKind::Call(to)) = req.to { Some(to) } else { None };
-                    let trace = TraceResult::from(executor.call_raw_committing(
-                        sender,
-                        to.expect("an address to be here"),
-                        data.into(),
-                        req.value.unwrap_or_default(),
-                    )?);
-
-                    handle_traces(trace, &config, chain, labels, debug).await?;
-
-                    return Ok(());
+                TxKind::Call(to) => {
+                    TraceResult::from(executor.call_raw_committing(sender, to, input, value)?)
                 }
+            };
 
-                (data, func)
-            }
-        };
+            handle_traces(trace, &config, chain, labels, debug).await?;
 
-        req.set_input(data);
+            return Ok(());
+        }
 
-        println!("{}", Cast::new(provider).call(&req, func.as_ref(), block).await?);
+        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block).await?);
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -1,3 +1,4 @@
+use crate::tx::CastTxBuilder;
 use alloy_primitives::{TxKind, U256};
 use alloy_rpc_types::BlockId;
 use cast::Cast;
@@ -12,8 +13,6 @@ use foundry_compilers::EvmVersion;
 use foundry_config::{find_project_root_path, Config};
 use foundry_evm::{executors::TracingExecutor, opts::EvmOpts};
 use std::str::FromStr;
-
-use crate::tx::CastTxBuilder;
 
 /// CLI arguments for `cast call`.
 #[derive(Debug, Parser)]

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -1,3 +1,4 @@
+use crate::tx::CastTxBuilder;
 use alloy_primitives::{TxKind, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
@@ -10,8 +11,6 @@ use foundry_cli::{
 use foundry_common::ens::NameOrAddress;
 use foundry_config::Config;
 use std::str::FromStr;
-
-use crate::tx::CastTxBuilder;
 
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -1,16 +1,17 @@
-use alloy_network::TransactionBuilder;
-use alloy_primitives::U256;
+use alloy_primitives::{TxKind, U256};
 use alloy_provider::Provider;
-use alloy_rpc_types::{TransactionRequest, WithOtherFields};
+use alloy_rpc_types::BlockId;
 use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
-    opts::{EtherscanOpts, RpcOpts},
-    utils::{self, parse_ether_value, parse_function_args},
+    opts::{EthereumOpts, TransactionOpts},
+    utils::{self, parse_ether_value},
 };
 use foundry_common::ens::NameOrAddress;
-use foundry_config::{figment::Figment, Config};
+use foundry_config::Config;
 use std::str::FromStr;
+
+use crate::tx::CastTxBuilder;
 
 /// CLI arguments for `cast estimate`.
 #[derive(Debug, Parser)]
@@ -25,32 +26,20 @@ pub struct EstimateArgs {
     /// The arguments of the function to call.
     args: Vec<String>,
 
-    /// The sender account.
-    #[arg(
-        short,
-        long,
-        value_parser = NameOrAddress::from_str,
-        default_value = "0x0000000000000000000000000000000000000000",
-        env = "ETH_FROM",
-    )]
-    from: NameOrAddress,
-
-    /// Ether to send in the transaction.
+    /// The block height to query at.
     ///
-    /// Either specified in wei, or as a string with a unit type:
-    ///
-    /// Examples: 1ether, 10gwei, 0.01ether
-    #[arg(long, value_parser = parse_ether_value)]
-    value: Option<U256>,
-
-    #[command(flatten)]
-    rpc: RpcOpts,
-
-    #[command(flatten)]
-    etherscan: EtherscanOpts,
+    /// Can also be the tags earliest, finalized, safe, latest, or pending.
+    #[arg(long, short = 'B')]
+    block: Option<BlockId>,
 
     #[command(subcommand)]
     command: Option<EstimateSubcommands>,
+
+    #[command(flatten)]
+    tx: TransactionOpts,
+
+    #[command(flatten)]
+    eth: EthereumOpts,
 }
 
 #[derive(Debug, Parser)]
@@ -79,56 +68,44 @@ pub enum EstimateSubcommands {
 
 impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
-        let EstimateArgs { from, to, sig, args, value, rpc, etherscan, command } = self;
+        let EstimateArgs { to, mut sig, mut args, mut tx, block, eth, command } = self;
 
-        let figment = Figment::from(Config::figment()).merge(etherscan).merge(rpc);
-        let config = Config::try_from(figment)?;
+        let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
-        let chain = utils::get_chain(config.chain, &provider).await?;
-        let api_key = config.get_etherscan_api_key(Some(chain));
+        let sender = eth.wallet.sender().await;
 
-        let from = from.resolve(&provider).await?;
-        let to = match to {
-            Some(to) => Some(to.resolve(&provider).await?),
-            None => None,
-        };
-
-        let mut req = WithOtherFields::<TransactionRequest>::default()
-            .with_from(from)
-            .with_value(value.unwrap_or_default());
-
-        if let Some(to) = to {
-            req.set_to(to);
+        let tx_kind = if let Some(to) = to {
+            TxKind::Call(to.resolve(&provider).await?)
         } else {
-            req.set_kind(alloy_primitives::TxKind::Create);
-        }
-
-        let data = match command {
-            Some(EstimateSubcommands::Create { code, sig, args, value }) => {
-                if let Some(value) = value {
-                    req.set_value(value);
-                }
-
-                let mut data = hex::decode(code)?;
-
-                if let Some(s) = sig {
-                    let (mut constructor_args, _) =
-                        parse_function_args(&s, args, to, chain, &provider, api_key.as_deref())
-                            .await?;
-                    data.append(&mut constructor_args);
-                }
-
-                data
-            }
-            _ => {
-                let sig = sig.ok_or_else(|| eyre::eyre!("Function signature must be provided."))?;
-                parse_function_args(&sig, args, to, chain, &provider, api_key.as_deref()).await?.0
-            }
+            TxKind::Create
         };
 
-        req.set_input(data);
+        let code = if let Some(EstimateSubcommands::Create {
+            code,
+            sig: create_sig,
+            args: create_args,
+            value,
+        }) = command
+        {
+            sig = create_sig;
+            args = create_args;
+            if let Some(value) = value {
+                tx.value = Some(value);
+            }
+            Some(code)
+        } else {
+            None
+        };
 
-        let gas = provider.estimate_gas(&req).await?;
+        let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
+            .await?
+            .with_tx_kind(tx_kind)
+            .with_code_sig_and_args(code, sig, args)
+            .await?
+            .build_raw(sender)
+            .await?;
+
+        let gas = provider.estimate_gas(&tx).block_id(block.unwrap_or_default()).await?;
         println!("{gas}");
         Ok(())
     }
@@ -141,6 +118,6 @@ mod tests {
     #[test]
     fn parse_estimate_value() {
         let args: EstimateArgs = EstimateArgs::parse_from(["foundry-cli", "--value", "100"]);
-        assert!(args.value.is_some());
+        assert!(args.tx.value.is_some());
     }
 }

--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -1,7 +1,5 @@
-use crate::tx;
+use crate::tx::{self, CastTxBuilder};
 use alloy_network::{eip2718::Encodable2718, EthereumSigner, TransactionBuilder};
-use alloy_primitives::U64;
-use alloy_provider::Provider;
 use alloy_signer::Signer;
 use clap::Parser;
 use eyre::Result;
@@ -27,10 +25,6 @@ pub struct MakeTxArgs {
 
     /// The arguments of the function to call.
     args: Vec<String>,
-
-    /// Reuse the latest nonce for the sender account.
-    #[arg(long, conflicts_with = "nonce")]
-    resend: bool,
 
     #[command(subcommand)]
     command: Option<MakeTxSubcommands>,
@@ -60,7 +54,7 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
-        let MakeTxArgs { to, mut sig, mut args, resend, command, mut tx, eth } = self;
+        let MakeTxArgs { to, mut sig, mut args, command, tx, eth } = self;
 
         let code = if let Some(MakeTxSubcommands::Create {
             code,
@@ -75,12 +69,10 @@ impl MakeTxArgs {
             None
         };
 
-        tx::validate_to_address(&code, &to)?;
-
         let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
-        let chain = utils::get_chain(config.chain, &provider).await?;
-        let api_key = config.get_etherscan_api_key(Some(chain));
+
+        let tx_kind = tx::resolve_tx_kind(&provider, &code, &to).await?;
 
         // Retrieve the signer, and bail if it can't be constructed.
         let signer = eth.wallet.signer().await?;
@@ -88,14 +80,15 @@ impl MakeTxArgs {
 
         tx::validate_from_address(eth.wallet.from, from)?;
 
-        if resend {
-            tx.nonce = Some(U64::from(provider.get_transaction_count(from).await?));
-        }
-
         let provider = get_provider(&config)?;
 
-        let (tx, _) =
-            tx::build_tx(&provider, from, to, code, sig, args, tx, chain, api_key, None).await?;
+        let tx = CastTxBuilder::new(provider, tx, &config)
+            .await?
+            .with_tx_kind(tx_kind)
+            .with_code_sig_and_args(code, sig, args)
+            .await?
+            .build(from)
+            .await?;
 
         let tx = tx.build(&EthereumSigner::new(signer)).await?;
 

--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -82,7 +82,7 @@ impl MakeTxArgs {
 
         let provider = get_provider(&config)?;
 
-        let tx = CastTxBuilder::new(provider, tx, &config)
+        let (tx, _) = CastTxBuilder::new(provider, tx, &config)
             .await?
             .with_tx_kind(tx_kind)
             .with_code_sig_and_args(code, sig, args)

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -142,7 +142,7 @@ impl SendTxArgs {
                 }
             }
 
-            let tx = builder.build(config.sender).await?;
+            let (tx, _) = builder.build(config.sender).await?;
 
             cast_send(provider, tx, cast_async, confirmations, to_json).await
         // Case 2:
@@ -161,7 +161,7 @@ impl SendTxArgs {
                 .signer(signer)
                 .on_provider(&provider);
 
-            let tx = builder.build(from).await?;
+            let (tx, _) = builder.build(from).await?;
 
             cast_send(provider, tx, cast_async, confirmations, to_json).await
         }

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -1,7 +1,7 @@
-use crate::tx;
+use crate::tx::{self, CastTxBuilder};
 use alloy_network::{AnyNetwork, EthereumSigner};
-use alloy_primitives::{Address, U64};
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::{TransactionRequest, WithOtherFields};
 use alloy_signer::Signer;
 use alloy_transport::Transport;
 use cast::Cast;
@@ -12,7 +12,7 @@ use foundry_cli::{
     utils,
 };
 use foundry_common::{cli_warn, ens::NameOrAddress};
-use foundry_config::{Chain, Config};
+use foundry_config::Config;
 use std::{path::PathBuf, str::FromStr};
 
 /// CLI arguments for `cast send`.
@@ -41,10 +41,6 @@ pub struct SendTxArgs {
     /// Print the transaction receipt as JSON.
     #[arg(long, short, help_heading = "Display options")]
     json: bool,
-
-    /// Reuse the latest nonce for the sender account.
-    #[arg(long, conflicts_with = "nonce")]
-    resend: bool,
 
     #[command(subcommand)]
     command: Option<SendTxSubcommands>,
@@ -88,10 +84,9 @@ impl SendTxArgs {
             mut sig,
             cast_async,
             mut args,
-            mut tx,
+            tx,
             confirmations,
             json: to_json,
-            resend,
             command,
             unlocked,
             path,
@@ -112,17 +107,16 @@ impl SendTxArgs {
             None
         };
 
-        tx::validate_to_address(&code, &to)?;
-
         let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
-        let chain = utils::get_chain(config.chain, &provider).await?;
-        let api_key = config.get_etherscan_api_key(Some(chain));
+        let tx_kind = tx::resolve_tx_kind(&provider, &code, &to).await?;
 
-        let to = match to {
-            Some(to) => Some(to.resolve(&provider).await?),
-            None => None,
-        };
+        let builder = CastTxBuilder::new(&provider, tx, &config)
+            .await?
+            .with_tx_kind(tx_kind)
+            .with_code_sig_and_args(code, sig, args)
+            .await?
+            .with_blob_data(blob_data)?;
 
         // Case 1:
         // Default to sending via eth_sendTransaction if the --unlocked flag is passed.
@@ -148,26 +142,9 @@ impl SendTxArgs {
                 }
             }
 
-            if resend {
-                tx.nonce = Some(U64::from(provider.get_transaction_count(config.sender).await?));
-            }
+            let tx = builder.build(config.sender).await?;
 
-            cast_send(
-                provider,
-                config.sender,
-                to,
-                code,
-                sig,
-                args,
-                tx,
-                chain,
-                api_key,
-                cast_async,
-                confirmations,
-                to_json,
-                blob_data,
-            )
-            .await
+            cast_send(provider, tx, cast_async, confirmations, to_json).await
         // Case 2:
         // An option to use a local signer was provided.
         // If we cannot successfully instantiate a local signer, then we will assume we don't have
@@ -179,54 +156,25 @@ impl SendTxArgs {
 
             tx::validate_from_address(eth.wallet.from, from)?;
 
-            if resend {
-                tx.nonce = Some(U64::from(provider.get_transaction_count(from).await?));
-            }
-
             let signer = EthereumSigner::from(signer);
-            let provider =
-                ProviderBuilder::<_, _, AnyNetwork>::default().signer(signer).on_provider(provider);
+            let provider = ProviderBuilder::<_, _, AnyNetwork>::default()
+                .signer(signer)
+                .on_provider(&provider);
 
-            cast_send(
-                provider,
-                from,
-                to,
-                code,
-                sig,
-                args,
-                tx,
-                chain,
-                api_key,
-                cast_async,
-                confirmations,
-                to_json,
-                blob_data,
-            )
-            .await
+            let tx = builder.build(from).await?;
+
+            cast_send(provider, tx, cast_async, confirmations, to_json).await
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn cast_send<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
     provider: P,
-    from: Address,
-    to: Option<Address>,
-    code: Option<String>,
-    sig: Option<String>,
-    args: Vec<String>,
-    tx: TransactionOpts,
-    chain: Chain,
-    etherscan_api_key: Option<String>,
+    tx: WithOtherFields<TransactionRequest>,
     cast_async: bool,
     confs: u64,
     to_json: bool,
-    blob_data: Option<Vec<u8>>,
 ) -> Result<()> {
-    let (tx, _) =
-        tx::build_tx(&provider, from, to, code, sig, args, tx, chain, etherscan_api_key, blob_data)
-            .await?;
-
     let cast = Cast::new(provider);
     let pending_tx = cast.send(tx).await?;
 

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -1,14 +1,16 @@
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
-use alloy_json_abi::Function;
 use alloy_network::{AnyNetwork, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, TxKind};
 use alloy_provider::Provider;
 use alloy_rpc_types::{TransactionRequest, WithOtherFields};
 use alloy_transport::Transport;
 use eyre::Result;
-use foundry_cli::{opts::TransactionOpts, utils::parse_function_args};
+use foundry_cli::{
+    opts::TransactionOpts,
+    utils::{self, parse_function_args},
+};
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Chain;
+use foundry_config::{Chain, Config};
 
 /// Prevents a misconfigured hwlib from sending a transaction that defies user-specified --from
 pub fn validate_from_address(
@@ -30,116 +32,226 @@ corresponds to the sender, or let foundry automatically detect it by not specify
 }
 
 /// Ensures the transaction is either a contract deployment or a recipient address is specified
-pub fn validate_to_address(code: &Option<String>, to: &Option<NameOrAddress>) -> Result<()> {
-    if code.is_none() && to.is_none() {
+pub async fn resolve_tx_kind<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
+    provider: &P,
+    code: &Option<String>,
+    to: &Option<NameOrAddress>,
+) -> Result<TxKind> {
+    if code.is_some() {
+        Ok(TxKind::Create)
+    } else if let Some(to) = to {
+        Ok(TxKind::Call(to.resolve(provider).await?))
+    } else {
         eyre::bail!("Must specify a recipient address or contract code to deploy");
     }
-    Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn build_tx<
+/// Initial state.
+pub struct InitState;
+
+/// State with known [TxKind].
+pub struct TxKindState {
+    kind: TxKind,
+}
+
+/// State with known input for the transaction.
+pub struct InputState {
+    kind: TxKind,
+    input: Vec<u8>,
+}
+
+pub struct CastTxBuilder<T, P, S> {
+    provider: P,
+    tx: WithOtherFields<TransactionRequest>,
+    legacy: bool,
+    blob: bool,
+    chain: Chain,
+    etherscan_api_key: Option<String>,
+    state: S,
+    _t: std::marker::PhantomData<T>,
+}
+
+impl<T, P> CastTxBuilder<T, P, InitState>
+where
     P: Provider<T, AnyNetwork>,
     T: Transport + Clone,
-    F: Into<NameOrAddress>,
-    TO: Into<NameOrAddress>,
->(
-    provider: &P,
-    from: F,
-    to: Option<TO>,
-    code: Option<String>,
-    sig: Option<String>,
-    args: Vec<String>,
-    tx: TransactionOpts,
-    chain: impl Into<Chain>,
-    etherscan_api_key: Option<String>,
-    blob_data: Option<Vec<u8>>,
-) -> Result<(WithOtherFields<TransactionRequest>, Option<Function>)> {
-    let chain = chain.into();
+{
+    pub async fn new(provider: P, tx_opts: TransactionOpts, config: &Config) -> Result<Self> {
+        let mut tx = WithOtherFields::<TransactionRequest>::default();
 
-    let from = from.into().resolve(provider).await?;
+        let chain = utils::get_chain(config.chain, &provider).await?;
+        let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
 
-    let sidecar = blob_data
-        .map(|data| {
-            let mut coder = SidecarBuilder::<SimpleCoder>::default();
-            coder.ingest(&data);
-            coder.build()
-        })
-        .transpose()?;
-
-    let mut req = WithOtherFields::<TransactionRequest>::default()
-        .with_from(from)
-        .with_value(tx.value.unwrap_or_default())
-        .with_chain_id(chain.id());
-
-    if let Some(sidecar) = sidecar {
-        req.set_blob_sidecar(sidecar);
-        req.populate_blob_hashes();
-        req.set_max_fee_per_blob_gas(
-            // If blob_base_fee is 0, uses 1 wei as minimum.
-            tx.blob_gas_price.map_or(provider.get_blob_base_fee().await?.max(1), |g| g.to()),
-        );
-    }
-
-    if let Some(to) = to {
-        req.set_to(to.into().resolve(provider).await?);
-    } else {
-        req.set_kind(alloy_primitives::TxKind::Create);
-    }
-
-    req.set_nonce(if let Some(nonce) = tx.nonce {
-        nonce.to()
-    } else {
-        provider.get_transaction_count(from).await?
-    });
-
-    if tx.legacy || chain.is_legacy() {
-        req.set_gas_price(if let Some(gas_price) = tx.gas_price {
-            gas_price.to()
-        } else {
-            provider.get_gas_price().await?
-        });
-    } else {
-        let (max_fee, priority_fee) = match (tx.gas_price, tx.priority_gas_price) {
-            (Some(gas_price), Some(priority_gas_price)) => (gas_price, priority_gas_price),
-            (_, _) => {
-                let estimate = provider.estimate_eip1559_fees(None).await?;
-                (
-                    tx.gas_price.unwrap_or(U256::from(estimate.max_fee_per_gas)),
-                    tx.priority_gas_price.unwrap_or(U256::from(estimate.max_priority_fee_per_gas)),
-                )
-            }
-        };
-
-        req.set_max_fee_per_gas(max_fee.to());
-        req.set_max_priority_fee_per_gas(priority_fee.to());
-    }
-
-    let params = sig.as_deref().map(|sig| (sig, args));
-    let (data, func) = if let Some(code) = code {
-        let mut data = hex::decode(code)?;
-
-        if let Some((sig, args)) = params {
-            let (mut sigdata, _) =
-                parse_function_args(sig, args, None, chain, provider, etherscan_api_key.as_deref())
-                    .await?;
-            data.append(&mut sigdata);
+        if let Some(gas_limit) = tx_opts.gas_limit {
+            tx.set_gas_limit(gas_limit.to());
         }
 
-        (data, None)
-    } else if let Some((sig, args)) = params {
-        parse_function_args(sig, args, None, chain, provider, etherscan_api_key.as_deref()).await?
-    } else {
-        (Vec::new(), None)
-    };
+        if let Some(value) = tx_opts.value {
+            tx.set_value(value);
+        }
 
-    req.set_input::<Bytes>(data.into());
+        if let Some(gas_price) = tx_opts.gas_price {
+            if tx_opts.legacy {
+                tx.set_gas_price(gas_price.to());
+            } else {
+                tx.set_max_fee_per_gas(gas_price.to());
+            }
+        }
 
-    req.set_gas_limit(if let Some(gas_limit) = tx.gas_limit {
-        gas_limit.to()
-    } else {
-        provider.estimate_gas(&req).await?
-    });
+        if !tx_opts.legacy {
+            if let Some(priority_fee) = tx_opts.priority_gas_price {
+                tx.set_max_priority_fee_per_gas(priority_fee.to());
+            }
+        }
 
-    Ok((req, func))
+        if let Some(max_blob_fee) = tx_opts.blob_gas_price {
+            tx.set_max_fee_per_blob_gas(max_blob_fee.to())
+        }
+
+        if let Some(nonce) = tx_opts.nonce {
+            tx.set_nonce(nonce.to());
+        }
+
+        Ok(Self {
+            provider,
+            tx,
+            legacy: tx_opts.legacy || chain.is_legacy(),
+            blob: tx_opts.blob,
+            chain,
+            etherscan_api_key,
+            state: InitState,
+            _t: std::marker::PhantomData,
+        })
+    }
+
+    pub fn with_tx_kind(self, kind: TxKind) -> CastTxBuilder<T, P, TxKindState> {
+        CastTxBuilder {
+            provider: self.provider,
+            tx: self.tx,
+            legacy: self.legacy,
+            blob: self.blob,
+            chain: self.chain,
+            etherscan_api_key: self.etherscan_api_key,
+            state: TxKindState { kind },
+            _t: self._t,
+        }
+    }
+}
+
+impl<T, P> CastTxBuilder<T, P, TxKindState>
+where
+    P: Provider<T, AnyNetwork>,
+    T: Transport + Clone,
+{
+    pub async fn with_code_sig_and_args(
+        self,
+        code: Option<String>,
+        sig: Option<String>,
+        args: Vec<String>,
+    ) -> Result<CastTxBuilder<T, P, InputState>> {
+        let mut args = if let Some(sig) = sig {
+            parse_function_args(
+                &sig,
+                args,
+                self.state.kind.to().cloned(),
+                self.chain,
+                &self.provider,
+                self.etherscan_api_key.as_deref(),
+            )
+            .await?
+            .0
+        } else {
+            Vec::new()
+        };
+
+        let input = if let Some(code) = code {
+            let mut code = hex::decode(code)?;
+            code.append(&mut args);
+            code
+        } else {
+            args
+        };
+
+        Ok(CastTxBuilder {
+            provider: self.provider,
+            tx: self.tx,
+            legacy: self.legacy,
+            blob: self.blob,
+            chain: self.chain,
+            etherscan_api_key: self.etherscan_api_key,
+            state: InputState { kind: self.state.kind, input },
+            _t: self._t,
+        })
+    }
+}
+
+impl<T, P> CastTxBuilder<T, P, InputState>
+where
+    P: Provider<T, AnyNetwork>,
+    T: Transport + Clone,
+{
+    pub async fn build(
+        mut self,
+        from: impl Into<NameOrAddress>,
+    ) -> Result<WithOtherFields<TransactionRequest>> {
+        let from = from.into().resolve(&self.provider).await?;
+
+        self.tx.set_kind(self.state.kind);
+        self.tx.set_input(self.state.input);
+        self.tx.set_from(from);
+        self.tx.set_chain_id(self.chain.id());
+
+        if self.legacy && self.tx.gas_price.is_none() {
+            self.tx.gas_price = Some(self.provider.get_gas_price().await?);
+        }
+
+        if self.blob && self.tx.max_fee_per_blob_gas.is_none() {
+            self.tx.max_fee_per_blob_gas = Some(self.provider.get_blob_base_fee().await?)
+        }
+
+        if !self.legacy &&
+            (self.tx.max_fee_per_gas.is_none() || self.tx.max_priority_fee_per_gas.is_none())
+        {
+            let estimate = self.provider.estimate_eip1559_fees(None).await?;
+
+            if !self.legacy {
+                if self.tx.max_fee_per_gas.is_none() {
+                    self.tx.max_fee_per_gas = Some(estimate.max_fee_per_gas);
+                }
+
+                if self.tx.max_priority_fee_per_gas.is_none() {
+                    self.tx.max_priority_fee_per_gas = Some(estimate.max_priority_fee_per_gas);
+                }
+            }
+        }
+
+        if self.tx.gas.is_none() {
+            self.tx.gas = Some(self.provider.estimate_gas(&self.tx).await?);
+        }
+
+        if self.tx.nonce.is_none() {
+            self.tx.nonce = Some(self.provider.get_transaction_count(from).await?);
+        }
+
+        Ok(self.tx)
+    }
+}
+
+impl<T, P, S> CastTxBuilder<T, P, S>
+where
+    P: Provider<T, AnyNetwork>,
+    T: Transport + Clone,
+{
+    pub fn with_blob_data(mut self, blob_data: Option<Vec<u8>>) -> Result<Self> {
+        let Some(blob_data) = blob_data else { return Ok(self) };
+
+        let mut coder = SidecarBuilder::<SimpleCoder>::default();
+        coder.ingest(&blob_data);
+        let sidecar = coder.build()?;
+
+        self.tx.set_blob_sidecar(sidecar);
+        self.tx.populate_blob_hashes();
+
+        Ok(self)
+    }
 }

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -47,19 +47,27 @@ pub async fn resolve_tx_kind<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
 }
 
 /// Initial state.
+#[derive(Debug)]
 pub struct InitState;
 
 /// State with known [TxKind].
+#[derive(Debug)]
 pub struct TxKindState {
     kind: TxKind,
 }
 
 /// State with known input for the transaction.
+#[derive(Debug)]
 pub struct InputState {
     kind: TxKind,
     input: Vec<u8>,
 }
 
+/// Builder type constructing [TransactionRequest] from cast send/mktx inputs.
+///
+/// It is implemented as a stateful builder with expected state transition of [InitState] ->
+/// [TxKindState] -> [InputState].
+#[derive(Debug)]
 pub struct CastTxBuilder<T, P, S> {
     provider: P,
     tx: WithOtherFields<TransactionRequest>,
@@ -126,6 +134,7 @@ where
         })
     }
 
+    /// Sets [TxKind] for this builder and changes state to [TxKindState].
     pub fn with_tx_kind(self, kind: TxKind) -> CastTxBuilder<T, P, TxKindState> {
         CastTxBuilder {
             provider: self.provider,
@@ -145,6 +154,7 @@ where
     P: Provider<T, AnyNetwork>,
     T: Transport + Clone,
 {
+    /// Accepts user-provided code, sig and args params and constructs calldata for the transaction. sig i
     pub async fn with_code_sig_and_args(
         self,
         code: Option<String>,

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -76,6 +76,8 @@ where
     P: Provider<T, AnyNetwork>,
     T: Transport + Clone,
 {
+    /// Creates a new instance of [CastTxBuilder] filling transaction with fields present in
+    /// provided [TransactionOpts].
     pub async fn new(provider: P, tx_opts: TransactionOpts, config: &Config) -> Result<Self> {
         let mut tx = WithOtherFields::<TransactionRequest>::default();
 
@@ -190,6 +192,7 @@ where
     P: Provider<T, AnyNetwork>,
     T: Transport + Clone,
 {
+    /// Builds tx from the [CastTxBuilder], filling missing fields (gas, gas_price, nonce).
     pub async fn build(
         mut self,
         from: impl Into<NameOrAddress>,

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -42,8 +42,8 @@ pub async fn parse_function_args<T: Transport + Clone, P: Provider<T, AnyNetwork
 
     let args = resolve_name_args(&args, provider).await;
 
-    if sig.starts_with("0x") {
-        return Ok((hex::decode(sig)?, None));
+    if let Ok(data) = hex::decode(sig) {
+        return Ok((data, None))
     }
 
     let func = if sig.contains('(') {


### PR DESCRIPTION
## Motivation

Refactor `build_tx` used in cast send and cast mktx

ref #7965
closes https://github.com/foundry-rs/foundry/issues/7959

## Solution

Implement `CastTxBuilder` as a replacement for `build_tx`.

It is implemented as a stateful builder because we require `tx_kind` to be known before resolving calldata.