### PR TITLE
chore: decode test logs only once and if needed

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1,7 +1,6 @@
 //! Test outcomes.
 
 use crate::{
-    decode::decode_console_logs,
     fuzz::{BaseCounterExample, FuzzedCases},
     gas_report::GasReport,
 };
@@ -356,9 +355,6 @@ pub struct TestResult {
     /// be printed to the user.
     pub logs: Vec<Log>,
 
-    /// The decoded DSTest logging events and Hardhat's `console.log` from [logs](Self::logs).
-    pub decoded_logs: Vec<String>,
-
     /// What kind of test this was
     pub kind: TestKind,
 
@@ -438,7 +434,6 @@ impl TestResult {
         Self {
             status: TestStatus::Failure,
             reason: setup.reason,
-            decoded_logs: decode_console_logs(&setup.logs),
             logs: setup.logs,
             traces: setup.traces,
             coverage: setup.coverage,
@@ -450,7 +445,6 @@ impl TestResult {
     /// Returns the skipped result for single test (used in skipped fuzz test too).
     pub fn single_skip(mut self) -> Self {
         self.status = TestStatus::Skipped;
-        self.decoded_logs = decode_console_logs(&self.logs);
         self
     }
 
@@ -483,7 +477,6 @@ impl TestResult {
             false => TestStatus::Failure,
         };
         self.reason = reason;
-        self.decoded_logs = decode_console_logs(&self.logs);
         self.breakpoints = raw_call_result.cheatcodes.map(|c| c.breakpoints).unwrap_or_default();
         self.duration = Duration::default();
         self.gas_report_traces = Vec::new();
@@ -512,7 +505,6 @@ impl TestResult {
         };
         self.reason = result.reason;
         self.counterexample = result.counterexample;
-        self.decoded_logs = decode_console_logs(&self.logs);
         self.duration = Duration::default();
         self.gas_report_traces = result.gas_report_traces.into_iter().map(|t| vec![t]).collect();
         self.breakpoints = result.breakpoints.unwrap_or_default();
@@ -523,7 +515,6 @@ impl TestResult {
     pub fn invariant_skip(mut self) -> Self {
         self.kind = TestKind::Invariant { runs: 1, calls: 1, reverts: 1 };
         self.status = TestStatus::Skipped;
-        self.decoded_logs = decode_console_logs(&self.logs);
         self
     }
 
@@ -542,7 +533,6 @@ impl TestResult {
             Some(format!("{invariant_name} persisted failure revert"))
         };
         self.counterexample = Some(CounterExample::Sequence(call_sequence));
-        self.decoded_logs = decode_console_logs(&self.logs);
         self
     }
 
@@ -551,7 +541,6 @@ impl TestResult {
         self.kind = TestKind::Invariant { runs: 0, calls: 0, reverts: 0 };
         self.status = TestStatus::Failure;
         self.reason = Some(format!("failed to set up invariant testing environment: {e}"));
-        self.decoded_logs = decode_console_logs(&self.logs);
         self
     }
 
@@ -576,7 +565,6 @@ impl TestResult {
         };
         self.reason = reason;
         self.counterexample = counterexample;
-        self.decoded_logs = decode_console_logs(&self.logs);
         self.gas_report_traces = gas_report_traces;
         self
     }

--- a/crates/forge/tests/it/config.rs
+++ b/crates/forge/tests/it/config.rs
@@ -125,7 +125,7 @@ pub fn assert_multiple(
             "We did not run as many test functions as we expected for {contract_name}"
         );
         for (test_name, should_pass, reason, expected_logs, expected_warning_count) in tests {
-            let logs = &actuals[*contract_name].test_results[*test_name].decoded_logs;
+            let logs = &decode_console_logs(&actuals[*contract_name].test_results[*test_name].logs);
 
             let warnings_count = &actuals[*contract_name].warnings.len();
 

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -3,6 +3,7 @@
 use crate::{config::*, test_helpers::TEST_DATA_DEFAULT};
 use alloy_primitives::{Bytes, U256};
 use forge::{
+    decode::decode_console_logs,
     fuzz::CounterExample,
     result::{SuiteResult, TestStatus},
 };
@@ -31,7 +32,7 @@ async fn test_fuzz() {
                     "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
-                    result.decoded_logs.join("\n")
+                    decode_console_logs(&result.logs).join("\n")
                 ),
                 _ => assert_eq!(
                     result.status,
@@ -39,7 +40,7 @@ async fn test_fuzz() {
                     "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
-                    result.decoded_logs.join("\n")
+                    decode_console_logs(&result.logs).join("\n")
                 ),
             }
         }
@@ -67,7 +68,7 @@ async fn test_successful_fuzz_cases() {
                     "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
                     test_name,
                     result.reason,
-                    result.decoded_logs.join("\n")
+                    decode_console_logs(&result.logs).join("\n")
                 ),
                 _ => {}
             }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt};
 use alloy_json_abi::Event;
 use alloy_primitives::{address, Address, U256};
-use forge::result::TestStatus;
+use forge::{decode::decode_console_logs, result::TestStatus};
 use foundry_config::{fs_permissions::PathPermission, Config, FsPermissions};
 use foundry_evm::{
     constants::HARDHAT_CONSOLE_ADDRESS,
@@ -252,7 +252,10 @@ test_repro!(6501, false, None, |res| {
     let mut res = res.remove("default/repros/Issue6501.t.sol:Issue6501Test").unwrap();
     let test = res.test_results.remove("test_hhLogs()").unwrap();
     assert_eq!(test.status, TestStatus::Success);
-    assert_eq!(test.decoded_logs, ["a".to_string(), "1".to_string(), "b 2".to_string()]);
+    assert_eq!(
+        decode_console_logs(&test.logs),
+        ["a".to_string(), "1".to_string(), "b 2".to_string()]
+    );
 
     let (kind, traces) = test.traces.last().unwrap().clone();
     let nodes = traces.into_nodes();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Logs collected during tests are decoded twice:
- in `TestResult` functions (regardless verbosity) e.g.
https://github.com/foundry-rs/foundry/blob/2ba3400c76f3a6e9b9a5d5595ac2ebd38b4bce58/crates/forge/src/result.rs#L441
https://github.com/foundry-rs/foundry/blob/2ba3400c76f3a6e9b9a5d5595ac2ebd38b4bce58/crates/forge/src/result.rs#L453
- when test results displayed, if `verbosity >= 2`
https://github.com/foundry-rs/foundry/blob/2ba3400c76f3a6e9b9a5d5595ac2ebd38b4bce58/crates/forge/bin/cmd/test/mod.rs#L454-L465
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Avoid unnecessary logs decoding in `TestResult` struct 