### PR TITLE
fix: add `Mantle` + `Mantle testnet` as exceptions for gas calculation during deployment

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -164,13 +164,15 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
         return matches!(
             chain,
             NamedChain::Arbitrum |
-                NamedChain::ArbitrumTestnet |
                 NamedChain::ArbitrumGoerli |
                 NamedChain::ArbitrumSepolia |
-                NamedChain::Moonbeam |
-                NamedChain::Moonriver |
+                NamedChain::ArbitrumTestnet |
+                NamedChain::Mantle |
+                NamedChain::MantleTestnet |
                 NamedChain::Moonbase |
-                NamedChain::MoonbeamDev
+                NamedChain::Moonbeam |
+                NamedChain::MoonbeamDev |
+                NamedChain::Moonriver
         );
     }
     false


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #8509 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Uses the existing `estimate_via_rpc` flow to make sure the RPC estimates the gas preventing the reported issue

Sorts the match list to keep it maintainable