### PR TITLE
feat: debug_getRawTransaction RPC endpoint

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -195,6 +195,18 @@ pub enum EthRequest {
     #[cfg_attr(feature = "serde", serde(rename = "eth_getTransactionByBlockNumberAndIndex"))]
     EthGetTransactionByBlockNumberAndIndex(BlockNumber, Index),
 
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "eth_getRawTransactionByHash", with = "sequence")
+    )]
+    EthGetRawTransactionByHash(TxHash),
+
+    #[cfg_attr(feature = "serde", serde(rename = "eth_getRawTransactionByBlockHashAndIndex"))]
+    EthGetRawTransactionByBlockHashAndIndex(TxHash, Index),
+
+    #[cfg_attr(feature = "serde", serde(rename = "eth_getRawTransactionByBlockNumberAndIndex"))]
+    EthGetRawTransactionByBlockNumberAndIndex(BlockNumber, Index),
+
     #[cfg_attr(feature = "serde", serde(rename = "eth_getTransactionReceipt", with = "sequence"))]
     EthGetTransactionReceipt(B256),
 
@@ -264,6 +276,10 @@ pub enum EthRequest {
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_syncing", with = "empty_params"))]
     EthSyncing(()),
+
+    /// geth's `debug_getRawTransaction`  endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "debug_getRawTransaction", with = "sequence"))]
+    DebugGetRawTransaction(TxHash),
 
     /// geth's `debug_traceTransaction`  endpoint
     #[cfg_attr(feature = "serde", serde(rename = "debug_traceTransaction"))]
@@ -1418,6 +1434,25 @@ mod tests {
         let s = r#"{"id": 1, "method": "eth_subscribe", "params": ["syncing"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthPubSub>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_raw_transaction() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawTransaction","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByHash","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockHashAndIndex","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c",1],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x3ed3a89b",0],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -34,7 +34,7 @@ use crate::{
 use alloy_consensus::transaction::eip4844::TxEip4844Variant;
 use alloy_dyn_abi::TypedData;
 use alloy_eips::eip2718::Encodable2718;
-use alloy_network::{eip2718::Decodable2718, TransactionResponse};
+use alloy_network::eip2718::Decodable2718;
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, B64, U256, U64};
 use alloy_rpc_types::{
     request::TransactionRequest,

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -77,7 +77,10 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
+<<<<<<< HEAD
     #[allow(dependency_on_unit_never_type_fallback)]
+=======
+>>>>>>> 38be5776e (clippy happy)
     pub async fn run(self) -> Result<(), eyre::Report> {
         let Self {
             eth,

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -77,10 +77,7 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
-<<<<<<< HEAD
     #[allow(dependency_on_unit_never_type_fallback)]
-=======
->>>>>>> 38be5776e (clippy happy)
     pub async fn run(self) -> Result<(), eyre::Report> {
         let Self {
             eth,

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -77,7 +77,7 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
-    #[allow(dependency_on_unit_never_type_fallback)]
+    #[allow(unknown_lints, dependency_on_unit_never_type_fallback)]
     pub async fn run(self) -> Result<(), eyre::Report> {
         let Self {
             eth,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #8152

## Solution

I'm not exactly sure about @mattsse reply:

> this includes endpoints:
> * `debug_getRawTransaction`
> * `eth_getRawTransactionByHash`
> * `eth_getRawTransactionByBlockHashAndIndex`
> * `eth_getRawTransactionByBlockNumberAndIndex`

Since, as shown here: https://ethereum.org/en/developers/docs/apis/json-rpc/ and here: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-eth, non-eth endpoints should not have `eth_` prefix. Maybe move them to `debug_`?
