### PR TITLE
fix: suppress compile reporting for forge flatten

### DIFF
--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -45,9 +45,8 @@ impl FlattenArgs {
 
         let target_path = dunce::canonicalize(target_path)?;
 
-        let flattener = with_compilation_reporter(build_args.silent, || {
-            Flattener::new(project.clone(), &target_path)
-        });
+        let flattener =
+            with_compilation_reporter(true, || Flattener::new(project.clone(), &target_path));
 
         let flattened = match flattener {
             Ok(flattener) => Ok(flattener.flatten()),


### PR DESCRIPTION
closes #8312

invoke solc quietly 