### PR TITLE
fix: Soldeer: Fixed the url bug, it should be optional

### DIFF
--- a/crates/config/src/soldeer.rs
+++ b/crates/config/src/soldeer.rs
@@ -11,7 +11,7 @@ pub struct SoldeerDependency {
     pub version: String,
 
     /// The url from where the dependency was retrieved
-    pub url: String,
+    pub url: Option<String>,
 }
 
 /// Type for Soldeer configs, under dependencies tag in the foundry.toml

--- a/crates/config/src/soldeer.rs
+++ b/crates/config/src/soldeer.rs
@@ -11,6 +11,7 @@ pub struct SoldeerDependency {
     pub version: String,
 
     /// The url from where the dependency was retrieved
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The URL in the soldeer config should be optional otherwise it will result in crash. 

## Solution
Made the URL optional in the `SoldeerDependency`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
