### PR TITLE
fix(verify-bytecode): use strong equality `==`,  not `.starts_with`

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -567,7 +567,7 @@ fn try_match(
     has_metadata: bool,
 ) -> Result<(bool, Option<VerificationType>)> {
     // 1. Try full match
-    if *match_type == VerificationType::Full && local_bytecode.starts_with(bytecode) {
+    if *match_type == VerificationType::Full && local_bytecode == bytecode {
         Ok((true, Some(VerificationType::Full)))
     } else {
         try_partial_match(local_bytecode, bytecode, constructor_args, is_runtime, has_metadata)
@@ -591,7 +591,7 @@ fn try_partial_match(
         }
 
         // Now compare the creation code and bytecode
-        return Ok(local_bytecode.starts_with(bytecode));
+        return Ok(local_bytecode == bytecode);
     }
 
     if is_runtime {
@@ -601,7 +601,7 @@ fn try_partial_match(
         }
 
         // Now compare the local code and bytecode
-        return Ok(local_bytecode.starts_with(bytecode));
+        return Ok(local_bytecode == bytecode);
     }
 
     // If not runtime, extract constructor args from the end of the bytecode
@@ -613,7 +613,7 @@ fn try_partial_match(
         bytecode = extract_metadata_hash(bytecode)?;
     }
 
-    Ok(local_bytecode.starts_with(bytecode))
+    Ok(local_bytecode == bytecode)
 }
 
 /// @dev This assumes that the metadata is at the end of the bytecode


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Ref #8012 

We currently use `.starts_with` to match local bytecode with onchain bytecode. This is not ideal as it will return true if the prefix needle matches. 

## Solution

Use strong equality. 

@mattsse @mds1 ptal. This was an oversight on my end, and it is a breaking change. As users could've made the mistake of assuming that their bytecode checks out even though it didn't. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
