### PR TITLE
feat(cheatcodes): add expectPartialRevert cheatcode

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4713,6 +4713,26 @@
     },
     {
       "func": {
+        "id": "expectPartialRevert",
+        "description": "Expects an error on next call that starts with the revert data.",
+        "declaration": "function expectPartialRevert(bytes4 revertData) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectPartialRevert(bytes4)",
+        "selector": "0x11fb5b9c",
+        "selectorBytes": [
+          17,
+          251,
+          91,
+          156
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "expectRevert_0",
         "description": "Expects an error on next call with any revert data.",
         "declaration": "function expectRevert() external;",
@@ -4734,7 +4754,7 @@
     {
       "func": {
         "id": "expectRevert_1",
-        "description": "Expects an error on next call that starts with the revert data.",
+        "description": "Expects an error on next call that exactly matches the revert data.",
         "declaration": "function expectRevert(bytes4 revertData) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -791,13 +791,17 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert() external;
 
-    /// Expects an error on next call that starts with the revert data.
+    /// Expects an error on next call that exactly matches the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes4 revertData) external;
 
     /// Expects an error on next call that exactly matches the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData) external;
+
+    /// Expects an error on next call that starts with the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectPartialRevert(bytes4 revertData) external;
 
     /// Expects an error on next cheatcode call with any revert data.
     #[cheatcode(group = Testing, safety = Unsafe, status = Internal)]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -642,6 +642,7 @@ impl Cheatcodes {
                     false,
                     true,
                     expected_revert.reason.as_deref(),
+                    expected_revert.partial_match,
                     outcome.result.result,
                     outcome.result.output.clone(),
                 ) {
@@ -1122,6 +1123,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                         cheatcode_call,
                         false,
                         expected_revert.reason.as_deref(),
+                        expected_revert.partial_match,
                         outcome.result.result,
                         outcome.result.output.clone(),
                     ) {

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1601,3 +1601,56 @@ contract ATest is DSTest {
 ...
 "#]]);
 });
+
+// Tests that `expectPartialRevert` cheatcode partially matches revert data.
+forgetest_init!(test_expect_partial_revert, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.insert_ds_test();
+    prj.insert_vm();
+    prj.clear();
+
+    prj.add_source(
+        "Counter.t.sol",
+        r#"pragma solidity 0.8.24;
+import {Vm} from "./Vm.sol";
+import {DSTest} from "./test.sol";
+contract Counter {
+    error WrongNumber(uint256 number);
+    function count() public pure {
+        revert WrongNumber(0);
+    }
+}
+
+contract CounterTest is DSTest {
+    Vm vm = Vm(HEVM_ADDRESS);
+
+    function testExpectPartialRevertWithSelector() public {
+        Counter counter = new Counter();
+        vm.expectPartialRevert(Counter.WrongNumber.selector);
+        counter.count();
+    }
+
+    function testExpectPartialRevertWith4Bytes() public {
+        Counter counter = new Counter();
+        vm.expectPartialRevert(bytes4(0x238ace70));
+        counter.count();
+    }
+
+    function testExpectRevert() public {
+        Counter counter = new Counter();
+        vm.expectRevert(Counter.WrongNumber.selector);
+        counter.count();
+    }
+}
+     "#,
+    )
+    .unwrap();
+
+    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
+...
+[PASS] testExpectPartialRevertWith4Bytes() ([GAS])
+[PASS] testExpectPartialRevertWithSelector() ([GAS])
+[FAIL. Reason: Error != expected error: 0x238ace700000000000000000000000000000000000000000000000000000000000000000 != 0x238ace70] testExpectRevert() ([GAS])
+...
+"#]]);
+});

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -231,6 +231,7 @@ interface Vm {
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     function expectEmit() external;
     function expectEmit(address emitter) external;
+    function expectPartialRevert(bytes4 revertData) external;
     function expectRevert() external;
     function expectRevert(bytes4 revertData) external;
     function expectRevert(bytes calldata revertData) external;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3725 
Closes #7629 

`vm.expectRevert(bytes4)` cheatcode checks for revert data to fully match whereas only the first 4 bytes should be checked. As suggested in #3725, for backwards compatibility reasons a new `vm.expectPartialRevert(bytes4)` cheatcode is introduced which checks only the first 4 bytes of reverted data.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add `ExpectedRevert.partial_match` and compare only the first 4 bytes actual / expected reverts if set to true
- add new `expectPartialRevert` cheatcode that sets `ExpectedRevert.partial_match` to true