### PR TITLE
feat: add transaction timeout config

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -396,7 +396,7 @@ async fn main() -> Result<()> {
             println!(
                 "{}",
                 Cast::new(provider)
-                    .receipt(tx_hash, field, confirmations, cast_async, json)
+                    .receipt(tx_hash, field, confirmations, None, cast_async, json)
                     .await?
             );
         }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -691,7 +691,7 @@ where
     ///     ProviderBuilder::<_, _, AnyNetwork>::default().on_builtin("http://localhost:8545").await?;
     /// let cast = Cast::new(provider);
     /// let tx_hash = "0xf8d1713ea15a81482958fb7ddf884baee8d3bcc478c5f2f604e008dc788ee4fc";
-    /// let receipt = cast.receipt(tx_hash.to_string(), None, 1, false, false).await?;
+    /// let receipt = cast.receipt(tx_hash.to_string(), None, 1, None, false, false).await?;
     /// println!("{}", receipt);
     /// # Ok(())
     /// # }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -42,6 +42,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
     sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
 };
 use tokio::signal::ctrl_c;
 
@@ -700,6 +701,7 @@ where
         tx_hash: String,
         field: Option<String>,
         confs: u64,
+        timeout: Option<u64>,
         cast_async: bool,
         to_json: bool,
     ) -> Result<String> {
@@ -716,6 +718,7 @@ where
                     } else {
                         PendingTransactionBuilder::new(self.provider.root(), tx_hash)
                             .with_required_confirmations(confs)
+                            .with_timeout(timeout.map(Duration::from_secs))
                             .get_receipt()
                             .await?
                     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -450,6 +450,9 @@ pub struct Config {
     /// Whether to enable Alphanet features.
     pub alphanet: bool,
 
+    /// Timeout for transactions in seconds.
+    pub transaction_timeout: u64,
+
     /// Warnings gathered when loading the Config. See [`WarningsProvider`] for more information
     #[serde(rename = "__warnings", default, skip_serializing)]
     pub warnings: Vec<Warning>,
@@ -2143,6 +2146,7 @@ impl Default for Config {
             extra_args: vec![],
             eof_version: None,
             alphanet: false,
+            transaction_timeout: 120,
             _non_exhaustive: (),
         }
     }

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -223,6 +223,7 @@ impl CreateArgs {
     }
 
     /// Deploys the contract
+    #[allow(clippy::too_many_arguments)]
     async fn deploy<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
         self,
         abi: JsonAbi,

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -20,8 +20,18 @@ use foundry_common::{
     fmt::parse_tokens,
 };
 use foundry_compilers::{artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize};
+use foundry_config::{
+    figment::{
+        self,
+        value::{Dict, Map},
+        Metadata, Profile,
+    },
+    merge_impl_figment_convert, Config,
+};
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc};
+
+merge_impl_figment_convert!(CreateArgs, opts, eth);
 
 /// CLI arguments for `forge create`.
 #[derive(Clone, Debug, Parser)]
