### PR TITLE
fix(anvil): get_transaction_count forking

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2651,7 +2651,7 @@ impl EthApi {
 
         if let BlockRequest::Number(number) = block_request {
             if let Some(fork) = self.get_fork() {
-                if fork.predates_fork_inclusive(number) {
+                if fork.predates_fork(number) {
                     return Ok(fork.get_nonce(address, number).await?)
                 }
             }


### PR DESCRIPTION
## Motivation

Results for `eth_getTransactionCount`  do not use the local cache when forking. This significantly slows down any fork tests that use `ethers.js` in combination with `anvil`. 

## Solution

Update `predates_fork_inclusive` to `predates_fork` as with most other operations.
