### PR TITLE
perf(invariant): do not include reverts in counterexample

### DIFF
--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -147,6 +147,10 @@ pub(crate) fn can_continue(
             invariant_data.failures.error = Some(InvariantFuzzError::Revert(case_data));
 
             return Ok(RichInvariantResults::new(false, None));
+        } else if call_result.reverted {
+            // If we don't fail test on revert then remove last reverted call from inputs.
+            // This improves shrinking performance as irrelevant calls won't be checked again.
+            invariant_run.inputs.pop();
         }
     }
     Ok(RichInvariantResults::new(true, call_results))

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -676,3 +676,21 @@ async fn test_invariant_selectors_weight() {
         )]),
     )
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_no_reverts_in_counterexample() {
+    let filter =
+        Filter::new(".*", ".*", ".*fuzz/invariant/common/InvariantSequenceNoReverts.t.sol");
+    let mut runner = TEST_DATA_DEFAULT.runner();
+    runner.test_options.invariant.fail_on_revert = false;
+    // Use original counterexample to test sequence len.
+    runner.test_options.invariant.shrink_run_limit = 0;
+
+    match get_counterexample!(runner, &filter) {
+        CounterExample::Single(_) => panic!("CounterExample should be a sequence."),
+        CounterExample::Sequence(sequence) => {
+            // ensure original counterexample len is 10 (even without shrinking)
+            assert_eq!(sequence.len(), 10);
+        }
+    };
+}

--- a/testdata/default/fuzz/invariant/common/InvariantSequenceNoReverts.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantSequenceNoReverts.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "ds-test/test.sol";
+
+contract SequenceNoReverts {
+    uint256 public count;
+
+    function work(uint256 x) public {
+        require(x % 2 != 0);
+        count++;
+    }
+}
+
+contract SequenceNoRevertsTest is DSTest {
+    SequenceNoReverts target;
+
+    function setUp() public {
+        target = new SequenceNoReverts();
+    }
+
+    function invariant_no_reverts() public view {
+        require(target.count() < 10, "condition met");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
When running invariants with `fail_on_revert = false` (default) the counterexample is created with all calls (including reverts). In this case the reverts are not relevant for reproducing the failure but will be considered and tested in shrinking phase, which is not efficient. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- remove call from inputs if call reverted and `fail_on_revert = false`
- test
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
