### PR TITLE
fix(invariant) - do not panic when evm call fails

### DIFF
--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -77,11 +77,7 @@ pub fn replay_run(
     let invariant_result = executor.call_raw(
         CALLER,
         invariant_contract.address,
-        invariant_contract
-            .invariant_function
-            .abi_encode_input(&[])
-            .expect("invariant should have no inputs")
-            .into(),
+        invariant_contract.invariant_function.abi_encode_input(&[])?.into(),
         U256::ZERO,
     )?;
     traces.push((TraceKind::Execution, invariant_result.traces.clone().unwrap()));

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -64,7 +64,7 @@ pub(crate) fn assert_invariants(
     let mut call_result = executor.call_raw(
         CALLER,
         invariant_contract.address,
-        func.abi_encode_input(&[]).expect("invariant should have no inputs").into(),
+        func.abi_encode_input(&[])?.into(),
         U256::ZERO,
     )?;
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -674,9 +674,6 @@ pub struct RawCallResult {
     /// Scripted transactions generated from this call
     pub transactions: Option<BroadcastableTransactions>,
     /// The changeset of the state.
-    ///
-    /// This is only present if the changed state was not committed to the database (i.e. if you
-    /// used `call` and `call_raw` not `call_committing` or `call_raw_committing`).
     pub state_changeset: Option<StateChangeset>,
     /// The `revm::Env` after the call
     pub env: EnvWithHandlerCfg,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7308 

- fail test case instead panic if 
  - No input generated to call fuzzed target
  - Could not make raw evm call
- unwrap changeset and remove misleading comment: `state_changeset` is Some also when call is committed (`call_raw_committing` -> `call_raw_with_env` -> `convert_executed_result` which sets `state_changeset: Some(state_changeset)`)
- remove duped `expect("invariant should have no inputs")` as we already ensure no input when  `invariant_fuzz`
https://github.com/foundry-rs/foundry/blob/83e6aec038760a58dbab1acd992ed5ce18b9d90b/crates/evm/evm/src/executors/invariant/mod.rs#L138-L146

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
