### PR TITLE
fix(cheatcodes): fail when trying to parse malformatted strings as addresses

### DIFF
--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -396,6 +396,14 @@ pub(super) fn parse_json_as(value: &Value, ty: &DynSolType) -> Result<DynSolValu
         (Value::Array(array), ty) => parse_json_array(array, ty),
         (Value::Object(object), ty) => parse_json_map(object, ty),
         (Value::String(s), DynSolType::String) => Ok(DynSolValue::String(s.clone())),
+        (Value::String(s), DynSolType::Address) => 
+            match s.len() {
+                42 => match Address::parse_checksummed(s, None) {
+                    Ok(address) => Ok(DynSolValue::Address(address)),
+                    Err(_) => Err(format!("could not parse address from string {s}").into())
+                }
+                _ => Err(format!("cannot parse address from wrongly sized string {s}, len={}", s.len()).into()),
+            }
         _ => string::parse_value(&to_string(value), ty),
     }
 }
@@ -734,5 +742,11 @@ mod tests {
             let value = parse_json_as(&json, &v.as_type().unwrap()).unwrap();
                 assert_eq!(value, v);
         }
+    }
+
+    #[test]
+    fn test_json_parse_address_fail_if_not_correct_length() {
+        let value = parse_json_as(&Value::String("0x0000".into()), &DynSolType::Address);
+        assert!(value.is_err());
     }
 }

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -570,7 +570,7 @@ pub(super) fn json_value_to_token(value: &Value) -> Result<DynSolValue> {
             if let Some(mut val) = string.strip_prefix("0x") {
                 let s; 
                 if val.len() == 39 {
-                    return Err(format!("Cannot parse \"{val}\" as an address. If you want to specify bytes, prepend zeroes to the value.").into())
+                    return Err(format!("Cannot parse \"{val}\" as an address. If you want to specify address, prepend zero to the value.").into())
                 }
                 if val.len() % 2 != 0 {
                     s = format!("0{val}");

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -749,4 +749,23 @@ mod tests {
         let value = parse_json_as(&Value::String("0x0000".into()), &DynSolType::Address);
         assert!(value.is_err());
     }
+
+    #[test]
+    fn test_json_parse_address_fail_if_not_an_address() {
+        let value = parse_json_as(&Value::String("this is a test".into()), &DynSolType::Address);
+        assert!(value.is_err());
+    }
+
+    #[test]
+    fn test_json_parse_address_fail_if_address_is_not_checksummed() {
+        // NOTE this address is not checksummed correctly
+        let value = parse_json_as(&Value::String("0x000000000000000000000000000000000000000a".into()), &DynSolType::Address);
+        assert!(value.is_err());
+    }
+
+    #[test]
+    fn test_json_parse_address_ok_on_address_zero() {
+        let value = parse_json_as(&Value::String("0x0000000000000000000000000000000000000000".into()), &DynSolType::Address);
+        assert!(value.is_ok());
+    }
 }

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -398,9 +398,9 @@ pub(super) fn parse_json_as(value: &Value, ty: &DynSolType) -> Result<DynSolValu
         (Value::String(s), DynSolType::String) => Ok(DynSolValue::String(s.clone())),
         (Value::String(s), DynSolType::Address) => 
             match s.len() {
-                42 => match Address::parse_checksummed(s, None) {
+                42 => match s.parse::<Address>() {
                     Ok(address) => Ok(DynSolValue::Address(address)),
-                    Err(_) => Err(format!("could not parse address from string {s}").into())
+                    Err(err) => Err(err.to_string().into()),
                 }
                 _ => Err(format!("cannot parse address from wrongly sized string {s}, len={}", s.len()).into()),
             }
@@ -756,13 +756,6 @@ mod tests {
     #[test]
     fn test_json_parse_address_fail_if_not_an_address() {
         let value = parse_json_as(&Value::String("this is a test".into()), &DynSolType::Address);
-        assert!(value.is_err());
-    }
-
-    #[test]
-    fn test_json_parse_address_fail_if_address_is_not_checksummed() {
-        // NOTE this address is not checksummed correctly
-        let value = parse_json_as(&Value::String("0x000000000000000000000000000000000000000a".into()), &DynSolType::Address);
         assert!(value.is_err());
     }
 

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -576,7 +576,10 @@ pub(super) fn json_value_to_token(value: &Value) -> Result<DynSolValue> {
         }
         Value::String(string) => {
             if let Some(mut val) = string.strip_prefix("0x") {
-                let s;
+                let s; 
+                if val.len() == 39 {
+                    return Err(format!("Cannot parse \"{val}\" as an address. If you want to specify bytes, prepend zeroes to the value.").into())
+                }
                 if val.len() % 2 != 0 {
                     s = format!("0{val}");
                     val = &s[..];

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -568,7 +568,7 @@ pub(super) fn json_value_to_token(value: &Value) -> Result<DynSolValue> {
         }
         Value::String(string) => {
             if let Some(mut val) = string.strip_prefix("0x") {
-                let s; 
+                let s;
                 if val.len() == 39 {
                     return Err(format!("Cannot parse \"{val}\" as an address. If you want to specify address, prepend zero to the value.").into())
                 }

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -396,14 +396,6 @@ pub(super) fn parse_json_as(value: &Value, ty: &DynSolType) -> Result<DynSolValu
         (Value::Array(array), ty) => parse_json_array(array, ty),
         (Value::Object(object), ty) => parse_json_map(object, ty),
         (Value::String(s), DynSolType::String) => Ok(DynSolValue::String(s.clone())),
-        (Value::String(s), DynSolType::Address) => 
-            match s.len() {
-                42 => match s.parse::<Address>() {
-                    Ok(address) => Ok(DynSolValue::Address(address)),
-                    Err(err) => Err(err.to_string().into()),
-                }
-                _ => Err(format!("cannot parse address from wrongly sized string {s}, len={}", s.len()).into()),
-            }
         _ => string::parse_value(&to_string(value), ty),
     }
 }
@@ -745,23 +737,5 @@ mod tests {
             let value = parse_json_as(&json, &v.as_type().unwrap()).unwrap();
                 assert_eq!(value, v);
         }
-    }
-
-    #[test]
-    fn test_json_parse_address_fail_if_not_correct_length() {
-        let value = parse_json_as(&Value::String("0x0000".into()), &DynSolType::Address);
-        assert!(value.is_err());
-    }
-
-    #[test]
-    fn test_json_parse_address_fail_if_not_an_address() {
-        let value = parse_json_as(&Value::String("this is a test".into()), &DynSolType::Address);
-        assert!(value.is_err());
-    }
-
-    #[test]
-    fn test_json_parse_address_ok_on_address_zero() {
-        let value = parse_json_as(&Value::String("0x0000000000000000000000000000000000000000".into()), &DynSolType::Address);
-        assert!(value.is_ok());
     }
 }


### PR DESCRIPTION
Hi, I'm here trying to solve #8778.

This is my first time contributing here, and also my first time writing Rust on a real project. Please let me know if the approach I took is wrong here. Thanks!

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fix #8778 as it seemed like a small issue I could take on, and the current behaviour bugged me today as well.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Use the already imported `alloy_dyn_abi` crate to try and parse addresses when the passed in `DynSolType` is an address. We do some minimal validation on the passed in string, and handle it with the underlying crate.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
