### PR TITLE
chore: simplify assert/require shrink test

### DIFF
--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -301,6 +301,8 @@ async fn check_shrink_sequence(test_pattern: &str, expected_len: usize) {
         Filter::new(test_pattern, ".*", ".*fuzz/invariant/common/InvariantShrinkWithAssert.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
     runner.test_options.fuzz.seed = Some(U256::from(100u32));
+    runner.test_options.invariant.runs = 1;
+    runner.test_options.invariant.depth = 15;
 
     match get_counterexample!(runner, &filter) {
         CounterExample::Single(_) => panic!("CounterExample should be a sequence."),

--- a/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
+++ b/testdata/default/fuzz/invariant/common/InvariantShrinkWithAssert.t.sol
@@ -2,19 +2,9 @@
 pragma solidity ^0.8.13;
 
 import "ds-test/test.sol";
-import "cheats/Vm.sol";
-
-struct FuzzSelector {
-    address addr;
-    bytes4[] selectors;
-}
 
 contract Counter {
     uint256 public number;
-
-    function setNumber(uint256 newNumber) public {
-        number = newNumber;
-    }
 
     function increment() public {
         number++;
@@ -23,73 +13,20 @@ contract Counter {
     function decrement() public {
         number--;
     }
-
-    function double() public {
-        number *= 2;
-    }
-
-    function half() public {
-        number /= 2;
-    }
-
-    function triple() public {
-        number *= 3;
-    }
-
-    function third() public {
-        number /= 3;
-    }
-
-    function quadruple() public {
-        number *= 4;
-    }
-
-    function quarter() public {
-        number /= 4;
-    }
-}
-
-contract Handler is DSTest {
-    Counter public counter;
-
-    constructor(Counter _counter) {
-        counter = _counter;
-        counter.setNumber(0);
-    }
-
-    function increment() public {
-        counter.increment();
-    }
-
-    function setNumber(uint256 x) public {
-        counter.setNumber(x);
-    }
 }
 
 contract InvariantShrinkWithAssert is DSTest {
-    Vm constant vm = Vm(HEVM_ADDRESS);
     Counter public counter;
-    Handler handler;
 
     function setUp() public {
         counter = new Counter();
-        handler = new Handler(counter);
-    }
-
-    function targetSelectors() public returns (FuzzSelector[] memory) {
-        FuzzSelector[] memory targets = new FuzzSelector[](1);
-        bytes4[] memory selectors = new bytes4[](2);
-        selectors[0] = handler.increment.selector;
-        selectors[1] = handler.setNumber.selector;
-        targets[0] = FuzzSelector(address(handler), selectors);
-        return targets;
     }
 
     function invariant_with_assert() public {
-        assertTrue(counter.number() != 3, "wrong counter");
+        assertTrue(counter.number() < 2, "wrong counter");
     }
 
     function invariant_with_require() public {
-        require(counter.number() != 3, "wrong counter");
+        require(counter.number() < 2, "wrong counter");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
failures from https://github.com/foundry-rs/foundry/issues/4438#issuecomment-2275407139 are caused by `test_invariant_assert_shrink` being SIGed and not STDERR failures,
```
 TRY 3 SIG 7 [   1.084s] forge::it invariant::test_invariant_assert_shrink
```
which likely is caused by running it with default runs / depth of 500.
Since test was introduced to make sure asserts in invariant tests are treated the same as requires (and therefore can shrink to same len - see https://github.com/foundry-rs/foundry/issues/6683#issuecomment-1966794329) we can simplify the test and reduce to 1 run and depth of 15

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
