### PR TITLE
feat(foundryup): robustness checks and shell improvements

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -34,14 +34,14 @@ main() {
         warn "unknown option: $1"
         usage
         exit 1
-    esac; shift
+    ;; esac; shift
   done
 
   # Print the banner after successfully parsing args
   banner
 
-  if [ -n "$FOUNDRYUP_PR" ]; then
-    if [ -z "$FOUNDRYUP_BRANCH" ]; then
+  if [ "$FOUNDRYUP_PR" != "" ]; then
+    if [ "$FOUNDRYUP_BRANCH" = "" ]; then
       FOUNDRYUP_BRANCH="refs/pull/$FOUNDRYUP_PR/head"
     else
       err "can't use --pr and --branch at the same time"
@@ -53,7 +53,7 @@ main() {
     need_cmd cargo
 
     # Ignore branches/versions as we do not want to modify local git state
-    if [ -n "$FOUNDRYUP_REPO" ] || [ -n "$FOUNDRYUP_BRANCH" ] || [ -n "$FOUNDRYUP_VERSION" ]; then
+    if [ "$FOUNDRYUP_REPO" != "" ] || [ "$FOUNDRYUP_BRANCH" != "" ] || [ "$FOUNDRYUP_VERSION" != "" ]; then
       warn "--branch, --version, and --repo arguments are ignored during local install"
     fi
 
@@ -86,7 +86,7 @@ main() {
     elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
       # Add v prefix
       FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
-      FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
+      FOUNDRYUP_TAG="$FOUNDRYUP_VERSION"
     fi
 
     say "installing foundry (version ${FOUNDRYUP_VERSION}, tag ${FOUNDRYUP_TAG})"
@@ -110,14 +110,14 @@ main() {
 
     uname_m=$(uname -m)
     ARCHITECTURE=$(tolower "${FOUNDRYUP_ARCH:-$uname_m}")
-    if [ "${ARCHITECTURE}" = "x86_64" ]; then
+    if [ "$ARCHITECTURE" = "x86_64" ]; then
       # Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
       if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
         ARCHITECTURE="arm64" # Rosetta.
       else
         ARCHITECTURE="amd64" # Intel.
       fi
-    elif [ "${ARCHITECTURE}" = "arm64" ] ||[ "${ARCHITECTURE}" = "aarch64" ] ; then
+    elif [ "$ARCHITECTURE" = "arm64" ] ||[ "$ARCHITECTURE" = "aarch64" ] ; then
       ARCHITECTURE="arm64" # Arm.
     else
       ARCHITECTURE="amd64" # Amd.
@@ -156,7 +156,7 @@ main() {
 
       # Check if the default path of the binary is not in FOUNDRY_BIN_DIR
       which_path="$(command -v "$bin" || true)"
-      if [ -n "$which_path" ] && [ "$which_path" != "$bin_path" ]; then
+      if [ "$which_path" != "" ] && [ "$which_path" != "$bin_path" ]; then
         warn ""
         cat 1>&2 <<EOF
 There are multiple binaries with the name '$bin' present in your 'PATH'.
@@ -191,7 +191,7 @@ EOF
     ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
 
     # If set, checkout specific commit from branch
-    if [ -n "$FOUNDRYUP_COMMIT" ]; then
+    if [ "$FOUNDRYUP_COMMIT" != "" ]; then
       say "installing at commit $FOUNDRYUP_COMMIT"
       ensure git checkout "$FOUNDRYUP_COMMIT"
     fi
@@ -199,7 +199,7 @@ EOF
     # Build the repo and install the binaries locally to the .foundry bin directory.
     ensure cargo build --bins --release
     for bin in "${BINS[@]}"; do
-      for try_path in target/release/$bin target/release/$bin.exe; do
+      for try_path in target/release/"$bin" target/release/"$bin".exe; do
         if [ -f "$try_path" ]; then
           [ -e "$FOUNDRY_BIN_DIR/$bin" ] && warn "overwriting existing $bin in $FOUNDRY_BIN_DIR"
           mv -f "$try_path" "$FOUNDRY_BIN_DIR"
@@ -275,7 +275,7 @@ ensure() {
 
 # Downloads $1 into $2 or stdout
 download() {
-  if [ -n "$2" ]; then
+  if [ "$2" != "" ]; then
     # output into $2
     if check_cmd curl; then
       curl -#o "$2" -L "$1"

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
+# shellcheck shell=bash
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -10,155 +11,195 @@ BINS=(forge cast anvil chisel)
 
 export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=native}"
 
+check_bins_in_use() {
+	for bin in "${BINS[@]}"; do
+		if pgrep -x "$bin" >/dev/null; then
+			err "Error: '$bin' is currently running. Please stop the process and try again."
+		fi
+	done
+}
+
 main() {
-  need_cmd git
-  need_cmd curl
+	need_cmd git
+	need_cmd curl
 
-  while [[ -n $1 ]]; do
-    case $1 in
-      --)               shift; break;;
+	while [[ -n $1 ]]; do
+		case $1 in
+		--)
+			shift
+			break
+			;;
 
-      -r|--repo)        shift; FOUNDRYUP_REPO=$1;;
-      -b|--branch)      shift; FOUNDRYUP_BRANCH=$1;;
-      -v|--version)     shift; FOUNDRYUP_VERSION=$1;;
-      -p|--path)        shift; FOUNDRYUP_LOCAL_REPO=$1;;
-      -P|--pr)          shift; FOUNDRYUP_PR=$1;;
-      -C|--commit)      shift; FOUNDRYUP_COMMIT=$1;;
-      --arch)           shift; FOUNDRYUP_ARCH=$1;;
-      --platform)       shift; FOUNDRYUP_PLATFORM=$1;;
-      -h|--help)
-        usage
-        exit 0
-        ;;
-      *)
-        warn "unknown option: $1"
-        usage
-        exit 1
-    ;; esac; shift
-  done
+		-r | --repo)
+			shift
+			FOUNDRYUP_REPO=$1
+			;;
+		-b | --branch)
+			shift
+			FOUNDRYUP_BRANCH=$1
+			;;
+		-v | --version)
+			shift
+			FOUNDRYUP_VERSION=$1
+			;;
+		-p | --path)
+			shift
+			FOUNDRYUP_LOCAL_REPO=$1
+			;;
+		-P | --pr)
+			shift
+			FOUNDRYUP_PR=$1
+			;;
+		-C | --commit)
+			shift
+			FOUNDRYUP_COMMIT=$1
+			;;
+		--arch)
+			shift
+			FOUNDRYUP_ARCH=$1
+			;;
+		--platform)
+			shift
+			FOUNDRYUP_PLATFORM=$1
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			warn "unknown option: $1"
+			usage
+			exit 1
+			;;
+		esac
+		shift
+	done
 
