### PR TITLE
Fix wrong absolute link in doc generated markdown

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -187,7 +187,7 @@ impl DocBuilder {
                             path.clone(),
                             target_path,
                             from_library,
-                            self.config.out.clone(),
+                            self.root.join(&self.config.out),
                         )
                         .with_content(DocumentContent::Single(item), ident))
                     })

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -442,11 +442,16 @@ impl DocBuilder {
                         .transpose()?
                         .unwrap_or(summary_path);
                     readme.write_link_list_item(ident, &readme_path.display().to_string(), 0)?;
+                    println!("if readme_path: {}", readme_path.display());
+                    println!("if summary_path: {}", summary_path.display());
                 }
             } else {
                 let name = path.iter().last().unwrap().to_string_lossy();
-                let readme_path = Path::new("/").join(&path).display().to_string();
-                readme.write_link_list_item(&name, &readme_path, 0)?;
+                let doc_root = self.out_dir();
+                let relative_path = path.strip_prefix(&self.root).unwrap_or(&path);
+                let full_path = doc_root.join("book/").join(relative_path);
+                let full_absolute_link = format!("file://{}/index.html", full_path.display());
+                readme.write_link_list_item(&name, &full_absolute_link, 0)?;
                 self.write_summary_section(summary, &files, Some(&path), depth + 1)?;
             }
         }

--- a/crates/doc/src/document.rs
+++ b/crates/doc/src/document.rs
@@ -62,6 +62,10 @@ impl Document {
         context.insert(id, output);
     }
 
+    pub fn full_output_path(&self) -> PathBuf {
+        self.out_target_dir.join(self.relative_output_path())
+    }
+
     /// Read preprocessor result from context
     pub fn get_from_context(&self, id: PreprocessorId) -> Option<PreprocessorOutput> {
         let context = self.context.lock().expect("failed to lock context");

--- a/crates/doc/src/preprocessor/contract_inheritance.rs
+++ b/crates/doc/src/preprocessor/contract_inheritance.rs
@@ -59,7 +59,8 @@ impl ContractInheritance {
             if let DocumentContent::Single(ref item) = candidate.content {
                 if let ParseSource::Contract(ref contract) = item.source {
                     if base == contract.name.safe_unwrap().name {
-                        return Some(candidate.target_path.clone())
+                        let full_path = candidate.full_output_path();
+                        return Some(full_path);
                     }
                 }
             }


### PR DESCRIPTION

## Motivation

#8576 This issue found a link problem in `forge doc` generated website. Some link uses the wrong absolute link like `/contracts/foo` which is an invalid URL.

## Solution
There are two parts using the wrong absolute link
* inheritance part
* summary page link for folders( if the contract is inside a subfolder of contract src page, like `contracts/consensus/authority/`

![Screenshot 2024-08-04 at 22 52 01](https://github.com/user-attachments/assets/951d7fc8-3e95-487f-812b-41bfdf1a18c3)

![Screenshot 2024-08-04 at 22 51 27](https://github.com/user-attachments/assets/0570b568-174e-49a7-9bed-d532b5440c95)

For the inheritance page, we changed how the inheritance contract is processed and stored the relevant path( like ` docs/src/contracts/portals/IERC20Portal.sol/interface.IERC20Portal.md`). We assemble the final link in the as_doc where inheritance is processed. We concatenate the link (like `/Users/glaze/developer/foundry/rollups-contracts/docs/docs/src/contracts/inputs/IInputBox.sol/interface.IInputBox.md`) and clean it up and output the correct link (like `file:///Users/glaze/developer/foundry/rollups-contracts/docs/book/contracts/portals/IPortal.sol/interface.IPortal.html`.)