### PR TITLE
perf(invariant): collect push bytes only once

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -221,6 +221,7 @@ impl FuzzDictionary {
     }
 
     /// Insert values from push bytes into fuzz dictionary.
+    /// Values are collected only once for a given address.
     /// If values are newly collected then they are removed at the end of current run.
     fn insert_push_bytes_values(
         &mut self,
@@ -228,7 +229,7 @@ impl FuzzDictionary {
         account_info: &AccountInfo,
         collected: bool,
     ) {
-        if self.config.include_push_bytes {
+        if self.config.include_push_bytes && !self.addresses.contains(address) {
             // Insert push bytes
             if let Some(code) = account_info.code.clone() {
                 self.insert_address(*address, collected);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- no need to collect push bytes multiple times for the same contract / address

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- collect push bytes only if address is not already in dict
