### PR TITLE
fix: order of personal sign

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -141,8 +141,13 @@ pub enum EthRequest {
     EthGetProof(Address, Vec<B256>, Option<BlockId>),
 
     /// The sign method calculates an Ethereum specific signature with:
-    #[cfg_attr(feature = "serde", serde(rename = "eth_sign", alias = "personal_sign"))]
+    #[cfg_attr(feature = "serde", serde(rename = "eth_sign"))]
     EthSign(Address, Bytes),
+
+    /// The sign method calculates an Ethereum specific signature, equivalent to eth_sign:
+    /// <https://docs.metamask.io/wallet/reference/personal_sign/>
+    #[cfg_attr(feature = "serde", serde(rename = "personal_sign"))]
+    PersonalSign(Bytes, Address),
 
     #[cfg_attr(feature = "serde", serde(rename = "eth_signTransaction", with = "sequence"))]
     EthSignTransaction(Box<WithOtherFields<TransactionRequest>>),
@@ -1562,7 +1567,7 @@ true}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
         let s = r#"{"method": "personal_sign", "params":
-["0xd84de507f3fada7df80908082d3239466db55a71", "0x00"]}"#;
+["0x00", "0xd84de507f3fada7df80908082d3239466db55a71"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -211,6 +211,9 @@ impl EthApi {
                 self.get_proof(addr, keys, block).await.to_rpc_result()
             }
             EthRequest::EthSign(addr, content) => self.sign(addr, content).await.to_rpc_result(),
+            EthRequest::PersonalSign(content, addr) => {
+                self.sign(addr, content).await.to_rpc_result()
+            }
             EthRequest::EthSignTransaction(request) => {
                 self.sign_transaction(*request).await.to_rpc_result()
             }


### PR DESCRIPTION
closes #8322

personal_sign has different args order

https://docs.metamask.io/wallet/reference/personal_sign/