### PR TITLE
docs(`forge script`): improve `Mac Mismatch` error referring to failure to decrypt of keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,6 +4103,7 @@ dependencies = [
  "aws-sdk-kms",
  "clap",
  "derive_builder",
+ "eth-keystore",
  "eyre",
  "foundry-config",
  "gcloud-sdk",

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -45,6 +45,7 @@ rpassword = "7"
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+eth-keystore = "0.5.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -22,6 +22,8 @@ pub enum PrivateKeyError {
 pub enum WalletSignerError {
     #[error(transparent)]
     Local(#[from] LocalSignerError),
+    #[error("Failed to decrypt keystore: incorrect password")]
+    KeystoreDecryptionError,
     #[error(transparent)]
     Ledger(#[from] LedgerError),
     #[error(transparent)]

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -23,7 +23,7 @@ pub enum WalletSignerError {
     #[error(transparent)]
     Local(#[from] LocalSignerError),
     #[error("Failed to decrypt keystore: incorrect password")]
-    KeystoreDecryptionError,
+    IncorrectKeystorePassword,
     #[error(transparent)]
     Ledger(#[from] LedgerError),
     #[error(transparent)]

--- a/crates/wallets/src/wallet_signer.rs
+++ b/crates/wallets/src/wallet_signer.rs
@@ -263,7 +263,17 @@ impl PendingSigner {
         match self {
             Self::Keystore(path) => {
                 let password = rpassword::prompt_password("Enter keystore password:")?;
-                Ok(WalletSigner::Local(PrivateKeySigner::decrypt_keystore(path, password)?))
+                match PrivateKeySigner::decrypt_keystore(path, password) {
+                    Ok(signer) => Ok(WalletSigner::Local(signer)),
+                    Err(e) => match e {
+                        // Catch the `MacMismatch` error, which indicates an incorrect password and
+                        // return a more user-friendly `KeystoreDecryptionError`.
+                        alloy_signer_local::LocalSignerError::EthKeystoreError(
+                            eth_keystore::KeystoreError::MacMismatch,
+                        ) => Err(WalletSignerError::KeystoreDecryptionError),
+                        _ => Err(WalletSignerError::Local(e)),
+                    },
+                }
             }
             Self::Interactive => {
                 let private_key = rpassword::prompt_password("Enter private key:")?;

--- a/crates/wallets/src/wallet_signer.rs
+++ b/crates/wallets/src/wallet_signer.rs
@@ -267,10 +267,10 @@ impl PendingSigner {
                     Ok(signer) => Ok(WalletSigner::Local(signer)),
                     Err(e) => match e {
                         // Catch the `MacMismatch` error, which indicates an incorrect password and
-                        // return a more user-friendly `KeystoreDecryptionError`.
+                        // return a more user-friendly `IncorrectKeystorePassword`.
                         alloy_signer_local::LocalSignerError::EthKeystoreError(
                             eth_keystore::KeystoreError::MacMismatch,
-                        ) => Err(WalletSignerError::KeystoreDecryptionError),
+                        ) => Err(WalletSignerError::IncorrectKeystorePassword),
                         _ => Err(WalletSignerError::Local(e)),
                     },
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #7592 

When executing `forge script` with the `--account` and `--sender` flags, users are prompted to input their keystore password. If an incorrect password is entered, the command fails, producing a cryptic `Mac Mismatch` error.

A more user-friendly error message, such as `Failed to decrypt keystore: incorrect password` would be more helpful and informative for users.

## Test

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

### Set up the test environment.

<details>
<summary>Click to expand</summary>

Start anvil.

```bash
anvil
```

Create a keystore.

```bash
cast wallet import anvilDefaultKey --unsafe-password aaaa --private-key <pk>
```

Set up a small foundry project.

```bash
pushd /tmp
forge init hello_world
pushd hello_world
forge build
```

</details>

### Reproduce the issue with the latest version of `forge`.

<details>
<summary>Click to expand</summary>

```bash
$ forge --version
forge 0.2.0 (26a755975 2024-07-31T06:56:19.582946000Z)
```

Run the script using `--account` and `--sender` to use the keystore.

```bash
forge script script/Counter.s.sol:CounterScript --rpc-url localhost:8545 --account anvilDefaultKey --sender <address> --broadcast
```

When asked to enter a password, enter a wrong password.

```bash
[⠊] Compiling...
No files changed, compilation skipped
EIP-3855 is not supported in one or more of the RPCs used.
Unsupported Chain IDs: 31337.
Contracts deployed with a Solidity version equal or higher than 0.8.20 might not work properly.
For more information, please see https://eips.ethereum.org/EIPS/eip-3855
Script ran successfully.

## Setting up 1 EVM.

==========================

Chain 31337

Estimated gas price: 1.751778685 gwei

Estimated total gas used for script: 138713

Estimated amount required: 0.000242994476732405 ETH

==========================
Enter keystore password:
``` 

The command should fail with `Mac Mismatch`.

```bash
Transactions saved to: /private/tmp/hello_world/broadcast/Counter.s.sol/31337/run-latest.json

Sensitive values saved to: /private/tmp/hello_world/cache/Counter.s.sol/31337/run-latest.json

Error: 
Mac Mismatch
```

</details>

### Test the solution

<details>
<summary>Click to expand</summary>

Build the new version of `forge` including the fix.

```bash
cargo install --path ./crates/forge --profile release --force --locked
# set foundry_path
alias forgedev=$foundry_path/target/release/forge
```

```bash
$ forgedev --version
forge 0.2.0 (3e169108c 2024-07-31T07:15:21.011808000Z)
```

Run the script using `--account` and `--sender` to use the keystore one more time.

```bash
forgedev script script/Counter.s.sol:CounterScript --rpc-url localhost:8545 --account anvilDefaultKey --sender <address> --broadcast
```

When asked to enter a password, enter a wrong password.

```bash
[⠊] Compiling...
No files changed, compilation skipped
EIP-3855 is not supported in one or more of the RPCs used.
Unsupported Chain IDs: 31337.
Contracts deployed with a Solidity version equal or higher than 0.8.20 might not work properly.
For more information, please see https://eips.ethereum.org/EIPS/eip-3855
Script ran successfully.

## Setting up 1 EVM.

==========================

Chain 31337

Estimated gas price: 1.751778685 gwei

Estimated total gas used for script: 138713

Estimated amount required: 0.000242994476732405 ETH

==========================
Enter keystore password:
``` 

It should return a more informative error message.

```bash
Transactions saved to: /private/tmp/hello_world/broadcast/Counter.s.sol/31337/run-latest.json

Sensitive values saved to: /private/tmp/hello_world/cache/Counter.s.sol/31337/run-latest.json

Error: 
Failed to decrypt keystore: incorrect password
```

</details>