-  # Print the banner after successfully parsing args
-  banner
+	# Print the banner after successfully parsing args
+	banner
 
-  if [ "$FOUNDRYUP_PR" != "" ]; then
-    if [ "$FOUNDRYUP_BRANCH" = "" ]; then
-      FOUNDRYUP_BRANCH="refs/pull/$FOUNDRYUP_PR/head"
-    else
-      err "can't use --pr and --branch at the same time"
-    fi
-  fi
+	if [ "$FOUNDRYUP_PR" != "" ]; then
+		if [ "$FOUNDRYUP_BRANCH" = "" ]; then
+			FOUNDRYUP_BRANCH="refs/pull/$FOUNDRYUP_PR/head"
+		else
+			err "can't use --pr and --branch at the same time"
+		fi
+	fi
 
-  # Installs foundry from a local repository if --path parameter is provided
-  if [[ -n "$FOUNDRYUP_LOCAL_REPO" ]]; then
-    need_cmd cargo
+	# Installs foundry from a local repository if --path parameter is provided
+	if [[ -n "$FOUNDRYUP_LOCAL_REPO" ]]; then
+		need_cmd cargo
 
-    # Ignore branches/versions as we do not want to modify local git state
-    if [ "$FOUNDRYUP_REPO" != "" ] || [ "$FOUNDRYUP_BRANCH" != "" ] || [ "$FOUNDRYUP_VERSION" != "" ]; then
-      warn "--branch, --version, and --repo arguments are ignored during local install"
-    fi
+		# Ignore branches/versions as we do not want to modify local git state
+		if [ "$FOUNDRYUP_REPO" != "" ] || [ "$FOUNDRYUP_BRANCH" != "" ] || [ "$FOUNDRYUP_VERSION" != "" ]; then
+			warn "--branch, --version, and --repo arguments are ignored during local install"
+		fi
 
