### PR TITLE
fix(cheatcodes): use `call.bytecode_address` in mockCalls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -879,7 +879,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         }
 
         // Handle mocked calls
-        if let Some(mocks) = self.mocked_calls.get(&call.target_address) {
+        if let Some(mocks) = self.mocked_calls.get(&call.bytecode_address) {
             let ctx =
                 MockCallDataContext { calldata: call.input.clone(), value: call.transfer_value() };
             if let Some(return_data) = mocks.get(&ctx).or_else(|| {

--- a/testdata/default/cheats/MockCall.t.sol
+++ b/testdata/default/cheats/MockCall.t.sol
@@ -50,12 +50,8 @@ contract NestedMockDelegateCall {
     }
 
     function sum() public returns (uint256) {
-        (, bytes memory dataA) = address(inner).delegatecall(
-            abi.encodeWithSelector(Mock.numberA.selector)
-        );
-        (, bytes memory dataB) = address(inner).delegatecall(
-            abi.encodeWithSelector(Mock.numberB.selector)
-        );
+        (, bytes memory dataA) = address(inner).delegatecall(abi.encodeWithSelector(Mock.numberA.selector));
+        (, bytes memory dataB) = address(inner).delegatecall(abi.encodeWithSelector(Mock.numberB.selector));
         return abi.decode(dataA, (uint256)) + abi.decode(dataB, (uint256));
     }
 }
@@ -70,11 +66,7 @@ contract MockCallTest is DSTest {
         assertEq(target.numberA(), 1);
         assertEq(target.numberB(), 2);
 
-        vm.mockCall(
-            address(target),
-            abi.encodeWithSelector(target.numberB.selector),
-            abi.encode(10)
-        );
+        vm.mockCall(address(target), abi.encodeWithSelector(target.numberB.selector), abi.encode(10));
 
         // post-mock
         assertEq(target.numberA(), 1);
@@ -88,11 +80,7 @@ contract MockCallTest is DSTest {
         // pre-mock
         assertEq(target.sum(), 3);
 
-        vm.mockCall(
-            address(inner),
-            abi.encodeWithSelector(inner.numberB.selector),
-            abi.encode(9)
-        );
+        vm.mockCall(address(inner), abi.encodeWithSelector(inner.numberB.selector), abi.encode(9));
 
         // post-mock
         assertEq(target.sum(), 10);
@@ -105,11 +93,7 @@ contract MockCallTest is DSTest {
 
         assertEq(target.sum(), 3);
 
-        vm.mockCall(
-            address(inner),
-            abi.encodeWithSelector(inner.numberB.selector),
-            abi.encode(9)
-        );
+        vm.mockCall(address(inner), abi.encodeWithSelector(inner.numberB.selector), abi.encode(9));
 
         assertEq(target.sum(), 10);
     }
@@ -118,11 +102,7 @@ contract MockCallTest is DSTest {
         Mock target = new Mock();
         assertEq(target.add(5, 5), 10);
 
-        vm.mockCall(
-            address(target),
-            abi.encodeWithSelector(target.add.selector),
-            abi.encode(11)
-        );
+        vm.mockCall(address(target), abi.encodeWithSelector(target.add.selector), abi.encode(11));
 
         assertEq(target.add(5, 5), 11);
     }
@@ -132,11 +112,7 @@ contract MockCallTest is DSTest {
         assertEq(target.add(5, 5), 10);
         assertEq(target.add(6, 4), 10);
 
-        vm.mockCall(
-            address(target),
-            abi.encodeWithSelector(target.add.selector, 5, 5),
-            abi.encode(11)
-        );
+        vm.mockCall(address(target), abi.encodeWithSelector(target.add.selector, 5, 5), abi.encode(11));
 
         assertEq(target.add(5, 5), 11);
         assertEq(target.add(6, 4), 10);
@@ -145,11 +121,7 @@ contract MockCallTest is DSTest {
     function testClearMockedCalls() public {
         Mock target = new Mock();
 
-        vm.mockCall(
-            address(target),
-            abi.encodeWithSelector(target.numberB.selector),
-            abi.encode(10)
-        );
+        vm.mockCall(address(target), abi.encodeWithSelector(target.numberB.selector), abi.encode(10));
 
         assertEq(target.numberA(), 1);
         assertEq(target.numberB(), 10);
@@ -163,21 +135,9 @@ contract MockCallTest is DSTest {
     function testMockCallMultiplePartialMatch() public {
         Mock mock = new Mock();
 
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            abi.encode(10)
-        );
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector, 2),
-            abi.encode(20)
-        );
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector, 2, 3),
-            abi.encode(30)
-        );
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(10));
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector, 2), abi.encode(20));
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector, 2, 3), abi.encode(30));
 
         assertEq(mock.add(1, 2), 10);
         assertEq(mock.add(2, 2), 20);
