### PR TITLE
feat(forge): option to replay last test run failures only

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -255,6 +255,8 @@ pub struct Config {
     /// Only show coverage for files that do not match the specified regex pattern.
     #[serde(rename = "no_match_coverage")]
     pub coverage_pattern_inverse: Option<RegexWrapper>,
+    /// Path where last test run failures are recorded.
+    pub test_failures_file: PathBuf,
     /// Configuration for fuzz testing
     pub fuzz: FuzzConfig,
     /// Configuration for invariant testing
@@ -835,6 +837,9 @@ impl Config {
     /// Cleans the project.
     pub fn cleanup<C: Compiler>(&self, project: &Project<C>) -> Result<(), SolcError> {
         project.cleanup()?;
+
+        // Remove last test run failures file.
+        let _ = fs::remove_file(&self.test_failures_file);
 
         // Remove fuzz and invariant cache directories.
         let remove_test_dir = |test_dir: &Option<PathBuf>| {
@@ -2077,6 +2082,7 @@ impl Default for Config {
             path_pattern: None,
             path_pattern_inverse: None,
             coverage_pattern_inverse: None,
+            test_failures_file: "cache/test-failures".into(),
             fuzz: FuzzConfig::new("cache/fuzz".into()),
             invariant: InvariantConfig::new("cache/invariant".into()),
             always_use_create_2_factory: false,

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -17,7 +17,7 @@ use foundry_cli::{
 use foundry_common::{
     compile::{ContractSources, ProjectCompiler},
     evm::EvmArgs,
-    shell,
+    fs, shell,
 };
 use foundry_compilers::{
     artifacts::output_selection::OutputSelection,
@@ -116,8 +116,17 @@ pub struct TestArgs {
     #[arg(long)]
     pub max_threads: Option<u64>,
 
+    /// Show test execution progress.
+    #[arg(long)]
+    pub show_progress: bool,
+
     #[command(flatten)]
     filter: FilterArgs,
+
+    /// Re-run recorded test failures from last run.
+    /// If no failure recorded then regular test run is performed.
+    #[arg(long)]
+    pub run_failures: bool,
 
     #[command(flatten)]
     evm_opts: EvmArgs,
@@ -135,10 +144,6 @@ pub struct TestArgs {
     /// Print detailed test summary table.
     #[arg(long, help_heading = "Display options", requires = "summary")]
     pub detailed: bool,
-
-    /// Show test execution progress.
-    #[arg(long)]
-    pub show_progress: bool,
 }
 
 impl TestArgs {
@@ -565,12 +570,20 @@ impl TestArgs {
             }
         }
 
+        // Persist test run failures to enable replaying.
+        persist_run_failures(&config, &outcome);
+
         Ok(outcome)
     }
 
     /// Returns the flattened [`FilterArgs`] arguments merged with [`Config`].
+    /// Loads and applies filter from file if only last test run failures performed.
     pub fn filter(&self, config: &Config) -> ProjectPathsAwareFilter {
-        self.filter.clone().merge_with_config(config)
+        let mut filter = self.filter.clone();
+        if self.run_failures {
+            filter.test_pattern = last_run_failures(config);
+        }
+        filter.merge_with_config(config)
     }
 
     /// Returns whether `BuildArgs` was configured with `--watch`
@@ -638,6 +651,29 @@ fn list(
         }
     }
     Ok(TestOutcome::empty(false))
+}
+
+/// Load persisted filter (with last test run failures) from file.
+fn last_run_failures(config: &Config) -> Option<regex::Regex> {
+    match fs::read_to_string(&config.test_failures_file) {
+        Ok(filter) => Some(Regex::new(&filter).unwrap()),
+        Err(_) => None,
+    }
+}
+
+/// Persist filter with last test run failures (only if there's any failure).
+fn persist_run_failures(config: &Config, outcome: &TestOutcome) {
+    if outcome.failed() > 0 && fs::create_file(&config.test_failures_file).is_ok() {
+        let mut filter = String::new();
+        let mut failures = outcome.failures().peekable();
+        while let Some((test_name, _)) = failures.next() {
+            filter.push_str(test_name.split("(").next().unwrap());
+            if failures.peek().is_some() {
+                filter.push('|');
+            }
+        }
+        let _ = fs::write(&config.test_failures_file, filter);
+    }
 }
 
 #[cfg(test)]

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -65,6 +65,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         path_pattern: None,
         path_pattern_inverse: None,
         coverage_pattern_inverse: None,
+        test_failures_file: "test-cache/test-failures".into(),
         fuzz: FuzzConfig {
             runs: 1000,
             max_test_rejects: 100203,

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -674,7 +674,7 @@ contract ReplayFailuresTest is Test {
 
     // Perform only the 2 failing tests from last run.
     cmd.forge_fuse();
-    cmd.args(["test", "--run-failures"]).unchecked_output().stdout_matches_path(
+    cmd.args(["test", "--rerun"]).unchecked_output().stdout_matches_path(
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/replay_last_run_failures.stdout"),
     );

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -638,3 +638,44 @@ fn extract_number_of_runs(stderr: String) -> usize {
     });
     runs.unwrap().parse::<usize>().unwrap()
 }
+
+forgetest_init!(should_replay_failures_only, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_test(
+        "ReplayFailures.t.sol",
+        r#"pragma solidity 0.8.24;
+import {Test} from "forge-std/Test.sol";
+
+contract ReplayFailuresTest is Test {
+    function testA() public pure {
+        require(2 > 1);
+    }
+
+    function testB() public pure {
+        require(1 > 2, "testB failed");
+    }
+
+    function testC() public pure {
+        require(2 > 1);
+    }
+
+    function testD() public pure {
+        require(1 > 2, "testD failed");
+    }
+}
+     "#,
+    )
+    .unwrap();
+
+    cmd.args(["test"]);
+    cmd.assert_err();
+    // Test failure filter should be persisted.
+    assert!(prj.root().join("cache/test-failures").exists());
+
+    // Perform only the 2 failing tests from last run.
+    cmd.forge_fuse();
+    cmd.args(["test", "--run-failures"]).unchecked_output().stdout_matches_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/replay_last_run_failures.stdout"),
+    );
+});

--- a/crates/forge/tests/fixtures/replay_last_run_failures.stdout
+++ b/crates/forge/tests/fixtures/replay_last_run_failures.stdout
@@ -1,0 +1,15 @@
+No files changed, compilation skipped
+
+Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
+[FAIL. Reason: revert: testB failed] testB() (gas: 303)
+[FAIL. Reason: revert: testD failed] testD() (gas: 314)
+Suite result: FAILED. 0 passed; 2 failed; 0 skipped; finished in 555.95µs (250.31µs CPU time)
+
+Ran 1 test suite in 3.24ms (555.95µs CPU time): 0 tests passed, 2 failed, 0 skipped (2 total tests)
+
+Failing tests:
+Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
+[FAIL. Reason: revert: testB failed] testB() (gas: 303)
+[FAIL. Reason: revert: testD failed] testD() (gas: 314)
+
+Encountered a total of 2 failing tests, 0 tests succeeded


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4000 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add new option `--run-failures` in filter args to run only test failures from last run
- persist filter with failures of last run in file (if any), defaults to `cache/test-failures` file. File path can be configured in toml `test_failures_file = path/to/file` and is removed on `forge clean` 
- cleanup: move `--show-progress` in test args