### PR TITLE
fix: `cast --to-ascii` does not work if input has trailing whitespaces

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         CastSubcommand::ToAscii { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_ascii(&value.trim_end())?);
+            println!("{}", SimpleCast::to_ascii(&value.trim())?);
         }
         CastSubcommand::ToUtf8 { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         CastSubcommand::ToAscii { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_ascii(&value)?);
+            println!("{}", SimpleCast::to_ascii(&value.trim_end())?);
         }
         CastSubcommand::ToUtf8 { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         CastSubcommand::ToAscii { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_ascii(&value.trim())?);
+            println!("{}", SimpleCast::to_ascii(value.trim())?);
         }
         CastSubcommand::ToUtf8 { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -168,7 +168,7 @@ where
 
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {
-            format!("{}", res.to_string())
+            res.to_string()
         } else if json {
             let tokens = decoded.iter().map(format_token_raw).collect::<Vec<_>>();
             serde_json::to_string_pretty(&tokens).unwrap()

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -168,7 +168,7 @@ where
 
         // handle case when return type is not specified
         Ok(if decoded.is_empty() {
-            format!("{res}\n")
+            format!("{}", res.to_string())
         } else if json {
             let tokens = decoded.iter().map(format_token_raw).collect::<Vec<_>>();
             serde_json::to_string_pretty(&tokens).unwrap()
@@ -1503,7 +1503,7 @@ impl SimpleCast {
     ///         decoded[1].as_address().unwrap().to_string().to_lowercase(),
     ///         decoded[2].as_uint().unwrap().0.to_string(),
     ///         decoded[3].as_uint().unwrap().0.to_string(),
-    ///         hex::encode(decoded[4].as_bytes().unwrap())    
+    ///         hex::encode(decoded[4].as_bytes().unwrap())
     ///     ]
     ///     .into_iter()
     ///     .collect::<Vec<_>>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #8652 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR contains two things:

1. A fix of `cast --to-ascii` to remove any trailing whitespace before converting the value to ascii.

```bash
# before
$ cast call 0xdAC17F958D2ee523a2206206994597C13D831ec7 "symbol()" --rpc-url https://eth.llamarpc.com | cast to-ascii
Error: 
Invalid character '\n' at position 192

# after
$ cast call 0xdAC17F958D2ee523a2206206994597C13D831ec7 "symbol()" --rpc-url https://eth.llamarpc.com | cast to-ascii
 USDT
```

3. A fix of `cast call` to remove the additional break line.

```bash
# before: two additional break lines
$ cast call 0xdAC17F958D2ee523a2206206994597C13D831ec7 "symbol()" --rpc-url https://eth.llamarpc.com
0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000045553445400000000000000000000000000000000000000000000000000000000


# after: only one additional break line
$ cast call 0xdAC17F958D2ee523a2206206994597C13D831ec7 "symbol()" --rpc-url https://eth.llamarpc.com
0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000045553445400000000000000000000000000000000000000000000000000000000

```
