### PR TITLE
fix(coverage): proper single path branch support

### DIFF
--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -295,6 +295,11 @@ pub enum CoverageItemKind {
         /// The first path has ID 0, the next ID 1, and so on.
         path_id: usize,
     },
+    /// A branch in the code.
+    SinglePathBranch {
+        /// The ID that identifies the branch.
+        branch_id: usize,
+    },
     /// A function in the code.
     Function {
         /// The name of the function.
@@ -323,6 +328,9 @@ impl Display for CoverageItem {
             }
             CoverageItemKind::Branch { branch_id, path_id } => {
                 write!(f, "Branch (branch: {branch_id}, path: {path_id})")?;
+            }
+            CoverageItemKind::SinglePathBranch { branch_id } => {
+                write!(f, "Branch (branch: {branch_id}, path: 0)")?;
             }
             CoverageItemKind::Function { name } => {
                 write!(f, r#"Function "{name}""#)?;
@@ -408,7 +416,7 @@ impl AddAssign<&CoverageItem> for CoverageSummary {
                     self.statement_hits += 1;
                 }
             }
-            CoverageItemKind::Branch { .. } => {
+            CoverageItemKind::Branch { .. } | CoverageItemKind::SinglePathBranch { .. } => {
                 self.branch_count += 1;
                 if item.hits > 0 {
                     self.branch_hits += 1;

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -116,6 +116,13 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }
+                    CoverageItemKind::SinglePathBranch { branch_id } => {
+                        writeln!(
+                            self.destination,
+                            "BRDA:{line},{branch_id},0,{}",
+                            if hits == 0 { "-".to_string() } else { hits.to_string() }
+                        )?;
+                    }
                     // Statements are not in the LCOV format.
                     // We don't add them in order to avoid doubling line hits.
                     _ => {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Follow up for #8512

proper handling of empty if/else statements and empty single if statement

![image](https://github.com/user-attachments/assets/25c8d573-6902-456e-b297-053bfb18bf53)


Consistent behavior for `IfStatement` without else statement with `YulIf` 

![image](https://github.com/user-attachments/assets/b6b7b701-48e6-4e2a-80dd-6c9b64d2ab55)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- do not add branch coverage item when if/else does not have statements or when single if doesn't have statements
- introduce CoverageItemKind::SinglePathBranch kind for single if statement - lookup anchor instruction from ic/pc map instead using `find_anchor_branch` logic (that assume there are 2 branches to execute / results in 2 anchors) 
- fix failing tests, add test for single path branch