### PR TITLE
chore: decode only ASCII reverts

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -582,10 +582,13 @@ pub(crate) fn handle_expect_revert(
         Ok(success_return())
     } else {
         let stringify = |data: &[u8]| {
-            String::abi_decode(data, false)
-                .ok()
-                .or_else(|| std::str::from_utf8(data).ok().map(ToOwned::to_owned))
-                .unwrap_or_else(|| hex::encode_prefixed(data))
+            if let Ok(s) = String::abi_decode(data, false) {
+                return s;
+            }
+            if data.is_ascii() {
+                return std::str::from_utf8(data).unwrap().to_owned();
+            }
+            hex::encode_prefixed(data)
         };
         Err(fmt_err!(
             "Error != expected error: {} != {}",

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -171,9 +171,9 @@ impl RevertDecoder {
             return Some(s);
         }
 
-        // UTF-8-encoded string.
-        if let Ok(s) = std::str::from_utf8(err) {
-            return Some(s.to_string());
+        // ASCII string.
+        if err.is_ascii() {
+            return Some(std::str::from_utf8(err).unwrap().to_string());
         }
 
         // Generic custom error.


### PR DESCRIPTION
Sometimes revert data happens to be valid UTF-8 but not in any meaningful way. By restricting to ASCII it's more likely that the revert is actually human-readable.