### PR TITLE
fix: correctly apply genesis

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -947,7 +947,6 @@ impl NodeConfig {
             timestamp: self.get_genesis_timestamp(),
             balance: self.genesis_balance,
             accounts: self.genesis_accounts.iter().map(|acc| acc.address()).collect(),
-            fork_genesis_account_infos: Arc::new(Default::default()),
             genesis_init: self.genesis.clone(),
         };
 

--- a/crates/anvil/src/eth/backend/genesis.rs
+++ b/crates/anvil/src/eth/backend/genesis.rs
@@ -7,8 +7,6 @@ use foundry_evm::{
     backend::DatabaseResult,
     revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY},
 };
-use parking_lot::Mutex;
-use std::sync::Arc;
 use tokio::sync::RwLockWriteGuard;
 
 /// Genesis settings
@@ -20,11 +18,6 @@ pub struct GenesisConfig {
     pub balance: U256,
     /// All accounts that should be initialised at genesis
     pub accounts: Vec<Address>,
-    /// The account object stored in the [`revm::Database`]
-    ///
-    /// We store this for forking mode so we can cheaply reset the dev accounts and don't
-    /// need to fetch them again.
-    pub fork_genesis_account_infos: Arc<Mutex<Vec<AccountInfo>>>,
     /// The `genesis.json` if provided
     pub genesis_init: Option<Genesis>,
 }

--- a/crates/evm/core/src/backend/error.rs
+++ b/crates/evm/core/src/backend/error.rs
@@ -14,7 +14,7 @@ pub enum BackendError {
     #[error("cheatcodes are not enabled for {0}; see `vm.allowCheatcodes(address)`")]
     NoCheats(Address),
     #[error(transparent)]
-    Backend(#[from] DatabaseError),
+    Database(#[from] DatabaseError),
     #[error("failed to fetch account info for {0}")]
     MissingAccount(Address),
     #[error(


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/4173

Caching genesis accounts state is not really correct because we might reset fork to a forked block where account nonce is lower than the one we cached and inserted during reset. This would cause `eth_getTransactionCount` to return nonce lower than the one actually stored in the db

## Solution

This PR removes caching of genesis accounts state, which makes `anvil_reset` a bit slower

Another approach could be to instead serve overriden data over `getTransactionCound`/`getBalance` etc, but I don't think that it's great to mess with the actual forked state