### PR TITLE
feat(test): allow custom txes before unit and fuzz test

### DIFF
--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -44,9 +44,9 @@ pub trait TestFunctionExt {
         matches!(self.test_function_kind(), TestFunctionKind::UnitTest { .. })
     }
 
-    /// Returns `true` if this function is a `beforeTestSelectors` function.
-    fn is_before_test(&self) -> bool {
-        self.tfe_as_str().eq_ignore_ascii_case("beforetestselectors")
+    /// Returns `true` if this function is a `beforeTestSetup` function.
+    fn is_before_test_setup(&self) -> bool {
+        self.tfe_as_str().eq_ignore_ascii_case("beforetestsetup")
     }
 
     /// Returns `true` if this function is a fuzz test.

--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -46,7 +46,7 @@ pub trait TestFunctionExt {
 
     /// Returns `true` if this function is a `beforeTestSelectors` function.
     fn is_before_test(&self) -> bool {
-        self.test_function_kind().is_before_test()
+        self.tfe_as_str().eq_ignore_ascii_case("beforetestselectors")
     }
 
     /// Returns `true` if this function is a fuzz test.
@@ -120,8 +120,6 @@ pub enum TestFunctionKind {
     AfterInvariant,
     /// `fixture*`.
     Fixture,
-    /// `beforeTestSelectors`.
-    BeforeTestSelectors,
     /// Unknown kind.
     Unknown,
 }
@@ -145,7 +143,6 @@ impl TestFunctionKind {
             _ if name.eq_ignore_ascii_case("setup") => Self::Setup,
             _ if name.eq_ignore_ascii_case("afterinvariant") => Self::AfterInvariant,
             _ if name.starts_with("fixture") => Self::Fixture,
-            _ if name.eq_ignore_ascii_case("beforetestselectors") => Self::BeforeTestSelectors,
             _ => Self::Unknown,
         }
     }
@@ -161,7 +158,6 @@ impl TestFunctionKind {
             Self::InvariantTest => "invariant",
             Self::AfterInvariant => "afterInvariant",
             Self::Fixture => "fixture",
-            Self::BeforeTestSelectors => "beforeTestSelectors",
             Self::Unknown => "unknown",
         }
     }
@@ -188,12 +184,6 @@ impl TestFunctionKind {
     #[inline]
     pub fn is_unit_test(&self) -> bool {
         matches!(self, Self::UnitTest { .. })
-    }
-
-    /// Returns `true` if this function is a `beforeTestSelectors` function.
-    #[inline]
-    pub const fn is_before_test(&self) -> bool {
-        matches!(self, Self::BeforeTestSelectors)
     }
 
     /// Returns `true` if this function is a fuzz test.

--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -44,6 +44,11 @@ pub trait TestFunctionExt {
         matches!(self.test_function_kind(), TestFunctionKind::UnitTest { .. })
     }
 
+    /// Returns `true` if this function is a `beforeTestSelectors` function.
+    fn is_before_test(&self) -> bool {
+        self.test_function_kind().is_before_test()
+    }
+
     /// Returns `true` if this function is a fuzz test.
     fn is_fuzz_test(&self) -> bool {
         self.test_function_kind().is_fuzz_test()
@@ -115,6 +120,8 @@ pub enum TestFunctionKind {
     AfterInvariant,
     /// `fixture*`.
     Fixture,
+    /// `beforeTestSelectors`.
+    BeforeTestSelectors,
     /// Unknown kind.
     Unknown,
 }
@@ -138,6 +145,7 @@ impl TestFunctionKind {
             _ if name.eq_ignore_ascii_case("setup") => Self::Setup,
             _ if name.eq_ignore_ascii_case("afterinvariant") => Self::AfterInvariant,
             _ if name.starts_with("fixture") => Self::Fixture,
+            _ if name.eq_ignore_ascii_case("beforetestselectors") => Self::BeforeTestSelectors,
             _ => Self::Unknown,
         }
     }
@@ -153,6 +161,7 @@ impl TestFunctionKind {
             Self::InvariantTest => "invariant",
             Self::AfterInvariant => "afterInvariant",
             Self::Fixture => "fixture",
+            Self::BeforeTestSelectors => "beforeTestSelectors",
             Self::Unknown => "unknown",
         }
     }
