### PR TITLE
fuzz console log & test cases

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -1,7 +1,8 @@
 //! Configuration for fuzz testing.
 
 use crate::inline::{
-    parse_config_u32, InlineConfigParser, InlineConfigParserError, INLINE_CONFIG_FUZZ_KEY,
+    parse_config_bool, parse_config_u32, InlineConfigParser, InlineConfigParserError,
+    INLINE_CONFIG_FUZZ_KEY,
 };
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,8 @@ pub struct FuzzConfig {
     pub failure_persist_dir: Option<PathBuf>,
     /// Name of the file to record fuzz failures, defaults to `failures`.
     pub failure_persist_file: Option<String>,
+    /// show `console.log` in fuzz test, defaults to `false`
+    pub show_execution_logs: bool,
 }
 
 impl Default for FuzzConfig {
@@ -41,6 +44,7 @@ impl Default for FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: None,
             failure_persist_file: None,
+            show_execution_logs: false,
         }
     }
 }
@@ -56,6 +60,7 @@ impl FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: Some(cache_dir),
             failure_persist_file: Some("failures".to_string()),
+            show_execution_logs: false,
         }
     }
 }
@@ -84,6 +89,9 @@ impl InlineConfigParser for FuzzConfig {
                     conf_clone.dictionary.dictionary_weight = parse_config_u32(key, value)?
                 }
                 "failure-persist-file" => conf_clone.failure_persist_file = Some(value),
+                "show-execution-logs" => {
+                    conf_clone.show_execution_logs = parse_config_bool(key, value)?
+                }
                 _ => Err(InlineConfigParserError::InvalidConfigProperty(key))?,
             }
         }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -31,7 +31,7 @@ pub struct FuzzConfig {
     /// Name of the file to record fuzz failures, defaults to `failures`.
     pub failure_persist_file: Option<String>,
     /// show `console.log` in fuzz test, defaults to `false`
-    pub show_execution_logs: bool,
+    pub show_fuzz_logs: bool,
 }
 
 impl Default for FuzzConfig {
@@ -44,7 +44,7 @@ impl Default for FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: None,
             failure_persist_file: None,
-            show_execution_logs: false,
+            show_fuzz_logs: false,
         }
     }
 }
@@ -60,7 +60,7 @@ impl FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: Some(cache_dir),
             failure_persist_file: Some("failures".to_string()),
-            show_execution_logs: false,
+            show_fuzz_logs: false,
         }
     }
 }
@@ -89,9 +89,7 @@ impl InlineConfigParser for FuzzConfig {
                     conf_clone.dictionary.dictionary_weight = parse_config_u32(key, value)?
                 }
                 "failure-persist-file" => conf_clone.failure_persist_file = Some(value),
-                "show-execution-logs" => {
-                    conf_clone.show_execution_logs = parse_config_bool(key, value)?
-                }
+                "show-fuzz-logs" => conf_clone.show_fuzz_logs = parse_config_bool(key, value)?,
                 _ => Err(InlineConfigParserError::InvalidConfigProperty(key))?,
             }
         }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -31,7 +31,7 @@ pub struct FuzzConfig {
     /// Name of the file to record fuzz failures, defaults to `failures`.
     pub failure_persist_file: Option<String>,
     /// show `console.log` in fuzz test, defaults to `false`
-    pub show_fuzz_logs: bool,
+    pub show_logs: bool,
 }
 
 impl Default for FuzzConfig {
@@ -44,7 +44,7 @@ impl Default for FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: None,
             failure_persist_file: None,
-            show_fuzz_logs: false,
+            show_logs: false,
         }
     }
 }
@@ -60,7 +60,7 @@ impl FuzzConfig {
             gas_report_samples: 256,
             failure_persist_dir: Some(cache_dir),
             failure_persist_file: Some("failures".to_string()),
-            show_fuzz_logs: false,
+            show_logs: false,
         }
     }
 }
@@ -89,7 +89,7 @@ impl InlineConfigParser for FuzzConfig {
                     conf_clone.dictionary.dictionary_weight = parse_config_u32(key, value)?
                 }
                 "failure-persist-file" => conf_clone.failure_persist_file = Some(value),
