### PR TITLE
ci: release x86_64 darwin binaries with macos-12 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
                       svm_target_platform: linux-aarch64
                       platform: linux
                       arch: arm64
-                    - runner: macos-latest-large
+                    - runner: macos-12-large
                       target: x86_64-apple-darwin
                       svm_target_platform: macosx-amd64
                       platform: darwin


### PR DESCRIPTION
(hopefully) fixes https://github.com/foundry-rs/foundry/issues/7936