### PR TITLE
Pretty printed logs and events in cast run

### DIFF
--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -87,7 +87,6 @@ pub async fn render_trace_arena(
 
             // Display trace header
             let (trace, return_data) = render_trace(&node.trace, decoder).await?;
-            // writeln!(s, "{left}{trace}")?;
 
             // Prepend our tree structure symbols to each line of the displayed trace
             let call_left_prefix = left.to_string();

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -227,22 +227,22 @@ async fn render_trace_log(
             for (i, topic) in log.topics().iter().enumerate() {
                 writeln!(
                     s,
-                    "{:>13}: {}",
-                    if i == 0 { "emit topic 0".to_string() } else { format!("topic {i}") },
+                    "{}: {}",
+                    if i == 0 { "emit topic 0".to_string() } else { format!("      topic {i}") },
                     format!("{topic:?}").cyan()
                 )?;
             }
 
-            write!(s, "          data: {}", hex::encode_prefixed(&log.data).cyan())?;
+            write!(s, "         data: {}", hex::encode_prefixed(&log.data).cyan())?;
         }
         DecodedCallLog::Decoded(name, params) => {
             let params = params
                 .iter()
-                .map(|(name, value)| format!("{name}: {value}"))
+                .map(|(name, value)| format!("     {name}: {value}"))
                 .collect::<Vec<String>>()
-                .join(", ");
+                .join(", \n");
 
-            write!(s, "emit {}({params})", name.clone().cyan())?;
+            write!(s, "emit {}(\n{params}\n )", name.clone().cyan())?;
         }
     }
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -92,7 +92,12 @@ pub async fn render_trace_arena(
             let call_left_prefix = left.to_string();
             let call_right_prefix = format!("{child} ");
             trace.lines().enumerate().try_for_each(|(i, line)| {
-                writeln!( s, "{}{}", if i == 0 { &call_left_prefix } else { &call_right_prefix }, line)
+                writeln!(
+                    s,
+                    "{}{}",
+                    if i == 0 { &call_left_prefix } else { &call_right_prefix },
+                    line
+                )
             })?;
 
             // Display logs and subcalls
@@ -203,11 +208,7 @@ pub async fn render_trace(
         };
 
         let color = trace_color(trace);
-        let inputs_padded = if inputs.len() > 0 {
-            format!("\n    {inputs}\n")
-        } else {
-            inputs
-        };
+        let inputs_padded = if !inputs.is_empty() { format!("\n    {inputs}\n") } else { inputs };
         write!(
             &mut s,
             "{addr}::{func_name}{opt_value}({inputs_padded}){action}",
@@ -253,10 +254,11 @@ async fn render_trace_log(
                 .collect::<Vec<String>>()
                 .join(",\n");
 
-            if params.len() > 0 {
-                write!(s, "emit {}(\n{params}\n )", name.clone().cyan())?;
+            let pretty_name = name.cyan();
+            if !params.is_empty() {
+                write!(s, "emit {pretty_name}(\n{params}\n )")?;
             } else {
-                write!(s, "emit {}()", name.clone().cyan())?;
+                write!(s, "emit {pretty_name}()")?;
             }
         }
     }

--- a/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
+++ b/crates/forge/tests/fixtures/include_custom_types_in_traces.stdout
@@ -11,7 +11,9 @@ Traces:
 [PASS] testEvent() (gas: 1312)
 Traces:
   [1312] CustomTypesTest::testEvent()
-    ├─ emit MyEvent(a: 100)
+    ├─ emit MyEvent(
+    │      a: 100
+    │  )
     └─ ← [Stop] 
 
 Suite result: FAILED. 1 passed; 1 failed; 0 skipped; finished in 3.88ms

--- a/crates/forge/tests/fixtures/repro_6531.stdout
+++ b/crates/forge/tests/fixtures/repro_6531.stdout
@@ -6,7 +6,9 @@ Ran 1 test for test/Contract.t.sol:USDTCallingTest
 [PASS] test() (gas: 9559)
 Traces:
   [9559] USDTCallingTest::test()
-    ├─ [0] VM::createSelectFork("<url>")
+    ├─ [0] VM::createSelectFork(
+    │      "<url>"
+    │  )
     │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
     │   └─ ← [Return] "Tether USD"


### PR DESCRIPTION
## Motivation

Recently I got quite big events in cast, so made them a bit more pretty printed, also fixed padding of topics in logs

## Solution

Before:
![image](https://github.com/foundry-rs/foundry/assets/170802707/d142f00b-2c37-40b5-98df-05b515c4f004)
After:
![image](https://github.com/foundry-rs/foundry/assets/170802707/f6aefd53-3e6e-4c14-873b-c65c538e637d)

P.S. I don't remember any log bigger than 4 topics, so removed number 13 for string formating.