### PR TITLE
feat(config): Add option for env_path

### DIFF
--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -35,7 +35,7 @@ pub enum AnvilSubcommand {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    utils::load_dotenv();
+    utils::load_dotenv(&None);
 
     let mut app = Anvil::parse();
     app.node.evm_opts.resolve_rpc_alias();

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -36,7 +36,8 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[tokio::main]
 async fn main() -> Result<()> {
     handler::install();
-    utils::load_dotenv();
+    let config = utils::load_config();
+    utils::load_dotenv(&config.env_path);
     utils::subscriber();
     utils::enable_paint();
 

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -98,7 +98,6 @@ pub enum ChiselSubcommand {
 async fn main() -> eyre::Result<()> {
     handler::install();
     utils::subscriber();
-    utils::load_dotenv();
 
     // Parse command args
     let args = Chisel::parse();
@@ -108,6 +107,7 @@ async fn main() -> eyre::Result<()> {
 
     // Load configuration
     let (config, evm_opts) = args.load_config_and_evm_opts()?;
+    utils::load_dotenv(&config.env_path);
 
     // Create a new cli dispatcher
     let mut dispatcher = ChiselDispatcher::new(chisel::session_source::SessionSourceConfig {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -432,6 +432,9 @@ pub struct Config {
     /// Whether `failed()` should be invoked to check if the test have failed.
     pub legacy_assertions: bool,
 
+    /// File path to the environment file
+    pub env_path: Option<PathBuf>,
+
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information
     #[serde(rename = "__warnings", default, skip_serializing)]
     pub warnings: Vec<Warning>,
@@ -2137,6 +2140,7 @@ impl Default for Config {
             dependencies: Default::default(),
             assertions_revert: true,
             legacy_assertions: false,
+            env_path: None,
             warnings: vec![],
             _non_exhaustive: (),
         }

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -19,7 +19,8 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() -> Result<()> {
     handler::install();
-    utils::load_dotenv();
+    let config = utils::load_config();
+    utils::load_dotenv(&config.env_path);
     utils::subscriber();
     utils::enable_paint();
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -142,6 +142,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         warnings: vec![],
         assertions_revert: true,
         legacy_assertions: false,
+        env_path: None,
         _non_exhaustive: (),
     };
     prj.write_config(input.clone());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Implements #5723

## Motivation
Now, the .env file is only loaded from the project root. A config option can be added to load the .env file from another directory. This will be helpful if Foundry is used within a monorepo that uses a single .env file.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I have added an option for the config to allow adding the env_file location. Since it will not change often, I thought making it a config item instead of a CLI flag would make more sense.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
