### PR TITLE
test: consolidate RPC URLs, remove flaky ones

### DIFF
--- a/.github/scripts/format.sh
+++ b/.github/scripts/format.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# We have to ignore at shell level because testdata/ is not a valid Foundry project,
+# so running `forge fmt` with `--root testdata` won't actually check anything
+shopt -s extglob
+cargo run --bin forge -- fmt "$@" $(find testdata -name '*.sol' ! -name Vm.sol)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,11 +86,7 @@ jobs:
           cache-on-failure: true
       - name: forge fmt
         shell: bash
-        # We have to ignore at shell level because testdata/ is not a valid Foundry project,
-        # so running `forge fmt` with `--root testdata` won't actually check anything
-        run: |
-          shopt -s extglob
-          cargo run --bin forge -- fmt --check $(find testdata -name '*.sol' ! -name Vm.sol)
+        run: ./.github/scripts/format.sh --check
 
   crate-checks:
     runs-on: ubuntu-latest

--- a/crates/forge/tests/it/fork.rs
+++ b/crates/forge/tests/it/fork.rs
@@ -110,8 +110,8 @@ async fn test_storage_caching_config() {
         Filter::new("testStorageCaching", ".*", &format!(".*cheats{RE_PATH_SEPARATOR}Fork"))
             .exclude_tests(".*Revert");
     TestConfig::with_filter(runner, filter).run().await;
-    let cache_dir = Config::foundry_block_cache_dir(Chain::mainnet(), 19800000);
-    assert!(!cache_dir.unwrap().exists());
+    let cache_dir = Config::foundry_block_cache_dir(Chain::mainnet(), 19800000).unwrap();
+    let _ = fs::remove_file(cache_dir);
 
     // no_storage_caching set to false: storage should be cached
     let mut config = TEST_DATA_DEFAULT.config.clone();

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -1,5 +1,6 @@
 //! Test helpers for Forge integration tests.
 
+use alloy_chains::NamedChain;
 use alloy_primitives::U256;
 use forge::{
     revm::primitives::SpecId, MultiContractRunner, MultiContractRunnerBuilder, TestOptions,
@@ -18,7 +19,7 @@ use foundry_evm::{
     constants::CALLER,
     opts::{Env, EvmOpts},
 };
-use foundry_test_utils::{fd_lock, init_tracing};
+use foundry_test_utils::{fd_lock, init_tracing, rpc::next_rpc_endpoint};
 use once_cell::sync::Lazy;
 use std::{
     env, fmt,
@@ -357,18 +358,13 @@ pub fn manifest_root() -> &'static Path {
 /// the RPC endpoints used during tests
 pub fn rpc_endpoints() -> RpcEndpoints {
     RpcEndpoints::new([
-        (
-            "rpcAlias",
-            RpcEndpoint::Url(
-                "https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf".to_string(),
-            ),
-        ),
-        (
-            "rpcAliasSepolia",
-            RpcEndpoint::Url(
-                "https://eth-sepolia.g.alchemy.com/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf".to_string(),
-            ),
-        ),
-        ("rpcEnvAlias", RpcEndpoint::Env("${RPC_ENV_ALIAS}".to_string())),
+        ("mainnet", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Mainnet))),
+        ("mainnet2", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Mainnet))),
+        ("sepolia", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Sepolia))),
+        ("optimism", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Optimism))),
+        ("arbitrum", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Arbitrum))),
+        ("polygon", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Polygon))),
+        ("avaxTestnet", RpcEndpoint::Url("https://api.avax-test.network/ext/bc/C/rpc".into())),
+        ("rpcEnvAlias", RpcEndpoint::Env("${RPC_ENV_ALIAS}".into())),
     ])
 }

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -163,7 +163,7 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
             _ => chain.as_str(),
         }
     };
-    let full = if prefix == "" { network.to_string() } else { format!("{prefix}-{network}") };
+    let full = if prefix.is_empty() { network.to_string() } else { format!("{prefix}-{network}") };
 
     match (is_ws, is_infura) {
         (false, true) => format!("https://{full}.infura.io/v3/{key}"),

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -1,5 +1,6 @@
 //! RPC API keys utilities.
 
+use foundry_config::NamedChain;
 use once_cell::sync::Lazy;
 use rand::seq::SliceRandom;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -18,7 +19,7 @@ static INFURA_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
 });
 
 // List of alchemy keys for mainnet
