### PR TITLE
fix(coverage): proper instruction for 1st branch anchor

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -417,7 +417,7 @@ impl<'a> ContractVisitor<'a> {
                     if let Some(NodeType::Identifier) = expr.as_ref().map(|expr| &expr.node_type) {
                         // Might be a require call, add branch coverage.
                         let name: Option<String> = expr.and_then(|expr| expr.attribute("name"));
-                        if let Some("require") = name.as_deref() {
+                        if let Some("require" | "assert") = name.as_deref() {
                             let branch_id = self.branch_id;
                             self.branch_id += 1;
                             self.push_item(CoverageItem {

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -149,7 +149,7 @@ pub fn find_anchor_branch(
                     ItemAnchor {
                         item_id,
                         // The first branch is the opcode directly after JUMPI
-                        instruction: pc + 1,
+                        instruction: pc + 2,
                     },
                     ItemAnchor { item_id, instruction: pc_jump },
                 ));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Re https://t.me/foundry_support/55383
PR https://github.com/foundry-rs/foundry/pull/8414 fixed the branch coverage report (issue reported in #7784 ) by properly mapping if/else source bodies

https://github.com/foundry-rs/foundry/blob/5af9d16ecb620192d4fe5ae61d33e429b7f5aff3/crates/evm/coverage/src/analysis.rs#L236-L241

but it also made the wrong assumption that the first branch opcode after JUMPI should be `pc + 1`

https://github.com/foundry-rs/foundry/blob/5af9d16ecb620192d4fe5ae61d33e429b7f5aff3/crates/evm/coverage/src/anchors.rs#L149-L153

This is not true because the evaluation is done for the opcode before JUMPI (so JUMPI is `pc + 1` and next opcode is `pc + 2`)

https://github.com/foundry-rs/foundry/blob/5af9d16ecb620192d4fe5ae61d33e429b7f5aff3/crates/evm/coverage/src/anchors.rs#L134-L136

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Proper source mappings fixes #7784 and #4294 (require and assert branches properly reported now), hence this PR reverts the instruction for first branch and adds back branching for asserts
Added unit tests for all require/assert branches
#4309 #4310 and #4315 tests were passing with wrong branch opcode, will follow up with a fix for them