### PR TITLE
Fix shadowed branch coverage PC variable

### DIFF
--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -143,15 +143,15 @@ pub fn find_anchor_branch(
                 let push_bytes = &bytecode[push_bytes_start..push_bytes_start + push_size];
                 let mut pc_bytes = [0u8; 8];
                 pc_bytes[8 - push_size..].copy_from_slice(push_bytes);
-                let pc = u64::from_be_bytes(pc_bytes);
-                let pc = usize::try_from(pc).expect("PC is too big");
+                let pc_jump = u64::from_be_bytes(pc_bytes);
+                let pc_jump = usize::try_from(pc_jump).expect("PC is too big");
                 anchors = Some((
                     ItemAnchor {
                         item_id,
                         // The first branch is the opcode directly after JUMPI
                         instruction: pc + 2,
                     },
-                    ItemAnchor { item_id, instruction: pc },
+                    ItemAnchor { item_id, instruction: pc_jump },
                 ));
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

The refactor of coverage code (#8025) is casting a shadow over `pc` variable for the first branch and results in invalid branch coverage reports.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fix branch coverage reports.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Use a different name for the jump `pc` variable to prevent shadowing it for use in the first branch anchor.
