### PR TITLE
Increase retry count for default profile to improve reliability nexte…

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }
+retries = { backoff = "exponential", count = 3, delay = "2s", jitter = true }
 slow-timeout = { period = "1m", terminate-after = 3 }
 
 [[profile.default.overrides]]


### PR DESCRIPTION
Pull Request Proposal:
Title: Increase retry count for default profile to improve reliability

Description:

This PR increases the retry count from 2 to 3 for the profile.default section. By providing an additional retry attempt, this change aims to enhance the robustness and reliability of operations that may occasionally fail due to transient issues.

Justification:

Improved Reliability: An extra retry attempt can help mitigate temporary failures, improving overall operation success rates.
Minimal Impact: This change introduces a minor adjustment that does not affect other configurations or profiles, ensuring minimal disruption while enhancing functionality.
Impact: This change is backward compatible and does not introduce any breaking changes. It simply adjusts the retry mechanism to be slightly more resilient.
