### PR TITLE
fix comment of `--sender`

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -85,7 +85,7 @@ pub struct EvmArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_balance: Option<U256>,
 
-    /// The address which will be executing tests.
+    /// The address which will be executing tests/scripts.
     #[arg(long, value_name = "ADDRESS")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender: Option<Address>,


### PR DESCRIPTION
After typing `forge script --help`, the help message of `--sender`  is:

```
The address which will be executing tests.
```

It's a bit confusing because `forge script` is not executing tests.