### PR TITLE
chore(evm): clean up executor methods some more

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -176,7 +176,7 @@ impl RunArgs {
 
                     if let Some(to) = tx.to {
                         trace!(tx=?tx.hash,?to, "executing previous call transaction");
-                        executor.commit_tx_with_env(env.clone()).wrap_err_with(|| {
+                        executor.call_raw_with_env_committing(env.clone()).wrap_err_with(|| {
                             format!(
                                 "Failed to execute transaction: {:?} in block {}",
                                 tx.hash, env.block.number
@@ -213,7 +213,10 @@ impl RunArgs {
 
             if let Some(to) = tx.to {
                 trace!(tx=?tx.hash, to=?to, "executing call transaction");
-                TraceResult::from_raw(executor.commit_tx_with_env(env)?, TraceKind::Execution)
+                TraceResult::from_raw(
+                    executor.call_raw_with_env_committing(env)?,
+                    TraceKind::Execution,
+                )
             } else {
                 trace!(tx=?tx.hash, "executing create transaction");
                 TraceResult::try_from(executor.deploy_with_env(env, None))?

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -15,7 +15,7 @@ use foundry_evm_fuzz::{
 };
 use foundry_evm_traces::CallTraceArena;
 use proptest::test_runner::{TestCaseError, TestError, TestRunner};
-use std::{borrow::Cow, cell::RefCell};
+use std::cell::RefCell;
 
 mod types;
 pub use types::{CaseOutcome, CounterExampleOutcome, FuzzOutcome};
@@ -195,7 +195,6 @@ impl FuzzedExecutor {
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|_| TestCaseError::fail(FuzzError::FailedContractCall))?;
-        let state_changeset = call.state_changeset.take().unwrap();
 
         // When the `assume` cheatcode is called it returns a special string
         if call.result.as_ref() == MAGIC_ASSUME {
@@ -207,13 +206,7 @@ impl FuzzedExecutor {
             .as_ref()
             .map_or_else(Default::default, |cheats| cheats.breakpoints.clone());
 
-        let success = self.executor.is_raw_call_success(
-            address,
-            Cow::Owned(state_changeset),
-            &call,
-            should_fail,
-        );
-
+        let success = self.executor.is_raw_call_mut_success(address, &mut call, should_fail);
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {
                 case: FuzzCase { calldata, gas: call.gas_used, stipend: call.stipend },

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -155,7 +155,7 @@ impl<'a> InvariantExecutor<'a> {
         let failures = RefCell::new(InvariantFailures::new());
 
         // Stores the calldata in the last run.
-        let last_run_calldata: RefCell<Vec<BasicTxDetails>> = RefCell::new(vec![]);
+        let last_run_inputs: RefCell<Vec<BasicTxDetails>> = RefCell::new(vec![]);
 
         // Stores additional traces for gas report.
         let gas_report_traces: RefCell<Vec<Vec<CallTraceArena>>> = RefCell::default();
@@ -233,7 +233,7 @@ impl<'a> InvariantExecutor<'a> {
                     }
                 } else {
                     // Collect data for fuzzing from the state changeset.
-                    let mut state_changeset = call_result.state_changeset.to_owned().unwrap();
+                    let mut state_changeset = call_result.state_changeset.clone().unwrap();
 
                     if !call_result.reverted {
                         collect_data(
@@ -281,7 +281,7 @@ impl<'a> InvariantExecutor<'a> {
                     .map_err(|e| TestCaseError::fail(e.to_string()))?;
 
                     if !result.can_continue || current_run == self.config.depth - 1 {
-                        last_run_calldata.borrow_mut().clone_from(&inputs);
+                        last_run_inputs.borrow_mut().clone_from(&inputs);
                     }
 
                     if !result.can_continue {
@@ -330,7 +330,7 @@ impl<'a> InvariantExecutor<'a> {
             error,
             cases: fuzz_cases.into_inner(),
             reverts,
-            last_run_inputs: last_run_calldata.take(),
+            last_run_inputs: last_run_inputs.into_inner(),
             gas_report_traces: gas_report_traces.into_inner(),
         })
     }

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -68,12 +68,8 @@ pub(crate) fn assert_invariants(
         U256::ZERO,
     )?;
 
-    let success = executor.is_raw_call_success(
-        invariant_contract.address,
-        Cow::Owned(call_result.state_changeset.take().unwrap()),
-        &call_result,
-        false,
-    );
+    let success =
+        executor.is_raw_call_mut_success(invariant_contract.address, &mut call_result, false);
     if !success {
         // We only care about invariants which we haven't broken yet.
         if invariant_failures.error.is_none() {
@@ -111,7 +107,7 @@ pub(crate) fn can_continue(
     let mut call_results = None;
 
     let handlers_succeeded = || {
-        targeted_contracts.targets.lock().iter().all(|(address, ..)| {
+        targeted_contracts.targets.lock().keys().all(|address| {
             executor.is_success(*address, false, Cow::Borrowed(state_changeset), false)
         })
     };

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -3,7 +3,6 @@ use alloy_primitives::{Address, Bytes, U256};
 use foundry_evm_core::constants::CALLER;
 use foundry_evm_fuzz::invariant::BasicTxDetails;
 use proptest::bits::{BitSetLike, VarBitSet};
-use std::borrow::Cow;
 
 #[derive(Clone, Copy, Debug)]
 struct Shrink {
@@ -147,13 +146,6 @@ pub fn check_sequence(
 
     // Check the invariant for call sequence.
     let mut call_result = executor.call_raw(CALLER, test_address, calldata, U256::ZERO)?;
-    Ok((
-        executor.is_raw_call_success(
-            test_address,
-            Cow::Owned(call_result.state_changeset.take().unwrap()),
-            &call_result,
-            false,
-        ),
-        true,
-    ))
+    let success = executor.is_raw_call_mut_success(test_address, &mut call_result, false);
+    Ok((success, true))
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -37,7 +37,6 @@ use foundry_evm::{
 use proptest::test_runner::TestRunner;
 use rayon::prelude::*;
 use std::{
-    borrow::Cow,
     cmp::min,
     collections::{BTreeMap, HashMap},
     time::Instant,
@@ -425,9 +424,8 @@ impl<'a> ContractRunner<'a> {
         } = setup;
 
         // Run unit test
-        let mut executor = self.executor.clone();
         let start: Instant = Instant::now();
-        let (raw_call_result, reason) = match executor.execute_test(
+        let (mut raw_call_result, reason) = match self.executor.call(
             self.sender,
             address,
             func,
@@ -463,6 +461,9 @@ impl<'a> ContractRunner<'a> {
             }
         };
 
+        let success =
+            self.executor.is_raw_call_mut_success(setup.address, &mut raw_call_result, should_fail);
+
         let RawCallResult {
             reverted,
             gas_used: gas,
@@ -471,7 +472,6 @@ impl<'a> ContractRunner<'a> {
             traces: execution_trace,
             coverage: execution_coverage,
             labels: new_labels,
-            state_changeset,
             debug,
             cheatcodes,
             ..
@@ -483,13 +483,6 @@ impl<'a> ContractRunner<'a> {
         labeled_addresses.extend(new_labels);
         logs.extend(execution_logs);
         coverage = merge_coverages(coverage, execution_coverage);
-
-        let success = executor.is_success(
-            setup.address,
-            reverted,
-            Cow::Owned(state_changeset.unwrap()),
-            should_fail,
-        );
 
         // Record test execution time
         let duration = start.elapsed();
@@ -531,7 +524,7 @@ impl<'a> ContractRunner<'a> {
 
         // First, run the test normally to see if it needs to be skipped.
         let start = Instant::now();
-        if let Err(EvmError::SkipError) = self.executor.clone().execute_test(
+        if let Err(EvmError::SkipError) = self.executor.call(
             self.sender,
             address,
             func,

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -315,10 +315,10 @@ impl VerifyBytecodeArgs {
             if to != DEFAULT_CREATE2_DEPLOYER {
                 eyre::bail!("Transaction `to` address is not the default create2 deployer i.e the tx is not a contract creation tx.");
             }
-            let result = executor.commit_tx_with_env(env_with_handler.to_owned())?;
+            let result = executor.call_raw_with_env_committing(env_with_handler.clone())?;
 
-            if result.result.len() > 20 {
-                eyre::bail!("Failed to deploy contract using commit_tx_with_env on fork at block {} | Err: Call result is greater than 20 bytes, cannot be converted to Address", simulation_block);
+            if result.result.len() != 20 {
+                eyre::bail!("Failed to deploy contract on fork at block {simulation_block}: call result is not exactly 20 bytes");
             }
 
             Address::from_slice(&result.result)


### PR DESCRIPTION
reorder, rename, dedup, always use Cow for `call*`, simplify `is_success`