### PR TITLE
feat(forge): modify `events` in `forge inspect` to return event signature

### DIFF
--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -169,8 +169,7 @@ impl InspectArgs {
                     for ev in abi.events.iter().flat_map(|(_, events)| events) {
                         let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
                         let sig = &ev.signature();
-                        let topic =
-                            hex::encode(&keccak256(sig.strip_prefix("0x").unwrap_or(sig))[..4]);
+                        let topic = hex::encode(&keccak256(sig.strip_prefix("0x").unwrap_or(sig)));
                         out.insert(format!("{}({})", ev.name, types.join(",")), topic.into());
                     }
                 }

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -150,21 +150,6 @@ impl InspectArgs {
                 let mut out = serde_json::Map::new();
                 if let Some(abi) = &artifact.abi {
                     let abi = &abi;
-                    // Print the signature of all events including anonymous.
-                    for ev in abi.events.iter().flat_map(|(_, events)| events) {
-                        let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
-                        out.insert(
-                            format!("{}({})", ev.name, types.join(",")),
-                            format!("{:?}", ev.signature()).into(),
-                        );
-                    }
-                }
-                print_json(&out)?;
-            }
-            ContractArtifactField::EventIdentifiers => {
-                let mut out = serde_json::Map::new();
-                if let Some(abi) = &artifact.abi {
-                    let abi = &abi;
                     // Print the topic of all events including anonymous.
                     for ev in abi.events.iter().flat_map(|(_, events)| events) {
                         let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
@@ -237,7 +222,6 @@ pub enum ContractArtifactField {
     Ewasm,
     Errors,
     Events,
-    EventIdentifiers,
     Eof,
     EofInit,
 }
@@ -326,8 +310,6 @@ impl_value_enum! {
         Ewasm             => "ewasm" | "e-wasm",
         Errors            => "errors" | "er",
         Events            => "events" | "ev",
-        EventIdentifiers  => "eventIdentifiers" | "eventidentifiers" | "event_identifiers"
-                             | "event-identifiers" | "ei",
         Eof               => "eof" | "eof-container" | "eof-deployed",
         EofInit           => "eof-init" | "eof-initcode" | "eof-initcontainer",
     }
@@ -354,7 +336,6 @@ impl From<ContractArtifactField> for ContractOutputSelection {
             Caf::Ewasm => Self::Ewasm(EwasmOutputSelection::All),
             Caf::Errors => Self::Abi,
             Caf::Events => Self::Abi,
-            Caf::EventIdentifiers => Self::Abi,
             Caf::Eof => Self::Evm(EvmOutputSelection::DeployedByteCode(
                 DeployedBytecodeOutputSelection::All,
             )),
@@ -369,7 +350,7 @@ impl PartialEq<ContractOutputSelection> for ContractArtifactField {
         type Eos = EvmOutputSelection;
         matches!(
             (self, other),
-            (Self::Abi | Self::Events | Self::EventIdentifiers, Cos::Abi) |
+            (Self::Abi | Self::Events, Cos::Abi) |
                 (Self::Errors, Cos::Abi) |
                 (Self::Bytecode, Cos::Evm(Eos::ByteCode(_))) |
                 (Self::DeployedBytecode, Cos::Evm(Eos::DeployedByteCode(_))) |

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -368,7 +368,7 @@ impl PartialEq<ContractOutputSelection> for ContractArtifactField {
         type Eos = EvmOutputSelection;
         matches!(
             (self, other),
-            (Self::Abi | Self::Events, Cos::Abi) |
+            (Self::Abi | Self::Events | Self::EventIdentifiers, Cos::Abi) |
                 (Self::Errors, Cos::Abi) |
                 (Self::Bytecode, Cos::Evm(Eos::ByteCode(_))) |
                 (Self::DeployedBytecode, Cos::Evm(Eos::DeployedByteCode(_))) |

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -168,9 +168,11 @@ impl InspectArgs {
                     // Print the topic of all events including anonymous.
                     for ev in abi.events.iter().flat_map(|(_, events)| events) {
                         let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
-                        let sig = &ev.signature();
-                        let topic = hex::encode(&keccak256(sig.strip_prefix("0x").unwrap_or(sig)));
-                        out.insert(format!("{}({})", ev.name, types.join(",")), topic.into());
+                        let topic = hex::encode(keccak256(ev.signature()));
+                        out.insert(
+                            format!("{}({})", ev.name, types.join(",")),
+                            format!("0x{topic}").into(),
+                        );
                     }
                 }
                 print_json(&out)?;

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -171,10 +171,7 @@ impl InspectArgs {
                         let sig = &ev.signature();
                         let topic =
                             hex::encode(&keccak256(sig.strip_prefix("0x").unwrap_or(sig))[..4]);
-                        out.insert(
-                            format!("{}({})", ev.name, types.join(",")),
-                            format!("{:?}", topic).into(),
-                        );
+                        out.insert(format!("{}({})", ev.name, types.join(",")), topic.into());
                     }
                 }
                 print_json(&out)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

(*edited) 

## Motivation

Closes #7947

Revise the output of the `forge inspect <contract> events` command to display events signatures along with their topics. The previous version of the command was not useful because it displayed the signatures twice.

Before:

```bash
$ forge inspect ERC20 events                                                                                                                                                            
{
  "Approval(address,address,uint256)": "\"Approval(address,address,uint256)\"",
  "Transfer(address,address,uint256)": "\"Transfer(address,address,uint256)\""
}
```

After:

```bash
$ forge inspect ERC20 events                                                                                                                                                            
{
  "Approval(address,address,uint256)": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
  "Transfer(address,address,uint256)": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
}
```

Double check event topics using `cast keccak`.

```bash
$ cast keccak "Approval(address,address,uint256)"
0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925

$ cast keccak "Transfer(address,address,uint256)"
0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
```
