### PR TITLE
fix(docker build): update index checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN [[ "$TARGETARCH" = "arm64" ]] && echo "export CFLAGS=-mno-outline-atomics" >
 WORKDIR /opt/foundry
 COPY . .
 
+# see <https://github.com/foundry-rs/foundry/issues/7925>
+RUN git update-index --force-write-index
+
 RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/opt/foundry/target \
     source $HOME/.profile && cargo build --release \
     && mkdir out \


### PR DESCRIPTION
Fixes https://github.com/foundry-rs/foundry/issues/7925

This is needed to ensure that we have computed the trailing checksum for the index. 
`index.skipHash=true` speeds up index writes by not computing a trailing checksum[^1].
This is a result of having `features.manyFiles` enabled and cargo computing this for fingerprint[^2].
 
Confirmed on macos-arm64 `ea2eff95b@master`
 
---
 [^1]: see <https://git-scm.com/docs/git-config#Documentation/git-config.txt-featuremanyFiles>
 [^2]: see <https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/fingerprint/index.html>