### PR TITLE
feat(cast): call json flag

### DIFF
--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -62,6 +62,10 @@ pub struct CallArgs {
     #[arg(long, short)]
     block: Option<BlockId>,
 
+    /// Print the decoded output as JSON.
+    #[arg(long, short, help_heading = "Display options")]
+    json: bool,
+
     #[command(subcommand)]
     command: Option<CallSubcommands>,
 
@@ -112,6 +116,7 @@ impl CallArgs {
             decode_internal,
             labels,
             data,
+            json,
         } = self;
 
         if let Some(data) = data {
@@ -190,7 +195,7 @@ impl CallArgs {
             return Ok(());
         }
 
-        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block).await?);
+        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, json).await?);
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -195,7 +195,7 @@ impl CallArgs {
             return Ok(());
         }
 
-        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, Some(json)).await?);
+        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, json).await?);
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -195,7 +195,7 @@ impl CallArgs {
             return Ok(());
         }
 
-        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, json).await?);
+        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, Some(json)).await?);
 
         Ok(())
     }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -118,7 +118,7 @@ where
     /// let tx = TransactionRequest::default().to(to).input(bytes.into());
     /// let tx = WithOtherFields::new(tx);
     /// let cast = Cast::new(alloy_provider);
-    /// let data = cast.call(&tx, None, None, None).await?;
+    /// let data = cast.call(&tx, None, None, false).await?;
     /// println!("{}", data);
     /// # Ok(())
     /// # }
@@ -128,10 +128,9 @@ where
         req: &WithOtherFields<TransactionRequest>,
         func: Option<&Function>,
         block: Option<BlockId>,
-        json: Option<bool>,
+        json: bool,
     ) -> Result<String> {
         let res = self.provider.call(req).block(block.unwrap_or_default()).await?;
-        let json = json.unwrap_or(false);
 
         let mut decoded = vec![];
 

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -128,6 +128,7 @@ where
         req: &WithOtherFields<TransactionRequest>,
         func: Option<&Function>,
         block: Option<BlockId>,
+        json: bool,
     ) -> Result<String> {
         let res = self.provider.call(req).block(block.unwrap_or_default()).await?;
 
@@ -168,6 +169,9 @@ where
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {
             format!("{res}\n")
+        } else if json {
+            let tokens = decoded.iter().map(format_token_raw).collect::<Vec<_>>();
+            serde_json::to_string_pretty(&tokens).unwrap()
         } else {
             // seth compatible user-friendly return type conversions
             decoded.iter().map(format_token).collect::<Vec<_>>().join("\n")

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -118,7 +118,7 @@ where
     /// let tx = TransactionRequest::default().to(to).input(bytes.into());
     /// let tx = WithOtherFields::new(tx);
     /// let cast = Cast::new(alloy_provider);
-    /// let data = cast.call(&tx, None, None).await?;
+    /// let data = cast.call(&tx, None, None, None).await?;
     /// println!("{}", data);
     /// # Ok(())
     /// # }
@@ -128,9 +128,10 @@ where
         req: &WithOtherFields<TransactionRequest>,
         func: Option<&Function>,
         block: Option<BlockId>,
-        json: bool,
+        json: Option<bool>,
     ) -> Result<String> {
         let res = self.provider.call(req).block(block.unwrap_or_default()).await?;
+        let json = json.unwrap_or(false);
 
         let mut decoded = vec![];
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

- Adds `-j` or `--json` flag to `cast call` to have JSON formatted output. This is helpful when using `cast call` in scripts with tools like `jq`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

```bash
$ cargo run call -r https://rpc.ankr.com/eth 0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2 "rollupIDToRollupData(uint32)(address,uint64,address,uint64,bytes32,uint64,uint64,uint64,uint64,uint64,uint64,uint8)" 1 -j

[
  "0x519E42c24163192Dca44CD3fBDCEBF6be9130987",
  "1101",
  "0x0775e11309d75aA6b0967917fB0213C5673eDf81",
  "9",
  "0x51c3cc08917f8837e12cca778e6d636a3eb467e31e006d58db6c6022f4551199",
  "2086321",
  "2086269",
  "0",
  "0",
  "2001442",
  "3",
  "0"
]
```