-    # Enter local repo and build
-    say "installing from $FOUNDRYUP_LOCAL_REPO"
-    cd "$FOUNDRYUP_LOCAL_REPO"
-    ensure cargo build --bins --release # need 4 speed
+		# Enter local repo and build
+		say "installing from $FOUNDRYUP_LOCAL_REPO"
+		cd "$FOUNDRYUP_LOCAL_REPO"
+		ensure cargo build --bins --release # need 4 speed
 
-    for bin in "${BINS[@]}"; do
-      # Remove prior installations if they exist
-      rm -f "$FOUNDRY_BIN_DIR/$bin"
-      # Symlink from local repo binaries to bin dir
-      ensure ln -s "$PWD/target/release/$bin" "$FOUNDRY_BIN_DIR/$bin"
-    done
+		for bin in "${BINS[@]}"; do
+			# Check to make sure we are not running a foundry binary
+			check_bins_in_use
+			# Remove prior installations if they exist
+			rm -f "$FOUNDRY_BIN_DIR/$bin"
+			# Symlink from local repo binaries to bin dir
+			ensure ln -s "$PWD/target/release/$bin" "$FOUNDRY_BIN_DIR/$bin"
+		done
 
-    say "done"
-    exit 0
-  fi
+		say "done"
+		exit 0
+	fi
 
-  FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-foundry-rs/foundry}
+	FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-foundry-rs/foundry}
 
-  # Install by downloading binaries
-  if [[ "$FOUNDRYUP_REPO" == "foundry-rs/foundry" && -z "$FOUNDRYUP_BRANCH" && -z "$FOUNDRYUP_COMMIT" ]]; then
-    FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-nightly}
-    FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
+	# Install by downloading binaries
+	if [[ "$FOUNDRYUP_REPO" == "foundry-rs/foundry" && -z "$FOUNDRYUP_BRANCH" && -z "$FOUNDRYUP_COMMIT" ]]; then
+		FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-nightly}
+		FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
 
-    # Normalize versions (handle channels, versions without v prefix
-    if [[ "$FOUNDRYUP_VERSION" =~ ^nightly ]]; then
-      FOUNDRYUP_VERSION="nightly"
-    elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
-      # Add v prefix
-      FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
-      FOUNDRYUP_TAG="$FOUNDRYUP_VERSION"
-    fi
+		# Normalize versions (handle channels, versions without v prefix
+		if [[ "$FOUNDRYUP_VERSION" =~ ^nightly ]]; then
+			FOUNDRYUP_VERSION="nightly"
+		elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
+			# Add v prefix
+			FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
+			FOUNDRYUP_TAG="$FOUNDRYUP_VERSION"
+		fi
 
-    say "installing foundry (version ${FOUNDRYUP_VERSION}, tag ${FOUNDRYUP_TAG})"
+		say "installing foundry (version ${FOUNDRYUP_VERSION}, tag ${FOUNDRYUP_TAG})"
 
