### PR TITLE
Docs improvement

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo update
-        # Remove first line that always just says "Updating crates.io index"
+        # Remove the first line that always just says "Updating crates.io index"
         run: cargo update --color never 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
 
       - name: craft commit message and PR body

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ elsewhere.
 If you have reviewed existing documentation and still have questions, or you are having problems, you can get help in the following ways:
 
 -   **Asking in the support Telegram:** The [Foundry Support Telegram][support-tg] is a fast and easy way to ask questions.
--   **Opening a discussion:** This repository comes with a discussions board where you can also ask for help. Click the "Discussions" tab at the top.
+-   **Opening a discussion:** This repository comes with a discussion board where you can also ask for help. Click the "Discussions" tab at the top.
 
 As Foundry is still in heavy development, the documentation can be a bit scattered.
 The [Foundry Book][foundry-book] is our current best-effort attempt at keeping up-to-date information.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [Developer Docs](./docs/dev/)
 | [Crate Docs](https://foundry-rs.github.io/foundry)
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+**Foundry is a blazingly fast, portable and modular toolkit for Ethereum application development written in Rust.**
 
 Foundry consists of:
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -10,7 +10,7 @@ $ cargo test
 
 should be enough to get you started!
 
-To learn more about how foundry's tools works, see [./architecture.md](./architecture.md).
+To learn more about how foundry's tools work, see [./architecture.md](./architecture.md).
 It also explains the high-level layout of some aspects of the source code.
 To read more about how to use it, see [📖 Foundry Book][foundry-book]
 Note though, that the internal documentation is very incomplete.

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -6,7 +6,7 @@ This is a working document intended to outline some commands contributors can us
 
 All crates use [tracing](https://docs.rs/tracing/latest/tracing/) for logging. A console formatter is installed in each binary (`cast`, `forge`, `anvil`).
 
-By setting `RUST_LOG=<filter>` you can get a lot more info out of Forge and Cast. For example, running Forge with `RUST_LOG=forge` will emit all logs of the `cli` crate, same for Cast.
+By setting `RUST_LOG=<filter>` you can get a lot more info out of Forge and Cast. For example, running Forge with `RUST_LOG=forge` will emit all logs of the `cli` crate, the same for Cast.
 
 The most basic valid filter is a log level, of which these are valid:
 

--- a/docs/dev/scripting.md
+++ b/docs/dev/scripting.md
@@ -90,7 +90,7 @@ Executor::call-. BroadcastableTransactions .->ScriptArgs::handle_broadcastable_t
 
 During the first execution stage on `forge script`, foundry has to adjust the nonce from the sender to make sure the execution and state are as close as possible to its on-chain representation.
 
-Making sure that `msg.sender` is our signer when calling `setUp()` and `run()` and that its nonce is correct (decreased by one on each call) when calling `vm.broadcast` to create a contract.
+Make sure that `msg.sender` is our signer when calling `setUp()` and `run()` and that its nonce is correct (decreased by one on each call) when calling `vm.broadcast` to create a contract.
 
 We skip this, if the user hasn't set a sender and they're using the `Config::DEFAULT_SENDER`.
 

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -136,7 +136,7 @@ contract BroadcastTest is DSTest {
         vm.broadcast(address(0x1337));
         Test test = new Test();
 
-        // This panics because this would cause an additional relinking that isnt conceptually correct
+        // This panics because this would cause an additional relinking that isn't conceptually correct
         // from a solidity standpoint. Basically, this contract `BroadcastTest`, injects the code of
         // `Test` *into* its code. So it isn't reasonable to break solidity to our will of having *two*
         // versions of `Test` based on the sender/linker.


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.