### PR TITLE
feat(cast): get create2 address

### DIFF
--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -48,7 +48,8 @@ pub struct Create2Args {
     )]
     deployer: Address,
 
-    /// Salt to be used for the contract deployment.
+    /// Salt to be used for the contract deployment. This option separate from the default salt
+    /// mining with filters.
     #[arg(
         long,
         conflicts_with_all = [

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -22,7 +22,7 @@ pub struct Create2Args {
     #[arg(
         long,
         short,
-        required_unless_present_any = &["ends_with", "matching"],
+        required_unless_present_any = &["ends_with", "matching", "salt"],
         value_name = "HEX"
     )]
     starts_with: Option<String>,
@@ -47,6 +47,22 @@ pub struct Create2Args {
         value_name = "ADDRESS"
     )]
     deployer: Address,
+
+    /// Salt to be used for the contract deployment.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "starts_with",
+            "ends_with",
+            "matching",
+            "case_sensitive",
+            "caller",
+            "seed",
+            "no_random"
+        ],
+        value_name = "HEX"
+    )]
+    salt: Option<String>,
 
     /// Init code of the contract to be deployed.
     #[arg(short, long, value_name = "HEX")]
@@ -87,6 +103,7 @@ impl Create2Args {
             matching,
             case_sensitive,
             deployer,
+            salt,
             init_code,
             init_code_hash,
             jobs,
@@ -94,6 +111,21 @@ impl Create2Args {
             seed,
             no_random,
         } = self;
+
+        let init_code_hash = if let Some(init_code_hash) = init_code_hash {
+            hex::FromHex::from_hex(init_code_hash)
+        } else if let Some(init_code) = init_code {
+            hex::decode(init_code).map(keccak256)
+        } else {
+            unreachable!();
+        }?;
+
+        if let Some(salt) = salt {
+            let salt = hex::FromHex::from_hex(salt)?;
+            let address = deployer.create2(salt, init_code_hash);
+            println!("{address}");
+            return Ok(Create2Output { address, salt });
+        }
 
         let mut regexs = vec![];
 
@@ -133,14 +165,6 @@ impl Create2Args {
         );
 
         let regex = RegexSetBuilder::new(regexs).case_insensitive(!case_sensitive).build()?;
-
-        let init_code_hash = if let Some(init_code_hash) = init_code_hash {
-            hex::FromHex::from_hex(init_code_hash)
-        } else if let Some(init_code) = init_code {
-            hex::decode(init_code).map(keccak256)
-        } else {
-            unreachable!();
-        }?;
 
         let mut n_threads = std::thread::available_parallelism().map_or(1, |n| n.get());
         if let Some(jobs) = jobs {
@@ -300,6 +324,22 @@ mod tests {
         let create2_out = args.run().unwrap();
         let address = create2_out.address;
         assert!(format!("{address:x}").starts_with("bb"));
+    }
+
+    #[test]
+    fn create2_salt() {
+        let args = Create2Args::parse_from([
+            "foundry-cli",
+            "--deployer=0x8ba1f109551bD432803012645Ac136ddd64DBA72",
+            "--salt=0x7c5ea36004851c764c44143b1dcb59679b11c9a68e5f41497f6cf3d480715331",
+            "--init-code=0x6394198df16000526103ff60206004601c335afa6040516060f3",
+        ]);
+        let create2_out = args.run().unwrap();
+        let address = create2_out.address;
+        assert_eq!(
+            address,
+            Address::from_str("0x533AE9D683B10C02EBDB05471642F85230071FC3").unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Compute the address that would result from a `CREATE2` operation with the given `deployer`, `salt` and either `initCode` or `initCodeHash`.

The following is a test script using `ethers.js`: 
<img width="529" alt="image" src="https://github.com/user-attachments/assets/c9cd214c-0194-4cab-850e-66e27049dab6">


## Solution

Add argument `salt` to `create2` command.

```
cast create2 --deployer=0x8ba1f109551bD432803012645Ac136ddd64DBA72 --salt=0x7c5ea36004851c764c44143b1dcb59679b11c9a68e5f41497f6cf3d480715331 --init-code=0x6394198df16000526103ff60206004601c335afa6040516060f3
0x533ae9d683B10C02EbDb05471642F85230071FC3

cast create2 --deployer=0x8ba1f109551bD432803012645Ac136ddd64DBA72 --salt=0x7c5ea36004851c764c44143b1dcb59679b11c9a68e5f41497f6cf3d480715331 --init-code-hash=0x9fd9ed530ad2d3bac509a72be6fb4b53ff252bef5702e88e99a0718cf4433d02
0x533ae9d683B10C02EbDb05471642F85230071FC3
```