### PR TITLE
fix: etherscan identifier for scripts

### DIFF
--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -332,14 +332,6 @@ impl ExecutedState {
             self.script_config.evm_opts.get_remote_chain_id().await,
         )?;
 
-        // Decoding traces using etherscan is costly as we run into rate limits,
-        // causing scripts to run for a very long time unnecessarily.
-        // Therefore, we only try and use etherscan if the user has provided an API key.
-        let should_use_etherscan_traces = self.script_config.config.etherscan_api_key.is_some();
-        if !should_use_etherscan_traces {
-            identifier.etherscan = None;
-        }
-
         for (_, trace) in &self.execution_result.traces {
             decoder.identify(trace, &mut identifier);
         }


### PR DESCRIPTION
Removes incorrect check from `ExecutedState::build_trace_decoder`. It is redundant as `with_etherscan` will already set etherscan identifier to `None` if no key is found. 

This check always used `etherscan_api_key` and didn't take `[etherscan]` section into account, thus causing script traces not being identified unless `--etherscan-api-key` was set.


