### PR TITLE
fix(forge): ensure contract managing fork is  persistent

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -62,6 +62,7 @@ impl Cheatcode for createSelectFork_2Call {
 impl Cheatcode for rollFork_0Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { blockNumber } = self;
+        ensure_persistent_caller(ccx);
         ccx.ecx.db.roll_fork(
             None,
             (*blockNumber).to(),
@@ -75,6 +76,7 @@ impl Cheatcode for rollFork_0Call {
 impl Cheatcode for rollFork_1Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { txHash } = self;
+        ensure_persistent_caller(ccx);
         ccx.ecx.db.roll_fork_to_transaction(
             None,
             *txHash,
@@ -88,6 +90,7 @@ impl Cheatcode for rollFork_1Call {
 impl Cheatcode for rollFork_2Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId, blockNumber } = self;
+        ensure_persistent_caller(ccx);
         ccx.ecx.db.roll_fork(
             Some(*forkId),
             (*blockNumber).to(),
@@ -101,6 +104,7 @@ impl Cheatcode for rollFork_2Call {
 impl Cheatcode for rollFork_3Call {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId, txHash } = self;
+        ensure_persistent_caller(ccx);
         ccx.ecx.db.roll_fork_to_transaction(
             Some(*forkId),
             *txHash,
@@ -114,6 +118,7 @@ impl Cheatcode for rollFork_3Call {
 impl Cheatcode for selectForkCall {
     fn apply_full<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { forkId } = self;
+        ensure_persistent_caller(ccx);
         check_broadcast(ccx.state)?;
 
         ccx.ecx.db.select_fork(*forkId, &mut ccx.ecx.env, &mut ccx.ecx.journaled_state)?;
@@ -334,6 +339,8 @@ fn create_fork_request<DB: DatabaseExt>(
     url_or_alias: &str,
     block: Option<u64>,
 ) -> Result<CreateFork> {
+    ensure_persistent_caller(ccx);
+
     let url = ccx.state.config.rpc_url(url_or_alias)?;
     let mut evm_opts = ccx.state.config.evm_opts.clone();
     evm_opts.fork_block_number = block;
@@ -353,5 +360,15 @@ fn check_broadcast(state: &Cheatcodes) -> Result<()> {
         Ok(())
     } else {
         Err(fmt_err!("cannot select forks during a broadcast"))
+    }
+}
+
+// Helper to ensure that the caller managing the fork is persistent.
+// Applies to create, select and roll forks actions.
+// https://github.com/foundry-rs/foundry/issues/8004
+#[inline]
+fn ensure_persistent_caller<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>) {
+    if !ccx.ecx.db.is_persistent(&ccx.caller) {
+        ccx.ecx.db.add_persistent_account(ccx.caller);
     }
 }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -329,3 +329,6 @@ test_repro!(7481);
 
 // https://github.com/foundry-rs/foundry/issues/5739
 test_repro!(5739);
+
+// https://github.com/foundry-rs/foundry/issues/8004
+test_repro!(8004);

--- a/testdata/default/repros/Issue8004.t.sol
+++ b/testdata/default/repros/Issue8004.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract NonPersistentHelper is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    uint256 public curState;
+
+    function createSelectFork() external {
+        vm.createSelectFork("rpcAlias");
+        curState += 1;
+    }
+
+    function createSelectForkAtBlock() external {
+        vm.createSelectFork("rpcAlias", 19000000);
+        curState += 1;
+    }
+
+    function createSelectForkAtTx() external {
+        vm.createSelectFork(
+            "rpcAlias", vm.parseBytes32("0xb5c978f15d01fcc9b4d78967e8189e35ecc21ff4e78315ea5d616f3467003c84")
+        );
+        curState += 1;
+    }
+
+    function selectFork(uint256 forkId) external {
+        vm.selectFork(forkId);
+        curState += 1;
+    }
+
+    function rollForkAtBlock() external {
+        vm.rollFork(19000000);
+        curState += 1;
+    }
+
+    function rollForkIdAtBlock(uint256 forkId) external {
+        vm.rollFork(forkId, 19000000);
+        curState += 1;
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/8004
+contract Issue8004CreateSelectForkTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    NonPersistentHelper helper;
+
+    function setUp() public {
+        helper = new NonPersistentHelper();
+    }
+
+    function testNonPersistentHelperCreateFork() external {
+        helper.createSelectFork();
+        assertEq(helper.curState(), 1);
+    }
+
+    function testNonPersistentHelperCreateForkAtBlock() external {
+        helper.createSelectForkAtBlock();
+        assertEq(helper.curState(), 1);
+    }
+
+    function testNonPersistentHelperCreateForkAtTx() external {
+        helper.createSelectForkAtBlock();
+        assertEq(helper.curState(), 1);
+    }
+
+    function testNonPersistentHelperSelectFork() external {
+        uint256 forkId = vm.createFork("rpcAlias");
+        helper.selectFork(forkId);
+        assertEq(helper.curState(), 1);
+    }
+}
+
+contract Issue8004RollForkTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    NonPersistentHelper helper;
+    uint256 forkId;
+
+    function setUp() public {
+        forkId = vm.createSelectFork("rpcAlias");
+        helper = new NonPersistentHelper();
+    }
+
+    function testNonPersistentHelperRollForkAtBlock() external {
+        helper.rollForkAtBlock();
+        assertEq(helper.curState(), 1);
+    }
+
+    function testNonPersistentHelperRollForkIdAtBlock() external {
+        helper.rollForkIdAtBlock(forkId);
+        assertEq(helper.curState(), 1);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #8004 

Test contract that manage forks (create / select / roll) should be made persistent, otherwise their state can be lost

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- ensure caller is persistent for create, select and roll fork cheatcodes