### PR TITLE
test: add builtin redactions to snapbox assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7981,6 +7981,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "normalize-line-endings",
+ "regex",
  "serde",
  "serde_json",
  "similar",

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1,5 +1,5 @@
 use foundry_config::Config;
-use foundry_test_utils::{forgetest, str};
+use foundry_test_utils::{forgetest, snapbox::IntoData, str};
 use globset::Glob;
 
 // tests that json is printed when --json is passed
@@ -19,7 +19,6 @@ contract Dummy {
 
     // set up command
     cmd.args(["compile", "--format-json"]).assert_success().stdout_eq(str![[r#"
-...
 {
   "errors": [
     {
@@ -32,23 +31,25 @@ contract Dummy {
       "component": "general",
       "severity": "error",
       "errorCode": "7576",
-      "message": "Undeclared identifier. Did you mean /"newNumber/"?",
-      "formattedMessage": "DeclarationError: Undeclared identifier. Did you mean /"newNumber/"?/n --> src/jsonError.sol:7:18:/n  |/n7 |         number = newnumber; // error here/n  |                  ^^^^^^^^^/n/n"
+      "message": "Undeclared identifier. Did you mean \"newNumber\"?",
+      "formattedMessage": "DeclarationError: Undeclared identifier. Did you mean \"newNumber\"?\n [FILE]:7:18:\n  |\n7 |         number = newnumber; // error here\n  |                  ^^^^^^^^^\n\n"
     }
   ],
   "sources": {},
   "contracts": {},
-  "build_infos": [
-    {
-...
+  "build_infos": "{...}"
 }
-...
-"#]]);
+"#]].is_json());
 });
 
 // tests build output is as expected
 forgetest_init!(exact_build_output, |prj, cmd| {
-    cmd.args(["build", "--force"]).assert_success().stdout_eq(str!["Compiling[..]\n..."]);
+    cmd.args(["build", "--force"]).assert_success().stdout_eq(str![[r#"
+Compiling 27 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+"#]]);
 });
 
 // tests build output is as expected

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -235,8 +235,7 @@ forgetest!(can_detect_dirty_git_status_on_init, |prj, cmd| {
 
     cmd.current_dir(&nested);
     cmd.arg("init").assert_failure().stderr_eq(str![[r#"
-...
-Error:[..]
+Error: 
 The target directory is a part of or on its own an already initialized git repository,
 and it requires clean working and staging areas, including no untracked files.
 
@@ -246,7 +245,7 @@ ignore them in the `.gitignore` file, or run this command again with the `--no-c
 
 If none of the previous steps worked, please open an issue at:
 https://github.com/foundry-rs/foundry/issues/new/choose
-...
+
 "#]]);
 
     // ensure nothing was emitted, dir is empty
@@ -398,7 +397,7 @@ forgetest!(can_init_vscode, |prj, cmd| {
     assert_eq!(
         settings,
         serde_json::json!({
-             "solidity.packageDefaultDependenciesContractsDirectory": "src",
+            "solidity.packageDefaultDependenciesContractsDirectory": "src",
             "solidity.packageDefaultDependenciesDirectory": "lib"
         })
     );
@@ -758,11 +757,16 @@ contract ATest is DSTest {
     .unwrap();
 
     cmd.args(["snapshot"]).assert_success().stdout_eq(str![[r#"
-...
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 1 test for src/ATest.t.sol:ATest
-[PASS] testExample() (gas: 168)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in [..]
-...
+[PASS] testExample() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 
     cmd.arg("--check");
@@ -1689,22 +1693,20 @@ function test_run() external {}
     cmd.args(["build", "--skip", "*/test/**", "--skip", "*/script/**", "--force"])
         .assert_success()
         .stdout_eq(str![[r#"
-...
-Compiling 1 files [..]
-[..]
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 
     cmd.forge_fuse()
         .args(["build", "--skip", "./test/**", "--skip", "./script/**", "--force"])
         .assert_success()
         .stdout_eq(str![[r#"
-...
-Compiling 1 files [..]
-[..]
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 });
 
@@ -1738,44 +1740,40 @@ function test_bar() external {}
     // Build 2 files within test dir
     prj.clear();
     cmd.args(["build", "test", "--force"]).assert_success().stdout_eq(str![[r#"
-...
-Compiling 2 files with Solc 0.8.23
-[..]
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 
     // Build one file within src dir
     prj.clear();
     cmd.forge_fuse();
     cmd.args(["build", "src", "--force"]).assert_success().stdout_eq(str![[r#"
-...
-Compiling 1 files with Solc 0.8.23
-[..]
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 
     // Build 3 files from test and src dirs
     prj.clear();
     cmd.forge_fuse();
     cmd.args(["build", "src", "test", "--force"]).assert_success().stdout_eq(str![[r#"
-...
-Compiling 3 files with Solc 0.8.23
-[..]
+Compiling 3 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 
     // Build single test file
     prj.clear();
     cmd.forge_fuse();
     cmd.args(["build", "test/Bar.sol", "--force"]).assert_success().stdout_eq(str![[r#"
-...
-Compiling 1 files with Solc 0.8.23
-[..]
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
-...
+
 "#]]);
 });
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -400,15 +400,15 @@ contract Foo {
     .unwrap();
 
     cmd.arg("build").assert_failure().stderr_eq(str![[r#"
-...
-Error:[..]
+Error: 
 Compiler run failed:
 Error (6553): The msize instruction cannot be used when the Yul optimizer is activated because it can change its semantics. Either disable the Yul optimizer or do not use the instruction.
- --> src/foo.sol:6:8:
+ [FILE]:6:8:
   |
 6 |        assembly {
   |        ^ (Relevant source part starts here and spans across multiple lines).
-...
+
+
 "#]]);
 
     // disable yul optimizer explicitly

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -151,11 +151,12 @@ forgetest_async!(can_create_template_contract, |prj, cmd| {
     ]);
 
     cmd.assert().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
 
@@ -163,7 +164,7 @@ Transaction hash: [..]
 No files changed, compilation skipped
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
 });
@@ -191,18 +192,19 @@ forgetest_async!(can_create_using_unlocked, |prj, cmd| {
     ]);
 
     cmd.assert().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
     cmd.assert().stdout_eq(str![[r#"
 No files changed, compilation skipped
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
 });
@@ -247,11 +249,12 @@ contract ConstructorContract {
         ])
         .assert_success()
         .stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
 
@@ -283,11 +286,12 @@ contract TupleArrayConstructorContract {
         ])
         .assert()
         .stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Deployed to: 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
-Transaction hash: [..]
+[TX_HASH]
 
 "#]]);
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -54,13 +54,15 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
 Script ran successfully.
-Gas used: 22815
+[GAS]
 
 == Logs ==
   script ran
-...
+
 "#]]);
 });
 
@@ -80,17 +82,15 @@ contract Demo {
         )
         .unwrap();
 
-    cmd.arg("script").arg(format!("{}:Demo", script.display())).assert_success().stdout_eq(str![[
-        r#"
+    cmd.arg("script").arg(format!("{}:Demo", script.display())).assert_success().stdout_eq(str![[r#"
 ...
 Script ran successfully.
-Gas used: 22815
+[GAS]
 
 == Logs ==
   script ran
 ...
-"#
-    ]]);
+"#]]);
 });
 
 // Tests that the run command can run arbitrary functions
@@ -109,17 +109,22 @@ contract Demo {
         )
         .unwrap();
 
-    cmd.arg("script").arg(script).arg("--sig").arg("myFunction()").assert_success().stdout_eq(
-        str![[r#"
-...
+    cmd.arg("script")
+        .arg(script)
+        .arg("--sig")
+        .arg("myFunction()")
+        .assert_success()
+        .stdout_eq(str![[r#"
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
 Script ran successfully.
-Gas used: 22815
+[GAS]
 
 == Logs ==
   script ran
-...
-"#]],
-    );
+
+"#]]);
 });
 
 static FAILING_SCRIPT: &str = r#"
@@ -296,15 +301,17 @@ contract Demo {
         .arg("2")
         .assert_success()
         .stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
 Script ran successfully.
-Gas used: 25301
+[GAS]
 
 == Logs ==
   script ran
   1
   2
-...
+
 "#]]);
 });
 
@@ -325,9 +332,11 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
 Script ran successfully.
-Gas used: 22900
+[GAS]
 
 == Return ==
 result: uint256 255
@@ -335,7 +344,7 @@ result: uint256 255
 
 == Logs ==
   script ran
-...
+
 "#]]);
 });
 
@@ -973,9 +982,11 @@ contract Demo {
         .args(["--skip", "tests", "--skip", TEMPLATE_CONTRACT])
         .assert_success()
         .stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
 Script ran successfully.
-Gas used: 22900
+[GAS]
 
 == Return ==
 result: uint256 255
@@ -983,7 +994,7 @@ result: uint256 255
 
 == Logs ==
   script ran
-...
+
 "#]]);
 });
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -82,7 +82,8 @@ contract Demo {
         )
         .unwrap();
 
-    cmd.arg("script").arg(format!("{}:Demo", script.display())).assert_success().stdout_eq(str![[r#"
+    cmd.arg("script").arg(format!("{}:Demo", script.display())).assert_success().stdout_eq(str![[
+        r#"
 ...
 Script ran successfully.
 [GAS]
@@ -90,7 +91,8 @@ Script ran successfully.
 == Logs ==
   script ran
 ...
-"#]]);
+"#
+    ]]);
 });
 
 // Tests that the run command can run arbitrary functions
@@ -109,12 +111,8 @@ contract Demo {
         )
         .unwrap();
 
-    cmd.arg("script")
-        .arg(script)
-        .arg("--sig")
-        .arg("myFunction()")
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.arg("script").arg(script).arg("--sig").arg("myFunction()").assert_success().stdout_eq(
+        str![[r#"
 Compiling 1 files with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -124,7 +122,8 @@ Script ran successfully.
 == Logs ==
   script ran
 
-"#]]);
+"#]],
+    );
 });
 
 static FAILING_SCRIPT: &str = r#"

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -302,7 +302,7 @@ forgetest_init!(can_test_repeatedly, |_prj, cmd| {
 No files changed, compilation skipped
 
 Ran 2 tests for test/Counter.t.sol:CounterTest
-[PASS] testFuzz_SetNumber(uint256) ([RUNS])
+[PASS] testFuzz_SetNumber(uint256) (runs: 256, [AVG_GAS])
 [PASS] test_Increment() ([GAS])
 Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -743,14 +743,14 @@ Compiling 23 files with [SOLC_VERSION]
 Compiler run successful!
 
 Ran 1 test for test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) ([RUNS])
+[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) ([RUNS])
+[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -52,7 +52,6 @@ contract Dummy {}
 
     // run command and assert
     cmd.assert_failure().stdout_eq(str![[r#"
-...
 No tests found in project! Forge looks for functions that starts with `test`.
 
 "#]]);
@@ -75,7 +74,6 @@ contract Dummy {}
 
     // run command and assert
     cmd.assert_failure().stdout_eq(str![[r#"
-...
 No tests match the provided pattern:
 	match-test: `testA.*`
 	no-match-test: `testB.*`
@@ -108,7 +106,6 @@ contract TestC {
 
     // run command and assert
     cmd.assert_failure().stdout_eq(str![[r#"
-...
 No tests match the provided pattern:
 	match-test: `testA.*`
 	no-match-test: `testB.*`
@@ -197,12 +194,16 @@ contract FailTest is DSTest {
     .unwrap();
 
     cmd.args(["test", "--match-path", "*src/ATest.t.sol"]).assert_success().stdout_eq(str![[r#"
-...
+Compiling 3 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 1 test for src/ATest.t.sol:ATest
-[PASS] testPass() (gas: 190)
-...
-Ran 1 test suite in [..] 1 tests passed, 0 failed, 0 skipped (1 total tests)
-...
+[PASS] testPass() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -240,12 +241,16 @@ contract FailTest is DSTest {
     let test_path = test_path.to_string_lossy();
 
     cmd.args(["test", "--match-path", test_path.as_ref()]).assert_success().stdout_eq(str![[r#"
-...
+Compiling 3 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 1 test for src/ATest.t.sol:ATest
-[PASS] testPass() (gas: 190)
-...
-Ran 1 test suite in [..] 1 tests passed, 0 failed, 0 skipped (1 total tests)
-...
+[PASS] testPass() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -273,10 +278,16 @@ contract MyTest is DSTest {
     .unwrap();
 
     cmd.arg("test").assert_success().stdout_eq(str![[r#"
-...
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 1 test for src/nested/forge-tests/MyTest.t.sol:MyTest
-[PASS] testTrue() (gas: 168)
-...
+[PASS] testTrue() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -288,13 +299,14 @@ forgetest_init!(can_test_repeatedly, |_prj, cmd| {
 
     for _ in 0..5 {
         cmd.assert_success().stdout_eq(str![[r#"
-...
-Ran 2 tests for test/Counter.t.sol:CounterTest
-[PASS] testFuzz_SetNumber(uint256) (runs: 256, μ: [..], ~: [..])
-[PASS] test_Increment() (gas: 31303)
-Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in [..] ([..] CPU time)
+No files changed, compilation skipped
 
-Ran 1 test suite in [..] ([..] CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
+Ran 2 tests for test/Counter.t.sol:CounterTest
+[PASS] testFuzz_SetNumber(uint256) ([RUNS])
+[PASS] test_Increment() ([GAS])
+Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 
 "#]]);
     }
@@ -327,17 +339,16 @@ contract ContractTest is DSTest {
     prj.write_config(config);
 
     cmd.arg("test").assert_success().stdout_eq(str![[r#"
-...
-Compiling 2 files with Solc 0.8.23
-Solc 0.8.23 finished in [..]
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
-[PASS] testExample() (gas: 190)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in [..]
+[PASS] testExample() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite in [..] 1 tests passed, 0 failed, 0 skipped (1 total tests)
-...
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 
     // pin version
@@ -345,17 +356,16 @@ Ran 1 test suite in [..] 1 tests passed, 0 failed, 0 skipped (1 total tests)
     prj.write_config(config);
 
     cmd.forge_fuse().arg("test").assert_success().stdout_eq(str![[r#"
-...
-Compiling 2 files with Solc 0.8.22
-Solc 0.8.22 finished in [..]
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
 Ran 1 test for src/Contract.t.sol:ContractTest
-[PASS] testExample() (gas: 190)
-Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in [..]
+[PASS] testExample() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
-Ran 1 test suite in [..] 1 tests passed, 0 failed, 0 skipped (1 total tests)
-...
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -407,10 +417,16 @@ contract ContractTest is Test {
     .unwrap();
 
     cmd.arg("test").assert_success().stdout_eq(str![[r#"
-...
+Compiling 2 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 1 test for test/Contract.t.sol:ContractTest
-[PASS] test() (gas: 70360)
-...
+[PASS] test() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -473,19 +489,24 @@ contract USDTCallingTest is Test {
     .unwrap();
 
     cmd.args(["test", "-vvvv"]).assert_success().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
 Ran 1 test for test/Contract.t.sol:USDTCallingTest
-[PASS] test() (gas: 9537)
+[PASS] test() ([GAS])
 Traces:
   [9537] USDTCallingTest::test()
     ├─ [0] VM::createSelectFork("[..]")
     │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
     │   └─ ← [Return] "Tether USD"
-    └─ ← [Stop][..]
-...
+    └─ ← [Stop] 
+
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 
@@ -514,19 +535,32 @@ contract CustomTypesTest is Test {
     .unwrap();
 
     cmd.args(["test", "-vvvv"]).assert_failure().stdout_eq(str![[r#"
-...
+Compiling 1 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
 Ran 2 tests for test/Contract.t.sol:CustomTypesTest
-[FAIL. Reason: PoolNotInitialized()] testErr() (gas: 254)
+[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
 Traces:
   [254] CustomTypesTest::testErr()
     └─ ← [Revert] PoolNotInitialized()
 
-[PASS] testEvent() (gas: 1268)
+[PASS] testEvent() ([GAS])
 Traces:
   [1268] CustomTypesTest::testEvent()
     ├─ emit MyEvent(a: 100)
-    └─ ← [Stop][..]
-...
+    └─ ← [Stop] 
+
+Suite result: FAILED. 1 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 1 failed, 0 skipped (2 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/Contract.t.sol:CustomTypesTest
+[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
+
+Encountered a total of 1 failing tests, 1 tests succeeded
+
 "#]]);
 });
 
@@ -704,9 +738,22 @@ contract CounterTest is Test {
 
     // make sure there are only 61 runs (with proptest shrinking same test results in 298 runs)
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
-...
-[..]testAddOne(uint256) (runs: 61, μ: [..], ~: [..])
-...
+Compiling 23 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/CounterFuzz.t.sol:CounterTest
+[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) ([RUNS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/CounterFuzz.t.sol:CounterTest
+[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) ([RUNS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
 "#]]);
 });
 
@@ -742,9 +789,22 @@ contract CounterTest is Test {
 
     // make sure invariant test exit early with 0 runs
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
-...
-[..]invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
-...
+Compiling 23 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/CounterInvariant.t.sol:CounterTest
+[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/CounterInvariant.t.sol:CounterTest
+[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
 "#]]);
 });
 
@@ -783,11 +843,22 @@ contract ReplayFailuresTest is Test {
 
     // Perform only the 2 failing tests from last run.
     cmd.forge_fuse().args(["test", "--rerun"]).assert_failure().stdout_eq(str![[r#"
-...
+No files changed, compilation skipped
+
 Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() (gas: 303)
-[FAIL. Reason: revert: testD failed] testD() (gas: 314)
-...
+[FAIL. Reason: revert: testB failed] testB() ([GAS])
+[FAIL. Reason: revert: testD failed] testD() ([GAS])
+Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 2 failed, 0 skipped (2 total tests)
+
+Failing tests:
+Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
+[FAIL. Reason: revert: testB failed] testB() ([GAS])
+[FAIL. Reason: revert: testD failed] testD() ([GAS])
+
+Encountered a total of 2 failing tests, 0 tests succeeded
+
 "#]]);
 });
 
@@ -1013,7 +1084,12 @@ contract SimpleContractTest is Test {
     )
     .unwrap();
     cmd.args(["test", "-vvvv", "--decode-internal"]).assert_success().stdout_eq(str![[r#"
-...
+Compiling 24 files with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/Simple.sol:SimpleContractTest
+[PASS] test() ([GAS])
 Traces:
   [250463] SimpleContractTest::test()
     ├─ [171014] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
@@ -1029,7 +1105,11 @@ Traces:
     │   │   └─ ← 0x0000000000000000000000000000000000000000
     │   └─ ← [Stop] 
     └─ ← [Stop] 
-...
+
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
 "#]]);
 });
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -33,7 +33,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 walkdir.workspace = true
 rand.workspace = true
-snapbox = { version = "0.6.9", features = ["json"] }
+snapbox = { version = "0.6.9", features = ["json", "regex"] }
 
 [features]
 # feature for integration tests that test external projects

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -28,7 +28,7 @@ pub use script::{ScriptOutcome, ScriptTester};
 // re-exports for convenience
 pub use foundry_compilers;
 
-pub use snapbox::{assert_data_eq, file, str};
+pub use snapbox::{self, assert_data_eq, file, str};
 
 /// Initializes tracing for tests.
 pub fn init_tracing() {

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -1082,8 +1082,8 @@ fn test_redactions() -> snapbox::Redactions {
         let redactions = [
             ("[SOLC_VERSION]", r"Solc( version)? \d+.\d+.\d+"),
             ("[ELAPSED]", r"(finished )?in \d+(\.\d+)?\w?s( \(.*?s CPU time\))?"),
-            ("[RUNS]", r"runs: \d+, μ: \d+, ~: \d+"),
             ("[GAS]", r"[Gg]as( used)?: \d+"),
+            ("[AVG_GAS]", r"μ: \d+, ~: \d+"),
             ("[FILE]", r"-->.*\.sol"),
             ("[FILE]", r"Location(.|\n)*\.rs(.|\n)*Backtrace"),
             ("[TX_HASH]", r"Transaction hash: 0x[0-9A-Fa-f]{64}"),

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -920,18 +920,6 @@ impl TestCommand {
         output
     }
 
-    /// Runs the command and asserts that it resulted in success
-    #[track_caller]
-    pub fn assert_success(&mut self) -> OutputAssert {
-        self.assert().success()
-    }
-
-    /// Runs the command and asserts that it failed.
-    #[track_caller]
-    pub fn assert_failure(&mut self) -> OutputAssert {
-        self.assert().failure()
-    }
-
     /// Executes command, applies stdin function and returns output
     #[track_caller]
     pub fn execute(&mut self) -> Output {
@@ -1063,9 +1051,49 @@ stderr:
         )
     }
 
+    /// Runs the command, returning a [`snapbox`] object to assert the command output.
+    #[track_caller]
     pub fn assert(&mut self) -> OutputAssert {
-        OutputAssert::new(self.execute())
+        OutputAssert::new(self.execute()).with_assert(test_assert())
     }
+
+    /// Runs the command and asserts that it resulted in success.
+    #[track_caller]
+    pub fn assert_success(&mut self) -> OutputAssert {
+        self.assert().success()
+    }
+
+    /// Runs the command and asserts that it failed.
+    #[track_caller]
+    pub fn assert_failure(&mut self) -> OutputAssert {
+        self.assert().failure()
+    }
+}
+
+fn test_assert() -> snapbox::Assert {
+    snapbox::Assert::new()
+        .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
+        .redact_with(test_redactions())
+}
+
+fn test_redactions() -> snapbox::Redactions {
+    static REDACTIONS: Lazy<snapbox::Redactions> = Lazy::new(|| {
+        let mut r = snapbox::Redactions::new();
+        let redactions = [
+            ("[SOLC_VERSION]", r"Solc( version)? \d+.\d+.\d+"),
+            ("[ELAPSED]", r"(finished )?in \d+(\.\d+)?\w?s( \(.*?s CPU time\))?"),
+            ("[RUNS]", r"runs: \d+, μ: \d+, ~: \d+"),
+            ("[GAS]", r"[Gg]as( used)?: \d+"),
+            ("[FILE]", r"-->.*\.sol"),
+            ("[FILE]", r"Location(.|\n)*\.rs(.|\n)*Backtrace"),
+            ("[TX_HASH]", r"Transaction hash: 0x[0-9A-Fa-f]{64}"),
+        ];
+        for (placeholder, re) in redactions {
+            r.insert(placeholder, Regex::new(re).expect(re)).expect(re);
+        }
+        r
+    });
+    REDACTIONS.clone()
 }
 
 /// Extension trait for [`Output`].


### PR DESCRIPTION
Use `SNAPSHOTS=overwrite` to generate all assertions except for coverage.
We want assertions to be as much as possible auto generated, rather than writing manually `[...]` and the other catch-all filters everywhere.