-    uname_s=$(uname -s)
-    PLATFORM=$(tolower "${FOUNDRYUP_PLATFORM:-$uname_s}")
-    EXT="tar.gz"
-    case $PLATFORM in
-      linux) ;;
-      darwin|mac*)
-        PLATFORM="darwin"
-        ;;
-      mingw*|win*)
-        EXT="zip"
-        PLATFORM="win32"
-        ;;
-      *)
-        err "unsupported platform: $PLATFORM"
-        ;;
-    esac
+		uname_s=$(uname -s)
+		PLATFORM=$(tolower "${FOUNDRYUP_PLATFORM:-$uname_s}")
+		EXT="tar.gz"
+		case $PLATFORM in
+		linux) ;;
+		darwin | mac*)
+			PLATFORM="darwin"
+			;;
+		mingw* | win*)
+			EXT="zip"
+			PLATFORM="win32"
+			;;
+		*)
+			err "unsupported platform: $PLATFORM"
+			;;
+		esac
 
-    uname_m=$(uname -m)
-    ARCHITECTURE=$(tolower "${FOUNDRYUP_ARCH:-$uname_m}")
-    if [ "$ARCHITECTURE" = "x86_64" ]; then
-      # Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
-      if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
-        ARCHITECTURE="arm64" # Rosetta.
-      else
-        ARCHITECTURE="amd64" # Intel.
-      fi
-    elif [ "$ARCHITECTURE" = "arm64" ] ||[ "$ARCHITECTURE" = "aarch64" ] ; then
-      ARCHITECTURE="arm64" # Arm.
-    else
-      ARCHITECTURE="amd64" # Amd.
-    fi
+		uname_m=$(uname -m)
+		ARCHITECTURE=$(tolower "${FOUNDRYUP_ARCH:-$uname_m}")
+		if [ "$ARCHITECTURE" = "x86_64" ]; then
+			# Redirect stderr to /dev/null to avoid printing errors if non Rosetta.
+			if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+				ARCHITECTURE="arm64" # Rosetta.
+			else
+				ARCHITECTURE="amd64" # Intel.
+			fi
+		elif [ "$ARCHITECTURE" = "arm64" ] || [ "$ARCHITECTURE" = "aarch64" ]; then
+			ARCHITECTURE="arm64" # Arm.
+		else
+			ARCHITECTURE="amd64" # Amd.
+		fi
 
-    # Compute the URL of the release tarball in the Foundry repository.
-    RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_TAG}/"
-    BIN_ARCHIVE_URL="${RELEASE_URL}foundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.$EXT"
-    MAN_TARBALL_URL="${RELEASE_URL}foundry_man_${FOUNDRYUP_VERSION}.tar.gz"
+		# Compute the URL of the release tarball in the Foundry repository.
+		RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_TAG}/"
+		BIN_ARCHIVE_URL="${RELEASE_URL}foundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.$EXT"
+		MAN_TARBALL_URL="${RELEASE_URL}foundry_man_${FOUNDRYUP_VERSION}.tar.gz"
 
-    # Download and extract the binaries archive
-    say "downloading latest forge, cast, anvil, and chisel"
-    if [ "$PLATFORM" = "win32" ]; then
-      tmp="$(mktemp -d 2>/dev/null || echo ".")/foundry.zip"
-      ensure download "$BIN_ARCHIVE_URL" "$tmp"
-      ensure unzip "$tmp" -d "$FOUNDRY_BIN_DIR"
-      rm -f "$tmp"
-    else
-      ensure download "$BIN_ARCHIVE_URL" | ensure tar -xzC "$FOUNDRY_BIN_DIR"
-    fi
+		# Download and extract the binaries archive
+		check_bins_in_use
+		say "downloading latest forge, cast, anvil, and chisel"
+		if [ "$PLATFORM" = "win32" ]; then
+			tmp="$(mktemp -d 2>/dev/null || echo ".")/foundry.zip"
+			ensure download "$BIN_ARCHIVE_URL" "$tmp"
+			ensure unzip "$tmp" -d "$FOUNDRY_BIN_DIR"
+			rm -f "$tmp"
+		else
+			ensure download "$BIN_ARCHIVE_URL" | ensure tar -xzC "$FOUNDRY_BIN_DIR"
+		fi
 
