### PR TITLE
fix(invariant): do not continue test runs if invariant fails

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -370,8 +370,9 @@ impl<'a> InvariantExecutor<'a> {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
 
+                    // If test cannot continue then stop current run and exit test suite.
                     if !result.can_continue {
-                        break
+                        return Err(TestCaseError::fail("Test cannot continue."))
                     }
 
                     invariant_test.set_last_call_results(result.call_result);

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -86,9 +86,8 @@ pub(crate) fn assert_invariants(
     Ok(Some(call_result))
 }
 
-/// Verifies that the invariant run execution can continue.
-/// Returns the mapping of (Invariant Function Name -> Call Result, Logs, Traces) if invariants were
-/// asserted.
+/// Returns if invariant test can continue and last successful call result of the invariant test
+/// function (if it can continue).
 pub(crate) fn can_continue(
     invariant_contract: &InvariantContract<'_>,
     invariant_test: &InvariantTest,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- atm after invariant is asserted and if it failed, we only exit current run (by breaking current run depth loop) but we don't interrupt the whole test. This results in unnecessary runs performed after invariant failed (e.g. if we have 1000 runs configured and run 500 breaks the invariant, there will still be 1000 runs performed)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- exit invariant test and do not perform remaining runs if test cannot continue