### PR TITLE
perf: optimize inspector stack dispatching

### DIFF
--- a/crates/anvil/core/src/eth/transaction/optimism.rs
+++ b/crates/anvil/core/src/eth/transaction/optimism.rs
@@ -108,7 +108,6 @@ impl DepositTransactionRequest {
     }
 
     /// Calculates a heuristic for the in-memory size of the [DepositTransaction] transaction.
-    #[inline]
     pub fn size(&self) -> usize {
         mem::size_of::<B256>() + // source_hash
         mem::size_of::<Address>() + // from

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2678,7 +2678,6 @@ fn ensure_return_ok(exit: InstructionResult, out: &Option<Output>) -> Result<Byt
 }
 
 /// Determines the minimum gas needed for a transaction depending on the transaction kind.
-#[inline]
 fn determine_base_gas_by_kind(request: &WithOtherFields<TransactionRequest>) -> u128 {
     match transaction_request_to_typed(request.clone()) {
         Some(request) => match request {

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -45,46 +45,39 @@ impl Inspector {
 }
 
 impl<DB: Database> revm::Inspector<DB> for Inspector {
-    #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.initialize_interp(interp, ecx);
         });
     }
 
-    #[inline]
     fn step(&mut self, interp: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.step(interp, ecx);
         });
     }
 
-    #[inline]
     fn step_end(&mut self, interp: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.step_end(interp, ecx);
         });
     }
 
-    #[inline]
     fn log(&mut self, ecx: &mut EvmContext<DB>, log: &Log) {
         call_inspectors!([&mut self.tracer, Some(&mut self.log_collector)], |inspector| {
             inspector.log(ecx, log);
         });
     }
 
-    #[inline]
     fn call(&mut self, ecx: &mut EvmContext<DB>, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        call_inspectors!([&mut self.tracer, Some(&mut self.log_collector)], |inspector| {
-            if let Some(outcome) = inspector.call(ecx, inputs) {
-                return Some(outcome);
-            }
-        });
-
+        call_inspectors!(
+            #[ret]
+            [&mut self.tracer, Some(&mut self.log_collector)],
+            |inspector| inspector.call(ecx, inputs).map(Some),
+        );
         None
     }
 
-    #[inline]
     fn call_end(
         &mut self,
         ecx: &mut EvmContext<DB>,
@@ -98,7 +91,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         outcome
     }
 
-    #[inline]
     fn create(
         &mut self,
         ecx: &mut EvmContext<DB>,
@@ -112,7 +104,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         None
     }
 
-    #[inline]
     fn create_end(
         &mut self,
         ecx: &mut EvmContext<DB>,
@@ -126,7 +117,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         outcome
     }
 
