### PR TITLE
fix(eip7702): small fixes

### DIFF
--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -231,6 +231,12 @@ pub enum InvalidTransactionError {
     /// Thrown when there are no `blob_hashes` in the transaction.
     #[error("There should be at least one blob in a Blob transaction.")]
     EmptyBlobs,
+    /// Thrown when an access list is used before the berlin hard fork.
+    #[error("EIP-7702 authorization lists are not supported before the Prague hardfork")]
+    AuthorizationListNotSupported,
+    /// Forwards error from the revm
+    #[error(transparent)]
+    Revm(revm::primitives::InvalidTransaction),
 }
 
 impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
@@ -263,7 +269,14 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
             InvalidTransaction::BlobVersionNotSupported => Self::BlobVersionNotSupported,
             InvalidTransaction::EmptyBlobs => Self::EmptyBlobs,
             InvalidTransaction::TooManyBlobs { max, have } => Self::TooManyBlobs(max, have),
-            _ => todo!(),
+            InvalidTransaction::AuthorizationListNotSupported => {
+                Self::AuthorizationListNotSupported
+            }
+            InvalidTransaction::AuthorizationListInvalidFields |
+            InvalidTransaction::InvalidAuthorizationList |
+            InvalidTransaction::OptimismError(_) |
+            InvalidTransaction::EofCrateShouldHaveToAddress |
+            InvalidTransaction::EmptyAuthorizationList => Self::Revm(err),
         }
     }
 }

--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -1,5 +1,4 @@
 use crate::tx::{CastTxBuilder, SenderKind};
-use alloy_primitives::TxKind;
 use alloy_rpc_types::BlockId;
 use cast::Cast;
 use clap::Parser;
