### PR TITLE
refactor: deploy all libraries when running tests

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -536,11 +536,6 @@ impl Backend {
     /// This will also grant cheatcode access to the test account
     pub fn set_test_contract(&mut self, acc: Address) -> &mut Self {
         trace!(?acc, "setting test account");
-        // toggle the previous sender
-        if let Some(current) = self.inner.test_contract_address.take() {
-            self.remove_persistent_account(&current);
-            self.revoke_cheatcode_access(&acc);
-        }
 
         self.add_persistent_account(acc);
         self.allow_cheatcode_access(acc);

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -246,6 +246,8 @@ impl CoverageArgs {
             .set_coverage(true)
             .build(&root, output, env, evm_opts)?;
 
+        let known_contracts = runner.known_contracts.clone();
+
         let outcome = self
             .test
             .run_tests(runner, config.clone(), verbosity, &self.test.filter(&config))
@@ -257,12 +259,10 @@ impl CoverageArgs {
             for result in suite.test_results.values() {
                 let Some(hit_maps) = result.coverage.as_ref() else { continue };
                 for map in hit_maps.0.values() {
-                    if let Some((id, _)) =
-                        suite.known_contracts.find_by_deployed_code(&map.bytecode)
-                    {
+                    if let Some((id, _)) = known_contracts.find_by_deployed_code(&map.bytecode) {
                         hits.push((id, map, true));
                     } else if let Some((id, _)) =
-                        suite.known_contracts.find_by_creation_code(&map.bytecode)
+                        known_contracts.find_by_creation_code(&map.bytecode)
                     {
                         hits.push((id, map, false));
                     }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -399,7 +399,7 @@ impl TestArgs {
                 config.offline,
             )?);
         }
-        let mut decoder = builder.build();
+        let decoder = builder.build();
 
         // Run tests.
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -419,8 +419,7 @@ impl TestArgs {
         for (contract_name, suite_result) in rx {
             let tests = &suite_result.test_results;
 
-            // Clear the addresses and labels from previous tests.
-            decoder.clear_addresses();
+            let mut decoder = decoder.clone();
 
             // We identify addresses if we're going to print *any* trace or gas report.
             let identify_addresses = verbosity >= 3 || self.gas_report || self.debug.is_some();

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -1,11 +1,13 @@
 //! Forge test runner for multiple contracts.
 
-use crate::{result::SuiteResult, ContractRunner, TestFilter, TestOptions};
+use crate::{
+    result::SuiteResult, runner::LIBRARY_DEPLOYER, ContractRunner, TestFilter, TestOptions,
+};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_common::{get_contract_name, ContractsByArtifact, TestFunctionExt};
-use foundry_compilers::{artifacts::Libraries, Artifact, ArtifactId, ProjectCompileOutput, Solc};
+use foundry_compilers::{artifacts::Libraries, Artifact, ArtifactId, ProjectCompileOutput};
 use foundry_config::Config;
 use foundry_evm::{
     backend::Backend, decode::RevertDecoder, executors::ExecutorBuilder, fork::CreateFork,
@@ -27,8 +29,6 @@ use std::{
 pub struct TestContract {
     pub abi: JsonAbi,
     pub bytecode: Bytes,
-    pub libs_to_deploy: Vec<Bytes>,
-    pub libraries: Libraries,
 }
 
 pub type DeployableContracts = BTreeMap<ArtifactId, TestContract>;
@@ -61,8 +61,12 @@ pub struct MultiContractRunner {
     pub test_options: TestOptions,
     /// Whether to enable call isolation
     pub isolation: bool,
-    /// Output of the project compilation
-    pub output: ProjectCompileOutput,
+    /// Known contracts linked with computed library addresses.
+    pub known_contracts: ContractsByArtifact,
+    /// Libraries to deploy.
+    pub libs_to_deploy: Vec<Bytes>,
+    /// Library addresses used to link contracts.
+    pub libraries: Libraries,
 }
 
 impl MultiContractRunner {
@@ -181,17 +185,10 @@ impl MultiContractRunner {
         let identifier = artifact_id.identifier();
         let mut span_name = identifier.as_str();
 
-        let linker = Linker::new(
-            self.config.project_paths::<Solc>().root,
-            self.output.artifact_ids().collect(),
-        );
-        let linked_contracts = linker.get_linked_artifacts(&contract.libraries).unwrap_or_default();
-        let known_contracts = ContractsByArtifact::new(linked_contracts);
-
         let cheats_config = CheatsConfig::new(
             &self.config,
             self.evm_opts.clone(),
-            Some(known_contracts.clone()),
+            Some(self.known_contracts.clone()),
             None,
             Some(artifact_id.version.clone()),
         );
@@ -220,12 +217,13 @@ impl MultiContractRunner {
             &identifier,
             executor,
             contract,
+            &self.libs_to_deploy,
             self.evm_opts.initial_balance,
             self.sender,
             &self.revert_decoder,
             self.debug,
         );
-        let r = runner.run_tests(filter, &self.test_options, known_contracts, handle);
+        let r = runner.run_tests(filter, &self.test_options, self.known_contracts.clone(), handle);
 
         debug!(duration=?r.duration, "executed all tests in contract");
 
@@ -332,10 +330,19 @@ impl MultiContractRunnerBuilder {
             .filter_map(|(_, contract)| contract.abi.as_ref().map(|abi| abi.borrow()));
         let revert_decoder = RevertDecoder::new().with_abis(abis);
 
+        let LinkOutput { libraries, libs_to_deploy } = linker.link_with_nonce_or_address(
+            Default::default(),
+            LIBRARY_DEPLOYER,
+            0,
+            linker.contracts.keys(),
+        )?;
+
+        let linked_contracts = linker.get_linked_artifacts(&libraries)?;
+
         // Create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
 
-        for (id, contract) in linker.contracts.iter() {
+        for (id, contract) in linked_contracts.iter() {
             let Some(abi) = contract.abi.as_ref() else {
                 continue;
             };
@@ -344,34 +351,18 @@ impl MultiContractRunnerBuilder {
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                 abi.functions().any(|func| func.name.is_test() || func.name.is_invariant_test())
             {
-                let LinkOutput { libs_to_deploy, libraries } = linker.link_with_nonce_or_address(
-                    Default::default(),
-                    evm_opts.sender,
-                    1,
-                    id,
-                )?;
-
-                let linked_contract = linker.link(id, &libraries)?;
-
-                let Some(bytecode) = linked_contract
-                    .get_bytecode_bytes()
-                    .map(|b| b.into_owned())
-                    .filter(|b| !b.is_empty())
+                let Some(bytecode) =
+                    contract.get_bytecode_bytes().map(|b| b.into_owned()).filter(|b| !b.is_empty())
                 else {
                     continue;
                 };
 
-                deployable_contracts.insert(
-                    id.clone(),
-                    TestContract {
-                        abi: abi.clone().into_owned(),
-                        bytecode,
-                        libs_to_deploy,
-                        libraries,
-                    },
-                );
+                deployable_contracts
+                    .insert(id.clone(), TestContract { abi: abi.clone(), bytecode });
             }
         }
+
+        let known_contracts = ContractsByArtifact::new(linked_contracts);
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,
@@ -386,7 +377,9 @@ impl MultiContractRunnerBuilder {
             debug: self.debug,
             test_options: self.test_options.unwrap_or_default(),
             isolation: self.isolation,
-            output,
+            known_contracts,
+            libs_to_deploy,
+            libraries,
         })
     }
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -2,10 +2,7 @@
 
 use crate::gas_report::GasReport;
 use alloy_primitives::{Address, Log};
-use foundry_common::{
-    evm::Breakpoints, get_contract_name, get_file_name, shell, ContractsByArtifact,
-};
-use foundry_compilers::artifacts::Libraries;
+use foundry_common::{evm::Breakpoints, get_contract_name, get_file_name, shell};
 use foundry_evm::{
     coverage::HitMaps,
     debug::DebugArena,
@@ -196,13 +193,6 @@ pub struct SuiteResult {
     pub test_results: BTreeMap<String, TestResult>,
     /// Generated warnings.
     pub warnings: Vec<String>,
-    /// Libraries used to link test contract.
-    pub libraries: Libraries,
-    /// Contracts linked with correct libraries.
-    ///
-    /// This is cleared at the end of the test run if coverage is not enabled.
-    #[serde(skip)]
-    pub known_contracts: ContractsByArtifact,
 }
 
 impl SuiteResult {
@@ -210,17 +200,8 @@ impl SuiteResult {
         duration: Duration,
         test_results: BTreeMap<String, TestResult>,
         warnings: Vec<String>,
-        libraries: Libraries,
-        known_contracts: ContractsByArtifact,
     ) -> Self {
-        Self { duration, test_results, warnings, libraries, known_contracts }
-    }
-
-    /// Frees memory that is not used for the final output.
-    pub fn clear_unneeded(&mut self) {
-        if !self.test_results.values().any(|r| r.coverage.is_some()) {
-            ContractsByArtifact::clear(&mut self.known_contracts);
-        }
+        Self { duration, test_results, warnings }
     }
 
     /// Returns an iterator over all individual succeeding tests and their names.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -44,10 +44,10 @@ use std::{
 };
 
 /// When running tests, we deploy all external libraries present in the project. To avoid additional
-/// libraries affecting nonces of senders used in tests, we are using separsate address to
+/// libraries affecting nonces of senders used in tests, we are using separate address to
 /// predeploy libraries.
 ///
-/// address(uint160(uint256(keccak256("foundry library deployer"))))
+/// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
 /// A type that executes all tests of a contract

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloy_dyn_abi::DynSolValue;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{address, Address, Bytes, U256};
 use eyre::Result;
 use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
@@ -43,12 +43,21 @@ use std::{
     time::Instant,
 };
 
+/// When running tests, we deploy all external libraries present in the project. To avoid additional
+/// libraries affecting nonces of senders used in tests, we are using separsate address to
+/// predeploy libraries.
+///
+/// address(uint160(uint256(keccak256("foundry library deployer"))))
+pub const LIBRARY_DEPLOYER: Address = address!("1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
+
 /// A type that executes all tests of a contract
 #[derive(Clone, Debug)]
 pub struct ContractRunner<'a> {
     pub name: &'a str,
     /// The data of the contract being ran.
     pub contract: &'a TestContract,
+    /// The libraries that need to be deployed before the contract.
+    pub libs_to_deploy: &'a Vec<Bytes>,
     /// The executor used by the runner.
     pub executor: Executor,
     /// Revert decoder. Contains all known errors.
@@ -62,10 +71,12 @@ pub struct ContractRunner<'a> {
 }
 
 impl<'a> ContractRunner<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &'a str,
         executor: Executor,
         contract: &'a TestContract,
+        libs_to_deploy: &'a Vec<Bytes>,
         initial_balance: U256,
         sender: Option<Address>,
         revert_decoder: &'a RevertDecoder,
@@ -75,6 +86,7 @@ impl<'a> ContractRunner<'a> {
             name,
             executor,
             contract,
+            libs_to_deploy,
             initial_balance,
             sender: sender.unwrap_or_default(),
             revert_decoder,
@@ -104,11 +116,13 @@ impl<'a> ContractRunner<'a> {
         self.executor.set_nonce(self.sender, 1)?;
 
         // Deploy libraries
+        self.executor.set_balance(LIBRARY_DEPLOYER, U256::MAX)?;
+
         let mut logs = Vec::new();
-        let mut traces = Vec::with_capacity(self.contract.libs_to_deploy.len());
-        for code in self.contract.libs_to_deploy.iter() {
+        let mut traces = Vec::with_capacity(self.libs_to_deploy.len());
+        for code in self.libs_to_deploy.iter() {
             match self.executor.deploy(
-                self.sender,
+                LIBRARY_DEPLOYER,
                 code.clone(),
                 U256::ZERO,
                 Some(self.revert_decoder),
@@ -286,8 +300,6 @@ impl<'a> ContractRunner<'a> {
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
                     .into(),
                 warnings,
-                self.contract.libraries.clone(),
-                known_contracts,
             )
         }
 
@@ -324,8 +336,6 @@ impl<'a> ContractRunner<'a> {
                 )]
                 .into(),
                 warnings,
-                self.contract.libraries.clone(),
-                known_contracts,
             )
         }
 
@@ -383,13 +393,7 @@ impl<'a> ContractRunner<'a> {
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        let suite_result = SuiteResult::new(
-            duration,
-            test_results,
-            warnings,
-            self.contract.libraries.clone(),
-            known_contracts,
-        );
+        let suite_result = SuiteResult::new(duration, test_results, warnings);
         info!(
             duration=?suite_result.duration,
             "done. {}/{} successful",

--- a/crates/forge/tests/it/core.rs
+++ b/crates/forge/tests/it/core.rs
@@ -710,12 +710,12 @@ async fn test_trace() {
                 result.traces.iter().filter(|(kind, _)| *kind == TraceKind::Deployment);
             let setup_traces = result.traces.iter().filter(|(kind, _)| *kind == TraceKind::Setup);
             let execution_traces =
-                result.traces.iter().filter(|(kind, _)| *kind == TraceKind::Deployment);
+                result.traces.iter().filter(|(kind, _)| *kind == TraceKind::Execution);
 
             assert_eq!(
                 deployment_traces.count(),
-                1,
-                "Test {test_name} did not have exactly 1 deployment trace."
+                12,
+                "Test {test_name} did not have exactly 12 deployment trace."
             );
             assert!(setup_traces.count() <= 1, "Test {test_name} had more than 1 setup trace.");
             assert_eq!(

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -158,7 +158,7 @@ async fn test_persist_fuzz_failure() {
 async fn test_scrape_bytecode() {
     let filter = Filter::new(".*", ".*", ".*fuzz/FuzzScrapeBytecode.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options.fuzz.runs = 750;
+    runner.test_options.fuzz.runs = 2000;
     runner.test_options.fuzz.seed = Some(U256::from(6u32));
     let suite_result = runner.test_collect(&filter);
 

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -254,7 +254,7 @@ test_repro!(6501, false, None, |res| {
     assert_eq!(test.status, TestStatus::Success);
     assert_eq!(test.decoded_logs, ["a".to_string(), "1".to_string(), "b 2".to_string()]);
 
-    let (kind, traces) = test.traces[1].clone();
+    let (kind, traces) = test.traces.last().unwrap().clone();
     let nodes = traces.into_nodes();
     assert_eq!(kind, TraceKind::Execution);
 

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -138,14 +138,16 @@ impl<'a> Linker<'a> {
         libraries: Libraries,
         sender: Address,
         mut nonce: u64,
-        target: &'a ArtifactId,
+        targets: impl IntoIterator<Item = &'a ArtifactId>,
     ) -> Result<LinkOutput, LinkerError> {
         // Library paths in `link_references` keys are always stripped, so we have to strip
         // user-provided paths to be able to match them correctly.
         let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
 
         let mut needed_libraries = BTreeSet::new();
-        self.collect_dependencies(target, &mut needed_libraries)?;
+        for target in targets {
+            self.collect_dependencies(target, &mut needed_libraries)?;
+        }
 
         let mut libs_to_deploy = Vec::new();
 
@@ -324,7 +326,7 @@ mod tests {
             let linker = Linker::new(self.project.root(), self.output.artifact_ids().collect());
             for (id, identifier) in self.iter_linking_targets(&linker) {
                 let output = linker
-                    .link_with_nonce_or_address(Default::default(), sender, initial_nonce, id)
+                    .link_with_nonce_or_address(Default::default(), sender, initial_nonce, [id])
                     .expect("Linking failed");
                 self.validate_assertions(identifier, output);
             }

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -81,7 +81,7 @@ impl BuildData {
                 known_libraries,
                 script_config.evm_opts.sender,
                 script_config.sender_nonce,
-                &self.target,
+                [&self.target],
             )?;
 
             (output.libraries, ScriptPredeployLibraries::Default(output.libs_to_deploy))


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/1161 
Closes https://github.com/foundry-rs/foundry/issues/6120
Closes https://github.com/foundry-rs/foundry/issues/8014

Keeping #4049 open as this still won't work in scripts.

## Solution

Instead of linking each contract separately and keeping separate `libs_to_deploy` for each test contract we now link entire project output and keep single `libs_to_deploy` and `known_contracts`. That way, we reduce memory usage and by deploying all needed libraries unblock usage of `getCode`/`getDeployedCode` with artifacts requiring linking.

To avoid nonce of the `sender` being affected by the number of external libraries used in project, I've inroduced separate `LIBRARY_DEPLOYER` which deploys all libraries, that way, test contract will always have the same address regardless of the number of libraries it requires to run. 


