### PR TITLE
feat: better run feedback for scripts

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -5,10 +5,8 @@ use cast::revm::primitives::EnvWithHandlerCfg;
 use clap::Parser;
 use eyre::{Result, WrapErr};
 use foundry_cli::{
-    init_progress,
     opts::RpcOpts,
-    update_progress,
-    utils::{handle_traces, TraceResult},
+    utils::{handle_traces, init_progress, TraceResult},
 };
 use foundry_common::{is_known_system_sender, SYSTEM_TRANSACTION_TYPE};
 use foundry_compilers::EvmVersion;
@@ -153,7 +151,7 @@ impl RunArgs {
             println!("Executing previous transactions from the block.");
 
             if let Some(block) = block {
-                let pb = init_progress!(block.transactions, "tx");
+                let pb = init_progress(block.transactions.len() as u64, "tx");
                 pb.set_position(0);
 
                 let BlockTransactions::Full(txs) = block.transactions else {
@@ -167,7 +165,7 @@ impl RunArgs {
                     if is_known_system_sender(tx.from) ||
                         tx.transaction_type == Some(SYSTEM_TRANSACTION_TYPE)
                     {
-                        update_progress!(pb, index);
+                        pb.set_position((index + 1) as u64);
                         continue;
                     }
                     if tx.hash == tx_hash {
@@ -202,7 +200,7 @@ impl RunArgs {
                         }
                     }
 
-                    update_progress!(pb, index);
+                    pb.set_position((index + 1) as u64);
                 }
             }
         }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -141,29 +141,20 @@ pub fn eta_key(state: &indicatif::ProgressState, f: &mut dyn Write) {
     write!(f, "{:.1}s", state.eta().as_secs_f64()).unwrap()
 }
 
-#[macro_export]
-macro_rules! init_progress {
-    ($local:expr, $label:expr) => {{
-        let pb = indicatif::ProgressBar::new($local.len() as u64);
-        let mut template =
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ".to_string();
-        template += $label;
-        template += " ({eta})";
-        pb.set_style(
-            indicatif::ProgressStyle::with_template(&template)
-                .unwrap()
-                .with_key("eta", $crate::utils::eta_key)
-                .progress_chars("#>-"),
-        );
-        pb
-    }};
-}
-
-#[macro_export]
-macro_rules! update_progress {
-    ($pb:ident, $index:expr) => {
-        $pb.set_position(($index + 1) as u64);
-    };
+pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
+    let pb = indicatif::ProgressBar::new(len);
+    let mut template =
+        "{prefix}{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} "
+            .to_string();
+    write!(template, "{}", label).unwrap();
+    template += " ({eta})";
+    pb.set_style(
+        indicatif::ProgressStyle::with_template(&template)
+            .unwrap()
+            .with_key("eta", crate::utils::eta_key)
+            .progress_chars("#>-"),
+    );
+    pb
 }
 
 /// True if the network calculates gas costs differently.

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,7 +1,7 @@
 use super::receipts;
 use crate::{
-    build::LinkedBuildData, sequence::ScriptSequenceKind, verify::BroadcastedState, ScriptArgs,
-    ScriptConfig,
+    build::LinkedBuildData, progress::ScriptProgress, sequence::ScriptSequenceKind,
+    verify::BroadcastedState, ScriptArgs, ScriptConfig,
 };
 use alloy_chains::Chain;
 use alloy_eips::eip2718::Encodable2718;
@@ -13,14 +13,8 @@ use alloy_transport::Transport;
 use eyre::{bail, Context, Result};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::ScriptWallets;
-use foundry_cli::{
-    init_progress, update_progress,
-    utils::{has_batch_support, has_different_gas_calc},
-};
-use foundry_common::{
-    provider::{get_http_provider, try_get_http_provider, RetryProvider},
-    shell,
-};
+use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
+use foundry_common::provider::{get_http_provider, try_get_http_provider, RetryProvider};
 use foundry_config::Config;
 use futures::{future::join_all, StreamExt};
 use itertools::Itertools;
@@ -160,14 +154,17 @@ pub struct BundledState {
 
 impl BundledState {
     pub async fn wait_for_pending(mut self) -> Result<Self> {
+        let progress = ScriptProgress::default();
+        let progress_ref = &progress;
         let futs = self
             .sequence
             .sequences_mut()
             .iter_mut()
-            .map(|sequence| async move {
+            .enumerate()
+            .map(|(sequence_idx, sequence)| async move {
                 let rpc_url = sequence.rpc_url();
                 let provider = Arc::new(get_http_provider(rpc_url));
-                receipts::wait_for_pending(provider, sequence).await
+                receipts::wait_for_pending(provider, sequence_idx, sequence, progress_ref).await
             })
             .collect::<Vec<_>>();
 
@@ -229,11 +226,15 @@ impl BundledState {
             SendTransactionsKind::Raw(signers)
         };
 
+        let progress = ScriptProgress::default();
+
         for i in 0..self.sequence.sequences().len() {
             let mut sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
             let provider = Arc::new(try_get_http_provider(sequence.rpc_url())?);
             let already_broadcasted = sequence.receipts.len();
+
+            let seq_progress = progress.get_sequence_progress(i, sequence);
 
             if already_broadcasted < sequence.transactions.len() {
                 let is_legacy = Chain::from(sequence.chain).is_legacy() || self.args.legacy;
@@ -313,8 +314,6 @@ impl BundledState {
                     send_kind.signers_count() != 1 ||
                     !has_batch_support(sequence.chain);
 
-                let pb = init_progress!(transactions, "txes");
-
                 // We send transactions and wait for receipts in batches.
                 let batch_size = if sequential_broadcast { 1 } else { self.args.batch_size };
                 let mut index = already_broadcasted;
@@ -322,11 +321,11 @@ impl BundledState {
                 for (batch_number, batch) in transactions.chunks(batch_size).enumerate() {
                     let mut pending_transactions = vec![];
 
-                    shell::println(format!(
-                        "##\nSending transactions [{} - {}].",
+                    seq_progress.inner.write().set_status(&format!(
+                        "Sending transactions [{} - {}]",
                         batch_number * batch_size,
                         batch_number * batch_size + std::cmp::min(batch_size, batch.len()) - 1
-                    ))?;
+                    ));
                     for (tx, kind, is_fixed_gas_limit) in batch {
                         let fut = send_transaction(
                             provider.clone(),
@@ -351,7 +350,7 @@ impl BundledState {
                             self.sequence.save(true, false)?;
                             sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
-                            update_progress!(pb, index - already_broadcasted);
+                            seq_progress.inner.write().tx_sent(tx_hash);
                             index += 1;
                         }
 
@@ -359,17 +358,15 @@ impl BundledState {
                         self.sequence.save(true, false)?;
                         sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
-                        shell::println("##\nWaiting for receipts.")?;
-                        receipts::clear_pendings(provider.clone(), sequence, None).await?;
+                        seq_progress.inner.write().set_status("Waiting for receipts");
+                        receipts::clear_pendings(provider.clone(), sequence, None, &seq_progress)
+                            .await?;
                     }
                     // Checkpoint save
                     self.sequence.save(true, false)?;
                     sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
                 }
             }
-
-            shell::println("\n\n==========================")?;
-            shell::println("\nONCHAIN EXECUTION COMPLETE & SUCCESSFUL.")?;
 
             let (total_gas, total_gas_price, total_paid) =
                 sequence.receipts.iter().fold((0, 0, 0), |acc, receipt| {
@@ -381,12 +378,13 @@ impl BundledState {
             let avg_gas_price = format_units(total_gas_price / sequence.receipts.len() as u128, 9)
                 .unwrap_or_else(|_| "N/A".to_string());
 
-            shell::println(format!(
-                "Total Paid: {} ETH ({} gas * avg {} gwei)",
+            seq_progress.inner.write().set_status(&format!(
+                "Total Paid: {} ETH ({} gas * avg {} gwei)\n",
                 paid.trim_end_matches('0'),
                 total_gas,
                 avg_gas_price.trim_end_matches('0').trim_end_matches('.')
-            ))?;
+            ));
+            seq_progress.inner.write().finish();
         }
 
         Ok(BroadcastedState {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -14,7 +14,10 @@ use eyre::{bail, Context, Result};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cheatcodes::ScriptWallets;
 use foundry_cli::utils::{has_batch_support, has_different_gas_calc};
-use foundry_common::provider::{get_http_provider, try_get_http_provider, RetryProvider};
+use foundry_common::{
+    provider::{get_http_provider, try_get_http_provider, RetryProvider},
+    shell,
+};
 use foundry_config::Config;
 use futures::{future::join_all, StreamExt};
 use itertools::Itertools;
@@ -386,6 +389,9 @@ impl BundledState {
             ));
             seq_progress.inner.write().finish();
         }
+
+        shell::println("\n\n==========================")?;
+        shell::println("\nONCHAIN EXECUTION COMPLETE & SUCCESSFUL.")?;
 
         Ok(BroadcastedState {
             args: self.args,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -51,6 +51,7 @@ mod broadcast;
 mod build;
 mod execute;
 mod multi_sequence;
+mod progress;
 mod providers;
 mod receipts;
 mod runner;

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -1,0 +1,156 @@
+use crate::sequence::ScriptSequence;
+use alloy_chains::Chain;
+use alloy_primitives::B256;
+use foundry_cli::init_progress;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use parking_lot::RwLock;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use yansi::Paint;
+
+/// State of [ProgressBar]s displayed for the given [ScriptSequence].
+#[derive(Debug)]
+pub struct SequenceProgressState {
+    /// The top spinner with containt of the format "Sequence #{id} on {network} | {status}""
+    top_spinner: ProgressBar,
+    /// Progress bar with the count of transactions.
+    txs: ProgressBar,
+    /// Progress var with the count of confirmed transactions.
+    receipts: ProgressBar,
+    /// Standalone spinners for pending transactions.
+    tx_spinners: HashMap<B256, ProgressBar>,
+    /// Copy of the main [MultiProgress] instance.
+    multi: MultiProgress,
+}
+
+impl SequenceProgressState {
+    pub fn new(sequence_idx: usize, sequence: &ScriptSequence, multi: MultiProgress) -> Self {
+        let mut template = "{spinner:.green}".to_string();
+        template.push_str(
+            format!(" Sequence #{} on {}", sequence_idx + 1, Chain::from(sequence.chain)).as_str(),
+        );
+        template.push_str("{msg}");
+
+        let top_spinner = ProgressBar::new_spinner()
+            .with_style(ProgressStyle::with_template(&template).unwrap().tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈✅"));
+        let top_spinner = multi.add(top_spinner);
+
+        let txs = multi.insert_after(
+            &top_spinner,
+            init_progress!(sequence.transactions, "txes").with_prefix("    "),
+        );
+
+        let receipts = multi.insert_after(
+            &txs,
+            init_progress!(sequence.transactions, "receipts").with_prefix("    "),
+        );
+
+        top_spinner.enable_steady_tick(Duration::from_millis(100));
+        txs.enable_steady_tick(Duration::from_millis(1000));
+        receipts.enable_steady_tick(Duration::from_millis(1000));
+
+        txs.set_position(sequence.receipts.len() as u64);
+        receipts.set_position(sequence.receipts.len() as u64);
+
+        let mut state = SequenceProgressState {
+            top_spinner,
+            txs,
+            receipts,
+            tx_spinners: Default::default(),
+            multi,
+        };
+
+        for tx_hash in sequence.pending.iter() {
+            state.tx_sent(*tx_hash);
+        }
+
+        state
+    }
+
+    /// Called when a new transaction is sent. Displays a spinner with a hash of the transaction and
+    /// advances the sent transactions progress bar.
+    pub fn tx_sent(&mut self, tx_hash: B256) {
+        // Avoid showing more than 10 spinners.
+        if self.tx_spinners.len() < 10 {
+            let spinner = ProgressBar::new_spinner()
+                .with_style(
+                    ProgressStyle::with_template("    {spinner:.green} {msg}")
+                        .unwrap()
+                        .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈"),
+                )
+                .with_message(format!("{} {}", "[Pending]".yellow(), tx_hash));
+
+            let spinner = self.multi.insert_before(&self.txs, spinner);
+            spinner.enable_steady_tick(Duration::from_millis(100));
+
+            self.tx_spinners.insert(tx_hash, spinner);
+        }
+        self.txs.inc(1);
+    }
+
+    /// Removes the pending transaction spinner and advances confirmed transactions progress bar.
+    pub fn finish_tx_spinner(&mut self, tx_hash: B256) {
+        if let Some(spinner) = self.tx_spinners.remove(&tx_hash) {
+            spinner.finish_and_clear();
+        }
+        self.receipts.inc(1);
+    }
+
+    /// Same as finish_tx_spinner but also prints a message to stdout above all other progress bars.
+    pub fn finish_tx_spinner_with_msg(&mut self, tx_hash: B256, msg: &str) -> std::io::Result<()> {
+        self.finish_tx_spinner(tx_hash);
+        self.multi.println(msg)?;
+
+        Ok(())
+    }
+
+    /// Sets status for the current sequence progress.
+    pub fn set_status(&mut self, status: &str) {
+        self.top_spinner.set_message(format!(" | {status}"));
+    }
+
+    /// Hides transactions and receipts progress bar, leaving only top line with the latest set
+    /// status.
+    pub fn finish(&self) {
+        self.top_spinner.finish();
+        self.txs.finish_and_clear();
+        self.receipts.finish_and_clear();
+    }
+}
+
+/// Clonable wrapper around [SequenceProgressState].
+#[derive(Debug, Clone)]
+pub struct SequenceProgress {
+    pub inner: Arc<RwLock<SequenceProgressState>>,
+}
+
+impl SequenceProgress {
+    pub fn new(sequence_idx: usize, sequence: &ScriptSequence, multi: MultiProgress) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(SequenceProgressState::new(sequence_idx, sequence, multi))),
+        }
+    }
+}
+
+/// Container for multiple [SequenceProgress] instances keyed by sequence index.
+#[derive(Debug, Clone, Default)]
+pub struct ScriptProgress {
+    state: Arc<RwLock<HashMap<usize, SequenceProgress>>>,
+    multi: MultiProgress,
+}
+
+impl ScriptProgress {
+    /// Returns a [SequenceProgress] instance for the given sequence index. If it doesn't exist,
+    /// creates one.
+    pub fn get_sequence_progress(
+        &self,
+        sequence_idx: usize,
+        sequence: &ScriptSequence,
+    ) -> SequenceProgress {
+        if let Some(progress) = self.state.read().get(&sequence_idx) {
+            return progress.clone();
+        }
+        let progress = SequenceProgress::new(sequence_idx, sequence, self.multi.clone());
+        self.state.write().insert(sequence_idx, progress.clone());
+        progress
+    }
+}

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,16 +1,12 @@
-use super::sequence::ScriptSequence;
-use crate::progress::{ScriptProgress, SequenceProgress};
 use alloy_chains::Chain;
 use alloy_primitives::{utils::format_units, TxHash, U256};
 use alloy_provider::{PendingTransactionBuilder, Provider};
 use alloy_rpc_types::AnyTransactionReceipt;
 use eyre::Result;
 use foundry_common::provider::RetryProvider;
-use futures::StreamExt;
-use std::sync::Arc;
 
 /// Convenience enum for internal signalling of transaction status
-enum TxStatus {
+pub enum TxStatus {
     Dropped,
     Success(AnyTransactionReceipt),
     Revert(AnyTransactionReceipt),
@@ -26,105 +22,9 @@ impl From<AnyTransactionReceipt> for TxStatus {
     }
 }
 
-/// Gets the receipts of previously pending transactions, or removes them from
-/// the deploy sequence's pending vector
-pub async fn wait_for_pending(
-    provider: Arc<RetryProvider>,
-    sequence_idx: usize,
-    deployment_sequence: &mut ScriptSequence,
-    progress: &ScriptProgress,
-) -> Result<()> {
-    if deployment_sequence.pending.is_empty() {
-        return Ok(());
-    }
-
-    let progress = progress.get_sequence_progress(sequence_idx, deployment_sequence);
-    progress.inner.write().set_status("Checking previously pending transactions");
-    clear_pendings(provider, deployment_sequence, None, &progress).await
-}
-
-/// Traverses a set of pendings and either finds receipts, or clears them from
-/// the deployment sequence.
-///
-/// If no `tx_hashes` are provided, then `deployment_sequence.pending` will be
-/// used. For each `tx_hash`, we check if it has confirmed. If it has
-/// confirmed, we push the receipt (if successful) or push an error (if
-/// revert). If the transaction has not confirmed, but can be found in the
-/// node's mempool, we wait for its receipt to be available. If the transaction
-/// has not confirmed, and cannot be found in the mempool, we remove it from
-/// the `deploy_sequence.pending` vector so that it will be rebroadcast in
-/// later steps.
-pub async fn clear_pendings(
-    provider: Arc<RetryProvider>,
-    deployment_sequence: &mut ScriptSequence,
-    tx_hashes: Option<Vec<TxHash>>,
-    progress: &SequenceProgress,
-) -> Result<()> {
-    let to_query = tx_hashes.unwrap_or_else(|| deployment_sequence.pending.clone());
-
-    let count = deployment_sequence.pending.len();
-
-    trace!("Checking status of {count} pending transactions");
-
-    let futs = to_query.iter().copied().map(|tx| check_tx_status(&provider, tx));
-    let mut tasks = futures::stream::iter(futs).buffer_unordered(10);
-
-    let mut errors: Vec<String> = vec![];
-
-    while let Some((tx_hash, result)) = tasks.next().await {
-        match result {
-            Err(err) => {
-                errors.push(format!("Failure on receiving a receipt for {tx_hash:?}:\n{err}"));
-
-                progress.inner.write().finish_tx_spinner(tx_hash);
-            }
-            Ok(TxStatus::Dropped) => {
-                // We want to remove it from pending so it will be re-broadcast.
-                deployment_sequence.remove_pending(tx_hash);
-                errors.push(format!("Transaction dropped from the mempool: {tx_hash:?}"));
-
-                progress.inner.write().finish_tx_spinner(tx_hash);
-            }
-            Ok(TxStatus::Success(receipt)) => {
-                trace!(tx_hash=?tx_hash, "received tx receipt");
-
-                let msg = format_receipt(deployment_sequence.chain.into(), &receipt);
-                progress.inner.write().finish_tx_spinner_with_msg(tx_hash, &msg)?;
-
-                deployment_sequence.remove_pending(receipt.transaction_hash);
-                deployment_sequence.add_receipt(receipt);
-            }
-            Ok(TxStatus::Revert(receipt)) => {
-                // consider:
-                // if this is not removed from pending, then the script becomes
-                // un-resumable. Is this desirable on reverts?
-                warn!(tx_hash=?tx_hash, "Transaction Failure");
-                deployment_sequence.remove_pending(receipt.transaction_hash);
-
-                let msg = format_receipt(deployment_sequence.chain.into(), &receipt);
-                progress.inner.write().finish_tx_spinner_with_msg(tx_hash, &msg)?;
-
-                errors.push(format!("Transaction Failure: {:?}", receipt.transaction_hash));
-            }
-        }
-    }
-
-    // print any errors
-    if !errors.is_empty() {
-        let mut error_msg = errors.join("\n");
-        if !deployment_sequence.pending.is_empty() {
-            error_msg += "\n\n Add `--resume` to your command to try and continue broadcasting
-    the transactions."
-        }
-        eyre::bail!(error_msg);
-    }
-
-    Ok(())
-}
-
 /// Checks the status of a txhash by first polling for a receipt, then for
 /// mempool inclusion. Returns the tx hash, and a status
-async fn check_tx_status(
+pub async fn check_tx_status(
     provider: &RetryProvider,
     hash: TxHash,
 ) -> (TxHash, Result<TxStatus, eyre::Report>) {


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8017

## Solution

Adds `ScriptProgress` managing multiple `SequenceProgress` instances drawing progress bars for sequences. 

Current structure should allow managing progress bars for concurrently sent sequences which is something I want to bring back at some point as https://github.com/foundry-rs/foundry/pull/6271 was a bit of an overkill imo (we can still deploy in parallel if no chain ids overlap)

## Example output

https://github.com/foundry-rs/foundry/assets/62447812/900905cb-1e16-4f76-a003-f643578d0da0


