### PR TITLE
perf(link): keep around the cow for a bit longer

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -316,7 +316,7 @@ impl ContractSources {
                     format!("failed to read artifact source file for `{}`", id.identifier())
                 })?;
                 let linked = linker.link(&id, libraries)?;
-                let contract = compact_to_contract(linked)?;
+                let contract = compact_to_contract(linked.into_contract_bytecode())?;
                 sources.insert(&id, file_id, source_code, contract);
             } else {
                 warn!(id = id.identifier(), "source not found");

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -343,9 +343,7 @@ impl MultiContractRunnerBuilder {
         let mut deployable_contracts = DeployableContracts::default();
 
         for (id, contract) in linked_contracts.iter() {
-            let Some(abi) = contract.abi.as_ref() else {
-                continue;
-            };
+            let Some(abi) = &contract.abi else { continue };
 
             // if it's a test, link it and add to deployable contracts
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -2,13 +2,13 @@
 
 use alloy_primitives::{Address, Bytes, B256};
 use foundry_compilers::{
-    artifacts::{CompactContractBytecode, CompactContractBytecodeCow, Libraries},
+    artifacts::{CompactContractBytecodeCow, Libraries},
     contracts::ArtifactContracts,
     Artifact, ArtifactId,
 };
 use semver::Version;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -202,7 +202,7 @@ impl<'a> Linker<'a> {
                 let bytecode = self.link(id, &libraries).unwrap().bytecode.unwrap();
                 (id, bytecode)
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<Vec<_>>();
 
         let mut libs_to_deploy = Vec::new();
 
@@ -212,22 +212,22 @@ impl<'a> Linker<'a> {
             // Find any library which is fully linked.
             let deployable = needed_libraries
                 .iter()
-                .find(|(_, bytecode)| !bytecode.object.is_unlinked())
-                .map(|(id, _)| *id);
+                .enumerate()
+                .find(|(_, (_, bytecode))| !bytecode.object.is_unlinked());
 
             // If we haven't found any deployable library, it means we have a cyclic dependency.
-            let Some(id) = deployable else {
+            let Some((index, &(id, _))) = deployable else {
                 return Err(LinkerError::CyclicDependency);
             };
-            let bytecode = needed_libraries.remove(id).unwrap();
-            let code = bytecode.into_bytes().unwrap();
-            let address = sender.create2_from_code(salt, code.as_ref());
-            libs_to_deploy.push(code);
+            let (_, bytecode) = needed_libraries.swap_remove(index);
+            let code = bytecode.bytes().unwrap();
+            let address = sender.create2_from_code(salt, code);
+            libs_to_deploy.push(code.clone());
 
             let (file, name) = self.convert_artifact_id_to_lib_path(id);
 
-            for (_, bytecode) in needed_libraries.iter_mut() {
-                bytecode.link(file.to_string_lossy(), name.clone(), address);
+            for (_, bytecode) in &mut needed_libraries {
+                bytecode.to_mut().link(file.to_string_lossy(), name.clone(), address);
             }
 
             libraries.libs.entry(file).or_default().insert(name, address.to_checksum(None));
@@ -241,7 +241,7 @@ impl<'a> Linker<'a> {
         &self,
         target: &ArtifactId,
         libraries: &Libraries,
-    ) -> Result<CompactContractBytecode, LinkerError> {
+    ) -> Result<CompactContractBytecodeCow<'a>, LinkerError> {
         let mut contract =
             self.contracts.get(target).ok_or(LinkerError::MissingTargetArtifact)?.clone();
         for (file, libs) in &libraries.libs {
@@ -257,18 +257,20 @@ impl<'a> Linker<'a> {
                 }
             }
         }
-
-        Ok(CompactContractBytecode {
-            abi: contract.abi.map(|a| a.into_owned()),
-            bytecode: contract.bytecode.map(|b| b.into_owned()),
-            deployed_bytecode: contract.deployed_bytecode.map(|b| b.into_owned()),
-        })
+        Ok(contract)
     }
 
     pub fn get_linked_artifacts(
         &self,
         libraries: &Libraries,
     ) -> Result<ArtifactContracts, LinkerError> {
+        self.contracts.keys().map(|id| Ok((id.clone(), self.link(id, libraries)?))).collect()
+    }
+
+    pub fn get_linked_artifacts_cow(
+        &self,
+        libraries: &Libraries,
+    ) -> Result<ArtifactContracts<CompactContractBytecodeCow<'a>>, LinkerError> {
         self.contracts.keys().map(|id| Ok((id.clone(), self.link(id, libraries)?))).collect()
     }
 }


### PR DESCRIPTION
Keep the cow in `Linker::link`, leaving it up to the caller to clone it

I think we may still clone anyway because of eager `to_mut().link()`, which could return false 