### PR TITLE
ci: enable asm-keccak on more platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,11 @@ jobs:
         run: |
           set -eo pipefail
           target="${{ matrix.target }}"
-          flags=(--release --bins --no-default-features --features rustls,aws-kms,cli)
+          flags=(--release --bins --no-default-features --features rustls,aws-kms,cli,asm-keccak)
 
-          # `jemalloc` and `keccak-asm` are not supported on MSVC or aarch64 Linux.
+          # `jemalloc` is not fully supported on MSVC or aarch64 Linux.
           if [[ "$target" != *msvc* && "$target" != "aarch64-unknown-linux-gnu" ]]; then
-            flags+=(--features asm-keccak,jemalloc)
+            flags+=(--features jemalloc)
           fi
 
           [[ "$target" == *windows* ]] && exe=".exe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,9 +2833,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -3379,7 +3379,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.5",
  "revm-inspectors",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3601,7 +3601,7 @@ dependencies = [
  "proptest",
  "rand",
  "revm",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "semver 1.0.23",
  "serde_json",
  "thiserror",
@@ -3691,7 +3691,7 @@ dependencies = [
  "num-format",
  "once_cell",
  "reqwest 0.12.5",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3925,7 +3925,7 @@ dependencies = [
  "foundry-test-utils",
  "itertools 0.13.0",
  "once_cell",
- "rustc-hash 2.0.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -3954,7 +3954,7 @@ dependencies = [
  "parking_lot",
  "revm",
  "revm-inspectors",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
@@ -3973,7 +3973,7 @@ dependencies = [
  "foundry-evm-core",
  "rayon",
  "revm",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "semver 1.0.23",
  "tracing",
 ]
@@ -4025,7 +4025,7 @@ dependencies = [
  "rayon",
  "revm",
  "revm-inspectors",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "solang-parser",
  "tempfile",
@@ -4048,7 +4048,7 @@ dependencies = [
  "futures",
  "parking_lot",
  "revm",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
@@ -5304,9 +5304,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -6803,16 +6803,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "rustls 0.23.12",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -6820,14 +6821,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -6844,6 +6845,7 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -7342,12 +7344,6 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -7591,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a870e34715d5d59c8536040d4d4e7a41af44d527dc50237036ba4090db7996fc"
+checksum = "8d777f59627453628a9a5be1ee8d948745b94b1dfc2d0c3099cbd9e08ab89e7c"
 dependencies = [
  "sdd",
 ]
@@ -7960,9 +7956,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
  "cfg-if",


### PR DESCRIPTION
Releases 0.1.2 and 0.1.3 added support for aarch64 Linux and MSVC, among others. See:
- https://github.com/DaniPopes/keccak-asm/pull/5
- https://github.com/DaniPopes/keccak-asm/pull/6
- https://github.com/DaniPopes/keccak-asm/pull/8