### PR TITLE
fix(fmt): `params_first_multi` split if more than one param

### DIFF
--- a/crates/config/src/fmt.rs
+++ b/crates/config/src/fmt.rs
@@ -153,11 +153,13 @@ pub enum SingleLineBlockStyle {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MultilineFuncHeaderStyle {
-    /// Write function parameters multiline first
+    /// Write function parameters multiline first.
     ParamsFirst,
-    /// Write function attributes multiline first
+    /// Write function parameters multiline first when there is more than one param.
+    ParamsFirstMulti,
+    /// Write function attributes multiline first.
     AttributesFirst,
-    /// If function params or attrs are multiline
+    /// If function params or attrs are multiline.
     /// split the rest
     All,
 }

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1617,7 +1617,9 @@ impl<'a, W: Write> Formatter<'a, W> {
                     let should_multiline = header_multiline &&
                         matches!(
                             fmt.config.multiline_func_header,
-                            MultilineFuncHeaderStyle::ParamsFirst | MultilineFuncHeaderStyle::All
+                            MultilineFuncHeaderStyle::ParamsFirst |
+                                MultilineFuncHeaderStyle::ParamsFirstMulti |
+                                MultilineFuncHeaderStyle::All
                         );
                     params_multiline = should_multiline ||
                         multiline ||
@@ -1626,8 +1628,13 @@ impl<'a, W: Write> Formatter<'a, W> {
                             &params,
                             ",",
                         )?;
-                    // Write new line if we have only one parameter and params on multiline set.
-                    if params.len() == 1 && params_multiline {
+                    // Write new line if we have only one parameter and params first set.
+                    if params.len() == 1 &&
+                        matches!(
+                            fmt.config.multiline_func_header,
+                            MultilineFuncHeaderStyle::ParamsFirst
+                        )
+                    {
                         writeln!(fmt.buf())?;
                     }
                     fmt.write_chunks_separated(&params, ",", params_multiline)?;

--- a/crates/fmt/testdata/FunctionDefinition/all.fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinition/all.fmt.sol
@@ -717,9 +717,7 @@ contract FunctionOverrides is
         a = 1;
     }
 
-    function oneParam(
-        uint256 x
-    )
+    function oneParam(uint256 x)
         override(
             FunctionInterfaces,
             FunctionDefinitions,

--- a/crates/fmt/testdata/FunctionDefinition/params-multi.fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinition/params-multi.fmt.sol
@@ -1,11 +1,9 @@
 // config: line_length = 60
-// config: multiline_func_header = "params_first"
+// config: multiline_func_header = "params_first_multi"
 interface FunctionInterfaces {
     function noParamsNoModifiersNoReturns();
 
-    function oneParam(
-        uint256 x
-    );
+    function oneParam(uint256 x);
 
     function oneModifier() modifier1;
 
@@ -337,9 +335,7 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function oneParam(
-        uint256 x
-    ) {
+    function oneParam(uint256 x) {
         a = 1;
     }
 
@@ -701,9 +697,7 @@ contract FunctionOverrides is
         a = 1;
     }
 
-    function oneParam(
-        uint256 x
-    )
+    function oneParam(uint256 x)
         override(
             FunctionInterfaces,
             FunctionDefinitions,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8761 - introduced breaking change for `params_first`

As suggested in https://github.com/foundry-rs/foundry/issues/8761#issuecomment-2314199656
`params_first` Writes function parameters multiline first regardless number of params
`params_first_multiline` new option added which only splits parameters onto their own line when there is more than one param

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
