### PR TITLE
feat(cheatcodes): expectRevert with specific reverter address

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4713,7 +4713,7 @@
     },
     {
       "func": {
-        "id": "expectPartialRevert",
+        "id": "expectPartialRevert_0",
         "description": "Expects an error on next call that starts with the revert data.",
         "declaration": "function expectPartialRevert(bytes4 revertData) external;",
         "visibility": "external",
@@ -4725,6 +4725,26 @@
           251,
           91,
           156
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectPartialRevert_1",
+        "description": "Expects an error on next call to reverter address, that starts with the revert data.",
+        "declaration": "function expectPartialRevert(bytes4 revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectPartialRevert(bytes4,address)",
+        "selector": "0x51aa008a",
+        "selectorBytes": [
+          81,
+          170,
+          0,
+          138
         ]
       },
       "group": "testing",
@@ -4785,6 +4805,66 @@
           141,
           206,
           179
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_3",
+        "description": "Expects an error with any revert data on next call to reverter address.",
+        "declaration": "function expectRevert(address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(address)",
+        "selector": "0xd814f38a",
+        "selectorBytes": [
+          216,
+          20,
+          243,
+          138
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_4",
+        "description": "Expects an error from reverter address on next call, with any revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,address)",
+        "selector": "0x260bc5de",
+        "selectorBytes": [
+          38,
+          11,
+          197,
+          222
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_5",
+        "description": "Expects an error from reverter address on next call, that exactly matches the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, address reverter) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,address)",
+        "selector": "0x61ebcf12",
+        "selectorBytes": [
+          97,
+          235,
+          207,
+          18
         ]
       },
       "group": "testing",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -799,9 +799,25 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData) external;
 
+    /// Expects an error with any revert data on next call to reverter address.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(address reverter) external;
+
+    /// Expects an error from reverter address on next call, with any revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, address reverter) external;
+
+    /// Expects an error from reverter address on next call, that exactly matches the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, address reverter) external;
+
     /// Expects an error on next call that starts with the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectPartialRevert(bytes4 revertData) external;
+
+    /// Expects an error on next call to reverter address, that starts with the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectPartialRevert(bytes4 revertData, address reverter) external;
 
     /// Expects an error on next cheatcode call with any revert data.
     #[cheatcode(group = Testing, safety = Unsafe, status = Internal)]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -641,10 +641,10 @@ impl Cheatcodes {
                 return match expect::handle_expect_revert(
                     false,
                     true,
-                    expected_revert.reason.as_deref(),
-                    expected_revert.partial_match,
+                    &expected_revert,
                     outcome.result.result,
                     outcome.result.output.clone(),
+                    None,
                     &self.config.available_artifacts,
                 ) {
                     Ok((address, retdata)) => {
@@ -1123,10 +1123,10 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
                     return match expect::handle_expect_revert(
                         cheatcode_call,
                         false,
-                        expected_revert.reason.as_deref(),
-                        expected_revert.partial_match,
+                        &expected_revert,
                         outcome.result.result,
                         outcome.result.output.clone(),
+                        Some(call.target_address),
                         &self.config.available_artifacts,
                     ) {
                         Err(error) => {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -82,6 +82,8 @@ pub struct ExpectedRevert {
     pub partial_match: bool,
     /// Contract expected to revert next call.
     pub reverter: Option<Address>,
+    /// Actual reverter of the call.
+    pub reverted_by: Option<Address>,
 }
 
 #[derive(Clone, Debug)]
@@ -672,6 +674,7 @@ fn expect_revert(
         },
         partial_match,
         reverter,
+        reverted_by: None,
     });
     Ok(Default::default())
 }
@@ -682,7 +685,6 @@ pub(crate) fn handle_expect_revert(
     expected_revert: &ExpectedRevert,
     status: InstructionResult,
     retdata: Bytes,
-    target_address: Option<Address>,
     known_contracts: &Option<ContractsByArtifact>,
 ) -> Result<(Option<Address>, Bytes)> {
     let success_return = || {
@@ -697,7 +699,7 @@ pub(crate) fn handle_expect_revert(
 
     // If expected reverter address is set then check it matches the actual reverter.
     if let (Some(expected_reverter), Some(actual_reverter)) =
-        (expected_revert.reverter, target_address)
+        (expected_revert.reverter, expected_revert.reverted_by)
     {
         if expected_reverter != actual_reverter {
             return Err(fmt_err!(

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -80,6 +80,8 @@ pub struct ExpectedRevert {
     pub kind: ExpectedRevertKind,
     /// If true then only the first 4 bytes of expected data returned by the revert are checked.
     pub partial_match: bool,
+    /// Contract expected to revert next call.
+    pub reverter: Option<Address>,
 }
 
 #[derive(Clone, Debug)]
@@ -288,7 +290,7 @@ impl Cheatcode for expectEmitAnonymous_3Call {
 impl Cheatcode for expectRevert_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self {} = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false)
+        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None)
     }
 }
 
@@ -301,6 +303,7 @@ impl Cheatcode for expectRevert_1Call {
             ccx.ecx.journaled_state.depth(),
             false,
             false,
+            None,
         )
     }
 }
@@ -308,11 +311,60 @@ impl Cheatcode for expectRevert_1Call {
 impl Cheatcode for expectRevert_2Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
-        expect_revert(ccx.state, Some(revertData), ccx.ecx.journaled_state.depth(), false, false)
+        expect_revert(
+            ccx.state,
+            Some(revertData),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            None,
+        )
     }
 }
 
-impl Cheatcode for expectPartialRevertCall {
+impl Cheatcode for expectRevert_3Call {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { reverter } = self;
+        expect_revert(
+            ccx.state,
+            None,
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+        )
+    }
+}
+
+impl Cheatcode for expectRevert_4Call {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { revertData, reverter } = self;
+        expect_revert(
+            ccx.state,
+            Some(revertData.as_ref()),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+        )
+    }
+}
+
+impl Cheatcode for expectRevert_5Call {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { revertData, reverter } = self;
+        expect_revert(
+            ccx.state,
+            Some(revertData),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+        )
+    }
+}
+
+impl Cheatcode for expectPartialRevert_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
         expect_revert(
@@ -321,13 +373,28 @@ impl Cheatcode for expectPartialRevertCall {
             ccx.ecx.journaled_state.depth(),
             false,
             true,
+            None,
+        )
+    }
+}
+
+impl Cheatcode for expectPartialRevert_1Call {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { revertData, reverter } = self;
+        expect_revert(
+            ccx.state,
+            Some(revertData.as_ref()),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            true,
+            Some(*reverter),
         )
     }
 }
 
 impl Cheatcode for _expectCheatcodeRevert_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false)
