### PR TITLE
feat(anvil): more flexible configuration `LogCollector`

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -509,7 +509,7 @@ pub struct AnvilEvmArgs {
     pub steps_tracing: bool,
 
     /// Disable printing of `console.log` invocations to stdout.
-    #[arg(long), alias = "no-console-log"]
+    #[arg(long, visible_alias = "no-console-log")]
     pub disable_console_log: bool,
 
     /// Enable autoImpersonate on startup

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -230,7 +230,7 @@ impl NodeArgs {
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm_opts.steps_tracing)
-            .with_print_logs(!self.evm_opts.disable_logs)
+            .with_print_logs(!self.evm_opts.disable_console_log)
             .with_auto_impersonate(self.evm_opts.auto_impersonate)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm_opts.code_size_limit)
@@ -509,8 +509,8 @@ pub struct AnvilEvmArgs {
     pub steps_tracing: bool,
 
     /// Disable printing of `console.log` invocations to stdout.
-    #[arg(long)]
-    pub disable_logs: bool,
+    #[arg(long), alias = "no-console-log"]
+    pub disable_console_log: bool,
 
     /// Enable autoImpersonate on startup
     #[arg(long, visible_alias = "auto-impersonate")]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -230,6 +230,7 @@ impl NodeArgs {
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm_opts.steps_tracing)
+            .with_print_logs(self.evm_opts.print_logs)
             .with_auto_impersonate(self.evm_opts.auto_impersonate)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm_opts.code_size_limit)
