### PR TITLE
fix(forge-bind): alloy deps and file consistency check

### DIFF
--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -77,7 +77,7 @@ pub enum SendTxSubcommands {
 }
 
 impl SendTxArgs {
-    #[allow(dependency_on_unit_never_type_fallback)]
+    #[allow(unknown_lints, dependency_on_unit_never_type_fallback)]
     pub async fn run(self) -> Result<(), eyre::Report> {
         let Self {
             eth,

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -336,7 +336,7 @@ edition = "2021"
                 version
             )
         } else {
-            &r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
+            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
         };
         let toml_consistent = cargo_toml_contents.contains(name_check) &&
             cargo_toml_contents.contains(version_check) &&

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -306,8 +306,16 @@ edition = "2021"
             file_path.display()
         );
         let file_contents = &fs::read_to_string(file_path).wrap_err("Failed to read file")?;
+
+        // Format both
+        let file_contents = syn::parse_file(file_contents)?;
+        let formatted_file = prettyplease::unparse(&file_contents);
+
+        let expected_contents = syn::parse_file(expected_contents)?;
+        let formatted_exp = prettyplease::unparse(&expected_contents);
+
         eyre::ensure!(
-            file_contents == expected_contents,
+            formatted_file == formatted_exp,
             "File contents do not match expected contents for {file_path:?}"
         );
         Ok(())
@@ -336,7 +344,7 @@ edition = "2021"
                 version
             )
         } else {
-            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
+            &r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
         };
         let toml_consistent = cargo_toml_contents.contains(name_check) &&
             cargo_toml_contents.contains(version_check) &&

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -336,19 +336,18 @@ edition = "2021"
         let cargo_toml_contents =
             fs::read_to_string(cargo_toml_path).wrap_err("Failed to read Cargo.toml")?;
 
-        let name_check = &format!("name = \"{}\"", name);
-        let version_check = &format!("version = \"{}\"", version);
+        let name_check = format!("name = \"{name}\"");
+        let version_check = format!("version = \"{version}\"");
         let alloy_dep_check = if let Some(version) = alloy_version {
-            &format!(
-                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{}", features = ["sol-types", "contract"] }}"#,
-                version
+            format!(
+                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{version}", features = ["sol-types", "contract"] }}"#,
             )
         } else {
-            &r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
+            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
         };
-        let toml_consistent = cargo_toml_contents.contains(name_check) &&
-            cargo_toml_contents.contains(version_check) &&
-            cargo_toml_contents.contains(alloy_dep_check);
+        let toml_consistent = cargo_toml_contents.contains(&name_check) &&
+            cargo_toml_contents.contains(&version_check) &&
+            cargo_toml_contents.contains(&alloy_dep_check);
         eyre::ensure!(
             toml_consistent,
             r#"The contents of Cargo.toml do not match the expected output of the latest `sol!` version.

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -123,7 +123,7 @@ edition = "2021"
                 alloy_version
             )
         } else {
-            r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }}"#.to_string()
+            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
         };
         write!(toml_contents, "{}", alloy_dep)?;
 
@@ -336,7 +336,7 @@ edition = "2021"
                 version
             )
         } else {
-            &r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }}"#.to_string()
+            &r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
         };
         let toml_consistent = cargo_toml_contents.contains(name_check) &&
             cargo_toml_contents.contains(version_check) &&


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

1. Invalid deps format in `Cargo.toml` when version is not specified. 
2. Checking unformatted code for consistency can lead to failures even though code might be the same. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. Remove extra braces 
2. Format code before checking for consistency

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