-                "show-fuzz-logs" => conf_clone.show_fuzz_logs = parse_config_bool(key, value)?,
+                "show-logs" => conf_clone.show_logs = parse_config_bool(key, value)?,
                 _ => Err(InlineConfigParserError::InvalidConfigProperty(key))?,
             }
         }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -90,7 +90,7 @@ impl FuzzedExecutor {
         ];
         // We want to collect at least one trace which will be displayed to user.
         let max_traces_to_collect = std::cmp::max(1, self.config.gas_report_samples) as usize;
-        let show_execution_logs = self.config.show_execution_logs;
+        let show_fuzz_logs = self.config.show_fuzz_logs;
 
         //Stores logs for all fuzz cases
         let logs: RefCell<Vec<Log>> = RefCell::default();
@@ -157,7 +157,7 @@ impl FuzzedExecutor {
         };
 
         // decide whether to use trace logs or only error logs
-        let actual_logs = if show_execution_logs { logs.into_inner() } else { call.logs };
+        let actual_logs = if show_fuzz_logs { logs.into_inner() } else { call.logs };
 
         let mut result = FuzzTestResult {
             first_case: fuzz_result.first_case.unwrap_or_default(),

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -92,7 +92,7 @@ impl FuzzedExecutor {
         ];
         // We want to collect at least one trace which will be displayed to user.
         let max_traces_to_collect = std::cmp::max(1, self.config.gas_report_samples) as usize;
-        let show_fuzz_logs = self.config.show_fuzz_logs;
+        let show_logs = self.config.show_logs;
 
         let run_result = self.runner.clone().run(&strat, |calldata| {
             let fuzz_res = self.single_fuzz(address, should_fail, calldata)?;
@@ -157,7 +157,7 @@ impl FuzzedExecutor {
         };
 
         // decide whether to use trace logs or only error logs
-        let actual_logs = if show_fuzz_logs { fuzz_result.logs } else { call.logs };
+        let actual_logs = if show_logs { fuzz_result.logs } else { call.logs };
 
         let mut result = FuzzTestResult {
             first_case: fuzz_result.first_case.unwrap_or_default(),

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -5,10 +5,7 @@ use alloy_primitives::{Address, Bytes, Log, U256};
 use eyre::Result;
 use foundry_common::evm::Breakpoints;
 use foundry_config::FuzzConfig;
-use foundry_evm_core::{
-    constants::MAGIC_ASSUME,
-    decode::RevertDecoder,
-};
+use foundry_evm_core::{constants::MAGIC_ASSUME, decode::RevertDecoder};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
     strategies::{fuzz_calldata, fuzz_calldata_from_state, EvmFuzzState},

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -1,5 +1,5 @@
 use crate::executors::RawCallResult;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, Log};
 use foundry_common::evm::Breakpoints;
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::FuzzCase;
@@ -17,6 +17,8 @@ pub struct CaseOutcome {
     pub coverage: Option<HitMaps>,
     /// Breakpoints char pc map
     pub breakpoints: Breakpoints,
+    /// logs of a single fuzz test case
+    pub logs: Vec<Log>,
 }
 
 /// Returned by a single fuzz when a counterexample has been discovered

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -163,9 +163,6 @@ pub struct FuzzTestResult {
     /// be printed to the user.
     pub logs: Vec<Log>,
 
-    /// The decoded DSTest logging events and Hardhat's `console.log` from [logs](Self::logs).
-    pub decoded_logs: Vec<String>,
-
     /// Labeled addresses
     pub labeled_addresses: HashMap<Address, String>,
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -74,6 +74,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             seed: Some(U256::from(1000)),
             failure_persist_dir: Some("test-cache/fuzz".into()),
             failure_persist_file: Some("failures".to_string()),
+            show_execution_logs: false,
             ..Default::default()
         },
         invariant: InvariantConfig {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -74,7 +74,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             seed: Some(U256::from(1000)),
             failure_persist_dir: Some("test-cache/fuzz".into()),
             failure_persist_file: Some("failures".to_string()),
-            show_execution_logs: false,
+            show_fuzz_logs: false,
             ..Default::default()
         },
         invariant: InvariantConfig {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -74,7 +74,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             seed: Some(U256::from(1000)),
             failure_persist_dir: Some("test-cache/fuzz".into()),
             failure_persist_file: Some("failures".to_string()),
-            show_fuzz_logs: false,
+            show_logs: false,
             ..Default::default()
         },
         invariant: InvariantConfig {

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -729,14 +729,14 @@ contract PrecompileLabelsTest is Test {
     assert!(output.contains("PointEvaluation: [0x000000000000000000000000000000000000000A]"));
 });
 
-// tests that `forge test` with config `show_fuzz_logs: true` for fuzz tests will
+// tests that `forge test` with config `show_logs: true` for fuzz tests will
 // display `console.log` info
-forgetest_init!(should_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
+forgetest_init!(should_show_logs_when_fuzz_test, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
     let config = Config {
-        fuzz: { FuzzConfig { runs: 3, show_fuzz_logs: true, ..Default::default() } },
+        fuzz: { FuzzConfig { runs: 3, show_logs: true, ..Default::default() } },
         ..Default::default()
     };
     prj.write_config(config);
@@ -760,9 +760,9 @@ forgetest_init!(should_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
     assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with inline config `show_fuzz_logs = true` for fuzz tests will
+// tests that `forge test` with inline config `show_logs = true` for fuzz tests will
 // display `console.log` info
-forgetest_init!(should_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
+forgetest_init!(should_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
@@ -778,7 +778,7 @@ forgetest_init!(should_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
         import {Test, console2} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
-      /// forge-config: default.fuzz.show-fuzz-logs = true
+      /// forge-config: default.fuzz.show-logs = true
       function testFuzzConsoleLog(uint256 x) public pure {
         console2.log("inside fuzz test, x is:", x);
       }
@@ -791,14 +791,14 @@ forgetest_init!(should_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
     assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with config `show_fuzz_logs: false` for fuzz tests will not display
+// tests that `forge test` with config `show_logs: false` for fuzz tests will not display
 // `console.log` info
-forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
+forgetest_init!(should_not_show_logs_when_fuzz_test, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
     let config = Config {
-        fuzz: { FuzzConfig { runs: 3, show_fuzz_logs: false, ..Default::default() } },
+        fuzz: { FuzzConfig { runs: 3, show_logs: false, ..Default::default() } },
         ..Default::default()
     };
     prj.write_config(config);
@@ -823,9 +823,9 @@ forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
     assert!(!stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with inline config `show_fuzz_logs = false` for fuzz tests will not
+// tests that `forge test` with inline config `show_logs = false` for fuzz tests will not
 // display `console.log` info
-forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
+forgetest_init!(should_not_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
@@ -841,7 +841,7 @@ forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cm
         import {Test, console2} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
-      /// forge-config: default.fuzz.show-fuzz-logs = false
+      /// forge-config: default.fuzz.show-logs = false
       function testFuzzConsoleLog(uint256 x) public pure {
         console2.log("inside fuzz test, x is:", x);
       }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -729,14 +729,14 @@ contract PrecompileLabelsTest is Test {
     assert!(output.contains("PointEvaluation: [0x000000000000000000000000000000000000000A]"));
 });
 
-// tests that `forge test` with config `show_execution_logs: true` for fuzz tests will
+// tests that `forge test` with config `show_fuzz_logs: true` for fuzz tests will
 // display `console.log` info
-forgetest_init!(should_show_execution_logs_when_fuzz_test, |prj, cmd| {
+forgetest_init!(should_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
     let config = Config {
-        fuzz: { FuzzConfig { runs: 3, show_execution_logs: true, ..Default::default() } },
+        fuzz: { FuzzConfig { runs: 3, show_fuzz_logs: true, ..Default::default() } },
         ..Default::default()
     };
     prj.write_config(config);
@@ -760,9 +760,9 @@ forgetest_init!(should_show_execution_logs_when_fuzz_test, |prj, cmd| {
     assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with inline config `show_execution_logs = true` for fuzz tests will
+// tests that `forge test` with inline config `show_fuzz_logs = true` for fuzz tests will
 // display `console.log` info
-forgetest_init!(should_show_execution_logs_when_fuzz_test_inline_config, |prj, cmd| {
+forgetest_init!(should_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
@@ -778,7 +778,7 @@ forgetest_init!(should_show_execution_logs_when_fuzz_test_inline_config, |prj, c
         import {Test, console2} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
-      /// forge-config: default.fuzz.show-execution-logs = true
+      /// forge-config: default.fuzz.show-fuzz-logs = true
       function testFuzzConsoleLog(uint256 x) public pure {
         console2.log("inside fuzz test, x is:", x);
       }
@@ -791,14 +791,14 @@ forgetest_init!(should_show_execution_logs_when_fuzz_test_inline_config, |prj, c
     assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with config `show_execution_logs: false` for fuzz tests will not display
+// tests that `forge test` with config `show_fuzz_logs: false` for fuzz tests will not display
 // `console.log` info
-forgetest_init!(should_not_show_execution_logs_when_fuzz_test, |prj, cmd| {
+forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
     let config = Config {
-        fuzz: { FuzzConfig { runs: 3, show_execution_logs: false, ..Default::default() } },
+        fuzz: { FuzzConfig { runs: 3, show_fuzz_logs: false, ..Default::default() } },
         ..Default::default()
     };
     prj.write_config(config);
@@ -823,9 +823,9 @@ forgetest_init!(should_not_show_execution_logs_when_fuzz_test, |prj, cmd| {
     assert!(!stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
 });
 
-// tests that `forge test` with inline config `show_execution_logs = false` for fuzz tests will not
+// tests that `forge test` with inline config `show_fuzz_logs = false` for fuzz tests will not
 // display `console.log` info
-forgetest_init!(should_not_show_execution_logs_when_fuzz_test_inline_config, |prj, cmd| {
+forgetest_init!(should_not_show_fuzz_logs_when_fuzz_test_inline_config, |prj, cmd| {
     prj.wipe_contracts();
 
     // run fuzz test 3 times
@@ -841,7 +841,7 @@ forgetest_init!(should_not_show_execution_logs_when_fuzz_test_inline_config, |pr
         import {Test, console2} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
-      /// forge-config: default.fuzz.show-execution-logs = false
+      /// forge-config: default.fuzz.show-fuzz-logs = false
       function testFuzzConsoleLog(uint256 x) public pure {
         console2.log("inside fuzz test, x is:", x);
       }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -728,3 +728,128 @@ contract PrecompileLabelsTest is Test {
     assert!(output.contains("Blake2F: [0x0000000000000000000000000000000000000009]"));
     assert!(output.contains("PointEvaluation: [0x000000000000000000000000000000000000000A]"));
 });
+
+// tests that `forge test` with config `show_execution_logs: true` for fuzz tests will
+// display `console.log` info
+forgetest_init!(should_show_execution_logs_when_fuzz_test, |prj, cmd| {
+    prj.wipe_contracts();
+
+    // run fuzz test 3 times
+    let config = Config {
+        fuzz: { FuzzConfig { runs: 3, show_execution_logs: true, ..Default::default() } },
+        ..Default::default()
+    };
+    prj.write_config(config);
+    let config = cmd.config();
+    assert_eq!(config.fuzz.runs, 3);
+
+    prj.add_test(
+        "ContractFuzz.t.sol",
+        r#"pragma solidity 0.8.24;
+        import {Test, console2} from "forge-std/Test.sol";
+    contract ContractFuzz is Test {
+      function testFuzzConsoleLog(uint256 x) public pure {
+        console2.log("inside fuzz test, x is:", x);
+      }
+    }
+     "#,
+    )
+    .unwrap();
+    cmd.args(["test", "-vv"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
+});
+
+// tests that `forge test` with inline config `show_execution_logs = true` for fuzz tests will
+// display `console.log` info
+forgetest_init!(should_show_execution_logs_when_fuzz_test_inline_config, |prj, cmd| {
+    prj.wipe_contracts();
+
+    // run fuzz test 3 times
+    let config =
+        Config { fuzz: { FuzzConfig { runs: 3, ..Default::default() } }, ..Default::default() };
+    prj.write_config(config);
+    let config = cmd.config();
+    assert_eq!(config.fuzz.runs, 3);
+
+    prj.add_test(
+        "ContractFuzz.t.sol",
+        r#"pragma solidity 0.8.24;
+        import {Test, console2} from "forge-std/Test.sol";
+    contract ContractFuzz is Test {
+
+      /// forge-config: default.fuzz.show-execution-logs = true
+      function testFuzzConsoleLog(uint256 x) public pure {
+        console2.log("inside fuzz test, x is:", x);
+      }
+    }
+     "#,
+    )
+    .unwrap();
+    cmd.args(["test", "-vv"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
+});
+
+// tests that `forge test` with config `show_execution_logs: false` for fuzz tests will not display
+// `console.log` info
+forgetest_init!(should_not_show_execution_logs_when_fuzz_test, |prj, cmd| {
+    prj.wipe_contracts();
+
+    // run fuzz test 3 times
+    let config = Config {
+        fuzz: { FuzzConfig { runs: 3, show_execution_logs: false, ..Default::default() } },
+        ..Default::default()
+    };
+    prj.write_config(config);
+    let config = cmd.config();
+    assert_eq!(config.fuzz.runs, 3);
+
+    prj.add_test(
+        "ContractFuzz.t.sol",
+        r#"pragma solidity 0.8.24;
+        import {Test, console2} from "forge-std/Test.sol";
+    contract ContractFuzz is Test {
+
+      function testFuzzConsoleLog(uint256 x) public pure {
+        console2.log("inside fuzz test, x is:", x);
+      }
+    }
+     "#,
+    )
+    .unwrap();
+    cmd.args(["test", "-vv"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(!stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
+});
+
+// tests that `forge test` with inline config `show_execution_logs = false` for fuzz tests will not
+// display `console.log` info
+forgetest_init!(should_not_show_execution_logs_when_fuzz_test_inline_config, |prj, cmd| {
+    prj.wipe_contracts();
+
+    // run fuzz test 3 times
+    let config =
+        Config { fuzz: { FuzzConfig { runs: 3, ..Default::default() } }, ..Default::default() };
+    prj.write_config(config);
+    let config = cmd.config();
+    assert_eq!(config.fuzz.runs, 3);
+
+    prj.add_test(
+        "ContractFuzz.t.sol",
+        r#"pragma solidity 0.8.24;
+        import {Test, console2} from "forge-std/Test.sol";
+    contract ContractFuzz is Test {
+
+      /// forge-config: default.fuzz.show-execution-logs = false
+      function testFuzzConsoleLog(uint256 x) public pure {
+        console2.log("inside fuzz test, x is:", x);
+      }
+    }
+     "#,
+    )
+    .unwrap();
+    cmd.args(["test", "-vv"]);
+    let stdout = cmd.stdout_lossy();
+    assert!(!stdout.contains("inside fuzz test, x is:"), "\n{stdout}");
+});

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -93,6 +93,7 @@ impl ForgeTestProfile {
                 gas_report_samples: 256,
                 failure_persist_dir: Some(tempfile::tempdir().unwrap().into_path()),
                 failure_persist_file: Some("testfailure".to_string()),
+                show_execution_logs: false,
             })
             .invariant(InvariantConfig {
                 runs: 256,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -93,7 +93,7 @@ impl ForgeTestProfile {
                 gas_report_samples: 256,
                 failure_persist_dir: Some(tempfile::tempdir().unwrap().into_path()),
                 failure_persist_file: Some("testfailure".to_string()),
-                show_execution_logs: false,
+                show_fuzz_logs: false,
             })
             .invariant(InvariantConfig {
                 runs: 256,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -93,7 +93,7 @@ impl ForgeTestProfile {
                 gas_report_samples: 256,
                 failure_persist_dir: Some(tempfile::tempdir().unwrap().into_path()),
                 failure_persist_file: Some("testfailure".to_string()),
-                show_fuzz_logs: false,
+                show_logs: false,
             })
             .invariant(InvariantConfig {
                 runs: 256,


### PR DESCRIPTION
## Motivation
As discussed in  #3844 , when using fuzz test, console.log doesn't work as expected(display console log info). This PR added a new fuzz config `show_execution_logs`, with which user could decide if the full console log should be displayed. by defaut, the value is `false`, so it won't affect any fuzz test prior to this change will be made.

## Solution
A `logs` field is added to `CaseOutcome` to keep track of logs that generated in a single fuzz test. And collect logs in `FuzzTestData` after each fuzz test finished. then use the config `show_logs` in `FuzzConfig` to decide if full console log output should be displayed. if not, the `console.log` behavior is the same as what it is now.

Also, you can use `/// forge-config: default.fuzz.show-logs = true` to enable fuzz test console log per test.

4 test cases is added, to test if the new config works as expected.