### PR TITLE
fix: enable cache when `--build-info` is enabled

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -804,7 +804,7 @@ impl Config {
                 Severity::Error
             })
             .set_offline(self.offline)
-            .set_cached(cached && !self.build_info)
+            .set_cached(cached)
             .set_build_info(!no_artifacts && self.build_info)
             .set_no_artifacts(no_artifacts);
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/7379

Since https://github.com/foundry-rs/compilers/pull/140 we provide enough data to match each cached artifact with build info which produced it, so workaround from https://github.com/foundry-rs/foundry/pull/7358 is not needed anymore 

## Solution