@@ -55,15 +54,10 @@ impl AccessListArgs {
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let tx_kind = if let Some(to) = to {
-            TxKind::Call(to.resolve(&provider).await?)
-        } else {
-            TxKind::Create
-        };
-
         let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
             .await?
-            .with_tx_kind(tx_kind)
+            .with_to(to)
+            .await?
             .with_code_sig_and_args(None, sig, args)
             .await?
             .build_raw(sender)

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -1,5 +1,5 @@
 use crate::tx::{CastTxBuilder, SenderKind};
-use alloy_primitives::{TxKind, U256};
+use alloy_primitives::U256;
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
 use clap::Parser;
@@ -73,12 +73,6 @@ impl EstimateArgs {
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 
-        let tx_kind = if let Some(to) = to {
-            TxKind::Call(to.resolve(&provider).await?)
-        } else {
-            TxKind::Create
-        };
-
         let code = if let Some(EstimateSubcommands::Create {
             code,
             sig: create_sig,
@@ -98,7 +92,8 @@ impl EstimateArgs {
 
         let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
             .await?
-            .with_tx_kind(tx_kind)
+            .with_to(to)
+            .await?
             .with_code_sig_and_args(code, sig, args)
             .await?
             .build_raw(sender)

--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::{self, get_provider},
+    utils::get_provider,
 };
 use foundry_common::ens::NameOrAddress;
 use foundry_config::Config;
@@ -83,9 +83,6 @@ impl MakeTxArgs {
         };
 
         let config = Config::from(&eth);
-        let provider = utils::get_provider(&config)?;
-
-        let tx_kind = tx::resolve_tx_kind(&provider, &code, &to).await?;
 
         // Retrieve the signer, and bail if it can't be constructed.
         let signer = eth.wallet.signer().await?;
@@ -97,7 +94,8 @@ impl MakeTxArgs {
 
         let (tx, _) = CastTxBuilder::new(provider, tx, &config)
             .await?
-            .with_tx_kind(tx_kind)
+            .with_to(to)
+            .await?
             .with_code_sig_and_args(code, sig, args)
             .await?
             .with_blob_data(blob_data)?

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -122,11 +122,11 @@ impl SendTxArgs {
 
         let config = Config::from(&eth);
         let provider = utils::get_provider(&config)?;
-        let tx_kind = tx::resolve_tx_kind(&provider, &code, &to).await?;
 
         let builder = CastTxBuilder::new(&provider, tx, &config)
             .await?
-            .with_tx_kind(tx_kind)
+            .with_to(to)
+            .await?
             .with_code_sig_and_args(code, sig, args)
             .await?
             .with_blob_data(blob_data)?;

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -253,7 +253,7 @@ where
             let has_auth = self.auth.is_some();
             // We only allow user to omit the recipient address if transaction is an EIP-7702 tx
             // without a value.
-            if !(has_auth && !has_value) {
+            if !has_auth || has_value {
                 eyre::bail!("Must specify a recipient address or contract code to deploy");
             }
         }

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -103,29 +103,14 @@ corresponds to the sender, or let foundry automatically detect it by not specify
     Ok(())
 }
 
-/// Ensures the transaction is either a contract deployment or a recipient address is specified
-pub async fn resolve_tx_kind<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
-    provider: &P,
-    code: &Option<String>,
-    to: &Option<NameOrAddress>,
-) -> Result<TxKind> {
-    if code.is_some() {
-        Ok(TxKind::Create)
-    } else if let Some(to) = to {
-        Ok(TxKind::Call(to.resolve(provider).await?))
-    } else {
-        eyre::bail!("Must specify a recipient address or contract code to deploy");
-    }
-}
-
 /// Initial state.
 #[derive(Debug)]
 pub struct InitState;
 
 /// State with known [TxKind].
 #[derive(Debug)]
-pub struct TxKindState {
-    kind: TxKind,
+pub struct ToState {
+    to: Option<Address>,
 }
 
 /// State with known input for the transaction.
@@ -211,8 +196,9 @@ where
     }
 
     /// Sets [TxKind] for this builder and changes state to [TxKindState].
-    pub fn with_tx_kind(self, kind: TxKind) -> CastTxBuilder<T, P, TxKindState> {
-        CastTxBuilder {
+    pub async fn with_to(self, to: Option<NameOrAddress>) -> Result<CastTxBuilder<T, P, ToState>> {
+        let to = if let Some(to) = to { Some(to.resolve(&self.provider).await?) } else { None };
+        Ok(CastTxBuilder {
             provider: self.provider,
             tx: self.tx,
             legacy: self.legacy,
@@ -220,13 +206,13 @@ where
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             auth: self.auth,
-            state: TxKindState { kind },
+            state: ToState { to },
             _t: self._t,
-        }
+        })
     }
 }
 
-impl<T, P> CastTxBuilder<T, P, TxKindState>
+impl<T, P> CastTxBuilder<T, P, ToState>
 where
     P: Provider<T, AnyNetwork>,
     T: Transport + Clone,
@@ -244,7 +230,7 @@ where
             parse_function_args(
                 &sig,
                 args,
-                self.state.kind.to().cloned(),
+                self.state.to,
                 self.chain,
                 &self.provider,
                 self.etherscan_api_key.as_deref(),
@@ -254,13 +240,23 @@ where
             (Vec::new(), None)
         };
 
-        let input = if let Some(code) = code {
+        let input = if let Some(code) = &code {
             let mut code = hex::decode(code)?;
             code.append(&mut args);
             code
         } else {
             args
         };
+
+        if self.state.to.is_none() && code.is_none() {
+            let has_value = self.tx.value.map_or(false, |v| !v.is_zero());
+            let has_auth = self.auth.is_some();
+            // We only allow user to omit the recipient address if transaction is an EIP-7702 tx
+            // without a value.
+            if !(has_auth && !has_value) {
+                eyre::bail!("Must specify a recipient address or contract code to deploy");
+            }
+        }
 
         Ok(CastTxBuilder {
             provider: self.provider,
@@ -270,7 +266,7 @@ where
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             auth: self.auth,
-            state: InputState { kind: self.state.kind, input, func },
+            state: InputState { kind: self.state.to.into(), input, func },
             _t: self._t,
         })
     }


### PR DESCRIPTION
## Motivation

Added handling for all revm error variants to anvil, caught a panic while testing EIP-7702.
Updated `CastTxBuilder` to allow omitting `to` if there's no value being transferred and tx is an EIP-7702 tx to allow doing just `cast --auth <authotization>`

## Solution
