### PR TITLE
fix(invariant): weight invariant selectors by number of selectors

### DIFF
--- a/crates/evm/fuzz/src/invariant/filters.rs
+++ b/crates/evm/fuzz/src/invariant/filters.rs
@@ -25,8 +25,7 @@ impl ArtifactFilters {
     /// Gets all the targeted functions from `artifact`. Returns error, if selectors do not match
     /// the `artifact`.
     ///
-    /// An empty vector means that it targets any mutable function. See `select_random_function` for
-    /// more.
+    /// An empty vector means that it targets any mutable function.
     pub fn get_targeted_functions(
         &self,
         artifact: &ArtifactId,

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -1,10 +1,13 @@
 use super::{fuzz_calldata, fuzz_param_from_state};
 use crate::{
-    invariant::{BasicTxDetails, CallDetails, FuzzRunIdentifiedContracts, SenderFilters},
+    invariant::{
+        abi_fuzzed_functions, BasicTxDetails, CallDetails, FuzzRunIdentifiedContracts,
+        SenderFilters,
+    },
     strategies::{fuzz_calldata_from_state, fuzz_param, EvmFuzzState},
     FuzzFixtures,
 };
-use alloy_json_abi::{Function, JsonAbi};
+use alloy_json_abi::Function;
 use alloy_primitives::Address;
 use parking_lot::RwLock;
 use proptest::prelude::*;
@@ -37,7 +40,8 @@ pub fn override_call_strat(
                 let (_, contract_specs) = contracts.iter().nth(rand_index).unwrap();
                 contract_specs
             });
-            select_random_function(abi, functions)
+            let fuzzed_functions = abi_fuzzed_functions(abi, functions);
+            any::<prop::sample::Index>().prop_map(move |index| index.get(&fuzzed_functions).clone())
         };
 
         func.prop_flat_map(move |func| {
@@ -64,27 +68,17 @@ pub fn invariant_strat(
     fuzz_fixtures: FuzzFixtures,
 ) -> impl Strategy<Value = BasicTxDetails> {
     let senders = Rc::new(senders);
-    any::<prop::sample::Selector>()
-        .prop_flat_map(move |selector| {
-            let (contract, func) = {
-                let contracts = contracts.targets.lock();
-                let contracts =
-                    contracts.iter().filter(|(_, (_, abi, _))| !abi.functions.is_empty());
-                let (&contract, (_, abi, functions)) = selector.select(contracts);
-
-                let func = select_random_function(abi, functions);
-                (contract, func)
-            };
-
-            let senders = senders.clone();
-            let fuzz_state = fuzz_state.clone();
-            let fuzz_fixtures = fuzz_fixtures.clone();
-            func.prop_flat_map(move |func| {
-                let sender = select_random_sender(&fuzz_state, senders.clone(), dictionary_weight);
-                let contract =
-                    fuzz_contract_with_calldata(&fuzz_state, &fuzz_fixtures, contract, func);
-                (sender, contract)
-            })
+    any::<prop::sample::Index>()
+        .prop_map(move |index| index.get(&contracts.fuzzed_functions()).clone())
+        .prop_flat_map(move |(target_address, target_function)| {
+            let sender = select_random_sender(&fuzz_state, senders.clone(), dictionary_weight);
+            let call_details = fuzz_contract_with_calldata(
+                &fuzz_state,
+                &fuzz_fixtures,
+                target_address,
+                target_function,
+            );
+            (sender, call_details)
         })
         .prop_map(|(sender, call_details)| BasicTxDetails { sender, call_details })
 }
@@ -110,30 +104,6 @@ fn select_random_sender(
         .prop_filter("excluded sender", move |addr| !senders.excluded.contains(addr))
         .boxed()
     }
-}
-
-/// Strategy to select a random mutable function from the abi.
-///
-/// If `targeted_functions` is not empty, select one from it. Otherwise, take any
-/// of the available abi functions.
-fn select_random_function(
-    abi: &JsonAbi,
-    targeted_functions: &[Function],
-) -> impl Strategy<Value = Function> {
-    let functions = if !targeted_functions.is_empty() {
-        targeted_functions.to_vec()
-    } else {
-        abi.functions()
-            .filter(|&func| {
-                !matches!(
-                    func.state_mutability,
-                    alloy_json_abi::StateMutability::Pure | alloy_json_abi::StateMutability::View
-                )
-            })
-            .cloned()
-            .collect()
-    };
-    any::<prop::sample::Index>().prop_map(move |index| index.get(&functions).clone())
 }
 
 /// Given a function, it returns a proptest strategy which generates valid abi-encoded calldata

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -69,8 +69,9 @@ pub fn invariant_strat(
 ) -> impl Strategy<Value = BasicTxDetails> {
     let senders = Rc::new(senders);
     any::<prop::sample::Index>()
-        .prop_map(move |index| index.get(&contracts.fuzzed_functions()).clone())
-        .prop_flat_map(move |(target_address, target_function)| {
+        .prop_flat_map(move |index| {
+            let (target_address, target_function) =
+                index.get(&contracts.fuzzed_functions()).clone();
             let sender = select_random_sender(&fuzz_state, senders.clone(), dictionary_weight);
             let call_details = fuzz_contract_with_calldata(
                 &fuzz_state,

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -11,7 +11,7 @@ mod calldata;
 pub use calldata::{fuzz_calldata, fuzz_calldata_from_state};
 
 mod state;
-pub use state::{collect_created_contracts, EvmFuzzState};
+pub use state::EvmFuzzState;
 
 mod invariants;
 pub use invariants::{fuzz_contract_with_calldata, invariant_strat, override_call_strat};

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -1,8 +1,7 @@
-use crate::invariant::{ArtifactFilters, BasicTxDetails, FuzzRunIdentifiedContracts};
+use crate::invariant::{BasicTxDetails, FuzzRunIdentifiedContracts};
 use alloy_dyn_abi::{DynSolType, DynSolValue, EventExt, FunctionExt};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, Log, B256, U256};
-use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::FuzzDictionaryConfig;
 use foundry_evm_core::utils::StateChangeset;
 use indexmap::IndexSet;
@@ -380,44 +379,4 @@ impl FuzzDictionary {
             "FuzzDictionary stats",
         );
     }
-}
-
-/// Collects all created contracts from a StateChangeset which haven't been discovered yet. Stores
-/// them at `targeted_contracts` and `created_contracts`.
-pub fn collect_created_contracts(
-    state_changeset: &StateChangeset,
-    project_contracts: &ContractsByArtifact,
-    setup_contracts: &ContractsByAddress,
-    artifact_filters: &ArtifactFilters,
-    targeted_contracts: &FuzzRunIdentifiedContracts,
-    created_contracts: &mut Vec<Address>,
-) -> eyre::Result<()> {
-    let mut writable_targeted = targeted_contracts.targets.lock();
-    for (address, account) in state_changeset {
-        if setup_contracts.contains_key(address) {
-            continue;
-        }
-        if !account.is_touched() {
-            continue;
-        }
-        let Some(code) = &account.info.code else {
-            continue;
-        };
-        if code.is_empty() {
-            continue;
-        }
-        let Some((artifact, contract)) =
-            project_contracts.find_by_deployed_code(code.original_byte_slice())
-        else {
-            continue;
-        };
-        let Some(functions) = artifact_filters.get_targeted_functions(artifact, &contract.abi)?
-        else {
-            continue;
-        };
-        created_contracts.push(*address);
-        writable_targeted
-            .insert(*address, (artifact.name.clone(), contract.abi.clone(), functions));
-    }
-    Ok(())
 }

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -264,6 +264,10 @@ async fn test_invariant() {
                     ),
                     ("invariant_success()", true, None, None, None),
                 ],
+            ),
+            (
+                "default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol:InvariantSelectorsWeightTest",
+                vec![("invariant_selectors_weight()", true, None, None, None)],
             )
         ]),
     );
@@ -764,4 +768,27 @@ async fn test_invariant_after_invariant() {
             ],
         )]),
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_selectors_weight() {
+    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
+    opts.fuzz.seed = Some(U256::from(119u32));
+
+    let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantSelectorsWeight.t.sol");
+    let mut runner = TEST_DATA_DEFAULT.runner();
+    runner.test_options = opts.clone();
+    runner.test_options.invariant.runs = 1;
+    runner.test_options.invariant.depth = 30;
+    runner.test_options.invariant.failure_persist_dir =
+        Some(tempfile::tempdir().unwrap().into_path());
+
+    let results = runner.test_collect(&filter);
+    assert_multiple(
+        &results,
+        BTreeMap::from([(
+            "default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol:InvariantSelectorsWeightTest",
+            vec![("invariant_selectors_weight()", true, None, None, None)],
+        )]),
+    )
 }

