### PR TITLE
fix(coverage): account if/else statements without brackets

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -534,10 +534,23 @@ impl<'a> ContractVisitor<'a> {
     }
 }
 
-/// Helper function to check if a given node contains any statement.
+/// Helper function to check if a given node is or contains any statement.
 fn has_statements(node: &Node) -> bool {
-    let statements: Vec<Node> = node.attribute("statements").unwrap_or_default();
-    !statements.is_empty()
+    match node.node_type {
+        NodeType::DoWhileStatement |
+        NodeType::EmitStatement |
+        NodeType::ExpressionStatement |
+        NodeType::ForStatement |
+        NodeType::IfStatement |
+        NodeType::RevertStatement |
+        NodeType::TryStatement |
+        NodeType::VariableDeclarationStatement |
+        NodeType::WhileStatement => true,
+        _ => {
+            let statements: Vec<Node> = node.attribute("statements").unwrap_or_default();
+            !statements.is_empty()
+        }
+    }
 }
 
 /// [`SourceAnalyzer`] result type.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8605 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- statements in if/else could be blocks but also single statements without brackets
- update `has_statements` fn to account  if/else statements types without brackets