### PR TITLE
chore: fix `test_assume_no_revert` failing test

### DIFF
--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1841,6 +1841,12 @@ forgetest_init!(test_assume_no_revert, |prj, cmd| {
     prj.insert_vm();
     prj.clear();
 
+    let config = Config {
+        fuzz: { FuzzConfig { runs: 100, seed: Some(U256::from(100)), ..Default::default() } },
+        ..Default::default()
+    };
+    prj.write_config(config);
+
     prj.add_source(
         "Counter.t.sol",
         r#"pragma solidity 0.8.24;
@@ -1909,7 +1915,7 @@ contract CounterRevertTest is DSTest {
 [FAIL. Reason: assertion failed; counterexample: [..]] test_assume_no_revert_fail_assert(uint256) [..]
 [FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_2nd_call(uint256) [..]
 [FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_3rd_call(uint256) [..]
-[PASS] test_assume_no_revert_pass(uint256) (runs: 256, [..])
+[PASS] test_assume_no_revert_pass(uint256) [..]
 ...
 "#]]);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- `test_assume_no_revert` CI on master fails sometimes with more runs than 256 - this could happen if there are persisted failures which are replayed

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add deterministic seed, make test faster by limiting runs to 100, ignore number of runs as we're only interested in test to pass 