### PR TITLE
fix: ensure suggested prio fee is at least 1e9

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -14,7 +14,7 @@ use crate::{
         error::{
             BlockchainError, FeeHistoryError, InvalidTransactionError, Result, ToRpcResponseResult,
         },
-        fees::{FeeDetails, FeeHistoryCache},
+        fees::{FeeDetails, FeeHistoryCache, MIN_SUGGESTED_PRIORITY_FEE},
         macros::node_info,
         miner::FixedBlockTimeMiner,
         pool::{
@@ -1357,20 +1357,18 @@ impl EthApi {
     }
 
     /// Returns the suggested fee cap.
+    ///
+    /// Returns at least [MIN_SUGGESTED_PRIORITY_FEE]
     fn lowest_suggestion_tip(&self) -> u128 {
         let block_number = self.backend.best_number();
         let latest_cached_block = self.fee_history_cache.lock().get(&block_number).cloned();
 
         match latest_cached_block {
-            Some(block) => block.rewards.iter().copied().min().unwrap_or(1e9 as u128),
-            None => self
-                .fee_history_cache
-                .lock()
-                .values()
-                .flat_map(|b| b.rewards.clone())
-                .min()
-                .unwrap_or(1e9 as u128),
+            Some(block) => block.rewards.iter().copied().min(),
+            None => self.fee_history_cache.lock().values().flat_map(|b| b.rewards.clone()).min(),
         }
+        .map(|fee| fee.max(MIN_SUGGESTED_PRIORITY_FEE))
+        .unwrap_or(MIN_SUGGESTED_PRIORITY_FEE)
     }
 
     /// Creates a filter object, based on filter options, to notify when the state changes (logs).

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -19,7 +19,7 @@ use crate::{
             validate::TransactionValidator,
         },
         error::{BlockchainError, ErrDetail, InvalidTransactionError},
-        fees::{FeeDetails, FeeManager},
+        fees::{FeeDetails, FeeManager, MIN_SUGGESTED_PRIORITY_FEE},
         macros::node_info,
         pool::transactions::PoolTransaction,
         util::get_precompiles_for,
@@ -1140,9 +1140,9 @@ impl Backend {
             env.block.basefee = U256::from(base);
         }
 
-        let gas_price = gas_price
-            .or(max_fee_per_gas)
-            .unwrap_or_else(|| self.fees().raw_gas_price().saturating_add(1e9 as u128));
+        let gas_price = gas_price.or(max_fee_per_gas).unwrap_or_else(|| {
+            self.fees().raw_gas_price().saturating_add(MIN_SUGGESTED_PRIORITY_FEE)
+        });
         let caller = from.unwrap_or_default();
         let to = to.as_ref().and_then(TxKind::to);
         env.tx = TxEnv {

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -31,6 +31,9 @@ pub const INITIAL_GAS_PRICE: u128 = 1_875_000_000;
 /// Bounds the amount the base fee can change between blocks.
 pub const BASE_FEE_CHANGE_DENOMINATOR: u128 = 8;
 
+/// Minimum suggested priority fee
+pub const MIN_SUGGESTED_PRIORITY_FEE: u128 = 1e9 as u128;
+
 pub fn default_elasticity() -> f64 {
     1f64 / BaseFeeParams::ethereum().elasticity_multiplier as f64
 }


### PR DESCRIPTION
introduced in #7984

there's an edge case where this can return 0

closes #8035

this ensures the suggested fee is at least 1e9 as it was previously