### PR TITLE
fix(cheatcodes): clarify vm.expectRevert error message

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -555,7 +555,7 @@ pub(crate) fn handle_expect_revert(
         }
     };
 
-    ensure!(!matches!(status, return_ok!()), "call did not revert as expected");
+    ensure!(!matches!(status, return_ok!()), "next call did not revert as expected");
 
     // If None, accept any revert
     let Some(expected_revert) = expected_revert else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

One of my tests which called `vm.expectRevert()` was failing with `FAIL. Reason: call did not revert as expected`, even though it was still reverting (with the expected reason) when I removed the call to `vm.expectRevert()`; for a while, I couldn't figure out why.

It took me a bit of time before realizing that the docs specify that `vm.expectRevert()` must be placed *immediately before* the call that is expected to revert. Part of my confusion was that I had another test that had a call to `vm.expectRevert()` followed by `vm.prank()`, and calls to other cheatcodes are ignored (so because that test was working, I thought I could just put `vm.expectRevert()` at the top of the test).

<img width="764" alt="Screenshot 2024-07-17 at 10 43 14" src="https://github.com/user-attachments/assets/89345920-2ffd-414e-a806-4c3b956bda9d">

https://book.getfoundry.sh/cheatcodes/expect-revert

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I updated the error message in the `vm.expectRevert()` cheatcode implementation to specify that failures are because the *next* call did not revert as expected. This wording also more closely matches the emphasis in the Foundry book docs.