@@ -179,6 +188,12 @@ impl TestFunctionKind {
     #[inline]
     pub fn is_unit_test(&self) -> bool {
         matches!(self, Self::UnitTest { .. })
+    }
+
+    /// Returns `true` if this function is a `beforeTestSelectors` function.
+    #[inline]
+    pub const fn is_before_test(&self) -> bool {
+        matches!(self, Self::BeforeTestSelectors)
     }
 
     /// Returns `true` if this function is a fuzz test.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -532,6 +532,7 @@ impl<'a> InvariantExecutor<'a> {
     /// targetArtifactSelectors > excludeArtifacts > targetArtifacts
     pub fn select_contract_artifacts(&mut self, invariant_address: Address) -> Result<()> {
         let result = self
+            .executor
             .call_sol_default(invariant_address, &IInvariantTest::targetArtifactSelectorsCall {});
 
         // Insert them into the executor `targeted_abi`.
@@ -542,10 +543,12 @@ impl<'a> InvariantExecutor<'a> {
             self.artifact_filters.targeted.entry(identifier).or_default().extend(selectors);
         }
 
-        let selected =
-            self.call_sol_default(invariant_address, &IInvariantTest::targetArtifactsCall {});
-        let excluded =
-            self.call_sol_default(invariant_address, &IInvariantTest::excludeArtifactsCall {});
+        let selected = self
+            .executor
+            .call_sol_default(invariant_address, &IInvariantTest::targetArtifactsCall {});
+        let excluded = self
+            .executor
+            .call_sol_default(invariant_address, &IInvariantTest::excludeArtifactsCall {});
 
         // Insert `excludeArtifacts` into the executor `excluded_abi`.
         for contract in excluded.excludedArtifacts {
@@ -620,10 +623,14 @@ impl<'a> InvariantExecutor<'a> {
         &self,
         to: Address,
     ) -> Result<(SenderFilters, FuzzRunIdentifiedContracts)> {
-        let targeted_senders =
-            self.call_sol_default(to, &IInvariantTest::targetSendersCall {}).targetedSenders;
-        let mut excluded_senders =
-            self.call_sol_default(to, &IInvariantTest::excludeSendersCall {}).excludedSenders;
+        let targeted_senders = self
+            .executor
+            .call_sol_default(to, &IInvariantTest::targetSendersCall {})
+            .targetedSenders;
+        let mut excluded_senders = self
+            .executor
+            .call_sol_default(to, &IInvariantTest::excludeSendersCall {})
+            .excludedSenders;
         // Extend with default excluded addresses - https://github.com/foundry-rs/foundry/issues/4163
         excluded_senders.extend([
             CHEATCODE_ADDRESS,
@@ -634,10 +641,14 @@ impl<'a> InvariantExecutor<'a> {
         excluded_senders.extend(PRECOMPILES);
         let sender_filters = SenderFilters::new(targeted_senders, excluded_senders);
 
-        let selected =
-            self.call_sol_default(to, &IInvariantTest::targetContractsCall {}).targetedContracts;
-        let excluded =
-            self.call_sol_default(to, &IInvariantTest::excludeContractsCall {}).excludedContracts;
+        let selected = self
+            .executor
+            .call_sol_default(to, &IInvariantTest::targetContractsCall {})
+            .targetedContracts;
+        let excluded = self
+            .executor
+            .call_sol_default(to, &IInvariantTest::excludeContractsCall {})
+            .excludedContracts;
 
         let contracts = self
             .setup_contracts
@@ -678,6 +689,7 @@ impl<'a> InvariantExecutor<'a> {
         targeted_contracts: &mut TargetedContracts,
     ) -> Result<()> {
         let interfaces = self
+            .executor
             .call_sol_default(invariant_address, &IInvariantTest::targetInterfacesCall {})
             .targetedInterfaces;
 
@@ -735,13 +747,15 @@ impl<'a> InvariantExecutor<'a> {
         }
 
         // Collect contract functions marked as target for fuzzing campaign.
-        let selectors = self.call_sol_default(address, &IInvariantTest::targetSelectorsCall {});
+        let selectors =
+            self.executor.call_sol_default(address, &IInvariantTest::targetSelectorsCall {});
         for IInvariantTest::FuzzSelector { addr, selectors } in selectors.targetedSelectors {
             self.add_address_with_functions(addr, &selectors, false, targeted_contracts)?;
         }
 
         // Collect contract functions excluded from fuzzing campaign.
-        let selectors = self.call_sol_default(address, &IInvariantTest::excludeSelectorsCall {});
+        let selectors =
+            self.executor.call_sol_default(address, &IInvariantTest::excludeSelectorsCall {});
         for IInvariantTest::FuzzSelector { addr, selectors } in selectors.excludedSelectors {
             self.add_address_with_functions(addr, &selectors, true, targeted_contracts)?;
         }
@@ -772,17 +786,6 @@ impl<'a> InvariantExecutor<'a> {
         };
         contract.add_selectors(selectors.iter().copied(), should_exclude)?;
         Ok(())
-    }
-
-    fn call_sol_default<C: SolCall>(&self, to: Address, args: &C) -> C::Return
-    where
-        C::Return: Default,
-    {
-        self.executor
-            .call_sol(CALLER, to, args, U256::ZERO, None)
-            .map(|c| c.decoded_result)
-            .inspect_err(|e| warn!(target: "forge::test", "failed calling {:?}: {e}", C::SIGNATURE))
-            .unwrap_or_default()
     }
 }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -48,17 +48,11 @@ pub use trace::TracingExecutor;
 
 sol! {
     interface ITest {
-        #[derive(Default)]
-        struct BeforeTestSelectors {
-            bytes4 test_selector;
-            bytes4[] before_selectors;
-        }
-
         function setUp() external;
         function failed() external view returns (bool failed);
 
         #[derive(Default)]
-        function beforeTestSelectors() public view returns (BeforeTestSelectors[] memory beforeSelectors);
+        function beforeTestSetup(bytes4 testSelector) public view returns (bytes[] memory beforeTestCalldata);
     }
 }
 

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -48,8 +48,17 @@ pub use trace::TracingExecutor;
 
 sol! {
     interface ITest {
+        #[derive(Default)]
+        struct BeforeTestSelectors {
+            bytes4 test_selector;
+            bytes4[] before_selectors;
+        }
+
         function setUp() external;
         function failed() external view returns (bool failed);
+
+        #[derive(Default)]
+        function beforeTestSelectors() public view returns (BeforeTestSelectors[] memory beforeSelectors);
     }
 }
 
@@ -601,6 +610,16 @@ impl Executor {
         };
 
         EnvWithHandlerCfg::new_with_spec_id(Box::new(env), self.spec_id())
+    }
+
+    pub fn call_sol_default<C: SolCall>(&self, to: Address, args: &C) -> C::Return
+    where
+        C::Return: Default,
+    {
+        self.call_sol(CALLER, to, args, U256::ZERO, None)
+            .map(|c| c.decoded_result)
+            .inspect_err(|e| warn!(target: "forge::test", "failed calling {:?}: {e}", C::SIGNATURE))
+            .unwrap_or_default()
     }
 }
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -449,9 +449,9 @@ impl TestResult {
     }
 
     /// Returns the failed result with reason for single test.
-    pub fn single_fail(mut self, err: EvmError) -> Self {
+    pub fn single_fail(mut self, reason: Option<String>) -> Self {
         self.status = TestStatus::Failure;
-        self.reason = Some(err.to_string());
+        self.reason = reason;
         self
     }
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -579,6 +579,14 @@ impl TestResult {
         format!("{self} {name} {}", self.kind.report())
     }
 
+    /// Function to merge logs, addresses, traces and coverage from a call result into test result.
+    pub fn merge_call_result(&mut self, call_result: &RawCallResult) {
+        self.logs.extend(call_result.logs.clone());
+        self.labeled_addresses.extend(call_result.labels.clone());
+        self.traces.extend(call_result.traces.clone().map(|traces| (TraceKind::Execution, traces)));
+        self.merge_coverages(call_result.coverage.clone());
+    }
+
     /// Function to merge given coverage in current test result coverage.
     pub fn merge_coverages(&mut self, other_coverage: Option<HitMaps>) {
         let old_coverage = std::mem::take(&mut self.coverage);

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -625,7 +625,7 @@ impl<'a> ContractRunner<'a> {
 
     /// Runs a fuzzed test.
     ///
-    /// Applies before test txes (if any), fuzz the current function and returns the
+    /// Applies the before test txes (if any), fuzzes the current function and returns the
     /// `TestResult`.
     ///
     /// Before test txes are applied in order and state modifications committed to the EVM database

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -651,7 +651,8 @@ impl<'a> ContractRunner<'a> {
         };
 
         // Run fuzz test.
-        let fuzzed_executor = FuzzedExecutor::new(executor, runner, self.sender, fuzz_config);
+        let fuzzed_executor =
+            FuzzedExecutor::new(executor.into_owned(), runner, self.sender, fuzz_config);
         let result = fuzzed_executor.fuzz(
             func,
             &fuzz_fixtures,
@@ -682,7 +683,7 @@ impl<'a> ContractRunner<'a> {
         &self,
         func: &Function,
         setup: TestSetup,
-    ) -> Result<(Executor, TestResult, Address), TestResult> {
+    ) -> Result<(Cow<'_, Executor>, TestResult, Address), TestResult> {
         let address = setup.address;
         let mut executor = Cow::Borrowed(&self.executor);
         let mut test_result = TestResult::new(setup);
@@ -713,6 +714,6 @@ impl<'a> ContractRunner<'a> {
                 }
             }
         }
-        Ok((executor.into_owned(), test_result, address))
+        Ok((executor, test_result, address))
     }
 }

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -364,3 +364,6 @@ test_repro!(8168);
 
 // https://github.com/foundry-rs/foundry/issues/8383
 test_repro!(8383);
+
+// https://github.com/foundry-rs/foundry/issues/1543
+test_repro!(1543);

--- a/testdata/default/repros/Issue1543.t.sol
+++ b/testdata/default/repros/Issue1543.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+
+struct BeforeTestSelectors {
+    bytes4 test_selector;
+    bytes4[] before_selectors;
+}
+
+contract SelfDestructor {
+    function kill() external {
+        selfdestruct(payable(msg.sender));
+    }
+}
+
+// https://github.com/foundry-rs/foundry/issues/1543
+contract Issue1543Test is DSTest {
+    SelfDestructor killer;
+    uint256 a;
+    uint256 b;
+
+    function setUp() public {
+        killer = new SelfDestructor();
+    }
+
+    function beforeTestSelectors() public pure returns (BeforeTestSelectors[] memory) {
+        BeforeTestSelectors[] memory targets = new BeforeTestSelectors[](3);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = this.kill_contract.selector;
+        targets[0] = BeforeTestSelectors(this.testKill.selector, selectors);
+
+        selectors = new bytes4[](3);
+        selectors[0] = this.testA.selector;
+        selectors[1] = this.testA.selector;
+        selectors[2] = this.testA.selector;
+        targets[1] = BeforeTestSelectors(this.testA.selector, selectors);
+
+        selectors = new bytes4[](1);
+        selectors[0] = this.setB.selector;
+        targets[2] = BeforeTestSelectors(this.testB.selector, selectors);
+
+        return targets;
+    }
+
+    function kill_contract() external {
+        uint256 killer_size = getSize(address(killer));
+        require(killer_size == 106);
+        killer.kill();
+    }
+
+    function testKill() public view {
+        uint256 killer_size = getSize(address(killer));
+        require(killer_size == 0);
+    }
+
+    function getSize(address c) public view returns (uint32) {
+        uint32 size;
+        assembly {
+            size := extcodesize(c)
+        }
+        return size;
+    }
+
+    function testA() public {
+        require(a <= 3);
+        a += 1;
+    }
+
+    function testSimpleA() public view {
+        require(a == 0);
+    }
+
+    function setB() public {
+        b = 100;
+    }
+
+    function testB() public {
+        require(b == 100);
+    }
+}

--- a/testdata/default/repros/Issue1543.t.sol
+++ b/testdata/default/repros/Issue1543.t.sol
@@ -3,11 +3,6 @@ pragma solidity 0.8.18;
 
 import "ds-test/test.sol";
 
-struct BeforeTestSelectors {
-    bytes4 test_selector;
-    bytes4[] before_selectors;
-}
-
 contract SelfDestructor {
     function kill() external {
         selfdestruct(payable(msg.sender));

--- a/testdata/default/repros/Issue1543.t.sol
+++ b/testdata/default/repros/Issue1543.t.sol
@@ -25,7 +25,7 @@ contract Issue1543Test is DSTest {
     }
 
     function beforeTestSelectors() public pure returns (BeforeTestSelectors[] memory) {
-        BeforeTestSelectors[] memory targets = new BeforeTestSelectors[](3);
+        BeforeTestSelectors[] memory targets = new BeforeTestSelectors[](4);
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = this.kill_contract.selector;
         targets[0] = BeforeTestSelectors(this.testKill.selector, selectors);
@@ -39,6 +39,11 @@ contract Issue1543Test is DSTest {
         selectors = new bytes4[](1);
         selectors[0] = this.setB.selector;
         targets[2] = BeforeTestSelectors(this.testB.selector, selectors);
+
+        selectors = new bytes4[](2);
+        selectors[0] = this.testA.selector;
+        selectors[1] = this.setB.selector;
+        targets[3] = BeforeTestSelectors(this.testC.selector, selectors);
 
         return targets;
     }
@@ -77,5 +82,10 @@ contract Issue1543Test is DSTest {
 
     function testB() public {
         require(b == 100);
+    }
+
+    function testC(uint256 x) public {
+        assertEq(a, 1);
+        assertEq(b, 100);
     }
 }

--- a/testdata/default/repros/Issue1543.t.sol
+++ b/testdata/default/repros/Issue1543.t.sol
@@ -24,28 +24,29 @@ contract Issue1543Test is DSTest {
         killer = new SelfDestructor();
     }
 
-    function beforeTestSelectors() public pure returns (BeforeTestSelectors[] memory) {
-        BeforeTestSelectors[] memory targets = new BeforeTestSelectors[](4);
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = this.kill_contract.selector;
-        targets[0] = BeforeTestSelectors(this.testKill.selector, selectors);
+    function beforeTestSetup(bytes4 testSelector) public pure returns (bytes[] memory beforeTestCalldata) {
+        if (testSelector == this.testKill.selector) {
+            beforeTestCalldata = new bytes[](1);
+            beforeTestCalldata[0] = abi.encodePacked(this.kill_contract.selector);
+        }
 
-        selectors = new bytes4[](3);
-        selectors[0] = this.testA.selector;
-        selectors[1] = this.testA.selector;
-        selectors[2] = this.testA.selector;
-        targets[1] = BeforeTestSelectors(this.testA.selector, selectors);
+        if (testSelector == this.testA.selector) {
+            beforeTestCalldata = new bytes[](3);
+            beforeTestCalldata[0] = abi.encodePacked(this.testA.selector);
+            beforeTestCalldata[1] = abi.encodePacked(this.testA.selector);
+            beforeTestCalldata[2] = abi.encodePacked(this.testA.selector);
+        }
 
-        selectors = new bytes4[](1);
-        selectors[0] = this.setB.selector;
-        targets[2] = BeforeTestSelectors(this.testB.selector, selectors);
+        if (testSelector == this.testB.selector) {
+            beforeTestCalldata = new bytes[](1);
+            beforeTestCalldata[0] = abi.encodePacked(this.setB.selector);
+        }
 
-        selectors = new bytes4[](2);
-        selectors[0] = this.testA.selector;
-        selectors[1] = this.setB.selector;
-        targets[3] = BeforeTestSelectors(this.testC.selector, selectors);
-
-        return targets;
+        if (testSelector == this.testC.selector) {
+            beforeTestCalldata = new bytes[](2);
+            beforeTestCalldata[0] = abi.encodePacked(this.testA.selector);
+            beforeTestCalldata[1] = abi.encodeWithSignature("setBWithValue(uint256)", 111);
+        }
     }
 
     function kill_contract() external {
@@ -84,8 +85,12 @@ contract Issue1543Test is DSTest {
         require(b == 100);
     }
 
-    function testC(uint256 x) public {
+    function setBWithValue(uint256 value) public {
+        b = value;
+    }
+
+    function testC(uint256 h) public {
         assertEq(a, 1);
-        assertEq(b, 100);
+        assertEq(b, 111);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8485
Closes #1543 

Atm unit / fuzz tests are performed only against the state resulting from `setup` call, but would be nice to support configuration of other txes / state modification for individual tests. This PR adds the possibility of per unit / fuzz test configuration of before test selectors / txes.

Configuration can be specified by implementing `beforeTestSetup` function
```Solidity
function beforeTestSetup(bytes4 testSelector) public pure returns (bytes[] memory beforeTestCalldata)
```
where
- `bytes4 testSelector` is the selector of the test that will run on before txes modified state
- `bytes[] memory beforeTestCalldata` is an array of arbitrary calldatas that will be applied before test run
E.g. for configuring `testC` to be executed on state modified by `testA` and `setB(uint256)` functions the `beforeTestCalldata` can be implemented as
```Solidity
    function beforeTestSetup(bytes4 testSelector) public pure returns (bytes[] memory beforeTestCalldata) {
        if (testSelector == this.testC.selector) {
            beforeTestCalldata = new bytes[](2);
            beforeTestCalldata[0] = abi.encodePacked(this.testA.selector);
            beforeTestCalldata[1] = abi.encodeWithSignature("setB(uint256)", 111);
        }
    }
```

- To continue test execution the before test call should be success.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
