### PR TITLE
fix(invariant): show labels when failure replay

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -640,11 +640,13 @@ impl<'a> ContractRunner<'a> {
                                 invariant_contract.invariant_function.name
                             ))
                         },
-                        decoded_logs: decode_console_logs(&logs),
-                        traces,
-                        coverage,
                         counterexample: Some(CounterExample::Sequence(call_sequence)),
+                        decoded_logs: decode_console_logs(&logs),
+                        logs,
                         kind: TestKind::Invariant { runs: 1, calls: 1, reverts: 1 },
+                        coverage,
+                        traces,
+                        labeled_addresses,
                         ..Default::default()
                     }
                 }
@@ -750,7 +752,7 @@ impl<'a> ContractRunner<'a> {
             },
             coverage,
             traces,
-            labeled_addresses: labeled_addresses.clone(),
+            labeled_addresses,
             gas_report_traces,
             ..Default::default() // TODO collect debug traces on the last run or error
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Labels are missing when replay an invariant failure, including it on the spot for now but going to follow up with a bigger PR to refactor `TestResult` creation as part of  `TestResult` struct

(CI failure unrelated)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
