### PR TITLE
fix(cast): mktx: add missing --path argument for blob txs

### DIFF
--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use crate::tx::{self, CastTxBuilder};
 use alloy_network::{eip2718::Encodable2718, EthereumWallet, TransactionBuilder};
 use alloy_primitives::hex;
@@ -11,7 +10,7 @@ use foundry_cli::{
 };
 use foundry_common::ens::NameOrAddress;
 use foundry_config::Config;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 /// CLI arguments for `cast mktx`.
 #[derive(Debug, Parser)]
@@ -35,7 +34,13 @@ pub struct MakeTxArgs {
     tx: TransactionOpts,
 
     /// The path of blob data to be sent.
-    #[arg(long, value_name = "BLOB_DATA_PATH", conflicts_with = "legacy", requires = "blob", help_heading = "Transaction options")]
+    #[arg(
+        long,
+        value_name = "BLOB_DATA_PATH",
+        conflicts_with = "legacy",
+        requires = "blob",
+        help_heading = "Transaction options"
+    )]
     path: Option<PathBuf>,
 
     #[command(flatten)]
@@ -60,15 +65,7 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
-        let Self {
-            to,
-            mut sig,
-            mut args,
-            command,
-            tx,
-            path,
-            eth,
-        } = self;
+        let Self { to, mut sig, mut args, command, tx, path, eth } = self;
 
         let blob_data = if let Some(path) = path { Some(std::fs::read(path)?) } else { None };
 

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -57,7 +57,13 @@ pub struct SendTxArgs {
     eth: EthereumOpts,
 
     /// The path of blob data to be sent.
-    #[arg(long, value_name = "BLOB_DATA_PATH", conflicts_with = "legacy", requires = "blob", help_heading = "Transaction options")]
+    #[arg(
+        long,
+        value_name = "BLOB_DATA_PATH",
+        conflicts_with = "legacy",
+        requires = "blob",
+        help_heading = "Transaction options"
+    )]
     path: Option<PathBuf>,
 }
 

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -57,7 +57,7 @@ pub struct SendTxArgs {
     eth: EthereumOpts,
 
     /// The path of blob data to be sent.
-    #[arg(long, value_name = "BLOB_DATA_PATH", conflicts_with = "legacy", requires = "blob")]
+    #[arg(long, value_name = "BLOB_DATA_PATH", conflicts_with = "legacy", requires = "blob", help_heading = "Transaction options")]
     path: Option<PathBuf>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

After learning about `mktx` (see https://github.com/foundry-rs/foundry/pull/8472 😅) I wanted to use it to create a blob tx, but received this error:

```
error: unexpected argument '--path' found
```

Or this error w/o `--path`:

```
Error:
server returned an error response: error code -32003: blob transaction missing blob hashes
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I replicated the same missing logic from `send` in `mktx`.  I also fixed the `--path` help showing up under `Wallet options` on both commands.  I also considered moving `path` into `TransactionOpts` but that's used in enough other spots I assumed there was a good reason it wasn't there already.


Anyways, it works now:

```
> cargo run --bin cast -- mktx --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --blob --path <(echo "hello") | wc -c
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.79s
     Running `target/debug/cast mktx --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --blob --path /dev/fd/11`
  262647
```