-static ALCHEMY_MAINNET_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
+static ALCHEMY_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
     let mut keys = vec![
         "ib1f4u1ojm-9lJJypwkeZeG-75TJRB7O",
         "7mTtk6IW4DwroGnKmG_bOWri2hyaGYhX",
@@ -44,6 +45,9 @@ static ALCHEMY_MAINNET_KEYS: Lazy<Vec<&'static str>> = Lazy::new(|| {
         "sDNCLu_e99YZRkbWlVHiuM3BQ5uxYCZU",
         "M6lfpxTBrywHOvKXOS4yb7cTTpa25ZQ9",
         "UK8U_ogrbYB4lQFTGJHHDrbiS4UPnac6",
+        "Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf",
+        "UVatYU2Ax0rX6bDiqddeTRDdcCxzdpoE",
+        "bVjX9v-FpmUhf5R_oHIgwJx2kXvYPRbx",
     ];
 
     keys.shuffle(&mut rand::thread_rng());
@@ -79,61 +83,94 @@ fn next() -> usize {
 }
 
 fn num_keys() -> usize {
-    INFURA_KEYS.len() + ALCHEMY_MAINNET_KEYS.len()
+    INFURA_KEYS.len() + ALCHEMY_KEYS.len()
 }
 
 /// Returns the next _mainnet_ rpc endpoint in inline
 ///
 /// This will rotate all available rpc endpoints
 pub fn next_http_rpc_endpoint() -> String {
-    next_rpc_endpoint("mainnet")
+    next_rpc_endpoint(NamedChain::Mainnet)
 }
 
 /// Returns the next _mainnet_ rpc endpoint in inline
 ///
 /// This will rotate all available rpc endpoints
 pub fn next_ws_rpc_endpoint() -> String {
-    next_ws_endpoint("mainnet")
+    next_ws_endpoint(NamedChain::Mainnet)
 }
 
 /// Returns the next HTTP RPC endpoint.
