### PR TITLE
fix(fmt): preserve function declaration if fmt disabled

### DIFF
--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -489,3 +489,19 @@ error TopLevelCustomErrorArgWithoutName  (string);
     event Event1(uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a);
 
 // forgefmt: disable-stop
+
+function setNumber(uint256 newNumber /* param1 */, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf /* param2 */) public view returns (bool,bool) { /* inline*/ number1 = newNumber1; // forgefmt: disable-line
+    number = newNumber;
+    return (true, true);
+}
+
+function setNumber1(uint256 newNumber /* param1 */, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf /* param2 */) public view returns (bool,bool) { /* inline*/ number1 = newNumber1; // forgefmt: disable-line
+}
+
+// forgefmt: disable-next-line
+function setNumber1(uint256 newNumber , uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public view returns (bool,bool) { number1 = newNumber1;
+}
+
+function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public { // forgefmt: disable-line
+    number = newNumber;
+}

--- a/crates/fmt/testdata/InlineDisable/fmt.sol
+++ b/crates/fmt/testdata/InlineDisable/fmt.sol
@@ -504,4 +504,5 @@ function setNumber1(uint256 newNumber , uint256 sjdfasdfasdfasdfasfsdfsadfasdfas
 
 function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public { // forgefmt: disable-line
     number = newNumber;
+    number1 =   newNumber1; // forgefmt: disable-line
 }

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -467,3 +467,19 @@ error TopLevelCustomErrorArgWithoutName  (string);
     event Event1(uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a, uint256 indexed a);
 
 // forgefmt: disable-stop
+
+function setNumber(uint256 newNumber /* param1 */, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf /* param2 */) public view returns (bool,bool) { /* inline*/ number1 = newNumber1; // forgefmt: disable-line
+    number = newNumber;
+    return (true, true);
+}
+
+function setNumber1(uint256 newNumber /* param1 */, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf /* param2 */) public view returns (bool,bool) { /* inline*/ number1 = newNumber1; // forgefmt: disable-line
+}
+
+// forgefmt: disable-next-line
+function setNumber1(uint256 newNumber , uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public view returns (bool,bool) { number1 = newNumber1;
+}
+
+function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public { // forgefmt: disable-line
+    number = newNumber;
+}

--- a/crates/fmt/testdata/InlineDisable/original.sol
+++ b/crates/fmt/testdata/InlineDisable/original.sol
@@ -482,4 +482,5 @@ function setNumber1(uint256 newNumber , uint256 sjdfasdfasdfasdfasfsdfsadfasdfas
 
 function setNumber(uint256 newNumber, uint256 sjdfasdfasdfasdfasfsdfsadfasdfasdfasdfsadjfkhasdfljkahsdfkjasdkfhsaf) public { // forgefmt: disable-line
     number = newNumber;
+    number1 =   newNumber1; // forgefmt: disable-line
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3790 
Closes #3789 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
-  do not format fn attrs and returns if disabled
- handle special case where body fn starts on a disabled line: determine first enabled statement and write raw code until
- add test variations of disable fn declaration
- add test for https://github.com/foundry-rs/foundry/issues/3789
TBD: follow ups on moving logic in `visit_body` fn  - should solve issues with disabling first / last lines of blocks as in https://github.com/foundry-rs/foundry/issues/3830