### PR TITLE
fix(fuzz): do not exceed configured runs

### DIFF
--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -149,6 +149,9 @@ impl TestOptions {
             failure_persistence: file_failure_persistence,
             cases,
             max_global_rejects: self.fuzz.max_test_rejects,
+            // Disable proptest shrink: for fuzz tests we provide single counterexample,
+            // for invariant tests we shrink outside proptest.
+            max_shrink_iters: 0,
             ..Default::default()
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #4139 

if I am not missing something here, there is no need to run additional shrinks for fuzz failed cases because
- for single standard fuzz test we already have the counterexample (one call) to break the test
- for invariant tests we do shrunk sequence outside proptest

`TestRunner.run` calls `TestRunner.run_in_process_with_replay` which in turn execute our test by calling `call_test`

https://github.com/proptest-rs/proptest/blob/63ef67c71ff050b473d2137fd3abce6115d0216b/proptest/src/test_runner/runner.rs#L713-L752

the result is matched and then shrunked in a loop until strategy cannot simplify it anymore or up to `max_shrink_iters` (since it is  not specified it defaults to `std::u32::MAX`)

https://github.com/proptest-rs/proptest/blob/63ef67c71ff050b473d2137fd3abce6115d0216b/proptest/src/test_runner/runner.rs#L734C13-L745

However at this point we already have the counterexample so this sequence is not necessary 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- create fuzzers with `max_shrink_iters` set to 0 to avoid unnecessary proptest shrink runs