### PR TITLE
fix(forge): needs a aws-kms feature to allow for continued support of the --aws flag

### DIFF
--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -135,6 +135,7 @@ rustls = [
 openssl = ["foundry-cli/openssl", "reqwest/default-tls"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["dep:tikv-jemallocator"]
+aws-kms = ["foundry-wallets/aws-kms"]
 
 [[bench]]
 name = "test"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Since the support for aws was put behind a feature flag the `--aws` flag in forge no longer functions. 

## Solution
This PR will add a feature to the `forge` crate to fix this. 
