### PR TITLE
fix: set both tx input fields

### DIFF
--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -1,9 +1,9 @@
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
 use alloy_json_abi::Function;
 use alloy_network::{AnyNetwork, TransactionBuilder};
-use alloy_primitives::{hex, Address, TxKind};
+use alloy_primitives::{hex, Address, Bytes, TxKind};
 use alloy_provider::Provider;
-use alloy_rpc_types::TransactionRequest;
+use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use alloy_transport::Transport;
 use eyre::Result;
@@ -232,7 +232,11 @@ where
         let from = from.into().resolve(&self.provider).await?;
 
         self.tx.set_kind(self.state.kind);
-        self.tx.set_input(self.state.input);
+
+        // we set both fields to the same value because some nodes only accept the legacy `data` field: <https://github.com/foundry-rs/foundry/issues/7764#issuecomment-2210453249>
+        let input = Bytes::from(self.state.input);
+        self.tx.input = TransactionInput { input: Some(input.clone()), data: Some(input) };
+
         self.tx.set_from(from);
         self.tx.set_chain_id(self.chain.id());
 


### PR DESCRIPTION
optimistically closes #7764

according to the eth api spec the tx input field is named "input", however it used to be "data", now this is a bit of a mess where you don't know if a client supports input or only data.
so we simply send both, 

since #7764 didn't surface any serialization issues, we can assume unknown request values are simply ignored. so this change should not have any downsides (besides including the data twice -.-)