### PR TITLE
feat(foundryup): add a `--jobs` flag while building from source

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -6,7 +6,7 @@ FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
-FOUNDRY_JOBS=$(nproc)
+FOUNDRYUP_JOBS=$(nproc)
 
 BINS=(forge cast anvil chisel)
 

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -6,6 +6,8 @@ FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
+FOUNDRY_JOBS=$(nproc)
+
 BINS=(forge cast anvil chisel)
 
 export RUSTFLAGS="${RUSTFLAGS:--C target-cpu=native}"
@@ -24,6 +26,7 @@ main() {
       -p|--path)        shift; FOUNDRYUP_LOCAL_REPO=$1;;
       -P|--pr)          shift; FOUNDRYUP_PR=$1;;
       -C|--commit)      shift; FOUNDRYUP_COMMIT=$1;;
+      -j|--jobs)        shift; FOUNDRYUP_JOBS=$1;;
       --arch)           shift; FOUNDRYUP_ARCH=$1;;
       --platform)       shift; FOUNDRYUP_PLATFORM=$1;;
       -h|--help)
@@ -60,7 +63,7 @@ main() {
     # Enter local repo and build
     say "installing from $FOUNDRYUP_LOCAL_REPO"
     cd "$FOUNDRYUP_LOCAL_REPO"
-    ensure cargo build --bins --release # need 4 speed
+    ensure cargo build --bins --release -j "$FOUNDRYUP_JOBS" # need 4 speed
 
     for bin in "${BINS[@]}"; do
       # Remove prior installations if they exist
@@ -197,7 +200,7 @@ EOF
     fi
 
     # Build the repo and install the binaries locally to the .foundry bin directory.
-    ensure cargo build --bins --release
+    ensure cargo build --bins --release -j "$FOUNDRYUP_JOBS"
     for bin in "${BINS[@]}"; do
       for try_path in target/release/$bin target/release/$bin.exe; do
         if [ -f "$try_path" ]; then
@@ -235,6 +238,7 @@ OPTIONS:
     -C, --commit    Install a specific commit
     -r, --repo      Install from a remote GitHub repo (uses default branch if no other options are set)
     -p, --path      Install a local repository
+    -j, --jobs      Number of CPUs to use for building Foundry (default: all CPUs)
     --arch          Install a specific architecture (supports amd64 and arm64)
     --platform      Install a specific platform (supports win32, linux, and darwin)
 EOF

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -227,17 +227,19 @@ The installer for Foundry.
 
 Update or revert to a specific Foundry version with ease.
 
+By default, the latest nightly version is installed from built binaries.
+
 USAGE:
     foundryup <OPTIONS>
 
 OPTIONS:
     -h, --help      Print help information
-    -v, --version   Install a specific version
-    -b, --branch    Install a specific branch
-    -P, --pr        Install a specific Pull Request
-    -C, --commit    Install a specific commit
-    -r, --repo      Install from a remote GitHub repo (uses default branch if no other options are set)
-    -p, --path      Install a local repository
+    -v, --version   Install a specific version from built binaries
+    -b, --branch    Build and install a specific branch
+    -P, --pr        Build and install a specific Pull Request
+    -C, --commit    Build and install a specific commit
+    -r, --repo      Build and install from a remote GitHub repo (uses default branch if no other options are set)
+    -p, --path      Build and install a local repository
     -j, --jobs      Number of CPUs to use for building Foundry (default: all CPUs)
     --arch          Install a specific architecture (supports amd64 and arm64)
     --platform      Install a specific platform (supports win32, linux, and darwin)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I needed to build foundry from an active PR. The build failed repeatedly on my machine due to overruns on system resources.

(Process expanded to eat all ram, eventual build failures or system crashes. Ubuntu 22, 16GB ram, for what it's worth). 

## Solution

I added a `--jobs` flag to foundryup, which is passed to the `cargo build` command. This is effectively a throttle on the build process. My local build worked fine after specifying `-j 2`. With no flag, foundryup uses `nproc` to recover the prior default behaviour of using all available CPUs.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Also, I clarified the `usage` string to indicate commands that build from source vs installing via compiled binaries.