### PR TITLE
fix(forge) - reset lib deployer balance to initial

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -160,7 +160,7 @@ impl<'a> ContractRunner<'a> {
             }
         };
 
-        // Reset `self.sender`s, `CALLER`s and LIBRARY_DEPLOYER's balance to the initial balance.
+        // Reset `self.sender`s, `CALLER`s and `LIBRARY_DEPLOYER`'s balance to the initial balance.
         self.executor.set_balance(self.sender, self.initial_balance)?;
         self.executor.set_balance(CALLER, self.initial_balance)?;
         self.executor.set_balance(LIBRARY_DEPLOYER, self.initial_balance)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Reset balance of newly introduced LIBRARY_DEPLOYER to avoid issues when fuzzing (see https://github.com/pcaversaccio/snekmate/blob/6da5649cff3441c341f1db66959050600fb27fae/test/utils/BatchDistributor.t.sol#L366-L377)

TBD: follow up on how to exclude internal addresses from fuzz inputs (maybe forge-std ref https://github.com/foundry-rs/foundry/issues/1228#issuecomment-1092260569)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
