### PR TITLE
fix: vm rpc encoding

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -1,4 +1,5 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result, Vm::*};
+use alloy_dyn_abi::DynSolValue;
 use alloy_primitives::{B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
@@ -246,7 +247,8 @@ impl Cheatcode for rpcCall {
         let result_as_tokens = crate::json::json_value_to_token(&result)
             .map_err(|err| fmt_err!("failed to parse result: {err}"))?;
 
-        Ok(result_as_tokens.abi_encode())
+        // the cheatcode expects bytes so we need to ensure the result is encoded as bytes
+        Ok(DynSolValue::Bytes(result_as_tokens.abi_encode()).abi_encode())
     }
 }
 

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -342,3 +342,6 @@ test_repro!(2851, false, None, |res| {
 
 // https://github.com/foundry-rs/foundry/issues/8006
 test_repro!(8006);
+
+// https://github.com/foundry-rs/foundry/issues/8287
+test_repro!(8287);

--- a/testdata/default/repros/Issue8287.t.sol
+++ b/testdata/default/repros/Issue8287.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+// https://github.com/foundry-rs/foundry/issues/8287
+contract Issue8287Test is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testSelectFork() public {
+        uint256 f2 = vm.createFork("rpcAlias", 10);
+        bytes memory data = vm.rpc("eth_getBalance", "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]");
+        // rpc response returns encoded bytes
+        bytes memory b = abi.decode(data, (bytes));
+        string memory m = vm.toString(b);
+        assertEq(m, "0x2086ac351052600000");
+    }
+}


### PR DESCRIPTION
closes #8287

@DaniPopes @klkvr I'm not sure what the appropriate behaviour here would be, but I think ensuring the cheatcode returns the abiencoded rpc response as abi bytes makes sense, but maybe we don't double encode if the `DynSolValue` is already `Bytes`?