### PR TITLE
fix: update persistent accounts handling

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -767,7 +767,13 @@ impl Backend {
 
         let test_contract = match env.tx.transact_to {
             TransactTo::Call(to) => to,
-            TransactTo::Create => env.tx.caller.create(env.tx.nonce.unwrap_or_default()),
+            TransactTo::Create => {
+                let nonce = self
+                    .basic_ref(env.tx.caller)
+                    .map(|b| b.unwrap_or_default().nonce)
+                    .unwrap_or_default();
+                env.tx.caller.create(nonce)
+            }
         };
         self.set_test_contract(test_contract);
     }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/foundry-rs/foundry/issues/8077

`initialize` function determines contract whis is being called or deployed and sets it as persistent. However, for calculating `CREATE` address it is using `env.tx.nonce.unwrap_or_default())` which is incorrect because we are never setting `env.tx.nonce` in `build_test_env`: https://github.com/foundry-rs/foundry/blob/0248a62892bb958c986b43d2444d318f960ad99b/crates/evm/evm/src/executors/mod.rs#L534

## Solution

Use correct nonce
