### PR TITLE
feat(cast/selectors): show function state mutability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,10 +3135,11 @@ dependencies = [
 
 [[package]]
 name = "evmole"
-version = "0.3.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffb1f458e6901be6a6aaa485ce3a5d81478644edde1ffbe95da114ad9c94467"
+checksum = "d55794094e85dd9d2a4a44de6554015c7d0d7193a28756f2ee3432bb763003a7"
 dependencies = [
+ "alloy-dyn-abi",
  "ruint",
 ]
 

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -79,7 +79,7 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "signal"] }
 tracing.workspace = true
 yansi.workspace = true
-evmole = "0.3.1"
+evmole = "0.4.1"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1103,7 +1103,7 @@ impl SimpleCast {
     pub fn to_ascii(hex: &str) -> Result<String> {
         let bytes = hex::decode(hex)?;
         if !bytes.iter().all(u8::is_ascii) {
-            return Err(eyre::eyre!("Invalid ASCII bytes"))
+            return Err(eyre::eyre!("Invalid ASCII bytes"));
         }
         Ok(String::from_utf8(bytes).unwrap())
     }
@@ -1405,7 +1405,7 @@ impl SimpleCast {
         let base_in = Base::unwrap_or_detect(base_in, value)?;
         let base_out: Base = base_out.parse()?;
         if base_in == base_out {
-            return Ok(value.to_string())
+            return Ok(value.to_string());
         }
 
         let mut n = NumberWithBase::parse_int(value, Some(&base_in.to_string()))?;
@@ -1469,7 +1469,7 @@ impl SimpleCast {
         let s = if let Some(stripped) = s.strip_prefix("000000000000000000000000") {
             stripped
         } else {
-            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"))
+            return Err(eyre::eyre!("Not convertible to address, there are non-zero bytes"));
         };
 
         let lowercase_address_string = format!("0x{s}");
@@ -1925,7 +1925,7 @@ impl SimpleCast {
         }
         if optimize == 0 {
             let selector = get_func(signature)?.selector();
-            return Ok((selector.to_string(), String::from(signature)))
+            return Ok((selector.to_string(), String::from(signature)));
         }
         let Some((name, params)) = signature.split_once('(') else {
             eyre::bail!("invalid function signature");
@@ -1947,7 +1947,7 @@ impl SimpleCast {
 
                     if selector.iter().take_while(|&&byte| byte == 0).count() == optimize {
                         found.store(true, Ordering::Relaxed);
-                        return Some((nonce, hex::encode_prefixed(selector), input))
+                        return Some((nonce, hex::encode_prefixed(selector), input));
                     }
 
                     nonce += nonce_step;
@@ -1961,7 +1961,7 @@ impl SimpleCast {
         }
     }
 
-    /// Extracts function selectors and arguments from bytecode
+    /// Extracts function selectors, arguments and state mutability from bytecode
     ///
     /// # Example
     ///
@@ -1969,16 +1969,21 @@ impl SimpleCast {
     /// use cast::SimpleCast as Cast;
     ///
     /// let bytecode = "6080604052348015600e575f80fd5b50600436106026575f3560e01c80632125b65b14602a575b5f80fd5b603a6035366004603c565b505050565b005b5f805f60608486031215604d575f80fd5b833563ffffffff81168114605f575f80fd5b925060208401356001600160a01b03811681146079575f80fd5b915060408401356001600160e01b03811681146093575f80fd5b80915050925092509256";
-    /// let selectors = Cast::extract_selectors(bytecode)?;
-    /// assert_eq!(selectors, vec![("0x2125b65b".to_string(), "uint32,address,uint224".to_string())]);
+    /// let functions = Cast::extract_functions(bytecode)?;
+    /// assert_eq!(functions, vec![("0x2125b65b".to_string(), "uint32,address,uint224".to_string(), "pure")]);
     /// # Ok::<(), eyre::Report>(())
     /// ```
-    pub fn extract_selectors(bytecode: &str) -> Result<Vec<(String, String)>> {
+    pub fn extract_functions(bytecode: &str) -> Result<Vec<(String, String, &str)>> {
         let code = hex::decode(strip_0x(bytecode))?;
-        let s = evmole::function_selectors(&code, 0);
-
-        Ok(s.iter()
-            .map(|s| (hex::encode_prefixed(s), evmole::function_arguments(&code, s, 0)))
+        Ok(evmole::function_selectors(&code, 0)
+            .into_iter()
+            .map(|s| {
+                (
+                    hex::encode_prefixed(s),
+                    evmole::function_arguments(&code, &s, 0),
+                    evmole::function_state_mutability(&code, &s, 0),
+                )
+            })
             .collect())
     }
 


### PR DESCRIPTION
## Motivation
The new version of EVMole can extract function state mutability with [high accuracy](https://github.com/cdump/evmole?tab=readme-ov-file#function-state-mutability). Let's use it in `cast selectors`

## Solution
Upgrade EVMole to 0.4.1 and show state mutability in the `cast selectors` output

```
$ cast selectors $(cast code 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2)
0x06fdde03                              view
0x095ea7b3      address,uint256         nonpayable
0x18160ddd                              view
0x23b872dd      address,address,uint256 nonpayable
0x2e1a7d4d      uint256                 nonpayable
0x313ce567                              view
0x70a08231      address                 view
0x95d89b41                              view
0xa9059cbb      address,uint256         nonpayable
0xd0e30db0                              payable
0xdd62ed3e      address,address         view

$ cast selectors $(cast code 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) --resolve
0x06fdde03                              view            name()
0x095ea7b3      address,uint256         nonpayable      approve(address,uint256)
0x18160ddd                              view            totalSupply()
0x23b872dd      address,address,uint256 nonpayable      transferFrom(address,address,uint256)
0x2e1a7d4d      uint256                 nonpayable      withdraw(uint256)|OwnerTransferV7b711143(uint256)
0x313ce567                              view            decimals()
0x70a08231      address                 view            balanceOf(address)
0x95d89b41                              view            symbol()
0xa9059cbb      address,uint256         nonpayable      transfer(address,uint256)
0xd0e30db0                              payable         deposit()
0xdd62ed3e      address,address         view            allowance(address,address)
```

According to [CONTRIBUTING.md](https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md#resolving-an-issue), I've used Cargo nightly, Cargo fmt added `;` to some existing return statements in `crates/cast/src/lib.rs`
```
$ cargo +nightly version
cargo 1.83.0-nightly (c1fa840a8 2024-08-29)

$ cargo +nightly fmt -- --check && cargo +nightly clippy --all --all-targets --all-features -- -D warnings && echo OK
...
OK
```