### PR TITLE
chore(cheatcodes): make pauseGasMetering more robust

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -209,7 +209,7 @@ impl Cheatcode for getRecordedLogsCall {
 impl Cheatcode for pauseGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
-        state.pause_gas_metering = true;
+        state.gas_metering.paused = true;
         Ok(Default::default())
     }
 }
@@ -217,8 +217,7 @@ impl Cheatcode for pauseGasMeteringCall {
 impl Cheatcode for resumeGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
-        state.pause_gas_metering = false;
-        state.paused_frame_gas.clear();
+        state.gas_metering.resume();
         Ok(Default::default())
     }
 }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -218,7 +218,7 @@ impl Cheatcode for resumeGasMeteringCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self {} = self;
         state.pause_gas_metering = false;
-        state.paused_frame_gas = vec![];
+        state.paused_frame_gas.clear();
         Ok(Default::default())
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1355,8 +1355,12 @@ impl Cheatcodes {
 
     #[cold]
     fn meter_gas_end(&mut self, interpreter: &mut Interpreter) {
+        fn will_exit(ir: InstructionResult) -> bool {
+            ir != InstructionResult::Continue && (ir.is_ok() || ir.is_error() || ir.is_revert())
+        }
+
         // Remove recorded gas if we exit frame.
-        if interpreter.instruction_result != InstructionResult::Continue {
+        if will_exit(interpreter.instruction_result) {
             self.paused_frame_gas.pop();
         }
     }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1356,7 +1356,7 @@ impl Cheatcodes {
     #[cold]
     fn meter_gas_end(&mut self, interpreter: &mut Interpreter) {
         fn will_exit(ir: InstructionResult) -> bool {
-            ir != InstructionResult::Continue && (ir.is_ok() || ir.is_error() || ir.is_revert())
+            !matches!(ir, InstructionResult::Continue | InstructionResult::CallOrCreate)
         }
 
         // Remove recorded gas if we exit frame.

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -664,7 +664,7 @@ impl<'a, DB: DatabaseExt> Inspector<DB> for InspectorStackRefMut<'a> {
 
     fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<DB>) {
         call_inspectors_adjust_depth!(
-            [&mut self.tracer, &mut self.chisel_state, &mut self.printer],
+            [&mut self.tracer, &mut self.cheatcodes, &mut self.chisel_state, &mut self.printer],
             |inspector| inspector.step_end(interpreter, ecx),
             self,
             ecx

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1313,7 +1313,7 @@ contract ATest is Test {
 
     cmd.args(["test"]).with_no_redact().assert_success().stdout_eq(str![[r#"
 ...
-[PASS] testSelfMeteringRevert() (gas: 3399)
+[PASS] testSelfMeteringRevert() (gas: 3299)
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1313,7 +1313,7 @@ contract ATest is Test {
 
     cmd.args(["test"]).with_no_redact().assert_success().stdout_eq(str![[r#"
 ...
-[PASS] testSelfMeteringRevert() (gas: 3299)
+[PASS] testSelfMeteringRevert() (gas: 3399)
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1366,3 +1366,31 @@ Logs:
 ...
 "#]]);
 });
+
+// https://github.com/foundry-rs/foundry/issues/4370
+forgetest_init!(repro_4370, |prj, cmd| {
+    prj.wipe_contracts();
+
+    prj.add_test(
+        "ATest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+contract ATest is Test {
+    uint a;
+    function test_negativeGas () public {
+        vm.pauseGasMetering();
+        a = 100;
+        vm.resumeGasMetering();
+        delete a;
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    cmd.args(["test"]).with_no_redact().assert_success().stdout_eq(str![[r#"
+...
+[PASS] test_negativeGas() (gas: 3252)
+...
+"#]]);
+});

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -462,8 +462,8 @@ forgetest_init!(exit_code_error_on_fail_fast_with_json, |prj, cmd| {
     cmd.assert_err();
 });
 
-// <https://github.com/foundry-rs/foundry/issues/6531>
-forgetest_init!(repro_6531, |prj, cmd| {
+// https://github.com/foundry-rs/foundry/pull/6531
+forgetest_init!(fork_traces, |prj, cmd| {
     prj.wipe_contracts();
 
     let endpoint = rpc::next_http_archive_rpc_endpoint();
@@ -510,7 +510,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
-// <https://github.com/foundry-rs/foundry/issues/6579>
+// https://github.com/foundry-rs/foundry/issues/6579
 forgetest_init!(include_custom_types_in_traces, |prj, cmd| {
     prj.wipe_contracts();
 
@@ -862,7 +862,7 @@ Encountered a total of 2 failing tests, 0 tests succeeded
 "#]]);
 });
 
-// <https://github.com/foundry-rs/foundry/issues/7530>
+// https://github.com/foundry-rs/foundry/issues/7530
 forgetest_init!(should_show_precompile_labels, |prj, cmd| {
     prj.wipe_contracts();
 
@@ -1239,9 +1239,9 @@ contract DeterministicRandomnessTest is Test {
     assert_ne!(res4, res3);
 });
 
-// tests that `pauseGasMetering` used at the end of test does not produce meaningless values
-// see https://github.com/foundry-rs/foundry/issues/5491
-forgetest_init!(repro_5491, |prj, cmd| {
+// Tests that `pauseGasMetering` used at the end of test does not produce meaningless values.
+// https://github.com/foundry-rs/foundry/issues/5491
+forgetest_init!(gas_metering_pause_last_call, |prj, cmd| {
     prj.wipe_contracts();
 
     prj.add_test(
@@ -1287,8 +1287,8 @@ contract ATest is Test {
 "#]]);
 });
 
-// see https://github.com/foundry-rs/foundry/issues/5564
-forgetest_init!(repro_5564, |prj, cmd| {
+// https://github.com/foundry-rs/foundry/issues/5564
+forgetest_init!(gas_metering_expect_revert, |prj, cmd| {
     prj.wipe_contracts();
 
     prj.add_test(
@@ -1318,51 +1318,51 @@ contract ATest is Test {
 "#]]);
 });
 
-// see https://github.com/foundry-rs/foundry/issues/4523
-forgetest_init!(repro_4523, |prj, cmd| {
+// https://github.com/foundry-rs/foundry/issues/4523
+forgetest_init!(gas_metering_gasleft, |prj, cmd| {
     prj.wipe_contracts();
 
     prj.add_test(
         "ATest.t.sol",
         r#"
 import "forge-std/Test.sol";
-contract ATest is Test {
-    mapping(uint => bytes32) map;
 
-    function test_GasMeter () public {
+contract ATest is Test {
+    mapping(uint256 => bytes32) map;
+
+    function test_GasMeter() public {
         vm.pauseGasMetering();
-        for (uint i = 0; i < 10000; i++) {
-            map[i] = keccak256(abi.encode(i));
-        }
+        consumeGas();
         vm.resumeGasMetering();
 
-        for (uint i = 0; i < 10000; i++) {
-            map[i] = keccak256(abi.encode(i));
-        }
+        consumeGas();
     }
 
-    function test_GasLeft () public {
-        for (uint i = 0; i < 10000; i++) {
-            map[i] = keccak256(abi.encode(i));
-        }
+    function test_GasLeft() public {
+        consumeGas();
 
-        uint start = gasleft();
-        for (uint i = 0; i < 10000; i++) {
+        uint256 start = gasleft();
+        consumeGas();
+        console.log("Gas cost:", start - gasleft());
+    }
+
+    function consumeGas() private {
+        for (uint256 i = 0; i < 100; i++) {
             map[i] = keccak256(abi.encode(i));
         }
-        console2.log("Gas cost:", start - gasleft());
     }
 }
    "#,
     )
     .unwrap();
 
+    // Log and test gas cost should be similar.
     cmd.args(["test", "-vvvv"]).with_no_redact().assert_success().stdout_eq(str![[r#"
 ...
 Logs:
-  Gas cost: 5754479
+  Gas cost: 34468
 ...
-[PASS] test_GasMeter() (gas: 5757137)
+[PASS] test_GasMeter() (gas: 37512)
 ...
 "#]]);
 });

--- a/crates/forge/tests/it/repros.rs
+++ b/crates/forge/tests/it/repros.rs
@@ -9,7 +9,10 @@ use crate::{
 use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt};
 use alloy_json_abi::Event;
 use alloy_primitives::{address, b256, Address, U256};
-use forge::{decode::decode_console_logs, result::TestStatus};
+use forge::{
+    decode::decode_console_logs,
+    result::{TestKind, TestStatus},
+};
 use foundry_config::{fs_permissions::PathPermission, Config, FsPermissions};
 use foundry_evm::{
     constants::HARDHAT_CONSOLE_ADDRESS,
@@ -363,7 +366,15 @@ test_repro!(8287);
 test_repro!(8168);
 
 // https://github.com/foundry-rs/foundry/issues/8383
-test_repro!(8383);
+test_repro!(8383, false, None, |res| {
+    let mut res = res.remove("default/repros/Issue8383.t.sol:Issue8383Test").unwrap();
+    let test = res.test_results.remove("testP256VerifyOutOfBounds()").unwrap();
+    assert_eq!(test.status, TestStatus::Success);
+    match test.kind {
+        TestKind::Unit { gas } => assert_eq!(gas, 3103),
+        _ => panic!("not a unit test kind"),
+    }
+});
 
 // https://github.com/foundry-rs/foundry/issues/1543
 test_repro!(1543);

--- a/testdata/default/cheats/GasMetering.t.sol
+++ b/testdata/default/cheats/GasMetering.t.sol
@@ -16,21 +16,21 @@ contract GasMeteringTest is DSTest {
     function testGasMetering() public {
         uint256 gas_start = gasleft();
 
-        addInLoop();
+        consumeGas();
 
         uint256 gas_end_normal = gas_start - gasleft();
 
         vm.pauseGasMetering();
         uint256 gas_start_not_metered = gasleft();
 
-        addInLoop();
+        consumeGas();
 
         uint256 gas_end_not_metered = gas_start_not_metered - gasleft();
         vm.resumeGasMetering();
 
         uint256 gas_start_metered = gasleft();
 
-        addInLoop();
+        consumeGas();
 
         uint256 gas_end_resume_metered = gas_start_metered - gasleft();
 
@@ -76,11 +76,9 @@ contract GasMeteringTest is DSTest {
         assertEq(gas_end_not_metered, 0);
     }
 
-    function addInLoop() internal returns (uint256) {
-        uint256 b;
+    function consumeGas() internal returns (uint256 x) {
         for (uint256 i; i < 10000; i++) {
-            b + i;
+            x += i;
         }
-        return b;
     }
 }


### PR DESCRIPTION
Follow-up https://github.com/foundry-rs/foundry/pull/8736

Move the gas pop to step_end, and trigger when the instruction result is not continue

Ideally this would be in something like a destroy_interpreter hook

- https://github.com/foundry-rs/foundry/pull/8744: Fixes #4370