### PR TITLE
Support WalletOpts in `cast wallet derive-private-key` command

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -377,9 +377,9 @@ flag to set your key via:
             Self::PrivateKey { wallet, mnemonic_override, mnemonic_index_override } => {
                 let wallet = mnemonic_override
                     .map(|mnemonic| WalletOpts {
-                        raw: RawWalletOpts { 
-                            mnemonic: Some(mnemonic), 
-                            mnemonic_index: mnemonic_index_override.unwrap_or_default(), 
+                        raw: RawWalletOpts {
+                            mnemonic: Some(mnemonic),
+                            mnemonic_index: mnemonic_index_override.unwrap_or_default(),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -391,10 +391,10 @@ flag to set your key via:
                     WalletSigner::Local(wallet) => {
                         let pk_bytes = wallet.signer().to_bytes();
                         println!("0x{}", hex::encode(pk_bytes));
-                    },
+                    }
                     _ => {
                         eyre::bail!("Only local wallets are supported by this command.");
-                    },
+                    }
                 }
             }
             Self::DecryptKeystore { account_name, keystore_dir, unsafe_password } => {

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -149,7 +149,7 @@ pub enum WalletSubcommands {
     List(ListArgs),
 
     /// Derives private key from mnemonic
-    #[command(name = "private-key", visible_alias = "pk")]
+    #[command(name = "private-key", visible_aliases = &["pk", "derive-private-key", "--derive-private-key"])]
     PrivateKey {
         /// If provided, the private key will be derived from the specified menomonic phrase.
         #[arg(value_name = "MNEMONIC")]

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -159,6 +159,10 @@ pub enum WalletSubcommands {
         #[arg(value_name = "MNEMONIC_INDEX")]
         mnemonic_index_override: Option<u32>,
 
+        /// Verbose mode, print the address and private key.
+        #[arg(short = 'v', long)]
+        verbose: bool,
+
         #[command(flatten)]
         wallet: WalletOpts,
     },
@@ -374,7 +378,7 @@ flag to set your key via:
             Self::List(cmd) => {
                 cmd.run().await?;
             }
-            Self::PrivateKey { wallet, mnemonic_override, mnemonic_index_override } => {
+            Self::PrivateKey { wallet, mnemonic_override, mnemonic_index_override, verbose } => {
                 let wallet = mnemonic_override
                     .map(|mnemonic| WalletOpts {
                         raw: RawWalletOpts {
@@ -390,7 +394,13 @@ flag to set your key via:
                 match wallet {
                     WalletSigner::Local(wallet) => {
                         let pk_bytes = wallet.signer().to_bytes();
-                        println!("0x{}", hex::encode(pk_bytes));
+                        if verbose {
+                            let address = wallet.address();
+                            println!("Address: {address}");
+                            println!("Private key: 0x{}", hex::encode(pk_bytes));
+                        } else {
+                            println!("0x{}", hex::encode(pk_bytes));
+                        }
                     }
                     _ => {
                         eyre::bail!("Only local wallets are supported by this command.");

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -149,7 +149,7 @@ pub enum WalletSubcommands {
     List(ListArgs),
 
     /// Derives private key from mnemonic
-    #[command(name = "private-key", visible_aliases = &["pk", "derive-private-key", "--derive-private-key"])]
+    #[command(name = "private-key", visible_alias = "pk", aliases = &["derive-private-key", "--derive-private-key"])]
     PrivateKey {
         /// If provided, the private key will be derived from the specified menomonic phrase.
         #[arg(value_name = "MNEMONIC")]

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -149,8 +149,8 @@ pub enum WalletSubcommands {
     List(ListArgs),
 
     /// Derives private key from mnemonic
-    #[command(name = "derive-private-key", visible_aliases = &["--derive-private-key"])]
-    DerivePrivateKey {
+    #[command(name = "private-key", visible_alias = "pk")]
+    PrivateKey {
         /// If provided, the private key will be derived from the specified menomonic phrase.
         #[arg(value_name = "MNEMONIC")]
         mnemonic_override: Option<String>,
@@ -374,7 +374,7 @@ flag to set your key via:
             Self::List(cmd) => {
                 cmd.run().await?;
             }
-            Self::DerivePrivateKey { wallet, mnemonic_override, mnemonic_index_override } => {
+            Self::PrivateKey { wallet, mnemonic_override, mnemonic_index_override } => {
                 let wallet = mnemonic_override
                     .map(|mnemonic| WalletOpts {
                         raw: RawWalletOpts { 

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -393,13 +393,11 @@ flag to set your key via:
                     .await?;
                 match wallet {
                     WalletSigner::Local(wallet) => {
-                        let pk_bytes = wallet.signer().to_bytes();
                         if verbose {
-                            let address = wallet.address();
-                            println!("Address: {address}");
-                            println!("Private key: 0x{}", hex::encode(pk_bytes));
+                            println!("Address:     {}", wallet.address());
+                            println!("Private key: 0x{}", hex::encode(wallet.signer().to_bytes()));
                         } else {
-                            println!("0x{}", hex::encode(pk_bytes));
+                            println!("0x{}", hex::encode(wallet.signer().to_bytes()));
                         }
                     }
                     _ => {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -163,6 +163,46 @@ casttest!(wallet_list_local_accounts, |prj, cmd| {
     assert_eq!(list_output.matches('\n').count(), 10);
 });
 
+// tests that `cast wallet private-key` with arguments outputs the private key
+casttest!(wallet_private_key_from_mnemonic_arg, |_prj, cmd| {
+    cmd.args([
+        "wallet",
+        "private-key",
+        "test test test test test test test test test test test junk",
+        "1",
+    ]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+});
+
+// tests that `cast wallet private-key` with options outputs the private key
+casttest!(wallet_private_key_from_mnemonic_option, |_prj, cmd| {
+    cmd.args([
+        "wallet",
+        "private-key",
+        "--mnemonic",
+        "test test test test test test test test test test test junk",
+        "--mnemonic-index",
+        "1",
+    ]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+});
+
+// tests that `cast wallet private-key` with derivation path outputs the private key
+casttest!(wallet_private_key_with_derivation_path, |_prj, cmd| {
+    cmd.args([
+        "wallet",
+        "private-key",
+        "--mnemonic",
+        "test test test test test test test test test test test junk",
+        "--mnemonic-derivation-path",
+        "m/44'/60'/0'/0/1",
+    ]);
+    let output = cmd.stdout_lossy();
+    assert_eq!(output.trim(), "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+});
+
 // tests that `cast wallet import` creates a keystore for a private key and that `cast wallet
 // decrypt-keystore` can access it
 casttest!(wallet_import_and_decrypt, |prj, cmd| {


### PR DESCRIPTION
## Motivation

Currently `derive-private-key` implements its own wallet init code with hardcoded derivation path. Replacing it with existing `WalletOpts` allows to reduce code duplication and also:

- specify custom derivation path
- use encrypted keystore
- use the same mnemonic flags as in other cast commands improving consistency

The command still supports explicitly specifying mnemonic and index as arguments.
Output format was changed to print private key only, allowing it to be used in shell scripts.

Breaking!! The command was renamed from `derive-private-key` to `private-key` and assigned `pk` alias. The old name is too verbose. The renaming is done in a separate commit, so it can be easily excluded from this PR if maintainers decide so.