### PR TITLE
feat: cast etherscan-source --flatten

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
  "rustls 0.23.10",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.23.0",
+ "tokio-tungstenite 0.23.1",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -8505,9 +8505,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becd34a233e7e31a3dbf7c7241b38320f57393dcae8e7324b0167d21b8e320b0"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -530,17 +530,20 @@ async fn main() -> Result<()> {
         CastSubcommand::RightShift { value, bits, base_in, base_out } => {
             println!("{}", SimpleCast::right_shift(&value, &bits, base_in.as_deref(), &base_out)?);
         }
-        CastSubcommand::EtherscanSource { address, directory, etherscan } => {
+        CastSubcommand::EtherscanSource { address, directory, etherscan, flatten } => {
             let config = Config::from(&etherscan);
             let chain = config.chain.unwrap_or_default();
             let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
-            match directory {
-                Some(dir) => {
+            match (directory, flatten) {
+                (Some(dir), false) => {
                     SimpleCast::expand_etherscan_source_to_directory(chain, address, api_key, dir)
                         .await?
                 }
-                None => {
+                (None, false) => {
                     println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?);
+                }
+                (dir, true) => {
+                    SimpleCast::etherscan_source_flatten(chain, address, api_key, dir).await?;
                 }
             }
         }

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -808,8 +808,12 @@ pub enum CastSubcommand {
         /// The contract's address.
         address: String,
 
-        /// The output directory to expand source tree into.
-        #[arg(short, value_hint = ValueHint::DirPath)]
+        /// Whether to flatten the source code.
+        #[arg(long, short)]
+        flatten: bool,
+
+        /// The output directory/file to expand source tree into.
+        #[arg(short, value_hint = ValueHint::DirPath, alias = "path")]
         directory: Option<PathBuf>,
 
         #[command(flatten)]

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -25,9 +25,11 @@ use eyre::{Context, ContextCompat, Result};
 use foundry_block_explorers::Client;
 use foundry_common::{
     abi::{encode_function_args, get_func},
+    compile::etherscan_project,
     fmt::*,
-    TransactionReceiptWithRevertReason,
+    fs, TransactionReceiptWithRevertReason,
 };
+use foundry_compilers::flatten::Flattener;
 use foundry_config::Chain;
 use futures::{future::Either, FutureExt, StreamExt};
 use rayon::prelude::*;
@@ -1844,6 +1846,37 @@ impl SimpleCast {
         let meta = client.contract_source_code(contract_address.parse()?).await?;
         let source_tree = meta.source_tree();
         source_tree.write_to(&output_directory)?;
+        Ok(())
+    }
+
+    /// Fetches the source code of verified contracts from etherscan, flattens it and writes it to
+    /// the given path or stdout.
+    pub async fn etherscan_source_flatten(
+        chain: Chain,
+        contract_address: String,
+        etherscan_api_key: String,
+        output_path: Option<PathBuf>,
+    ) -> Result<()> {
+        let client = Client::new(chain, etherscan_api_key)?;
+        let metadata = client.contract_source_code(contract_address.parse()?).await?;
+        let Some(metadata) = metadata.items.first() else {
+            eyre::bail!("Empty contract source code")
+        };
+
+        let tmp = tempfile::tempdir()?;
+        let project = etherscan_project(metadata, tmp.path())?;
+        let target_path = project.find_contract_path(&metadata.contract_name)?;
+
+        let flattened = Flattener::new(project, &target_path)?.flatten();
+
+        if let Some(path) = output_path {
+            fs::create_dir_all(path.parent().unwrap())?;
+            fs::write(&path, flattened)?;
+            println!("Flattened file written at {}", path.display());
+        } else {
+            println!("{flattened}");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/7352

## Solution

Implements small refactor in https://github.com/foundry-rs/compilers/pull/143 to avoid duplicating compilation logic.
Also extracts part of `ProjectCompiler` into `with_compilation_reporter` to allow displaying progress even if compilation is invoked by another entity (e.g. `Flattener`).
