### PR TITLE
chore: increase tx timeout

### DIFF
--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -41,7 +41,7 @@ pub async fn check_tx_status(
         // If the tx is present in the mempool, run the pending tx future, and
         // assume the next drop is really really real
         Ok(PendingTransactionBuilder::new(provider, hash)
-            .with_timeout(Some(Duration::from_secs(120)))
+            .with_timeout(Some(Duration::from_secs(180)))
             .get_receipt()
             .await
             .map_or(TxStatus::Dropped, |r| r.into()))


### PR DESCRIPTION
increases the timeout we wait for a tx to be mined, 

testnets have highly fluctuating prices so this function is problematic on testnets

in a next step we should check if the tx still exists and start over