@@ -187,23 +147,13 @@ contract MockCallTest is DSTest {
     function testMockCallWithValue() public {
         Mock mock = new Mock();
 
-        vm.mockCall(
-            address(mock),
-            10,
-            abi.encodeWithSelector(mock.pay.selector),
-            abi.encode(10)
-        );
+        vm.mockCall(address(mock), 10, abi.encodeWithSelector(mock.pay.selector), abi.encode(10));
 
         assertEq(mock.pay{value: 10}(1), 10);
         assertEq(mock.pay(1), 1);
 
         for (uint256 i = 0; i < 100; i++) {
-            vm.mockCall(
-                address(mock),
-                i,
-                abi.encodeWithSelector(mock.pay.selector),
-                abi.encode(i * 2)
-            );
+            vm.mockCall(address(mock), i, abi.encodeWithSelector(mock.pay.selector), abi.encode(i * 2));
         }
 
         assertEq(mock.pay(1), 0);
@@ -214,17 +164,8 @@ contract MockCallTest is DSTest {
     function testMockCallWithValueCalldataPrecedence() public {
         Mock mock = new Mock();
 
-        vm.mockCall(
-            address(mock),
-            10,
-            abi.encodeWithSelector(mock.pay.selector),
-            abi.encode(10)
-        );
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.pay.selector, 2),
-            abi.encode(2)
-        );
+        vm.mockCall(address(mock), 10, abi.encodeWithSelector(mock.pay.selector), abi.encode(10));
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.pay.selector, 2), abi.encode(2));
 
         assertEq(mock.pay{value: 10}(1), 10);
         assertEq(mock.pay{value: 10}(2), 2);
@@ -234,16 +175,8 @@ contract MockCallTest is DSTest {
     function testMockCallEmptyAccount() public {
         Mock mock = Mock(address(100));
 
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            abi.encode(10)
-        );
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.noReturnValue.selector),
-            abi.encode()
-        );
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(10));
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.noReturnValue.selector), abi.encode());
 
         assertEq(mock.add(1, 2), 10);
         mock.noReturnValue();