@@ -65,6 +75,10 @@ pub struct CreateArgs {
     #[arg(long, requires = "verify")]
     show_standard_json_input: bool,
 
+    /// Timeout to use for broadcasting transactions.
+    #[arg(long, env = "ETH_TIMEOUT")]
+    pub timeout: Option<u64>,
+
     #[command(flatten)]
     opts: CoreBuildArgs,
 
@@ -84,8 +98,9 @@ pub struct CreateArgs {
 impl CreateArgs {
     /// Executes the command to create a contract
     pub async fn run(mut self) -> Result<()> {
+        let config = self.try_load_config_emit_warnings()?;
         // Find Project & Compile
-        let project = self.opts.project()?;
+        let project = config.project()?;
 
         let target_path = if let Some(ref mut path) = self.contract.path {
             canonicalize(project.root().join(path))?
@@ -114,7 +129,6 @@ impl CreateArgs {
         };
 
         // Add arguments to constructor
-        let config = self.eth.try_load_config_emit_warnings()?;
         let provider = utils::get_provider(&config)?;
         let params = match abi.constructor {
             Some(ref v) => {
@@ -138,7 +152,8 @@ impl CreateArgs {
         if self.unlocked {
             // Deploy with unlocked account
             let sender = self.eth.wallet.from.expect("required");
-            self.deploy(abi, bin, params, provider, chain_id, sender).await
+            self.deploy(abi, bin, params, provider, chain_id, sender, config.transaction_timeout)
+                .await
         } else {
             // Deploy with signer
             let signer = self.eth.wallet.signer().await?;
@@ -146,7 +161,8 @@ impl CreateArgs {
             let provider = ProviderBuilder::<_, _, AnyNetwork>::default()
                 .wallet(EthereumWallet::new(signer))
                 .on_provider(provider);
-            self.deploy(abi, bin, params, provider, chain_id, deployer).await
+            self.deploy(abi, bin, params, provider, chain_id, deployer, config.transaction_timeout)
+                .await
         }
     }
 
@@ -215,12 +231,13 @@ impl CreateArgs {
         provider: P,
         chain: u64,
         deployer_address: Address,
+        timeout: u64,
     ) -> Result<()> {
         let bin = bin.into_bytes().unwrap_or_else(|| {
             panic!("no bytecode found in bin object for {}", self.contract.name)
         });
         let provider = Arc::new(provider);
-        let factory = ContractFactory::new(abi.clone(), bin.clone(), provider.clone());
+        let factory = ContractFactory::new(abi.clone(), bin.clone(), provider.clone(), timeout);
 
         let is_args_empty = args.is_empty();
         let mut deployer =
@@ -367,6 +384,20 @@ impl CreateArgs {
     }
 }
 
+impl figment::Provider for CreateArgs {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("Create Args Provider")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        let mut dict = Dict::default();
+        if let Some(timeout) = self.timeout {
+            dict.insert("transaction_timeout".to_string(), timeout.into());
+        }
+        Ok(Map::from([(Config::selected_profile(), dict)]))
+    }
+}
+
 /// `ContractFactory` is a [`DeploymentTxFactory`] object with an
 /// [`Arc`] middleware. This type alias exists to preserve backwards
 /// compatibility with less-abstract Contracts.
@@ -414,6 +445,7 @@ pub struct Deployer<B, P, T> {
     abi: JsonAbi,
     client: B,
     confs: usize,
+    timeout: u64,
     _p: PhantomData<P>,
     _t: PhantomData<T>,
 }
@@ -428,6 +460,7 @@ where
             abi: self.abi.clone(),
             client: self.client.clone(),
             confs: self.confs,
+            timeout: self.timeout,
             _p: PhantomData,
             _t: PhantomData,
         }
@@ -504,6 +537,7 @@ pub struct DeploymentTxFactory<B, P, T> {
     client: B,
     abi: JsonAbi,
     bytecode: Bytes,
+    timeout: u64,
     _p: PhantomData<P>,
     _t: PhantomData<T>,
 }
@@ -517,6 +551,7 @@ where
             client: self.client.clone(),
             abi: self.abi.clone(),
             bytecode: self.bytecode.clone(),
+            timeout: self.timeout,
             _p: PhantomData,
             _t: PhantomData,
         }
@@ -532,8 +567,8 @@ where
     /// Creates a factory for deployment of the Contract with bytecode, and the
     /// constructor defined in the abi. The client will be used to send any deployment
     /// transaction.
-    pub fn new(abi: JsonAbi, bytecode: Bytes, client: B) -> Self {
-        Self { client, abi, bytecode, _p: PhantomData, _t: PhantomData }
+    pub fn new(abi: JsonAbi, bytecode: Bytes, client: B, timeout: u64) -> Self {
+        Self { client, abi, bytecode, timeout, _p: PhantomData, _t: PhantomData }
     }
 
     /// Create a deployment tx using the provided tokens as constructor
@@ -567,6 +602,7 @@ where
             abi: self.abi,
             tx,
             confs: 1,
+            timeout: self.timeout,
             _p: PhantomData,
             _t: PhantomData,
         })

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -149,6 +149,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         extra_args: vec![],
         eof_version: None,
         alphanet: false,
+        transaction_timeout: 120,
         _non_exhaustive: (),
     };
     prj.write_config(input.clone());

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -170,7 +170,14 @@ impl BundledState {
             .map(|(sequence_idx, sequence)| async move {
                 let rpc_url = sequence.rpc_url();
                 let provider = Arc::new(get_http_provider(rpc_url));
-                progress_ref.wait_for_pending(sequence_idx, sequence, &provider).await
+                progress_ref
+                    .wait_for_pending(
+                        sequence_idx,
+                        sequence,
+                        &provider,
+                        self.script_config.config.transaction_timeout,
+                    )
+                    .await
             })
             .collect::<Vec<_>>();
 
@@ -368,7 +375,14 @@ impl BundledState {
                         self.sequence.save(true, false)?;
                         sequence = self.sequence.sequences_mut().get_mut(i).unwrap();
 
-                        progress.wait_for_pending(i, sequence, &provider).await?
+                        progress
+                            .wait_for_pending(
+                                i,
+                                sequence,
+                                &provider,
+                                self.script_config.config.transaction_timeout,
+                            )
+                            .await?
                     }
                     // Checkpoint save
                     self.sequence.save(true, false)?;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -181,6 +181,10 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
+    /// Timeout to use for broadcasting transactions.
+    #[arg(long, env = "ETH_TIMEOUT")]
+    pub timeout: Option<u64>,
+
     #[command(flatten)]
     pub opts: CoreBuildArgs,
 
@@ -452,6 +456,9 @@ impl Provider for ScriptArgs {
                 "etherscan_api_key".to_string(),
                 figment::value::Value::from(etherscan_api_key.to_string()),
             );
+        }
+        if let Some(timeout) = self.timeout {
+            dict.insert("transaction_timeout".to_string(), timeout.into());
         }
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -168,6 +168,7 @@ impl ScriptProgress {
         sequence_idx: usize,
         deployment_sequence: &mut ScriptSequence,
         provider: &RetryProvider,
+        timeout: u64,
     ) -> Result<()> {
         if deployment_sequence.pending.is_empty() {
             return Ok(());
@@ -180,8 +181,11 @@ impl ScriptProgress {
 
         trace!("Checking status of {count} pending transactions");
 
-        let futs =
-            deployment_sequence.pending.clone().into_iter().map(|tx| check_tx_status(provider, tx));
+        let futs = deployment_sequence
+            .pending
+            .clone()
+            .into_iter()
+            .map(|tx| check_tx_status(provider, tx, timeout));
         let mut tasks = futures::stream::iter(futs).buffer_unordered(10);
 
         let mut errors: Vec<String> = vec![];

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -28,6 +28,7 @@ impl From<AnyTransactionReceipt> for TxStatus {
 pub async fn check_tx_status(
     provider: &RetryProvider,
     hash: TxHash,
+    timeout: u64,
 ) -> (TxHash, Result<TxStatus, eyre::Report>) {
     // We use the inner future so that we can use ? operator in the future, but
     // still neatly return the tuple
@@ -40,7 +41,7 @@ pub async fn check_tx_status(
 
         loop {
             if let Ok(receipt) = PendingTransactionBuilder::new(provider, hash)
-                .with_timeout(Some(Duration::from_secs(120)))
+                .with_timeout(Some(Duration::from_secs(timeout)))
                 .get_receipt()
                 .await
             {


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8667

## Solution

Adds `--timeout` option to `forge create`, `forge script` and `cast send`. Also supports `transaction_timeout` config key and `ETH_TIMEOUT` env var