-    # Optionally download the manuals
-    if check_cmd tar; then
-      say "downloading manpages"
-      mkdir -p "$FOUNDRY_MAN_DIR"
-      download "$MAN_TARBALL_URL" | tar -xzC "$FOUNDRY_MAN_DIR"
-    else
-      say 'skipping manpage download: missing "tar"'
-    fi
+		# Optionally download the manuals
+		if check_cmd tar; then
+			say "downloading manpages"
+			mkdir -p "$FOUNDRY_MAN_DIR"
+			download "$MAN_TARBALL_URL" | tar -xzC "$FOUNDRY_MAN_DIR"
+		else
+			say 'skipping manpage download: missing "tar"'
+		fi
 
-    for bin in "${BINS[@]}"; do
-      bin_path="$FOUNDRY_BIN_DIR/$bin"
+		for bin in "${BINS[@]}"; do
+			bin_path="$FOUNDRY_BIN_DIR/$bin"
 
-      # Print installed msg
-      say "installed - $(ensure "$bin_path" --version)"
+			# Print installed msg
+			say "installed - $(ensure "$bin_path" --version)"
 
-      # Check if the default path of the binary is not in FOUNDRY_BIN_DIR
-      which_path="$(command -v "$bin" || true)"
-      if [ "$which_path" != "" ] && [ "$which_path" != "$bin_path" ]; then
-        warn ""
-        cat 1>&2 <<EOF
+			# Check if the default path of the binary is not in FOUNDRY_BIN_DIR
+			which_path="$(command -v "$bin" || true)"
+			if [ "$which_path" != "" ] && [ "$which_path" != "$bin_path" ]; then
+				warn ""
+				cat 1>&2 <<EOF
 There are multiple binaries with the name '$bin' present in your 'PATH'.
 This may be the result of installing '$bin' using another method,
 like Cargo or other package managers.
@@ -166,60 +207,60 @@ You may need to run 'rm $which_path' or move '$FOUNDRY_BIN_DIR'
 in your 'PATH' to allow the newly installed version to take precedence!
 
 EOF
-      fi
-    done
+			fi
+		done
 
-    say "done!"
+		say "done!"
 
-  # Install by cloning the repo with the provided branch/tag
-  else
-    need_cmd cargo
-    FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH:-master}
-    REPO_PATH="$FOUNDRY_DIR/$FOUNDRYUP_REPO"
+	# Install by cloning the repo with the provided branch/tag
+	else
+		need_cmd cargo
+		FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH:-master}
+		REPO_PATH="$FOUNDRY_DIR/$FOUNDRYUP_REPO"
 
-    # If repo path does not exist, grab the author from the repo, make a directory in .foundry, cd to it and clone.
-    if [ ! -d "$REPO_PATH" ]; then
-      AUTHOR="$(echo "$FOUNDRYUP_REPO" | cut -d'/' -f1 -)"
-      ensure mkdir -p "$FOUNDRY_DIR/$AUTHOR"
-      cd "$FOUNDRY_DIR/$AUTHOR"
-      ensure git clone "https://github.com/$FOUNDRYUP_REPO"
-    fi
+		# If repo path does not exist, grab the author from the repo, make a directory in .foundry, cd to it and clone.
+		if [ ! -d "$REPO_PATH" ]; then
+			AUTHOR="$(echo "$FOUNDRYUP_REPO" | cut -d'/' -f1 -)"
+			ensure mkdir -p "$FOUNDRY_DIR/$AUTHOR"
+			cd "$FOUNDRY_DIR/$AUTHOR"
+			ensure git clone "https://github.com/$FOUNDRYUP_REPO"
+		fi
 
-    # Force checkout, discarding any local changes
-    cd "$REPO_PATH"
-    ensure git fetch origin "${FOUNDRYUP_BRANCH}:remotes/origin/${FOUNDRYUP_BRANCH}"
-    ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
+		# Force checkout, discarding any local changes
+		cd "$REPO_PATH"
+		ensure git fetch origin "${FOUNDRYUP_BRANCH}:remotes/origin/${FOUNDRYUP_BRANCH}"
+		ensure git checkout "origin/${FOUNDRYUP_BRANCH}"
 
