### PR TITLE
feat(anvil): support millisecond mining with correct block.timestamp

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -581,7 +581,7 @@ pub enum EthRequest {
         feature = "serde",
         serde(rename = "anvil_setBlockTimestampInterval", with = "sequence")
     )]
-    EvmSetBlockTimeStampInterval(u64),
+    EvmSetBlockTimeStampInterval(f64),
 
     /// Removes a `anvil_setBlockTimestampInterval` if it exists
     #[cfg_attr(

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1845,12 +1845,12 @@ impl EthApi {
         Ok(true)
     }
 
-    /// Sets an interval for the block timestamp
+    /// Sets an interval for the block timestamp in milliseconds
     ///
     /// Handler for RPC call: `anvil_setBlockTimestampInterval`
-    pub fn evm_set_block_timestamp_interval(&self, seconds: u64) -> Result<()> {
+    pub fn evm_set_block_timestamp_interval(&self, milliseconds: u64) -> Result<()> {
         node_info!("anvil_setBlockTimestampInterval");
-        self.backend.time().set_block_timestamp_interval(seconds);
+        self.backend.time().set_block_timestamp_interval(milliseconds);
         Ok(())
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1848,9 +1848,14 @@ impl EthApi {
     /// Sets an interval for the block timestamp in milliseconds
     ///
     /// Handler for RPC call: `anvil_setBlockTimestampInterval`
-    pub fn evm_set_block_timestamp_interval(&self, milliseconds: u64) -> Result<()> {
+    pub fn evm_set_block_timestamp_interval(&self, seconds: f64) -> Result<()> {
         node_info!("anvil_setBlockTimestampInterval");
-        self.backend.time().set_block_timestamp_interval(milliseconds);
+        if seconds == 0.0 {
+            return Err(BlockchainError::Message("interval cannot be zero".to_string()));
+        }
+        let dur = Duration::try_from_secs_f64(seconds)
+            .map_err(|_| BlockchainError::Message("Cannot convert f64 to Duration".to_string()))?;
+        self.backend.time().set_block_timestamp_interval(dur.as_millis() as u64);
         Ok(())
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -244,8 +244,10 @@ impl Backend {
             precompile_factory,
         };
 
-        if let Some(interval_block_time) = automine_block_time {
-            backend.update_interval_mine_block_time(interval_block_time);
+        if let Some(interval) = automine_block_time {
+            // Set interval in TimeManager as milliseconds.
+            backend.time.set_block_timestamp_interval((interval).as_millis().try_into().unwrap());
+            backend.update_interval_mine_block_time(interval);
         }
 
         // Note: this can only fail in forking mode, in which case we can't recover
@@ -944,7 +946,7 @@ impl Backend {
             env.block.number = env.block.number.saturating_add(U256::from(1));
             env.block.basefee = U256::from(current_base_fee);
             env.block.blob_excess_gas_and_price = current_excess_blob_gas_and_price;
-            env.block.timestamp = U256::from(self.time.next_timestamp());
+            env.block.timestamp = U256::from(self.time.next_timestamp_as_secs());
 
             let best_hash = self.blockchain.storage.read().best_hash;
 

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -129,13 +129,11 @@ impl TimeManager {
         let current = duration_since_unix_epoch().as_secs() as i128; // TODO(yash): Getting current time here as seconds.
         let last_timestamp = *self.last_timestamp.read();
 
-        // TODO(yash): NOTE - interval in the TimeManager is always None even if --block-time has
-        // been used.
         let interval = *self.interval.read();
         let (mut next_timestamp, update_offset) =
             if let Some(next) = *self.next_exact_timestamp.read() {
                 if update_wall {
-                    self.update_wall_clock_timestamp(next);
+                    self.update_wall_clock_timestamp(next * 1000); // Needs to be in ms
                 }
                 (next, true)
             } else if let Some(interval) = interval {
@@ -152,7 +150,7 @@ impl TimeManager {
             } else {
                 let next = current.saturating_add(self.offset()) as u64;
                 if update_wall {
-                    self.update_wall_clock_timestamp(next);
+                    self.update_wall_clock_timestamp(next * 1000); // Needs to be in ms
                 }
                 (next, false)
             };

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -85,7 +85,7 @@ impl TimeManager {
     /// Fails if it's before (or at the same time) the last timestamp
     pub fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), BlockchainError> {
         trace!(target: "time", "override next timestamp {}", timestamp);
-        if timestamp <= *self.last_timestamp.read() {
+        if timestamp < *self.last_timestamp.read() {
             return Err(BlockchainError::TimestampError(format!(
                 "{timestamp} is lower than or equal to previous block's timestamp"
             )))

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -358,8 +358,7 @@ async fn test_timestamp_interval() {
     let provider = handle.http_provider();
 
     api.evm_mine(None).await.unwrap();
-    let interval = 1000; // 1s
-    let interval_secs = (interval as f64 / 1000.0) as u64;
+    let interval: f64 = 1.0; // 1s
 
     for _ in 0..5 {
         let block = provider.get_block(BlockId::default(), false).await.unwrap().unwrap();
@@ -370,7 +369,7 @@ async fn test_timestamp_interval() {
 
         let new_block = provider.get_block(BlockId::default(), false).await.unwrap().unwrap();
 
-        assert_eq!(new_block.header.timestamp, block.header.timestamp + interval_secs);
+        assert_eq!(new_block.header.timestamp, block.header.timestamp + interval as u64);
     }
 
     let block = provider.get_block(BlockId::default(), false).await.unwrap().unwrap();
@@ -386,7 +385,7 @@ async fn test_timestamp_interval() {
 
     let block = provider.get_block(BlockId::default(), false).await.unwrap().unwrap();
     // interval also works after setting the next timestamp manually
-    assert_eq!(block.header.timestamp, next_timestamp + interval_secs);
+    assert_eq!(block.header.timestamp, next_timestamp + interval as u64);
 
     assert!(api.evm_remove_block_timestamp_interval().unwrap());
 
@@ -399,7 +398,7 @@ async fn test_timestamp_interval() {
     api.evm_mine(None).await.unwrap();
     let another_block = provider.get_block(BlockId::default(), false).await.unwrap().unwrap();
     // check interval is disabled
-    assert!(another_block.header.timestamp - new_block.header.timestamp < interval);
+    assert!(another_block.header.timestamp - new_block.header.timestamp <= interval as u64);
 }
 
 // <https://github.com/foundry-rs/foundry/issues/2341>

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -810,7 +810,7 @@ async fn test_fork_block_timestamp() {
     api.anvil_mine(Some(U256::from(1)), None).await.unwrap();
     let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
-    assert!(initial_block.header.timestamp < latest_block.header.timestamp);
+    assert!(initial_block.header.timestamp <= latest_block.header.timestamp);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #7931 
Closes https://github.com/foundry-rs/foundry/issues/9142

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds `wall_clock_timestamp` in `TimeManager` with millisecond precision. 
This `wall_clock_timestamp` is then used as a reference in interval mining to update the `next_timestamp`. 

Moreover, we now interpret `TimeManager.interval` as milliseconds instead of seconds. This brings breaking changes to the following anvil API method: `evm_set_block_timestamp_interval`.

Note: We still interpret `--block-time` from CLI as seconds. Hence, for millisecond mining user sets the `--block-time` as `0.05` or `0.75` etc.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
