### PR TITLE
fix(anvil): correctly print logs

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -41,7 +41,7 @@ impl Inspector {
         self
     }
 
-    pub fn with_config(mut self, config: TracingInspectorConfig) -> Self {
+    pub fn with_tracing_config(mut self, config: TracingInspectorConfig) -> Self {
         self.tracer = Some(TracingInspector::new(config));
         self
     }


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8591

We didn't print logs correctly for `eth_call` and `eth_estimateGas` requests

## Solution
