### PR TITLE
perf(fuzz): store dict values once, track newly inserted indexes

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -354,8 +354,8 @@ impl FuzzDictionary {
 
     pub fn revert(&mut self) {
         // Revert new values collected during the run.
-        for value_index in self.new_values.iter() {
-            self.state_values.swap_remove_index(value_index.to_owned());
+        for &value_index in &self.new_values {
+            self.state_values.swap_remove_index(value_index);
         }
         for address_index in self.new_addreses.iter() {
             self.addresses.swap_remove_index(address_index.to_owned());

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -357,8 +357,8 @@ impl FuzzDictionary {
         for &value_index in &self.new_values {
             self.state_values.swap_remove_index(value_index);
         }
-        for address_index in self.new_addreses.iter() {
-            self.addresses.swap_remove_index(address_index.to_owned());
+        for &address_index in &self.new_addreses {
+            self.addresses.swap_remove_index(address_index);
         }
 
         self.new_values.clear();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fuzz dict tracks newly collected values and addresses in order to remove them at the end of each invariant run. Since they are already inserted in index sets it can be optimized to record only the indexes of newly added values and swap them by index when run completed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