-pub fn next_rpc_endpoint(network: &str) -> String {
-    let idx = next() % num_keys();
-    if idx < INFURA_KEYS.len() {
-        format!("https://{network}.infura.io/v3/{}", INFURA_KEYS[idx])
-    } else {
-        let idx = idx - INFURA_KEYS.len();
-        format!("https://eth-{network}.alchemyapi.io/v2/{}", ALCHEMY_MAINNET_KEYS[idx])
-    }
+pub fn next_rpc_endpoint(chain: NamedChain) -> String {
+    next_url(false, chain)
 }
 
 /// Returns the next WS RPC endpoint.
-pub fn next_ws_endpoint(network: &str) -> String {
-    let idx = next() % num_keys();
-    if idx < INFURA_KEYS.len() {
-        format!("wss://{network}.infura.io/v3/{}", INFURA_KEYS[idx])
-    } else {
-        let idx = idx - INFURA_KEYS.len();
-        format!("wss://eth-{network}.alchemyapi.io/v2/{}", ALCHEMY_MAINNET_KEYS[idx])
-    }
+pub fn next_ws_endpoint(chain: NamedChain) -> String {
+    next_url(true, chain)
 }
 
 /// Returns endpoint that has access to archive state
 pub fn next_http_archive_rpc_endpoint() -> String {
-    let idx = next() % ALCHEMY_MAINNET_KEYS.len();
-    format!("https://eth-mainnet.alchemyapi.io/v2/{}", ALCHEMY_MAINNET_KEYS[idx])
+    let idx = next() % ALCHEMY_KEYS.len();
+    format!("https://eth-mainnet.g.alchemy.com/v2/{}", ALCHEMY_KEYS[idx])
 }
 
 /// Returns endpoint that has access to archive state
 pub fn next_ws_archive_rpc_endpoint() -> String {
-    let idx = next() % ALCHEMY_MAINNET_KEYS.len();
-    format!("wss://eth-mainnet.alchemyapi.io/v2/{}", ALCHEMY_MAINNET_KEYS[idx])
+    let idx = next() % ALCHEMY_KEYS.len();
+    format!("wss://eth-mainnet.g.alchemy.com/v2/{}", ALCHEMY_KEYS[idx])
 }
 
 /// Returns the next etherscan api key
 pub fn next_etherscan_api_key() -> String {
     let idx = next() % ETHERSCAN_MAINNET_KEYS.len();
     ETHERSCAN_MAINNET_KEYS[idx].to_string()
+}
+
+fn next_url(is_ws: bool, chain: NamedChain) -> String {
+    use NamedChain::*;
+
+    let idx = next() % num_keys();
+    let is_infura = idx < INFURA_KEYS.len();
+
+    let key = if is_infura { INFURA_KEYS[idx] } else { ALCHEMY_KEYS[idx - INFURA_KEYS.len()] };
+
+    // Nowhere near complete.
+    let prefix = if is_infura {
+        match chain {
+            Optimism => "optimism",
+            Arbitrum => "arbitrum",
+            Polygon => "polygon",
+            _ => "",
+        }
+    } else {
+        match chain {
+            Optimism => "opt",
+            Arbitrum => "arb",
+            Polygon => "polygon",
+            _ => "eth",
+        }
+    };
+    let network = if is_infura {
+        match chain {
+            Mainnet | Optimism | Arbitrum | Polygon => "mainnet",
+            _ => chain.as_str(),
+        }
+    } else {
+        match chain {
+            Mainnet | Optimism | Arbitrum | Polygon => "mainnet",
+            _ => chain.as_str(),
+        }
+    };
+    let full = if prefix == "" { network.to_string() } else { format!("{prefix}-{network}") };
+
+    match (is_ws, is_infura) {
+        (false, true) => format!("https://{full}.infura.io/v3/{key}"),
+        (true, true) => format!("wss://{full}.infura.io/v3/{key}"),
+        (false, false) => format!("https://{full}.g.alchemy.com/v2/{key}"),
+        (true, false) => format!("wss://{full}.g.alchemy.com/v2/{key}"),
+    }
 }
 
 #[cfg(test)]

--- a/testdata/default/cheats/Fork.t.sol
+++ b/testdata/default/cheats/Fork.t.sol
@@ -23,8 +23,8 @@ contract ForkTest is DSTest {
 
     // this will create two _different_ forks during setup
     function setUp() public {
-        forkA = vm.createFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", mainblock);
-        forkB = vm.createFork("https://eth-mainnet.alchemyapi.io/v2/9VWGraLx0tMiSWx05WH-ywgSVmMxs66W", mainblock - 1);
+        forkA = vm.createFork("mainnet", mainblock);
+        forkB = vm.createFork("mainnet2", mainblock - 1);
         testValue = 999;
     }
 
@@ -35,7 +35,7 @@ contract ForkTest is DSTest {
 
     // ensures we can create and select in one step
     function testCreateSelect() public {
-        uint256 fork = vm.createSelectFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf");
+        uint256 fork = vm.createSelectFork("mainnet");
         assertEq(fork, vm.activeFork());
     }
 
@@ -114,12 +114,12 @@ contract ForkTest is DSTest {
 
     // ensures forks change chain ids automatically
     function testCanAutoUpdateChainId() public {
-        vm.createSelectFork("https://polygon-pokt.nodies.app"); // Polygon mainnet RPC URL
-        assertEq(block.chainid, 137);
+        vm.createSelectFork("sepolia");
+        assertEq(block.chainid, 11155111);
     }
 
     // ensures forks storage is cached at block
     function testStorageCaching() public {
-        vm.createSelectFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 19800000);
+        vm.createSelectFork("mainnet", 19800000);
     }
 }

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -35,8 +35,8 @@ contract ForkTest is DSTest {
 
     // this will create two _different_ forks during setup
     function setUp() public {
-        mainnetFork = vm.createFork("rpcAlias");
-        optimismFork = vm.createFork("https://opt-mainnet.g.alchemy.com/v2/UVatYU2Ax0rX6bDiqddeTRDdcCxzdpoE");
+        mainnetFork = vm.createFork("mainnet");
+        optimismFork = vm.createFork("optimism");
     }
 
     // ensures forks use different ids
@@ -57,7 +57,7 @@ contract ForkTest is DSTest {
     }
 
     function testCanCreateSelect() public {
-        uint256 anotherFork = vm.createSelectFork("rpcAlias");
+        uint256 anotherFork = vm.createSelectFork("mainnet");
         assertEq(anotherFork, vm.activeFork());
     }
 
@@ -75,12 +75,12 @@ contract ForkTest is DSTest {
     // test that we can switch between forks, and "roll" blocks
     function testCanRollFork() public {
         vm.selectFork(mainnetFork);
-        uint256 otherMain = vm.createFork("rpcAlias", block.number - 1);
+        uint256 otherMain = vm.createFork("mainnet", block.number - 1);
         vm.selectFork(otherMain);
         uint256 mainBlock = block.number;
 
         uint256 forkedBlock = 14608400;
-        uint256 otherFork = vm.createFork("rpcAlias", forkedBlock);
+        uint256 otherFork = vm.createFork("mainnet", forkedBlock);
         vm.selectFork(otherFork);
         assertEq(block.number, forkedBlock);
 
@@ -101,7 +101,7 @@ contract ForkTest is DSTest {
         uint256 block = 16261704;
 
         // fork until previous block
-        uint256 fork = vm.createSelectFork("rpcAlias", block - 1);
+        uint256 fork = vm.createSelectFork("mainnet", block - 1);
 
         // block transactions in order: https://beaconcha.in/block/16261704#transactions
         // run transactions from current block until tx
@@ -230,7 +230,7 @@ contract ForkTest is DSTest {
     }
 
     function testRpcWithUrl() public {
-        bytes memory result = vm.rpc("rpcAlias", "eth_blockNumber", "[]");
+        bytes memory result = vm.rpc("mainnet", "eth_blockNumber", "[]");
         uint256 decodedResult = vm.parseUint(vm.toString(result));
         assertGt(decodedResult, 20_000_000);
     }

--- a/testdata/default/cheats/RpcUrls.t.sol
+++ b/testdata/default/cheats/RpcUrls.t.sol
@@ -9,8 +9,8 @@ contract RpcUrlTest is DSTest {
 
     // returns the correct url
     function testCanGetRpcUrl() public {
-        string memory url = vm.rpcUrl("rpcAlias"); // note: this alias is pre-configured in the test runner
-        assertEq(url, "https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf");
+        string memory url = vm.rpcUrl("mainnet");
+        assertEq(bytes(url).length, 69);
     }
 
     // returns an error if env alias does not exist
@@ -27,21 +27,12 @@ contract RpcUrlTest is DSTest {
         );
         string[2][] memory _urls = vm.rpcUrls();
 
-        string memory url = vm.rpcUrl("rpcAlias");
+        string memory url = vm.rpcUrl("mainnet");
         vm.setEnv("RPC_ENV_ALIAS", url);
         string memory envUrl = vm.rpcUrl("rpcEnvAlias");
         assertEq(url, envUrl);
 
         string[2][] memory allUrls = vm.rpcUrls();
-        assertEq(allUrls.length, 3);
-
-        string[2] memory val = allUrls[0];
-        assertEq(val[0], "rpcAlias");
-
-        string[2] memory env = allUrls[1];
-        assertEq(env[0], "rpcAliasSepolia");
-
-        string[2] memory env2 = allUrls[2];
-        assertEq(env2[0], "rpcEnvAlias");
+        assertGe(allUrls.length, 2);
     }
 }

--- a/testdata/default/fork/ForkSame_1.t.sol
+++ b/testdata/default/fork/ForkSame_1.t.sol
@@ -11,7 +11,7 @@ contract ForkTest is DSTest {
 
     // this will create two _different_ forks during setup
     function setUp() public {
-        forkA = vm.createFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 15_977_624);
+        forkA = vm.createFork("mainnet", 15_977_624);
     }
 
     function testDummy() public {

--- a/testdata/default/fork/ForkSame_2.t.sol
+++ b/testdata/default/fork/ForkSame_2.t.sol
@@ -11,7 +11,7 @@ contract ForkTest is DSTest {
 
     // this will create two _different_ forks during setup
     function setUp() public {
-        forkA = vm.createFork("https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 15_977_624);
+        forkA = vm.createFork("mainnet", 15_977_624);
     }
 
     function testDummy() public {

--- a/testdata/default/fork/Transact.t.sol
+++ b/testdata/default/fork/Transact.t.sol
@@ -20,7 +20,7 @@ contract TransactOnForkTest is DSTest {
 
     function testTransact() public {
         // A random block https://etherscan.io/block/17134913
-        uint256 fork = vm.createFork("rpcAlias", 17134913);
+        uint256 fork = vm.createFork("mainnet", 17134913);
         vm.selectFork(fork);
         // a random transfer transaction in the next block: https://etherscan.io/tx/0xaf6201d435b216a858c580e20512a16136916d894aa33260650e164e3238c771
         bytes32 tx = 0xaf6201d435b216a858c580e20512a16136916d894aa33260650e164e3238c771;
@@ -48,7 +48,7 @@ contract TransactOnForkTest is DSTest {
 
     function testTransactCooperatesWithCheatcodes() public {
         // A random block https://etherscan.io/block/16260609
-        uint256 fork = vm.createFork("rpcAlias", 16260609);
+        uint256 fork = vm.createFork("mainnet", 16260609);
         vm.selectFork(fork);
 
         // a random ERC20 USDT transfer transaction in the next block: https://etherscan.io/tx/0x33350512fec589e635865cbdb38fa3a20a2aa160c52611f1783d0ba24ad13c8c

--- a/testdata/default/fuzz/invariant/common/InvariantRollFork.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantRollFork.t.sol
@@ -23,7 +23,7 @@ contract InvariantRollForkBlockTest is DSTest {
     RollForkHandler forkHandler;
 
     function setUp() public {
-        vm.createSelectFork("rpcAlias", 19812632);
+        vm.createSelectFork("mainnet", 19812632);
         forkHandler = new RollForkHandler();
     }
 
@@ -39,7 +39,7 @@ contract InvariantRollForkStateTest is DSTest {
     RollForkHandler forkHandler;
 
     function setUp() public {
-        vm.createSelectFork("rpcAlias", 19812632);
+        vm.createSelectFork("mainnet", 19812632);
         forkHandler = new RollForkHandler();
     }
 

--- a/testdata/default/repros/Issue2623.t.sol
+++ b/testdata/default/repros/Issue2623.t.sol
@@ -9,7 +9,7 @@ contract Issue2623Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testRollFork() public {
-        uint256 fork = vm.createFork("rpcAlias", 10);
+        uint256 fork = vm.createFork("mainnet", 10);
         vm.selectFork(fork);
 
         assertEq(block.number, 10);

--- a/testdata/default/repros/Issue2629.t.sol
+++ b/testdata/default/repros/Issue2629.t.sol
@@ -11,13 +11,13 @@ contract Issue2629Test is DSTest {
     function testSelectFork() public {
         address coinbase = 0x0193d941b50d91BE6567c7eE1C0Fe7AF498b4137;
 
-        uint256 f1 = vm.createSelectFork("rpcAlias", 9);
+        uint256 f1 = vm.createSelectFork("mainnet", 9);
         vm.selectFork(f1);
 
         assertEq(block.number, 9);
         assertEq(coinbase.balance, 11250000000000000000);
 
-        uint256 f2 = vm.createFork("rpcAlias", 10);
+        uint256 f2 = vm.createFork("mainnet", 10);
         vm.selectFork(f2);
 
         assertEq(block.number, 10);

--- a/testdata/default/repros/Issue2723.t.sol
+++ b/testdata/default/repros/Issue2723.t.sol
@@ -11,7 +11,7 @@ contract Issue2723Test is DSTest {
     function testRollFork() public {
         address coinbase = 0x0193d941b50d91BE6567c7eE1C0Fe7AF498b4137;
 
-        vm.createSelectFork("rpcAlias", 9);
+        vm.createSelectFork("mainnet", 9);
 
         assertEq(block.number, 9);
         assertEq(coinbase.balance, 11250000000000000000);

--- a/testdata/default/repros/Issue2956.t.sol
+++ b/testdata/default/repros/Issue2956.t.sol
@@ -11,8 +11,8 @@ contract Issue2956Test is DSTest {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("rpcAliasSepolia", 5565573);
-        fork2 = vm.createFork("https://api.avax-test.network/ext/bc/C/rpc", 12880747);
+        fork1 = vm.createFork("sepolia", 5565573);
+        fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {

--- a/testdata/default/repros/Issue2984.t.sol
+++ b/testdata/default/repros/Issue2984.t.sol
@@ -11,7 +11,7 @@ contract Issue2984Test is DSTest {
     uint256 snapshot;
 
     function setUp() public {
-        fork = vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc", 12880747);
+        fork = vm.createSelectFork("avaxTestnet", 12880747);
         snapshot = vm.snapshot();
     }
 
@@ -20,6 +20,6 @@ contract Issue2984Test is DSTest {
     }
 
     function testForkSelectSnapshot() public {
-        uint256 fork2 = vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc", 12880749);
+        uint256 fork2 = vm.createSelectFork("avaxTestnet", 12880749);
     }
 }

--- a/testdata/default/repros/Issue3077.t.sol
+++ b/testdata/default/repros/Issue3077.t.sol
@@ -15,7 +15,7 @@ abstract contract ZeroState is DSTest {
 
     function setUp() public virtual {
         vm.startPrank(deployer);
-        mainnetFork = vm.createFork("rpcAlias");
+        mainnetFork = vm.createFork("mainnet");
         vm.selectFork(mainnetFork);
         vm.rollFork(block.number - 20);
         // deploy tokens

--- a/testdata/default/repros/Issue3110.t.sol
+++ b/testdata/default/repros/Issue3110.t.sol
@@ -17,7 +17,7 @@ abstract contract ZeroState is DSTest {
         vm.label(deployer, "Deployer");
 
         vm.startPrank(deployer);
-        mainnetFork = vm.createFork("rpcAlias");
+        mainnetFork = vm.createFork("mainnet");
         vm.selectFork(mainnetFork);
 
         vm.rollFork(block.number - 20);

--- a/testdata/default/repros/Issue3119.t.sol
+++ b/testdata/default/repros/Issue3119.t.sol
@@ -12,7 +12,7 @@ contract Issue3119Test is DSTest {
     address public alice = vm.addr(2);
 
     function testRollFork() public {
-        uint256 fork = vm.createFork("rpcAlias");
+        uint256 fork = vm.createFork("mainnet");
         vm.selectFork(fork);
 
         FortressSwap fortressSwap = new FortressSwap(address(owner));

--- a/testdata/default/repros/Issue3192.t.sol
+++ b/testdata/default/repros/Issue3192.t.sol
@@ -11,8 +11,8 @@ contract Issue3192Test is DSTest {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("rpcAlias", 7475589);
-        fork2 = vm.createFork("rpcAlias", 12880747);
+        fork1 = vm.createFork("mainnet", 7475589);
+        fork2 = vm.createFork("mainnet", 12880747);
         vm.selectFork(fork1);
     }
 

--- a/testdata/default/repros/Issue3220.t.sol
+++ b/testdata/default/repros/Issue3220.t.sol
@@ -14,9 +14,9 @@ contract Issue3220Test is DSTest {
     uint256 counter;
 
     function setUp() public {
-        fork1 = vm.createFork("rpcAlias", 7475589);
+        fork1 = vm.createFork("mainnet", 7475589);
         vm.selectFork(fork1);
-        fork2 = vm.createFork("rpcAlias", 12880747);
+        fork2 = vm.createFork("mainnet", 12880747);
     }
 
     function testForkRevert() public {

--- a/testdata/default/repros/Issue3221.t.sol
+++ b/testdata/default/repros/Issue3221.t.sol
@@ -11,8 +11,8 @@ contract Issue3221Test is DSTest {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("rpcAliasSepolia", 5565573);
-        fork2 = vm.createFork("https://api.avax-test.network/ext/bc/C/rpc", 12880747);
+        fork1 = vm.createFork("sepolia", 5565573);
+        fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {

--- a/testdata/default/repros/Issue3223.t.sol
+++ b/testdata/default/repros/Issue3223.t.sol
@@ -11,8 +11,8 @@ contract Issue3223Test is DSTest {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("rpcAliasSepolia", 2362365);
-        fork2 = vm.createFork("https://api.avax-test.network/ext/bc/C/rpc", 12880747);
+        fork1 = vm.createFork("sepolia", 2362365);
+        fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {

--- a/testdata/default/repros/Issue3653.t.sol
+++ b/testdata/default/repros/Issue3653.t.sol
@@ -11,7 +11,7 @@ contract Issue3653Test is DSTest {
     Token token;
 
     constructor() {
-        fork = vm.createSelectFork("rpcAlias", 1000000);
+        fork = vm.createSelectFork("mainnet", 1000000);
         token = new Token();
         vm.makePersistent(address(token));
     }

--- a/testdata/default/repros/Issue3674.t.sol
+++ b/testdata/default/repros/Issue3674.t.sol
@@ -9,9 +9,9 @@ contract Issue3674Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testNonceCreateSelect() public {
-        vm.createSelectFork("rpcAliasSepolia");
+        vm.createSelectFork("sepolia");
 
-        vm.createSelectFork("https://api.avax-test.network/ext/bc/C/rpc");
+        vm.createSelectFork("avaxTestnet");
         assert(vm.getNonce(msg.sender) > 0x17);
     }
 }

--- a/testdata/default/repros/Issue3703.t.sol
+++ b/testdata/default/repros/Issue3703.t.sol
@@ -10,7 +10,7 @@ contract Issue3703Test is DSTest {
 
     function setUp() public {
         uint256 fork = vm.createSelectFork(
-            "https://polygon-mainnet.g.alchemy.com/v2/bVjX9v-FpmUhf5R_oHIgwJx2kXvYPRbx",
+            "polygon",
             bytes32(0xbed0c8c1b9ff8bf0452979d170c52893bb8954f18a904aa5bcbd0f709be050b9)
         );
     }

--- a/testdata/default/repros/Issue3703.t.sol
+++ b/testdata/default/repros/Issue3703.t.sol
@@ -9,10 +9,8 @@ contract Issue3703Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function setUp() public {
-        uint256 fork = vm.createSelectFork(
-            "polygon",
-            bytes32(0xbed0c8c1b9ff8bf0452979d170c52893bb8954f18a904aa5bcbd0f709be050b9)
-        );
+        uint256 fork =
+            vm.createSelectFork("polygon", bytes32(0xbed0c8c1b9ff8bf0452979d170c52893bb8954f18a904aa5bcbd0f709be050b9));
     }
 
     function poolState(address poolAddr, uint256 expectedSqrtPriceX96, uint256 expectedLiquidity) private {

--- a/testdata/default/repros/Issue4586.t.sol
+++ b/testdata/default/repros/Issue4586.t.sol
@@ -13,7 +13,7 @@ contract Issue4586Test is DSTest {
     InvariantHandler handler;
 
     function setUp() public {
-        vm.createSelectFork("rpcAlias", initialBlock);
+        vm.createSelectFork("mainnet", initialBlock);
         handler = new InvariantHandler();
     }
 

--- a/testdata/default/repros/Issue4640.t.sol
+++ b/testdata/default/repros/Issue4640.t.sol
@@ -10,7 +10,7 @@ contract Issue4640Test is DSTest {
 
     function testArbitrumBlockNumber() public {
         // <https://arbiscan.io/block/75219831>
-        vm.createSelectFork("https://arb-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf", 75219831);
+        vm.createSelectFork("arbitrum", 75219831);
         // L1 block number
         assertEq(block.number, 16939475);
     }

--- a/testdata/default/repros/Issue5739.t.sol
+++ b/testdata/default/repros/Issue5739.t.sol
@@ -14,7 +14,7 @@ contract Issue5739Test is DSTest {
     IERC20 dai;
 
     function setUp() public {
-        vm.createSelectFork("rpcAlias", 19000000);
+        vm.createSelectFork("mainnet", 19000000);
         dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
     }
 

--- a/testdata/default/repros/Issue5929.t.sol
+++ b/testdata/default/repros/Issue5929.t.sol
@@ -9,7 +9,7 @@ contract Issue5929Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function test_transact_not_working() public {
-        vm.createSelectFork("rpcAlias", 15625301);
+        vm.createSelectFork("mainnet", 15625301);
         // https://etherscan.io/tx/0x96a129768ec66fd7d65114bf182f4e173bf0b73a44219adaf71f01381a3d0143
         vm.transact(hex"96a129768ec66fd7d65114bf182f4e173bf0b73a44219adaf71f01381a3d0143");
     }

--- a/testdata/default/repros/Issue5935.t.sol
+++ b/testdata/default/repros/Issue5935.t.sol
@@ -12,15 +12,12 @@ contract SimpleStorage {
     }
 }
 
-/// @dev start anvil --port 35353
 contract Issue5935Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testFork() public {
-        uint256 forkId1 =
-            vm.createFork("https://eth-mainnet.alchemyapi.io/v2/QC55XC151AgkS3FNtWvz9VZGeu9Xd9lb", 18234083);
-        uint256 forkId2 =
-            vm.createFork("https://eth-mainnet.alchemyapi.io/v2/QC55XC151AgkS3FNtWvz9VZGeu9Xd9lb", 18234083);
+        uint256 forkId1 = vm.createFork("mainnet", 18234083);
+        uint256 forkId2 = vm.createFork("mainnet", 18234083);
         vm.selectFork(forkId1);
         SimpleStorage myContract = new SimpleStorage();
         myContract.set(42);

--- a/testdata/default/repros/Issue6032.t.sol
+++ b/testdata/default/repros/Issue6032.t.sol
@@ -15,7 +15,7 @@ contract Issue6032Test is DSTest {
 
         address counterAddress = address(counter);
         // Enter the fork
-        vm.createSelectFork("rpcAlias");
+        vm.createSelectFork("mainnet");
         assert(counterAddress.code.length > 0);
         // `Counter` is not deployed on the fork, which is expected.
 

--- a/testdata/default/repros/Issue6538.t.sol
+++ b/testdata/default/repros/Issue6538.t.sol
@@ -10,7 +10,7 @@ contract Issue6538Test is DSTest {
 
     function test_transact() public {
         bytes32 lastHash = 0xdbdce1d5c14a6ca17f0e527ab762589d6a73f68697606ae0bb90df7ac9ec5087;
-        vm.createSelectFork("rpcAlias", lastHash);
+        vm.createSelectFork("mainnet", lastHash);
         bytes32 txhash = 0xadbe5cf9269a001d50990d0c29075b402bcc3a0b0f3258821881621b787b35c6;
         vm.transact(txhash);
     }

--- a/testdata/default/repros/Issue6616.t.sol
+++ b/testdata/default/repros/Issue6616.t.sol
@@ -9,12 +9,12 @@ contract Issue6616Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testCreateForkRollLatestBlock() public {
-        vm.createSelectFork("rpcAlias");
+        vm.createSelectFork("mainnet");
         uint256 startBlock = block.number;
         // this will create new forks and exit once a new latest block is found
         for (uint256 i; i < 10; i++) {
             vm.sleep(5000);
-            vm.createSelectFork("rpcAlias");
+            vm.createSelectFork("mainnet");
             if (block.number > startBlock) break;
         }
         assertGt(block.number, startBlock);

--- a/testdata/default/repros/Issue6759.t.sol
+++ b/testdata/default/repros/Issue6759.t.sol
@@ -9,9 +9,9 @@ contract Issue6759Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testCreateMulti() public {
-        uint256 fork1 = vm.createFork("rpcAlias", 10);
-        uint256 fork2 = vm.createFork("rpcAlias", 10);
-        uint256 fork3 = vm.createFork("rpcAlias", 10);
+        uint256 fork1 = vm.createFork("mainnet", 10);
+        uint256 fork2 = vm.createFork("mainnet", 10);
+        uint256 fork3 = vm.createFork("mainnet", 10);
         assert(fork1 != fork2);
         assert(fork1 != fork3);
         assert(fork2 != fork3);

--- a/testdata/default/repros/Issue7481.t.sol
+++ b/testdata/default/repros/Issue7481.t.sol
@@ -10,7 +10,7 @@ contract Issue7481Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testFailTransact() public {
-        vm.createSelectFork("rpcAlias", 19514903);
+        vm.createSelectFork("mainnet", 19514903);
 
         // Transfer some funds to sender of tx being transacted to ensure that it appears in journaled state
         payable(address(0x5C60cD7a3D50877Bfebd484750FBeb245D936dAD)).call{value: 1}("");

--- a/testdata/default/repros/Issue8004.t.sol
+++ b/testdata/default/repros/Issue8004.t.sol
@@ -9,18 +9,18 @@ contract NonPersistentHelper is DSTest {
     uint256 public curState;
 
     function createSelectFork() external {
-        vm.createSelectFork("rpcAlias");
+        vm.createSelectFork("mainnet");
         curState += 1;
     }
 
     function createSelectForkAtBlock() external {
-        vm.createSelectFork("rpcAlias", 19000000);
+        vm.createSelectFork("mainnet", 19000000);
         curState += 1;
     }
 
     function createSelectForkAtTx() external {
         vm.createSelectFork(
-            "rpcAlias", vm.parseBytes32("0xb5c978f15d01fcc9b4d78967e8189e35ecc21ff4e78315ea5d616f3467003c84")
+            "mainnet", vm.parseBytes32("0xb5c978f15d01fcc9b4d78967e8189e35ecc21ff4e78315ea5d616f3467003c84")
         );
         curState += 1;
     }
@@ -66,7 +66,7 @@ contract Issue8004CreateSelectForkTest is DSTest {
     }
 
     function testNonPersistentHelperSelectFork() external {
-        uint256 forkId = vm.createFork("rpcAlias");
+        uint256 forkId = vm.createFork("mainnet");
         helper.selectFork(forkId);
         assertEq(helper.curState(), 1);
     }
@@ -78,7 +78,7 @@ contract Issue8004RollForkTest is DSTest {
     uint256 forkId;
 
     function setUp() public {
-        forkId = vm.createSelectFork("rpcAlias");
+        forkId = vm.createSelectFork("mainnet");
         helper = new NonPersistentHelper();
     }
 

--- a/testdata/default/repros/Issue8006.t.sol
+++ b/testdata/default/repros/Issue8006.t.sol
@@ -21,7 +21,7 @@ contract Issue8006Test is DSTest {
     bytes32 transaction = 0x67cbad73764049e228495a3f90144aab4a37cb4b5fd697dffc234aa5ed811ace;
 
     function setUp() public {
-        vm.createSelectFork("rpcAlias", 16261704);
+        vm.createSelectFork("mainnet", 16261704);
         dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
     }
 

--- a/testdata/default/repros/Issue8168.t.sol
+++ b/testdata/default/repros/Issue8168.t.sol
@@ -9,8 +9,8 @@ contract Issue8168Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testForkWarpRollPreserved() public {
-        uint256 fork1 = vm.createFork("rpcAlias");
-        uint256 fork2 = vm.createFork("rpcAlias");
+        uint256 fork1 = vm.createFork("mainnet");
+        uint256 fork2 = vm.createFork("mainnet");
 
         vm.selectFork(fork1);
         uint256 initial_fork1_number = block.number;

--- a/testdata/default/repros/Issue8287.t.sol
+++ b/testdata/default/repros/Issue8287.t.sol
@@ -9,14 +9,14 @@ contract Issue8287Test is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     function testRpcBalance() public {
-        uint256 f2 = vm.createSelectFork("rpcAlias", 10);
+        uint256 f2 = vm.createSelectFork("mainnet", 10);
         bytes memory data = vm.rpc("eth_getBalance", "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]");
         string memory m = vm.toString(data);
         assertEq(m, "0x2086ac351052600000");
     }
 
     function testRpcStorage() public {
-        uint256 f2 = vm.createSelectFork("rpcAlias", 10);
+        uint256 f2 = vm.createSelectFork("mainnet", 10);
         bytes memory data = vm.rpc(
             "eth_getStorageAt",
             "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x40BdB4497614bAe1A67061EE20AAdE3c2067AC9e\",\"0x0\"]"


### PR DESCRIPTION
- rename `rpcAlias` and friends to more sensible names
- consolidate all RPC URLs to use aliases
- use test utils RPC URLs instead of hardcoding them
- remove usage of URLs that are dead