-    #[inline]
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         if let Some(tracer) = &mut self.tracer {
             revm::Inspector::<DB>::selfdestruct(tracer, contract, target, value);
@@ -137,7 +127,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
 impl<DB: Database> InspectorExt<DB> for Inspector {}
 
 /// Prints all the logs
-#[inline]
 pub fn print_logs(logs: &[Log]) {
     for log in decode_console_logs(logs) {
         node_info!("{}", log);

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -197,44 +197,39 @@ macro_rules! call_inspectors {
     ([$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr $(,)?) => {
         $(
             if let Some($id) = $inspector {
-                $call
+                ({ #[inline(always)] #[cold] || $call })();
             }
         )+
-    }
+    };
+    (#[ret] [$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr $(,)?) => {
+        $(
+            if let Some($id) = $inspector {
+                if let Some(result) = ({ #[inline(always)] #[cold] || $call })() {
+                    return result;
+                }
+            }
+        )+
+    };
 }
 
-/// Same as [call_inspectors] macro, but with depth adjustment for isolated execution.
+/// Same as [`call_inspectors!`], but with depth adjustment for isolated execution.
 macro_rules! call_inspectors_adjust_depth {
-    (#[no_ret] [$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr, $self:ident, $data:ident $(,)?) => {
+    ([$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr, $self:ident, $data:ident $(,)?) => {
+        $data.journaled_state.depth += $self.in_inner_context as usize;
+        call_inspectors!([$($inspector),+], |$id| $call);
+        $data.journaled_state.depth -= $self.in_inner_context as usize;
+    };
+    (#[ret] [$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr, $self:ident, $data:ident $(,)?) => {
         $data.journaled_state.depth += $self.in_inner_context as usize;
         $(
             if let Some($id) = $inspector {
-                $call
+                if let Some(result) = ({ #[inline(always)] #[cold] || $call })() {
+                    $data.journaled_state.depth -= $self.in_inner_context as usize;
+                    return result;
+                }
             }
         )+
         $data.journaled_state.depth -= $self.in_inner_context as usize;
-    };
-    ([$($inspector:expr),+ $(,)?], |$id:ident $(,)?| $call:expr, $self:ident, $data:ident $(,)?) => {
-        if $self.in_inner_context {
-            $data.journaled_state.depth += 1;
-            $(
-                if let Some($id) = $inspector {
-                    if let Some(result) = $call {
-                        $data.journaled_state.depth -= 1;
-                        return result;
-                    }
-                }
-            )+
-            $data.journaled_state.depth -= 1;
-        } else {
-            $(
-                if let Some($id) = $inspector {
-                    if let Some(result) = $call {
-                        return result;
-                    }
-                }
-            )+
-        }
     };
 }
 
@@ -432,6 +427,7 @@ impl InspectorStack {
     ) -> CallOutcome {
         let result = outcome.result.result;
         call_inspectors_adjust_depth!(
+            #[ret]
             [
                 &mut self.fuzzer,
                 &mut self.debugger,
@@ -613,7 +609,6 @@ impl InspectorStack {
 impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
     fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut DB>) {
         call_inspectors_adjust_depth!(
-            #[no_ret]
             [&mut self.coverage, &mut self.tracer, &mut self.cheatcodes, &mut self.printer],
             |inspector| inspector.initialize_interp(interpreter, ecx),
             self,
@@ -623,7 +618,6 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
 
     fn step(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut DB>) {
         call_inspectors_adjust_depth!(
-            #[no_ret]
             [
                 &mut self.fuzzer,
                 &mut self.debugger,
@@ -640,7 +634,6 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
 
     fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut DB>) {
         call_inspectors_adjust_depth!(
-            #[no_ret]
             [&mut self.tracer, &mut self.chisel_state, &mut self.printer],
             |inspector| inspector.step_end(interpreter, ecx),
             self,
@@ -650,7 +643,6 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
 
     fn log(&mut self, ecx: &mut EvmContext<&mut DB>, log: &Log) {
         call_inspectors_adjust_depth!(
-            #[no_ret]
             [&mut self.tracer, &mut self.log_collector, &mut self.cheatcodes, &mut self.printer],
             |inspector| inspector.log(ecx, log),
             self,
@@ -669,6 +661,7 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
         }
 
         call_inspectors_adjust_depth!(
+            #[ret]
             [
                 &mut self.fuzzer,
                 &mut self.debugger,
@@ -745,6 +738,7 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
         }
 
         call_inspectors_adjust_depth!(
+            #[ret]
             [&mut self.debugger, &mut self.tracer, &mut self.coverage, &mut self.cheatcodes],
             |inspector| inspector.create(ecx, create).map(Some),
             self,
@@ -785,6 +779,7 @@ impl<DB: DatabaseExt + DatabaseCommit> Inspector<&mut DB> for InspectorStack {
         let result = outcome.result.result;
 
         call_inspectors_adjust_depth!(
+            #[ret]
             [&mut self.debugger, &mut self.tracer, &mut self.cheatcodes, &mut self.printer],
             |inspector| {
                 let new_outcome = inspector.create_end(ecx, call, outcome.clone());
@@ -817,6 +812,7 @@ impl<DB: DatabaseExt + DatabaseCommit> InspectorExt<&mut DB> for InspectorStack 
         inputs: &mut CreateInputs,
     ) -> bool {
         call_inspectors_adjust_depth!(
+            #[ret]
             [&mut self.cheatcodes],
             |inspector| { inspector.should_use_create2_factory(ecx, inputs).then_some(true) },
             self,


### PR DESCRIPTION
mark `Some(inspector) {}` blocks as cold to optimize the dispatching

Similar to https://github.com/foundry-rs/foundry/pull/8197. The `inline(always)` makes the closure just give the `cold` hint for the dispatching, and we want it inlined to avoid a call indirection when we do actually hit the inspector (eg cheatcodes is almost always enabled)

any instruction saved in step and step_end goes a long way since they're as hot as the interpreter itself
