### PR TITLE
chore: fix flaky invariant tests

### DIFF
--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -24,54 +24,61 @@ macro_rules! get_counterexample {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_invariant() {
-    let filter = Filter::new(".*", ".*", ".*fuzz/invariant/(target|targetAbi|common)");
-    let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options = TEST_DATA_DEFAULT.test_opts.clone();
-    runner.test_options.invariant.failure_persist_dir =
-        Some(tempfile::tempdir().unwrap().into_path());
-    let results = runner.test_collect(&filter);
-
+async fn test_invariant_with_alias() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantTest1.t.sol");
+    let results = TEST_DATA_DEFAULT.runner().test_collect(&filter);
     assert_multiple(
         &results,
-        BTreeMap::from([
-            (
-                "default/fuzz/invariant/common/InvariantHandlerFailure.t.sol:InvariantHandlerFailure",
-                vec![("statefulFuzz_BrokenInvariant()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantInnerContract.t.sol:InvariantInnerContract",
-                vec![(
-                    "invariantHideJesus()",
+        BTreeMap::from([(
+            "default/fuzz/invariant/common/InvariantTest1.t.sol:InvariantTest",
+            vec![
+                ("invariant_neverFalse()", false, Some("revert: false".into()), None, None),
+                (
+                    "statefulFuzz_neverFalseWithInvariantAlias()",
                     false,
-                    Some("revert: jesus betrayed".into()),
+                    Some("revert: false".into()),
                     None,
                     None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantReentrancy.t.sol:InvariantReentrancy",
-                vec![("invariantNotStolen()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantTest1.t.sol:InvariantTest",
-                vec![
-                    ("invariant_neverFalse()", false, Some("revert: false".into()), None, None),
-                    (
-                        "statefulFuzz_neverFalseWithInvariantAlias()",
-                        false,
-                        Some("revert: false".into()),
-                        None,
-                        None,
-                    ),
-                ],
-            ),
+                ),
+            ],
+        )]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_filters() {
+    let mut runner = TEST_DATA_DEFAULT.runner();
+    runner.test_options.invariant.runs = 10;
+
+    // Contracts filter tests.
+    assert_multiple(
+        &runner.test_collect(&Filter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/target/(ExcludeContracts|TargetContracts).t.sol",
+        )),
+        BTreeMap::from([
             (
                 "default/fuzz/invariant/target/ExcludeContracts.t.sol:ExcludeContracts",
                 vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
                 "default/fuzz/invariant/target/TargetContracts.t.sol:TargetContracts",
+                vec![("invariantTrueWorld()", true, None, None, None)],
+            ),
+        ]),
+    );
+
+    // Senders filter tests.
+    assert_multiple(
+        &runner.test_collect(&Filter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/target/(ExcludeSenders|TargetSenders).t.sol",
+        )),
+        BTreeMap::from([
+            (
+                "default/fuzz/invariant/target/ExcludeSenders.t.sol:ExcludeSenders",
                 vec![("invariantTrueWorld()", true, None, None, None)],
             ),
             (
@@ -84,28 +91,49 @@ async fn test_invariant() {
                     None,
                 )],
             ),
+        ]),
+    );
+
+    // Interfaces filter tests.
+    assert_multiple(
+        &runner.test_collect(&Filter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/target/TargetInterfaces.t.sol",
+        )),
+        BTreeMap::from([(
+            "default/fuzz/invariant/target/TargetInterfaces.t.sol:TargetWorldInterfaces",
+            vec![("invariantTrueWorld()", false, Some("revert: false world".into()), None, None)],
+        )]),
+    );
+
+    // Selectors filter tests.
+    assert_multiple(
+        &runner.test_collect(&Filter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/target/(ExcludeSelectors|TargetSelectors).t.sol",
+        )),
+        BTreeMap::from([
             (
-                "default/fuzz/invariant/target/TargetInterfaces.t.sol:TargetWorldInterfaces",
-                vec![(
-                    "invariantTrueWorld()",
-                    false,
-                    Some("revert: false world".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/target/ExcludeSenders.t.sol:ExcludeSenders",
-                vec![("invariantTrueWorld()", true, None, None, None)],
+                "default/fuzz/invariant/target/ExcludeSelectors.t.sol:ExcludeSelectors",
+                vec![("invariantFalseWorld()", true, None, None, None)],
             ),
             (
                 "default/fuzz/invariant/target/TargetSelectors.t.sol:TargetSelectors",
                 vec![("invariantTrueWorld()", true, None, None, None)],
             ),
-            (
-                "default/fuzz/invariant/target/ExcludeSelectors.t.sol:ExcludeSelectors",
-                vec![("invariantFalseWorld()", true, None, None, None)],
-            ),
+        ]),
+    );
+
+    // Artifacts filter tests.
+    assert_multiple(
+        &runner.test_collect(&Filter::new(
+            ".*",
+            ".*",
+            ".*fuzz/invariant/targetAbi/(ExcludeArtifacts|TargetArtifacts|TargetArtifactSelectors|TargetArtifactSelectors2).t.sol",
+        )),
+        BTreeMap::from([
             (
                 "default/fuzz/invariant/targetAbi/ExcludeArtifacts.t.sol:ExcludeArtifacts",
                 vec![("invariantShouldPass()", true, None, None, None)],
@@ -137,142 +165,6 @@ async fn test_invariant() {
                     None,
                 )],
             ),
-            (
-                "default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol:InvariantShrinkWithAssert",
-                vec![(
-                    "invariant_with_assert()",
-                    false,
-                    Some("<empty revert data>".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol:InvariantShrinkWithRequire",
-                vec![(
-                    "invariant_with_require()",
-                    false,
-                    Some("revert: wrong counter".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantPreserveState.t.sol:InvariantPreserveState",
-                vec![("invariant_preserve_state()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantCalldataDictionary.t.sol:InvariantCalldataDictionary",
-                vec![(
-                    "invariant_owner_never_changes()",
-                    false,
-                    Some("<empty revert data>".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantAssume.t.sol:InvariantAssume",
-                vec![("invariant_dummy()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantCustomError.t.sol:InvariantCustomError",
-                vec![("invariant_decode_error()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/target/FuzzedTargetContracts.t.sol:ExplicitTargetContract",
-                vec![("invariant_explicit_target()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/target/FuzzedTargetContracts.t.sol:DynamicTargetContract",
-                vec![("invariant_dynamic_targets()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantFixtures.t.sol:InvariantFixtures",
-                vec![(
-                    "invariant_target_not_compromised()",
-                    false,
-                    Some("<empty revert data>".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantShrinkBigSequence.t.sol:ShrinkBigSequenceTest",
-                vec![("invariant_shrink_big_sequence()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantShrinkFailOnRevert.t.sol:ShrinkFailOnRevertTest",
-                vec![("invariant_shrink_fail_on_revert()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantScrapeValues.t.sol:FindFromReturnValueTest",
-                vec![(
-                    "invariant_value_not_found()",
-                    false,
-                    Some("revert: value from return found".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantScrapeValues.t.sol:FindFromLogValueTest",
-                vec![(
-                    "invariant_value_not_found()",
-                    false,
-                    Some("revert: value from logs found".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantRollFork.t.sol:InvariantRollForkBlockTest",
-                vec![(
-                    "invariant_fork_handler_block()",
-                    false,
-                    Some("revert: too many blocks mined".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantRollFork.t.sol:InvariantRollForkStateTest",
-                vec![(
-                    "invariant_fork_handler_state()",
-                    false,
-                    Some("revert: wrong supply".into()),
-                    None,
-                    None,
-                )],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantExcludedSenders.t.sol:InvariantExcludedSendersTest",
-                vec![("invariant_check_sender()", true, None, None, None)],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantAfterInvariant.t.sol:InvariantAfterInvariantTest",
-                vec![
-                    (
-                        "invariant_after_invariant_failure()",
-                        false,
-                        Some("revert: afterInvariant failure".into()),
-                        None,
-                        None,
-                    ),
-                    (
-                        "invariant_failure()",
-                        false,
-                        Some("revert: invariant failure".into()),
-                        None,
-                        None,
-                    ),
-                    ("invariant_success()", true, None, None, None),
-                ],
-            ),
-            (
-                "default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol:InvariantSelectorsWeightTest",
-                vec![("invariant_selectors_weight()", true, None, None, None)],
-            )
         ]),
     );
 }
@@ -284,7 +176,6 @@ async fn test_invariant_override() {
     runner.test_options.invariant.fail_on_revert = false;
     runner.test_options.invariant.call_override = true;
     let results = runner.test_collect(&filter);
-
     assert_multiple(
         &results,
         BTreeMap::from([(
@@ -302,7 +193,6 @@ async fn test_invariant_fail_on_revert() {
     runner.test_options.invariant.runs = 1;
     runner.test_options.invariant.depth = 10;
     let results = runner.test_collect(&filter);
-
     assert_multiple(
         &results,
         BTreeMap::from([(
@@ -326,7 +216,6 @@ async fn test_invariant_storage() {
     runner.test_options.invariant.depth = 100 + (50 * cfg!(windows) as u32);
     runner.test_options.fuzz.seed = Some(U256::from(6u32));
     let results = runner.test_collect(&filter);
-
     assert_multiple(
         &results,
         BTreeMap::from([(
@@ -337,6 +226,25 @@ async fn test_invariant_storage() {
                 ("invariantChangeUint()", false, Some("changedUint".to_string()), None, None),
                 ("invariantPush()", false, Some("pushUint".to_string()), None, None),
             ],
+        )]),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invariant_inner_contract() {
+    let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantInnerContract.t.sol");
+    let results = TEST_DATA_DEFAULT.runner().test_collect(&filter);
+    assert_multiple(
+        &results,
+        BTreeMap::from([(
+            "default/fuzz/invariant/common/InvariantInnerContract.t.sol:InvariantInnerContract",
+            vec![(
+                "invariantHideJesus()",
+                false,
+                Some("revert: jesus betrayed".into()),
+                None,
+                None,
+            )],
         )]),
     );
 }
@@ -405,13 +313,10 @@ async fn test_shrink(opts: TestOptions, contract_pattern: &str) {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(windows, ignore = "for some reason there's different rng")]
 async fn test_shrink_big_sequence() {
-    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(119u32));
-
     let filter =
         Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantShrinkBigSequence.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options = opts.clone();
+    runner.test_options.fuzz.seed = Some(U256::from(119u32));
     runner.test_options.invariant.runs = 1;
     runner.test_options.invariant.depth = 500;
 
@@ -480,13 +385,10 @@ async fn test_shrink_big_sequence() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(windows, ignore = "for some reason there's different rng")]
 async fn test_shrink_fail_on_revert() {
-    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(119u32));
-
     let filter =
         Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantShrinkFailOnRevert.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options = opts.clone();
+    runner.test_options.fuzz.seed = Some(U256::from(119u32));
     runner.test_options.invariant.fail_on_revert = true;
     runner.test_options.invariant.runs = 1;
     runner.test_options.invariant.depth = 100;
@@ -656,8 +558,7 @@ async fn test_invariant_fixtures() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_scrape_values() {
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantScrapeValues.t.sol");
-    let mut runner = TEST_DATA_DEFAULT.runner();
-    let results = runner.test_collect(&filter);
+    let results = TEST_DATA_DEFAULT.runner().test_collect(&filter);
     assert_multiple(
         &results,
         BTreeMap::from([
@@ -687,17 +588,10 @@ async fn test_invariant_scrape_values() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_roll_fork_handler() {
-    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(119u32));
-
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantRollFork.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options = opts.clone();
-    runner.test_options.invariant.failure_persist_dir =
-        Some(tempfile::tempdir().unwrap().into_path());
-
+    runner.test_options.fuzz.seed = Some(U256::from(119u32));
     let results = runner.test_collect(&filter);
-
     assert_multiple(
         &results,
         BTreeMap::from([
@@ -744,11 +638,7 @@ async fn test_invariant_excluded_senders() {
 async fn test_invariant_after_invariant() {
     // Check failure on passing invariant and failed `afterInvariant` condition
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantAfterInvariant.t.sol");
-    let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options.invariant.failure_persist_dir =
-        Some(tempfile::tempdir().unwrap().into_path());
-
-    let results = runner.test_collect(&filter);
+    let results = TEST_DATA_DEFAULT.runner().test_collect(&filter);
     assert_multiple(
         &results,
         BTreeMap::from([(
@@ -776,17 +666,11 @@ async fn test_invariant_after_invariant() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invariant_selectors_weight() {
-    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(100u32));
-
     let filter = Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantSelectorsWeight.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
-    runner.test_options = opts.clone();
+    runner.test_options.fuzz.seed = Some(U256::from(119u32));
     runner.test_options.invariant.runs = 1;
-    runner.test_options.invariant.depth = 30;
-    runner.test_options.invariant.failure_persist_dir =
-        Some(tempfile::tempdir().unwrap().into_path());
-
+    runner.test_options.invariant.depth = 10;
     let results = runner.test_collect(&filter);
     assert_multiple(
         &results,

--- a/testdata/default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantSelectorsWeight.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import "ds-test/test.sol";
 
-contract HandlerWithOneSelector {
+contract HandlerOne {
     uint256 public hit1;
 
     function selector1() external {
@@ -11,12 +11,11 @@ contract HandlerWithOneSelector {
     }
 }
 
-contract HandlerWithFiveSelectors {
+contract HandlerTwo {
     uint256 public hit2;
     uint256 public hit3;
     uint256 public hit4;
     uint256 public hit5;
-    uint256 public hit6;
 
     function selector2() external {
         hit2 += 1;
@@ -33,69 +32,25 @@ contract HandlerWithFiveSelectors {
     function selector5() external {
         hit5 += 1;
     }
-
-    function selector6() external {
-        hit6 += 1;
-    }
-}
-
-contract HandlerWithFourSelectors {
-    uint256 public hit7;
-    uint256 public hit8;
-    uint256 public hit9;
-    uint256 public hit10;
-
-    function selector7() external {
-        hit7 += 1;
-    }
-
-    function selector8() external {
-        hit8 += 1;
-    }
-
-    function selector9() external {
-        hit9 += 1;
-    }
-
-    function selector10() external {
-        hit10 += 1;
-    }
 }
 
 contract InvariantSelectorsWeightTest is DSTest {
-    HandlerWithOneSelector handlerOne;
-    HandlerWithFiveSelectors handlerTwo;
-    HandlerWithFourSelectors handlerThree;
+    HandlerOne handlerOne;
+    HandlerTwo handlerTwo;
 
     function setUp() public {
-        handlerOne = new HandlerWithOneSelector();
-        handlerTwo = new HandlerWithFiveSelectors();
-        handlerThree = new HandlerWithFourSelectors();
+        handlerOne = new HandlerOne();
+        handlerTwo = new HandlerTwo();
     }
 
     function afterInvariant() public {
-        // selector hits before and after https://github.com/foundry-rs/foundry/issues/2986
-        // hit1: 11 | hit2: 4 | hit3: 0 | hit4: 0 | hit5: 4 | hit6: 1 | hit7: 2 | hit8: 2 | hit9: 2 | hit10: 4
-        // hit1:  2 | hit2: 5 | hit3: 4 | hit4: 5 | hit5: 3 | hit6: 1 | hit7: 4 | hit8: 1 | hit9: 1 | hit10: 4
-
-        uint256 hit1 = handlerOne.hit1();
-        uint256 hit2 = handlerTwo.hit2();
-        uint256 hit3 = handlerTwo.hit3();
-        uint256 hit4 = handlerTwo.hit4();
-        uint256 hit5 = handlerTwo.hit5();
-        uint256 hit6 = handlerTwo.hit6();
-        uint256 hit7 = handlerThree.hit7();
-        uint256 hit8 = handlerThree.hit8();
-        uint256 hit9 = handlerThree.hit9();
-        uint256 hit10 = handlerThree.hit10();
-
-        require(
-            hit1 > 0 && hit2 > 0 && hit3 > 0 && hit4 > 0 && hit5 > 0 && hit6 > 0 && hit7 > 0 && hit8 > 0 && hit9 > 0
-                && hit10 > 0
-        );
+        // selector hits uniformly distributed, see https://github.com/foundry-rs/foundry/issues/2986
+        assertEq(handlerOne.hit1(), 2);
+        assertEq(handlerTwo.hit2(), 2);
+        assertEq(handlerTwo.hit3(), 3);
+        assertEq(handlerTwo.hit4(), 1);
+        assertEq(handlerTwo.hit5(), 2);
     }
 
-    /// forge-config: default.invariant.runs = 1
-    /// forge-config: default.invariant.depth = 30
     function invariant_selectors_weight() public view {}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- `test_invariant` is a catch-all for invariant tests, however some tests require their own configuration (specific seed / runs / depth) so they could fail when executing this way. Since tests are performed twice (once by `test_invariant` and once by their own execution)  there are situations when a failure is persisted on 1st run and then 2nd run fails with unexpected message when replayed,

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- remove `test_invariant` catch all test and add individual tests (should also speed up tests as they'll be executed only once)
- cleanup runners test setup, remove individual failure persist dirs
- changed invariant selectors weight to assert exact hits of selector