### PR TITLE
fix(`forge bind`): default to alloy

### DIFF
--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -104,9 +104,9 @@ impl BindArgs {
             let _ = ProjectCompiler::new().compile(&project)?;
         }
 
-        if !self.alloy {
+        if self.ethers {
             eprintln!(
-                "Warning: `--ethers` (default) bindings are deprecated and will be removed in the future. \
+                "Warning: `--ethers` bindings are deprecated and will be removed in the future. \
                  Consider using `--alloy` instead."
             );
         }
@@ -191,7 +191,7 @@ impl BindArgs {
     fn get_json_files(&self, artifacts: &Path) -> Result<impl Iterator<Item = (String, PathBuf)>> {
         let filter = self.get_filter()?;
         let alloy_filter = self.get_alloy_filter()?;
-        let is_alloy = self.alloy;
+        let is_alloy = !self.ethers;
         Ok(json_files(artifacts)
             .filter_map(|path| {
                 // Ignore the build info JSON.
@@ -264,7 +264,7 @@ impl BindArgs {
 
     /// Check that the existing bindings match the expected abigen output
     fn check_existing_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
-        if !self.alloy {
+        if self.ethers {
             return self.check_ethers(artifacts, bindings_root);
         }
 
@@ -316,7 +316,7 @@ impl BindArgs {
 
     /// Generate the bindings
     fn generate_bindings(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
-        if !self.alloy {
+        if self.ethers {
             return self.generate_ethers(artifacts, bindings_root);
         }
 

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -107,7 +107,7 @@ impl BindArgs {
         if self.ethers {
             eprintln!(
                 "Warning: `--ethers` bindings are deprecated and will be removed in the future. \
-                 Consider using `--alloy` instead."
+                 Consider using `--alloy` (default) instead."
             );
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Alloy has been released and is ready for production. `forge bind` still defaults to `ethers`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Default to alloy, opening the prospect of removing `ethers` dependency completely in the future

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
