### PR TITLE
fix(coverage): lcov avoid double reporting for line hit

### DIFF
--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -116,10 +116,9 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }
-                    // Statements are not in the LCOV format
-                    CoverageItemKind::Statement => {
-                        writeln!(self.destination, "DA:{line},{hits}")?;
-                    }
+                    // Statements are not in the LCOV format.
+                    // We don't add them in order to avoid doubling line hits.
+                    _ => {}
                 }
             }
 

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1,4 +1,4 @@
-use foundry_test_utils::str;
+use foundry_test_utils::{assert_data_eq, str};
 
 forgetest!(basic_coverage, |_prj, cmd| {
     cmd.args(["coverage"]);
@@ -253,11 +253,10 @@ contract AContractTest is DSTest {
     cmd.assert_success();
     assert!(lcov_info.exists());
 
-    let lcov_report = std::fs::read_to_string(lcov_info).unwrap();
     // We want to make sure DA:8,1 is added only once so line hit is not doubled.
-    assert_eq!(
-        lcov_report,
-        r#"TN:
+    assert_data_eq!(
+        std::fs::read_to_string(lcov_info).unwrap(),
+        str![[r#"TN:
 SF:src/AContract.sol
 FN:7,AContract.foo
 FNDA:1,AContract.foo
@@ -268,7 +267,7 @@ LF:1
 LH:1
 BRF:0
 BRH:0
-end_of_record
-"#
+end[..]
+"#]]
     );
 });

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -28,7 +28,7 @@ pub use script::{ScriptOutcome, ScriptTester};
 // re-exports for convenience
 pub use foundry_compilers;
 
-pub use snapbox::{file, str};
+pub use snapbox::{assert_data_eq, file, str};
 
 /// Initializes tracing for tests.
 pub fn init_tracing() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The line hit is reported doubled in lcov report. That can be repro with a contract 
```Solidity
contract AContract {
    int256 public i;

    function foo() public {
        i = 1;
    }
}
```
and test
```Solidity
contract AContractTest is Test {
    function testFoo() public {
        AContract a = new AContract();
        a.foo();
    }
}
```
running
`forge coverage --report lcov && genhtml lcov.info -o report  && firefox report/index.html` will generate report below

![image](https://github.com/foundry-rs/foundry/assets/38490174/fe731d21-d17f-459a-977e-e0bf6b7ca918)

That happens because the generated lcov report contains `DA:8,1` line 2 times (`DA: line number, hit count`)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- avoid adding line hit count twice (as a line and also as a statement)