### PR TITLE
feat(invariant): exclude precompiles from senders

### DIFF
--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod decode;
 pub mod fork;
 pub mod opcodes;
 pub mod opts;
+pub mod precompiles;
 pub mod snapshot;
 pub mod utils;
 

--- a/crates/evm/core/src/precompiles.rs
+++ b/crates/evm/core/src/precompiles.rs
@@ -1,0 +1,45 @@
+use alloy_primitives::{address, Address};
+
+/// The ECRecover precompile address.
+pub const EC_RECOVER: Address = address!("0000000000000000000000000000000000000001");
+
+/// The SHA-256 precompile address.
+pub const SHA_256: Address = address!("0000000000000000000000000000000000000002");
+
+/// The RIPEMD-160 precompile address.
+pub const RIPEMD_160: Address = address!("0000000000000000000000000000000000000003");
+
+/// The Identity precompile address.
+pub const IDENTITY: Address = address!("0000000000000000000000000000000000000004");
+
+/// The ModExp precompile address.
+pub const MOD_EXP: Address = address!("0000000000000000000000000000000000000005");
+
+/// The ECAdd precompile address.
+pub const EC_ADD: Address = address!("0000000000000000000000000000000000000006");
+
+/// The ECMul precompile address.
+pub const EC_MUL: Address = address!("0000000000000000000000000000000000000007");
+
+/// The ECPairing precompile address.
+pub const EC_PAIRING: Address = address!("0000000000000000000000000000000000000008");
+
+/// The Blake2F precompile address.
+pub const BLAKE_2F: Address = address!("0000000000000000000000000000000000000009");
+
+/// The PointEvaluation precompile address.
+pub const POINT_EVALUATION: Address = address!("000000000000000000000000000000000000000a");
+
+/// Precompile addresses.
+pub const PRECOMPILES: &[Address] = &[
+    EC_RECOVER,
+    SHA_256,
+    RIPEMD_160,
+    IDENTITY,
+    MOD_EXP,
+    EC_ADD,
+    EC_MUL,
+    EC_PAIRING,
+    BLAKE_2F,
+    POINT_EVALUATION,
+];

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -7,8 +7,11 @@ use alloy_sol_types::{sol, SolCall};
 use eyre::{eyre, ContextCompat, Result};
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};
 use foundry_config::InvariantConfig;
-use foundry_evm_core::constants::{
-    CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME,
+use foundry_evm_core::{
+    constants::{
+        CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME,
+    },
+    precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
     invariant::{
@@ -627,6 +630,8 @@ impl<'a> InvariantExecutor<'a> {
             HARDHAT_CONSOLE_ADDRESS,
             DEFAULT_CREATE2_DEPLOYER,
         ]);
+        // Extend with precompiles - https://github.com/foundry-rs/foundry/issues/4287
+        excluded_senders.extend(PRECOMPILES);
         let sender_filters = SenderFilters::new(targeted_senders, excluded_senders);
 
         let selected =

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -17,6 +17,10 @@ use foundry_evm_core::{
         TEST_CONTRACT_ADDRESS,
     },
     decode::RevertDecoder,
+    precompiles::{
+        BLAKE_2F, EC_ADD, EC_MUL, EC_PAIRING, EC_RECOVER, IDENTITY, MOD_EXP, POINT_EVALUATION,
+        RIPEMD_160, SHA_256,
+    },
 };
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
@@ -160,6 +164,16 @@ impl CallTraceDecoder {
                 (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
                 (CALLER, "DefaultSender".to_string()),
                 (TEST_CONTRACT_ADDRESS, "DefaultTestContract".to_string()),
+                (EC_RECOVER, "ECRecover".to_string()),
+                (SHA_256, "SHA-256".to_string()),
+                (RIPEMD_160, "RIPEMD-160".to_string()),
+                (IDENTITY, "Identity".to_string()),
+                (MOD_EXP, "ModExp".to_string()),
+                (EC_ADD, "ECAdd".to_string()),
+                (EC_MUL, "ECMul".to_string()),
+                (EC_PAIRING, "ECPairing".to_string()),
+                (BLAKE_2F, "Blake2F".to_string()),
+                (POINT_EVALUATION, "PointEvaluation".to_string()),
             ]
             .into(),
             receive_contracts: Default::default(),

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -679,3 +679,52 @@ contract ReplayFailuresTest is Test {
             .join("tests/fixtures/replay_last_run_failures.stdout"),
     );
 });
