### PR TITLE
Update `ScriptArgs::preprocess()` visibility to `pub`

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -195,7 +195,7 @@ pub struct ScriptArgs {
 }
 
 impl ScriptArgs {
-    async fn preprocess(self) -> Result<PreprocessedState> {
+    pub async fn preprocess(self) -> Result<PreprocessedState> {
         let script_wallets =
             ScriptWallets::new(self.wallets.get_multi_wallet().await?, self.evm_opts.sender);
 


### PR DESCRIPTION
This PR updates the `preprocess()` function's visibility to `pub` so that projects using Foundry as a dependency can preprocess script args.