### PR TITLE
chore: improve git/project root pathfinding

### DIFF
--- a/crates/cast/bin/cmd/interface.rs
+++ b/crates/cast/bin/cmd/interface.rs
@@ -6,7 +6,7 @@ use foundry_block_explorers::Client;
 use foundry_cli::opts::EtherscanOpts;
 use foundry_common::{compile::ProjectCompiler, fs};
 use foundry_compilers::{info::ContractInfo, utils::canonicalize};
-use foundry_config::{find_project_root_path, load_config_with_root, Config};
+use foundry_config::{load_config_with_root, try_find_project_root, Config};
 use itertools::Itertools;
 use serde_json::Value;
 use std::{
@@ -118,8 +118,8 @@ fn load_abi_from_file(path: &str, name: Option<String>) -> Result<Vec<(JsonAbi, 
 
 /// Load the ABI from the artifact of a locally compiled contract.
 fn load_abi_from_artifact(path_or_contract: &str) -> Result<Vec<(JsonAbi, String)>> {
-    let root = find_project_root_path(None)?;
-    let config = load_config_with_root(Some(root));
+    let root = try_find_project_root(None)?;
+    let config = load_config_with_root(Some(&root));
     let project = config.project()?;
     let compiler = ProjectCompiler::new().quiet(true);
 

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -173,7 +173,7 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
             let config_path = canonicalized(config_path);
             Config::figment_with_root(config_path.parent().unwrap())
         } else {
-            Config::figment_with_root(&args.project_paths.project_root())
+            Config::figment_with_root(args.project_paths.project_root())
         };
 
         // remappings should stack

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -146,7 +146,7 @@ impl CoreBuildArgs {
     /// Returns the `Project` for the current workspace
     ///
     /// This loads the `foundry_config::Config` for the current workspace (see
-    /// `find_project_root_path` and merges the cli `BuildArgs` into it before returning
+    /// `find_project_root` and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]).
     pub fn project(&self) -> Result<Project<MultiCompiler>> {
         let config = self.try_load_config_emit_warnings()?;
@@ -173,7 +173,7 @@ impl<'a> From<&'a CoreBuildArgs> for Figment {
             let config_path = canonicalized(config_path);
             Config::figment_with_root(config_path.parent().unwrap())
         } else {
-            Config::figment_with_root(args.project_paths.project_root())
+            Config::figment_with_root(&args.project_paths.project_root())
         };
 
         // remappings should stack

--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -72,10 +72,7 @@ impl ProjectPathsArgs {
     ///
     /// Panics if the project root directory cannot be found. See [`find_project_root`].
     pub fn project_root(&self) -> PathBuf {
-        match &self.root {
-            Some(root) => root.clone(),
-            None => find_project_root(None),
-        }
+        self.root.clone().unwrap_or_else(|| find_project_root(None))
     }
 
     /// Returns the remappings to add to the config

--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -8,7 +8,7 @@ use foundry_config::{
         value::{Dict, Map, Value},
         Metadata, Profile, Provider,
     },
-    find_project_root_path, remappings_from_env_var, Config,
+    find_project_root, remappings_from_env_var, Config,
 };
 use serde::Serialize;
 use std::path::PathBuf;
@@ -66,15 +66,16 @@ pub struct ProjectPathsArgs {
 impl ProjectPathsArgs {
     /// Returns the root directory to use for configuring the project.
     ///
-    /// This will be the `--root` argument if provided, otherwise see [find_project_root_path()]
+    /// This will be the `--root` argument if provided, otherwise see [`find_project_root`].
     ///
     /// # Panics
     ///
-    /// If the project root directory cannot be found: [find_project_root_path()]
+    /// Panics if the project root directory cannot be found. See [`find_project_root`].
     pub fn project_root(&self) -> PathBuf {
-        self.root
-            .clone()
-            .unwrap_or_else(|| find_project_root_path(None).expect("Failed to find project root"))
+        match &self.root {
+            Some(root) => root.clone(),
+            None => find_project_root(None),
+        }
     }
 
     /// Returns the remappings to add to the config

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -191,9 +191,9 @@ pub fn load_dotenv() {
     };
 
     // we only want the .env file of the cwd and project root
-    // `find_project_root_path` calls `current_dir` internally so both paths are either both `Ok` or
+    // `find_project_root` calls `current_dir` internally so both paths are either both `Ok` or
     // both `Err`
-    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), find_project_root_path(None)) {
+    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), try_find_project_root(None)) {
         load(&prj_root);
         if cwd != prj_root {
             // prj root and cwd can be identical
@@ -602,7 +602,7 @@ mod tests {
         assert!(!p.is_sol_test());
     }
 
-    // loads .env from cwd and project dir, See [`find_project_root_path()`]
+    // loads .env from cwd and project dir, See [`find_project_root()`]
     #[test]
     fn can_load_dotenv() {
         let temp = tempdir().unwrap();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -540,7 +540,7 @@ impl Config {
     ///
     /// See `Config::figment_with_root`
     #[track_caller]
-    pub fn load_with_root(root: impl Into<PathBuf>) -> Self {
+    pub fn load_with_root(root: &Path) -> Self {
         Self::from_provider(Self::figment_with_root(root))
     }
 
@@ -1405,9 +1405,9 @@ impl Config {
     /// use foundry_config::Config;
     /// use serde::Deserialize;
     ///
-    /// let my_config = Config::figment_with_root(".").extract::<Config>();
+    /// let my_config = Config::figment_with_root(".".as_ref()).extract::<Config>();
     /// ```
-    pub fn figment_with_root(root: impl Into<PathBuf>) -> Figment {
+    pub fn figment_with_root(root: &Path) -> Figment {
         Self::with_root(root).into()
     }
 
@@ -1419,10 +1419,9 @@ impl Config {
     /// use foundry_config::Config;
     /// let my_config = Config::with_root(".");
     /// ```
-    pub fn with_root(root: impl Into<PathBuf>) -> Self {
+    pub fn with_root(root: &Path) -> Self {
         // autodetect paths
-        let root = root.into();
-        let paths = ProjectPathsConfig::builder().build_with_root::<()>(&root);
+        let paths = ProjectPathsConfig::builder().build_with_root::<()>(root);
         let artifacts: PathBuf = paths.artifacts.file_name().unwrap().into();
         Self {
             root: paths.root.into(),
@@ -1432,7 +1431,7 @@ impl Config {
             remappings: paths
                 .remappings
                 .into_iter()
-                .map(|r| RelativeRemapping::new(r, &root))
+                .map(|r| RelativeRemapping::new(r, root))
                 .collect(),
             fs_permissions: FsPermissions::new([PathPermission::read(artifacts)]),
             ..Self::default()
@@ -1481,7 +1480,7 @@ impl Config {
     ///
     /// **Note:** the closure will only be invoked if the `foundry.toml` file exists, See
     /// [Self::get_config_path()] and if the closure returns `true`.
-    pub fn update_at<F>(root: impl Into<PathBuf>, f: F) -> eyre::Result<()>
+    pub fn update_at<F>(root: &Path, f: F) -> eyre::Result<()>
     where
         F: FnOnce(&Self, &mut toml_edit::DocumentMut) -> bool,
     {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -540,8 +540,8 @@ impl Config {
     ///
     /// See [`figment_with_root`](Self::figment_with_root) for more details.
     #[track_caller]
-    pub fn load_with_root(root: &Path) -> Self {
-        Self::from_provider(Self::figment_with_root(root))
+    pub fn load_with_root(root: impl AsRef<Path>) -> Self {
+        Self::from_provider(Self::figment_with_root(root.as_ref()))
     }
 
     /// Extract a `Config` from `provider`, panicking if extraction fails.
@@ -1408,7 +1408,7 @@ impl Config {
     /// let my_config = Config::figment_with_root(".").extract::<Config>();
     /// ```
     pub fn figment_with_root(root: impl AsRef<Path>) -> Figment {
-        Self::with_root(root).into()
+        Self::with_root(root.as_ref()).into()
     }
 
     /// Creates a new Config that adds additional context extracted from the provided root.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1405,9 +1405,9 @@ impl Config {
     /// use foundry_config::Config;
     /// use serde::Deserialize;
     ///
-    /// let my_config = Config::figment_with_root(".".as_ref()).extract::<Config>();
+    /// let my_config = Config::figment_with_root(".").extract::<Config>();
     /// ```
-    pub fn figment_with_root(root: &Path) -> Figment {
+    pub fn figment_with_root(root: impl AsRef<Path>) -> Figment {
         Self::with_root(root).into()
     }
 
@@ -1419,7 +1419,11 @@ impl Config {
     /// use foundry_config::Config;
     /// let my_config = Config::with_root(".");
     /// ```
-    pub fn with_root(root: &Path) -> Self {
+    pub fn with_root(root: impl AsRef<Path>) -> Self {
+        Self::_with_root(root.as_ref())
+    }
+
+    fn _with_root(root: &Path) -> Self {
         // autodetect paths
         let paths = ProjectPathsConfig::builder().build_with_root::<()>(root);
         let artifacts: PathBuf = paths.artifacts.file_name().unwrap().into();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -522,7 +522,7 @@ impl Config {
 
     /// Returns the current `Config`
     ///
-    /// See `Config::figment`
+    /// See [`figment`](Self::figment) for more details.
     #[track_caller]
     pub fn load() -> Self {
         Self::from_provider(Self::figment())
@@ -530,7 +530,7 @@ impl Config {
 
     /// Returns the current `Config` with the given `providers` preset
     ///
-    /// See `Config::to_figment`
+    /// See [`figment`](Self::figment) for more details.
     #[track_caller]
     pub fn load_with_providers(providers: FigmentProviders) -> Self {
         Self::default().to_figment(providers).extract().unwrap()
@@ -538,7 +538,7 @@ impl Config {
 
     /// Returns the current `Config`
     ///
-    /// See `Config::figment_with_root`
+    /// See [`figment_with_root`](Self::figment_with_root) for more details.
     #[track_caller]
     pub fn load_with_root(root: &Path) -> Self {
         Self::from_provider(Self::figment_with_root(root))

--- a/crates/config/src/macros.rs
+++ b/crates/config/src/macros.rs
@@ -61,9 +61,8 @@ macro_rules! impl_figment_convert {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
             fn from(args: &'a $name) -> Self {
                 let root = args.root.clone()
-                    .unwrap_or_else(|| $crate::find_project_root_path(None)
-                        .unwrap_or_else(|e| panic!("could not find project root: {e}")));
-                $crate::Config::figment_with_root(root).merge(args)
+                    .unwrap_or_else(|| $crate::find_project_root(None));
+                $crate::Config::figment_with_root(&root).merge(args)
             }
         }
 
@@ -194,7 +193,7 @@ macro_rules! impl_figment_convert_cast {
     ($name:ty) => {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
             fn from(args: &'a $name) -> Self {
-                $crate::Config::with_root($crate::find_project_root_path(None).unwrap())
+                $crate::Config::with_root(&$crate::find_project_root(None))
                     .to_figment($crate::FigmentProviders::Cast)
                     .merge(args)
             }

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -58,7 +58,7 @@ pub fn find_git_root(relative_to: &Path) -> io::Result<Option<PathBuf>> {
 ///
 /// will still detect `repo` as root.
 ///
-/// Returns `cwd` bounded to `repo` if no `foundry.toml` is found in the tree.
+/// Returns `repo` or `cwd` if no `foundry.toml` is found in the tree.
 ///
 /// # Panics
 ///
@@ -79,13 +79,13 @@ pub fn try_find_project_root(cwd: Option<&Path>) -> io::Result<PathBuf> {
         None => &std::env::current_dir()?,
     };
     let boundary = find_git_root(cwd)?;
-    Ok(cwd
+    let found = cwd
         .ancestors()
         // Don't look outside of the git repo if it exists.
         .take_while(|p| if let Some(boundary) = &boundary { p.starts_with(boundary) } else { true })
         .find(|p| p.join(Config::FILE_NAME).is_file())
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| boundary.unwrap_or_else(|| cwd.to_path_buf())))
+        .map(Path::to_path_buf);
+    Ok(found.or(boundary).unwrap_or_else(|| cwd.to_path_buf()))
 }
 
 /// Returns all [`Remapping`]s contained in the `remappings` str separated by newlines

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -2,7 +2,6 @@
 
 use crate::Config;
 use alloy_primitives::U256;
-use eyre::WrapErr;
 use figment::value::Value;
 use foundry_compilers::artifacts::{
     remappings::{Remapping, RemappingError},
@@ -11,6 +10,7 @@ use foundry_compilers::artifacts::{
 use revm_primitives::SpecId;
 use serde::{de::Error, Deserialize, Deserializer};
 use std::{
+    io,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -21,36 +21,30 @@ pub fn load_config() -> Config {
     load_config_with_root(None)
 }
 
-/// Loads the config for the current project workspace or the provided root path
-pub fn load_config_with_root(root: Option<PathBuf>) -> Config {
-    if let Some(root) = root {
-        Config::load_with_root(root)
-    } else {
-        Config::load_with_root(find_project_root_path(None).unwrap())
-    }
-    .sanitized()
-}
-
-/// Returns the path of the top-level directory of the working git tree. If there is no working
-/// tree, an error is returned.
-pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf> {
-    let path = relative_to.as_ref();
-    let path = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(path)
-        .output()
-        .wrap_err_with(|| {
-            format!("Failed detect git root path in current dir: {}", path.display())
-        })?
-        .stdout;
-    let path = std::str::from_utf8(&path)?.trim_end_matches('\n');
-    Ok(PathBuf::from(path))
-}
-
-/// Returns the root path to set for the project root
+/// Loads the config for the current project workspace or the provided root path.
 ///
-/// traverse the dir tree up and look for a `foundry.toml` file starting at the given path or cwd,
-/// but only until the root dir of the current repo so that
+/// # Panics
+///
+/// Panics if the project root cannot be found. See [`find_project_root`].
+pub fn load_config_with_root(root: Option<&Path>) -> Config {
+    let root = match root {
+        Some(root) => root,
+        None => &find_project_root(None),
+    };
+    Config::load_with_root(root).sanitized()
+}
+
+/// Returns the path of the top-level directory of the working git tree.
+pub fn find_git_root(relative_to: &Path) -> io::Result<Option<PathBuf>> {
+    let root =
+        if relative_to.is_absolute() { relative_to } else { &dunce::canonicalize(relative_to)? };
+    Ok(root.ancestors().find(|p| p.join(".git").is_dir()).map(Path::to_path_buf))
+}
+
+/// Returns the root path to set for the project root.
+///
+/// Traverse the dir tree up and look for a `foundry.toml` file starting at the given path or cwd,
+/// but only until the root dir of the current repo so that:
 ///
 /// ```text
 /// -- foundry.toml
@@ -60,29 +54,34 @@ pub fn find_git_root_path(relative_to: impl AsRef<Path>) -> eyre::Result<PathBuf
 ///   |__sub
 ///      |__ [given_path | cwd]
 /// ```
-/// will still detect `repo` as root
-pub fn find_project_root_path(path: Option<&PathBuf>) -> std::io::Result<PathBuf> {
-    let cwd = &std::env::current_dir()?;
-    let cwd = path.unwrap_or(cwd);
-    let boundary = find_git_root_path(cwd)
-        .ok()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| cwd.clone());
-    let mut cwd = cwd.as_path();
-    // traverse as long as we're in the current git repo cwd
-    while cwd.starts_with(&boundary) {
-        let file_path = cwd.join(Config::FILE_NAME);
-        if file_path.is_file() {
-            return Ok(cwd.to_path_buf())
-        }
-        if let Some(parent) = cwd.parent() {
-            cwd = parent;
-        } else {
-            break
-        }
-    }
-    // no foundry.toml found
-    Ok(boundary)
+///
+/// will still detect `repo` as root.
+///
+/// # Panics
+///
+/// Panics if the project root cannot be found. This can only happen if `cwd` is not a valid path
+/// and the [`std::env::current_dir`] call fails.
+#[track_caller]
+pub fn find_project_root(cwd: Option<&Path>) -> PathBuf {
+    try_find_project_root(cwd).expect("Could not find project root")
+}
+
+/// Returns the root path to set for the project root.
+///
+/// Same as [`find_project_root`], but returns an error instead of panicking.
+pub fn try_find_project_root(cwd: Option<&Path>) -> io::Result<PathBuf> {
+    let cwd = match cwd {
+        Some(path) => path,
+        None => &std::env::current_dir()?,
+    };
+    let boundary = find_git_root(cwd)?;
+    Ok(cwd
+        .ancestors()
+        // Don't look outside of the git repo if it exists.
+        .take_while(|p| if let Some(boundary) = &boundary { p.starts_with(boundary) } else { true })
+        .find(|p| p.join(Config::FILE_NAME).is_file())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| cwd.to_path_buf()))
 }
 
 /// Returns all [`Remapping`]s contained in the `remappings` str separated by newlines

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -57,10 +57,13 @@ pub fn find_git_root(relative_to: &Path) -> io::Result<Option<PathBuf>> {
 ///
 /// will still detect `repo` as root.
 ///
+/// Returns `cwd` if no `foundry.toml` is found in the tree.
+///
 /// # Panics
 ///
-/// Panics if the project root cannot be found. This can only happen if `cwd` is not a valid path
-/// and the [`std::env::current_dir`] call fails.
+/// Panics if:
+/// - `cwd` is `Some` and is not a valid directory;
+/// - `cwd` is `None` and the [`std::env::current_dir`] call fails.
 #[track_caller]
 pub fn find_project_root(cwd: Option<&Path>) -> PathBuf {
     try_find_project_root(cwd).expect("Could not find project root")

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -117,7 +117,7 @@ impl BuildArgs {
     /// Returns the `Project` for the current workspace
     ///
     /// This loads the `foundry_config::Config` for the current workspace (see
-    /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
+    /// [`utils::find_project_root`] and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]
     pub fn project(&self) -> Result<Project> {
         self.args.project()

--- a/crates/forge/bin/cmd/clone.rs
+++ b/crates/forge/bin/cmd/clone.rs
@@ -546,7 +546,7 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
 }
 
 /// Compile the project in the root directory, and return the compilation result.
-pub fn compile_project(root: &PathBuf, quiet: bool) -> Result<ProjectCompileOutput> {
+pub fn compile_project(root: &Path, quiet: bool) -> Result<ProjectCompileOutput> {
     let mut config = Config::load_with_root(root).sanitized();
     config.extra_output.push(ContractOutputSelection::StorageLayout);
     let project = config.project()?;

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -6,7 +6,7 @@ use forge_doc::{
 };
 use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
 use foundry_common::compile::ProjectCompiler;
-use foundry_config::{find_project_root_path, load_config_with_root, Config};
+use foundry_config::{find_project_root, load_config_with_root, Config};
 use std::{path::PathBuf, process::Command};
 
 mod server;
@@ -139,7 +139,10 @@ impl DocArgs {
     }
 
     pub fn config(&self) -> Result<Config> {
-        let root = self.root.clone().unwrap_or(find_project_root_path(None)?);
+        let root = match &self.root {
+            Some(root) => root,
+            None => &find_project_root(None),
+        };
         Ok(load_config_with_root(Some(root)))
     }
 }

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
             Ok(())
         }
         ForgeSubcommand::Clean { root } => {
-            let config = utils::load_config_with_root(root);
+            let config = utils::load_config_with_root(root.as_deref());
             let project = config.project()?;
             config.cleanup(&project)?;
             Ok(())

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -195,7 +195,7 @@ forgetest_init!(can_override_config, |prj, cmd| {
     // remappings work
     let remappings_txt =
         prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
-    let config = forge_utils::load_config_with_root(Some(prj.root().into()));
+    let config = forge_utils::load_config_with_root(Some(prj.root()));
     assert_eq!(
         format!(
             "ds-test/={}/",
@@ -206,7 +206,7 @@ forgetest_init!(can_override_config, |prj, cmd| {
 
     // env vars work
     std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
-    let config = forge_utils::load_config_with_root(Some(prj.root().into()));
+    let config = forge_utils::load_config_with_root(Some(prj.root()));
     assert_eq!(
         format!(
             "ds-test/={}/",
@@ -283,7 +283,7 @@ Installing solmate in [..] (url: Some("https://github.com/transmissions11/solmat
         "remappings.txt",
         "solmate/=lib/solmate/src/\nsolmate-contracts/=lib/solmate/src/",
     );
-    let config = forge_utils::load_config_with_root(Some(prj.root().into()));
+    let config = forge_utils::load_config_with_root(Some(prj.root()));
     // trailing slashes are removed on windows `to_slash_lossy`
     let path = prj.root().join("lib/solmate/src/").to_slash_lossy().into_owned();
     #[cfg(windows)]

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -143,7 +143,7 @@ impl ForgeTestProfile {
     ///
     /// AST output is enabled by default to support inline configs.
     pub fn config(&self) -> Config {
-        let mut config = Config::with_root(self.root());
+        let mut config = Config::with_root(&self.root());
 
         config.ast = true;
         config.src = self.root().join(self.to_string());

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -143,7 +143,7 @@ impl ForgeTestProfile {
     ///
     /// AST output is enabled by default to support inline configs.
     pub fn config(&self) -> Config {
-        let mut config = Config::with_root(&self.root());
+        let mut config = Config::with_root(self.root());
 
         config.ast = true;
         config.src = self.root().join(self.to_string());


### PR DESCRIPTION
Removes the git command spawn by using `Path::ancestors` + impl cleanup

Saves a few ms on all commands startup because these functions are called multiple times