### PR TITLE
fix: allow result large err

### DIFF
--- a/crates/config/src/fix.rs
+++ b/crates/config/src/fix.rs
@@ -69,6 +69,7 @@ impl std::error::Error for InsertProfileError {}
 impl TomlFile {
     /// Insert a name as `[profile.name]`. Creating the `[profile]` table where necessary and
     /// throwing an error if there exists a conflict
+    #[allow(clippy::result_large_err)]
     fn insert_profile(
         &mut self,
         profile_str: &str,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
```
error: the `Err`-variant returned from this function is very large
  --> crates/config/src/fix.rs:76:10
   |
76 |     ) -> Result<(), InsertProfileError> {
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 200 bytes
   |
   = help: try reducing the size of `fix::InsertProfileError`, for example by boxing large elements or replacing it with `Box<fix::InsertProfileError>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
   = note: `-D clippy::result-large-err` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`

```
https://github.com/foundry-rs/foundry/actions/runs/10370884407/job/28709851170?pr=8632
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
 add `#[allow(clippy::result_large_err)]`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
