### PR TITLE
feat(cast run): try custom error decode from openchain signature database

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -1,7 +1,7 @@
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::Address;
 use eyre::{Result, WrapErr};
-use foundry_common::{cli_warn, fs, TestFunctionExt};
+use foundry_common::{cli_warn, fs, selectors::OpenChainClient, TestFunctionExt};
 use foundry_compilers::{
     artifacts::{CompactBytecode, CompactDeployedBytecode, Settings},
     cache::{CacheEntry, CompilerCache},
@@ -379,6 +379,7 @@ pub async fn handle_traces(
             Config::foundry_cache_dir(),
             config.offline,
         )?)
+        .with_openchain_client(OpenChainClient::new()?)
         .build();
 
     let mut etherscan_identifier = EtherscanIdentifier::new(config, chain)?;

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -1,7 +1,7 @@
 //! ABI related helper functions.
 
 use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt, JsonAbiExt};
-use alloy_json_abi::{Event, Function, Param};
+use alloy_json_abi::{Error, Event, Function, Param};
 use alloy_primitives::{hex, Address, LogData};
 use eyre::{Context, ContextCompat, Result};
 use foundry_block_explorers::{contract::ContractMetadata, errors::EtherscanError, Client};
@@ -83,6 +83,10 @@ pub fn get_func(sig: &str) -> Result<Function> {
 /// Given an event signature string, it tries to parse it as a `Event`
 pub fn get_event(sig: &str) -> Result<Event> {
     Event::parse(sig).wrap_err("could not parse event signature")
+}
+
+pub fn get_error(sig: &str) -> Result<Error> {
+    Error::parse(sig).wrap_err("could not parse error signature")
 }
 
 /// Given an event without indexed parameters and a rawlog, it tries to return the event with the

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -181,6 +181,16 @@ impl RevertDecoder {
             return Some(std::str::from_utf8(err).unwrap().to_string());
         }
 
+        // Generic custom error.
+        Some(format!(
+            "custom error {}:{}",
+            hex::encode(selector),
+            std::str::from_utf8(data).map_or_else(|_| trimmed_hex(data), String::from)
+        ))
+    }
+
+    pub fn may_decode_using_open_chain(&self, err: &[u8]) -> Option<String> {
+        let (selector, data) = err.split_at(SELECTOR_LEN);
         // try from https://openchain.xyz
         if let Some(client) = self.open_chain_client.clone() {
             if let Ok(handle) = Handle::try_current() {
@@ -214,13 +224,7 @@ impl RevertDecoder {
                 }
             }
         }
-
-        // Generic custom error.
-        Some(format!(
-            "custom error {}:{}",
-            hex::encode(selector),
-            std::str::from_utf8(data).map_or_else(|_| trimmed_hex(data), String::from)
-        ))
+        None
     }
 }
 

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -9,7 +9,8 @@ use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
 use alloy_primitives::{Address, LogData, Selector, B256};
 use foundry_common::{
-    abi::get_indexed_event, fmt::format_token, get_contract_name, ContractsByArtifact, SELECTOR_LEN,
+    abi::get_indexed_event, fmt::format_token, get_contract_name, selectors::OpenChainClient,
+    ContractsByArtifact, SELECTOR_LEN,
 };
 use foundry_evm_core::{
     abi::{Console, HardhatConsole, Vm, HARDHAT_CONSOLE_SELECTOR_PATCHES},
@@ -86,6 +87,13 @@ impl CallTraceDecoderBuilder {
     #[inline]
     pub fn with_signature_identifier(mut self, identifier: SingleSignaturesIdentifier) -> Self {
         self.decoder.signature_identifier = Some(identifier);
+        self
+    }
+
+    /// Sets the openchain client.
+    #[inline]
+    pub fn with_openchain_client(mut self, client: OpenChainClient) -> Self {
+        self.decoder.revert_decoder.open_chain_client = Some(client);
         self
     }
 

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -573,7 +573,15 @@ impl CallTraceDecoder {
 
     /// The default decoded return data for a trace.
     fn default_return_data(&self, trace: &CallTrace) -> Option<String> {
-        (!trace.success).then(|| self.revert_decoder.decode(&trace.output, Some(trace.status)))
+        (!trace.success).then(|| {
+            let err_str = self.revert_decoder.decode(&trace.output, Some(trace.status));
+            if err_str.contains("custom error") {
+                if let Some(err) = self.revert_decoder.may_decode_using_open_chain(&trace.output) {
+                    return err;
+                }
+            }
+            err_str
+        })
     }
 
     /// Decodes an event.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

contract OwnerControlled {
    address public owner;
    uint256 private value;

    event ValueChanged(uint256 newValue);
    error Unknown(string str);

    constructor() {
        owner = msg.sender;
    }

    modifier onlyOwner() {
        if(msg.sender != owner) {
            revert Unknown("only Owner");
        }
        _;
    }

    function setValue(uint256 _newValue) public onlyOwner {
        value = _newValue;
        emit ValueChanged(_newValue);
    }

    function getValue() public view returns (uint256) {
        return value;
    }
}
```
in this contract, when tx revert by using custom error.  
cast run result:
```
Executing previous transactions from the block.
Traces:
  [2462] 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9::setValue(1)
    └─ ← [Revert] custom error 7c45b126: 
only Owner


Transaction failed.
```

## Solution
I think we can make it more readable by using openchain's signature database online.   
In this pr, custom err would look like:

```
Executing previous transactions from the block.
Traces:
  [2462] 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9::setValue(1)
    └─ ← [Revert] Unknown("only Owner")


Transaction failed.

```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
