### PR TITLE
feat(cheatcodes): add `vm.getFoundryVersion()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,6 +3576,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "base64 0.22.1",
+ "chrono",
  "dialoguer",
  "eyre",
  "foundry-cheatcodes-spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "thiserror",
  "toml 0.8.15",
  "tracing",
+ "vergen",
  "walkdir",
 ]
 

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -54,6 +54,7 @@ semver.workspace = true
 rustc-hash.workspace = true
 dialoguer = "0.11.0"
 rand = "0.8"
+chrono.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -14,6 +14,13 @@ exclude.workspace = true
 [lints]
 workspace = true
 
+[build-dependencies]
+vergen = { workspace = true, default-features = false, features = [
+    "build",
+    "git",
+    "gitcl",
+] }
+
 [dependencies]
 foundry-cheatcodes-spec.workspace = true
 foundry-common.workspace = true

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4993,6 +4993,26 @@
     },
     {
       "func": {
+        "id": "getFoundryVersion",
+        "description": "Returns the Foundry version.",
+        "declaration": "function getFoundryVersion() external view returns (string memory version);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getFoundryVersion()",
+        "selector": "0xea991bb5",
+        "selectorBytes": [
+          234,
+          153,
+          27,
+          181
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getLabel",
         "description": "Gets the label for the specified address.",
         "declaration": "function getLabel(address account) external view returns (string memory currentLabel);",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4994,7 +4994,7 @@
     {
       "func": {
         "id": "getFoundryVersion",
-        "description": "Returns the Foundry version.\nFormat: <cargo_version>+<git_sha>+<build_timestamp>\nSample output: 0.2.0+faa94c384+202407110019",
+        "description": "Returns the Foundry version.\nFormat: <cargo_version>+<git_sha>+<build_timestamp>\nSample output: 0.2.0+faa94c384+202407110019\nNote: Build timestamps may vary slightly across platforms due to separate CI jobs.\nFor reliable version comparisons, use YYYYMMDD0000 format (e.g., >= 202407110000)\nto compare timestamps while ignoring minor time differences.",
         "declaration": "function getFoundryVersion() external view returns (string memory version);",
         "visibility": "external",
         "mutability": "view",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4994,7 +4994,7 @@
     {
       "func": {
         "id": "getFoundryVersion",
-        "description": "Returns the Foundry version.\nFormat: <cargo_version>+<build_timestamp>\nSample output: 0.2.0+202407110019",
+        "description": "Returns the Foundry version.\nFormat: <cargo_version>+<git_sha>+<build_timestamp>\nSample output: 0.2.0+faa94c384+202407110019",
         "declaration": "function getFoundryVersion() external view returns (string memory version);",
         "visibility": "external",
         "mutability": "view",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4994,7 +4994,7 @@
     {
       "func": {
         "id": "getFoundryVersion",
-        "description": "Returns the Foundry version.",
+        "description": "Returns the Foundry version.\nFormat: <cargo_version>+<build_timestamp>\nSample output: 0.2.0+202407110019",
         "declaration": "function getFoundryVersion() external view returns (string memory version);",
         "visibility": "external",
         "mutability": "view",

--- a/crates/cheatcodes/build.rs
+++ b/crates/cheatcodes/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vergen::EmitBuilder::builder().build_timestamp().git_sha(true).emit().unwrap();
+}

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -702,6 +702,10 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Safe)]
     function breakpoint(string calldata char, bool value) external;
 
+    /// Returns the Foundry version.
+    #[cheatcode(group = Testing, safety = Safe)]
+    function getFoundryVersion() external view returns (string memory version);
+
     /// Returns the RPC url for the given alias.
     #[cheatcode(group = Testing, safety = Safe)]
     function rpcUrl(string calldata rpcAlias) external view returns (string memory json);

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -703,8 +703,8 @@ interface Vm {
     function breakpoint(string calldata char, bool value) external;
 
     /// Returns the Foundry version.
-    /// Format: <cargo_version>+<build_timestamp>
-    /// Sample output: 0.2.0+202407110019
+    /// Format: <cargo_version>+<git_sha>+<build_timestamp>
+    /// Sample output: 0.2.0+faa94c384+202407110019
     #[cheatcode(group = Testing, safety = Safe)]
     function getFoundryVersion() external view returns (string memory version);
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -703,6 +703,8 @@ interface Vm {
     function breakpoint(string calldata char, bool value) external;
 
     /// Returns the Foundry version.
+    /// Format: <cargo_version>+<build_timestamp>
+    /// Sample output: 0.2.0+202407110019
     #[cheatcode(group = Testing, safety = Safe)]
     function getFoundryVersion() external view returns (string memory version);
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -705,6 +705,9 @@ interface Vm {
     /// Returns the Foundry version.
     /// Format: <cargo_version>+<git_sha>+<build_timestamp>
     /// Sample output: 0.2.0+faa94c384+202407110019
+    /// Note: Build timestamps may vary slightly across platforms due to separate CI jobs.
+    /// For reliable version comparisons, use YYYYMMDD0000 format (e.g., >= 202407110000)
+    /// to compare timestamps while ignoring minor time differences.
     #[cheatcode(group = Testing, safety = Safe)]
     function getFoundryVersion() external view returns (string memory version);
 

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -1,5 +1,7 @@
 //! Implementations of [`Testing`](spec::Group::Testing) cheatcodes.
 
+use std::env;
+
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Error, Result, Vm::*};
 use alloy_primitives::Address;
 use alloy_sol_types::SolValue;
@@ -30,6 +32,18 @@ impl Cheatcode for breakpoint_1Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { char, value } = self;
         breakpoint(ccx.state, &ccx.caller, char, *value)
+    }
+}
+
+impl Cheatcode for getFoundryVersionCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self {} = self;
+        let version = env!("CARGO_PKG_VERSION");
+        let git_sha = env::var("VERGEN_GIT_SHA").unwrap_or_else(|_| "unknown".to_string());
+        let build_timestamp =
+            env::var("VERGEN_BUILD_TIMESTAMP").unwrap_or_else(|_| "unknown".to_string());
+        let foundry_version = format!("{version} ({git_sha} {build_timestamp})");
+        Ok(foundry_version.abi_encode())
     }
 }
 

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -40,15 +40,12 @@ impl Cheatcode for getFoundryVersionCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         let cargo_version = env!("CARGO_PKG_VERSION");
-        let build_timestamp = env::var("VERGEN_BUILD_TIMESTAMP")
-            .map(|ts| {
-                DateTime::parse_from_rfc3339(&ts)
-                    .expect("Invalid build timestamp format")
-                    .format("%Y%m%d%H%M")
-                    .to_string()
-            })
-            .unwrap_or_else(|_| "unknown".to_string());
-        let foundry_version = format!("{cargo_version}+{build_timestamp}");
+        let git_sha = env!("VERGEN_GIT_SHA");
+        let build_timestamp = DateTime::parse_from_rfc3339(env!("VERGEN_BUILD_TIMESTAMP"))
+            .expect("Invalid build timestamp format")
+            .format("%Y%m%d%H%M")
+            .to_string();
+        let foundry_version = format!("{cargo_version}+{git_sha}+{build_timestamp}");
         Ok(foundry_version.abi_encode())
     }
 }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -245,6 +245,7 @@ interface Vm {
     function getBlockTimestamp() external view returns (uint256 timestamp);
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);
     function getDeployedCode(string calldata artifactPath) external view returns (bytes memory runtimeBytecode);
+    function getFoundryVersion() external view returns (string memory version);
     function getLabel(address account) external view returns (string memory currentLabel);
     function getMappingKeyAndParentOf(address target, bytes32 elementSlot) external returns (bool found, bytes32 key, bytes32 parent);
     function getMappingLength(address target, bytes32 mappingSlot) external returns (uint256 length);

--- a/testdata/default/cheats/GetFoundryVersion.t.sol
+++ b/testdata/default/cheats/GetFoundryVersion.t.sol
@@ -7,9 +7,16 @@ import "cheats/Vm.sol";
 contract GetFoundryVersionTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
-    function testChainId() public {
+    function testGetFoundryVersion() public view {
         string memory version = vm.getFoundryVersion();
-        uint256 buildId = vm.parseUint(vm.split(version, "+")[1]);
-        require(buildId >= 202406111234, "too old");
+
+        string memory cargoVersion = vm.split(version, "+")[0];
+        require(bytes(cargoVersion).length > 0, "Cargo version is empty");
+
+        string memory gitSHA = vm.split(version, "+")[1];
+        require(bytes(gitSHA).length > 0, "Git SHA is empty");
+
+        uint256 buildTimestamp = vm.parseUint(vm.split(version, "+")[2]);
+        require(buildTimestamp >= 202406111234, "too old");
     }
 }

--- a/testdata/default/cheats/GetFoundryVersion.t.sol
+++ b/testdata/default/cheats/GetFoundryVersion.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract GetFoundryVersionTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testChainId() public {
+        string memory version = vm.getFoundryVersion();
+        assertEq(version, ""); // TODO: Update the test.
+    }
+}

--- a/testdata/default/cheats/GetFoundryVersion.t.sol
+++ b/testdata/default/cheats/GetFoundryVersion.t.sol
@@ -8,15 +8,19 @@ contract GetFoundryVersionTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testGetFoundryVersion() public view {
-        string memory version = vm.getFoundryVersion();
+        string memory fullVersionString = vm.getFoundryVersion();
 
-        string memory cargoVersion = vm.split(version, "+")[0];
-        require(bytes(cargoVersion).length > 0, "Cargo version is empty");
+        string[] memory versionComponents = vm.split(fullVersionString, "+");
+        require(versionComponents.length == 3, "Invalid version format");
 
-        string memory gitSHA = vm.split(version, "+")[1];
-        require(bytes(gitSHA).length > 0, "Git SHA is empty");
+        string memory semanticVersion = versionComponents[0];
+        require(bytes(semanticVersion).length > 0, "Semantic version is empty");
 
-        uint256 buildTimestamp = vm.parseUint(vm.split(version, "+")[2]);
-        require(buildTimestamp >= 202406111234, "too old");
+        string memory commitHash = versionComponents[1];
+        require(bytes(commitHash).length > 0, "Commit hash is empty");
+
+        uint256 buildUnixTimestamp = vm.parseUint(versionComponents[2]);
+        uint256 minimumAcceptableTimestamp = 202406111234;
+        require(buildUnixTimestamp >= minimumAcceptableTimestamp, "Build timestamp is too old");
     }
 }

--- a/testdata/default/cheats/GetFoundryVersion.t.sol
+++ b/testdata/default/cheats/GetFoundryVersion.t.sol
@@ -9,6 +9,7 @@ contract GetFoundryVersionTest is DSTest {
 
     function testChainId() public {
         string memory version = vm.getFoundryVersion();
-        assertEq(version, ""); // TODO: Update the test.
+        uint256 buildId = vm.parseUint(vm.split(version, "+")[1]);
+        require(buildId >= 202406111234, "too old");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #8036 

Implement a new cheatcode to get the foundry version: `vm.getFoundryVersion`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The current versioning scheme incorporates the cargo version, the git SHA and the UTC timestamp of the build to simplify differentiating by version number until v1 is released.

The version format follows this structure: `<cargo_version>+<git_sha>+<build_timestamp>`.

For example, a typical version might look like this: `0.2.0+faa94c384+202407110019`.

## Test

Install `forge` locally.

```bash
cargo install --path ./crates/forge --profile release --force --locked
alias forgedev="$(pwd)/target/release/forge" 
```

Run `GetFoundryVersion` test.

```bash
$ pushd testdata
$ forgedev test --match-contract GetFoundryVersion
[⠊] Compiling...
[⠢] Compiling 1 files with Solc 0.8.18
[⠆] Solc 0.8.18 finished in 101.72ms
Compiler run successful!

Ran 1 test for default/cheats/GetFoundryVersion.t.sol:GetFoundryVersionTest
[PASS] testGetFoundryVersion() (gas: 12955)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 425.29µs (111.42µs CPU time)

Ran 1 test suite in 148.77ms (425.29µs CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
```
