### PR TITLE
fix(fmt): surround with returns in fn with format disabled

### DIFF
--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1537,7 +1537,17 @@ impl<'a, W: Write> Formatter<'a, W> {
                 let returns_start_loc = func.returns.first().unwrap().0;
                 let returns_loc = returns_start_loc.with_end_from(&func.returns.last().unwrap().0);
                 if fmt.inline_config.is_disabled(returns_loc) {
-                    fmt.indented(1, |fmt| fmt.visit_source(returns_loc))?;
+                    fmt.indented(1, |fmt| {
+                        fmt.surrounded(
+                            SurroundingChunk::new("returns (", Some(returns_loc.start()), None),
+                            SurroundingChunk::new(")", None, returns_end),
+                            |fmt, _| {
+                                fmt.visit_source(returns_loc)?;
+                                Ok(())
+                            },
+                        )?;
+                        Ok(())
+                    })?;
                 } else {
                     let mut returns = fmt.items_to_chunks(
                         returns_end,

--- a/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/fmt.sol
@@ -11,3 +11,11 @@ contract ReturnFnFormat {
         )
     {}
 }
+
+// https://github.com/foundry-rs/foundry/issues/7920
+contract ReturnFnDisableFormat {
+    // forgefmt: disable-next-line
+    function disableFnFormat() external returns (uint256) {
+        return 0;
+    }
+}

--- a/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/original.sol
+++ b/crates/fmt/testdata/FunctionDefinitionWithFunctionReturns/original.sol
@@ -11,3 +11,11 @@ contract ReturnFnFormat {
     )
     {}
 }
+
+// https://github.com/foundry-rs/foundry/issues/7920
+contract ReturnFnDisableFormat {
+    // forgefmt: disable-next-line
+    function disableFnFormat() external returns (uint256) {
+        return 0;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7920 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- if fn with returns format is disabled, surround returned params in `returns ()` to produce valid Solidity