### PR TITLE
feat: Vyper support for forge test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136f5e0af939b12cf072ac6577818a87cb7a408b269070f5d6f52ba23454660e"
+checksum = "8fbc0b5eaf47ad7ec2faef29289e1a1a05ad1550fa78e13fe902764dbf0db1fe"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -305,8 +305,8 @@ pub struct ContractSources {
 
 impl ContractSources {
     /// Collects the contract sources and artifacts from the project compile output.
-    pub fn from_project_output(
-        output: &ProjectCompileOutput,
+    pub fn from_project_output<E>(
+        output: &ProjectCompileOutput<E>,
         root: &Path,
         libraries: &Libraries,
     ) -> Result<ContractSources> {

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -26,7 +26,7 @@ impl NatSpec {
     /// Factory function that extracts a vector of [`NatSpec`] instances from
     /// a solc compiler output. The root path is to express contract base dirs.
     /// That is essential to match per-test configs at runtime.
-    pub fn parse(output: &ProjectCompileOutput, root: &Path) -> Vec<Self> {
+    pub fn parse<E>(output: &ProjectCompileOutput<E>, root: &Path) -> Vec<Self> {
         let mut natspecs: Vec<Self> = vec![];
 
         let solc = SolcParser::new();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -810,7 +810,7 @@ impl Config {
         compiler_config: CompilerConfig<C>,
         settings: C::Settings,
     ) -> Result<Project<C>, SolcError> {
-        let project = ProjectBuilder::<ConfigurableArtifacts, C>::new(Default::default())
+        let project = ProjectBuilder::<C>::new(Default::default())
             .artifacts(self.configured_artifacts_handler())
             .paths(self.project_paths())
             .settings(settings)
@@ -2797,6 +2797,24 @@ macro_rules! with_resolved_project {
             }
         }
     };
+}
+
+/// Helper trait to resolve project depending on [Compiler] generic.
+pub trait ResolveProject<C: Compiler> {
+    /// Returns configured project.
+    fn resolve_project(&self) -> Result<Project<C>, SolcError>;
+}
+
+impl ResolveProject<Solc> for Config {
+    fn resolve_project(&self) -> Result<Project<Solc>, SolcError> {
+        self.project()
+    }
+}
+
+impl ResolveProject<Vyper> for Config {
+    fn resolve_project(&self) -> Result<Project<Vyper>, SolcError> {
+        self.vyper_project()
+    }
 }
 
 #[cfg(test)]

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -90,7 +90,7 @@ impl BuildArgs {
         with_resolved_project!(config, |project| {
             let project = project?;
 
-            let filter = if let Some(ref skip) = self.skip {
+            let filter = if let Some(skip) = &self.skip {
                 if !skip.is_empty() {
                     let filter = SkipBuildFilters::new(skip.clone(), project.root().clone())?;
                     Some(filter)

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -161,6 +161,7 @@ impl TestArgs {
         let mut project = project.clone();
         *project.settings.output_selection_mut() =
             OutputSelection::common_output_selection(["abi".to_string()]);
+        project.no_artifacts = true;
 
         let output = project.compile_sparse(Box::new(filter.clone()))?;
 

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -45,8 +45,8 @@ pub struct TestOptions {
 impl TestOptions {
     /// Tries to create a new instance by detecting inline configurations from the project compile
     /// output.
-    pub fn new(
-        output: &ProjectCompileOutput,
+    pub fn new<E>(
+        output: &ProjectCompileOutput<E>,
         root: &Path,
         profiles: Vec<String>,
         base_fuzz: FuzzConfig,
@@ -201,9 +201,9 @@ impl TestOptionsBuilder {
     /// `root` is a reference to the user's project root dir. This is essential
     /// to determine the base path of generated contract identifiers. This is to provide correct
     /// matchers for inline test configs.
-    pub fn build(
+    pub fn build<E>(
         self,
-        output: &ProjectCompileOutput,
+        output: &ProjectCompileOutput<E>,
         root: &Path,
     ) -> Result<TestOptions, InlineConfigError> {
         let profiles: Vec<String> =

--- a/crates/forge/tests/it/cheats.rs
+++ b/crates/forge/tests/it/cheats.rs
@@ -4,14 +4,15 @@ use crate::{
     config::*,
     test_helpers::{
         ForgeTestData, RE_PATH_SEPARATOR, TEST_DATA_CANCUN, TEST_DATA_DEFAULT,
-        TEST_DATA_MULTI_VERSION,
+        TEST_DATA_MULTI_VERSION, TEST_DATA_VYPER,
     },
 };
+use foundry_compilers::compilers::Compiler;
 use foundry_config::{fs_permissions::PathPermission, FsPermissions};
 use foundry_test_utils::Filter;
 
 /// Executes all cheat code tests but not fork cheat codes or tests that require isolation mode
-async fn test_cheats_local(test_data: &ForgeTestData) {
+async fn test_cheats_local<C: Compiler>(test_data: &ForgeTestData<C>) {
     let mut filter = Filter::new(".*", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}*"))
         .exclude_paths("Fork")
         .exclude_contracts("Isolated");
@@ -57,4 +58,9 @@ async fn test_cheats_local_multi_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cheats_local_cancun() {
     test_cheats_local(&TEST_DATA_CANCUN).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cheats_local_vyper() {
+    test_cheats_local(&TEST_DATA_VYPER).await
 }

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -4,6 +4,7 @@ use forge::{
     result::{SuiteResult, TestStatus},
     MultiContractRunner,
 };
+use foundry_compilers::compilers::CompilationError;
 use foundry_evm::{
     decode::decode_console_logs,
     revm::primitives::SpecId,
@@ -15,18 +16,18 @@ use itertools::Itertools;
 use std::collections::BTreeMap;
 
 /// How to execute a test run.
-pub struct TestConfig {
-    pub runner: MultiContractRunner,
+pub struct TestConfig<E> {
+    pub runner: MultiContractRunner<E>,
     pub should_fail: bool,
     pub filter: Filter,
 }
 
-impl TestConfig {
-    pub fn new(runner: MultiContractRunner) -> Self {
+impl<E: CompilationError> TestConfig<E> {
+    pub fn new(runner: MultiContractRunner<E>) -> Self {
         Self::with_filter(runner, Filter::matches_all())
     }
 
-    pub fn with_filter(runner: MultiContractRunner, filter: Filter) -> Self {
+    pub fn with_filter(runner: MultiContractRunner<E>, filter: Filter) -> Self {
         init_tracing();
         Self { runner, should_fail: false, filter }
     }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -59,7 +59,7 @@ async fn repro_config(
     should_fail: bool,
     sender: Option<Address>,
     test_data: &ForgeTestData,
-) -> TestConfig {
+) -> TestConfig<foundry_compilers::artifacts::Error> {
     foundry_test_utils::init_tracing();
     let filter = Filter::path(&format!(".*repros/Issue{issue}.t.sol"));
 

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -79,7 +79,7 @@ impl ForgeTestProfile {
         SolcConfig::builder().settings(settings).build()
     }
 
-    pub fn test_opts<E>(&self, output: &ProjectCompileOutput<E>) -> TestOptions {
+    pub fn test_opts<E>(&self, output: &ProjectCompileOutput<E>, root: &Path) -> TestOptions {
         TestOptionsBuilder::default()
             .fuzz(FuzzConfig {
                 runs: 256,
@@ -113,7 +113,7 @@ impl ForgeTestProfile {
                 gas_report_samples: 256,
                 failure_persist_dir: Some(tempfile::tempdir().unwrap().into_path()),
             })
-            .build(output, &self.root())
+            .build(output, root)
             .expect("Config loaded")
     }
 
@@ -188,7 +188,7 @@ impl<C: Compiler> ForgeTestData<C> {
         let project = config.resolve_project().unwrap();
         let evm_opts = profile.evm_opts();
         let output = get_compiled(&project);
-        let test_opts = profile.test_opts(&output);
+        let test_opts = profile.test_opts(&output, project.root());
 
         Self { project, output, test_opts, evm_opts, config, profile }
     }

--- a/testdata/vyper/cheats/PrankTest.vy
+++ b/testdata/vyper/cheats/PrankTest.vy
@@ -1,0 +1,23 @@
+import Vm as Vm
+from . import PrankTest
+
+vm: constant(address) = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+
+@external
+def test_prank_simple(sender: address):
+    Vm(vm).startPrank(sender)
+    PrankTest(self).assert_sender(sender)
+
+@external
+def test_prank_with_origin(sender: address, origin: address):
+    Vm(vm).startPrank(sender, origin)
+    PrankTest(self).assert_sender(sender)
+    PrankTest(self).assert_origin(sender)
+
+@external
+def assert_sender(expected_sender: address):
+    Vm(vm).assertEq(msg.sender, expected_sender)
+
+@external
+def assert_origin(expected_sender: address):
+    Vm(vm).assertEq(msg.sender, expected_sender)

--- a/testdata/vyper/cheats/Vm.vy
+++ b/testdata/vyper/cheats/Vm.vy
@@ -1,0 +1,7 @@
+@external
+def startPrank(new_sender: address, new_origin: address = empty(address)):
+    pass
+
+@external
+def assertEq(left: address, right: address):
+    pass


### PR DESCRIPTION
## Motivation

Adds Vyper support for `forge test` and some tests for it.

## Solution

We should probably get rid of `CompilationError` generic on `ProjectCompileOutput` as it now ended up in `MultiContractRunner` and it doesn't make much sense there, though I think we'd have a compiler generic there at some point so should be OK to keep for now

CI will likely fail as no `vyper` is available, what's the right way to enable those tests? should we just download binary as it's done in compilers or we could inject it into CI env?

Closes https://github.com/foundry-rs/foundry/issues/5934