### PR TITLE
fix: make `paths` a positional argument

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -126,11 +126,6 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub skip: Option<Vec<SkipBuildFilter>>,
 
-    /// Build source files from specified paths.
-    #[arg(long, short, num_args(0..))]
-    #[serde(skip)]
-    pub paths: Option<Vec<PathBuf>>,
-
     #[command(flatten)]
     #[serde(flatten)]
     pub compiler: CompilerArgs,

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -91,9 +91,9 @@ impl BuildArgs {
 
         // Collect sources to compile if build subdirectories specified.
         let mut files = vec![];
-        if let Some(dirs) = self.paths {
-            for dir in dirs {
-                files.extend(source_files_iter(dir, MultiCompilerLanguage::FILE_EXTENSIONS));
+        if let Some(paths) = self.paths {
+            for path in paths {
+                files.extend(source_files_iter(path, MultiCompilerLanguage::FILE_EXTENSIONS));
             }
         }
 

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -18,6 +18,7 @@ use foundry_config::{
     Config,
 };
 use serde::Serialize;
+use std::path::PathBuf;
 use watchexec::config::{InitConfig, RuntimeConfig};
 
 foundry_config::merge_impl_figment_convert!(BuildArgs, args);
@@ -46,6 +47,10 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, args);
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 #[command(next_help_heading = "Build options", about = None, long_about = None)] // override doc
 pub struct BuildArgs {
+    /// Build source files from specified paths.
+    #[serde(skip)]
+    pub paths: Option<Vec<PathBuf>>,
+
     /// Print compiled contract names.
     #[arg(long)]
     #[serde(skip)]
@@ -86,7 +91,7 @@ impl BuildArgs {
 
         // Collect sources to compile if build subdirectories specified.
         let mut files = vec![];
-        if let Some(dirs) = self.args.paths {
+        if let Some(dirs) = self.paths {
             for dir in dirs {
                 files.extend(source_files_iter(dir, MultiCompilerLanguage::FILE_EXTENSIONS));
             }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1696,7 +1696,7 @@ function test_bar() external {}
 
     // Build 2 files within test dir
     prj.clear();
-    cmd.args(["build", "--paths", "test", "--force"]);
+    cmd.args(["build", "test", "--force"]);
     cmd.unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/can_build_path_with_two_files.stdout"),
@@ -1705,7 +1705,7 @@ function test_bar() external {}
     // Build one file within src dir
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "--paths", "src", "--force"]);
+    cmd.args(["build", "src", "--force"]);
     cmd.unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/can_build_path_with_one_file.stdout"),
@@ -1714,7 +1714,7 @@ function test_bar() external {}
     // Build 3 files from test and src dirs
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "--paths", "src", "test", "--force"]);
+    cmd.args(["build", "src", "test", "--force"]);
     cmd.unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/can_build_path_with_three_files.stdout"),
@@ -1723,7 +1723,7 @@ function test_bar() external {}
     // Build single test file
     prj.clear();
     cmd.forge_fuse();
-    cmd.args(["build", "--paths", "test/Bar.sol", "--force"]);
+    cmd.args(["build", "test/Bar.sol", "--force"]);
     cmd.unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/can_build_path_with_one_file.stdout"),


### PR DESCRIPTION
## Motivation

Follow-up for #8149. Allows `forge build <dir>` invocations

## Solution

