### PR TITLE
chore(coverage): remove SinglePathBranch kind, use Branch kind

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -236,7 +236,11 @@ impl<'a> ContractVisitor<'a> {
                         if has_statements(&true_body) {
                             // Add the coverage item for branch 0 (true body).
                             self.push_item_kind(
-                                CoverageItemKind::SinglePathBranch { branch_id },
+                                CoverageItemKind::Branch {
+                                    branch_id,
+                                    path_id: 0,
+                                    is_first_opcode: true,
+                                },
                                 &true_body.src,
                             );
                             // Process the true body.
@@ -451,12 +455,8 @@ impl<'a> ContractVisitor<'a> {
     fn push_item_kind(&mut self, kind: CoverageItemKind, src: &ast::LowFidelitySourceLocation) {
         let item = CoverageItem { kind, loc: self.source_location_for(src), hits: 0 };
         // Push a line item if we haven't already
-        if matches!(
-            item.kind,
-            CoverageItemKind::Statement |
-                CoverageItemKind::Branch { .. } |
-                CoverageItemKind::SinglePathBranch { .. }
-        ) && self.last_line < item.loc.line
+        if matches!(item.kind, CoverageItemKind::Statement | CoverageItemKind::Branch { .. }) &&
+            self.last_line < item.loc.line
         {
             self.items.push(CoverageItem {
                 kind: CoverageItemKind::Line,

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -297,11 +297,6 @@ pub enum CoverageItemKind {
         /// If true, then the branch anchor is the first opcode within the branch source range.
         is_first_opcode: bool,
     },
-    /// A branch in the code.
-    SinglePathBranch {
-        /// The ID that identifies the branch.
-        branch_id: usize,
-    },
     /// A function in the code.
     Function {
         /// The name of the function.
@@ -330,9 +325,6 @@ impl Display for CoverageItem {
             }
             CoverageItemKind::Branch { branch_id, path_id, .. } => {
                 write!(f, "Branch (branch: {branch_id}, path: {path_id})")?;
-            }
-            CoverageItemKind::SinglePathBranch { branch_id } => {
-                write!(f, "Branch (branch: {branch_id}, path: 0)")?;
             }
             CoverageItemKind::Function { name } => {
                 write!(f, r#"Function "{name}""#)?;
@@ -418,7 +410,7 @@ impl AddAssign<&CoverageItem> for CoverageSummary {
                     self.statement_hits += 1;
                 }
             }
-            CoverageItemKind::Branch { .. } | CoverageItemKind::SinglePathBranch { .. } => {
+            CoverageItemKind::Branch { .. } => {
                 self.branch_count += 1;
                 if item.hits > 0 {
                     self.branch_hits += 1;

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -116,13 +116,6 @@ impl<'a> CoverageReporter for LcovReporter<'a> {
                             if hits == 0 { "-".to_string() } else { hits.to_string() }
                         )?;
                     }
-                    CoverageItemKind::SinglePathBranch { branch_id } => {
-                        writeln!(
-                            self.destination,
-                            "BRDA:{line},{branch_id},0,{}",
-                            if hits == 0 { "-".to_string() } else { hits.to_string() }
-                        )?;
-                    }
                     // Statements are not in the LCOV format.
                     // We don't add them in order to avoid doubling line hits.
                     _ => {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`SinglePathBranch` kind is the same with `Branch` kind with `first_op_code` flag set to true
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- remove `SinglePathBranch` and use `Branch` with `first_op_code=true`