### PR TITLE
Update prune-prereleases.js to keep 30 nightlies around

### DIFF
--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -36,7 +36,7 @@ module.exports = async ({ github, context }) => {
 
     // Pruning rules:
     //   1. only keep the earliest (by created_at) release of the month
-    //   2. to keep the newest 3 nightlies
+    //   2. to keep the newest 30 nightlies (to make sure nightlies are kept until the next monthly release)
     // Notes:
     //   - This addresses https://github.com/foundry-rs/foundry/issues/6732
     //   - Name of the release may deviate from created_at due to the usage of different timezones.
@@ -47,7 +47,7 @@ module.exports = async ({ github, context }) => {
     const groups = groupBy(nightlies, i => i.created_at.slice(0, 7));
     const nightliesToPrune = Object.values(groups)
         .reduce((acc, cur) => acc.concat(cur.slice(0, -1)), []) // rule 1
-        .slice(3); // rule 2
+        .slice(30); // rule 2
 
     for (const nightly of nightliesToPrune) {
         console.log(`Deleting nightly: ${nightly.tag_name}`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes https://github.com/foundry-rs/foundry/issues/8000
I want to use nightly releases in a CI pipeline, but they currently get pruned, which forces me to wait for the next month before upgrading my tooling with new features. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This is just a hacky solution where we keep 30 nightlies around instead of just 3.
The better implementation would actually only keep all the nightlies of the current month, which is prob not that hard to implement actually, but want to see what you guys think before putting effort into this.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