@@ -506,6 +507,10 @@ pub struct AnvilEvmArgs {
     /// Enable steps tracing used for debug calls returning geth-style traces
     #[arg(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
+
+    /// Enable printing of `console.log` invocations to stdout.
+    #[arg(long)]
+    pub print_logs: bool,
 
     /// Enable autoImpersonate on startup
     #[arg(long, visible_alias = "auto-impersonate")]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -230,7 +230,7 @@ impl NodeArgs {
             .with_transaction_order(self.order)
             .with_genesis(self.init)
             .with_steps_tracing(self.evm_opts.steps_tracing)
-            .with_print_logs(self.evm_opts.print_logs)
+            .with_print_logs(!self.evm_opts.disable_logs)
             .with_auto_impersonate(self.evm_opts.auto_impersonate)
             .with_ipc(self.ipc)
             .with_code_size_limit(self.evm_opts.code_size_limit)
@@ -508,9 +508,9 @@ pub struct AnvilEvmArgs {
     #[arg(long, visible_alias = "tracing")]
     pub steps_tracing: bool,
 
-    /// Enable printing of `console.log` invocations to stdout.
+    /// Disable printing of `console.log` invocations to stdout.
     #[arg(long)]
-    pub print_logs: bool,
+    pub disable_logs: bool,
 
     /// Enable autoImpersonate on startup
     #[arg(long, visible_alias = "auto-impersonate")]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -155,6 +155,8 @@ pub struct NodeConfig {
     pub ipc_path: Option<Option<String>>,
     /// Enable transaction/call steps tracing for debug calls returning geth-style traces
     pub enable_steps_tracing: bool,
+    /// Enable printing of `console.log` invocations.
+    pub print_logs: bool,
     /// Enable auto impersonation of accounts on startup
     pub enable_auto_impersonate: bool,
     /// Configure the code size limit
@@ -404,6 +406,7 @@ impl Default for NodeConfig {
             blob_excess_gas_and_price: None,
             enable_tracing: true,
             enable_steps_tracing: false,
+            print_logs: true,
             enable_auto_impersonate: false,
             no_storage_caching: false,
             server_config: Default::default(),
@@ -789,6 +792,13 @@ impl NodeConfig {
         self
     }
 
+    /// Sets whether to print `console.log` invocations to stdout.
+    #[must_use]
+    pub fn with_print_logs(mut self, print_logs: bool) -> Self {
+        self.print_logs = print_logs;
+        self
+    }
+
     /// Sets whether to enable autoImpersonate
     #[must_use]
     pub fn with_auto_impersonate(mut self, enable_auto_impersonate: bool) -> Self {
@@ -949,6 +959,7 @@ impl NodeConfig {
             fees,
             Arc::new(RwLock::new(fork)),
             self.enable_steps_tracing,
+            self.print_logs,
             self.prune_history,
             self.transaction_block_keeper,
             self.block_time,

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -104,6 +104,7 @@ pub struct TransactionExecutor<'a, Db: ?Sized, Validator: TransactionValidator> 
     /// Cumulative blob gas used by all executed transactions
     pub blob_gas_used: u128,
     pub enable_steps_tracing: bool,
+    pub print_logs: bool,
     /// Precompiles to inject to the EVM.
     pub precompile_factory: Option<Arc<dyn PrecompileFactory>>,
 }
@@ -303,6 +304,9 @@ impl<'a, 'b, DB: Db + ?Sized, Validator: TransactionValidator> Iterator
         let mut inspector = Inspector::default().with_tracing();
         if self.enable_steps_tracing {
             inspector = inspector.with_steps_tracing();
+        }
+        if self.print_logs {
+            inspector = inspector.with_log_collector();
         }
 
         let exec_result = {

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -1,6 +1,6 @@
 //! Anvil specific [`revm::Inspector`] implementation
 
-use crate::{eth::macros::node_info, revm::Database};
+use crate::revm::Database;
 use alloy_primitives::{Address, Log};
 use foundry_evm::{
     call_inspectors,
@@ -166,6 +166,6 @@ impl<DB: Database> InspectorExt<DB> for Inspector {}
 /// Prints all the logs
 pub fn print_logs(logs: &[Log]) {
     for log in decode_console_logs(logs) {
-        node_info!("{}", log);
+        tracing::info!(target: crate::logging::EVM_CONSOLE_LOG_TARGET, "{}", log);
     }
 }

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -30,7 +30,9 @@ impl Inspector {
     ///
     /// This will log all `console.sol` logs
     pub fn print_logs(&self) {
-        self.log_collector.as_ref().map(|collector| print_logs(&collector.logs));
+        if let Some(collector) = &self.log_collector {
+            print_logs(&collector.logs);
+        }
     }
 
     /// Configures the `Tracer` [`revm::Inspector`]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -166,6 +166,7 @@ pub struct Backend {
     /// keeps track of active snapshots at a specific block
     active_snapshots: Arc<Mutex<HashMap<U256, (u64, B256)>>>,
     enable_steps_tracing: bool,
+    print_logs: bool,
     /// How to keep history state
     prune_state_history_config: PruneStateHistoryConfig,
     /// max number of blocks with transactions in memory
@@ -187,6 +188,7 @@ impl Backend {
         fees: FeeManager,
         fork: Arc<RwLock<Option<ClientFork>>>,
         enable_steps_tracing: bool,
+        print_logs: bool,
         prune_state_history_config: PruneStateHistoryConfig,
         transaction_block_keeper: Option<usize>,
         automine_block_time: Option<Duration>,
@@ -239,6 +241,7 @@ impl Backend {
             genesis,
             active_snapshots: Arc::new(Mutex::new(Default::default())),
             enable_steps_tracing,
+            print_logs,
             prune_state_history_config,
             transaction_block_keeper,
             node_config,
@@ -898,6 +901,7 @@ impl Backend {
             gas_used: 0,
             blob_gas_used: 0,
             enable_steps_tracing: self.enable_steps_tracing,
+            print_logs: self.print_logs,
             precompile_factory: self.precompile_factory.clone(),
         };
 
@@ -969,6 +973,7 @@ impl Backend {
                     gas_used: 0,
                     blob_gas_used: 0,
                     enable_steps_tracing: self.enable_steps_tracing,
+                    print_logs: self.print_logs,
                     precompile_factory: self.precompile_factory.clone(),
                 };
                 let executed_tx = executor.execute();

--- a/crates/anvil/src/logging.rs
+++ b/crates/anvil/src/logging.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::{layer::Context, Layer};
 /// The target that identifies the events intended to be logged to stdout
 pub(crate) const NODE_USER_LOG_TARGET: &str = "node::user";
 
-/// The target that identifies the events coming from the `console.log` invocations.`
+/// The target that identifies the events coming from the `console.log` invocations.
 pub(crate) const EVM_CONSOLE_LOG_TARGET: &str = "node::console";
 
 /// A logger that listens for node related events and displays them.

--- a/crates/anvil/src/logging.rs
+++ b/crates/anvil/src/logging.rs
@@ -8,6 +8,9 @@ use tracing_subscriber::{layer::Context, Layer};
 /// The target that identifies the events intended to be logged to stdout
 pub(crate) const NODE_USER_LOG_TARGET: &str = "node::user";
 
+/// The target that identifies the events coming from the `console.log` invocations.`
+pub(crate) const EVM_CONSOLE_LOG_TARGET: &str = "node::console";
+
 /// A logger that listens for node related events and displays them.
 ///
 /// This layer is intended to be used as filter for `NODE_USER_LOG_TARGET` events that will
@@ -30,7 +33,10 @@ where
     S: tracing::Subscriber,
 {
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
-        if self.state.is_enabled() && metadata.target() == NODE_USER_LOG_TARGET {
+        if self.state.is_enabled() &&
+            (metadata.target() == NODE_USER_LOG_TARGET ||
+                metadata.target() == EVM_CONSOLE_LOG_TARGET)
+        {
             Interest::always()
         } else {
             Interest::never()
@@ -38,7 +44,9 @@ where
     }
 
     fn enabled(&self, metadata: &Metadata<'_>, _ctx: Context<'_, S>) -> bool {
-        self.state.is_enabled() && metadata.target() == NODE_USER_LOG_TARGET
+        self.state.is_enabled() &&
+            (metadata.target() == NODE_USER_LOG_TARGET ||
+                metadata.target() == EVM_CONSOLE_LOG_TARGET)
     }
 }
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/7681

## Solution

Thisadds an option to disable `LogCollector` via `--disable-console-log` flag. Also sets `target` for traces captured by `LogCollector` to `node::console` to allow easier filtering of such logs through `RUST_LOG`