-    # If set, checkout specific commit from branch
-    if [ "$FOUNDRYUP_COMMIT" != "" ]; then
-      say "installing at commit $FOUNDRYUP_COMMIT"
-      ensure git checkout "$FOUNDRYUP_COMMIT"
-    fi
+		# If set, checkout specific commit from branch
+		if [ "$FOUNDRYUP_COMMIT" != "" ]; then
+			say "installing at commit $FOUNDRYUP_COMMIT"
+			ensure git checkout "$FOUNDRYUP_COMMIT"
+		fi
 
-    # Build the repo and install the binaries locally to the .foundry bin directory.
-    ensure cargo build --bins --release
-    for bin in "${BINS[@]}"; do
-      for try_path in target/release/"$bin" target/release/"$bin".exe; do
-        if [ -f "$try_path" ]; then
-          [ -e "$FOUNDRY_BIN_DIR/$bin" ] && warn "overwriting existing $bin in $FOUNDRY_BIN_DIR"
-          mv -f "$try_path" "$FOUNDRY_BIN_DIR"
-        fi
-      done
-    done
+		# Build the repo and install the binaries locally to the .foundry bin directory.
+		ensure cargo build --bins --release
+		for bin in "${BINS[@]}"; do
+			for try_path in target/release/"$bin" target/release/"$bin".exe; do
+				if [ -f "$try_path" ]; then
+					[ -e "$FOUNDRY_BIN_DIR/$bin" ] && warn "overwriting existing $bin in $FOUNDRY_BIN_DIR"
+					mv -f "$try_path" "$FOUNDRY_BIN_DIR"
+				fi
+			done
+		done
 
-    # If help2man is installed, use it to add Foundry man pages.
-    if check_cmd help2man; then
-      for bin in "${BINS[@]}"; do
-        help2man -N "$FOUNDRY_BIN_DIR/$bin" > "$FOUNDRY_MAN_DIR/$bin.1"
-      done
-    fi
+		# If help2man is installed, use it to add Foundry man pages.
+		if check_cmd help2man; then
+			for bin in "${BINS[@]}"; do
+				help2man -N "$FOUNDRY_BIN_DIR/$bin" >"$FOUNDRY_MAN_DIR/$bin.1"
+			done
+		fi
 
-    say "done"
-  fi
+		say "done"
+	fi
 }
 
 usage() {
-  cat 1>&2 <<EOF
+	cat 1>&2 <<EOF
 The installer for Foundry.
 
 Update or revert to a specific Foundry version with ease.
@@ -241,60 +282,60 @@ EOF
 }
 
 say() {
-  printf "foundryup: %s\n" "$1"
+	printf "foundryup: %s\n" "$1"
 }
 
 warn() {
-  say "warning: ${1}" >&2
+	say "warning: ${1}" >&2
 }
 
 err() {
-  say "$1" >&2
-  exit 1
+	say "$1" >&2
+	exit 1
 }
 
 tolower() {
-  echo "$1" | awk '{print tolower($0)}'
+	echo "$1" | awk '{print tolower($0)}'
 }
 
 need_cmd() {
-  if ! check_cmd "$1"; then
-    err "need '$1' (command not found)"
-  fi
+	if ! check_cmd "$1"; then
+		err "need '$1' (command not found)"
+	fi
 }
 
 check_cmd() {
-  command -v "$1" &>/dev/null
+	command -v "$1" >/dev/null 2>&1
 }
 
 # Run a command that should never fail. If the command fails execution
 # will immediately terminate with an error showing the failing command.
 ensure() {
-  if ! "$@"; then err "command failed: $*"; fi
+	if ! "$@"; then err "command failed: $*"; fi
 }
 
 # Downloads $1 into $2 or stdout
 download() {
-  if [ "$2" != "" ]; then
-    # output into $2
-    if check_cmd curl; then
-      curl -#o "$2" -L "$1"
-    else
-      wget --show-progress -qO "$2" "$1"
-    fi
-  else
-    # output to stdout
-    if check_cmd curl; then
-      curl -#L "$1"
-    else
-      wget --show-progress -qO- "$1"
-    fi
-  fi
+	if [ "$2" != "" ]; then
+		# output into $2
+		if check_cmd curl; then
+			curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
+		else
+			wget --https-only --secure-protocol=TLSv1_2 --show-progress -qO "$2" "$1"
+		fi
+	else
+		# output to stdout
+		if check_cmd curl; then
+			curl -#L "$1"
+		else
+			wget --show-progress -qO- "$1"
+		fi
+	fi
 }
 
 # Banner Function for Foundry
 banner() {
-  printf '
+	printf '
 
 .xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx.xOx
 
@@ -315,5 +356,4 @@ Contribute : https://github.com/orgs/foundry-rs/projects/2/
 '
 }
 
