### PR TITLE
Add --disable-code-size-limit flag for anvil

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -482,6 +482,14 @@ impl NodeConfig {
         self.code_size_limit = code_size_limit;
         self
     }
+    /// Disables  code size limit
+    #[must_use]
+    pub fn disable_code_size_limit(mut self, disable_code_size_limit: bool) -> Self {
+        if disable_code_size_limit {
+            self.code_size_limit = Some(usize::MAX);
+        }
+        self
+    }
 
     /// Sets the init state if any
     #[must_use]


### PR DESCRIPTION
## Motivation

Most of the times, devs don't want to set any particular code size limit but rather disable the whole thing. Previously `--code-size-limit=10000000` was required.

## Solution

Introduce new anvil flag: `--disable-code-size-limit` that sets size limit to uint::max.