### PR TITLE
feat: add default `T-needs-triage` label to default feature / bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report
-labels: ["T-bug"]
+labels: ["T-feature", "T-needs-triage"]
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report
-labels: ["T-feature", "T-needs-triage"]
+labels: ["T-bug", "T-needs-triage"]
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a feature
-labels: ["T-feature"]
+labels: ["T-feature", "T-needs-triage"]
 body:
     - type: markdown
       attributes:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Makes it easier to identify new tickets that require labeling

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds the `T-needs-triage` label to the default forms for ticket creation