### PR TITLE
fix(verify-bytecode): fix metadata extraction and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,6 +3498,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "async-trait",
+ "ciborium",
  "clap",
  "eyre",
  "foundry-block-explorers",

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -20,5 +20,6 @@ mod soldeer;
 mod svm;
 mod test_cmd;
 mod verify;
+mod verify_bytecode;
 
 mod ext_integration;

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -1,0 +1,85 @@
+use foundry_compilers::artifacts::{BytecodeHash, EvmVersion};
+use foundry_config::Config;
+use foundry_test_utils::{
+    forgetest_async,
+    rpc::{next_etherscan_api_key, next_http_archive_rpc_endpoint},
+    util::OutputExt,
+    TestCommand, TestProject,
+};
+
+fn test_verify_bytecode(
+    prj: TestProject,
+    mut cmd: TestCommand,
+    addr: &str,
+    contract_name: &str,
+    config: Config,
+    expected_matches: (&str, &str),
+) {
+    let etherscan_key = next_etherscan_api_key();
+    let rpc_url = next_http_archive_rpc_endpoint();
+
+    // fetch and flatten source code
+    let source_code = cmd
+        .cast_fuse()
+        .args(["etherscan-source", addr, "--flatten", "--etherscan-api-key", &etherscan_key])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    prj.add_source(contract_name, &source_code).unwrap();
+    prj.write_config(config);
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "verify-bytecode",
+            addr,
+            contract_name,
+            "--etherscan-api-key",
+            &etherscan_key,
+            "--rpc-url",
+            &rpc_url,
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(output
+        .contains(format!("Creation code matched with status {}", expected_matches.0).as_str()));
+    assert!(output
+        .contains(format!("Runtime code matched with status {}", expected_matches.1).as_str()));
+}
+
+forgetest_async!(can_verify_bytecode_no_metadata, |prj, cmd| {
+    test_verify_bytecode(
+        prj,
+        cmd,
+        "0xba2492e52F45651B60B8B38d4Ea5E2390C64Ffb1",
+        "SystemConfig",
+        Config {
+            evm_version: EvmVersion::London,
+            optimizer_runs: 999999,
+            optimizer: true,
+            cbor_metadata: false,
+            bytecode_hash: BytecodeHash::None,
+            ..Default::default()
+        },
+        ("full", "full"),
+    );
+});
+
+forgetest_async!(can_verify_bytecode_with_metadata, |prj, cmd| {
+    test_verify_bytecode(
+        prj,
+        cmd,
+        "0xb8901acb165ed027e32754e0ffe830802919727f",
+        "L1_ETH_Bridge",
+        Config {
+            evm_version: EvmVersion::Paris,
+            optimizer_runs: 50000,
+            optimizer: true,
+            ..Default::default()
+        },
+        ("partial", "partial"),
+    );
+});

--- a/crates/verify/Cargo.toml
+++ b/crates/verify/Cargo.toml
@@ -41,6 +41,8 @@ once_cell.workspace = true
 yansi.workspace = true
 itertools.workspace = true
 
+ciborium = "0.2"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }
 foundry-test-utils.workspace = true

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -206,11 +206,6 @@ impl VerifyBytecodeArgs {
                 self.build_project(&config)?
             };
 
