### PR TITLE
fix(fmt): write single param on multiline if `params_first`

### DIFF
--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1626,6 +1626,10 @@ impl<'a, W: Write> Formatter<'a, W> {
                             &params,
                             ",",
                         )?;
+                    // Write new line if we have only one parameter and params on multiline set.
+                    if params.len() == 1 && params_multiline {
+                        writeln!(fmt.buf())?;
+                    }
                     fmt.write_chunks_separated(&params, ",", params_multiline)?;
                     Ok(())
                 },

--- a/crates/fmt/testdata/FunctionDefinition/all.fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinition/all.fmt.sol
@@ -717,7 +717,9 @@ contract FunctionOverrides is
         a = 1;
     }
 
-    function oneParam(uint256 x)
+    function oneParam(
+        uint256 x
+    )
         override(
             FunctionInterfaces,
             FunctionDefinitions,

--- a/crates/fmt/testdata/FunctionDefinition/params-first.fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinition/params-first.fmt.sol
@@ -697,7 +697,9 @@ contract FunctionOverrides is
         a = 1;
     }
 
-    function oneParam(uint256 x)
+    function oneParam(
+        uint256 x
+    )
         override(
             FunctionInterfaces,
             FunctionDefinitions,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #7721 
`params_first`  for fns with single params doe not write param on its own line, as per docs :
"params_first" - Break the function header into multiple lines, with each parameter on its own line. The function name stays on the first line.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- write single param multiline if setting to params first