-
-main "$@"
+main "$@" || exit 1

--- a/foundryup/install
+++ b/foundryup/install
@@ -40,7 +40,7 @@ case $SHELL in
 *)
     echo "foundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
     exit 1
-esac
+;; esac
 
 # Only add foundryup if it isn't already in PATH.
 if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then

--- a/foundryup/install
+++ b/foundryup/install
@@ -22,40 +22,41 @@ mkdir -p "$FOUNDRY_MAN_DIR"
 # Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
 case $SHELL in
 */zsh)
-    PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
-    PREF_SHELL=zsh
-    ;;
+	PROFILE="${ZDOTDIR-"$HOME"}/.zshenv"
+	PREF_SHELL=zsh
+	;;
 */bash)
-    PROFILE=$HOME/.bashrc
-    PREF_SHELL=bash
-    ;;
+	PROFILE=$HOME/.bashrc
+	PREF_SHELL=bash
+	;;
 */fish)
-    PROFILE=$HOME/.config/fish/config.fish
-    PREF_SHELL=fish
-    ;;
+	PROFILE=$HOME/.config/fish/config.fish
+	PREF_SHELL=fish
+	;;
 */ash)
-    PROFILE=$HOME/.profile
-    PREF_SHELL=ash
-    ;;
+	PROFILE=$HOME/.profile
+	PREF_SHELL=ash
+	;;
 *)
-    echo "foundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
-    exit 1
-;; esac
+	echo "foundryup: could not detect shell, manually add ${FOUNDRY_BIN_DIR} to your PATH."
+	exit 1
+	;;
+esac
 
 # Only add foundryup if it isn't already in PATH.
 if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
-    # Add the foundryup directory to the path and ensure the old PATH variables remain.
-    # If the shell is fish, echo fish_add_path instead of export.
-    if [[ "$PREF_SHELL" == "fish" ]]; then
-        echo >> "$PROFILE" && echo "fish_add_path -a $FOUNDRY_BIN_DIR" >> "$PROFILE"
-    else
-        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> "$PROFILE"
-    fi
+	# Add the foundryup directory to the path and ensure the old PATH variables remain.
+	# If the shell is fish, echo fish_add_path instead of export.
+	if [[ "$PREF_SHELL" == "fish" ]]; then
+		echo >>"$PROFILE" && echo "fish_add_path -a $FOUNDRY_BIN_DIR" >>"$PROFILE"
+	else
+		echo >>"$PROFILE" && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >>"$PROFILE"
+	fi
 fi
 
 # Warn MacOS users that they may need to manually install libusb via Homebrew:
 if [[ "$OSTYPE" =~ ^darwin ]] && [[ ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib && ! -f /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
-    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
+	echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
 fi
 
 echo


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

foundryup is not robust.

make it robust.

## Solution

sanity checks and etc.

### `check_bins_in_use` 

Introduces a new function, `check_bins_in_use` which makes sure that something like `forge build -w` isn't running.

#### fix `check_cmd` 

also fixes `check_cmd` output


#### fix `curl`/`wget` 

enforce TLS v1.2 

> [!NOTE]
> `need_cmd curl` actually would prevent `wget` from running, as the script would error out and there is no if/else logic to fail over to using wget anyway.



