### PR TITLE
feat(cast): add `cast hash-message`

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate tracing;
 
-use alloy_primitives::{hex, keccak256, Address, B256};
+use alloy_primitives::{eip191_hash_message, hex, keccak256, Address, B256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, BlockNumberOrTag::Latest};
 use cast::{Cast, SimpleCast};
@@ -514,6 +514,14 @@ async fn main() -> Result<()> {
                     println!("0x{s}");
                 }
             };
+        }
+        CastSubcommand::HashMessage { message } => {
+            let message = stdin::unwrap_line(message)?;
+            let input = match message.strip_prefix("0x") {
+                Some(hex_str) => hex::decode(hex_str)?,
+                None => message.as_bytes().to_vec(),
+            };
+            println!("{}", eip191_hash_message(input));
         }
         CastSubcommand::SigEvent { event_string } => {
             let event_string = stdin::unwrap_line(event_string)?;

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -757,7 +757,7 @@ pub enum CastSubcommand {
     /// Hash a message according to EIP-191.
     #[command(visible_aliases = &["--hash-message", "hm"])]
     HashMessage {
-        /// the message to hash.
+        /// The message to hash.
         message: Option<String>,
     },
 

--- a/crates/cast/bin/opts.rs
+++ b/crates/cast/bin/opts.rs
@@ -754,6 +754,13 @@ pub enum CastSubcommand {
         data: Option<String>,
     },
 
+    /// Hash a message according to EIP-191.
+    #[command(visible_aliases = &["--hash-message", "hm"])]
+    HashMessage {
+        /// the message to hash.
+        message: Option<String>,
+    },
+
     /// Perform an ENS lookup.
     #[command(visible_alias = "rn")]
     ResolveName {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1057,3 +1057,14 @@ casttest!(send_eip7702, async |_prj, cmd| {
 
 "#]]);
 });
+
+casttest!(hash_message, |_prj, cmd| {
+    let tests = [
+        ("hello", "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750"),
+        ("0x68656c6c6f", "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750"),
+    ];
+    for (message, expected) in tests {
+        cmd.cast_fuse();
+        assert_eq!(cmd.args(["hash-message", message]).stdout_lossy().trim(), expected);
+    }
+});


### PR DESCRIPTION
## Motivation

Calculates an Ethereum-specific hash in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): 
```
keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))
```

## Solution

Add subcommand `hash-message` to `cast`.

```
cast hash-message 'Hello World'
0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2

cast hash-message 0x48656c6c6f20576f726c64
0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2

cast hm hello
0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750
```
