### PR TITLE
fix: use tx.into_signed directly

### DIFF
--- a/crates/anvil/src/eth/sign.rs
+++ b/crates/anvil/src/eth/sign.rs
@@ -1,5 +1,5 @@
 use crate::eth::error::BlockchainError;
-use alloy_consensus::{SignableTransaction, Signed};
+use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::TypedData;
 use alloy_network::TxSignerSync;
 use alloy_primitives::{Address, Signature, B256};
@@ -121,21 +121,15 @@ pub fn build_typed_transaction(
     signature: Signature,
 ) -> Result<TypedTransaction, BlockchainError> {
     let tx = match request {
-        TypedTransactionRequest::Legacy(tx) => {
-            let sighash = tx.signature_hash();
-            TypedTransaction::Legacy(Signed::new_unchecked(tx, signature, sighash))
-        }
+        TypedTransactionRequest::Legacy(tx) => TypedTransaction::Legacy(tx.into_signed(signature)),
         TypedTransactionRequest::EIP2930(tx) => {
-            let sighash = tx.signature_hash();
-            TypedTransaction::EIP2930(Signed::new_unchecked(tx, signature, sighash))
+            TypedTransaction::EIP2930(tx.into_signed(signature))
         }
         TypedTransactionRequest::EIP1559(tx) => {
-            let sighash = tx.signature_hash();
-            TypedTransaction::EIP1559(Signed::new_unchecked(tx, signature, sighash))
+            TypedTransaction::EIP1559(tx.into_signed(signature))
         }
         TypedTransactionRequest::EIP4844(tx) => {
-            let sighash = tx.signature_hash();
-            TypedTransaction::EIP4844(Signed::new_unchecked(tx, signature, sighash))
+            TypedTransaction::EIP4844(tx.into_signed(signature))
         }
         TypedTransactionRequest::Deposit(tx) => {
             let DepositTransactionRequest {


### PR DESCRIPTION
closes #8241

fixes api misuse when creating the signed tx which incorrectly used the sig hash as the tx hash