### PR TITLE
ci: switch macos test runner to use aarch64

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -69,7 +69,7 @@ is_pr = False and os.environ.get("EVENT_NAME") == "pull_request"
 t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
 # TODO: Figure out how to make this work
 # t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")
-t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
+t_macos = Target("macos-latest", "x86_64-apple-darwin", "macosx-amd64")
 t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
 targets = [t_linux_x86, t_windows] if is_pr else [t_linux_x86, t_macos, t_windows]
 

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -65,7 +65,7 @@ class Expanded:
         self.partition = partition
 
 
-is_pr = False and os.environ.get("EVENT_NAME") == "pull_request"
+is_pr = os.environ.get("EVENT_NAME") == "pull_request"
 t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
 # TODO: Figure out how to make this work
 # t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -65,7 +65,7 @@ class Expanded:
         self.partition = partition
 
 
-is_pr = os.environ.get("EVENT_NAME") == "pull_request"
+is_pr = False and os.environ.get("EVENT_NAME") == "pull_request"
 t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
 # TODO: Figure out how to make this work
 # t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -69,7 +69,7 @@ is_pr = os.environ.get("EVENT_NAME") == "pull_request"
 t_linux_x86 = Target("ubuntu-latest", "x86_64-unknown-linux-gnu", "linux-amd64")
 # TODO: Figure out how to make this work
 # t_linux_arm = Target("ubuntu-latest", "aarch64-unknown-linux-gnu", "linux-aarch64")
-t_macos = Target("macos-latest", "x86_64-apple-darwin", "macosx-amd64")
+t_macos = Target("macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("windows-latest", "x86_64-pc-windows-msvc", "windows-amd64")
 targets = [t_linux_x86, t_windows] if is_pr else [t_linux_x86, t_macos, t_windows]
 


### PR DESCRIPTION
`macos-latest` is now on aarch64.