### PR TITLE
perf: configure provider poll interval

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -27,6 +27,13 @@ use std::{
 };
 use url::ParseError;
 
+/// The assumed block time for unknown chains.
+/// We assume that these are chains have a faster block time.
+const DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME: Duration = Duration::from_secs(3);
+
+/// The factor to scale the block time by to get the poll interval.
+const POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR: f32 = 0.6;
+
 /// Helper type alias for a retry provider
 pub type RetryProvider<N = AnyNetwork> = RootProvider<RetryBackoffService<RuntimeTransport>, N>;
 
@@ -229,7 +236,7 @@ impl ProviderBuilder {
     pub fn build(self) -> Result<RetryProvider> {
         let Self {
             url,
-            chain: _,
+            chain,
             max_retry,
             initial_backoff,
             timeout,
@@ -249,6 +256,15 @@ impl ProviderBuilder {
             .with_jwt(jwt)
             .build();
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+
+        if !is_local {
+            client.set_poll_interval(
+                chain
+                    .average_blocktime_hint()
+                    .unwrap_or(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)
+                    .mul_f32(POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR),
+            );
+        }
 
         let provider = AlloyProviderBuilder::<_, _, AnyNetwork>::default()
             .on_provider(RootProvider::new(client));
@@ -260,7 +276,7 @@ impl ProviderBuilder {
     pub fn build_with_wallet(self, wallet: EthereumWallet) -> Result<RetryProviderWithSigner> {
         let Self {
             url,
-            chain: _,
+            chain,
             max_retry,
             initial_backoff,
             timeout,
@@ -281,6 +297,15 @@ impl ProviderBuilder {
             .build();
 
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
+
+        if !is_local {
+            client.set_poll_interval(
+                chain
+                    .average_blocktime_hint()
+                    .unwrap_or(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)
+                    .mul_f32(POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR),
+            );
+        }
 
         let provider = AlloyProviderBuilder::<_, _, AnyNetwork>::default()
             .with_recommended_fillers()


### PR DESCRIPTION
we currently don't configure a chain specific poll interval and this would fallback to 7s if not local in alloy's default impl.

we can use the chain if it's known or assume some reasonable default 