### PR TITLE
fix(forge) - reset interpreter gas only if previously set

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -950,8 +950,10 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         self.pc = interpreter.program_counter();
 
         // `pauseGasMetering`: reset interpreter gas.
-        if self.gas_metering.is_some() {
-            self.meter_gas(interpreter);
+        if let Some(gas_metering) = self.gas_metering {
+            if gas_metering.is_some() {
+                self.meter_gas(interpreter);
+            }
         }
 
         // `record`: record storage reads and writes.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8383 

- if pausing gas metering using `vm.pauseGasMetering` cheatcode when there's no gas metering set we set gas metering to `Some(None)`: https://github.com/foundry-rs/foundry/blob/8b694bbcabaedffc0337bf8dea9a135da5694ef9/crates/cheatcodes/src/evm.rs#L229-L231
- in inspector step we set meter gas interpreter if gas metering is Some : https://github.com/foundry-rs/foundry/blob/8b694bbcabaedffc0337bf8dea9a135da5694ef9/crates/cheatcodes/src/inspector.rs#L952-L955 This means we do this even for a paused gas metering, basically enabling it

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- do not set interpreter if `gas_metering` is `Some(None)` 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
