### PR TITLE
fix(invariant): exit early if invariant fails in initial state

### DIFF
--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -11,8 +11,6 @@ use proptest::test_runner::TestError;
 pub struct InvariantFailures {
     /// Total number of reverts.
     pub reverts: usize,
-    /// How many different invariants have been broken.
-    pub broken_invariants_count: usize,
     /// The latest revert reason of a run.
     pub revert_reason: Option<String>,
     /// Maps a broken invariant to its specific error.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -158,7 +158,7 @@ impl InvariantTest {
 
     /// Whether invariant test has errors or not.
     pub fn has_errors(&self) -> bool {
-        self.execution_data.borrow().failures.error.is_none()
+        self.execution_data.borrow().failures.error.is_some()
     }
 
     /// Set invariant test error.
@@ -389,7 +389,7 @@ impl<'a> InvariantExecutor<'a> {
             }
 
             // Call `afterInvariant` only if it is declared and test didn't fail already.
-            if invariant_contract.call_after_invariant && invariant_test.has_errors() {
+            if invariant_contract.call_after_invariant && !invariant_test.has_errors() {
                 assert_after_invariant(
                     &invariant_contract,
                     &invariant_test,
@@ -485,6 +485,9 @@ impl<'a> InvariantExecutor<'a> {
             &[],
             &mut failures,
         )?;
+        if let Some(error) = failures.error {
+            return Err(eyre!(error.revert_reason().unwrap_or_default()))
+        }
 
         Ok((
             InvariantTest::new(

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -589,10 +589,50 @@ contract CounterTest is Test {
 
     cmd.args(["test"]);
     let (stderr, _) = cmd.unchecked_output_lossy();
+    // make sure there are only 61 runs (with proptest shrinking same test results in 298 runs)
+    assert_eq!(extract_number_of_runs(stderr), 61);
+});
+
+forgetest_init!(should_exit_early_on_invariant_failure, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_test(
+        "CounterInvariant.t.sol",
+        r#"pragma solidity 0.8.24;
+import {Test} from "forge-std/Test.sol";
+
+contract Counter {
+    uint256 public number = 0;
+
+    function inc() external {
+        number += 1;
+    }
+}
+
+contract CounterTest is Test {
+    Counter public counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    function invariant_early_exit() public view {
+        assertTrue(counter.number() == 10, "wrong count");
+    }
+}
+     "#,
+    )
+    .unwrap();
+
+    cmd.args(["test"]);
+    let (stderr, _) = cmd.unchecked_output_lossy();
+    // make sure invariant test exit early with 0 runs
+    assert_eq!(extract_number_of_runs(stderr), 0);
+});
+
+fn extract_number_of_runs(stderr: String) -> usize {
     let runs = stderr.find("runs:").and_then(|start_runs| {
         let runs_split = &stderr[start_runs + 6..];
         runs_split.find(',').map(|end_runs| &runs_split[..end_runs])
     });
-    // make sure there are only 61 runs (with proptest shrinking same test results in 298 runs)
-    assert_eq!(runs.unwrap().parse::<usize>().unwrap(), 61);
-});
+    runs.unwrap().parse::<usize>().unwrap()
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- invariant test does not exit if failed in initial state but perform test runs
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- check if there is any failure right after initial check and return Err with revert reason
- cleanup
  - remove unused `broken_invariants_count` (there could be only one broken invariant per test)
  - correct `InvariantTest.has_errors` check: `is_some` instead of `is_none`