### PR TITLE
fix: add `--compiler-version` as alias of `use` in `forge create` 

### DIFF
--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -58,7 +58,12 @@ pub struct CoreBuildArgs {
     /// Specify the solc version, or a path to a local solc, to build with.
     ///
     /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
-    #[arg(long = "use", help_heading = "Compiler options", value_name = "SOLC_VERSION")]
+    #[arg(
+        long = "use",
+        alias = "compiler-version",
+        help_heading = "Compiler options",
+        value_name = "SOLC_VERSION"
+    )]
     #[serde(skip)]
     pub use_solc: Option<String>,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/3306

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`--compiler-version` is accepted as part of the `forge verify-contract` flow
`--use` is the same flag used in `forge create` but does not accept `--compiler-version` to be set

When passing the `--verify` flag the two intersect yielding an incorrect error message recommending users to use the `--compiler-version` flag when it is not available. This PR adds the `--compiler-version` as an alias, fixing it in a non-breaking way.