### PR TITLE
feat(cast,common): calldata-decode, abi-decode, and 4byte-decode json flag

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -12,7 +12,7 @@ use foundry_cli::{handler, prompt, stdin, utils};
 use foundry_common::{
     abi::get_event,
     ens::{namehash, ProviderEnsExt},
-    fmt::{format_token_raw, format_tokens, format_uint_exp},
+    fmt::{format_uint_exp, print_tokens},
     fs,
     selectors::{
         decode_calldata, decode_event_topic, decode_function_selector, decode_selectors,
@@ -163,10 +163,9 @@ async fn main() -> Result<()> {
         }
 
         // ABI encoding & decoding
-        CastSubcommand::AbiDecode { sig, calldata, input } => {
+        CastSubcommand::AbiDecode { sig, calldata, input, json } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
-            let tokens = format_tokens(&tokens);
-            tokens.for_each(|t| println!("{t}"));
+            print_tokens(&tokens, json)
         }
         CastSubcommand::AbiEncode { sig, packed, args } => {
             if !packed {
@@ -177,13 +176,7 @@ async fn main() -> Result<()> {
         }
         CastSubcommand::CalldataDecode { sig, calldata, json } => {
             let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;
-            if json {
-                let tokens: Vec<String> = tokens.iter().map(format_token_raw).collect();
-                println!("{}", serde_json::to_string_pretty(&tokens).unwrap());
-            } else {
-                let tokens = format_tokens(&tokens);
-                tokens.for_each(|t| println!("{t}"));
-            }
+            print_tokens(&tokens, json)
         }
         CastSubcommand::CalldataEncode { sig, args } => {
             println!("{}", SimpleCast::calldata_encode(sig, &args)?);
@@ -430,7 +423,7 @@ async fn main() -> Result<()> {
                 println!("{sig}");
             }
         }
-        CastSubcommand::FourByteDecode { calldata } => {
+        CastSubcommand::FourByteDecode { calldata, json } => {
             let calldata = stdin::unwrap_line(calldata)?;
             let sigs = decode_calldata(&calldata).await?;
             sigs.iter().enumerate().for_each(|(i, sig)| println!("{}) \"{sig}\"", i + 1));
@@ -445,9 +438,7 @@ async fn main() -> Result<()> {
             };
 
             let tokens = SimpleCast::calldata_decode(sig, &calldata, true)?;
-            for token in format_tokens(&tokens) {
-                println!("{token}");
-            }
+            print_tokens(&tokens, json)
         }
         CastSubcommand::FourByteEvent { topic } => {
             let topic = stdin::unwrap_line(topic)?;

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -12,7 +12,7 @@ use foundry_cli::{handler, prompt, stdin, utils};
 use foundry_common::{
     abi::get_event,
     ens::{namehash, ProviderEnsExt},
-    fmt::{format_tokens, format_uint_exp},
+    fmt::{format_token_raw, format_tokens, format_uint_exp},
     fs,
     selectors::{
         decode_calldata, decode_event_topic, decode_function_selector, decode_selectors,
@@ -175,10 +175,15 @@ async fn main() -> Result<()> {
                 println!("{}", SimpleCast::abi_encode_packed(&sig, &args)?);
             }
         }
-        CastSubcommand::CalldataDecode { sig, calldata } => {
+        CastSubcommand::CalldataDecode { sig, calldata, json } => {
             let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;
-            let tokens = format_tokens(&tokens);
-            tokens.for_each(|t| println!("{t}"));
+            if json {
+                let tokens: Vec<String> = tokens.iter().map(format_token_raw).collect();
+                println!("{}", serde_json::to_string_pretty(&tokens).unwrap());
+            } else {
+                let tokens = format_tokens(&tokens);
+                tokens.for_each(|t| println!("{t}"));
+            }
         }
         CastSubcommand::CalldataEncode { sig, args } => {
             println!("{}", SimpleCast::calldata_encode(sig, &args)?);

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -490,6 +490,10 @@ pub enum CastSubcommand {
 
         /// The ABI-encoded calldata.
         calldata: String,
+
+        /// Print the decoded calldata as JSON.
+        #[arg(long, short, help_heading = "Display options")]
+        json: bool,
     },
 
     /// Decode ABI-encoded input or output data.

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -512,6 +512,10 @@ pub enum CastSubcommand {
         /// Whether to decode the input or output data.
         #[arg(long, short, help_heading = "Decode input data instead of output data")]
         input: bool,
+
+        /// Print the decoded calldata as JSON.
+        #[arg(long, short, help_heading = "Display options")]
+        json: bool,
     },
 
     /// ABI encode the given function argument, excluding the selector.
@@ -598,6 +602,10 @@ pub enum CastSubcommand {
     FourByteDecode {
         /// The ABI-encoded calldata.
         calldata: Option<String>,
+
+        /// Print the decoded calldata as JSON.
+        #[arg(long, short, help_heading = "Display options")]
+        json: bool,
     },
 
     /// Get the event signature for a given topic 0 from https://openchain.xyz.

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -128,10 +128,10 @@ pub fn format_tokens_raw(tokens: &[DynSolValue]) -> impl Iterator<Item = String>
 /// parameter.
 pub fn print_tokens(tokens: &[DynSolValue], json: bool) {
     if json {
-        let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+        let tokens: Vec<String> = format_tokens_raw(tokens).collect();
         println!("{}", serde_json::to_string_pretty(&tokens).unwrap());
     } else {
-        let tokens = format_tokens(&tokens);
+        let tokens = format_tokens(tokens);
         tokens.for_each(|t| println!("{t}"));
     }
 }

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -119,6 +119,23 @@ pub fn format_tokens(tokens: &[DynSolValue]) -> impl Iterator<Item = String> + '
     tokens.iter().map(format_token)
 }
 
+/// Pretty-prints a slice of tokens using [`format_token_raw`].
+pub fn format_tokens_raw(tokens: &[DynSolValue]) -> impl Iterator<Item = String> + '_ {
+    tokens.iter().map(format_token_raw)
+}
+
+/// Prints slice of tokens using [`format_tokens`] or [`format_tokens_raw`] depending on `json`
+/// parameter.
+pub fn print_tokens(tokens: &[DynSolValue], json: bool) {
+    if json {
+        let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+        println!("{}", serde_json::to_string_pretty(&tokens).unwrap());
+    } else {
+        let tokens = format_tokens(&tokens);
+        tokens.for_each(|t| println!("{t}"));
+    }
+}
+
 /// Pretty-prints the given value into a string suitable for user output.
 pub fn format_token(value: &DynSolValue) -> String {
     DynValueDisplay::new(value, false).to_string()

--- a/crates/common/fmt/src/lib.rs
+++ b/crates/common/fmt/src/lib.rs
@@ -4,7 +4,9 @@ mod console;
 pub use console::{console_format, ConsoleFmt, FormatSpec};
 
 mod dynamic;
-pub use dynamic::{format_token, format_token_raw, format_tokens, parse_tokens};
+pub use dynamic::{
+    format_token, format_token_raw, format_tokens, format_tokens_raw, parse_tokens, print_tokens,
+};
 
 mod exp;
 pub use exp::{format_int_exp, format_uint_exp, to_exp_notation};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- When using `cast calldata-decode` and similar functions in a script, it's helpful to have the output be in json so that it can be used with tools like `jq`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Adds `--json` or `-j` flag to `cast calldata-decode`,  to print output as json array
- Adds `--json` flag to `cast 4byte-decode`
- Adds `--json` flag to `cast abi-decode`

### Testing

```bash
$ cargo run calldata-decode "transfer(address,uint256)" -j \
0xa9059cbb000000000000000000000000e78388b4ce79068e89bf8aa7f218ef6b9ab0e9d0000000000000000000000000000000000000000000000000008a8e4b1a3d8000 | jq

[
  "0xE78388b4CE79068e89Bf8aA7f218eF6b9AB0e9d0",
  "39000000000000000"
]
```

```bash
$ cargo run 4byte-decode -j 0x095ea7b30000000000000000000000001111111254eeb25477b68fb85ed929f73a9605820000000000000000000000000000000000000000000f0664af93dce3ad1d31f9

[
  "0x1111111254EEB25477B68fb85Ed929f73A960582",
  "18164078819222675080950265"
]
```

```bash
$ cargo run abi-decode --input 'approve(address spender,uint256 value)' -j 0000000000000000000000001111111254eeb25477b68fb85ed929f73a9605820000000000000000000000000000000000000000000f0664af93dce3ad1d31f9

[
  "0x1111111254EEB25477B68fb85Ed929f73A960582",
  "18164078819222675080950265"
]
```