@@ -264,11 +197,7 @@ contract MockCallRevertTest is DSTest {
         assertEq(target.numberA(), 1);
         assertEq(target.numberB(), 2);
 
-        vm.mockCallRevert(
-            address(target),
-            abi.encodeWithSelector(target.numberB.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(target), abi.encodeWithSelector(target.numberB.selector), ERROR_MESSAGE);
 
         // post-mock
         assertEq(target.numberA(), 1);
@@ -282,16 +211,9 @@ contract MockCallRevertTest is DSTest {
         assertEq(target.numberA(), 1);
         assertEq(target.numberB(), 2);
 
-        bytes memory customError = abi.encodeWithSelector(
-            TestError.selector,
-            ERROR_MESSAGE
-        );
+        bytes memory customError = abi.encodeWithSelector(TestError.selector, ERROR_MESSAGE);
 
-        vm.mockCallRevert(
-            address(target),
-            abi.encodeWithSelector(target.numberB.selector),
-            customError
-        );
+        vm.mockCallRevert(address(target), abi.encodeWithSelector(target.numberB.selector), customError);
 
         assertEq(target.numberA(), 1);
         vm.expectRevert(customError);
@@ -304,11 +226,7 @@ contract MockCallRevertTest is DSTest {
 
         assertEq(target.sum(), 3);
 
-        vm.mockCallRevert(
-            address(inner),
-            abi.encodeWithSelector(inner.numberB.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(inner), abi.encodeWithSelector(inner.numberB.selector), ERROR_MESSAGE);
 
         vm.expectRevert(ERROR_MESSAGE);
         target.sum();
@@ -319,11 +237,7 @@ contract MockCallRevertTest is DSTest {
         assertEq(target.add(5, 5), 10);
         assertEq(target.add(6, 4), 10);
 
-        vm.mockCallRevert(
-            address(target),
-            abi.encodeWithSelector(target.add.selector, 5, 5),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(target), abi.encodeWithSelector(target.add.selector, 5, 5), ERROR_MESSAGE);
 
         assertEq(target.add(6, 4), 10);
 
@@ -334,11 +248,7 @@ contract MockCallRevertTest is DSTest {
     function testClearMockRevertedCalls() public {
         Mock target = new Mock();
 
-        vm.mockCallRevert(
-            address(target),
-            abi.encodeWithSelector(target.numberB.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(target), abi.encodeWithSelector(target.numberB.selector), ERROR_MESSAGE);
 
         vm.clearMockedCalls();
 
@@ -349,11 +259,7 @@ contract MockCallRevertTest is DSTest {
     function testMockCallRevertPartialMatch() public {
         Mock mock = new Mock();
 
-        vm.mockCallRevert(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector, 2),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector, 2), ERROR_MESSAGE);
 
         assertEq(mock.add(1, 2), 3);
 
@@ -364,12 +270,7 @@ contract MockCallRevertTest is DSTest {
     function testMockCallRevertWithValue() public {
         Mock mock = new Mock();
 
-        vm.mockCallRevert(
-            address(mock),
-            10,
-            abi.encodeWithSelector(mock.pay.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(mock), 10, abi.encodeWithSelector(mock.pay.selector), ERROR_MESSAGE);
 
         assertEq(mock.pay(1), 1);
         assertEq(mock.pay(2), 2);
@@ -381,35 +282,19 @@ contract MockCallRevertTest is DSTest {
     function testMockCallResetsMockCallRevert() public {
         Mock mock = new Mock();
 
-        vm.mockCallRevert(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), ERROR_MESSAGE);
 
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            abi.encode(5)
-        );
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(5));
         assertEq(mock.add(2, 3), 5);
     }
 
     function testMockCallRevertResetsMockCall() public {
         Mock mock = new Mock();
 
-        vm.mockCall(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            abi.encode(5)
-        );
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(5));
         assertEq(mock.add(2, 3), 5);
 
-        vm.mockCallRevert(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), ERROR_MESSAGE);
 
         vm.expectRevert(ERROR_MESSAGE);
         mock.add(2, 3);
@@ -418,20 +303,11 @@ contract MockCallRevertTest is DSTest {
     function testMockCallRevertWithCall() public {
         Mock mock = new Mock();
 
-        bytes memory customError = abi.encodeWithSelector(
-            TestError.selector,
-            ERROR_MESSAGE
-        );
+        bytes memory customError = abi.encodeWithSelector(TestError.selector, ERROR_MESSAGE);
 
-        vm.mockCallRevert(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            customError
-        );
+        vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), customError);
 
-        (bool success, bytes memory data) = address(mock).call(
-            abi.encodeWithSelector(Mock.add.selector, 2, 3)
-        );
+        (bool success, bytes memory data) = address(mock).call(abi.encodeWithSelector(Mock.add.selector, 2, 3));
         assertEq(success, false);
         assertEq(data, customError);
     }
@@ -439,11 +315,7 @@ contract MockCallRevertTest is DSTest {
     function testMockCallEmptyAccount() public {
         Mock mock = Mock(address(100));
 
-        vm.mockCallRevert(
-            address(mock),
-            abi.encodeWithSelector(mock.add.selector),
-            ERROR_MESSAGE
-        );
+        vm.mockCallRevert(address(mock), abi.encodeWithSelector(mock.add.selector), ERROR_MESSAGE);
 
         vm.expectRevert(ERROR_MESSAGE);
         mock.add(1, 2);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #8066 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `call.bytecode_address`. This handles both static and delegate calls. Whereas `call.target_address` will not handle delegate call as it is the address the call is being sent to i.e the `to` address, and not the address whose bytecode is being executed. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
