### PR TITLE
feat: add --no-request-size-limit option to anvil

### DIFF
--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -25,10 +25,7 @@ pub struct ServerConfig {
     pub no_cors: bool,
 
     /// Whether to disable the axum default body size limit
-    #[cfg_attr(
-        feature = "clap",
-        arg(long, help = "Disable the default request body size limit")
-    )]
+    #[cfg_attr(feature = "clap", arg(long, help = "Disable the default request body size limit. At time of writing the default limit is 2MB"))]
     pub no_request_size_limit: bool,
 }
 
@@ -48,7 +45,11 @@ impl ServerConfig {
 
 impl Default for ServerConfig {
     fn default() -> Self {
-        Self { allow_origin: "*".parse::<HeaderValue>().unwrap().into(), no_cors: false, no_request_size_limit: false }
+        Self {
+            allow_origin: "*".parse::<HeaderValue>().unwrap().into(),
+            no_cors: false,
+            no_request_size_limit: false,
+        }
     }
 }
 

--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -7,38 +7,28 @@ use std::str::FromStr;
 #[cfg_attr(feature = "clap", derive(clap::Parser), command(next_help_heading = "Server options"))]
 pub struct ServerConfig {
     /// The cors `allow_origin` header
-    #[cfg_attr(
-        feature = "clap",
-        arg(
-            long,
-            help = "Set the CORS allow_origin",
-            default_value = "*",
-            value_name = "ALLOW_ORIGIN"
-        )
-    )]
+    #[cfg_attr(feature = "clap", arg(long, default_value = "*"))]
     pub allow_origin: HeaderValueWrapper,
-    /// Whether to enable CORS
-    #[cfg_attr(
-        feature = "clap",
-        arg(long, help = "Disable CORS", conflicts_with = "allow_origin")
-    )]
+
+    /// Disable CORS.
+    #[cfg_attr(feature = "clap", arg(long, conflicts_with = "allow_origin"))]
     pub no_cors: bool,
 
-    /// Whether to disable the axum default body size limit
-    #[cfg_attr(feature = "clap", arg(long, help = "Disable the default request body size limit. At time of writing the default limit is 2MB"))]
+    /// Disable the default request body size limit. At time of writing the default limit is 2MB.
+    #[cfg_attr(feature = "clap", arg(long))]
     pub no_request_size_limit: bool,
 }
 
 impl ServerConfig {
-    /// Sets the "allow origin" header for cors
+    /// Sets the "allow origin" header for CORS.
     pub fn with_allow_origin(mut self, allow_origin: impl Into<HeaderValueWrapper>) -> Self {
         self.allow_origin = allow_origin.into();
         self
     }
 
-    /// Whether to enable CORS
+    /// Whether to enable CORS.
     pub fn set_cors(mut self, cors: bool) -> Self {
-        self.no_cors = cors;
+        self.no_cors = !cors;
         self
     }
 }

--- a/crates/anvil/server/src/config.rs
+++ b/crates/anvil/server/src/config.rs
@@ -23,6 +23,13 @@ pub struct ServerConfig {
         arg(long, help = "Disable CORS", conflicts_with = "allow_origin")
     )]
     pub no_cors: bool,
+
+    /// Whether to disable the axum default body size limit
+    #[cfg_attr(
+        feature = "clap",
+        arg(long, help = "Disable the default request body size limit")
+    )]
+    pub no_request_size_limit: bool,
 }
 
 impl ServerConfig {
@@ -41,7 +48,7 @@ impl ServerConfig {
 
 impl Default for ServerConfig {
     fn default() -> Self {
-        Self { allow_origin: "*".parse::<HeaderValue>().unwrap().into(), no_cors: false }
+        Self { allow_origin: "*".parse::<HeaderValue>().unwrap().into(), no_cors: false, no_request_size_limit: false }
     }
 }
 

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -12,10 +12,10 @@ use anvil_rpc::{
     response::{ResponseResult, RpcResponse},
 };
 use axum::{
+    extract::DefaultBodyLimit,
     http::{header, HeaderValue, Method},
     routing::{post, MethodRouter},
     Router,
-    extract::DefaultBodyLimit,
 };
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -73,7 +73,7 @@ fn router_inner<S: Clone + Send + Sync + 'static>(
                 .allow_methods([Method::GET, Method::POST]),
         );
     }
-    if !no_request_size_limit {
+    if no_request_size_limit {
         router = router.layer(DefaultBodyLimit::disable());
     }
     router

--- a/crates/anvil/server/src/lib.rs
+++ b/crates/anvil/server/src/lib.rs
@@ -15,6 +15,7 @@ use axum::{
     http::{header, HeaderValue, Method},
     routing::{post, MethodRouter},
     Router,
+    extract::DefaultBodyLimit,
 };
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -56,7 +57,7 @@ fn router_inner<S: Clone + Send + Sync + 'static>(
     root_method_router: MethodRouter<S>,
     state: S,
 ) -> Router {
-    let ServerConfig { allow_origin, no_cors } = config;
+    let ServerConfig { allow_origin, no_cors, no_request_size_limit } = config;
 
     let mut router = Router::new()
         .route("/", root_method_router)
@@ -71,6 +72,9 @@ fn router_inner<S: Clone + Send + Sync + 'static>(
                 .allow_headers([header::CONTENT_TYPE])
                 .allow_methods([Method::GET, Method::POST]),
         );
+    }
+    if !no_request_size_limit {
+        router = router.layer(DefaultBodyLimit::disable());
     }
     router
 }


### PR DESCRIPTION
Add a `--no-request-size-limit` option to anvil cli to optionally disable RPC body request size limits

## Motivation

When using the [anvil_loadState](https://book.getfoundry.sh/reference/anvil/#custom-methods) RPC methods on localhost to re-hydrate state for local testing, if that hex string is >2mb then the request fails with:

```
2024-06-20T05:23:32.699724Z  WARN request{method=POST uri=/ version=HTTP/1.1}: rpc: invalid request err=BytesRejection(FailedToBufferBody(LengthLimitError(LengthLimitError(Error { inner: LengthLimitError }))))
```

See [axum::extract::DefaultBodyLimit](https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html) for details on the 2mb default limit [and how to disable](https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html#method.disable)

## Solution

Add a cli option to disable this body size restriction. The size restriction remains enabled by default.
```
      --no-request-size-limit
          Disable the default request body size limit. At time of writing the default limit is 2MB
```