### PR TITLE
fix(fmt): apply multi statement block config to else block

### DIFF
--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1782,7 +1782,7 @@ impl<'a, W: Write> Formatter<'a, W> {
                 self.visit_if(*loc, cond, if_branch, else_branch, false)?;
             } else {
                 let else_branch_is_single_line =
-                    self.visit_stmt_as_block(else_branch, if_branch_is_single_line)?;
+                    self.visit_stmt_as_block(else_branch, attempt_single_line)?;
                 if single_line_stmt_wide && !else_branch_is_single_line {
                     bail!(FormatterError::fmt())
                 }

--- a/crates/fmt/testdata/Repros/fmt.sol
+++ b/crates/fmt/testdata/Repros/fmt.sol
@@ -131,3 +131,17 @@ library MyLib {
     );
     // forgefmt: disable-end
 }
+
+contract IfElseTest {
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+        if (newNumber = 1) {
+            number = 1;
+        } else if (newNumber = 2) {
+            //            number = 2;
+        }
+        else {
+            newNumber = 3;
+        }
+    }
+}

--- a/crates/fmt/testdata/Repros/original.sol
+++ b/crates/fmt/testdata/Repros/original.sol
@@ -129,3 +129,17 @@ library MyLib {
     );
     // forgefmt: disable-end
 }
+
+contract IfElseTest {
+     function setNumber(uint256 newNumber) public {
+         number = newNumber;
+         if (newNumber = 1) {
+             number = 1;
+         } else if (newNumber = 2) {
+         //            number = 2;
+         }
+         else {
+             newNumber = 3;
+         }
+     }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8650 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- apply single_line_statement_blocks to else block