### PR TITLE
fix(invariant): exclude default addresses from senders

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -497,7 +497,7 @@ impl<'a> InvariantExecutor<'a> {
         let mut excluded_senders =
             self.call_sol_default(to, &IInvariantTest::excludeSendersCall {}).excludedSenders;
         // Extend with default excluded addresses - https://github.com/foundry-rs/foundry/issues/4163
-        excluded_senders.extend(vec![
+        excluded_senders.extend([
             CHEATCODE_ADDRESS,
             HARDHAT_CONSOLE_ADDRESS,
             DEFAULT_CREATE2_DEPLOYER,

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -229,6 +229,10 @@ async fn test_invariant() {
                     None,
                     None,
                 )],
+            ),
+            (
+                "default/fuzz/invariant/common/InvariantExcludedSenders.t.sol:InvariantExcludedSendersTest",
+                vec![("invariant_check_sender()", true, None, None, None)],
             )
         ]),
     );
@@ -665,6 +669,21 @@ async fn test_invariant_roll_fork_handler() {
                 None,
                 None,
             )],
+        )]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_excluded_senders() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantExcludedSenders.t.sol");
+    let mut runner = TEST_DATA_DEFAULT.runner();
+    runner.test_options.invariant.fail_on_revert = true;
+    let results = runner.test_collect(&filter);
+    assert_multiple(
+        &results,
+        BTreeMap::from([(
+            "default/fuzz/invariant/common/InvariantExcludedSenders.t.sol:InvariantExcludedSendersTest",
+            vec![("invariant_check_sender()", true, None, None, None)],
         )]),
     );
 }

--- a/testdata/default/fuzz/invariant/common/InvariantExcludedSenders.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantExcludedSenders.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+
+contract InvariantSenders {
+    function checkSender() external {
+        require(msg.sender != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D, "sender cannot be cheatcode address");
+        require(msg.sender != 0x000000000000000000636F6e736F6c652e6c6f67, "sender cannot be console address");
+        require(msg.sender != 0x4e59b44847b379578588920cA78FbF26c0B4956C, "sender cannot be CREATE2 deployer");
+    }
+}
+
+contract InvariantExcludedSendersTest is DSTest {
+    InvariantSenders target;
+
+    function setUp() public {
+        target = new InvariantSenders();
+    }
+
+    function invariant_check_sender() public view {}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4163 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- exclude  `CHEATCODE_ADDRESS`, `HARDHAT_CONSOLE_ADDRESS` and `DEFAULT_CREATE2_DEPLOYER` from senders