### PR TITLE
fix(forge): preserve state of persisted accounts on rollFork(tx) / transact

### DIFF
--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1918,10 +1918,7 @@ pub fn update_state<DB: Database>(
     persistent_accounts: Option<&HashSet<Address>>,
 ) -> Result<(), DB::Error> {
     for (addr, acc) in state.iter_mut() {
-        let is_persistent =
-            if let Some(accounts) = persistent_accounts { accounts.contains(addr) } else { false };
-
-        if !is_persistent {
+        if !persistent_accounts.map_or(false, |accounts| accounts.contains(addr)) {
             acc.info = db.basic(*addr)?.unwrap_or_default();
             for (key, val) in acc.storage.iter_mut() {
                 val.present_value = db.storage(*addr, *key)?;

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -515,7 +515,7 @@ impl InspectorStack {
         ecx.db.commit(res.state.clone());
 
         // Update both states with new DB data after commit.
-        if let Err(e) = update_state(&mut ecx.journaled_state.state, &mut ecx.db) {
+        if let Err(e) = update_state(&mut ecx.journaled_state.state, &mut ecx.db, None) {
             let res = InterpreterResult {
                 result: InstructionResult::Revert,
                 output: Bytes::from(e.to_string()),
@@ -523,7 +523,7 @@ impl InspectorStack {
             };
             return (res, None)
         }
-        if let Err(e) = update_state(&mut res.state, &mut ecx.db) {
+        if let Err(e) = update_state(&mut res.state, &mut ecx.db, None) {
             let res = InterpreterResult {
                 result: InstructionResult::Revert,
                 output: Bytes::from(e.to_string()),

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -339,3 +339,6 @@ test_repro!(2851, false, None, |res| {
     let test = res.test_results.remove("invariantNotZero()").unwrap();
     assert_eq!(test.status, TestStatus::Failure);
 });
+
+// https://github.com/foundry-rs/foundry/issues/8006
+test_repro!(8006);

--- a/testdata/default/repros/Issue8006.t.sol
+++ b/testdata/default/repros/Issue8006.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256 supply);
+}
+
+contract Mock {
+    function totalSupply() external view returns (uint256 supply) {
+        return 1;
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/8006
+contract Issue5739Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+    IERC20 dai;
+    bytes32 transaction = 0x67cbad73764049e228495a3f90144aab4a37cb4b5fd697dffc234aa5ed811ace;
+
+    function setUp() public {
+        vm.createSelectFork("rpcAlias", 16261704);
+        dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    }
+
+    function testRollForkEtchNotCalled() public {
+        // dai not persistent so should not call mock code
+        vm.etch(address(dai), address(new Mock()).code);
+        assertEq(dai.totalSupply(), 1);
+        vm.rollFork(transaction);
+        assertEq(dai.totalSupply(), 5155217627191887307044676292);
+    }
+
+    function testRollForkEtchCalled() public {
+        // make dai persistent so mock code is preserved
+        vm.etch(address(dai), address(new Mock()).code);
+        vm.makePersistent(address(dai));
+        assertEq(dai.totalSupply(), 1);
+        vm.rollFork(transaction);
+        assertEq(dai.totalSupply(), 1);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8006 accounts state marked as persistent is overwritten in `rollFork(tx)` and `transact` calls
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add `persistent_accounts` arg in `update_state` helper. Update state only if account is not marked as persistent
- `persistent_accounts` is some when called from `commit_transaction` (used by `rollFork` / transact)
- `persistent_accounts` is none when update state from stack 