### PR TITLE
feat(cheatcodes): add event expecter which supports anonymous events

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4533,6 +4533,86 @@
     },
     {
       "func": {
+        "id": "expectEmitAnonymous_0",
+        "description": "Prepare an expected anonymous log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData.).\nCall this function, then emit an anonymous event, then call a function. Internally after the call, we check if\nlogs were emitted in the expected order with the expected topics and data (as specified by the booleans).",
+        "declaration": "function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectEmitAnonymous(bool,bool,bool,bool,bool)",
+        "selector": "0xc948db5e",
+        "selectorBytes": [
+          201,
+          72,
+          219,
+          94
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectEmitAnonymous_1",
+        "description": "Same as the previous method, but also checks supplied address against emitting contract.",
+        "declaration": "function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectEmitAnonymous(bool,bool,bool,bool,bool,address)",
+        "selector": "0x71c95899",
+        "selectorBytes": [
+          113,
+          201,
+          88,
+          153
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectEmitAnonymous_2",
+        "description": "Prepare an expected anonymous log with all topic and data checks enabled.\nCall this function, then emit an anonymous event, then call a function. Internally after the call, we check if\nlogs were emitted in the expected order with the expected topics and data.",
+        "declaration": "function expectEmitAnonymous() external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectEmitAnonymous()",
+        "selector": "0x2e5f270c",
+        "selectorBytes": [
+          46,
+          95,
+          39,
+          12
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectEmitAnonymous_3",
+        "description": "Same as the previous method, but also checks supplied address against emitting contract.",
+        "declaration": "function expectEmitAnonymous(address emitter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectEmitAnonymous(address)",
+        "selector": "0x6fc68705",
+        "selectorBytes": [
+          111,
+          198,
+          135,
+          5
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "expectEmit_0",
         "description": "Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData.).\nCall this function, then emit an event, then call a function. Internally after the call, we check if\nlogs were emitted in the expected order with the expected topics and data (as specified by the booleans).",
         "declaration": "function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -773,6 +773,27 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectEmit(address emitter) external;
 
+    /// Prepare an expected anonymous log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData.).
+    /// Call this function, then emit an anonymous event, then call a function. Internally after the call, we check if
+    /// logs were emitted in the expected order with the expected topics and data (as specified by the booleans).
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
+
+    /// Same as the previous method, but also checks supplied address against emitting contract.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter)
+        external;
+
+    /// Prepare an expected anonymous log with all topic and data checks enabled.
+    /// Call this function, then emit an anonymous event, then call a function. Internally after the call, we check if
+    /// logs were emitted in the expected order with the expected topics and data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectEmitAnonymous() external;
+
+    /// Same as the previous method, but also checks supplied address against emitting contract.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectEmitAnonymous(address emitter) external;
+
     /// Expects an error on next call with any revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert() external;

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -331,6 +331,10 @@ test_repro!(6634; |config| {
   config.runner.config = Arc::new(prj_config);
 });
 
+// https://github.com/foundry-rs/foundry/issues/7457
+test_repro!(7457);
+
+// https://github.com/foundry-rs/foundry/issues/7481
 test_repro!(7481);
 
 // https://github.com/foundry-rs/foundry/issues/5739

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -222,6 +222,10 @@ interface Vm {
     function expectCall(address callee, uint256 msgValue, bytes calldata data, uint64 count) external;
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data) external;
     function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data, uint64 count) external;
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
+    function expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
+    function expectEmitAnonymous() external;
+    function expectEmitAnonymous(address emitter) external;
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmit() external;

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+interface ITarget {
+    event AnonymousEventEmpty() anonymous;
+    event AnonymousEventNonIndexed(uint256 a) anonymous;
+
+    event DifferentAnonymousEventEmpty() anonymous;
+    event DifferentAnonymousEventNonIndexed(string a) anonymous;
+
+    event AnonymousEventWith1Topic(uint256 indexed a, uint256 b) anonymous;
+    event AnonymousEventWith2Topics(uint256 indexed a, uint256 indexed b, uint256 c) anonymous;
+    event AnonymousEventWith3Topics(uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 d) anonymous;
+    event AnonymousEventWith4Topics(
+        uint256 indexed a, uint256 indexed b, uint256 indexed c, uint256 indexed d, uint256 e
+    ) anonymous;
+}
+
+contract Target is ITarget {
+    function emitAnonymousEventEmpty() external {
+        emit AnonymousEventEmpty();
+    }
+
+    function emitAnonymousEventNonIndexed(uint256 a) external {
+        emit AnonymousEventNonIndexed(a);
+    }
+
+    function emitAnonymousEventWith1Topic(uint256 a, uint256 b) external {
+        emit AnonymousEventWith1Topic(a, b);
+    }
+
+    function emitAnonymousEventWith2Topics(uint256 a, uint256 b, uint256 c) external {
+        emit AnonymousEventWith2Topics(a, b, c);
+    }
+
+    function emitAnonymousEventWith3Topics(uint256 a, uint256 b, uint256 c, uint256 d) external {
+        emit AnonymousEventWith3Topics(a, b, c, d);
+    }
+
+    function emitAnonymousEventWith4Topics(uint256 a, uint256 b, uint256 c, uint256 d, uint256 e) external {
+        emit AnonymousEventWith4Topics(a, b, c, d, e);
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/7457
+contract Issue7457Test is DSTest, ITarget {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    Target public target;
+
+    function setUp() external {
+        target = new Target();
+    }
+
+    function testEmitEvent() public {
+        vm.expectEmitAnonymous(false, false, false, false, true);
+        emit AnonymousEventEmpty();
+        target.emitAnonymousEventEmpty();
+    }
+
+    function testFailEmitEventNonIndexed() public {
+        vm.expectEmit(false, false, false, true);
+        emit AnonymousEventNonIndexed(1);
+        target.emitAnonymousEventNonIndexed(1);
+    }
+
+    function testEmitEventNonIndexed() public {
+        vm.expectEmitAnonymous(false, false, false, false, true);
+        emit AnonymousEventNonIndexed(1);
+        target.emitAnonymousEventNonIndexed(1);
+    }
+
+    // function testFailEmitDifferentEvent() public {
+    //     vm.expectEmitAnonymous(false, false, false, true);
+    //     emit DifferentAnonymousEventEmpty();
+    //     target.emitAnonymousEventEmpty();
+    // }
+
+    function testFailEmitDifferentEventNonIndexed() public {
+        vm.expectEmitAnonymous(false, false, false, false, true);
+        emit DifferentAnonymousEventNonIndexed("1");
+        target.emitAnonymousEventNonIndexed(1);
+    }
+
+    function testEmitEventWith1Topic() public {
+        vm.expectEmitAnonymous(true, false, false, false, true);
+        emit AnonymousEventWith1Topic(1, 2);
+        target.emitAnonymousEventWith1Topic(1, 2);
+    }
+
+    function testEmitEventWith2Topics() public {
+        vm.expectEmitAnonymous(true, true, false, false, true);
+        emit AnonymousEventWith2Topics(1, 2, 3);
+        target.emitAnonymousEventWith2Topics(1, 2, 3);
+    }
+
+    function testEmitEventWith3Topics() public {
+        vm.expectEmitAnonymous(true, true, true, false, true);
+        emit AnonymousEventWith3Topics(1, 2, 3, 4);
+        target.emitAnonymousEventWith3Topics(1, 2, 3, 4);
+    }
+
+    function testEmitEventWith4Topics() public {
+        vm.expectEmitAnonymous(true, true, true, true, true);
+        emit AnonymousEventWith4Topics(1, 2, 3, 4, 5);
+        target.emitAnonymousEventWith4Topics(1, 2, 3, 4, 5);
+    }
+}


### PR DESCRIPTION
closes #7457, closes #7545

--

*From #7545*:
> Add support for a new cheatcode: vm.expectEmitAnonymous(bool checkTopic0, bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) (and corresponding equivalent overloads).

> The rationale is that vm.expectEmit always checks topic0, which is the event signature, and checking everything else is optional. But with an anonymous event, you don't have an event signature, so it doesn't make sense to still force the user to check topic0.

This PR introduces the `vm.expectEmitAnonymous` cheatcode and corresponding overloads. Additionally, it disallows matching anonymous events with no indexed topics via `vm.expectEmit`. If the anonymous has at least one indexed event, it's impossible to differentiate from a non-anonymous event. 

The restriction is necessary, because the way `vm.expectEmit` works is surprising (see #8416). The value `checkTopic1` is basically disregarded. Since Solidity uses it to encode the event signature, it is the best way to match the signature between the expected event and actual.

The ideal solution would be to break this interface and only allow checking of 3 topics via `expectEmit`, since that is essentially what's possible now.