### PR TITLE
chore(anvil): fix install cmd in README

### DIFF
--- a/crates/anvil/README.md
+++ b/crates/anvil/README.md
@@ -27,7 +27,7 @@ A local Ethereum node, akin to Ganache, designed for development with [**Forge**
 ### Installing from source
 
 ```sh
-cargo install --git https://github.com/foundry-rs/foundry --locked --force
+cargo install --git https://github.com/foundry-rs/foundry anvil --locked --force
 ```
 
 ## Getting started


### PR DESCRIPTION
Fix install command in anvil readme

## Motivation

Current command from readme gives this error
```
error: multiple packages with binaries found: anvil, cast, chisel, forge. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/foundry-rs/foundry anvil`.
```

## Solution

adding `anvil` to the command enables correct install
