### PR TITLE
feat: better EOF/Prague support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,7 +6693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",
@@ -7118,8 +7118,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.5.1"
-source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=085f8df#085f8df30deee4eb2ec4b431bbb2cafc0a2bb971"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2dc001e37ac3b061dc9087876aea91e28756c188a97cd99416d23a5562ca73"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.5.0"
+source = "git+https://github.com/foundry-rs/block-explorers?rev=61beba3#61beba368e00d7ad9b25cd9ebbb1bb102855463b"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -3708,7 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06d58fce261a37f7c90ec4d2f14af729825bf7abbda14b64f8d728bc701480"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3744,7 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a0b1e385a5f9d88b0d6c9c8c1a5d89e33e5465e62096034abcd0dfd48a8618"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3752,7 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-solc"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff1e9120d86202a81a7729f33fabfc77c12beca7233765d36c49ebcd8da100b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3774,7 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b88e8a09b7689253885c5171512987d6dea96ac328b2384f6a0233a332ec8d9"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3787,7 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-core"
-version = "0.9.0"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad521e38281f70e99a5487883179b4bfb74c855abebe5d5390d8e6d993503a"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
@@ -7107,6 +7118,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.5.1"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=085f8df#085f8df30deee4eb2ec4b431bbb2cafc0a2bb971"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,8 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-block-explorers"
-version = "0.5.0"
-source = "git+https://github.com/foundry-rs/block-explorers?rev=61beba3#61beba368e00d7ad9b25cd9ebbb1bb102855463b"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3306c1dfb236a3f7c86f7f6c9a88843d621cea96add97fdefbdc53ef3ecf6dfe"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,8 +3544,6 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecb3c05dbf9454cf58c6c440f84c5d2c8f4e94edb4b16f87cfad9e4d818065a"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -3711,8 +3709,6 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f506a672502997fbc778f1d30eb4a06a58654049ccc6cd0bdb93a785175f682"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3749,8 +3745,6 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c352516419487416dde3250dbb56b576e0605429eb7b7b16f26849d924ee519"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3759,8 +3753,6 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49104d442d6f0266c07edbdd23baa9a1db0f01d04bfdc69b6ac060a57e6f3e27"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3772,6 +3764,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
+ "serde_repr",
  "thiserror",
  "tokio",
  "tracing",
@@ -3782,22 +3775,19 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f012d22d0690ad6b6bbcc8d70467325212ddea3457e8efda6affe17fb5ae938"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-core",
  "path-slash",
+ "semver 1.0.23",
  "serde",
 ]
 
 [[package]]
 name = "foundry-compilers-core"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23760fd6df67a9878ed0fe91e024bf1ff3b7358369cf54129539a8493177c6e7"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
@@ -7117,8 +7107,6 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d485a7ccfbbcaf2d0c08c3d866dae279c6f71d7357862cbea637f23f27b7b695"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.5.0", default-features = false }
-foundry-compilers = { version = "0.9.0", default-features = false }
+foundry-compilers = { version = "0.10.0", default-features = false }
 foundry-fork-db = "0.2"
 solang-parser = "=0.3.3"
 
@@ -265,6 +265,5 @@ soldeer = "0.2.19"
 proptest = "1"
 
 [patch.crates-io]