+
+// <https://github.com/foundry-rs/foundry/issues/7530>
+forgetest_init!(should_show_precompile_labels, |prj, cmd| {
+    prj.wipe_contracts();
+
+    prj.add_test(
+        "Contract.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+contract PrecompileLabelsTest is Test {
+    function testPrecompileLabels() public {
+        vm.deal(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D), 1 ether);
+        vm.deal(address(0x000000000000000000636F6e736F6c652e6c6f67), 1 ether);
+        vm.deal(address(0x4e59b44847b379578588920cA78FbF26c0B4956C), 1 ether);
+        vm.deal(address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38), 1 ether);
+        vm.deal(address(0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84), 1 ether);
+        vm.deal(address(1), 1 ether);
+        vm.deal(address(2), 1 ether);
+        vm.deal(address(3), 1 ether);
+        vm.deal(address(4), 1 ether);
+        vm.deal(address(5), 1 ether);
+        vm.deal(address(6), 1 ether);
+        vm.deal(address(7), 1 ether);
+        vm.deal(address(8), 1 ether);
+        vm.deal(address(9), 1 ether);
+        vm.deal(address(10), 1 ether);
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    let output = cmd.args(["test", "-vvvv"]).stdout_lossy();
+    assert!(output.contains("VM: [0x7109709ECfa91a80626fF3989D68f67F5b1DD12D]"));
+    assert!(output.contains("console: [0x000000000000000000636F6e736F6c652e6c6f67]"));
+    assert!(output.contains("Create2Deployer: [0x4e59b44847b379578588920cA78FbF26c0B4956C]"));
+    assert!(output.contains("DefaultSender: [0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38]"));
+    assert!(output.contains("DefaultTestContract: [0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84]"));
+    assert!(output.contains("ECRecover: [0x0000000000000000000000000000000000000001]"));
+    assert!(output.contains("SHA-256: [0x0000000000000000000000000000000000000002]"));
+    assert!(output.contains("RIPEMD-160: [0x0000000000000000000000000000000000000003]"));
+    assert!(output.contains("Identity: [0x0000000000000000000000000000000000000004]"));
+    assert!(output.contains("ModExp: [0x0000000000000000000000000000000000000005]"));
+    assert!(output.contains("ECAdd: [0x0000000000000000000000000000000000000006]"));
+    assert!(output.contains("ECMul: [0x0000000000000000000000000000000000000007]"));
+    assert!(output.contains("ECPairing: [0x0000000000000000000000000000000000000008]"));
+    assert!(output.contains("Blake2F: [0x0000000000000000000000000000000000000009]"));
+    assert!(output.contains("PointEvaluation: [0x000000000000000000000000000000000000000A]"));
+});

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -2,7 +2,7 @@
 
 use crate::{config::*, test_helpers::TEST_DATA_DEFAULT};
 use alloy_primitives::U256;
-use forge::{fuzz::CounterExample, TestOptions};
+use forge::fuzz::CounterExample;
 use foundry_test_utils::Filter;
 use std::collections::BTreeMap;
 
@@ -285,20 +285,16 @@ async fn test_invariant_shrink() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(windows, ignore = "for some reason there's different rng")]
 async fn test_invariant_assert_shrink() {
-    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(55u32));
-
     // ensure assert and require shrinks to same sequence of 3 or less
-    test_shrink(opts.clone(), "InvariantShrinkWithAssert").await;
-    test_shrink(opts.clone(), "InvariantShrinkWithRequire").await;
+    test_shrink("invariant_with_assert").await;
+    test_shrink("invariant_with_require").await;
 }
 
-async fn test_shrink(opts: TestOptions, contract_pattern: &str) {
-    let filter = Filter::new(
-        ".*",
-        contract_pattern,
-        ".*fuzz/invariant/common/InvariantShrinkWithAssert.t.sol",
-    );
+async fn test_shrink(test_pattern: &str) {
+    let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
+    opts.fuzz.seed = Some(U256::from(100u32));
+    let filter =
+        Filter::new(test_pattern, ".*", ".*fuzz/invariant/common/InvariantShrinkWithAssert.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
     runner.test_options = opts;
 

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -286,7 +286,7 @@ async fn test_invariant_shrink() {
 #[cfg_attr(windows, ignore = "for some reason there's different rng")]
 async fn test_invariant_assert_shrink() {
     let mut opts = TEST_DATA_DEFAULT.test_opts.clone();
-    opts.fuzz.seed = Some(U256::from(119u32));
+    opts.fuzz.seed = Some(U256::from(55u32));
 
     // ensure assert and require shrinks to same sequence of 3 or less
     test_shrink(opts.clone(), "InvariantShrinkWithAssert").await;

--- a/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
@@ -88,26 +88,6 @@ contract InvariantShrinkWithAssert is DSTest {
     function invariant_with_assert() public {
         assertTrue(counter.number() != 3, "wrong counter");
     }
-}
-
-contract InvariantShrinkWithRequire is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
-    Counter public counter;
-    Handler handler;
-
-    function setUp() public {
-        counter = new Counter();
-        handler = new Handler(counter);
-    }
-
-    function targetSelectors() public returns (FuzzSelector[] memory) {
-        FuzzSelector[] memory targets = new FuzzSelector[](1);
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = handler.increment.selector;
-        selectors[1] = handler.setNumber.selector;
-        targets[0] = FuzzSelector(address(handler), selectors);
-        return targets;
-    }
 
     function invariant_with_require() public {
         require(counter.number() != 3, "wrong counter");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4287 
Closes #7530 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- extract precompiles addresses into own module
- extend list of excluded senders with precompiles (#4287)
- add labels to display along traces when precompile is not decoded (#7530) + test