### PR TITLE
fix: respect profiles in inline configs

### DIFF
--- a/crates/config/src/inline/conf_parser.rs
+++ b/crates/config/src/inline/conf_parser.rs
@@ -37,12 +37,14 @@ where
     /// - `Err(InlineConfigParserError)` in case of wrong configuration.
     fn try_merge(&self, configs: &[String]) -> Result<Option<Self>, InlineConfigParserError>;
 
-    /// Validates and merges the natspec configs into the current config.
+    /// Validates and merges the natspec configs for current profile into the current config.
     fn merge(&self, natspec: &NatSpec) -> Result<Option<Self>, InlineConfigError> {
         let config_key = Self::config_key();
 
-        let configs =
-            natspec.config_lines().filter(|l| l.contains(&config_key)).collect::<Vec<String>>();
+        let configs = natspec
+            .current_profile_configs()
+            .filter(|l| l.contains(&config_key))
+            .collect::<Vec<String>>();
 
         self.try_merge(&configs).map_err(|e| {
             let line = natspec.debug_context();

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -904,6 +904,7 @@ forgetest_init!(should_not_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
 });
 
 // tests internal functions trace
+#[cfg(not(feature = "isolate-by-default"))]
 forgetest_init!(internal_functions_trace, |prj, cmd| {
     prj.wipe_contracts();
     prj.clear();
@@ -971,6 +972,7 @@ Traces:
 });
 
 // tests internal functions trace with memory decoding
+#[cfg(not(feature = "isolate-by-default"))]
 forgetest_init!(internal_functions_trace_memory, |prj, cmd| {
     prj.wipe_contracts();
     prj.clear();


### PR DESCRIPTION
## Motivation

This got lost in https://github.com/foundry-rs/foundry/pull/8388

Also disables couple tests for test-isolate job 

