### PR TITLE
[WIP] Support for Flamegraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,7 +2891,7 @@ dependencies = [
  "console_error_panic_hook",
  "pest",
  "pest_derive",
- "quick-xml",
+ "quick-xml 0.18.1",
  "wasm-bindgen",
 ]
 
@@ -2944,6 +2944,15 @@ checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -3341,6 +3350,7 @@ dependencies = [
  "humantime-serde",
  "hyper 1.3.1",
  "indicatif",
+ "inferno",
  "itertools 0.13.0",
  "mockall",
  "once_cell",
@@ -5041,6 +5051,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger 0.10.2",
+ "indexmap 2.2.6",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5457,7 +5490,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "elasticlunr-rs",
- "env_logger",
+ "env_logger 0.11.3",
  "handlebars",
  "log",
  "memchr",
@@ -6647,6 +6680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7066,6 +7108,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7439be6844e40133eda024efd85bf07f59d0dd2f59b10c00dd6cfb92cc5c741"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -8015,6 +8066,12 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "string_cache"

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -935,7 +935,7 @@ impl ChiselDispatcher {
         for (kind, trace) in &result.traces {
             // Display all Setup + Execution traces.
             if matches!(kind, TraceKind::Setup | TraceKind::Execution) {
-                println!("{}", render_trace_arena(trace, decoder).await?);
+                println!("{}", render_trace_arena(trace, decoder).await?.0);
             }
         }
 

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -412,7 +412,7 @@ pub async fn print_traces(result: &mut TraceResult, decoder: &CallTraceDecoder) 
 
     println!("Traces:");
     for (_, arena) in traces {
-        println!("{}", render_trace_arena(arena, decoder).await?);
+        println!("{}", render_trace_arena(arena, decoder).await?.0);
     }
     println!();
 

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -1,0 +1,150 @@
+#[derive(Debug, Clone, Default)]
+pub struct FoldedStackTrace {
+    traces: Vec<(Vec<String>, i64)>,
+    exits: Option<u64>,
+}
+
+impl FoldedStackTrace {
+    pub fn enter(&mut self, label: String, gas: i64) {
+        let mut trace_entry = self.traces.last().map(|entry| entry.0.clone()).unwrap_or_default();
+
+        let mut exits = self.exits.unwrap_or_default();
+        while exits > 0 {
+            trace_entry.pop();
+            exits -= 1;
+        }
+        self.exits = None;
+
+        trace_entry.push(label);
+        self.traces.push((trace_entry, gas));
+    }
+
+    pub fn exit(&mut self) {
+        self.exits = self.exits.map(|exits| exits + 1).or(Some(1));
+    }
+
+    pub fn fold(mut self) -> Vec<String> {
+        self.subtract_children();
+        self.fold_without_subtraction()
+    }
+
+    pub fn fold_without_subtraction(&mut self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for (trace, gas) in self.traces.iter() {
+            lines.push(format!("{} {}", trace.join(";"), gas));
+        }
+        lines
+    }
+
+    pub fn subtract_children(&mut self) {
+        // Iterate over each trace to find the children and subtract their values from the parents
+        for i in 0..self.traces.len() {
+            let (left, right) = self.traces.split_at_mut(i);
+            let (trace, gas) = &right[0];
+            if trace.len() > 1 {
+                let parent_trace_to_match = &trace[..trace.len() - 1];
+                for parent in left {
+                    if parent.0 == parent_trace_to_match {
+                        parent.1 -= gas;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+mod tests {
+    #[test]
+    fn test_insert_1() {
+        let mut trace = super::FoldedStackTrace::default();
+        trace.enter("top".to_string(), 500);
+        trace.enter("child_a".to_string(), 100);
+        trace.exit();
+        trace.enter("child_b".to_string(), 200);
+
+        assert_eq!(
+            trace.fold_without_subtraction(),
+            vec![
+                "top 500", //
+                "top;child_a 100",
+                "top;child_b 200",
+            ]
+        );
+        assert_eq!(
+            trace.fold(),
+            vec![
+                "top 200", // 500 - 100 - 200
+                "top;child_a 100",
+                "top;child_b 200",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_insert_2() {
+        let mut trace = super::FoldedStackTrace::default();
+        trace.enter("top".to_string(), 500);
+        trace.enter("child_a".to_string(), 300);
+        trace.enter("child_b".to_string(), 100);
+        trace.exit();
+        trace.exit();
+        trace.enter("child_c".to_string(), 100);
+
+        assert_eq!(
+            trace.fold_without_subtraction(),
+            vec![
+                "top 500", //
+                "top;child_a 300",
+                "top;child_a;child_b 100",
+                "top;child_c 100",
+            ]
+        );
+
+        assert_eq!(
+            trace.fold(),
+            vec![
+                "top 100",         // 500 - 300 - 100
+                "top;child_a 200", // 300 - 100
+                "top;child_a;child_b 100",
+                "top;child_c 100",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_insert_3() {
+        let mut trace = super::FoldedStackTrace::default();
+        trace.enter("top".to_string(), 1700);
+        trace.enter("child_a".to_string(), 500);
+        trace.exit();
+        trace.enter("child_b".to_string(), 500);
+        trace.enter("child_c".to_string(), 500);
+        trace.exit();
+        trace.exit();
+        trace.exit();
+        trace.enter("top2".to_string(), 1700);
+
+        assert_eq!(
+            trace.fold_without_subtraction(),
+            vec![
+                "top 1700", //
+                "top;child_a 500",
+                "top;child_b 500",
+                "top;child_b;child_c 500",
+                "top2 1700",
+            ]
+        );
+
+        assert_eq!(
+            trace.fold(),
+            vec![
+                "top 700", //
+                "top;child_a 500",
+                "top;child_b 0",
+                "top;child_b;child_c 500",
+                "top2 1700",
+            ]
+        );
+    }
+}

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -79,6 +79,7 @@ dunce.workspace = true
 futures.workspace = true
 indicatif = "0.17"
 itertools.workspace = true
+inferno = "0.11.19"
 once_cell.workspace = true
 parking_lot.workspace = true
 regex = { version = "1", default-features = false }

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -428,7 +428,7 @@ impl PreSimulationState {
                 } || !result.success;
 
                 if should_include {
-                    shell::println(render_trace_arena(trace, decoder).await?)?;
+                    shell::println(render_trace_arena(trace, decoder).await?.0)?;
                 }
             }
             shell::println(String::new())?;

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -161,7 +161,7 @@ impl PreSimulationState {
                 for (_, trace) in &traces {
                     println!(
                         "{}",
-                        render_trace_arena(trace, &self.execution_artifacts.decoder).await?
+                        render_trace_arena(trace, &self.execution_artifacts.decoder).await?.0
                     );
                 }
             }


### PR DESCRIPTION
## Motivation

This PR closes #776 and builds on top of #8222.

## Solution

The current implementation modifies existing logic in test subcommand and evm/traces crate. 

It adds a `flamegraph` flag to the test subcommand. The interface is similar to the `debug` flag. A pattern is to be provided to the `flamegraph` flag and additional `match-contract` or `match-path` maybe used. Finally it is required that just a single test case must be run.

Example:

```
forge test --flamegraph test_hash_1_a_sol --decode-internal
```

This will execute the `test_hash_1_a_sol` test and generate a `flamegraph.svg` file in the project root.

