### PR TITLE
chore: fix docstring and add tests for random cheats

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6454,7 +6454,7 @@
     {
       "func": {
         "id": "randomUint_1",
-        "description": "Returns random uin256 value between the provided range (min..=max).",
+        "description": "Returns random uin256 value between the provided range (=min..=max).",
         "declaration": "function randomUint(uint256 min, uint256 max) external returns (uint256);",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2148,7 +2148,7 @@ interface Vm {
     #[cheatcode(group = Utilities)]
     function randomUint() external returns (uint256);
 
-    /// Returns random uin256 value between the provided range (min..=max).
+    /// Returns random uin256 value between the provided range (=min..=max).
     #[cheatcode(group = Utilities)]
     function randomUint(uint256 min, uint256 max) external returns (uint256);
 

--- a/testdata/default/cheats/RandomUint.t.sol
+++ b/testdata/default/cheats/RandomUint.t.sol
@@ -7,9 +7,29 @@ import "cheats/Vm.sol";
 contract RandomUint is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
+    // All tests use `>=` and `<=` to verify that ranges are inclusive and that
+    // a value of zero may be generated.
     function testRandomUint() public {
         uint256 rand = vm.randomUint();
+        assertTrue(rand >= 0);
+    }
 
-        assertTrue(rand > 0);
+    function testRandomUint(uint256 min, uint256 max) public {
+        if (min > max) {
+            (min, max) = (max, min);
+        }
+        uint256 rand = vm.randomUint(min, max);
+        assertTrue(rand >= min, "rand >= min");
+        assertTrue(rand <= max, "rand <= max");
+    }
+
+    function testRandomUint(uint256 val) public {
+        uint256 rand = vm.randomUint(val, val);
+        assertTrue(rand == val);
+    }
+
+    function testRandomAddress() public {
+        address rand = vm.randomAddress();
+        assertTrue(rand >= address(0));
     }
 }


### PR DESCRIPTION
Addresses https://github.com/foundry-rs/foundry/pull/7960#discussion_r1619015391 and https://github.com/foundry-rs/foundry/pull/7960#discussion_r1618868613

I just edited the docstring in both `cheatcodes.json` and `vm.rs` manually, but I think one of them is supposed to be autogenerated somehow?