### PR TITLE
perf: only instantiate Vyper when necessary

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -32,7 +32,7 @@ use foundry_compilers::{
         Compiler,
     },
     error::SolcError,
-    ConfigurableArtifacts, Project, ProjectPathsConfig,
+    ConfigurableArtifacts, Project, ProjectPathsConfig, VyperLanguage,
 };
 use inflector::Inflector;
 use regex::Regex;
@@ -957,6 +957,10 @@ impl Config {
 
     /// Returns configured [Vyper] compiler.
     pub fn vyper_compiler(&self) -> Result<Option<Vyper>, SolcError> {
+        // Only instantiate Vyper if there are any Vyper files in the project.
+        if self.project_paths::<VyperLanguage>().input_files_iter().next().is_none() {
+            return Ok(None)
+        }
         let vyper = if let Some(path) = &self.vyper.path {
             Some(Vyper::new(path)?)
         } else {


### PR DESCRIPTION
## Motivation

`vyper --version` is pretty slow, avoid calling it when vyper compiler won't be needed

## Solution

