### PR TITLE
fix: correctly adjust depth when calling cheatcodes with `--isolate`

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -702,13 +702,16 @@ impl<'a, DB: DatabaseExt> Inspector<DB> for InspectorStackRefMut<'a> {
             ecx
         );
 
+        ecx.journaled_state.depth += self.in_inner_context as usize;
         if let Some(cheatcodes) = self.cheatcodes.as_deref_mut() {
             if let Some(output) = cheatcodes.call_with_executor(ecx, call, self.inner) {
                 if output.result.result != InstructionResult::Continue {
+                    ecx.journaled_state.depth -= self.in_inner_context as usize;
                     return Some(output)
                 }
             }
         }
+        ecx.journaled_state.depth -= self.in_inner_context as usize;
 
         if self.enable_isolation &&
             call.scheme == CallScheme::Call &&


### PR DESCRIPTION
## Motivation

After #8181 cheatcodes are called separately in `InspectorStack::call` and currently depth for its invocation is not adjusted while in isolation, resulting in failing test-isolate CI job https://github.com/foundry-rs/foundry/actions/runs/9688379922

## Solution

Adjust depth separately for `Cheatcodes` call
