### PR TITLE
feat(cheatcode): promptSecretUint

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6373,6 +6373,26 @@
     },
     {
       "func": {
+        "id": "promptSecretUint",
+        "description": "Prompts the user for hidden uint256 in the terminal (usually pk).",
+        "declaration": "function promptSecretUint(string calldata promptText) external returns (uint256);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "promptSecretUint(string)",
+        "selector": "0x69ca02b7",
+        "selectorBytes": [
+          105,
+          202,
+          2,
+          183
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "promptUint",
         "description": "Prompts the user for uint256 in the terminal.",
         "declaration": "function promptUint(string calldata promptText) external returns (uint256);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1499,6 +1499,10 @@ interface Vm {
     #[cheatcode(group = Filesystem)]
     function promptSecret(string calldata promptText) external returns (string memory input);
 
+    /// Prompts the user for hidden uint256 in the terminal (usually pk).
+    #[cheatcode(group = Filesystem)]
+    function promptSecretUint(string calldata promptText) external returns (uint256);
+
     /// Prompts the user for an address in the terminal.
     #[cheatcode(group = Filesystem)]
     function promptAddress(string calldata promptText) external returns (address);

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -426,6 +426,13 @@ impl Cheatcode for promptSecretCall {
     }
 }
 
+impl Cheatcode for promptSecretUintCall {
+    fn apply(&self, state: &mut Cheatcodes) -> Result {
+        let Self { promptText: text } = self;
+        parse(&prompt(state, text, prompt_password)?, &DynSolType::Uint(256))
+    }
+}
+
 impl Cheatcode for promptAddressCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { promptText: text } = self;

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -523,7 +523,7 @@ impl CallTraceDecoder {
         match func.name.as_str() {
             s if s.starts_with("env") => Some("<env var value>"),
             "createWallet" | "deriveKey" => Some("<pk>"),
-            "promptSecret" => Some("<secret>"),
+            "promptSecret" | "promptSecretUint" => Some("<secret>"),
             "parseJson" if self.verbosity < 5 => Some("<encoded JSON value>"),
             "readFile" if self.verbosity < 5 => Some("<file>"),
             _ => None,

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -314,6 +314,7 @@ interface Vm {
     function prompt(string calldata promptText) external returns (string memory input);
     function promptAddress(string calldata promptText) external returns (address);
     function promptSecret(string calldata promptText) external returns (string memory input);
+    function promptSecretUint(string calldata promptText) external returns (uint256);
     function promptUint(string calldata promptText) external returns (uint256);
     function randomAddress() external returns (address);
     function randomUint() external returns (uint256);

--- a/testdata/default/cheats/Prompt.t.sol
+++ b/testdata/default/cheats/Prompt.t.sol
@@ -15,6 +15,9 @@ contract PromptTest is DSTest {
 
         vm._expectCheatcodeRevert();
         vm.promptSecret("test");
+
+        vm._expectCheatcodeRevert();
+        uint256 test = vm.promptSecretUint("test");
     }
 
     function testPrompt_Address() public {


### PR DESCRIPTION
## Motivation

As explained in #7939, there's no reliable way to currently obfuscate dynamically entering a private key in the terminal. 

## Solution
This PR adds `promptSecretUint(string calldata)(uint)` to aid, reusing the `prompt_password` helper introduced in https://github.com/foundry-rs/foundry/pull/7012.

<img width="680" alt="image" src="https://github.com/foundry-rs/foundry/assets/55102840/f9d6edd9-22bc-45c2-947f-3131b3325d96">

I can raise followup PRs on forge-std & book if this gets in.