### PR TITLE
fix(anvil): receipts root calculation

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -9,6 +9,7 @@ use crate::{
     PrecompileFactory,
 };
 use alloy_consensus::{Header, Receipt, ReceiptWithBloom};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Bloom, BloomInput, Log, B256};
 use anvil_core::eth::{
     block::{Block, BlockInfo, PartialHeader},
@@ -65,7 +66,7 @@ impl ExecutedTransaction {
             TypedTransaction::Deposit(tx) => TypedReceipt::Deposit(DepositReceipt {
                 inner: receipt_with_bloom,
                 deposit_nonce: Some(tx.nonce),
-                deposit_nonce_version: Some(1),
+                deposit_receipt_version: Some(1),
             }),
         }
     }
@@ -201,7 +202,8 @@ impl<'a, DB: Db + ?Sized, Validator: TransactionValidator> TransactionExecutor<'
         }
 
         let ommers: Vec<Header> = Vec::new();
-        let receipts_root = trie::ordered_trie_root(receipts.iter().map(alloy_rlp::encode));
+        let receipts_root =
+            trie::ordered_trie_root(receipts.iter().map(Encodable2718::encoded_2718));
 
         let partial_header = PartialHeader {
             parent_hash,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2063,7 +2063,7 @@ impl Backend {
             TypedReceipt::Deposit(r) => TypedReceipt::Deposit(DepositReceipt {
                 inner: receipt_with_bloom,
                 deposit_nonce: r.deposit_nonce,
-                deposit_nonce_version: r.deposit_nonce_version,
+                deposit_receipt_version: r.deposit_receipt_version,
             }),
         };
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8073

## Solution

Similarly to https://github.com/foundry-rs/foundry/pull/7718 implements `Encodable2718` and `Decodable2718` for `TypedReceipt`.

Also improved handling of optimism-specific fields.

Receipt root calculation verified against random optimism blocks.
