### PR TITLE
fix: overflow in randomUint

### DIFF
--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -158,11 +158,12 @@ impl Cheatcode for randomUint_0Call {
 
 impl Cheatcode for randomUint_1Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
-        let Self { min, max } = self;
+        let Self { min, max } = *self;
+        ensure!(min <= max, "min must be less than or equal to max");
         // Generate random between range min..=max
         let mut rng = rand::thread_rng();
-        let range = *max - *min + U256::from(1);
-        let random_number = rng.gen::<U256>() % range + *min;
+        let range = max - min + U256::from(1);
+        let random_number = rng.gen::<U256>() % range + min;
         Ok(random_number.abi_encode())
     }
 }

--- a/testdata/default/cheats/RandomUint.t.sol
+++ b/testdata/default/cheats/RandomUint.t.sol
@@ -15,9 +15,7 @@ contract RandomUint is DSTest {
     }
 
     function testRandomUint(uint256 min, uint256 max) public {
-        if (min > max) {
-            (min, max) = (max, min);
-        }
+        vm.assume(max >= min);
         uint256 rand = vm.randomUint(min, max);
         assertTrue(rand >= min, "rand >= min");
         assertTrue(rand <= max, "rand <= max");


### PR DESCRIPTION
Don't overflow `max - min` by rejecting `max > min`. CC @yash-atreya @mds1