### PR TITLE
fix(verify-bytecode): check contract name in cache

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -224,11 +224,14 @@ impl VerifyBytecodeArgs {
                 (VerificationType::Partial, _) => (VerificationType::Partial, true),
             };
 
+        trace!("verification_type: {:?}", verification_type);
+        trace!("has_metadata: {}", has_metadata);
         // Etherscan compilation metadata
         let etherscan_metadata = source_code.items.first().unwrap();
 
         let local_bytecode =
             if let Some(local_bytecode) = self.build_using_cache(etherscan_metadata, &config) {
+                trace!("Using cache");
                 local_bytecode
             } else {
                 self.build_project(&config)?
@@ -410,37 +413,44 @@ impl VerifyBytecodeArgs {
         for (key, value) in cached_artifacts {
             let name = self.contract.name.to_owned() + ".sol";
             let version = etherscan_settings.compiler_version.to_owned();
+            // Ignores vyper
             if version.starts_with("vyper:") {
                 return None;
             }
             // Parse etherscan version string
             let version =
                 version.split('+').next().unwrap_or("").trim_start_matches('v').to_string();
+
+            // Check if `out/directory` name matches the contract name
             if key.ends_with(name.as_str()) {
-                if let Some(artifact) = value.into_iter().next() {
+                let artifacts: Vec<_> =
+                    value.iter().flat_map(|a| a.1.iter().map(|a_| a_)).collect();
+
+                for artifact in artifacts {
+                    // Check if ABI files matches the name
+                    if !artifact.file.ends_with(name.replace(".sol", ".json")) {
+                        continue;
+                    }
+
+                    // Check if Solidity version matches
                     if let Ok(version) = Version::parse(&version) {
-                        if let Some(artifact) = artifact.1.iter().find(|a| {
-                            a.version.major == version.major &&
-                                a.version.minor == version.minor &&
-                                a.version.patch == version.patch
-                        }) {
-                            return artifact
-                                .artifact
-                                .bytecode
-                                .as_ref()
-                                .and_then(|bytes| bytes.bytes().to_owned())
-                                .cloned();
+                        if !(artifact.version.major == version.major &&
+                            artifact.version.minor == version.minor &&
+                            artifact.version.patch == version.patch)
+                        {
+                            continue;
                         }
                     }
-                    let artifact = artifact.1.first().unwrap(); // Get the first artifact
-                    let local_bytecode = if let Some(local_bytecode) = &artifact.artifact.bytecode {
-                        local_bytecode.bytes()
-                    } else {
-                        None
-                    };
 
-                    return local_bytecode.map(|bytes| bytes.to_owned());
+                    return artifact
+                        .artifact
+                        .bytecode
+                        .as_ref()
+                        .and_then(|bytes| bytes.bytes().to_owned())
+                        .cloned();
                 }
+
+                return None
             }
         }
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -224,14 +224,13 @@ impl VerifyBytecodeArgs {
                 (VerificationType::Partial, _) => (VerificationType::Partial, true),
             };
 
-        trace!("verification_type: {:?}", verification_type);
-        trace!("has_metadata: {}", has_metadata);
+        trace!("verification_type: {:?}, has_metadata: {}", verification_type, has_metadata);
         // Etherscan compilation metadata
         let etherscan_metadata = source_code.items.first().unwrap();
 
         let local_bytecode =
             if let Some(local_bytecode) = self.build_using_cache(etherscan_metadata, &config) {
-                trace!("Using cache");
+                trace!("using cache");
                 local_bytecode
             } else {
                 self.build_project(&config)?
@@ -423,13 +422,12 @@ impl VerifyBytecodeArgs {
 
             // Check if `out/directory` name matches the contract name
             if key.ends_with(name.as_str()) {
-                // let artifacts: Vec<_> =
                 let artifacts =
                     value.iter().flat_map(|(_, artifacts)| artifacts.iter()).collect::<Vec<_>>();
-
+                let name = name.replace(".sol", ".json");
                 for artifact in artifacts {
                     // Check if ABI file matches the name
-                    if !artifact.file.ends_with(name.replace(".sol", ".json")) {
+                    if !artifact.file.ends_with(name.to_owned()) {
                         continue;
                     }
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -423,11 +423,12 @@ impl VerifyBytecodeArgs {
 
             // Check if `out/directory` name matches the contract name
             if key.ends_with(name.as_str()) {
-                let artifacts: Vec<_> =
-                    value.iter().flat_map(|a| a.1.iter().map(|a_| a_)).collect();
+                // let artifacts: Vec<_> =
+                let artifacts =
+                    value.iter().flat_map(|(_, artifacts)| artifacts.iter()).collect::<Vec<_>>();
 
                 for artifact in artifacts {
-                    // Check if ABI files matches the name
+                    // Check if ABI file matches the name
                     if !artifact.file.ends_with(name.replace(".sol", ".json")) {
                         continue;
                     }

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -224,7 +224,7 @@ impl VerifyBytecodeArgs {
                 (VerificationType::Partial, _) => (VerificationType::Partial, true),
             };
 
-        trace!("verification_type: {:?}, has_metadata: {}", verification_type, has_metadata);
+        trace!(?verification_type, has_metadata);
         // Etherscan compilation metadata
         let etherscan_metadata = source_code.items.first().unwrap();
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -427,7 +427,7 @@ impl VerifyBytecodeArgs {
                 let name = name.replace(".sol", ".json");
                 for artifact in artifacts {
                     // Check if ABI file matches the name
-                    if !artifact.file.ends_with(name.to_owned()) {
+                    if !artifact.file.ends_with(&name) {
                         continue;
                     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes an issue where if multiple ABI files were located in the `out/Contract.sol/**` directory it would fetch the first ABI file or the one where the solidity version matched on the first round without matching the `name` of the ABI file with the contract being verified. 

This would lead to fetching the wrong file from cache. 

For example, if the bytecode being verified is for the `PSMVariant1Actions` contract, the `out/PSMVariant1Actions.sol` tree looks like:

```bash
├── PSMVariant1Actions.sol
│   ├── GemJoinLike.json
│   ├── PSMVariant1Actions.json
│   └── PSMVariant1Like.json
```

It would lead to `GemJoinLike.json` being fetched from cache instead of `PSMVariant1Actions.json`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Strongly check the `name` of the abi file and then the solidity version.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