-revm-inspectors = { path = "../evm-inspectors" }
-foundry-compilers = { path = "../compilers/crates/compilers" }
-foundry-block-explorers = { path = "../block-explorers/crates/block-explorers" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "085f8df" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers", rev = "61beba3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,3 +263,8 @@ tower-http = "0.5"
 soldeer = "0.2.19"
 
 proptest = "1"
+
+[patch.crates-io]
+revm-inspectors = { path = "../evm-inspectors" }
+foundry-compilers = { path = "../compilers/crates/compilers" }
+foundry-block-explorers = { path = "../block-explorers/crates/block-explorers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,3 @@ tower-http = "0.5"
 soldeer = "0.2.19"
 
 proptest = "1"
-
-[patch.crates-io]
-revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "085f8df" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ foundry-wallets = { path = "crates/wallets" }
 foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
-foundry-block-explorers = { version = "0.5.0", default-features = false }
+foundry-block-explorers = { version = "0.5.1", default-features = false }
 foundry-compilers = { version = "0.10.0", default-features = false }
 foundry-fork-db = "0.2"
 solang-parser = "=0.3.3"
@@ -266,4 +266,3 @@ proptest = "1"
 
 [patch.crates-io]
 revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "085f8df" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers", rev = "61beba3" }

--- a/crates/anvil/src/hardfork.rs
+++ b/crates/anvil/src/hardfork.rs
@@ -21,6 +21,8 @@ pub enum Hardfork {
     Paris,
     Shanghai,
     Cancun,
+    Prague,
+    PragueEOF,
     #[default]
     Latest,
 }
@@ -45,6 +47,8 @@ impl Hardfork {
             Self::Paris => 15537394,
             Self::Shanghai => 17034870,
             Self::Cancun | Self::Latest => 19426587,
+            // TODO: add block after activation
+            Self::Prague | Self::PragueEOF => unreachable!(),
         }
     }
 }
@@ -72,6 +76,8 @@ impl FromStr for Hardfork {
             "paris" | "merge" | "15" => Self::Paris,
             "shanghai" | "16" => Self::Shanghai,
             "cancun" | "17" => Self::Cancun,
+            "prague" | "18" => Self::Prague,
+            "pragueeof" | "19" | "prague-eof" => Self::PragueEOF,
             "latest" => Self::Latest,
             _ => return Err(format!("Unknown hardfork {s}")),
         };
@@ -99,6 +105,9 @@ impl From<Hardfork> for SpecId {
             Hardfork::Paris => Self::MERGE,
             Hardfork::Shanghai => Self::SHANGHAI,
             Hardfork::Cancun | Hardfork::Latest => Self::CANCUN,
+            Hardfork::Prague => Self::PRAGUE,
+            // TODO: switch to latest after activation
+            Hardfork::PragueEOF => Self::PRAGUE_EOF,
         }
     }
 }

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -11,6 +11,7 @@ use foundry_compilers::{
         Compiler,
     },
     report::{BasicStdoutReporter, NoReporter, Report},
+    solc::SolcSettings,
     Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
 };
 use num_format::{Locale, ToFormattedString};
