### PR TITLE
chore: enable redundant-lifetimes lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 version = "0.2.0"
 edition = "2021"
 # Remember to update clippy.toml as well
-rust-version = "1.76"
+rust-version = "1.79"
 authors = ["Foundry Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/foundry-rs/foundry"
@@ -48,6 +48,7 @@ octal-escapes = "allow"
 rust-2018-idioms = "warn"
 # unreachable-pub = "warn"
 unused-must-use = "warn"
+redundant-lifetimes = "warn"
 
 [workspace.lints.rustdoc]
 all = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.76"
+msrv = "1.79"
 # bytes::Bytes is included by default and alloy_primitives::Bytes is a wrapper around it,
 # so it is safe to ignore it as well
 ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]

--- a/crates/forge/bin/cmd/fmt.rs
+++ b/crates/forge/bin/cmd/fmt.rs
@@ -202,10 +202,7 @@ impl fmt::Display for Line {
     }
 }
 
-fn format_diff_summary<'a, 'b, 'r>(name: &str, diff: &'r TextDiff<'a, 'b, '_, str>) -> String
-where
-    'r: 'a + 'b,
-{
+fn format_diff_summary<'a>(name: &str, diff: &'a TextDiff<'a, 'a, '_, str>) -> String {
     let cap = 128;
     let mut diff_summary = String::with_capacity(cap);
 


### PR DESCRIPTION
Added in 1.79