### PR TITLE
fix(coverage): ensure contract hash to record coverage for is not zero

### DIFF
--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1271,3 +1271,53 @@ contract AContractTest is DSTest {
 
 "#]]);
 });
+
+forgetest!(test_constructors_coverage, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    bool public active;
+
+    constructor() {
+        active = true;
+    }
+}
+
+contract BContract {
+    bool public active;
+
+    constructor() {
+        active = true;
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import "./AContract.sol";
+
+contract AContractTest is DSTest {
+    function test_constructors() public {
+        AContract a = new AContract();
+        BContract b = new BContract();
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    cmd.arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(str![[r#"
+...
+| File              | % Lines       | % Statements  | % Branches    | % Funcs       |
+|-------------------|---------------|---------------|---------------|---------------|
+| src/AContract.sol | 100.00% (2/2) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
+| Total             | 100.00% (2/2) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
+
+"#]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- for contracts that are not already created the hash in interpreter is 0x. This leads to recording coverage for 0x hash instead of contract hash (and if multiple contracts created in same test then only the first one will have constructor covered).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- in coverage collector, if hash is 0 then recalculate it from contract bytecode