### PR TITLE
fix: update bytecode matching for coverage

### DIFF
--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -118,24 +118,22 @@ impl ContractsByArtifact {
 
     /// Finds a contract which has a similar bytecode as `code`.
     pub fn find_by_creation_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef<'_>> {
-        self.iter()
-            .filter_map(|(id, contract)| {
-                if let Some(bytecode) = contract.bytecode() {
-                    let score = bytecode_diff_score(bytecode.as_ref(), code);
-                    (score <= 0.1).then_some((score, (id, contract)))
-                } else {
-                    None
-                }
-            })
-            .min_by(|(score1, _), (score2, _)| score1.partial_cmp(score2).unwrap())
-            .map(|(_, data)| data)
+        self.find_by_code(code, ContractData::bytecode)
     }
 
     /// Finds a contract which has a similar deployed bytecode as `code`.
     pub fn find_by_deployed_code(&self, code: &[u8]) -> Option<ArtifactWithContractRef<'_>> {
+        self.find_by_code(code, ContractData::deployed_bytecode)
+    }
+
+    fn find_by_code(
+        &self,
+        code: &[u8],
+        get: impl Fn(&ContractData) -> Option<&Bytes>,
+    ) -> Option<ArtifactWithContractRef<'_>> {
         self.iter()
             .filter_map(|(id, contract)| {
-                if let Some(deployed_bytecode) = contract.deployed_bytecode() {
+                if let Some(deployed_bytecode) = get(contract) {
                     let score = bytecode_diff_score(deployed_bytecode.as_ref(), code);
                     (score <= 0.1).then_some((score, (id, contract)))
                 } else {

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -10,7 +10,7 @@ use foundry_compilers::{
     },
     ArtifactId,
 };
-use std::{collections::BTreeMap, f64::consts::E, ops::Deref, str::FromStr, sync::Arc};
+use std::{collections::BTreeMap, ops::Deref, str::FromStr, sync::Arc};
 
 /// Libraries' runtime code always starts with the following instruction:
 /// `PUSH20 0x0000000000000000000000000000000000000000`


### PR DESCRIPTION
## Motivation

ref https://github.com/foundry-rs/foundry/issues/6875#issueacomment-2180523566

## Solution

Update `find_by_{deployed,creation}_code` to not exit after first diff_score < 0.1, but instead try matching until the minimal diff score is found.

cc @grandizzy this fixes the issue for https://github.com/grandizzy/forge-coverage-bug/tree/master though not sure about other repos
