### PR TITLE
fix(forge vb): bail when args expected but none provided

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -209,6 +209,10 @@ impl VerifyBytecodeArgs {
             check_explorer_args(source_code.clone())?
         };
 
+        // This fails only when the contract expects constructor args but NONE were provided OR
+        // retrieved from explorer (in case of predeploys).
+        crate::utils::check_args_len(&artifact, &constructor_args)?;
+
         if maybe_predeploy {
             if !self.json {
                 println!(

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -307,6 +307,21 @@ pub fn check_explorer_args(source_code: ContractMetadata) -> Result<Bytes, eyre:
     }
 }
 
+pub fn check_args_len(
+    artifact: &CompactContractBytecode,
+    args: &Bytes,
+) -> Result<(), eyre::ErrReport> {
+    if let Some(constructor) = artifact.abi.as_ref().and_then(|abi| abi.constructor()) {
+        if !constructor.inputs.is_empty() && args.len() == 0 {
+            eyre::bail!(
+                "Contract expects {} constructor argument(s), but none were provided",
+                constructor.inputs.len()
+            );
+        }
+    }
+    Ok(())
+}
+
 pub async fn get_tracing_executor(
     fork_config: &mut Config,
     fork_blk_num: u64,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref https://github.com/foundry-rs/foundry/issues/8722#issuecomment-2306849788 

Verification will fail if the contract is expecting constructor args but none are provided by the user using `--constructor-args` and the explorer also doesn't return any (in case of predeploys).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a check that bails and notifies the user.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
