### PR TITLE
fix(forge): fix the bug where source code incorrectly overlaps during debugging

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -322,6 +322,14 @@ impl DebuggerContext<'_> {
             lines.push(u_num, line, u_text);
         }
 
+        // pad with empty to each line to ensure the previous text is cleared
+        for line in &mut lines.lines {
+            // note that the \n is not included in the line length
+            if area.width as usize > line.width() + 1 {
+                line.push_span(Span::raw(" ".repeat(area.width as usize - line.width() - 1)));
+            }
+        }
+
         Text::from(lines.lines)
     }
 


### PR DESCRIPTION
## Motivation

When using the debugger mode (i.e., `forge script XXX --debug`), the source code panel/area does not clear the previous content. It will make the output quite messy.  

For example, when debugging [uniswapv2.zip](https://github.com/user-attachments/files/15797549/uniswapv2.zip) with the command `forge script script/run.sol --debug`.

![image](https://github.com/foundry-rs/foundry/assets/14835483/853e2748-6133-40dd-b52e-87d9045b914c)

All the grey text is rendered in the previous tick. A correct one should look as follows.

![image](https://github.com/foundry-rs/foundry/assets/14835483/cca4146a-2a10-4e07-92f2-41b89444467d) 


## Solution

This commit adds padding to the source code, ensuring all the previous content could be cleared. 