### PR TITLE
perf(cheatcodes): don't recover verify signature after signing

### DIFF
--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -204,12 +204,8 @@ fn encode_vrs(sig: alloy_primitives::Signature) -> Vec<u8> {
 pub(super) fn sign(private_key: &U256, digest: &B256) -> Result {
     // The `ecrecover` precompile does not use EIP-155. No chain ID is needed.
     let wallet = parse_wallet(private_key)?;
-
     let sig = wallet.sign_hash_sync(digest)?;
-    let recovered = sig.recover_address_from_prehash(digest)?;
-
-    assert_eq!(recovered, wallet.address());
-
+    debug_assert_eq!(sig.recover_address_from_prehash(digest)?, wallet.address());
     Ok(encode_vrs(sig))
 }
 
@@ -243,8 +239,10 @@ pub(super) fn sign_with_wallet<DB: DatabaseExt>(
     let sig =
         foundry_common::block_on(wallet.sign_hash(digest)).map_err(|err| fmt_err!("{err}"))?;
 
-    let recovered = sig.recover_address_from_prehash(digest).map_err(|err| fmt_err!("{err}"))?;
-    assert_eq!(recovered, signer);
+    debug_assert_eq!(
+        sig.recover_address_from_prehash(digest).map_err(|err| fmt_err!("{err}"))?,
+        signer
+    );
 
     Ok(encode_vrs(sig))
 }


### PR DESCRIPTION
No point since an invalid signature would mean the underlying cryptography is broken, and we would panic anyway.

This signature recovery accounts for 70% of the time spent in `vm.sign`.