### PR TITLE
chore: tweak profiles once more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,33 @@ all = "warn"
 # NOTE: Debuggers may provide less useful information with this setting.
 # Uncomment this section if you're using a debugger.
 [profile.dev]
-debug = 1
+# https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+debug = "line-tables-only"
+strip = "symbols"
+panic = "abort"
+codegen-units = 16
+
+# Use the `--profile profiling` flag to show symbols in release mode.
+# e.g. `cargo build --profile profiling`
+[profile.profiling]
+inherits = "release"
+debug = 2
+split-debuginfo = "unpacked"
+strip = false
+
+[profile.bench]
+inherits = "profiling"
+
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
 
 # Speed up tests and dev build.
 [profile.dev.package]
@@ -95,26 +121,10 @@ axum.opt-level = 3
 # keystores
 scrypt.opt-level = 3
 
-[profile.release]
-opt-level = 3
-lto = "thin"
-debug = "line-tables-only"
-strip = true
-panic = "abort"
-codegen-units = 16
-
-# Use the `--profile profiling` flag to show symbols in release mode.
-# e.g. `cargo build --profile profiling`
-[profile.profiling]
-inherits = "release"
-debug = 1
-strip = false
-
 # Override packages which aren't perf-sensitive for faster compilation speed.
 [profile.release.package]
 mdbook.opt-level = 1
 protobuf.opt-level = 1
-toml_edit.opt-level = 1
 trezor-client.opt-level = 1
 
 [workspace.dependencies]

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -48,13 +48,11 @@ impl EyreHandler for Handler {
 ///
 /// Panics are always caught by the more debug-centric handler.
 pub fn install() {
-    // If the user has not explicitly overridden "RUST_BACKTRACE", then produce full backtraces.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
-        std::env::set_var("RUST_BACKTRACE", "full");
+        std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    let debug_enabled = std::env::var("FOUNDRY_DEBUG").is_ok();
-    if debug_enabled {
+    if std::env::var_os("FOUNDRY_DEBUG").is_some() {
         if let Err(e) = color_eyre::install() {
             debug!("failed to install color eyre error hook: {e}");
         }


### PR DESCRIPTION
line-tables-only

```
debug=                   strip=            `stat -c%s`  backtrace effect

debug=0                  strip=true         67,790,640  no backtraces
debug="line-tables-only" strip=true         67,742,176  no backtraces (somehow smaller?)
debug=0                  strip="debuginfo"  85,458,608  backtraces, no file/line (except for the exact panic location)
debug="line-tables-only" strip="debuginfo"  85,539,392  backtraces, no file/line (except for the exact panic location)
debug=0                  strip=false        97,679,800  backtraces, no file/line (except for the exact panic location)
debug="line-tables-only" strip=false       391,022,576  full backtraces
```

Looks like "line-tables-only" does nothing if stripping at least on linux. Keeping anyway since it might work somewhere else and doesnt cost anything


---

other changes are to debug and strip for dev and profiling, added maxperf but not running in CI, I think I'm content with this