### PR TITLE
feat: publish linux/arm64 Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,9 @@ jobs:
               id: checkout
               uses: actions/checkout@v4
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
             - name: Install Docker BuildX
               uses: docker/setup-buildx-action@v2
               id: buildx
@@ -86,6 +89,7 @@ jobs:
               with:
                   context: .
                   push: true
+                  platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.docker_tagging.outputs.docker_tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=gha


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes https://github.com/foundry-rs/foundry/issues/7964.

Currently there's no arm64 image published which leads to errors like this:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

In some cases it's possible to use `linux/amd64` image, but it has worse performance. In some cases this is not an option, e.g. when running minikube on an Apple Silicon laptop.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Modify the GitHub Action according to the "multi-platform image" example in https://github.com/docker/build-push-action.

I'm not sure if there's an easy way to test this change.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

