### PR TITLE
perf: manually set code hash when inserting cheatcodes account

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -839,7 +839,7 @@ impl Backend {
 
         let db = self.db.read().await;
         let mut inspector = Inspector::default();
-        let mut evm = self.new_evm_with_inspector_ref(&*db, env, &mut inspector);
+        let mut evm = self.new_evm_with_inspector_ref(&**db, env, &mut inspector);
         let ResultAndState { result, state } = evm.transact()?;
         let (exit_reason, gas_used, out, logs) = match result {
             ExecutionResult::Success { reason, gas_used, logs, output, .. } => {

--- a/crates/evm/core/src/backend/in_memory_db.rs
+++ b/crates/evm/core/src/backend/in_memory_db.rs
@@ -29,6 +29,7 @@ impl Default for MemDb {
 
 impl DatabaseRef for MemDb {
     type Error = DatabaseError;
+
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         DatabaseRef::basic_ref(&self.inner, address)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -496,15 +496,11 @@ impl Backend {
         slot: U256,
         value: U256,
     ) -> Result<(), DatabaseError> {
-        let ret = if let Some(db) = self.active_fork_db_mut() {
+        if let Some(db) = self.active_fork_db_mut() {
             db.insert_account_storage(address, slot, value)
         } else {
             self.mem_db.insert_account_storage(address, slot, value)
-        };
-
-        debug_assert!(self.storage(address, slot).unwrap() == value);
-
-        ret
+        }
     }
 
     /// Completely replace an account's storage without overriding account info.
@@ -598,11 +594,11 @@ impl Backend {
     /// Instead, it stores whether an `assert` failed in a boolean variable that we can read
     pub fn is_failed_test_contract(&self, address: Address) -> bool {
         /*
-         contract DSTest {
+        contract DSTest {
             bool public IS_TEST = true;
             // slot 0 offset 1 => second byte of slot0
             bool private _failed;
-         }
+        }
         */
         let value = self.storage_ref(address, U256::ZERO).unwrap_or_default();
         value.as_le_bytes()[1] != 0
@@ -670,9 +666,8 @@ impl Backend {
         active_journaled_state: &mut JournaledState,
         target_fork: &mut Fork,
     ) {
-        if let Some((_, fork_idx)) = self.active_fork_ids.as_ref() {
-            let active = self.inner.get_fork(*fork_idx);
-            merge_account_data(accounts, &active.db, active_journaled_state, target_fork)
+        if let Some(db) = self.active_fork_db() {
+            merge_account_data(accounts, db, active_journaled_state, target_fork)
         } else {
             merge_account_data(accounts, &self.mem_db, active_journaled_state, target_fork)
         }
@@ -711,6 +706,24 @@ impl Backend {
     /// Returns the currently active `ForkDB`, if any
     pub fn active_fork_db_mut(&mut self) -> Option<&mut ForkDB> {
         self.active_fork_mut().map(|f| &mut f.db)
+    }
+
+    /// Returns the current database implementation as a `&dyn` value.
+    #[inline(always)]
+    pub fn db(&self) -> &dyn Database<Error = DatabaseError> {
+        match self.active_fork_db() {
+            Some(fork_db) => fork_db,
+            None => &self.mem_db,
+        }
+    }
+
+    /// Returns the current database implementation as a `&mut dyn` value.
+    #[inline(always)]
+    pub fn db_mut(&mut self) -> &mut dyn Database<Error = DatabaseError> {
+        match self.active_fork_ids.map(|(_, idx)| &mut self.inner.get_fork_mut(idx).db) {
+            Some(fork_db) => fork_db,
+            None => &mut self.mem_db,
+        }
     }
 
     /// Creates a snapshot of the currently active database

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -1,11 +1,19 @@
-use alloy_primitives::{address, hex, Address};
+use alloy_primitives::{address, b256, hex, Address, B256};
 
 /// The cheatcode handler address.
 ///
 /// This is the same address as the one used in DappTools's HEVM.
-/// It is calculated as:
+///
+/// This is calculated as:
 /// `address(bytes20(uint160(uint256(keccak256('hevm cheat code')))))`
 pub const CHEATCODE_ADDRESS: Address = address!("7109709ECfa91a80626fF3989D68f67F5b1DD12D");
+
+/// The contract hash at [`CHEATCODE_ADDRESS`].
+///
+/// This is calculated as:
+/// `keccak256(abi.encodePacked(CHEATCODE_ADDRESS))`.
+pub const CHEATCODE_CONTRACT_HASH: B256 =
+    b256!("b0450508e5a2349057c3b4c9c84524d62be4bb17e565dbe2df34725a26872291");
 
 /// The Hardhat console address.
 ///

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -235,9 +235,21 @@ where
     DB: revm::Database,
     I: InspectorExt<DB>,
 {
+    let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
+
     // NOTE: We could use `revm::Evm::builder()` here, but on the current patch it has some
     // performance issues.
-    let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
+    /*
+    revm::Evm::builder()
+        .with_db(db)
+        .with_env(env)
+        .with_external_context(inspector)
+        .with_handler_cfg(handler_cfg)
+        .append_handler_register(revm::inspector_handle_register)
+        .append_handler_register(create2_handler_register)
+        .build()
+    */
+
     let context = revm::Context::new(revm::EvmContext::new_with_env(db, env), inspector);
     let mut handler = revm::Handler::new(handler_cfg);
     handler.append_handler_register_plain(revm::inspector_handle_register);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -235,7 +235,7 @@ impl<'a> InvariantExecutor<'a> {
                     // Collect data for fuzzing from the state changeset.
                     let mut state_changeset = call_result.state_changeset.to_owned().unwrap();
 
-                    if !&call_result.reverted {
+                    if !call_result.reverted {
                         collect_data(
                             &mut state_changeset,
                             &targeted_contracts,

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -16,7 +16,8 @@ use alloy_sol_types::{sol, SolCall};
 use foundry_evm_core::{
     backend::{Backend, CowBackend, DatabaseError, DatabaseExt, DatabaseResult},
     constants::{
-        CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, DEFAULT_CREATE2_DEPLOYER_CODE,
+        CALLER, CHEATCODE_ADDRESS, CHEATCODE_CONTRACT_HASH, DEFAULT_CREATE2_DEPLOYER,
+        DEFAULT_CREATE2_DEPLOYER_CODE,
     },
     debug::DebugArena,
     decode::RevertDecoder,
@@ -93,6 +94,9 @@ impl Executor {
             CHEATCODE_ADDRESS,
             revm::primitives::AccountInfo {
                 code: Some(Bytecode::new_raw(Bytes::from_static(&[0]))),
+                // Also set the code hash manually so that it's not computed later.
+                // The code hash value does not matter, as long as it's not zero or `KECCAK_EMPTY`.
+                code_hash: CHEATCODE_CONTRACT_HASH,
                 ..Default::default()
             },
         );


### PR DESCRIPTION
Default code hash is `KECCAK_EMPTY`, and it will get re-computed in `CacheDB::insert_contract` because code is not empty.
Set it as something that is neither `KECCAK_EMPTY` nor zero, so as to not mess up anything (not verified but better safe than sorry).