### PR TITLE
fix: include Vyper sources when compiling scripts

### DIFF
--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -16,9 +16,10 @@ use foundry_common::{
 };
 use foundry_compilers::{
     artifacts::{BytecodeObject, Libraries},
+    compilers::{multi::MultiCompilerLanguage, Language},
     info::ContractInfo,
     utils::source_files_iter,
-    ArtifactId, ProjectCompileOutput, SOLC_EXTENSIONS,
+    ArtifactId, ProjectCompileOutput,
 };
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use foundry_linking::Linker;
@@ -184,9 +185,11 @@ impl PreprocessedState {
             }
         };
 
-        let sources_to_compile =
-            source_files_iter(project.paths.sources.as_path(), SOLC_EXTENSIONS)
-                .chain([target_path.to_path_buf()]);
+        let sources_to_compile = source_files_iter(
+            project.paths.sources.as_path(),
+            MultiCompilerLanguage::FILE_EXTENSIONS,
+        )
+        .chain([target_path.to_path_buf()]);
 
         let output = ProjectCompiler::new()
             .quiet_if(args.opts.silent)


### PR DESCRIPTION
## Motivation

Needed to support `deployCode` for Vyper contracts in scripts

## Solution


