### PR TITLE
Issue #8664 | Bug 🐛: --match-path does not work with watch mode: cannot be used multiple times #8664

### DIFF
--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -259,6 +259,10 @@ pub async fn watch_snapshot(args: SnapshotArgs) -> Result<()> {
 pub async fn watch_test(args: TestArgs) -> Result<()> {
     let config: Config = args.build_args().into();
     let filter = args.filter(&config);
+    
+    // Check if any of the filters are present
+    let path_pattern_exists = filter.args().path_pattern.is_some();
+
     // Marker to check whether to override the command.
     let _no_reconfigure = filter.args().test_pattern.is_some() ||
         filter.args().path_pattern.is_some() ||
@@ -302,8 +306,11 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
             }
 
             trace!(?file, "reconfigure test command");
-
-            command.arg("--match-path").arg(&file);
+            
+            // Before appending `--match-path`, check if it already exists
+            if !path_pattern_exists {
+                command.arg("--match-path").arg(file);
+            }
         },
     )?;
     run(config).await?;
@@ -383,3 +390,4 @@ mod tests {
         assert_eq!(cleaned, vec!["-v".to_string()]);
     }
 }
+

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -302,7 +302,7 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
             }
 
             trace!(?file, "reconfigure test command");
-            
+
             // Before appending `--match-path`, check if it already exists
             if !no_reconfigure {
                 command.arg("--match-path").arg(file);

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -259,10 +259,8 @@ pub async fn watch_snapshot(args: SnapshotArgs) -> Result<()> {
 pub async fn watch_test(args: TestArgs) -> Result<()> {
     let config: Config = args.build_args().into();
     let filter = args.filter(&config);
-
-
     // Marker to check whether to override the command.
-    let _no_reconfigure = filter.args().test_pattern.is_some() ||
+    let no_reconfigure = filter.args().test_pattern.is_some() ||
         filter.args().path_pattern.is_some() ||
         filter.args().contract_pattern.is_some() ||
         args.watch.run_all;
@@ -306,7 +304,7 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
             trace!(?file, "reconfigure test command");
             
             // Before appending `--match-path`, check if it already exists
-            if !_no_reconfigure {
+            if !no_reconfigure {
                 command.arg("--match-path").arg(file);
             }
         },
@@ -388,4 +386,3 @@ mod tests {
         assert_eq!(cleaned, vec!["-v".to_string()]);
     }
 }
-

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -259,9 +259,7 @@ pub async fn watch_snapshot(args: SnapshotArgs) -> Result<()> {
 pub async fn watch_test(args: TestArgs) -> Result<()> {
     let config: Config = args.build_args().into();
     let filter = args.filter(&config);
-    
-    // Check if any of the filters are present
-    let path_pattern_exists = filter.args().path_pattern.is_some();
+
 
     // Marker to check whether to override the command.
     let _no_reconfigure = filter.args().test_pattern.is_some() ||
@@ -308,7 +306,7 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
             trace!(?file, "reconfigure test command");
             
             // Before appending `--match-path`, check if it already exists
-            if !path_pattern_exists {
+            if !_no_reconfigure {
                 command.arg("--match-path").arg(file);
             }
         },


### PR DESCRIPTION
Issue Link -> https://github.com/foundry-rs/foundry/issues/8664

## Pull Request Description
Currently the following command was being attempted to be executed:

forge test --match-path test/Counter.t.sol -w

But by default it can be done without the --math-path, since the command adds it by itself

--match-path does not work with watch mode: cannot be used multiple times 

`error: the argument '--match-path <GLOB>' cannot be used multiple times

Usage: forge test [OPTIONS]

For more information, try '--help'.
[Command exited with 2, lasted 10.7375ms]`

## Motivation

My motivation is to continue contributing to tools like Foundry, to learn from them and how they work in Open Source environments. I really like to always be in constant practice and what better way to do it than by practicing and helping the community.

## Solution


Currently when running the command:

forge test --match-path test/Counter.t.sol --watch

It is not necessary to add the ---match-path because by default the --watch is added by code, now what I did was add a validation that if it already has it in the arguments, do not add it to avoid redundancy and errors like the reported issue
