### PR TITLE
test: ignore 502 in can_clone_keep_directory_structure

### DIFF
--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -1027,7 +1027,7 @@ impl TestCommand {
         eyre::eyre!("{}", self.make_error_message(out, expected_fail))
     }
 
-    fn make_error_message(&self, out: &Output, expected_fail: bool) -> String {
+    pub fn make_error_message(&self, out: &Output, expected_fail: bool) -> String {
         let msg = if expected_fail {
             "expected failure but command succeeded!"
         } else {
@@ -1071,6 +1071,12 @@ pub trait OutputExt {
 
     /// Ensure the command wrote the expected data to `stderr`.
     fn stderr_matches_path(&self, expected_path: impl AsRef<Path>);
+
+    /// Returns the stderr as lossy string
+    fn stderr_lossy(&self) -> String;
+
+    /// Returns the stdout as lossy string
+    fn stdout_lossy(&self) -> String;
 }
 
 /// Patterns to remove from fixtures before comparing output
@@ -1117,6 +1123,14 @@ impl OutputExt for Output {
         let expected = fs::read_to_string(expected_path).unwrap();
         let err = lossy_string(&self.stderr);
         similar_asserts::assert_eq!(normalize_output(&err), normalize_output(&expected));
+    }
+
+    fn stderr_lossy(&self) -> String {
+        lossy_string(&self.stderr)
+    }
+
+    fn stdout_lossy(&self) -> String {
+        lossy_string(&self.stdout)
     }
 }
 


### PR DESCRIPTION
this test is flaky due to some nginx proxy issues:
https://github.com/foundry-rs/foundry/actions/runs/9807607407/job/27081719593?pr=8367

we can skip if we see 502 in stdout