### PR TITLE
chore: propagate fmt parser errors

### DIFF
--- a/crates/cast/bin/cmd/interface.rs
+++ b/crates/cast/bin/cmd/interface.rs
@@ -1,6 +1,9 @@
-use cast::{AbiPath, SimpleCast};
+use alloy_chains::Chain;
+use alloy_json_abi::ContractObject;
+use alloy_primitives::Address;
 use clap::Parser;
 use eyre::{Context, Result};
+use foundry_block_explorers::Client;
 use foundry_cli::opts::EtherscanOpts;
 use foundry_common::fs;
 use foundry_config::Config;
@@ -58,7 +61,42 @@ impl InterfaceArgs {
             }
         };
 
-        let interfaces = SimpleCast::generate_interface(source).await?;
+        let items = match source {
+            AbiPath::Local { path, name } => {
+                let file = std::fs::read_to_string(&path).wrap_err("unable to read abi file")?;
+                let obj: ContractObject = serde_json::from_str(&file)?;
+                let abi =
+                    obj.abi.ok_or_else(|| eyre::eyre!("could not find ABI in file {path}"))?;
+                let name = name.unwrap_or_else(|| "Interface".to_owned());
+                vec![(abi, name)]
+            }
+            AbiPath::Etherscan { address, chain, api_key } => {
+                let client = Client::new(chain, api_key)?;
+                let source = client.contract_source_code(address).await?;
+                source
+                    .items
+                    .into_iter()
+                    .map(|item| Ok((item.abi()?, item.contract_name)))
+                    .collect::<Result<Vec<_>>>()?
+            }
+        };
+
+        let interfaces = items
+            .into_iter()
+            .map(|(contract_abi, name)| {
+                let source = match foundry_cli::utils::abi_to_solidity(&contract_abi, &name) {
+                    Ok(generated_source) => generated_source,
+                    Err(e) => {
+                        warn!("Failed to format interface for {name}: {e}");
+                        contract_abi.to_sol(&name, None)
+                    }
+                };
+                Ok(InterfaceSource {
+                    json_abi: serde_json::to_string_pretty(&contract_abi)?,
+                    source,
+                })
+            })
+            .collect::<Result<Vec<InterfaceSource>>>()?;
 
         // put it all together
         let res = if json {
@@ -84,4 +122,16 @@ impl InterfaceArgs {
         }
         Ok(())
     }
+}
+
+struct InterfaceSource {
+    json_abi: String,
+    source: String,
+}
+
+// Local is a path to the directory containing the ABI files
+// In case of etherscan, ABI is fetched from the address on the chain
+enum AbiPath {
+    Local { path: String, name: Option<String> },
+    Etherscan { address: Address, chain: Chain, api_key: String },
 }

--- a/crates/fmt/src/helpers.rs
+++ b/crates/fmt/src/helpers.rs
@@ -22,8 +22,19 @@ pub struct Parsed<'a> {
     pub invalid_inline_config_items: Vec<(Loc, InvalidInlineConfigItem)>,
 }
 
-/// Parse source code
-pub fn parse(src: &str) -> Result<Parsed<'_>, Vec<Diagnostic>> {
+/// Parse source code.
+pub fn parse(src: &str) -> Result<Parsed<'_>, FormatterError> {
+    parse_raw(src).map_err(|diag| FormatterError::Parse(src.to_string(), None, diag))
+}
+
+/// Parse source code with a path for diagnostics.
+pub fn parse2<'s>(src: &'s str, path: Option<&Path>) -> Result<Parsed<'s>, FormatterError> {
+    parse_raw(src)
+        .map_err(|diag| FormatterError::Parse(src.to_string(), path.map(ToOwned::to_owned), diag))
+}
+
+/// Parse source code, returning a list of diagnostics on failure.
+pub fn parse_raw(src: &str) -> Result<Parsed<'_>, Vec<Diagnostic>> {
     let (pt, comments) = solang_parser::parse(src, 0)?;
     let comments = Comments::new(comments, src);
     let (inline_config_items, invalid_inline_config_items): (Vec<_>, Vec<_>) =
