### PR TITLE
fix: unchecked getCode

### DIFF
--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -364,19 +364,22 @@ fn get_artifact_code(state: &Cheatcodes, path: &str, deployed: bool) -> Result<B
             return maybe_bytecode
                 .ok_or_else(|| fmt_err!("No bytecode for contract. Is it abstract or unlinked?"));
         } else {
-            match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
-                (Some(file), Some(contract_name)) => {
-                    PathBuf::from(format!("{file}/{contract_name}.json"))
-                }
-                (None, Some(contract_name)) => {
-                    PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
-                }
-                (Some(file), None) => {
-                    let name = file.replace(".sol", "");
-                    PathBuf::from(format!("{file}/{name}.json"))
-                }
-                _ => return Err(fmt_err!("Invalid artifact path")),
-            }
+            let path_in_artifacts =
+                match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
+                    (Some(file), Some(contract_name)) => {
+                        PathBuf::from(format!("{file}/{contract_name}.json"))
+                    }
+                    (None, Some(contract_name)) => {
+                        PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
+                    }
+                    (Some(file), None) => {
+                        let name = file.replace(".sol", "");
+                        PathBuf::from(format!("{file}/{name}.json"))
+                    }
+                    _ => return Err(fmt_err!("Invalid artifact path")),
+                };
+
+            state.config.paths.artifacts.join(path_in_artifacts)
         }
     };
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -881,7 +881,15 @@ impl Config {
                         version_manager.install(version)?
                     }
                 }
-                SolcReq::Local(solc) => Solc::new(solc)?,
+                SolcReq::Local(solc) => {
+                    if !solc.is_file() {
+                        return Err(SolcError::msg(format!(
+                            "`solc` {} does not exist",
+                            solc.display()
+                        )))
+                    }
+                    Solc::new(solc)?
+                }
             };
             return Ok(Some(solc))
         }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -363,7 +363,7 @@ contract Foo {}
 
     // fails to use solc that does not exist
     cmd.forge_fuse().args(["build", "--use", "this/solc/does/not/exist"]);
-    assert!(cmd.stderr_lossy().contains("No such file or directory"));
+    assert!(cmd.stderr_lossy().contains("`solc` this/solc/does/not/exist does not exist"));
 
     // `OTHER_SOLC_VERSION` was installed in previous step, so we can use the path to this directly
     let local_solc =

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -363,9 +363,7 @@ contract Foo {}
 
     // fails to use solc that does not exist
     cmd.forge_fuse().args(["build", "--use", "this/solc/does/not/exist"]);
-    assert!(cmd
-        .stderr_lossy()
-        .contains(r#""this/solc/does/not/exist": No such file or directory"#));
+    assert!(cmd.stderr_lossy().contains("No such file or directory"));
 
     // `OTHER_SOLC_VERSION` was installed in previous step, so we can use the path to this directly
     let local_solc =


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/7973

## Solution

With `unchecked_cheatcode_artifacts`, we are relying on old `getCode` behavior when `getCode("Contract")` is being mapped to artifact path in the form of `out/Contract.sol/Contract.json`. This logic is currently incorrect as we look for just `Contract.sol/Contract.json`