+        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false, None)
     }
 }
 
@@ -340,6 +407,7 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
             ccx.ecx.journaled_state.depth(),
             true,
             false,
+            None,
         )
     }
 }
@@ -347,7 +415,14 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
 impl Cheatcode for _expectCheatcodeRevert_2Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { revertData } = self;
-        expect_revert(ccx.state, Some(revertData), ccx.ecx.journaled_state.depth(), true, false)
+        expect_revert(
+            ccx.state,
+            Some(revertData),
+            ccx.ecx.journaled_state.depth(),
+            true,
+            false,
+            None,
+        )
     }
 }
 
@@ -568,6 +643,7 @@ fn expect_revert(
     depth: u64,
     cheatcode: bool,
     partial_match: bool,
+    reverter: Option<Address>,
 ) -> Result {
     ensure!(
         state.expected_revert.is_none(),
@@ -582,6 +658,7 @@ fn expect_revert(
             ExpectedRevertKind::Default
         },
         partial_match,
+        reverter,
     });
     Ok(Default::default())
 }
@@ -589,10 +666,10 @@ fn expect_revert(
 pub(crate) fn handle_expect_revert(
     is_cheatcode: bool,
     is_create: bool,
-    expected_revert: Option<&[u8]>,
-    partial_match: bool,
+    expected_revert: &ExpectedRevert,
     status: InstructionResult,
     retdata: Bytes,
+    target_address: Option<Address>,
     known_contracts: &Option<ContractsByArtifact>,
 ) -> Result<(Option<Address>, Bytes)> {
     let success_return = || {
@@ -605,19 +682,33 @@ pub(crate) fn handle_expect_revert(
 
     ensure!(!matches!(status, return_ok!()), "next call did not revert as expected");
 
+    // If expected reverter address is set then check it matches the actual reverter.
+    if let (Some(expected_reverter), Some(actual_reverter)) =
+        (expected_revert.reverter, target_address)
+    {
+        if expected_reverter != actual_reverter {
+            return Err(fmt_err!(
+                "Reverter != expected reverter: {} != {}",
+                actual_reverter,
+                expected_reverter
+            ));
+        }
+    }
+
+    let expected_reason = expected_revert.reason.as_deref();
     // If None, accept any revert.
-    let Some(expected_revert) = expected_revert else {
+    let Some(expected_reason) = expected_reason else {
         return Ok(success_return());
     };
 
-    if !expected_revert.is_empty() && retdata.is_empty() {
+    if !expected_reason.is_empty() && retdata.is_empty() {
         bail!("call reverted as expected, but without data");
     }
 
     let mut actual_revert: Vec<u8> = retdata.into();
 
     // Compare only the first 4 bytes if partial match.
-    if partial_match && actual_revert.get(..4) == expected_revert.get(..4) {
+    if expected_revert.partial_match && actual_revert.get(..4) == expected_reason.get(..4) {
         return Ok(success_return())
     }
 
@@ -631,8 +722,8 @@ pub(crate) fn handle_expect_revert(
         }
     }
 
-    if actual_revert == expected_revert ||
-        (is_cheatcode && memchr::memmem::find(&actual_revert, expected_revert).is_some())
+    if actual_revert == expected_reason ||
+        (is_cheatcode && memchr::memmem::find(&actual_revert, expected_reason).is_some())
     {
         Ok(success_return())
     } else {
@@ -640,7 +731,7 @@ pub(crate) fn handle_expect_revert(
             let decoder = RevertDecoder::new().with_abis(contracts.iter().map(|(_, c)| &c.abi));
             (
                 &decoder.decode(actual_revert.as_slice(), Some(status)),
-                &decoder.decode(expected_revert, Some(status)),
+                &decoder.decode(expected_reason, Some(status)),
             )
         } else {
             let stringify = |data: &[u8]| {
@@ -652,7 +743,7 @@ pub(crate) fn handle_expect_revert(
                 }
                 hex::encode_prefixed(data)
             };
-            (&stringify(&actual_revert), &stringify(expected_revert))
+            (&stringify(&actual_revert), &stringify(expected_reason))
         };
         Err(fmt_err!("Error != expected error: {} != {}", actual, expected,))
     }

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -144,9 +144,29 @@ impl RevertDecoder {
                 let e = Vm::expectRevert_2Call::abi_decode_raw(data, false).ok()?;
                 return self.maybe_decode(&e.revertData[..], status);
             }
+            // `expectRevert(bytes,address)`
+            Vm::expectRevert_5Call::SELECTOR => {
+                let e = Vm::expectRevert_5Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
             // `expectRevert(bytes4)`
             Vm::expectRevert_1Call::SELECTOR => {
                 let e = Vm::expectRevert_1Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
+            // `expectRevert(bytes4,address)`
+            Vm::expectRevert_4Call::SELECTOR => {
+                let e = Vm::expectRevert_4Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
+            // `expectPartialRevert(bytes4)`
+            Vm::expectPartialRevert_0Call::SELECTOR => {
+                let e = Vm::expectPartialRevert_0Call::abi_decode_raw(data, false).ok()?;
+                return self.maybe_decode(&e.revertData[..], status);
+            }
+            // `expectPartialRevert(bytes4,address)`
+            Vm::expectPartialRevert_1Call::SELECTOR => {
+                let e = Vm::expectPartialRevert_1Call::abi_decode_raw(data, false).ok()?;
                 return self.maybe_decode(&e.revertData[..], status);
             }
             _ => {}

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -529,12 +529,12 @@ Compiler run successful!
 Ran 1 test for test/Contract.t.sol:USDTCallingTest
 [PASS] test() ([GAS])
 Traces:
-  [9537] USDTCallingTest::test()
+  [9516] USDTCallingTest::test()
     ├─ [0] VM::createSelectFork("[..]")
     │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
     │   └─ ← [Return] "Tether USD"
-    └─ ← [Stop]
+    └─ ← [Stop] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -573,7 +573,7 @@ contract CustomTypesTest is Test {
 Compiler run successful!
 
 Ran 2 tests for test/Contract.t.sol:CustomTypesTest
-[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
+[FAIL: PoolNotInitialized()] testErr() ([GAS])
 Traces:
   [254] CustomTypesTest::testErr()
     └─ ← [Revert] PoolNotInitialized()
@@ -582,7 +582,7 @@ Traces:
 Traces:
   [1268] CustomTypesTest::testEvent()
     ├─ emit MyEvent(a: 100)
-    └─ ← [Stop]
+    └─ ← [Stop] 
 
 Suite result: FAILED. 1 passed; 1 failed; 0 skipped; [ELAPSED]
 
@@ -590,7 +590,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 1 failed, 0 skipped (2 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/Contract.t.sol:CustomTypesTest
-[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
+[FAIL: PoolNotInitialized()] testErr() ([GAS])
 
 Encountered a total of 1 failing tests, 1 tests succeeded
 
@@ -632,7 +632,8 @@ forgetest_init!(can_test_transient_storage_with_isolation, |prj, cmd| {
 
     prj.add_test(
         "Contract.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
+pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 
 contract TransientTester {
@@ -687,7 +688,7 @@ forgetest_init!(can_disable_block_gas_limit, |prj, cmd| {
 
     prj.add_test(
         "Contract.t.sol",
-        &r#"pragma solidity 0.8.24;
+        &r#"
 import {Test} from "forge-std/Test.sol";
 
 contract C is Test {}
@@ -743,7 +744,7 @@ forgetest_init!(should_not_shrink_fuzz_failure, |prj, cmd| {
 
     prj.add_test(
         "CounterFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract Counter {
@@ -776,14 +777,14 @@ contract CounterTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
+[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
+[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -794,7 +795,7 @@ forgetest_init!(should_exit_early_on_invariant_failure, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(
         "CounterInvariant.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract Counter {
@@ -827,14 +828,14 @@ contract CounterTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/CounterInvariant.t.sol:CounterTest
-[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterInvariant.t.sol:CounterTest
-[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -845,7 +846,7 @@ forgetest_init!(should_replay_failures_only, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(
         "ReplayFailures.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract ReplayFailuresTest is Test {
@@ -876,17 +877,17 @@ Compiler run successful!
 
 Ran 4 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
 [PASS] testA() ([GAS])
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
 [PASS] testC() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 Suite result: FAILED. 2 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 2 failed, 0 skipped (4 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 2 tests succeeded
 
@@ -900,16 +901,16 @@ Encountered a total of 2 failing tests, 2 tests succeeded
 No files changed, compilation skipped
 
 Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 2 failed, 0 skipped (2 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 0 tests succeeded
 
@@ -924,6 +925,7 @@ forgetest_init!(should_show_precompile_labels, |prj, cmd| {
         "Contract.t.sol",
         r#"
 import {Test} from "forge-std/Test.sol";
+
 contract PrecompileLabelsTest is Test {
     function testPrecompileLabels() public {
         vm.deal(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D), 1 ether);
@@ -957,36 +959,36 @@ Ran 1 test for test/Contract.t.sol:PrecompileLabelsTest
 Traces:
   [9474] PrecompileLabelsTest::testPrecompileLabels()
     ├─ [0] VM::deal(VM: [0x7109709ECfa91a80626fF3989D68f67F5b1DD12D], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(console: [0x000000000000000000636F6e736F6c652e6c6f67], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(Create2Deployer: [0x4e59b44847b379578588920cA78FbF26c0B4956C], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(DefaultSender: [0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(DefaultTestContract: [0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(ECRecover: [0x0000000000000000000000000000000000000001], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(SHA-256: [0x0000000000000000000000000000000000000002], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(RIPEMD-160: [0x0000000000000000000000000000000000000003], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(Identity: [0x0000000000000000000000000000000000000004], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(ModExp: [0x0000000000000000000000000000000000000005], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(ECAdd: [0x0000000000000000000000000000000000000006], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(ECMul: [0x0000000000000000000000000000000000000007], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(ECPairing: [0x0000000000000000000000000000000000000008], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(Blake2F: [0x0000000000000000000000000000000000000009], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [0] VM::deal(PointEvaluation: [0x000000000000000000000000000000000000000A], 1000000000000000000 [1e18])
-    │   └─ ← [Return]
-    └─ ← [Stop]
+    │   └─ ← [Return] 
+    └─ ← [Stop] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -1011,14 +1013,15 @@ forgetest_init!(should_show_logs_when_fuzz_test, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+        r#"
+import {Test, console} from "forge-std/Test.sol";
+
+contract ContractFuzz is Test {
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
-     "#,
+}
+    "#,
     )
     .unwrap();
     cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
@@ -1054,16 +1057,16 @@ forgetest_init!(should_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
-      /// forge-config: default.fuzz.show-logs = true
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+contract ContractFuzz is Test {
+    /// forge-config: default.fuzz.show-logs = true
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
-     "#,
+}
+    "#,
     )
     .unwrap();
     cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
@@ -1101,12 +1104,12 @@ forgetest_init!(should_not_show_logs_when_fuzz_test, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
+        r#"
+        import {Test, console} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
       function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
+        console.log("inside fuzz test, x is:", x);
       }
     }
      "#,
@@ -1140,15 +1143,15 @@ forgetest_init!(should_not_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
-      /// forge-config: default.fuzz.show-logs = false
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+contract ContractFuzz is Test {
+    /// forge-config: default.fuzz.show-logs = false
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
+}
      "#,
     )
     .unwrap();
@@ -1177,8 +1180,9 @@ forgetest_init!(internal_functions_trace, |prj, cmd| {
 
     prj.add_test(
         "Simple",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
+        r#"
+import {Test, console} from "forge-std/Test.sol";
+
 contract SimpleContract {
     uint256 public num;
     address public addr;
@@ -1227,14 +1231,14 @@ Traces:
     ├─ [22638] SimpleContract::increment()
     │   ├─ [20150] SimpleContract::_setNum(1)
     │   │   └─ ← 0
-    │   └─ ← [Stop]
+    │   └─ ← [Stop] 
     ├─ [23219] SimpleContract::setValues(100, 0x0000000000000000000000000000000000000123)
     │   ├─ [250] SimpleContract::_setNum(100)
     │   │   └─ ← 1
     │   ├─ [22339] SimpleContract::_setAddr(0x0000000000000000000000000000000000000123)
     │   │   └─ ← 0x0000000000000000000000000000000000000000
-    │   └─ ← [Stop]
-    └─ ← [Stop]
+    │   └─ ← [Stop] 
+    └─ ← [Stop] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 
@@ -1254,8 +1258,8 @@ forgetest_init!(internal_functions_trace_memory, |prj, cmd| {
 
     prj.add_test(
         "Simple",
-        r#"pragma solidity 0.8.24;
-import {Test, console2} from "forge-std/Test.sol";
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
 contract SimpleContract {
     string public str = "initial value";
@@ -1283,14 +1287,14 @@ contract SimpleContractTest is Test {
         r#"
 ...
 Traces:
-  [421960] SimpleContractTest::test()
+  [421947] SimpleContractTest::test()
     ├─ [385978] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
     │   └─ ← [Return] 1814 bytes of code
     ├─ [2534] SimpleContract::setStr("new value")
     │   ├─ [1600] SimpleContract::_setStr("new value")
     │   │   └─ ← "initial value"
-    │   └─ ← [Stop]
-    └─ ← [Stop]
+    │   └─ ← [Stop] 
+    └─ ← [Stop] 
 ...
 "#
     ]]);
@@ -1506,7 +1510,7 @@ Logs:
 });
 
 // https://github.com/foundry-rs/foundry/issues/4370
-forgetest_init!(repro_4370, |prj, cmd| {
+forgetest_init!(pause_gas_metering_with_delete, |prj, cmd| {
     prj.wipe_contracts();
 
     prj.add_test(
@@ -1543,7 +1547,7 @@ forgetest_init!(pause_tracing, |prj, cmd| {
 
     prj.add_source(
         "Pause.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract TraceGenerator is DSTest {
@@ -1588,34 +1592,34 @@ Traces:
   [7285] PauseTracingTest::setUp()
     ├─ emit DummyEvent(i: 1)
     ├─ [0] VM::pauseTracing() [staticcall]
-    │   └─ ← [Return]
-    └─ ← [Stop]
+    │   └─ ← [Return] 
+    └─ ← [Stop] 
 
   [294725] PauseTracingTest::test()
     ├─ [0] VM::resumeTracing() [staticcall]
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [18373] TraceGenerator::generate()
     │   ├─ [1280] TraceGenerator::call(0)
     │   │   ├─ emit DummyEvent(i: 0)
-    │   │   └─ ← [Stop]
+    │   │   └─ ← [Stop] 
     │   ├─ [1280] TraceGenerator::call(1)
     │   │   ├─ emit DummyEvent(i: 1)
-    │   │   └─ ← [Stop]
+    │   │   └─ ← [Stop] 
     │   ├─ [1280] TraceGenerator::call(2)
     │   │   ├─ emit DummyEvent(i: 2)
-    │   │   └─ ← [Stop]
+    │   │   └─ ← [Stop] 
     │   ├─ [0] VM::pauseTracing() [staticcall]
-    │   │   └─ ← [Return]
+    │   │   └─ ← [Return] 
     │   ├─ [0] VM::resumeTracing() [staticcall]
-    │   │   └─ ← [Return]
+    │   │   └─ ← [Return] 
     │   ├─ [1280] TraceGenerator::call(8)
     │   │   ├─ emit DummyEvent(i: 8)
-    │   │   └─ ← [Stop]
+    │   │   └─ ← [Stop] 
     │   ├─ [1280] TraceGenerator::call(9)
     │   │   ├─ emit DummyEvent(i: 9)
-    │   │   └─ ← [Stop]
-    │   └─ ← [Stop]
-    └─ ← [Stop]
+    │   │   └─ ← [Stop] 
+    │   └─ ← [Stop] 
+    └─ ← [Stop] 
 ...
 "#]]);
 });
@@ -1628,7 +1632,7 @@ forgetest_init!(gas_metering_reset, |prj, cmd| {
 
     prj.add_source(
         "ATest.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract B {
@@ -1780,8 +1784,8 @@ contract CounterTest is Test {
 
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL. Reason: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
-[FAIL. Reason: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
+[FAIL: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
+[FAIL: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
 ...
 "#]]);
 });
@@ -1795,7 +1799,7 @@ forgetest_init!(test_expect_partial_revert, |prj, cmd| {
 
     prj.add_source(
         "Counter.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract Counter {
@@ -1830,7 +1834,7 @@ contract CounterTest is DSTest {
 ...
 [PASS] testExpectPartialRevertWith4Bytes() ([GAS])
 [PASS] testExpectPartialRevertWithSelector() ([GAS])
-[FAIL. Reason: Error != expected error: WrongNumber(0) != custom error 238ace70:] testExpectRevert() ([GAS])
+[FAIL: Error != expected error: WrongNumber(0) != custom error 0x238ace70] testExpectRevert() ([GAS])
 ...
 "#]]);
 });
@@ -1841,9 +1845,15 @@ forgetest_init!(test_assume_no_revert, |prj, cmd| {
     prj.insert_vm();
     prj.clear();
 
+    let config = Config {
+        fuzz: { FuzzConfig { runs: 100, seed: Some(U256::from(100)), ..Default::default() } },
+        ..Default::default()
+    };
+    prj.write_config(config);
+
     prj.add_source(
         "Counter.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract CounterWithRevert {
@@ -1906,80 +1916,179 @@ contract CounterRevertTest is DSTest {
 
     cmd.args(["test"]).with_no_redact().assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL. Reason: assertion failed; counterexample: [..]] test_assume_no_revert_fail_assert(uint256) [..]
-[FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_2nd_call(uint256) [..]
-[FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_3rd_call(uint256) [..]
-[PASS] test_assume_no_revert_pass(uint256) (runs: 256, [..])
+[FAIL; counterexample: [..]] test_assume_no_revert_fail_assert(uint256) [..]
+[FAIL: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_2nd_call(uint256) [..]
+[FAIL: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_3rd_call(uint256) [..]
+[PASS] test_assume_no_revert_pass(uint256) [..]
 ...
 "#]]);
 });
 
-// Tests `expectRevert` with specific reverter address.
-forgetest_init!(test_expect_revert_with_reverter, |prj, cmd| {
+forgetest_init!(skip_output, |prj, cmd| {
     prj.wipe_contracts();
     prj.insert_ds_test();
     prj.insert_vm();
     prj.clear();
 
     prj.add_source(
-        "Reverter.t.sol",
-        r#"pragma solidity 0.8.24;
-import {Vm} from "./Vm.sol";
-import {DSTest} from "./test.sol";
-contract Reverter {
-    error CustomError();
-    function withRevert() public pure {
-        revert CustomError();
-    }
-    function withNoRevert() public pure {}
-}
-contract ReverterTest is DSTest {
-    Vm vm = Vm(HEVM_ADDRESS);
-    error CustomError();
-    function test_match_reverters() public {
-        Reverter reverter = new Reverter();
-        vm.expectRevert(address(reverter));
-        reverter.withRevert();
-        vm.expectRevert(CustomError.selector, address(reverter));
-        reverter.withRevert();
-        vm.expectPartialRevert(CustomError.selector, address(reverter));
-        reverter.withRevert();
-    }
-    function test_next_call_fail() public {
-        Reverter reverter = new Reverter();
-        vm.expectRevert(address(reverter));
-        reverter.withNoRevert();
-    }
-    function test_wrong_reverter_fail_1() public {
-        Reverter reverter = new Reverter();
-        Reverter bReverter = new Reverter();
-        vm.expectRevert(address(bReverter));
-        reverter.withRevert();
-    }
-    function test_wrong_reverter_fail_2() public {
-        Reverter reverter = new Reverter();
-        Reverter bReverter = new Reverter();
-        vm.expectRevert(CustomError.selector, address(bReverter));
-        reverter.withRevert();
-    }
-    function test_wrong_reverter_fail_3() public {
-        Reverter reverter = new Reverter();
-        Reverter bReverter = new Reverter();
-        vm.expectPartialRevert(CustomError.selector, address(bReverter));
-        reverter.withRevert();
-    }
-}
-     "#,
+        "Counter.t.sol",
+        r#"
+        import {Vm} from "./Vm.sol";
+        import {DSTest} from "./test.sol";
+
+        contract Skips is DSTest {
+            Vm constant vm = Vm(HEVM_ADDRESS);
+
+            function test_skipUnit() public {
+                vm.skip(true);
+            }
+            function test_skipUnitReason() public {
+                vm.skip(true, "unit");
+            }
+
+            function test_skipFuzz(uint) public {
+                vm.skip(true);
+            }
+            function test_skipFuzzReason(uint) public {
+                vm.skip(true, "fuzz");
+            }
+
+            function invariant_skipInvariant() public {
+                vm.skip(true);
+            }
+            function invariant_skipInvariantReason() public {
+                vm.skip(true, "invariant");
+            }
+        }
+    "#,
     )
     .unwrap();
 
-    cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
+    cmd.arg("test").assert_success().stdout_eq(str![[r#"
 ...
-[PASS] test_match_reverters() ([GAS])
-[FAIL. Reason: next call did not revert as expected] test_next_call_fail() ([GAS])
-[FAIL. Reason: Reverter != expected reverter: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f != 0x2e234DAe75C793f67A35089C9d99245E1C58470b] test_wrong_reverter_fail_1() ([GAS])
-[FAIL. Reason: Reverter != expected reverter: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f != 0x2e234DAe75C793f67A35089C9d99245E1C58470b] test_wrong_reverter_fail_2() ([GAS])
-[FAIL. Reason: Reverter != expected reverter: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f != 0x2e234DAe75C793f67A35089C9d99245E1C58470b] test_wrong_reverter_fail_3() ([GAS])
-...
+Ran 6 tests for src/Counter.t.sol:Skips
+[SKIP] invariant_skipInvariant() (runs: 1, calls: 1, reverts: 1)
+[SKIP: invariant] invariant_skipInvariantReason() (runs: 1, calls: 1, reverts: 1)
+[SKIP] test_skipFuzz(uint256) (runs: 0, [AVG_GAS])
+[SKIP: fuzz] test_skipFuzzReason(uint256) (runs: 0, [AVG_GAS])
+[SKIP] test_skipUnit() ([GAS])
+[SKIP: unit] test_skipUnitReason() ([GAS])
+Suite result: ok. 0 passed; 0 failed; 6 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 0 failed, 6 skipped (6 total tests)
+
+"#]]);
+});
+
+forgetest_init!(should_generate_junit_xml_report, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.insert_ds_test();
+    prj.insert_vm();
+    prj.clear();
+
+    prj.add_source(
+        "JunitReportTest.t.sol",
+        r#"
+        import {Vm} from "./Vm.sol";
+        import {DSTest} from "./test.sol";
+
+        contract AJunitReportTest is DSTest {
+            function test_junit_assert_fail() public {
+                assert(1 > 2);
+            }
+
+            function test_junit_revert_fail() public {
+                require(1 > 2, "Revert");
+            }
+        }
+
+        contract BJunitReportTest is DSTest {
+            Vm constant vm = Vm(HEVM_ADDRESS);
+            function test_junit_pass() public {
+                require(1 < 2, "Revert");
+            }
+
+            function test_junit_skip() public {
+                vm.skip(true);
+            }
+
+            function test_junit_skip_with_message() public {
+                vm.skip(true, "skipped test");
+            }
+
+            function test_junit_pass_fuzz(uint256 a) public {
+            }
+        }
+   "#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "--junit"]).assert_failure().stdout_eq(str![[r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Test run" tests="6" failures="2" errors="0" timestamp="[..]" time="[..]">
+    <testsuite name="src/JunitReportTest.t.sol:AJunitReportTest" tests="2" disabled="0" errors="0" failures="2" time="[..]">
+        <testcase name="test_junit_assert_fail()" time="[..]">
+            <failure message="panic: assertion failed (0x01)"/>
+            <system-out>[FAIL: panic: assertion failed (0x01)] test_junit_assert_fail() ([GAS])</system-out>
+        </testcase>
+        <testcase name="test_junit_revert_fail()" time="[..]">
+            <failure message="revert: Revert"/>
+            <system-out>[FAIL: revert: Revert] test_junit_revert_fail() ([GAS])</system-out>
+        </testcase>
+        <system-out>Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]</system-out>
+    </testsuite>
+    <testsuite name="src/JunitReportTest.t.sol:BJunitReportTest" tests="4" disabled="2" errors="0" failures="0" time="[..]">
+        <testcase name="test_junit_pass()" time="[..]">
+            <system-out>[PASS] test_junit_pass() ([GAS])</system-out>
+        </testcase>
+        <testcase name="test_junit_pass_fuzz(uint256)" time="[..]">
+            <system-out>[PASS] test_junit_pass_fuzz(uint256) (runs: 256, [AVG_GAS])</system-out>
+        </testcase>
+        <testcase name="test_junit_skip()" time="[..]">
+            <skipped/>
+            <system-out>[SKIP] test_junit_skip() ([GAS])</system-out>
+        </testcase>
+        <testcase name="test_junit_skip_with_message()" time="[..]">
+            <skipped message="skipped test"/>
+            <system-out>[SKIP: skipped test] test_junit_skip_with_message() ([GAS])</system-out>
+        </testcase>
+        <system-out>Suite result: ok. 2 passed; 0 failed; 2 skipped; [ELAPSED]</system-out>
+    </testsuite>
+</testsuites>
+
+
+"#]]);
+});
+
+forgetest_init!(should_generate_junit_xml_report_with_logs, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_source(
+        "JunitReportTest.t.sol",
+        r#"
+import "forge-std/Test.sol";
+contract JunitReportTest is Test {
+    function test_junit_with_logs() public {
+        console.log("Step1");
+        console.log("Step2");
+        console.log("Step3");
+        assert(2 > 1);
+    }
+}
+   "#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "--junit", "-vvvv"]).assert_success().stdout_eq(str![[r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Test run" tests="1" failures="0" errors="0" timestamp="[..]" time="[..]">
+    <testsuite name="src/JunitReportTest.t.sol:JunitReportTest" tests="1" disabled="0" errors="0" failures="0" time="[..]">
+        <testcase name="test_junit_with_logs()" time="[..]">
+            <system-out>[PASS] test_junit_with_logs() ([GAS])/nLogs:/n  Step1/n  Step2/n  Step3/n</system-out>
+        </testcase>
+        <system-out>Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]</system-out>
+    </testsuite>
+</testsuites>
+
+
 "#]]);
 });

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -160,7 +160,7 @@ async fn test_scrape_bytecode() {
     let filter = Filter::new(".*", ".*", ".*fuzz/FuzzScrapeBytecode.t.sol");
     let mut runner = TEST_DATA_DEFAULT.runner();
     runner.test_options.fuzz.runs = 2000;
-    runner.test_options.fuzz.seed = Some(U256::from(6u32));
+    runner.test_options.fuzz.seed = Some(U256::from(100u32));
     let suite_result = runner.test_collect(&filter);
 
     assert!(!suite_result.is_empty());

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -232,9 +232,13 @@ interface Vm {
     function expectEmit() external;
     function expectEmit(address emitter) external;
     function expectPartialRevert(bytes4 revertData) external;
+    function expectPartialRevert(bytes4 revertData, address reverter) external;
     function expectRevert() external;
     function expectRevert(bytes4 revertData) external;
     function expectRevert(bytes calldata revertData) external;
+    function expectRevert(address reverter) external;
+    function expectRevert(bytes4 revertData, address reverter) external;
+    function expectRevert(bytes calldata revertData, address reverter) external;
     function expectSafeMemory(uint64 min, uint64 max) external;
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
     function fee(uint256 newBasefee) external;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #5299 
Closes https://github.com/foundry-rs/book/issues/945
https://github.com/foundry-rs/foundry/issues/5299#issuecomment-1623838745

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- added `expectRevert` cheatcodes with reverter (expects an error on next call from the given address)
```Solidity
function expectRevert(bytes calldata revertData, address reverter) external;
function expectRevert(bytes4 revertData, address reverter) external;
function expectRevert(address reverter) external;
function expectPartialRevert(address reverter) external;
```
- when reverter arg passed then process expected revert for next call, at any depth. If address of contract that reverted the call (call's target address) is different than the expected reverter, then fail test with `Reason: Reverter != expected reverter` reason.
- code refactoring: pass `ExpectedRevert` directly to `handle_expect_revert` 
- added tests