@@ -46,10 +57,7 @@ pub fn format_to<W: Write>(
 
 /// Parse and format a string with default settings
 pub fn format(src: &str) -> Result<String, FormatterError> {
-    let parsed = parse(src).map_err(|err| {
-        debug!(?err, "Parse error");
-        FormatterError::Fmt(std::fmt::Error)
-    })?;
+    let parsed = parse(src)?;
 
     let mut output = String::new();
     format_to(&mut output, parsed, FormatterConfig::default())?;
@@ -75,18 +83,19 @@ pub fn offset_to_line_column(content: &str, start: usize) -> (usize, usize) {
     unreachable!("content.len() > start")
 }
 
-/// Print the report of parser's diagnostics
-pub fn print_diagnostics_report(
+/// Formats parser diagnostics
+pub fn format_diagnostics_report(
     content: &str,
     path: Option<&Path>,
-    diagnostics: Vec<Diagnostic>,
-) -> std::io::Result<()> {
+    diagnostics: &[Diagnostic],
+) -> String {
     if diagnostics.is_empty() {
-        return Ok(());
+        return String::new();
     }
 
     let filename =
         path.map(|p| p.file_name().unwrap().to_string_lossy().to_string()).unwrap_or_default();
+    let mut s = Vec::new();
     for diag in diagnostics {
         let (start, end) = (diag.loc.start(), diag.loc.end());
         let mut report = Report::build(ReportKind::Error, &filename, start)
@@ -94,16 +103,16 @@ pub fn print_diagnostics_report(
             .with_label(
                 Label::new((&filename, start..end))
                     .with_color(Color::Red)
-                    .with_message(format!("{}", diag.message.fg(Color::Red))),
+                    .with_message(format!("{}", diag.message.as_str().fg(Color::Red))),
             );
 
-        for note in diag.notes {
-            report = report.with_note(note.message);
+        for note in &diag.notes {
+            report = report.with_note(&note.message);
         }
 
-        report.finish().print((&filename, Source::from(content)))?;
+        report.finish().write((&filename, Source::from(content)), &mut s).unwrap();
     }
-    Ok(())
+    String::from_utf8(s).unwrap()
 }
 
 pub fn import_path_string(path: &ImportPath) -> String {

--- a/crates/fmt/src/lib.rs
+++ b/crates/fmt/src/lib.rs
@@ -21,7 +21,7 @@ pub use foundry_config::fmt::*;
 pub use comments::Comments;
 pub use formatter::{Formatter, FormatterError};
 pub use helpers::{
-    format, format_to, offset_to_line_column, parse, print_diagnostics_report, Parsed,
+    format, format_diagnostics_report, format_to, offset_to_line_column, parse, parse2, Parsed,
 };
 pub use inline_config::InlineConfig;
 pub use visit::{Visitable, Visitor};

--- a/crates/forge/bin/cmd/fmt.rs
+++ b/crates/forge/bin/cmd/fmt.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, ValueHint};
-use eyre::Result;
-use forge_fmt::{format_to, parse, print_diagnostics_report};
+use eyre::{Context, Result};
+use forge_fmt::{format_to, parse};
 use foundry_cli::utils::{FoundryPathExt, LoadConfig};
 use foundry_common::{fs, term::cli_warn};
 use foundry_compilers::{compilers::solc::SolcLanguage, SOLC_EXTENSIONS};
@@ -102,9 +102,8 @@ impl FmtArgs {
                 None => "stdin".to_string(),
             };
 
-            let parsed = parse(&source).map_err(|diagnostics| {
-                let _ = print_diagnostics_report(&source, path, diagnostics);
-                eyre::eyre!("Failed to parse Solidity code for {name}. Leaving source unchanged.")
+            let parsed = parse(&source).wrap_err_with(|| {
+                format!("Failed to parse Solidity code for {name}. Leaving source unchanged.")
             })?;
 
             if !parsed.invalid_inline_config_items.is_empty() {

--- a/crates/forge/bin/cmd/geiger/error.rs
+++ b/crates/forge/bin/cmd/geiger/error.rs
@@ -1,12 +1,11 @@
+use forge_fmt::FormatterError;
 use foundry_common::errors::FsPathError;
-use solang_parser::diagnostics::Diagnostic;
-use std::path::PathBuf;
 
 /// Possible errors when scanning a solidity file
 #[derive(Debug, thiserror::Error)]
 pub enum ScanFileError {
     #[error(transparent)]
     Io(#[from] FsPathError),
-    #[error("Failed to parse {1:?}: {0:?}")]
-    ParseSol(Vec<Diagnostic>, PathBuf),
+    #[error(transparent)]
+    ParseSol(#[from] FormatterError),
 }


### PR DESCRIPTION
Also print the raw ABI string regardless if formatting fails

Fixes https://github.com/foundry-rs/foundry/issues/8099