--- a/testdata/default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+
+contract HandlerWithOneSelector {
+    uint256 public hit1;
+
+    function selector1() external {
+        hit1 += 1;
+    }
+}
+
+contract HandlerWithFiveSelectors {
+    uint256 public hit2;
+    uint256 public hit3;
+    uint256 public hit4;
+    uint256 public hit5;
+    uint256 public hit6;
+
+    function selector2() external {
+        hit2 += 1;
+    }
+
+    function selector3() external {
+        hit3 += 1;
+    }
+
+    function selector4() external {
+        hit4 += 1;
+    }
+
+    function selector5() external {
+        hit5 += 1;
+    }
+
+    function selector6() external {
+        hit6 += 1;
+    }
+}
+
+contract HandlerWithFourSelectors {
+    uint256 public hit7;
+    uint256 public hit8;
+    uint256 public hit9;
+    uint256 public hit10;
+
+    function selector7() external {
+        hit7 += 1;
+    }
+
+    function selector8() external {
+        hit8 += 1;
+    }
+
+    function selector9() external {
+        hit9 += 1;
+    }
+
+    function selector10() external {
+        hit10 += 1;
+    }
+}
+
+contract InvariantSelectorsWeightTest is DSTest {
+    HandlerWithOneSelector handlerOne;
+    HandlerWithFiveSelectors handlerTwo;
+    HandlerWithFourSelectors handlerThree;
+
+    function setUp() public {
+        handlerOne = new HandlerWithOneSelector();
+        handlerTwo = new HandlerWithFiveSelectors();
+        handlerThree = new HandlerWithFourSelectors();
+    }
+
+    function afterInvariant() public {
+        // selector hits before and after https://github.com/foundry-rs/foundry/issues/2986
+        // hit1: 11 | hit2: 4 | hit3: 0 | hit4: 0 | hit5: 4 | hit6: 1 | hit7: 2 | hit8: 2 | hit9: 2 | hit10: 4
+        // hit1:  2 | hit2: 5 | hit3: 4 | hit4: 5 | hit5: 3 | hit6: 1 | hit7: 4 | hit8: 1 | hit9: 1 | hit10: 4
+
+        uint256 hit1 = handlerOne.hit1();
+        uint256 hit2 = handlerTwo.hit2();
+        uint256 hit3 = handlerTwo.hit3();
+        uint256 hit4 = handlerTwo.hit4();
+        uint256 hit5 = handlerTwo.hit5();
+        uint256 hit6 = handlerTwo.hit6();
+        uint256 hit7 = handlerThree.hit7();
+        uint256 hit8 = handlerThree.hit8();
+        uint256 hit9 = handlerThree.hit9();
+        uint256 hit10 = handlerThree.hit10();
+
+        require(
+            hit1 > 0 && hit2 > 0 && hit3 > 0 && hit4 > 0 && hit5 > 0 && hit6 > 0 && hit7 > 0 && hit8 > 0 && hit9 > 0
+                && hit10 > 0
+        );
+    }
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 30
+    function invariant_selectors_weight() public view {}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #2986 

In addition to [issue explanation](https://github.com/foundry-rs/foundry/issues/2986#issue-1353388549) we're using `proptest::sample::Selector` strategy which according to docs `Initially, the selection is roughly uniform, with a very slight bias towards items earlier in the iterator.`

Note: test is a little bit flaky in CI (locally it gives the same results for same seed constantly) might consider to ignore if failures start to pop up

Test with 3 handlers / 10 selectors (per handler: 1 selector, 5 selectors and 4 selectors), 1 run and depth of 500, result of hits / selector:
| | s1 | s2 | s3 | s4 | s5 | s6 | s7 | s8 | s9 | s10 |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| master | 167 | 37 | 28 | 31 | 30 | 32 | 39 | 35 | 41 | 60 |
| PR | 52 | 51 | 60 | 61 | 45 | 40 | 45 | 38 | 58 | 50 |


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- Consolidate `FuzzRunIdentifiedContracts` logic
  - move logic to update collect / clear invariant run contracts
  - add function to flatten contracts function in order to be used by strategy, return vector of (targeted address, function)
- use `proptest::sample::Index` strategy to randomly pick a (targeted address, function) pair
- test