### PR TITLE
fix(tracing): storage diff

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -81,7 +81,7 @@ impl ExecutedTransaction {
 pub struct ExecutedTransactions {
     /// The block created after executing the `included` transactions
     pub block: BlockInfo,
-    /// All transactions included in the
+    /// All transactions included in the block
     pub included: Vec<Arc<PoolTransaction>>,
     /// All transactions that were invalid at the point of their execution and were not included in
     /// the block

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -50,7 +50,7 @@ impl Inspector {
 
     /// Enables steps recording for `Tracer`.
     pub fn with_steps_tracing(mut self) -> Self {
-        self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all()));
+        self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all().with_state_diffs()));
         self
     }
 


### PR DESCRIPTION
## Motivation

Tries to resolve #8688. This issue was discovered when performing some tests with the `debug_traceTransaction` endpoint which seemed to fail to return any storage diffs created by a transaction.

## Solution

Add the call to `with_state_diffs()` when creating the `TracingInspectorConfig::all()` which doesn't include the state diffs.
