### PR TITLE
fix(verify-etherscan): continue verification even if errors occur

### DIFF
--- a/crates/common/src/retry.rs
+++ b/crates/common/src/retry.rs
@@ -1,7 +1,16 @@
 //! Retry utilities.
 
-use eyre::{Error, Result};
+use eyre::{Error, Report, Result};
 use std::{future::Future, time::Duration};
+
+/// Error type for Retry.
+#[derive(Debug, thiserror::Error)]
+pub enum RetryError<E = Report> {
+    /// Keeps retrying operation.
+    Retry(E),
+    /// Stops retrying operation immediately.
+    Break(E),
+}
 
 /// A type that keeps track of attempts.
 #[derive(Clone, Debug)]
@@ -47,6 +56,27 @@ impl Retry {
                     }
                 }
                 res => return res,
+            };
+        }
+    }
+
+    /// Runs the given async closure in a loop, retrying if it fails up to the specified number of
+    /// times or immediately returning an error if the closure returned [`RetryError::Break`].
+    pub async fn run_async_until_break<F, Fut, T>(mut self, mut callback: F) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, RetryError>>,
+    {
+        loop {
+            match callback().await {
+                Err(RetryError::Retry(e)) if self.retries > 0 => {
+                    self.handle_err(e);
+                    if let Some(delay) = self.delay {
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+                Err(RetryError::Retry(e) | RetryError::Break(e)) => return Err(e),
+                Ok(t) => return Ok(t),
             };
         }
     }

--- a/crates/script/src/sequence.rs
+++ b/crates/script/src/sequence.rs
@@ -314,7 +314,7 @@ impl ScriptSequence {
                     Ok(_) => {
                         num_of_successful_verifications += 1;
                     }
-                    Err(err) => println!("Error during verification: {err:#}"),
+                    Err(err) => eprintln!("Error during verification: {err:#}"),
                 }
             }
 

--- a/crates/script/src/sequence.rs
+++ b/crates/script/src/sequence.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloy_primitives::{hex, Address, TxHash};
 use alloy_rpc_types::{AnyTransactionReceipt, TransactionRequest};
 use alloy_serde::WithOtherFields;
-use eyre::{ContextCompat, Result, WrapErr};
+use eyre::{eyre, ContextCompat, Result, WrapErr};
 use forge_verify::provider::VerificationProviderType;
 use foundry_cli::utils::{now, Git};
 use foundry_common::{fs, shell, SELECTOR_LEN};
@@ -307,9 +307,19 @@ impl ScriptSequence {
             self.check_unverified(unverifiable_contracts, verify);
 
             let num_verifications = future_verifications.len();
-            println!("##\nStart verification for ({num_verifications}) contracts",);
+            let mut num_of_successful_verifications = 0;
+            println!("##\nStart verification for ({num_verifications}) contracts");
             for verification in future_verifications {
-                verification.await?;
+                match verification.await {
+                    Ok(_) => {
+                        num_of_successful_verifications += 1;
+                    }
+                    Err(err) => println!("Error during verification: {err:#}"),
+                }
+            }
+
+            if num_of_successful_verifications < num_verifications {
+                return Err(eyre!("Not all ({num_of_successful_verifications} / {num_verifications}) contracts were verified!"))
             }
 
             println!("All ({num_verifications}) contracts were verified!");

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -11,7 +11,11 @@ use foundry_block_explorers::{
     Client,
 };
 use foundry_cli::utils::{self, read_constructor_args_file, LoadConfig};
-use foundry_common::{abi::encode_function_args, retry::Retry, shell};
+use foundry_common::{
+    abi::encode_function_args,
+    retry::{Retry, RetryError},
+    shell,
+};
 use foundry_compilers::{artifacts::BytecodeObject, Artifact};
 use foundry_config::{Chain, Config};
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
@@ -150,12 +154,13 @@ impl VerificationProvider for EtherscanVerificationProvider {
         )?;
         let retry: Retry = args.retry.into();
         retry
-            .run_async(|| {
+            .run_async_until_break(|| {
                 async {
                     let resp = etherscan
                         .check_contract_verification_status(args.id.clone())
                         .await
-                        .wrap_err("Failed to request verification status")?;
+                        .wrap_err("Failed to request verification status")
+                        .map_err(RetryError::Retry)?;
 
                     trace!(target: "forge::verify", ?resp, "Received verification response");
 
@@ -165,11 +170,11 @@ impl VerificationProvider for EtherscanVerificationProvider {
                     );
 
                     if resp.result == "Pending in queue" {
-                        return Err(eyre!("Verification is still pending...",))
+                        return Err(RetryError::Retry(eyre!("Verification is still pending...",)))
                     }
 
                     if resp.result == "Unable to verify" {
-                        return Err(eyre!("Unable to verify.",))
+                        return Err(RetryError::Retry(eyre!("Unable to verify.",)))
                     }
 
                     if resp.result == "Already Verified" {
@@ -178,8 +183,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                     }
 
                     if resp.status == "0" {
-                        println!("Contract failed to verify.");
-                        std::process::exit(1);
+                        return Err(RetryError::Break(eyre!("Contract failed to verify.",)))
                     }
 
                     if resp.result == "Pass - Verified" {
@@ -191,7 +195,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                 .boxed()
             })
             .await
-            .wrap_err("Checking verification result failed:")
+            .wrap_err("Checking verification result failed")
     }
 }
 


### PR DESCRIPTION
### Motivation

The `ProxyAdmin` contract from OpenZeppelin cannot be verified for some reason and this also prevents verification of other contracts (process just terminates with exit code 1). 

https://github.com/foundry-rs/foundry/issues/6023#issuecomment-2212541094

### Solution

Instead of terminating process a new method `run_async_until_break` has been introduced, which allows to continue retrying or instantly exit with an error. Also added counter of successfully verified smart contracts.

### Changes

Deploying contracts on testnet:
- before: [deploy logs 1](https://gist.github.com/StackOverflowExcept1on/deb09c438afb820c8ab7169b17f12e81)
  `Program` contract is not verified because the process terminates on ProxyAdmin verification (2 / 4)
- after: [deploy logs 2](https://gist.github.com/StackOverflowExcept1on/e1baebcbf1a20437545036a760bf3a69)
  `Program` contract is verified (3 / 4)
