### PR TITLE
perf: optimize load_contracts

### DIFF
--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -30,7 +30,7 @@ pub fn replay_run(
     logs: &mut Vec<Log>,
     traces: &mut Traces,
     coverage: &mut Option<HitMaps>,
-    inputs: Vec<BasicTxDetails>,
+    inputs: &[BasicTxDetails],
 ) -> Result<Vec<BaseCounterExample>> {
     // We want traces for a failed case.
     executor.set_tracing(true);
@@ -38,7 +38,7 @@ pub fn replay_run(
     let mut counterexample_sequence = vec![];
 
     // Replay each call from the sequence, collect logs, traces and coverage.
-    for tx in inputs.iter() {
+    for tx in inputs {
         let call_result = executor.transact_raw(
             tx.sender,
             tx.call_details.target,
@@ -57,10 +57,7 @@ pub fn replay_run(
         }
 
         // Identify newly generated contracts, if they exist.
-        ided_contracts.extend(load_contracts(
-            vec![(TraceKind::Execution, call_result.traces.clone().unwrap())],
-            known_contracts,
-        ));
+        ided_contracts.extend(load_contracts(call_result.traces.as_slice(), known_contracts));
 
         // Create counter example to be used in failed case.
         counterexample_sequence.push(BaseCounterExample::from_invariant_call(
@@ -133,7 +130,7 @@ pub fn replay_error(
                 logs,
                 traces,
                 coverage,
-                calls,
+                &calls,
             )
         }
     }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -200,7 +200,7 @@ impl CallTraceDecoder {
     ///
     /// Unknown contracts are contracts that either lack a label or an ABI.
     pub fn identify(&mut self, trace: &CallTraceArena, identifier: &mut impl TraceIdentifier) {
-        self.collect_identities(identifier.identify_addresses(self.addresses(trace)));
+        self.collect_identities(identifier.identify_addresses(self.trace_addresses(trace)));
     }
 
     /// Adds a single event to the decoder.
@@ -230,7 +230,8 @@ impl CallTraceDecoder {
         self.revert_decoder.push_error(error);
     }
 
-    fn addresses<'a>(
+    /// Returns an iterator over the trace addresses.
+    pub fn trace_addresses<'a>(
         &'a self,
         arena: &'a CallTraceArena,
     ) -> impl Iterator<Item = (&'a Address, Option<&'a [u8]>)> + Clone + 'a {
@@ -243,8 +244,8 @@ impl CallTraceDecoder {
                     node.trace.kind.is_any_create().then_some(&node.trace.output[..]),
                 )
             })
-            .filter(|(address, _)| {
-                !self.labels.contains_key(*address) || !self.contracts.contains_key(*address)
+            .filter(|&(address, _)| {
+                !self.labels.contains_key(address) || !self.contracts.contains_key(address)
             })
     }
 

--- a/crates/evm/traces/src/identifier/local.rs
+++ b/crates/evm/traces/src/identifier/local.rs
@@ -95,7 +95,7 @@ impl<'a> LocalTraceIdentifier<'a> {
     /// artifact with a greater code length if the exact code length is not found.
     fn find_index(&self, len: usize) -> usize {
         let (Ok(mut idx) | Err(mut idx)) =
-            self.ordered_ids.binary_search_by(|(_, probe)| probe.cmp(&len));
+            self.ordered_ids.binary_search_by_key(&len, |(_, probe)| *probe);
 
         // In case of multiple artifacts with the same code length, we need to find the first one.
         while idx > 0 && self.ordered_ids[idx - 1].1 == len {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -384,8 +384,8 @@ impl<'a> ContractRunner<'a> {
             find_time,
         );
 
-        let identified_contracts =
-            has_invariants.then(|| load_contracts(setup.traces.clone(), &known_contracts));
+        let identified_contracts = has_invariants
+            .then(|| load_contracts(setup.traces.iter().map(|(_, t)| t), &known_contracts));
         let test_results = functions
             .par_iter()
             .map(|&func| {
@@ -596,13 +596,12 @@ impl<'a> ContractRunner<'a> {
         {
             // Create calls from failed sequence and check if invariant still broken.
             let txes = call_sequence
-                .clone()
-                .into_iter()
+                .iter()
                 .map(|seq| BasicTxDetails {
                     sender: seq.sender.unwrap_or_default(),
                     call_details: CallDetails {
                         target: seq.addr.unwrap_or_default(),
-                        calldata: seq.calldata,
+                        calldata: seq.calldata.clone(),
                     },
                 })
                 .collect::<Vec<BasicTxDetails>>();
@@ -626,7 +625,7 @@ impl<'a> ContractRunner<'a> {
                         &mut logs,
                         &mut traces,
                         &mut coverage,
-                        txes,
+                        &txes,
                     );
                     return TestResult {
                         status: TestStatus::Failure,
@@ -728,7 +727,7 @@ impl<'a> ContractRunner<'a> {
                     &mut logs,
                     &mut traces,
                     &mut coverage,
-                    last_run_inputs.clone(),
+                    &last_run_inputs,
                 ) {
                     error!(%err, "Failed to replay last invariant run");
                 }


### PR DESCRIPTION
There's no need to go through the entire `CallTraceDecoder` machinery (and its instatiation, which is expensive) when all we care about are contract names and ABI