### PR TITLE
perf: new-type TargetedContracts

### DIFF
--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -80,7 +80,7 @@ impl FailedInvariantCaseData {
     ) -> Self {
         // Collect abis of fuzzed and invariant contracts to decode custom error.
         let revert_reason = RevertDecoder::new()
-            .with_abis(targeted_contracts.targets.lock().iter().map(|(_, (_, abi, _))| abi))
+            .with_abis(targeted_contracts.targets.lock().iter().map(|(_, c)| &c.abi))
             .with_abi(invariant_contract.abi)
             .decode(call_result.result.as_ref(), Some(call_result.exit_reason));
 

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -64,10 +64,12 @@ impl EvmFuzzState {
         run_depth: u32,
     ) {
         let mut dict = self.inner.write();
-        fuzzed_contracts.with_fuzzed_artifacts(tx, |target_abi, target_function| {
+        {
+            let targets = fuzzed_contracts.targets.lock();
+            let (target_abi, target_function) = targets.fuzzed_artifacts(tx);
             dict.insert_logs_values(target_abi, logs, run_depth);
             dict.insert_result_values(target_function, result, run_depth);
-        });
+        }
         dict.insert_new_state_values(state_changeset);
     }
 

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -773,7 +773,7 @@ async fn test_invariant_after_invariant() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_selectors_weight() {
     let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(119u32));
+    opts.fuzz.seed = Some(U256::from(100u32));
 
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantSelectorsWeight.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();

--- a/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
@@ -86,7 +86,7 @@ contract InvariantShrinkWithAssert is DSTest {
     }
 
     function invariant_with_assert() public {
-        assertTrue(counter.number() != 3);
+        assertTrue(counter.number() != 3, "wrong counter");
     }
 }
 


### PR DESCRIPTION
Move some methods to a TargetedContracts new-type to be able to borrow from it nicely

To avoid collecting `fuzzed_functions` I re-added proptest `Selector` in `invariant_strat`, should still be OK, PTAL @grandizzy 