### PR TITLE
fix: throw error if `vm.expectEmit` is used on anonymous event

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1031,9 +1031,9 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
         }
     }
 
-    fn log(&mut self, _interpreter: &mut Interpreter, _ecx: &mut EvmContext<DB>, log: &Log) {
+    fn log(&mut self, interpreter: &mut Interpreter, _ecx: &mut EvmContext<DB>, log: &Log) {
         if !self.expected_emits.is_empty() {
-            expect::handle_expect_emit(self, log);
+            expect::handle_expect_emit(self, log, interpreter);
         }
 
         // `recordLogs`

--- a/testdata/default/repros/Issue7457.t.sol
+++ b/testdata/default/repros/Issue7457.t.sol
@@ -61,10 +61,10 @@ contract Issue7457Test is DSTest, ITarget {
         target.emitAnonymousEventEmpty();
     }
 
-    function testFailEmitEventNonIndexed() public {
+    function testEmitEventNonIndexedReverts() public {
         vm.expectEmit(false, false, false, true);
+        vm.expectRevert("use vm.expectEmitAnonymous to match anonymous events");
         emit AnonymousEventNonIndexed(1);
-        target.emitAnonymousEventNonIndexed(1);
     }
 
     function testEmitEventNonIndexed() public {


### PR DESCRIPTION
## Motivation

ref https://github.com/foundry-rs/foundry/pull/8429#discussion_r1677178655

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
