### PR TITLE
Change absolute link to relative link during doc generation 

### DIFF
--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -445,7 +445,15 @@ impl DocBuilder {
                 }
             } else {
                 let name = path.iter().last().unwrap().to_string_lossy();
-                let readme_path = Path::new("/").join(&path).display().to_string();
+                let readme_path = Path::new("/")
+                    .join(&path)
+                    .display()
+                    .to_string()
+                    .trim_start_matches('/')
+                    .to_string();
+                let slash_count = readme_path.chars().filter(|&c| c == '/').count();
+                let prefix = "../".repeat(slash_count);
+                let readme_path = format!("{prefix}{readme_path}/index.html");
                 readme.write_link_list_item(&name, &readme_path, 0)?;
                 self.write_summary_section(summary, &files, Some(&path), depth + 1)?;
             }

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -146,8 +146,16 @@ impl AsDoc for Document {
                                                     .ok()
                                                     .unwrap_or(path),
                                             );
-                                            Markdown::Link(&base_doc, &path.display().to_string())
-                                                .as_doc()
+                                            Markdown::Link(
+                                                &base_doc,
+                                                &format!(
+                                                    "../../../{}",
+                                                    path.display()
+                                                        .to_string()
+                                                        .trim_start_matches('/')
+                                                ),
+                                            )
+                                            .as_doc()
                                         })
                                     })
                                     .transpose()?


### PR DESCRIPTION
# Motivation
#8576 This issue found a link problem in forge doc generated website. Some link uses the absolute link like /contracts/foo which is an invalid URL.

# Solution
There are two parts using the wrong absolute link

- inheritance part: change `"/contracts/foo"` to `"../../../contracts/foo"`
- readme page link for folders( if the contract is inside a subfolder of contract src page, like `contracts/consensus/authority/`): delete the beginning `"/"`, add some `"../"`, add `index.html` at the end.
![image](https://github.com/user-attachments/assets/23b4e02d-a661-40db-b8d6-6884b68e172b)
![image](https://github.com/user-attachments/assets/6e071c61-5f5c-44f4-943f-67049fdbaf90)

I tested this PR on [cartesi/rollups-contracts](https://github.com/cartesi/rollups-contracts). You can view the doc [website](https://www.inevitable.tech/rollup/contracts/portals/ERC1155BatchPortal.sol/contract.ERC1155BatchPortal.html) 