### PR TITLE
perf(fuzz): use ahash for state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -3583,6 +3584,7 @@ dependencies = [
 name = "foundry-evm-fuzz"
 version = "0.2.0"
 dependencies = [
+ "ahash",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ scrypt.opt-level = 3
 inherits = "dev"
 opt-level = 1
 debug-assertions = false
+overflow-checks = false
 strip = "debuginfo"
 panic = "abort"
 codegen-units = 16
@@ -186,6 +187,7 @@ alloy-rlp = "0.3.3"
 solang-parser = "=0.3.3"
 
 ## misc
+ahash = "0.8"
 arrayvec = "0.7"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -50,7 +50,7 @@ pub use tracing::TracingExecutor;
 sol! {
     interface ITest {
         function setUp() external;
-        function failed() external view returns (bool);
+        function failed() external view returns (bool failed);
     }
 }
 
@@ -515,8 +515,7 @@ impl Executor {
             let executor =
                 Executor::new(backend, self.env.clone(), self.inspector.clone(), self.gas_limit);
             let call = executor.call_sol(CALLER, address, &ITest::failedCall {}, U256::ZERO, None);
-            if let Ok(CallResult { raw: _, decoded_result: ITest::failedReturn { _0: failed } }) =
-                call
+            if let Ok(CallResult { raw: _, decoded_result: ITest::failedReturn { failed } }) = call
             {
                 debug!(failed, "DSTest::failed()");
                 success = !failed;

--- a/crates/evm/fuzz/Cargo.toml
+++ b/crates/evm/fuzz/Cargo.toml
@@ -20,7 +20,12 @@ foundry-evm-traces.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-json-abi.workspace = true
-alloy-primitives = { workspace = true, features = ["serde", "getrandom", "arbitrary", "rlp"] }
+alloy-primitives = { workspace = true, features = [
+    "serde",
+    "getrandom",
+    "arbitrary",
+    "rlp",
+] }
 revm = { workspace = true, features = [
     "std",
     "serde",
@@ -40,3 +45,4 @@ serde = "1"
 thiserror = "1"
 tracing = "0.1"
 indexmap.workspace = true
+ahash.workspace = true

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -1,5 +1,4 @@
 use crate::{invariant::RandomCallGenerator, strategies::EvmFuzzState};
-use alloy_primitives::U256;
 use revm::{
     interpreter::{CallInputs, CallOutcome, CallScheme, Interpreter},
     Database, EvmContext, Inspector,
@@ -62,7 +61,7 @@ impl<DB: Database> Inspector<DB> for Fuzzer {
 impl Fuzzer {
     /// Collects `stack` and `memory` values into the fuzz dictionary.
     fn collect_data(&mut self, interpreter: &Interpreter) {
-        self.fuzz_state.collect_values(interpreter.stack().data().iter().map(U256::to_be_bytes));
+        self.fuzz_state.collect_values(interpreter.stack().data().iter().copied().map(Into::into));
 
         // TODO: disabled for now since it's flooding the dictionary
         // for index in 0..interpreter.shared_memory.len() / 32 {

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -140,11 +140,11 @@ pub fn fuzz_param_from_state(
     // Convert the value based on the parameter type
     match *param {
         DynSolType::Address => value()
-            .prop_map(move |value| DynSolValue::Address(Address::from_word(value.into())))
+            .prop_map(move |value| DynSolValue::Address(Address::from_word(value)))
             .boxed(),
         DynSolType::Function => value()
             .prop_map(move |value| {
-                DynSolValue::Function(alloy_primitives::Function::from_word(value.into()))
+                DynSolValue::Function(alloy_primitives::Function::from_word(value))
             })
             .boxed(),
         DynSolType::FixedBytes(size @ 1..=32) => value()

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -139,9 +139,9 @@ pub fn fuzz_param_from_state(
 
     // Convert the value based on the parameter type
     match *param {
-        DynSolType::Address => value()
-            .prop_map(move |value| DynSolValue::Address(Address::from_word(value)))
-            .boxed(),
+        DynSolType::Address => {
+            value().prop_map(move |value| DynSolValue::Address(Address::from_word(value))).boxed()
+        }
         DynSolType::Function => value()
             .prop_map(move |value| {
                 DynSolValue::Function(alloy_primitives::Function::from_word(value))

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -128,23 +128,13 @@ pub fn fuzz_param_from_state(
         // Generate a bias and use it to pick samples or non-persistent values (50 / 50).
         // Use `Index` instead of `Selector` when selecting a value to avoid iterating over the
         // entire dictionary.
-        ((0..100).prop_flat_map(Just), any::<prop::sample::Index>()).prop_map(
-            move |(bias, index)| {
-                let state = state.dictionary_read();
-                let values = match bias {
-                    x if x < 50 => {
-                        if let Some(sample_values) = state.samples(param.clone()) {
-                            sample_values
-                        } else {
-                            state.values()
-                        }
-                    }
-                    _ => state.values(),
-                };
-                let index = index.index(values.len());
-                *values.iter().nth(index).unwrap()
-            },
-        )
+        any::<(bool, prop::sample::Index)>().prop_map(move |(bias, index)| {
+            let state = state.dictionary_read();
+            let values = if bias { state.samples(&param) } else { None }
+                .unwrap_or_else(|| state.values())
+                .as_slice();
+            values[index.index(values.len())]
+        })
     };
 
     // Convert the value based on the parameter type
@@ -172,19 +162,17 @@ pub fn fuzz_param_from_state(
             })
             .boxed(),
         DynSolType::Bytes => {
-            value().prop_map(move |value| DynSolValue::Bytes(value.into())).boxed()
+            value().prop_map(move |value| DynSolValue::Bytes(value.0.into())).boxed()
         }
         DynSolType::Int(n @ 8..=256) => match n / 8 {
             32 => value()
-                .prop_map(move |value| {
-                    DynSolValue::Int(I256::from_raw(U256::from_be_bytes(value)), 256)
-                })
+                .prop_map(move |value| DynSolValue::Int(I256::from_raw(value.into()), 256))
                 .boxed(),
             1..=31 => value()
                 .prop_map(move |value| {
                     // Generate a uintN in the correct range, then shift it to the range of intN
                     // by subtracting 2^(N-1)
-                    let uint = U256::from_be_bytes(value) % U256::from(1).wrapping_shl(n);
+                    let uint = U256::from_be_bytes(value.0) % U256::from(1).wrapping_shl(n);
                     let max_int_plus1 = U256::from(1).wrapping_shl(n - 1);
                     let num = I256::from_raw(uint.wrapping_sub(max_int_plus1));
                     DynSolValue::Int(num, n)
@@ -194,11 +182,12 @@ pub fn fuzz_param_from_state(
         },
         DynSolType::Uint(n @ 8..=256) => match n / 8 {
             32 => value()
-                .prop_map(move |value| DynSolValue::Uint(U256::from_be_bytes(value), 256))
+                .prop_map(move |value| DynSolValue::Uint(U256::from_be_bytes(value.0), 256))
                 .boxed(),
             1..=31 => value()
                 .prop_map(move |value| {
-                    DynSolValue::Uint(U256::from_be_bytes(value) % U256::from(1).wrapping_shl(n), n)
+                    let uint = U256::from_be_bytes(value.0) % U256::from(1).wrapping_shl(n);
+                    DynSolValue::Uint(uint, n)
                 })
                 .boxed(),
             _ => unreachable!(),

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -130,7 +130,7 @@ impl FuzzDictionary {
         let collected = false;
         for (address, account) in db_state {
             // Insert basic account information
-            self.insert_value(address.into_word().into(), collected);
+            self.insert_value(address.into_word(), collected);
             // Insert push bytes
             self.insert_push_bytes_values(address, &account.info, collected);
             // Insert storage values.
@@ -147,7 +147,7 @@ impl FuzzDictionary {
         // otherwise we can't select random data for state fuzzing.
         if self.values().is_empty() {
             // Prefill with a random address.
-            self.insert_value(Address::random().into_word().into(), false);
+            self.insert_value(Address::random().into_word(), false);
         }
     }
 
@@ -212,7 +212,7 @@ impl FuzzDictionary {
         let collected = true;
         for (address, account) in state_changeset {
             // Insert basic account information.
-            self.insert_value(address.into_word().into(), collected);
+            self.insert_value(address.into_word(), collected);
             // Insert push bytes.
             self.insert_push_bytes_values(address, &account.info, collected);
             // Insert storage values.
@@ -323,7 +323,6 @@ impl FuzzDictionary {
     ) {
         for sample in sample_values {
             if let (Some(sample_type), Some(sample_value)) = (sample.as_type(), sample.as_word()) {
-                let sample_value = sample_value.into();
                 if let Some(values) = self.sample_values.get_mut(&sample_type) {
                     if values.len() < limit as usize {
                         values.insert(sample_value);

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -18,6 +18,8 @@ use std::{
     sync::Arc,
 };
 
+type AIndexSet<T> = IndexSet<T, std::hash::BuildHasherDefault<ahash::AHasher>>;
+
 /// The maximum number of bytes we will look at in bytecodes to find push bytes (24 KiB).
 ///
 /// This is to limit the performance impact of fuzz tests that might deploy arbitrarily sized
@@ -44,7 +46,7 @@ impl EvmFuzzState {
         Self { inner: Arc::new(RwLock::new(dictionary)) }
     }
 
-    pub fn collect_values(&self, values: impl IntoIterator<Item = [u8; 32]>) {
+    pub fn collect_values(&self, values: impl IntoIterator<Item = B256>) {
         let mut dict = self.inner.write();
         for value in values {
             dict.insert_value(value, true);
@@ -88,9 +90,9 @@ impl EvmFuzzState {
 #[derive(Default)]
 pub struct FuzzDictionary {
     /// Collected state values.
-    state_values: IndexSet<[u8; 32]>,
+    state_values: AIndexSet<B256>,
     /// Addresses that already had their PUSH bytes collected.
-    addresses: IndexSet<Address>,
+    addresses: AIndexSet<Address>,
     /// Configuration for the dictionary.
     config: FuzzDictionaryConfig,
     /// New key indexes added to the dictionary since container initialization.
@@ -98,7 +100,7 @@ pub struct FuzzDictionary {
     /// New address indexes added to the dictionary since container initialization.
     new_addreses: Vec<usize>,
     /// Sample typed values that are collected from call result and used across invariant runs.
-    sample_values: HashMap<DynSolType, IndexSet<[u8; 32]>>,
+    sample_values: HashMap<DynSolType, AIndexSet<B256>>,
 }
 
 impl fmt::Debug for FuzzDictionary {
@@ -119,31 +121,32 @@ impl FuzzDictionary {
 
     /// Insert common values into the dictionary at initialization.
     fn prefill(&mut self) {
-        self.insert_value([0; 32], false);
+        self.insert_value(B256::ZERO, false);
     }
 
     /// Insert values from initial db state into fuzz dictionary.
     /// These values are persisted across invariant runs.
     fn insert_db_values(&mut self, db_state: Vec<(&Address, &DbAccount)>) {
+        let collected = false;
         for (address, account) in db_state {
             // Insert basic account information
-            self.insert_value(address.into_word().into(), false);
+            self.insert_value(address.into_word().into(), collected);
             // Insert push bytes
-            self.insert_push_bytes_values(address, &account.info, false);
+            self.insert_push_bytes_values(address, &account.info, collected);
             // Insert storage values.
             if self.config.include_storage {
                 // Sort storage values before inserting to ensure deterministic dictionary.
                 let values = account.storage.iter().collect::<BTreeMap<_, _>>();
                 for (slot, value) in values {
-                    self.insert_storage_value(slot, value, false);
+                    self.insert_storage_value(slot, value, collected);
                 }
             }
         }
 
-        // need at least some state data if db is empty otherwise we can't select random data for
-        // state fuzzing
+        // We need at least some state data if DB is empty,
+        // otherwise we can't select random data for state fuzzing.
         if self.values().is_empty() {
-            // prefill with a random addresses
+            // Prefill with a random address.
             self.insert_value(Address::random().into_word().into(), false);
         }
     }
@@ -185,8 +188,8 @@ impl FuzzDictionary {
 
             // If we weren't able to decode event then we insert raw data in fuzz dictionary.
             if !log_decoded {
-                for topic in log.topics() {
-                    self.insert_value(topic.0, true);
+                for &topic in log.topics() {
+                    self.insert_value(topic, true);
                 }
                 let chunks = log.data.data.chunks_exact(32);
                 let rem = chunks.remainder();
@@ -194,7 +197,7 @@ impl FuzzDictionary {
                     self.insert_value(chunk.try_into().unwrap(), true);
                 }
                 if !rem.is_empty() {
-                    self.insert_value(B256::right_padding_from(rem).0, true);
+                    self.insert_value(B256::right_padding_from(rem), true);
                 }
             }
         }
@@ -206,15 +209,16 @@ impl FuzzDictionary {
     /// Insert values from call state changeset into fuzz dictionary.
     /// These values are removed at the end of current run.
     fn insert_state_values(&mut self, state_changeset: &StateChangeset) {
+        let collected = true;
         for (address, account) in state_changeset {
             // Insert basic account information.
-            self.insert_value(address.into_word().into(), true);
+            self.insert_value(address.into_word().into(), collected);
             // Insert push bytes.
-            self.insert_push_bytes_values(address, &account.info, true);
+            self.insert_push_bytes_values(address, &account.info, collected);
             // Insert storage values.
             if self.config.include_storage {
                 for (slot, value) in &account.storage {
-                    self.insert_storage_value(slot, &value.present_value, true);
+                    self.insert_storage_value(slot, &value.present_value, collected);
                 }
             }
         }
@@ -230,7 +234,7 @@ impl FuzzDictionary {
     ) {
         if self.config.include_push_bytes {
             // Insert push bytes
-            if let Some(code) = account_info.code.clone() {
+            if let Some(code) = &account_info.code {
                 self.insert_address(*address, collected);
                 self.collect_push_bytes(code.bytes_slice(), collected);
             }
@@ -253,16 +257,16 @@ impl FuzzDictionary {
                 }
 
                 let push_value = U256::try_from_be_slice(&code[push_start..push_end]).unwrap();
-                // Also add the value below and above the push value to the dictionary.
                 if push_value != U256::ZERO {
-                    // Never add 0 to the dictionary as it's always present, and it's a pretty
-                    // common value that this is worth it.
-                    self.insert_value(push_value.to_be_bytes(), collected);
+                    // Never add 0 to the dictionary as it's always present.
+                    self.insert_value(push_value.into(), collected);
 
-                    self.insert_value((push_value - U256::from(1)).to_be_bytes(), collected);
-                }
-                if push_value != U256::MAX {
-                    self.insert_value((push_value + U256::from(1)).to_be_bytes(), collected);
+                    // Also add the value below and above the push value to the dictionary.
+                    self.insert_value((push_value - U256::from(1)).into(), collected);
+
+                    if push_value != U256::MAX {
+                        self.insert_value((push_value + U256::from(1)).into(), collected);
+                    }
                 }
 
                 i += push_size;
@@ -274,16 +278,16 @@ impl FuzzDictionary {
     /// Insert values from single storage slot and storage value into fuzz dictionary.
     /// If storage values are newly collected then they are removed at the end of current run.
     fn insert_storage_value(&mut self, storage_slot: &U256, storage_value: &U256, collected: bool) {
-        self.insert_value(B256::from(*storage_slot).0, collected);
-        self.insert_value(B256::from(*storage_value).0, collected);
+        self.insert_value(B256::from(*storage_slot), collected);
+        self.insert_value(B256::from(*storage_value), collected);
         // also add the value below and above the storage value to the dictionary.
         if *storage_value != U256::ZERO {
             let below_value = storage_value - U256::from(1);
-            self.insert_value(B256::from(below_value).0, collected);
+            self.insert_value(B256::from(below_value), collected);
         }
         if *storage_value != U256::MAX {
             let above_value = storage_value + U256::from(1);
-            self.insert_value(B256::from(above_value).0, collected);
+            self.insert_value(B256::from(above_value), collected);
         }
     }
 
@@ -300,7 +304,7 @@ impl FuzzDictionary {
 
     /// Insert raw value into fuzz dictionary.
     /// If value is newly collected then it is removed by index at the end of current run.
-    fn insert_value(&mut self, value: [u8; 32], collected: bool) {
+    fn insert_value(&mut self, value: B256, collected: bool) {
         if self.state_values.len() < self.config.max_fuzz_dictionary_values {
             let (index, new_value) = self.state_values.insert_full(value);
             if new_value && collected {
@@ -312,7 +316,11 @@ impl FuzzDictionary {
     /// Insert sample values that are reused across multiple runs.
     /// The number of samples is limited to invariant run depth.
     /// If collected samples limit is reached then values are inserted as regular values.
-    pub fn insert_sample_values(&mut self, sample_values: Vec<DynSolValue>, limit: u32) {
+    pub fn insert_sample_values(
+        &mut self,
+        sample_values: impl IntoIterator<Item = DynSolValue>,
+        limit: u32,
+    ) {
         for sample in sample_values {
             if let (Some(sample_type), Some(sample_value)) = (sample.as_type(), sample.as_word()) {
                 let sample_value = sample_value.into();
@@ -330,7 +338,7 @@ impl FuzzDictionary {
         }
     }
 
-    pub fn values(&self) -> &IndexSet<[u8; 32]> {
+    pub fn values(&self) -> &AIndexSet<B256> {
         &self.state_values
     }
 
@@ -343,12 +351,12 @@ impl FuzzDictionary {
     }
 
     #[inline]
-    pub fn samples(&self, param_type: DynSolType) -> Option<&IndexSet<[u8; 32]>> {
-        self.sample_values.get(&param_type)
+    pub fn samples(&self, param_type: &DynSolType) -> Option<&AIndexSet<B256>> {
+        self.sample_values.get(param_type)
     }
 
     #[inline]
-    pub fn addresses(&self) -> &IndexSet<Address> {
+    pub fn addresses(&self) -> &AIndexSet<Address> {
         &self.addresses
     }
 
@@ -378,25 +386,30 @@ pub fn collect_created_contracts(
 ) -> eyre::Result<()> {
     let mut writable_targeted = targeted_contracts.targets.lock();
     for (address, account) in state_changeset {
-        if !setup_contracts.contains_key(address) {
-            if let (true, Some(code)) = (&account.is_touched(), &account.info.code) {
-                if !code.is_empty() {
-                    if let Some((artifact, contract)) =
-                        project_contracts.find_by_deployed_code(&code.original_bytes())
-                    {
-                        if let Some(functions) =
-                            artifact_filters.get_targeted_functions(artifact, &contract.abi)?
-                        {
-                            created_contracts.push(*address);
-                            writable_targeted.insert(
-                                *address,
-                                (artifact.name.clone(), contract.abi.clone(), functions),
-                            );
-                        }
-                    }
-                }
-            }
+        if setup_contracts.contains_key(address) {
+            continue;
         }
+        if !account.is_touched() {
+            continue;
+        }
+        let Some(code) = &account.info.code else {
+            continue;
+        };
+        if code.is_empty() {
+            continue;
+        }
+        let Some((artifact, contract)) =
+            project_contracts.find_by_deployed_code(code.original_byte_slice())
+        else {
+            continue;
+        };
+        let Some(functions) = artifact_filters.get_targeted_functions(artifact, &contract.abi)?
+        else {
+            continue;
+        };
+        created_contracts.push(*address);
+        writable_targeted
+            .insert(*address, (artifact.name.clone(), contract.abi.clone(), functions));
     }
     Ok(())
 }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -591,6 +591,6 @@ contract CounterTest is Test {
         let runs_split = &stderr[start_runs + 6..];
         runs_split.find(',').map(|end_runs| &runs_split[..end_runs])
     });
-    // make sure there are only 54 runs (with proptest shrinking same test results in 292 runs)
-    assert_eq!(runs.unwrap().parse::<usize>().unwrap(), 54);
+    // make sure there are only 61 runs (with proptest shrinking same test results in 298 runs)
+    assert_eq!(runs.unwrap().parse::<usize>().unwrap(), 61);
 });


### PR DESCRIPTION
Plus some cleanups.

Note that collecting push bytes still accounts for ~40% of total invariant runtime. What about reducing the max analysis? I don't really know how to improve this further @grandizzy 