-        let local_bytecode = artifact
-            .bytecode
-            .and_then(|b| b.into_bytes())
-            .ok_or_eyre("Unlinked bytecode is not supported for verification")?;
-
         // Get the constructor args from etherscan
         let mut constructor_args = if let Some(args) = source_code.items.first() {
             args.constructor_arguments.clone()

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -21,7 +21,7 @@ use foundry_evm::{
 use revm_primitives::{db::Database, EnvWithHandlerCfg, HandlerCfg};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt, path::PathBuf, str::FromStr};
+use std::{fmt, path::PathBuf, str::FromStr};
 use yansi::Paint;
 
 impl_figment_convert!(VerifyBytecodeArgs);
@@ -638,7 +638,7 @@ fn extract_metadata_hash(bytecode: &[u8]) -> &[u8] {
     let metadata_len = u16::from_be_bytes([metadata_len[0], metadata_len[1]]);
 
     if metadata_len as usize <= bytecode.len() {
-        if ciborium::from_reader::<BTreeMap<String, Vec<u8>>, _>(
+        if ciborium::from_reader::<ciborium::Value, _>(
             &bytecode[bytecode.len() - 2 - metadata_len as usize..bytecode.len() - 2],
         )
         .is_ok()
@@ -681,94 +681,4 @@ fn find_mismatch_in_settings(
     }
 
     mismatches
-}
-
-#[cfg(test)]
-mod tests {
-    use foundry_compilers::artifacts::{BytecodeHash, EvmVersion};
-    use foundry_config::Config;
-    use foundry_test_utils::{
-        forgetest_async,
-        rpc::{next_etherscan_api_key, next_http_archive_rpc_endpoint},
-        util::OutputExt,
-        TestCommand, TestProject,
-    };
-
-    fn test_verify_bytecode(
-        prj: TestProject,
-        mut cmd: TestCommand,
-        addr: &str,
-        contract_name: &str,
-        config: Config,
-        expected_matches: (&str, &str),
-    ) {
-        let etherscan_key = next_etherscan_api_key();
-        let rpc_url = next_http_archive_rpc_endpoint();
-
-        // fetch and flatten source code
-        let source_code = cmd
-            .cast_fuse()
-            .args(["etherscan-source", addr, "--flatten", "--etherscan-api-key", &etherscan_key])
-            .assert_success()
-            .get_output()
-            .stdout_lossy();
-
-        prj.add_source(contract_name, &source_code).unwrap();
-        prj.write_config(config);
-
-        let output = cmd
-            .forge_fuse()
-            .args([
-                "verify-bytecode",
-                addr,
-                contract_name,
-                "--etherscan-api-key",
-                &etherscan_key,
-                "--rpc-url",
-                &rpc_url,
-            ])
-            .assert_success()
-            .get_output()
-            .stdout_lossy();
-
-        assert!(output.contains(
-            format!("Creation code matched with status {}", expected_matches.0).as_str()
-        ));
-        assert!(output
-            .contains(format!("Runtime code matched with status {}", expected_matches.1).as_str()));
-    }
-
-    forgetest_async!(can_verify_bytecode_no_metadata, |prj, cmd| {
-        test_verify_bytecode(
-            prj,
-            cmd,
-            "0xba2492e52F45651B60B8B38d4Ea5E2390C64Ffb1",
-            "SystemConfig",
-            Config {
-                evm_version: EvmVersion::London,
-                optimizer_runs: 999999,
-                optimizer: true,
-                cbor_metadata: false,
-                bytecode_hash: BytecodeHash::None,
-                ..Default::default()
-            },
-            ("full", "full"),
-        );
-    });
-
-    forgetest_async!(can_verify_bytecode_with_metadata, |prj, cmd| {
-        test_verify_bytecode(
-            prj,
-            cmd,
-            "0xb8901acb165ed027e32754e0ffe830802919727f",
-            "L1_ETH_Bridge",
-            Config {
-                evm_version: EvmVersion::Paris,
-                optimizer_runs: 50000,
-                optimizer: true,
-                ..Default::default()
-            },
-            ("partial", "partial"),
-        );
-    });
 }

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -640,7 +640,9 @@ fn extract_metadata_hash(bytecode: &[u8]) -> &[u8] {
     if metadata_len as usize <= bytecode.len() {
         if ciborium::from_reader::<BTreeMap<String, Vec<u8>>, _>(
             &bytecode[bytecode.len() - 2 - metadata_len as usize..bytecode.len() - 2],
-        ).is_ok() {
+        )
+        .is_ok()
+        {
             &bytecode[..bytecode.len() - 2 - metadata_len as usize]
         } else {
             bytecode
@@ -688,7 +690,6 @@ mod tests {
     use foundry_test_utils::{
         forgetest_async,
         rpc::{next_etherscan_api_key, next_http_archive_rpc_endpoint},
-        str,
         util::OutputExt,
         TestCommand, TestProject,
     };

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -206,6 +206,11 @@ impl VerifyBytecodeArgs {
                 self.build_project(&config)?
             };
 
+        let local_bytecode = artifact
+            .bytecode
+            .and_then(|b| b.into_bytes())
+            .ok_or_eyre("Unlinked bytecode is not supported for verification")?;
+
         // Get the constructor args from etherscan
         let mut constructor_args = if let Some(args) = source_code.items.first() {
             args.constructor_arguments.clone()
@@ -256,11 +261,6 @@ impl VerifyBytecodeArgs {
                 }
             }
         }
-
-        let local_bytecode = artifact
-            .bytecode
-            .and_then(|b| b.into_bytes())
-            .ok_or_eyre("Unlinked bytecode is not supported for verification")?;
 
         // Append constructor args to the local_bytecode
         trace!(%constructor_args);
@@ -364,10 +364,8 @@ impl VerifyBytecodeArgs {
 
         configure_tx_env(&mut env, &transaction);
 
-        let env_with_handler = EnvWithHandlerCfg::new(
-            Box::new(env.clone()),
-            HandlerCfg::new(config.evm_spec_id()),
-        );
+        let env_with_handler =
+            EnvWithHandlerCfg::new(Box::new(env.clone()), HandlerCfg::new(config.evm_spec_id()));
 
         let contract_address = if let Some(to) = transaction.to {
             if to != DEFAULT_CREATE2_DEPLOYER {

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -18,7 +18,7 @@ use foundry_config::{figment, filter::SkipBuildFilter, impl_figment_convert, Cha
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER, executors::TracingExecutor, utils::configure_tx_env,
 };
-use revm_primitives::{db::Database, EnvWithHandlerCfg, HandlerCfg, SpecId};
+use revm_primitives::{db::Database, EnvWithHandlerCfg, HandlerCfg};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, path::PathBuf, str::FromStr};
@@ -638,9 +638,9 @@ fn extract_metadata_hash(bytecode: &[u8]) -> &[u8] {
     let metadata_len = u16::from_be_bytes([metadata_len[0], metadata_len[1]]);
 
     if metadata_len as usize <= bytecode.len() {
-        if let Ok(_) = ciborium::from_reader::<BTreeMap<String, Vec<u8>>, _>(
+        if ciborium::from_reader::<BTreeMap<String, Vec<u8>>, _>(
             &bytecode[bytecode.len() - 2 - metadata_len as usize..bytecode.len() - 2],
-        ) {
+        ).is_ok() {
             &bytecode[..bytecode.len() - 2 - metadata_len as usize]
         } else {
             bytecode


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/8555

Instead of relying on `Config` to determine whether we need to strip metadata, we now just look at the end of the bytecode and try decoding it into CBOR as suggested by @mds1 in https://github.com/foundry-rs/foundry/issues/8555#issuecomment-2256902230. If decoding succeeds, we strip the suffix

I've also added tests and a helper to add them. Tests are simply running `cast etherscan-source --flatten` and then try to verify compiled downloaded source against on-chain bytecode.
