### PR TITLE
support positional `--mp` parameter for `forge test`

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -641,8 +641,7 @@ impl TestArgs {
         }
         if filter.path_pattern.is_some() {
             if self.path.is_some() {
-                println!("Can not supply both --match-path and |path|");
-                std::process::exit(0);
+                panic!("Can not supply both --match-path and |path|");
             }
         } else {
             filter.path_pattern = self.path.clone();

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -1,6 +1,6 @@
 use super::{install, test::filter::ProjectPathsAwareFilter, watch::WatchArgs};
 use alloy_primitives::U256;
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use eyre::Result;
 use forge::{
     decode::decode_console_logs,
@@ -32,6 +32,7 @@ use foundry_config::{
         value::{Dict, Map},
         Metadata, Profile, Provider,
     },
+    filter::GlobMatcher,
     get_available_profiles, Config,
 };
 use foundry_debugger::Debugger;
@@ -58,6 +59,10 @@ foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
 #[derive(Clone, Debug, Parser)]
 #[command(next_help_heading = "Test options")]
 pub struct TestArgs {
+    /// The contract file you want to test, it's a shortcut for --match-path.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: Option<GlobMatcher>,
+
     /// Run a test in the debugger.
     ///
     /// The argument passed to this flag is the name of the test function you want to run, and it
@@ -633,6 +638,14 @@ impl TestArgs {
         let mut filter = self.filter.clone();
         if self.rerun {
             filter.test_pattern = last_run_failures(config);
+        }
+        if filter.path_pattern.is_some() {
+            if self.path.is_some() {
+                println!("Can not supply both --match-path and |path|");
+                std::process::exit(0);
+            }
+        } else {
+            filter.path_pattern = self.path.clone();
         }
         filter.merge_with_config(config)
     }


### PR DESCRIPTION
This PR tries to fix [this issue](https://github.com/foundry-rs/foundry/issues/8742), users can now simply type `forge test path_to_sol` to run test.