### PR TITLE
fix(invariant): prevent new values leaking between runs

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -6,7 +6,6 @@ use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::FuzzDictionaryConfig;
 use foundry_evm_core::utils::StateChangeset;
 use indexmap::IndexSet;
-use itertools::Itertools;
 use parking_lot::{lock_api::RwLockReadGuard, RawRwLock, RwLock};
 use revm::{
     db::{CacheDB, DatabaseRef, DbAccount},
@@ -365,22 +364,10 @@ impl FuzzDictionary {
         &self.addresses
     }
 
+    /// Revert values and addresses collected during the run by truncating to initial db len.
     pub fn revert(&mut self) {
-        // Revert values and addresses collected during the run by truncating to initial db values.
-        // Generate range of indexes from last db index to end and remove them in reverse order.
-        let mut new_values_range =
-            (self.db_state_values - 1..self.state_values.len() - 1).collect_vec();
-        new_values_range.reverse();
-        for new_value in new_values_range {
-            self.state_values.swap_remove_index(new_value);
-        }
-
-        let mut new_addresses_range =
-            (self.db_addresses - 1..self.addresses.len() - 1).collect_vec();
-        new_addresses_range.reverse();
-        for new_address in new_addresses_range {
-            self.addresses.swap_remove_index(new_address);
-        }
+        self.state_values.truncate(self.db_state_values);
+        self.addresses.truncate(self.db_addresses);
     }
 
     pub fn log_stats(&self) {

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -106,7 +106,7 @@ pub struct FuzzDictionary {
     db_state_values: usize,
     /// Number of address values initially collected from db.
     /// Used to revert new collected addresses at the end of each run.
-    db_addreses: usize,
+    db_addresses: usize,
     /// Sample typed values that are collected from call result and used across invariant runs.
     sample_values: HashMap<DynSolType, AIndexSet<B256>>,
 
@@ -163,7 +163,7 @@ impl FuzzDictionary {
         // Record number of values and addresses inserted from db to be used for reverting at the
         // end of each run.
         self.db_state_values = self.state_values.len();
-        self.db_addreses = self.addresses.len();
+        self.db_addresses = self.addresses.len();
     }
 
     /// Insert values collected from call result into fuzz dictionary.
@@ -376,7 +376,7 @@ impl FuzzDictionary {
         }
 
         let mut new_addresses_range =
-            (self.db_addreses - 1..self.addresses.len() - 1).collect_vec();
+            (self.db_addresses - 1..self.addresses.len() - 1).collect_vec();
         new_addresses_range.reverse();
         for new_address in new_addresses_range {
             self.addresses.swap_remove_index(new_address);

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -371,10 +371,17 @@ impl FuzzDictionary {
     }
 
     pub fn revert(&mut self) {
-        // Revert new values collected during the run.
+        // Revert values and addresses collected during the run, using recorded indexes.
+        // Indexes are sorted and removed in reverse in order to point to same value as when they
+        // were recorded.
+        self.new_values.sort();
+        self.new_values.reverse();
         for &value_index in &self.new_values {
             self.state_values.swap_remove_index(value_index);
         }
+
+        self.new_addreses.sort();
+        self.new_addreses.reverse();
         for &address_index in &self.new_addreses {
             self.addresses.swap_remove_index(address_index);
         }

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -6,6 +6,7 @@ use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::FuzzDictionaryConfig;
 use foundry_evm_core::utils::StateChangeset;
 use indexmap::IndexSet;
+use itertools::Itertools;
 use parking_lot::{lock_api::RwLockReadGuard, RawRwLock, RwLock};
 use revm::{
     db::{CacheDB, DatabaseRef, DbAccount},
@@ -49,7 +50,7 @@ impl EvmFuzzState {
     pub fn collect_values(&self, values: impl IntoIterator<Item = B256>) {
         let mut dict = self.inner.write();
         for value in values {
-            dict.insert_value(value, true);
+            dict.insert_value(value);
         }
     }
 
@@ -69,12 +70,12 @@ impl EvmFuzzState {
             dict.insert_logs_values(target_abi, logs, run_depth);
             dict.insert_result_values(target_function, result, run_depth);
         });
-        dict.insert_state_values(state_changeset);
+        dict.insert_new_state_values(state_changeset);
     }
 
     /// Removes all newly added entries from the dictionary.
     ///
-    /// Should be called between fuzz/invariant runs to avoid accumumlating data derived from fuzz
+    /// Should be called between fuzz/invariant runs to avoid accumulating data derived from fuzz
     /// inputs.
     pub fn revert(&self) {
         self.inner.write().revert();
@@ -100,10 +101,12 @@ pub struct FuzzDictionary {
     addresses: AIndexSet<Address>,
     /// Configuration for the dictionary.
     config: FuzzDictionaryConfig,
-    /// New key indexes added to the dictionary since container initialization.
-    new_values: Vec<usize>,
-    /// New address indexes added to the dictionary since container initialization.
-    new_addreses: Vec<usize>,
+    /// Number of state values initially collected from db.
+    /// Used to revert new collected values at the end of each run.
+    db_state_values: usize,
+    /// Number of address values initially collected from db.
+    /// Used to revert new collected addresses at the end of each run.
+    db_addreses: usize,
     /// Sample typed values that are collected from call result and used across invariant runs.
     sample_values: HashMap<DynSolType, AIndexSet<B256>>,
 
@@ -129,24 +132,23 @@ impl FuzzDictionary {
 
     /// Insert common values into the dictionary at initialization.
     fn prefill(&mut self) {
-        self.insert_value(B256::ZERO, false);
+        self.insert_value(B256::ZERO);
     }
 
     /// Insert values from initial db state into fuzz dictionary.
     /// These values are persisted across invariant runs.
     fn insert_db_values(&mut self, db_state: Vec<(&Address, &DbAccount)>) {
-        let collected = false;
         for (address, account) in db_state {
             // Insert basic account information
-            self.insert_value(address.into_word(), collected);
+            self.insert_value(address.into_word());
             // Insert push bytes
-            self.insert_push_bytes_values(address, &account.info, collected);
+            self.insert_push_bytes_values(address, &account.info);
             // Insert storage values.
             if self.config.include_storage {
                 // Sort storage values before inserting to ensure deterministic dictionary.
                 let values = account.storage.iter().collect::<BTreeMap<_, _>>();
                 for (slot, value) in values {
-                    self.insert_storage_value(slot, value, collected);
+                    self.insert_storage_value(slot, value);
                 }
             }
         }
@@ -155,8 +157,13 @@ impl FuzzDictionary {
         // otherwise we can't select random data for state fuzzing.
         if self.values().is_empty() {
             // Prefill with a random address.
-            self.insert_value(Address::random().into_word(), false);
+            self.insert_value(Address::random().into_word());
         }
+
+        // Record number of values and addresses inserted from db to be used for reverting at the
+        // end of each run.
+        self.db_state_values = self.state_values.len();
+        self.db_addreses = self.addresses.len();
     }
 
     /// Insert values collected from call result into fuzz dictionary.
@@ -197,15 +204,15 @@ impl FuzzDictionary {
             // If we weren't able to decode event then we insert raw data in fuzz dictionary.
             if !log_decoded {
                 for &topic in log.topics() {
-                    self.insert_value(topic, true);
+                    self.insert_value(topic);
                 }
                 let chunks = log.data.data.chunks_exact(32);
                 let rem = chunks.remainder();
                 for chunk in chunks {
-                    self.insert_value(chunk.try_into().unwrap(), true);
+                    self.insert_value(chunk.try_into().unwrap());
                 }
                 if !rem.is_empty() {
-                    self.insert_value(B256::right_padding_from(rem), true);
+                    self.insert_value(B256::right_padding_from(rem));
                 }
             }
         }
@@ -216,17 +223,16 @@ impl FuzzDictionary {
 
     /// Insert values from call state changeset into fuzz dictionary.
     /// These values are removed at the end of current run.
-    fn insert_state_values(&mut self, state_changeset: &StateChangeset) {
-        let collected = true;
+    fn insert_new_state_values(&mut self, state_changeset: &StateChangeset) {
         for (address, account) in state_changeset {
             // Insert basic account information.
-            self.insert_value(address.into_word(), collected);
+            self.insert_value(address.into_word());
             // Insert push bytes.
-            self.insert_push_bytes_values(address, &account.info, collected);
+            self.insert_push_bytes_values(address, &account.info);
             // Insert storage values.
             if self.config.include_storage {
                 for (slot, value) in &account.storage {
-                    self.insert_storage_value(slot, &value.present_value, collected);
+                    self.insert_storage_value(slot, &value.present_value);
                 }
             }
         }
@@ -235,22 +241,17 @@ impl FuzzDictionary {
     /// Insert values from push bytes into fuzz dictionary.
     /// Values are collected only once for a given address.
     /// If values are newly collected then they are removed at the end of current run.
-    fn insert_push_bytes_values(
-        &mut self,
-        address: &Address,
-        account_info: &AccountInfo,
-        collected: bool,
-    ) {
+    fn insert_push_bytes_values(&mut self, address: &Address, account_info: &AccountInfo) {
         if self.config.include_push_bytes && !self.addresses.contains(address) {
             // Insert push bytes
             if let Some(code) = &account_info.code {
-                self.insert_address(*address, collected);
-                self.collect_push_bytes(code.bytes_slice(), collected);
+                self.insert_address(*address);
+                self.collect_push_bytes(code.bytes_slice());
             }
         }
     }
 
-    fn collect_push_bytes(&mut self, code: &[u8], collected: bool) {
+    fn collect_push_bytes(&mut self, code: &[u8]) {
         let mut i = 0;
         let len = code.len().min(PUSH_BYTE_ANALYSIS_LIMIT);
         while i < len {
@@ -268,13 +269,13 @@ impl FuzzDictionary {
                 let push_value = U256::try_from_be_slice(&code[push_start..push_end]).unwrap();
                 if push_value != U256::ZERO {
                     // Never add 0 to the dictionary as it's always present.
-                    self.insert_value(push_value.into(), collected);
+                    self.insert_value(push_value.into());
 
                     // Also add the value below and above the push value to the dictionary.
-                    self.insert_value((push_value - U256::from(1)).into(), collected);
+                    self.insert_value((push_value - U256::from(1)).into());
 
                     if push_value != U256::MAX {
-                        self.insert_value((push_value + U256::from(1)).into(), collected);
+                        self.insert_value((push_value + U256::from(1)).into());
                     }
                 }
 
@@ -286,41 +287,35 @@ impl FuzzDictionary {
 
     /// Insert values from single storage slot and storage value into fuzz dictionary.
     /// If storage values are newly collected then they are removed at the end of current run.
-    fn insert_storage_value(&mut self, storage_slot: &U256, storage_value: &U256, collected: bool) {
-        self.insert_value(B256::from(*storage_slot), collected);
-        self.insert_value(B256::from(*storage_value), collected);
+    fn insert_storage_value(&mut self, storage_slot: &U256, storage_value: &U256) {
+        self.insert_value(B256::from(*storage_slot));
+        self.insert_value(B256::from(*storage_value));
         // also add the value below and above the storage value to the dictionary.
         if *storage_value != U256::ZERO {
             let below_value = storage_value - U256::from(1);
-            self.insert_value(B256::from(below_value), collected);
+            self.insert_value(B256::from(below_value));
         }
         if *storage_value != U256::MAX {
             let above_value = storage_value + U256::from(1);
-            self.insert_value(B256::from(above_value), collected);
+            self.insert_value(B256::from(above_value));
         }
     }
 
     /// Insert address into fuzz dictionary.
     /// If address is newly collected then it is removed by index at the end of current run.
-    fn insert_address(&mut self, address: Address, collected: bool) {
+    fn insert_address(&mut self, address: Address) {
         if self.addresses.len() < self.config.max_fuzz_dictionary_addresses {
-            let (index, new_address) = self.addresses.insert_full(address);
-            if new_address && collected {
-                self.new_addreses.push(index);
-            }
+            self.addresses.insert(address);
         }
     }
 
     /// Insert raw value into fuzz dictionary.
     /// If value is newly collected then it is removed by index at the end of current run.
-    fn insert_value(&mut self, value: B256, collected: bool) {
+    fn insert_value(&mut self, value: B256) {
         if self.state_values.len() < self.config.max_fuzz_dictionary_values {
-            let (index, new_value) = self.state_values.insert_full(value);
+            let new_value = self.state_values.insert(value);
             let counter = if new_value { &mut self.misses } else { &mut self.hits };
             *counter += 1;
-            if new_value && collected {
-                self.new_values.push(index);
-            }
         }
     }
 
@@ -339,7 +334,7 @@ impl FuzzDictionary {
                         values.insert(sample_value);
                     } else {
                         // Insert as state value (will be removed at the end of the run).
-                        self.insert_value(sample_value, true);
+                        self.insert_value(sample_value);
                     }
                 } else {
                     self.sample_values.entry(sample_type).or_default().insert(sample_value);
@@ -371,23 +366,21 @@ impl FuzzDictionary {
     }
 
     pub fn revert(&mut self) {
-        // Revert values and addresses collected during the run, using recorded indexes.
-        // Indexes are sorted and removed in reverse in order to point to same value as when they
-        // were recorded.
-        self.new_values.sort();
-        self.new_values.reverse();
-        for &value_index in &self.new_values {
-            self.state_values.swap_remove_index(value_index);
+        // Revert values and addresses collected during the run by truncating to initial db values.
+        // Generate range of indexes from last db index to end and remove them in reverse order.
+        let mut new_values_range =
+            (self.db_state_values - 1..self.state_values.len() - 1).collect_vec();
+        new_values_range.reverse();
+        for new_value in new_values_range {
+            self.state_values.swap_remove_index(new_value);
         }
 
-        self.new_addreses.sort();
-        self.new_addreses.reverse();
-        for &address_index in &self.new_addreses {
-            self.addresses.swap_remove_index(address_index);
+        let mut new_addresses_range =
+            (self.db_addreses - 1..self.addresses.len() - 1).collect_vec();
+        new_addresses_range.reverse();
+        for new_address in new_addresses_range {
+            self.addresses.swap_remove_index(new_address);
         }
-
-        self.new_values.clear();
-        self.new_addreses.clear();
     }
 
     pub fn log_stats(&self) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Regression introduced in https://github.com/foundry-rs/foundry/pull/8043, new fuzz dict values collected are not completely removed at the end of each run. This happens due to keeping indexes of new values and use them to remove values by calling `swap_remove_index`. However, after the indexset is altered the stored indexes to remove are no longer relevant.

The issue was noticed when re running invariant benchmarks (DSChief test case), would be nice to have it as a test but it needs 1000 runs to be replicated and will considerably slow down the CI. Will work on setting up a different project / CI to run daily benchmarks and make sure these regressions are automatically caught.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- ~keep new values (instead their index) and remove them by calling `swap_remove` (alternatively we could still keep the new indexes only, then at the end of invariant run retrieve values to be removed and then `swap_remove` each value)~
- (better solution, suggested by @DaniPopes thank you) : sort and reverse indexes before removal so they remain relevant when removing