### PR TITLE
chore(evm): use u64 for gas limit

### DIFF
--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -123,13 +123,13 @@ impl EvmOpts {
                 difficulty: U256::from(self.env.block_difficulty),
                 prevrandao: Some(self.env.block_prevrandao),
                 basefee: U256::from(self.env.block_base_fee_per_gas),
-                gas_limit: self.gas_limit(),
+                gas_limit: U256::from(self.gas_limit()),
                 ..Default::default()
             },
             cfg,
             tx: TxEnv {
                 gas_price: U256::from(self.env.gas_price.unwrap_or_default()),
-                gas_limit: self.gas_limit().to(),
+                gas_limit: self.gas_limit(),
                 caller: self.sender,
                 ..Default::default()
             },
@@ -156,8 +156,8 @@ impl EvmOpts {
     }
 
     /// Returns the gas limit to use
-    pub fn gas_limit(&self) -> U256 {
-        U256::from(self.env.block_gas_limit.unwrap_or(self.env.gas_limit))
+    pub fn gas_limit(&self) -> u64 {
+        self.env.block_gas_limit.unwrap_or(self.env.gas_limit)
     }
 
     /// Returns the configured chain id, which will be

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,5 +1,4 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
-use alloy_primitives::U256;
 use foundry_evm_core::backend::Backend;
 use revm::primitives::{Env, EnvWithHandlerCfg, SpecId};
 
@@ -16,7 +15,7 @@ pub struct ExecutorBuilder {
     /// The configuration used to build an `InspectorStack`.
     stack: InspectorStackBuilder,
     /// The gas limit.
-    gas_limit: Option<U256>,
+    gas_limit: Option<u64>,
     /// The spec ID.
     spec_id: SpecId,
 }
@@ -54,7 +53,7 @@ impl ExecutorBuilder {
 
     /// Sets the executor gas limit.
     #[inline]
-    pub fn gas_limit(mut self, gas_limit: U256) -> Self {
+    pub fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = Some(gas_limit);
         self
     }
@@ -63,14 +62,14 @@ impl ExecutorBuilder {
     #[inline]
     pub fn build(self, env: Env, db: Backend) -> Executor {
         let Self { mut stack, gas_limit, spec_id } = self;
-        stack.block = Some(env.block.clone());
-        stack.gas_price = Some(env.tx.gas_price);
-        let gas_limit = gas_limit.unwrap_or(env.block.gas_limit);
-        Executor::new(
-            db,
-            EnvWithHandlerCfg::new_with_spec_id(Box::new(env), spec_id),
-            stack.build(),
-            gas_limit,
-        )
+        if stack.block.is_none() {
+            stack.block = Some(env.block.clone());
+        }
+        if stack.gas_price.is_none() {
+            stack.gas_price = Some(env.tx.gas_price);
+        }
+        let gas_limit = gas_limit.unwrap_or_else(|| env.block.gas_limit.saturating_to());
+        let env = EnvWithHandlerCfg::new_with_spec_id(Box::new(env), spec_id);
+        Executor::new(db, env, stack.build(), gas_limit)
     }
 }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -80,17 +80,23 @@ pub struct Executor {
     /// The gas limit for calls and deployments. This is different from the gas limit imposed by
     /// the passed in environment, as those limits are used by the EVM for certain opcodes like
     /// `gaslimit`.
-    gas_limit: U256,
+    gas_limit: u64,
 }
 
 impl Executor {
+    /// Creates a new `ExecutorBuilder`.
+    #[inline]
+    pub fn builder() -> ExecutorBuilder {
+        ExecutorBuilder::new()
+    }
+
     /// Creates a new `Executor` with the given arguments.
     #[inline]
     pub fn new(
         mut backend: Backend,
         env: EnvWithHandlerCfg,
         inspector: InspectorStack,
-        gas_limit: U256,
+        gas_limit: u64,
     ) -> Self {
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks
         // does not fail
@@ -190,7 +196,7 @@ impl Executor {
     }
 
     #[inline]
-    pub fn set_gas_limit(&mut self, gas_limit: U256) -> &mut Self {
+    pub fn set_gas_limit(&mut self, gas_limit: u64) -> &mut Self {
         self.gas_limit = gas_limit;
         self
     }
@@ -529,7 +535,7 @@ impl Executor {
             // the cheatcode handler if it is enabled
             block: BlockEnv {
                 basefee: U256::ZERO,
-                gas_limit: self.gas_limit,
+                gas_limit: U256::from(self.gas_limit),
                 ..self.env.block.clone()
             },
             tx: TxEnv {
@@ -540,7 +546,7 @@ impl Executor {
                 // As above, we set the gas price to 0.
                 gas_price: U256::ZERO,
                 gas_priority_fee: None,
-                gas_limit: self.gas_limit.to(),
+                gas_limit: self.gas_limit,
                 ..self.env.tx.clone()
             },
         };


### PR DESCRIPTION
Values higher than `u64::MAX` would panic in `local_evm_env`/`build_test_env`.