@@ -405,7 +406,10 @@ pub fn etherscan_project(
     let compiler = SolcCompiler::Specific(solc);
 
     Ok(ProjectBuilder::<SolcCompiler>::default()
-        .settings(SolcConfig::builder().settings(settings).build().settings)
+        .settings(SolcSettings {
+            settings: SolcConfig::builder().settings(settings).build().settings,
+            ..Default::default()
+        })
         .paths(paths)
         .ephemeral()
         .no_artifacts()

--- a/crates/debugger/src/op.rs
+++ b/crates/debugger/src/op.rs
@@ -18,23 +18,23 @@ impl OpcodeParam {
         match op {
             // Handle special cases requiring immediate bytes
             opcode::DUPN => immediate
-                .and_then(|i| i.get(0).copied())
-                .map(|i| vec![OpcodeParam { name: "dup_value", index: i as usize }]),
+                .and_then(|i| i.first().copied())
+                .map(|i| vec![Self { name: "dup_value", index: i as usize }]),
             opcode::SWAPN => immediate.and_then(|i| {
-                i.get(0).map(|i| {
+                i.first().map(|i| {
                     vec![
-                        OpcodeParam { name: "a", index: 1 },
-                        OpcodeParam { name: "swap_value", index: *i as usize },
+                        Self { name: "a", index: 1 },
+                        Self { name: "swap_value", index: *i as usize },
                     ]
                 })
             }),
             opcode::EXCHANGE => immediate.and_then(|i| {
-                i.get(0).map(|imm| {
-                    let n = imm >> 4 + 1;
-                    let m = imm & 0xf + 1;
+                i.first().map(|imm| {
+                    let n = (imm >> 4) + 1;
+                    let m = (imm & 0xf) + 1;
                     vec![
-                        OpcodeParam { name: "value1", index: n as usize },
-                        OpcodeParam { name: "value2", index: m as usize },
+                        Self { name: "value1", index: n as usize },
+                        Self { name: "value2", index: m as usize },
                     ]
                 })
             }),

--- a/crates/debugger/src/op.rs
+++ b/crates/debugger/src/op.rs
@@ -1,3 +1,6 @@
+use alloy_primitives::Bytes;
+use revm::interpreter::opcode;
+
 /// Named parameter of an EVM opcode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct OpcodeParam {
@@ -8,10 +11,35 @@ pub(crate) struct OpcodeParam {
 }
 
 impl OpcodeParam {
-    /// Returns the list of named parameters for the given opcode.
+    /// Returns the list of named parameters for the given opcode, accounts for special opcodes
+    /// requiring immediate bytes to determine stack items.
     #[inline]
-    pub(crate) fn of(op: u8) -> &'static [Self] {
-        MAP[op as usize]
+    pub(crate) fn of(op: u8, immediate: Option<&Bytes>) -> Option<Vec<Self>> {
+        match op {
+            // Handle special cases requiring immediate bytes
+            opcode::DUPN => immediate
+                .and_then(|i| i.get(0).copied())
+                .map(|i| vec![OpcodeParam { name: "dup_value", index: i as usize }]),
+            opcode::SWAPN => immediate.and_then(|i| {
+                i.get(0).map(|i| {
+                    vec![
+                        OpcodeParam { name: "a", index: 1 },
+                        OpcodeParam { name: "swap_value", index: *i as usize },
+                    ]
+                })
+            }),
+            opcode::EXCHANGE => immediate.and_then(|i| {
+                i.get(0).map(|imm| {
+                    let n = imm >> 4 + 1;
+                    let m = imm & 0xf + 1;
+                    vec![
+                        OpcodeParam { name: "value1", index: n as usize },
+                        OpcodeParam { name: "value2", index: m as usize },
+                    ]
+                })
+            }),
+            _ => Some(MAP[op as usize].to_vec()),
+        }
     }
 }
 
@@ -41,11 +69,12 @@ const fn map_opcode(op: u8) -> &'static [OpcodeParam] {
 
     // https://www.evm.codes
     // https://github.com/smlxl/evm.codes
-    // https://github.com/smlxl/evm.codes/blob/HEAD/opcodes.json
+    // https://github.com/klkvr/evm.codes
+    // https://github.com/klkvr/evm.codes/blob/HEAD/opcodes.json
     // jq -rf opcodes.jq opcodes.json
     /*
     def mkargs(input):
-        input | split(" | ") | to_entries | map("\(.key): \(.value)") | join(", ");
+        input | split(" | ") | to_entries | map("\(.key): \"\(.value)\"") | join(", ");
 
     to_entries[] | "0x\(.key)(\(mkargs(.value.input))),"
     */
@@ -265,10 +294,10 @@ const fn map_opcode(op: u8) -> &'static [OpcodeParam] {
         0xcd(),
         0xce(),
         0xcf(),
-        0xd0(),
+        0xd0(0: "offset"),
         0xd1(),
         0xd2(),
-        0xd3(),
+        0xd3(0: "memOffset", 1: "offset", 2: "size"),
         0xd4(),
         0xd5(),
         0xd6(),
@@ -282,8 +311,8 @@ const fn map_opcode(op: u8) -> &'static [OpcodeParam] {
         0xde(),
         0xdf(),
         0xe0(),
-        0xe1(),
-        0xe2(),
+        0xe1(0: "condition"),
+        0xe2(0: "case"),
         0xe3(),
         0xe4(),
         0xe5(),
@@ -293,9 +322,9 @@ const fn map_opcode(op: u8) -> &'static [OpcodeParam] {
         0xe9(),
         0xea(),
         0xeb(),
-        0xec(),
+        0xec(0: "value", 1: "salt", 2: "offset", 3: "size"),
         0xed(),
-        0xee(),
+        0xee(0: "offset", 1: "size"),
         0xef(),
         0xf0(0: "value", 1: "offset", 2: "size"),
         0xf1(0: "gas", 1: "address", 2: "value", 3: "argsOffset", 4: "argsSize", 5: "retOffset", 6: "retSize"),
@@ -304,11 +333,11 @@ const fn map_opcode(op: u8) -> &'static [OpcodeParam] {
         0xf4(0: "gas", 1: "address", 2: "argsOffset", 3: "argsSize", 4: "retOffset", 5: "retSize"),
         0xf5(0: "value", 1: "offset", 2: "size", 3: "salt"),
         0xf6(),
-        0xf7(),
-        0xf8(),
-        0xf9(),
+        0xf7(0: "offset"),
+        0xf8(0: "address", 1: "argsOffset", 2: "argsSize", 3: "value"),
+        0xf9(0: "address", 1: "argsOffset", 2: "argsSize"),
         0xfa(0: "gas", 1: "address", 2: "argsOffset", 3: "argsSize", 4: "retOffset", 5: "retSize"),
-        0xfb(),
+        0xfb(0: "address", 1: "argsOffset", 2: "argsSize"),
         0xfc(),
         0xfd(0: "offset", 1: "size"),
         0xfe(),

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -374,9 +374,7 @@ fn is_jump(step: &CallTraceStep, prev: &CallTraceStep) -> bool {
 
     if step.pc != prev.pc + 1 + immediate_len {
         true
-    } else if step.code_section_idx != prev.code_section_idx {
-        true
     } else {
-        false
+        step.code_section_idx != prev.code_section_idx
     }
 }

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -3,7 +3,7 @@
 use crate::{DebugNode, Debugger, ExitReason};
 use alloy_primitives::{hex, Address};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
-use revm::interpreter::opcode;
+use revm::interpreter::OpCode;
 use revm_inspectors::tracing::types::{CallKind, CallTraceStep};
 use std::ops::ControlFlow;
 
@@ -115,8 +115,8 @@ impl<'a> DebuggerContext<'a> {
     fn gen_opcode_list(&mut self) {
         self.opcode_list.clear();
         let debug_steps = &self.debugger.debug_arena[self.draw_memory.inner_call_index].steps;
-        for (i, step) in debug_steps.iter().enumerate() {
-            self.opcode_list.push(pretty_opcode(step, debug_steps.get(i + 1)));
+        for step in debug_steps {
+            self.opcode_list.push(pretty_opcode(step));
         }
     }
 
@@ -230,20 +230,20 @@ impl DebuggerContext<'_> {
 
             // Step forward
             KeyCode::Char('s') => self.repeat(|this| {
-                let remaining_ops = &this.opcode_list[this.current_step..];
-                if let Some((i, _)) = remaining_ops.iter().enumerate().skip(1).find(|&(i, op)| {
-                    let prev = &remaining_ops[i - 1];
-                    let prev_is_jump = prev.contains("JUMP") && prev != "JUMPDEST";
-                    let is_jumpdest = op == "JUMPDEST";
-                    prev_is_jump && is_jumpdest
-                }) {
-                    this.current_step += i;
+                let remaining_steps = &this.debug_steps()[this.current_step..];
+                if let Some((i, _)) =
+                    remaining_steps.iter().enumerate().skip(1).find(|(i, step)| {
+                        let prev = &remaining_steps[*i - 1];
+                        is_jump(step, prev)
+                    })
+                {
+                    this.current_step += i
                 }
             }),
 
             // Step backwards
             KeyCode::Char('a') => self.repeat(|this| {
-                let ops = &this.opcode_list[..this.current_step];
+                let ops = &this.debug_steps()[..this.current_step];
                 this.current_step = ops
                     .iter()
                     .enumerate()
@@ -251,9 +251,7 @@ impl DebuggerContext<'_> {
                     .rev()
                     .find(|&(i, op)| {
                         let prev = &ops[i - 1];
-                        let prev_is_jump = prev.contains("JUMP") && prev != "JUMPDEST";
-                        let is_jumpdest = op == "JUMPDEST";
-                        prev_is_jump && is_jumpdest
+                        is_jump(op, prev)
                     })
                     .map(|(i, _)| i)
                     .unwrap_or_default();
@@ -349,23 +347,36 @@ fn buffer_as_number(s: &str) -> usize {
     s.parse().unwrap_or(MIN).clamp(MIN, MAX)
 }
 
-fn pretty_opcode(step: &CallTraceStep, next_step: Option<&CallTraceStep>) -> String {
-    let op = step.op;
-    let instruction = op.get();
-    let push_size = if (opcode::PUSH1..=opcode::PUSH32).contains(&instruction) {
-        (instruction - opcode::PUSH0) as usize
+fn pretty_opcode(step: &CallTraceStep) -> String {
+    if let Some(immediate) = step.immediate_bytes.as_ref().filter(|b| !b.is_empty()) {
+        format!("{}(0x{})", step.op, hex::encode(immediate))
     } else {
-        0
-    };
-    if push_size == 0 {
-        return step.op.to_string();
+        step.op.to_string()
+    }
+}
+
+fn is_jump(step: &CallTraceStep, prev: &CallTraceStep) -> bool {
+    if !matches!(
+        prev.op,
+        OpCode::JUMP |
+            OpCode::JUMPI |
+            OpCode::JUMPF |
+            OpCode::RJUMP |
+            OpCode::RJUMPI |
+            OpCode::RJUMPV |
+            OpCode::CALLF |
+            OpCode::RETF
+    ) {
+        return false
     }
 
-    // Get push byte as the top-most stack item on the next step
-    if let Some(pushed) = next_step.and_then(|s| s.stack.as_ref()).and_then(|s| s.last()) {
-        let bytes = &pushed.to_be_bytes_vec()[32 - push_size..];
-        format!("{op}(0x{})", hex::encode(bytes))
+    let immediate_len = prev.immediate_bytes.as_ref().map_or(0, |b| b.len());
+
+    if step.pc != prev.pc + 1 + immediate_len {
+        true
+    } else if step.code_section_idx != prev.code_section_idx {
+        true
     } else {
-        op.to_string()
+        false
     }
 }

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -673,7 +673,7 @@ fn get_buffer_accesses(op: u8, stack: &[U256]) -> Option<BufferAccesses> {
         opcode::RETURNCONTRACT => (Some((BufferKind::Memory, 1, 2)), None),
         opcode::DATACOPY => (None, Some((1, 3))),
         opcode::EXTCALL | opcode::EXTSTATICCALL | opcode::EXTDELEGATECALL => {
-            (Some((BufferKind::Memory, 1, 2)), None)
+            (Some((BufferKind::Memory, 2, 3)), None)
         }
         _ => Default::default(),
     };

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -377,10 +377,11 @@ impl DebuggerContext<'_> {
             .collect::<Vec<_>>();
 
         let title = format!(
-            "Address: {} | PC: {} | Gas used in call: {}",
+            "Address: {} | PC: {} | Gas used in call: {} | Code section: {}",
             self.address(),
             self.current_step().pc,
             self.current_step().gas_used,
+            self.current_step().code_section_idx,
         );
         let block = Block::default().title(title).borders(Borders::ALL);
         let list = List::new(items)

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -400,7 +400,7 @@ impl DebuggerContext<'_> {
 
         let min_len = decimal_digits(stack_len).max(2);
 
-        let params = OpcodeParam::of(step.op.get());
+        let params = OpcodeParam::of(step.op.get(), step.immediate_bytes.as_ref());
 
         let text: Vec<Line<'_>> = stack
             .map(|stack| {
@@ -410,7 +410,9 @@ impl DebuggerContext<'_> {
                     .enumerate()
                     .skip(self.draw_memory.current_stack_startline)
                     .map(|(i, stack_item)| {
-                        let param = params.iter().find(|param| param.index == i);
+                        let param = params
+                            .as_ref()
+                            .and_then(|params| params.iter().find(|param| param.index == i));
 
                         let mut spans = Vec::with_capacity(1 + 32 * 2 + 3);
 
@@ -666,6 +668,13 @@ fn get_buffer_accesses(op: u8, stack: &[U256]) -> Option<BufferAccesses> {
         opcode::CALL | opcode::CALLCODE => (Some((BufferKind::Memory, 4, 5)), None),
         opcode::DELEGATECALL | opcode::STATICCALL => (Some((BufferKind::Memory, 3, 4)), None),
         opcode::MCOPY => (Some((BufferKind::Memory, 2, 3)), Some((1, 3))),
+        opcode::RETURNDATALOAD => (Some((BufferKind::Returndata, 1, -1)), None),
+        opcode::EOFCREATE => (Some((BufferKind::Memory, 3, 4)), None),
+        opcode::RETURNCONTRACT => (Some((BufferKind::Memory, 1, 2)), None),
+        opcode::DATACOPY => (None, Some((1, 3))),
+        opcode::EXTCALL | opcode::EXTSTATICCALL | opcode::EXTDELEGATECALL => {
+            (Some((BufferKind::Memory, 1, 2)), None)
+        }
         _ => Default::default(),
     };
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -210,6 +210,7 @@ impl TraceMode {
                 record_opcodes_filter: (self.is_jump() || self.is_jump_simple())
                     .then(|| OpcodeFilter::new().enabled(OpCode::JUMP).enabled(OpCode::JUMPDEST)),
                 exclude_precompile_calls: false,
+                record_immediate_bytes: self.is_debug(),
             }
             .into()
         }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -127,7 +127,8 @@ impl CoverageArgs {
             // https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
             // And also in new releases of solidity:
             // https://github.com/ethereum/solidity/issues/13972#issuecomment-1628632202
-            project.settings.solc = project.settings.solc.with_via_ir_minimum_optimization()
+            project.settings.solc.settings =
+                project.settings.solc.settings.with_via_ir_minimum_optimization()
         } else {
             project.settings.solc.optimizer.disable();
             project.settings.solc.optimizer.runs = None;

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -147,6 +147,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         warnings: vec![],
         assertions_revert: true,
         legacy_assertions: false,
+        extra_args: vec![],
         eof_version: None,
         _non_exhaustive: (),
     };

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -147,6 +147,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         warnings: vec![],
         assertions_revert: true,
         legacy_assertions: false,
+        eof_version: None,
         _non_exhaustive: (),
     };
     prj.write_config(input.clone());

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -1,11 +1,11 @@
 use crate::init_tracing;
 use eyre::{Result, WrapErr};
 use foundry_compilers::{
-    artifacts::Settings,
     cache::CompilerCache,
     compilers::multi::MultiCompiler,
     error::Result as SolcResult,
     project_util::{copy_dir, TempProject},
+    solc::SolcSettings,
     ArtifactOutput, ConfigurableArtifacts, PathStyle, ProjectPathsConfig,
 };
 use foundry_config::Config;
@@ -547,7 +547,7 @@ impl TestProject {
     #[track_caller]
     pub fn assert_create_dirs_exists(&self) {
         self.paths().create_all().unwrap_or_else(|_| panic!("Failed to create project paths"));
-        CompilerCache::<Settings>::default()
+        CompilerCache::<SolcSettings>::default()
             .write(&self.paths().cache)
             .expect("Failed to create cache");
         self.assert_all_paths_exist();

--- a/crates/verify/src/etherscan/standard_json.rs
+++ b/crates/verify/src/etherscan/standard_json.rs
@@ -2,7 +2,7 @@ use super::{EtherscanSourceProvider, VerifyArgs};
 use crate::provider::VerificationContext;
 use eyre::{Context, Result};
 use foundry_block_explorers::verify::CodeFormat;
-use foundry_compilers::artifacts::StandardJsonCompilerInput;
+use foundry_compilers::{artifacts::StandardJsonCompilerInput, solc::SolcLanguage};
 
 #[derive(Debug)]
 pub struct EtherscanStandardJsonSource;
@@ -29,7 +29,7 @@ impl EtherscanSourceProvider for EtherscanStandardJsonSource {
             .collect();
 
         // remove all incompatible settings
-        input.settings.sanitize(&context.compiler_version);
+        input.settings.sanitize(&context.compiler_version, SolcLanguage::Solidity);
 
         let source =
             serde_json::to_string(&input).wrap_err("Failed to parse standard json input")?;


### PR DESCRIPTION
Forwards `eofVersion` key from compilers to foundry.toml, allowing native usage of https://github.com/ipsilon/solidity for compiling EOF contracts

Adds `Prague` and `PragueEOF` variants for anvil's `Hardfork` allowing to run EOF-enabled Anvil

Adds debugger support for EOF opcodes