### PR TITLE
fix: some verify-bytecode fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,7 @@ dependencies = [
 name = "forge-verify"
 version = "0.2.0"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -22,6 +22,7 @@ serde_json.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
+alloy-dyn-abi.workspace = true
 revm-primitives.workspace = true
 serde.workspace = true
 eyre.workspace = true

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -184,6 +184,13 @@ impl VerifyBytecodeArgs {
         }
         .map(|args| {
             if let Some(constructor) = artifact.abi.as_ref().and_then(|abi| abi.constructor()) {
+                if constructor.inputs.len() != args.len() {
+                    eyre::bail!(
+                        "Mismatch of constructor arguments length. Expected {}, got {}",
+                        constructor.inputs.len(),
+                        args.len()
+                    );
+                }
                 encode_args(&constructor.inputs, &args)
                     .map(|args| DynSolValue::Tuple(args).abi_encode())
             } else {


### PR DESCRIPTION
Cleans up code a bit, removing redundant `Result` and preferring checking `match_type.is_none()` instead of keeping a separate bool.

Also removes `--verification-type` flag as it doesn't make much sense because user'd expect us to determine match type during comparison.

Closes #8505. The cause is etherscan bug - it returns invalid constructor arguments for mentioned contract.

I've updated logic to not rely on etherscan constructor args if `--constructor-args` are passed.

Also updated `--constructor-args` to expect multiple values and abi-encode them similarly to `forge create` as this seems to be the expected UX at least by the author of #8505. I've kept an option for abi-encoded args as `--encoded-constructor-args`

