### PR TITLE
Updated the soldeer version to 0.2.18 and added extra CLI tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,21 +4325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "gix-actor"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,20 +5353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5398,36 +5369,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libusb1-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -8112,15 +8057,14 @@ dependencies = [
 
 [[package]]
 name = "soldeer"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f503a515e8c5e3d690ee087dc79a9d34e2df000bfb15f7c5a2dbaceabb2e2"
+checksum = "d584c27ebf7ad3e2557d029a07b19fa0d192d67bd73eea1e1695936eb5666e34"
 dependencies = [
  "chrono",
  "clap",
  "email-address-parser",
  "futures",
- "git2",
  "once_cell",
  "regex",
  "reqwest 0.12.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "gix-actor"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,6 +5368,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5369,10 +5398,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libusb1-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -8057,14 +8112,15 @@ dependencies = [
 
 [[package]]
 name = "soldeer"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef46372c17d5650cb18b7f374c45732334fa0867de6c7f14c1fc6973559cd3ff"
+checksum = "943f503a515e8c5e3d690ee087dc79a9d34e2df000bfb15f7c5a2dbaceabb2e2"
 dependencies = [
  "chrono",
  "clap",
  "email-address-parser",
  "futures",
+ "git2",
  "once_cell",
  "regex",
  "reqwest 0.12.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,6 @@ reqwest = { version = "0.12", default-features = false }
 tower = "0.4"
 tower-http = "0.5"
 # soldeer
-soldeer = "0.2.18"
+soldeer = "0.2.19"
 
 proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,6 @@ reqwest = { version = "0.12", default-features = false }
 tower = "0.4"
 tower-http = "0.5"
 # soldeer
-soldeer = "0.2.17"
+soldeer = "0.2.18"
 
 proptest = "1"

--- a/crates/config/src/soldeer.rs
+++ b/crates/config/src/soldeer.rs
@@ -16,7 +16,7 @@ pub struct MapDependency {
 
     /// The commit in case git is used as dependency retrieval
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub commit: Option<String>,
+    pub rev: Option<String>,
 }
 
 /// Type for Soldeer configs, under dependencies tag in the foundry.toml

--- a/crates/config/src/soldeer.rs
+++ b/crates/config/src/soldeer.rs
@@ -13,6 +13,10 @@ pub struct MapDependency {
     /// The url from where the dependency was retrieved
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+
+    /// The commit in case git is used as dependency retrieval
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
 }
 
 /// Type for Soldeer configs, under dependencies tag in the foundry.toml

--- a/crates/forge/bin/cmd/soldeer.rs
+++ b/crates/forge/bin/cmd/soldeer.rs
@@ -6,6 +6,8 @@ use soldeer::commands::Subcommands;
 // CLI arguments for `forge soldeer`.
 #[derive(Clone, Debug, Parser)]
 #[clap(override_usage = "forge soldeer install [DEPENDENCY]~[VERSION] <REMOTE_URL>
+    forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL>
+    forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL> <COMMIT>
     forge soldeer push [DEPENDENCY]~[VERSION] <CUSTOM_PATH_OF_FILES>
     forge soldeer login
     forge soldeer update

--- a/crates/forge/bin/cmd/soldeer.rs
+++ b/crates/forge/bin/cmd/soldeer.rs
@@ -7,7 +7,8 @@ use soldeer::commands::Subcommands;
 #[derive(Clone, Debug, Parser)]
 #[clap(override_usage = "forge soldeer install [DEPENDENCY]~[VERSION] <REMOTE_URL>
     forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL>
-    forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL> <COMMIT>
+    forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL> --rev <REVISION>
+    forge soldeer install [DEPENDENCY]~[VERSION] <GIT_URL> --rev <TAG>
     forge soldeer push [DEPENDENCY]~[VERSION] <CUSTOM_PATH_OF_FILES>
     forge soldeer login
     forge soldeer update

--- a/crates/forge/tests/cli/soldeer.rs
+++ b/crates/forge/tests/cli/soldeer.rs
@@ -58,14 +58,12 @@ forgesoldeer!(install_dependency_git, |prj, cmd| {
 
     let foundry_file = prj.root().join("foundry.toml");
 
-    
     cmd.arg("soldeer").args([command, dependency, git]);
     cmd.execute();
 
     // Making sure the path was created to the dependency and that README.md exists
     // meaning that the dependencies were installed correctly
-    let path_dep_forge =
-        prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
+    let path_dep_forge = prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
     assert!(path_dep_forge.exists());
 
     // Making sure the lock contents are the right ones
@@ -110,8 +108,7 @@ forgesoldeer!(install_dependency_git_commit, |prj, cmd| {
 
     // Making sure the path was created to the dependency and that README.md exists
     // meaning that the dependencies were installed correctly
-    let path_dep_forge =
-        prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
+    let path_dep_forge = prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
     assert!(path_dep_forge.exists());
 
     // Making sure the lock contents are the right ones
@@ -142,7 +139,6 @@ forge-std = { version = "1.8.1", url = "git@gitlab.com:mario4582928/Mario.git", 
     let actual_foundry_contents = read_file_to_string(&foundry_file);
     assert_eq!(foundry_contents, actual_foundry_contents);
 });
-
 
 forgesoldeer!(update_dependencies, |prj, cmd| {
     let command = "update";

--- a/crates/forge/tests/cli/soldeer.rs
+++ b/crates/forge/tests/cli/soldeer.rs
@@ -51,6 +51,99 @@ forge-std = "1.8.1"
     assert_eq!(foundry_contents, actual_foundry_contents);
 });
 
+forgesoldeer!(install_dependency_git, |prj, cmd| {
+    let command = "install";
+    let dependency = "forge-std~1.8.1";
+    let git = "git@gitlab.com:mario4582928/Mario.git";
+
+    let foundry_file = prj.root().join("foundry.toml");
+
+    
+    cmd.arg("soldeer").args([command, dependency, git]);
+    cmd.execute();
+
+    // Making sure the path was created to the dependency and that README.md exists
+    // meaning that the dependencies were installed correctly
+    let path_dep_forge =
+        prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
+    assert!(path_dep_forge.exists());
+
+    // Making sure the lock contents are the right ones
+    let path_lock_file = prj.root().join("soldeer.lock");
+    let lock_contents = r#"
+[[dependencies]]
+name = "forge-std"
+version = "1.8.1"
+source = "git@gitlab.com:mario4582928/Mario.git"
+checksum = "bedb1775bd60e3e142a6db863982254a4b891b20"
+"#;
+
+    let actual_lock_contents = read_file_to_string(&path_lock_file);
+    assert_eq!(lock_contents, actual_lock_contents);
+
+    // Making sure the foundry contents are the right ones
+    let foundry_contents = r#"[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+
+[dependencies]
+forge-std = { version = "1.8.1", url = "git@gitlab.com:mario4582928/Mario.git", commit = "bedb1775bd60e3e142a6db863982254a4b891b20" }
+"#;
+
+    let actual_foundry_contents = read_file_to_string(&foundry_file);
+    assert_eq!(foundry_contents, actual_foundry_contents);
+});
+
+forgesoldeer!(install_dependency_git_commit, |prj, cmd| {
+    let command = "install";
+    let dependency = "forge-std~1.8.1";
+    let git = "git@gitlab.com:mario4582928/Mario.git";
+    let commit = "bedb1775bd60e3e142a6db863982254a4b891b20";
+
+    let foundry_file = prj.root().join("foundry.toml");
+
+    cmd.arg("soldeer").args([command, dependency, git, commit]);
+    cmd.execute();
+
+    // Making sure the path was created to the dependency and that README.md exists
+    // meaning that the dependencies were installed correctly
+    let path_dep_forge =
+        prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
+    assert!(path_dep_forge.exists());
+
+    // Making sure the lock contents are the right ones
+    let path_lock_file = prj.root().join("soldeer.lock");
+    let lock_contents = r#"
+[[dependencies]]
+name = "forge-std"
+version = "1.8.1"
+source = "git@gitlab.com:mario4582928/Mario.git"
+checksum = "bedb1775bd60e3e142a6db863982254a4b891b20"
+"#;
+
+    let actual_lock_contents = read_file_to_string(&path_lock_file);
+    assert_eq!(lock_contents, actual_lock_contents);
+
+    // Making sure the foundry contents are the right ones
+    let foundry_contents = r#"[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+
+[dependencies]
+forge-std = { version = "1.8.1", url = "git@gitlab.com:mario4582928/Mario.git", commit = "bedb1775bd60e3e142a6db863982254a4b891b20" }
+"#;
+
+    let actual_foundry_contents = read_file_to_string(&foundry_file);
+    assert_eq!(foundry_contents, actual_foundry_contents);
+});
+
+
 forgesoldeer!(update_dependencies, |prj, cmd| {
     let command = "update";
 

--- a/crates/forge/tests/cli/soldeer.rs
+++ b/crates/forge/tests/cli/soldeer.rs
@@ -47,8 +47,7 @@ libs = ["lib"]
 forge-std = "1.8.1"
 "#;
 
-    let actual_foundry_contents = read_file_to_string(&foundry_file);
-    assert_eq!(foundry_contents, actual_foundry_contents);
+    assert_data_eq!(read_file_to_string(&foundry_file), foundry_contents);
 });
 
 forgesoldeer!(install_dependency_git, |prj, cmd| {
@@ -73,7 +72,7 @@ forgesoldeer!(install_dependency_git, |prj, cmd| {
 name = "forge-std"
 version = "1.8.1"
 source = "git@gitlab.com:mario4582928/Mario.git"
-checksum = "bedb1775bd60e3e142a6db863982254a4b891b20"
+checksum = "22868f426bd4dd0e682b5ec5f9bd55507664240c"
 "#;
 
     let actual_lock_contents = read_file_to_string(&path_lock_file);
@@ -88,27 +87,28 @@ libs = ["lib"]
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
 [dependencies]
-forge-std = { version = "1.8.1", url = "git@gitlab.com:mario4582928/Mario.git", commit = "bedb1775bd60e3e142a6db863982254a4b891b20" }
+forge-std = { version = "1.8.1", git = "git@gitlab.com:mario4582928/Mario.git", rev = "22868f426bd4dd0e682b5ec5f9bd55507664240c" }
 "#;
 
-    let actual_foundry_contents = read_file_to_string(&foundry_file);
-    assert_eq!(foundry_contents, actual_foundry_contents);
+    assert_data_eq!(read_file_to_string(&foundry_file), foundry_contents);
 });
 
 forgesoldeer!(install_dependency_git_commit, |prj, cmd| {
     let command = "install";
     let dependency = "forge-std~1.8.1";
     let git = "git@gitlab.com:mario4582928/Mario.git";
-    let commit = "bedb1775bd60e3e142a6db863982254a4b891b20";
+    let rev_flag = "--rev";
+    let commit = "7a0663eaf7488732f39550be655bad6694974cb3";
 
     let foundry_file = prj.root().join("foundry.toml");
 
-    cmd.arg("soldeer").args([command, dependency, git, commit]);
+    cmd.arg("soldeer").args([command, dependency, git, rev_flag, commit]);
     cmd.execute();
 
     // Making sure the path was created to the dependency and that README.md exists
     // meaning that the dependencies were installed correctly
-    let path_dep_forge = prj.root().join("dependencies").join("forge-std-1.8.1").join("README.md");
+    let path_dep_forge =
+        prj.root().join("dependencies").join("forge-std-1.8.1").join("JustATest2.md");
     assert!(path_dep_forge.exists());
 
     // Making sure the lock contents are the right ones
@@ -118,7 +118,7 @@ forgesoldeer!(install_dependency_git_commit, |prj, cmd| {
 name = "forge-std"
 version = "1.8.1"
 source = "git@gitlab.com:mario4582928/Mario.git"
-checksum = "bedb1775bd60e3e142a6db863982254a4b891b20"
+checksum = "7a0663eaf7488732f39550be655bad6694974cb3"
 "#;
 
     let actual_lock_contents = read_file_to_string(&path_lock_file);
@@ -133,11 +133,10 @@ libs = ["lib"]
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
 [dependencies]
-forge-std = { version = "1.8.1", url = "git@gitlab.com:mario4582928/Mario.git", commit = "bedb1775bd60e3e142a6db863982254a4b891b20" }
+forge-std = { version = "1.8.1", git = "git@gitlab.com:mario4582928/Mario.git", rev = "7a0663eaf7488732f39550be655bad6694974cb3" }
 "#;
 
-    let actual_foundry_contents = read_file_to_string(&foundry_file);
-    assert_eq!(foundry_contents, actual_foundry_contents);
+    assert_data_eq!(read_file_to_string(&foundry_file), foundry_contents);
 });
 
 forgesoldeer!(update_dependencies, |prj, cmd| {
@@ -190,8 +189,7 @@ libs = ["lib"]
 forge-std = { version = "1.8.1" }
 "#;
 
-    let actual_foundry_contents = read_file_to_string(&foundry_file);
-    assert_eq!(foundry_contents, actual_foundry_contents);
+    assert_data_eq!(read_file_to_string(&foundry_file), foundry_contents);
 });
 
 forgesoldeer!(update_dependencies_simple_version, |prj, cmd| {
@@ -245,8 +243,7 @@ libs = ["lib"]
 forge-std = "1.8.1" 
 "#;
 
-    let actual_foundry_contents = read_file_to_string(&foundry_file);
-    assert_eq!(foundry_contents, actual_foundry_contents);
+    assert_data_eq!(read_file_to_string(&foundry_file), foundry_contents);
 });
 
 forgesoldeer!(login, |prj, cmd| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We added new functionality to Soldeer, using a git repo as a dependency.
https://github.com/mario-eth/soldeer/issues/48

This feature has been requested even tho I do not encourage abusing it but it can be used for various unpublished repos.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Now we can use git to pull dependencies. It supports github and gitlab

Example:
```bash
forge soldeer install test-project~v1 git@github.com:test/test.git
forge soldeer install test-project~v1 git@gitlab.com:test/test.git
```

```bash
forge soldeer install test-project~v1 https://github.com/test/test.git
forge soldeer install test-project~v1 https://gitlab.com/test/test.git
```

Or using custom commit hashes
```bash
forge soldeer install test-project~v1 git@github.com:test/test.git 345e611cd84bfb4e62c583fa1886c1928bc1a464
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
