### PR TITLE
fix(config): deprecated key warnings

### DIFF
--- a/crates/config/src/providers/mod.rs
+++ b/crates/config/src/providers/mod.rs
@@ -3,6 +3,7 @@ use figment::{
     value::{Dict, Map, Value},
     Error, Figment, Metadata, Profile, Provider,
 };
+use std::collections::BTreeMap;
 
 /// Remappings provider
 pub mod remappings;
@@ -43,15 +44,15 @@ impl<P> WarningsProvider<P> {
 impl<P: Provider> WarningsProvider<P> {
     /// Collects all warnings.
     pub fn collect_warnings(&self) -> Result<Vec<Warning>, Error> {
+        let data = self.provider.data().unwrap_or_default();
+
         let mut out = self.old_warnings.clone()?;
-        // add warning for unknown sections
+
+        // Add warning for unknown sections.
         out.extend(
-            self.provider
-                .data()
-                .unwrap_or_default()
-                .keys()
+            data.keys()
                 .filter(|k| {
-                    k != &Config::PROFILE_SECTION &&
+                    **k != Config::PROFILE_SECTION &&
                         !Config::STANDALONE_SECTIONS.iter().any(|s| s == k)
                 })
                 .map(|unknown_section| {
@@ -59,26 +60,33 @@ impl<P: Provider> WarningsProvider<P> {
                     Warning::UnknownSection { unknown_section: unknown_section.clone(), source }
                 }),
         );
-        // add warning for deprecated keys
-        out.extend(
-            self.provider
-                .data()
-                .unwrap_or_default()
-                .iter()
-                .flat_map(|(profile, dict)| dict.keys().map(move |key| format!("{profile}.{key}")))
-                .filter_map(|key| {
-                    DEPRECATIONS.iter().find_map(|(deprecated_key, new_value)| {
-                        if key == *deprecated_key {
-                            Some(Warning::DeprecatedKey {
-                                old: deprecated_key.to_string(),
-                                new: new_value.to_string(),
-                            })
-                        } else {
-                            None
-                        }
+
+        // Add warning for deprecated keys.
+        let deprecated_key_warning = |key| {
+            DEPRECATIONS.iter().find_map(|(deprecated_key, new_value)| {
+                if key == *deprecated_key {
+                    Some(Warning::DeprecatedKey {
+                        old: deprecated_key.to_string(),
+                        new: new_value.to_string(),
                     })
-                }),
+                } else {
+                    None
+                }
+            })
+        };
+        let profiles = data
+            .iter()
+            .filter(|(profile, _)| **profile == Config::PROFILE_SECTION)
+            .map(|(_, dict)| dict);
+        out.extend(profiles.clone().flat_map(BTreeMap::keys).filter_map(deprecated_key_warning));
+        out.extend(
+            profiles
+                .filter_map(|dict| dict.get(self.profile.as_str().as_str()))
+                .filter_map(Value::as_dict)
+                .flat_map(BTreeMap::keys)
+                .filter_map(deprecated_key_warning),
         );
+
         Ok(out)
     }
 }
@@ -91,6 +99,7 @@ impl<P: Provider> Provider for WarningsProvider<P> {
             Metadata::named("Warnings")
         }
     }
+
     fn data(&self) -> Result<Map<Profile, Dict>, Error> {
         Ok(Map::from([(
             self.profile.clone(),
@@ -100,6 +109,7 @@ impl<P: Provider> Provider for WarningsProvider<P> {
             )]),
         )]))
     }
+
     fn profile(&self) -> Option<Profile> {
         Some(self.profile.clone())
     }


### PR DESCRIPTION
1. it would literally try to match `"<profile>.<key>"`, which doesn't match any set deprecated key
2. it would not recurse into the current profile so `profile.default.cancun` never gets visited