### PR TITLE
fix: add Mandala + Karura + Acala as exceptions for gas calculation during deployment

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -173,7 +173,12 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                 NamedChain::Moonbase |
                 NamedChain::Moonbeam |
                 NamedChain::MoonbeamDev |
-                NamedChain::Moonriver
+                NamedChain::Moonriver |
+                NamedChain::Mandala |
+                NamedChain::KaruraTestnet |
+                NamedChain::AcalaTestnet |
+                NamedChain::Karura |
+                NamedChain::Acala
         );
     }
     false


### PR DESCRIPTION
## Motivation

add Mandala + Karura + Acala as exceptions for gas calculation during deployment
Resolves: https://github.com/AcalaNetwork/Acala/discussions/2769#discussioncomment-10263166

## Solution

