### PR TITLE
fix: use inclusive check for logs range fetch in fork

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1385,7 +1385,7 @@ impl Backend {
                 to_on_fork = fork.block_number();
             }
 
-            if fork.predates_fork(from) {
+            if fork.predates_fork_inclusive(from) {
                 // this data is only available on the forked client
                 let filter = filter.clone().from_block(from).to_block(to_on_fork);
                 all_logs = fork.logs(&filter).await?;


### PR DESCRIPTION
closes #8242

fixes an edge cases where the logs for the block we forked off are not fetched from remote.

we need to fetch them if the from is before or the fork block