### PR TITLE
fix(coverage): use first opcode for if block with statements

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -218,29 +218,26 @@ impl<'a> ContractVisitor<'a> {
                         // statements.
                         if has_statements(&true_body) || has_statements(&false_body) {
                             // Add the coverage item for branch 0 (true body).
-                            // The relevant source range for the true branch is the `if(...)`
-                            // statement itself and the true body of the if statement.
-                            //
-                            // The false body of the statement is processed as its own thing.
-                            // If this source range is not processed like this, it is virtually
-                            // impossible to correctly map instructions back to branches that
-                            // include more complex logic like conditional logic.
+                            // The branch instruction is mapped to the first opcode within the true
+                            // body source range.
                             self.push_item(CoverageItem {
-                                kind: CoverageItemKind::Branch { branch_id, path_id: 0 },
-                                loc: self.source_location_for(&ast::LowFidelitySourceLocation {
-                                    start: node.src.start,
-                                    length: true_body.src.length.map(|length| {
-                                        true_body.src.start - node.src.start + length
-                                    }),
-                                    index: node.src.index,
-                                }),
+                                kind: CoverageItemKind::Branch {
+                                    branch_id,
+                                    path_id: 0,
+                                    first_opcode: true,
+                                },
+                                loc: self.source_location_for(&true_body.src),
                                 hits: 0,
                             });
                             // Add the coverage item for branch 1 (false body).
                             // The relevant source range for the false branch is the `else`
                             // statement itself and the false body of the else statement.
                             self.push_item(CoverageItem {
-                                kind: CoverageItemKind::Branch { branch_id, path_id: 1 },
+                                kind: CoverageItemKind::Branch {
+                                    branch_id,
+                                    path_id: 1,
+                                    first_opcode: false,
+                                },
                                 loc: self.source_location_for(&ast::LowFidelitySourceLocation {
                                     start: node.src.start,
                                     length: false_body.src.length.map(|length| {
@@ -294,7 +291,7 @@ impl<'a> ContractVisitor<'a> {
                 self.branch_id += 1;
 
                 self.push_item(CoverageItem {
-                    kind: CoverageItemKind::Branch { branch_id, path_id: 0 },
+                    kind: CoverageItemKind::Branch { branch_id, path_id: 0, first_opcode: false },
                     loc: self.source_location_for(&node.src),
                     hits: 0,
                 });
@@ -424,12 +421,20 @@ impl<'a> ContractVisitor<'a> {
                             let branch_id = self.branch_id;
                             self.branch_id += 1;
                             self.push_item(CoverageItem {
-                                kind: CoverageItemKind::Branch { branch_id, path_id: 0 },
+                                kind: CoverageItemKind::Branch {
+                                    branch_id,
+                                    path_id: 0,
+                                    first_opcode: false,
+                                },
                                 loc: self.source_location_for(&node.src),
                                 hits: 0,
                             });
                             self.push_item(CoverageItem {
-                                kind: CoverageItemKind::Branch { branch_id, path_id: 1 },
+                                kind: CoverageItemKind::Branch {
+                                    branch_id,
+                                    path_id: 1,
+                                    first_opcode: false,
+                                },
                                 loc: self.source_location_for(&node.src),
                                 hits: 0,
                             });

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -224,7 +224,7 @@ impl<'a> ContractVisitor<'a> {
                                 kind: CoverageItemKind::Branch {
                                     branch_id,
                                     path_id: 0,
-                                    first_opcode: true,
+                                    is_first_opcode: true,
                                 },
                                 loc: self.source_location_for(&true_body.src),
                                 hits: 0,
@@ -236,7 +236,7 @@ impl<'a> ContractVisitor<'a> {
                                 kind: CoverageItemKind::Branch {
                                     branch_id,
                                     path_id: 1,
-                                    first_opcode: false,
+                                    is_first_opcode: false,
                                 },
                                 loc: self.source_location_for(&ast::LowFidelitySourceLocation {
                                     start: node.src.start,
@@ -291,7 +291,11 @@ impl<'a> ContractVisitor<'a> {
                 self.branch_id += 1;
 
                 self.push_item(CoverageItem {
-                    kind: CoverageItemKind::Branch { branch_id, path_id: 0, first_opcode: false },
+                    kind: CoverageItemKind::Branch {
+                        branch_id,
+                        path_id: 0,
+                        is_first_opcode: false,
+                    },
                     loc: self.source_location_for(&node.src),
                     hits: 0,
                 });
@@ -424,7 +428,7 @@ impl<'a> ContractVisitor<'a> {
                                 kind: CoverageItemKind::Branch {
                                     branch_id,
                                     path_id: 0,
-                                    first_opcode: false,
+                                    is_first_opcode: false,
                                 },
                                 loc: self.source_location_for(&node.src),
                                 hits: 0,
@@ -433,7 +437,7 @@ impl<'a> ContractVisitor<'a> {
                                 kind: CoverageItemKind::Branch {
                                     branch_id,
                                     path_id: 1,
-                                    first_opcode: false,
+                                    is_first_opcode: false,
                                 },
                                 loc: self.source_location_for(&node.src),
                                 hits: 0,

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -24,27 +24,34 @@ pub fn find_anchors(
             }
 
             let item = &items[item_id];
+            let find_anchor_by_first_opcode = |item: &CoverageItem| match find_anchor_simple(
+                source_map, ic_pc_map, item_id, &item.loc,
+            ) {
+                Ok(anchor) => Some(anchor),
+                Err(e) => {
+                    warn!("Could not find anchor for item {item}: {e}");
+                    None
+                }
+            };
             match item.kind {
-                CoverageItemKind::Branch { path_id, .. } => {
-                    match find_anchor_branch(bytecode, source_map, item_id, &item.loc) {
-                        Ok(anchors) => match path_id {
-                            0 => Some(anchors.0),
-                            1 => Some(anchors.1),
-                            _ => panic!("Too many paths for branch"),
-                        },
-                        Err(e) => {
-                            warn!("Could not find anchor for item {item}: {e}");
-                            None
+                CoverageItemKind::Branch { path_id, first_opcode, .. } => {
+                    if first_opcode {
+                        find_anchor_by_first_opcode(item)
+                    } else {
+                        match find_anchor_branch(bytecode, source_map, item_id, &item.loc) {
+                            Ok(anchors) => match path_id {
+                                0 => Some(anchors.0),
+                                1 => Some(anchors.1),
+                                _ => panic!("Too many paths for branch"),
+                            },
+                            Err(e) => {
+                                warn!("Could not find anchor for item {item}: {e}");
+                                None
+                            }
                         }
                     }
                 }
-                _ => match find_anchor_simple(source_map, ic_pc_map, item_id, &item.loc) {
-                    Ok(anchor) => Some(anchor),
-                    Err(e) => {
-                        warn!("Could not find anchor for item {item}: {e}");
-                        None
-                    }
-                },
+                _ => find_anchor_by_first_opcode(item),
             }
         })
         .collect()

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -34,8 +34,8 @@ pub fn find_anchors(
                 }
             };
             match item.kind {
-                CoverageItemKind::Branch { path_id, first_opcode, .. } => {
-                    if first_opcode {
+                CoverageItemKind::Branch { path_id, is_first_opcode, .. } => {
+                    if is_first_opcode {
                         find_anchor_by_first_opcode(item)
                     } else {
                         match find_anchor_branch(bytecode, source_map, item_id, &item.loc) {

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -294,6 +294,8 @@ pub enum CoverageItemKind {
         ///
         /// The first path has ID 0, the next ID 1, and so on.
         path_id: usize,
+        /// If true, then the branch anchor is the first opcode within the branch source range.
+        first_opcode: bool,
     },
     /// A branch in the code.
     SinglePathBranch {
@@ -326,7 +328,7 @@ impl Display for CoverageItem {
             CoverageItemKind::Statement => {
                 write!(f, "Statement")?;
             }
-            CoverageItemKind::Branch { branch_id, path_id } => {
+            CoverageItemKind::Branch { branch_id, path_id, .. } => {
                 write!(f, "Branch (branch: {branch_id}, path: {path_id})")?;
             }
             CoverageItemKind::SinglePathBranch { branch_id } => {

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -295,7 +295,7 @@ pub enum CoverageItemKind {
         /// The first path has ID 0, the next ID 1, and so on.
         path_id: usize,
         /// If true, then the branch anchor is the first opcode within the branch source range.
-        first_opcode: bool,
+        is_first_opcode: bool,
     },
     /// A branch in the code.
     SinglePathBranch {

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -109,7 +109,7 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
                     CoverageItemKind::Line => {
                         writeln!(self.destination, "DA:{line},{hits}")?;
                     }
-                    CoverageItemKind::Branch { branch_id, path_id } => {
+                    CoverageItemKind::Branch { branch_id, path_id, .. } => {
                         writeln!(
                             self.destination,
                             "BRDA:{line},{branch_id},{path_id},{}",

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1094,10 +1094,10 @@ contract AContractTest is DSTest {
         .assert_success()
         .stdout_eq(str![[r#"
 ...
-| File              | % Lines       | % Statements | % Branches   | % Funcs       |
-|-------------------|---------------|--------------|--------------|---------------|
-| src/AContract.sol | 100.00% (4/4) | 50.00% (2/4) | 50.00% (2/4) | 100.00% (1/1) |
-| Total             | 100.00% (4/4) | 50.00% (2/4) | 50.00% (2/4) | 100.00% (1/1) |
+| File              | % Lines      | % Statements | % Branches   | % Funcs       |
+|-------------------|--------------|--------------|--------------|---------------|
+| src/AContract.sol | 50.00% (2/4) | 50.00% (2/4) | 50.00% (2/4) | 100.00% (1/1) |
+| Total             | 50.00% (2/4) | 50.00% (2/4) | 50.00% (2/4) | 100.00% (1/1) |
 
 "#]]);
 
@@ -1109,6 +1109,95 @@ contract AContractTest is DSTest {
 |-------------------|---------------|---------------|---------------|---------------|
 | src/AContract.sol | 100.00% (4/4) | 100.00% (4/4) | 100.00% (4/4) | 100.00% (1/1) |
 | Total             | 100.00% (4/4) | 100.00% (4/4) | 100.00% (4/4) | 100.00% (1/1) |
+
+"#]],
+    );
+});
+
+// https://github.com/foundry-rs/foundry/issues/8604
+forgetest!(test_branch_with_calldata_reads, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    event IsTrue(bool isTrue);
+    event IsFalse(bool isFalse);
+
+    function execute(bool[] calldata isTrue) external {
+        for (uint256 i = 0; i < isTrue.length; i++) {
+            if (isTrue[i]) {
+                emit IsTrue(isTrue[i]);
+            } else {
+                emit IsFalse(!isTrue[i]);
+            }
+        }
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import {AContract} from "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function testTrueCoverage() external {
+        AContract a = new AContract();
+        bool[] memory isTrue = new bool[](1);
+        isTrue[0] = true;
+        a.execute(isTrue);
+    }
+
+    function testFalseCoverage() external {
+        AContract a = new AContract();
+        bool[] memory isFalse = new bool[](1);
+        isFalse[0] = false;
+        a.execute(isFalse);
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    // Assert 50% coverage for true branches.
+    cmd.arg("coverage")
+        .args(["--mt".to_string(), "testTrueCoverage".to_string()])
+        .assert_success()
+        .stdout_eq(str![[r#"
+...
+| File              | % Lines      | % Statements | % Branches   | % Funcs       |
+|-------------------|--------------|--------------|--------------|---------------|
+| src/AContract.sol | 75.00% (3/4) | 80.00% (4/5) | 50.00% (1/2) | 100.00% (1/1) |
+| Total             | 75.00% (3/4) | 80.00% (4/5) | 50.00% (1/2) | 100.00% (1/1) |
+
+"#]]);
+
+    // Assert 50% coverage for false branches.
+    cmd.forge_fuse()
+        .arg("coverage")
+        .args(["--mt".to_string(), "testFalseCoverage".to_string()])
+        .assert_success()
+        .stdout_eq(str![[r#"
+...
+| File              | % Lines      | % Statements | % Branches   | % Funcs       |
+|-------------------|--------------|--------------|--------------|---------------|
+| src/AContract.sol | 50.00% (2/4) | 80.00% (4/5) | 50.00% (1/2) | 100.00% (1/1) |
+| Total             | 50.00% (2/4) | 80.00% (4/5) | 50.00% (1/2) | 100.00% (1/1) |
+
+"#]]);
+
+    // Assert 100% coverage (true/false branches properly covered).
+    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
+        str![[r#"
+...
+| File              | % Lines       | % Statements  | % Branches    | % Funcs       |
+|-------------------|---------------|---------------|---------------|---------------|
+| src/AContract.sol | 100.00% (4/4) | 100.00% (5/5) | 100.00% (2/2) | 100.00% (1/1) |
+| Total             | 100.00% (4/4) | 100.00% (5/5) | 100.00% (2/2) | 100.00% (1/1) |
 
 "#]],
     );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8604 

Atm for branches we determine instruction anchors for both if / else statements. This works OK but in some edge cases like https://github.com/foundry-rs/foundry/issues/8604#issuecomment-2270443031 where last JUMPI instruction within if block triggers replacement of anchor properly / previously identified. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- for if blocks with statements the anchor is always the opcode of first statement: introduce `is_first_opcode` flag for `Branch` coverage item kind. Set flag to true for if with statements and test flag when finding branch anchors. If set as first opcode then find instruction from source map /  ic-pc map (`find_anchor_simple`), otherwise by looking up last JUMPI instruction (`find_anchor_branch`). 
- tests (fixed test for single statement coverage false path where all lines were shown as hit)