### PR TITLE
fix(script): correctly fill metadata + prompt on noop transactions

### DIFF
--- a/crates/common/src/transactions.rs
+++ b/crates/common/src/transactions.rs
@@ -216,6 +216,13 @@ impl TransactionMaybeSigned {
             Self::Unsigned(tx) => tx.gas,
         }
     }
+
+    pub fn nonce(&self) -> Option<u64> {
+        match self {
+            Self::Signed { tx, .. } => Some(tx.nonce()),
+            Self::Unsigned(tx) => tx.nonce,
+        }
+    }
 }
 
 impl From<TransactionRequest> for TransactionMaybeSigned {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -244,7 +244,6 @@ Script ran successfully.
 ==========================
 Simulated On-chain Traces:
 
-Gas limit was set in script to 500000
   [45299] → new GasWaster@[..]
     └─ ← [Return] 226 bytes of code
 
@@ -352,7 +351,6 @@ Script ran successfully.
 ==========================
 Simulated On-chain Traces:
 
-Gas limit was set in script to 500000
   [45299] → new GasWaster@[..]
     └─ ← [Return] 226 bytes of code
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1687,6 +1687,7 @@ contract SimpleScript is Script {
         "2000000",
         "--priority-gas-price",
         "100000",
+        "--non-interactive",
     ])
     .assert_success()
     .stdout_eq(str![[r#"
@@ -1700,6 +1701,7 @@ Script ran successfully.
 success: bool true
 
 ## Setting up 1 EVM.
+Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 ==========================
 
@@ -1736,6 +1738,7 @@ ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.
             format!("{dev:?}").as_str(),
             "--broadcast",
             "--unlocked",
+            "--non-interactive",
         ])
         .assert_success()
         .stdout_eq(str![[r#"
@@ -1747,6 +1750,7 @@ Script ran successfully.
 success: bool true
 
 ## Setting up 1 EVM.
+Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 ==========================
 
@@ -1800,6 +1804,7 @@ contract SimpleScript is Script {
         &handle.http_endpoint(),
         "--broadcast",
         "--unlocked",
+        "--non-interactive",
     ])
     .assert_success()
     .stdout_eq(str![[r#"
@@ -1813,6 +1818,7 @@ Script ran successfully.
 success: bool true
 
 ## Setting up 1 EVM.
+Script contains a transaction to 0x0000000000000000000000000000000000000000 which does not contain any code.
 
 ==========================
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -276,7 +276,7 @@ impl ScriptArgs {
         };
 
         // Exit early in case user didn't provide any broadcast/verify related flags.
-        if !bundled.args.broadcast && !bundled.args.resume && !bundled.args.verify {
+        if !bundled.args.should_broadcast() {
             shell::println("\nSIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet configuration(s) to the previous command. See forge script --help for more.")?;
             return Ok(());
         }
@@ -419,7 +419,7 @@ impl ScriptArgs {
                 let deployment_size = deployed_code.len();
 
                 if deployment_size > max_size {
-                    prompt_user = self.broadcast;
+                    prompt_user = self.should_broadcast();
                     shell::println(format!(
                         "{}",
                         format!(
@@ -439,6 +439,11 @@ impl ScriptArgs {
         }
 
         Ok(())
+    }
+
+    /// We only broadcast transactions if --broadcast or --resume was passed.
+    fn should_broadcast(&self) -> bool {
+        self.broadcast || self.resume
     }
 }
 

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -76,10 +76,7 @@ impl TransactionWithMetadata {
         let mut metadata = Self::from_tx_request(transaction);
         metadata.rpc = rpc;
         // If tx.gas is already set that means it was specified in script
-        if let Some(gas) = metadata.transaction.gas() {
-            println!("Gas limit was set in script to {gas}");
-            metadata.is_fixed_gas_limit = true;
-        }
+        metadata.is_fixed_gas_limit = metadata.tx().gas().is_some();
 
         if let Some(TxKind::Call(to)) = metadata.transaction.to() {
             if to == DEFAULT_CREATE2_DEPLOYER {

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -1,7 +1,7 @@
 use super::ScriptResult;
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::{hex, Address, Bytes, TxKind, B256};
-use eyre::{ContextCompat, Result, WrapErr};
+use eyre::{Result, WrapErr};
 use foundry_common::{fmt::format_token_raw, ContractData, TransactionMaybeSigned, SELECTOR_LEN};
 use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, traces::CallTraceDecoder};
 use itertools::Itertools;
@@ -70,53 +70,54 @@ impl TransactionWithMetadata {
     pub fn new(
         transaction: TransactionMaybeSigned,
         rpc: String,
-        result: &ScriptResult,
         local_contracts: &BTreeMap<Address, &ContractData>,
         decoder: &CallTraceDecoder,
-        additional_contracts: Vec<AdditionalContract>,
-        is_fixed_gas_limit: bool,
     ) -> Result<Self> {
         let mut metadata = Self::from_tx_request(transaction);
         metadata.rpc = rpc;
-        metadata.is_fixed_gas_limit = is_fixed_gas_limit;
 
-        // Specify if any contract was directly created with this transaction
         if let Some(TxKind::Call(to)) = metadata.transaction.to() {
             if to == DEFAULT_CREATE2_DEPLOYER {
-                metadata.set_create(
-                    true,
-                    Address::from_slice(&result.returned),
-                    local_contracts,
-                )?;
+                if let Some(input) = metadata.transaction.input() {
+                    let (salt, init_code) = input.split_at(32);
+                    metadata.set_create(
+                        true,
+                        DEFAULT_CREATE2_DEPLOYER
+                            .create2_from_code(B256::from_slice(salt), init_code),
+                        local_contracts,
+                    )?;
+                }
             } else {
                 metadata
                     .set_call(to, local_contracts, decoder)
                     .wrap_err("Could not decode transaction type.")?;
             }
         } else {
-            metadata.set_create(
-                false,
-                result.address.wrap_err("There should be a contract address from CREATE.")?,
-                local_contracts,
-            )?;
-        }
-
-        // Add the additional contracts created in this transaction, so we can verify them later.
-        if let Some(tx_address) = metadata.contract_address {
-            metadata.additional_contracts = additional_contracts
-                .into_iter()
-                .filter_map(|contract| {
-                    // Filter out the transaction contract repeated init_code.
-                    if contract.address != tx_address {
-                        Some(contract)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+            let sender =
+                metadata.transaction.from().expect("all transactions should have a sender");
+            let nonce = metadata.transaction.nonce().expect("all transactions should have a nonce");
+            metadata.set_create(false, sender.create(nonce), local_contracts)?;
         }
 
         Ok(metadata)
+    }
+
+    pub fn with_fixed_gas_limit(mut self, yes: bool) -> Self {
+        self.is_fixed_gas_limit = yes;
+        self
+    }
+
+    /// Populates additional data from the transaction execution result.
+    pub fn with_execution_result(mut self, result: &ScriptResult) -> Self {
+        let created_contracts = result.get_created_contracts();
+
+        // Add the additional contracts created in this transaction, so we can verify them later.
+        self.additional_contracts = created_contracts
+            .into_iter()
+            .filter(|contract| self.contract_address.map_or(true, |addr| addr != contract.address))
+            .collect();
+
+        self
     }
 
     /// Populate the transaction as CREATE tx

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -76,7 +76,10 @@ impl TransactionWithMetadata {
         let mut metadata = Self::from_tx_request(transaction);
         metadata.rpc = rpc;
         // If tx.gas is already set that means it was specified in script
-        metadata.is_fixed_gas_limit = metadata.transaction.gas().is_some();
+        if let Some(gas) = metadata.transaction.gas() {
+            println!("Gas limit was set in script to {gas}");
+            metadata.is_fixed_gas_limit = true;
+        }
 
         if let Some(TxKind::Call(to)) = metadata.transaction.to() {
             if to == DEFAULT_CREATE2_DEPLOYER {
@@ -120,6 +123,7 @@ impl TransactionWithMetadata {
 
         if !self.is_fixed_gas_limit {
             if let Some(unsigned) = self.transaction.as_unsigned_mut() {
+                // We inflate the gas used by the user specified percentage
                 unsigned.gas = Some((result.gas_used * gas_estimate_multiplier / 100) as u128);
             }
         }

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -110,13 +110,13 @@ impl TransactionWithMetadata {
         result: &ScriptResult,
         gas_estimate_multiplier: u64,
     ) -> Self {
-        let created_contracts = result.get_created_contracts();
+        let mut created_contracts = result.get_created_contracts();
 
         // Add the additional contracts created in this transaction, so we can verify them later.
-        self.additional_contracts = created_contracts
-            .into_iter()
-            .filter(|contract| self.contract_address.map_or(true, |addr| addr != contract.address))
-            .collect();
+        created_contracts.retain(|contract| {
+            // Filter out the contract that was created by the transaction itself.
+            self.contract_address.map_or(true, |addr| addr != contract.address)
+        });
 
         if !self.is_fixed_gas_limit {
             if let Some(unsigned) = self.transaction.as_unsigned_mut() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8817 + some cleanup

## Solution

Right now we don't fill metadata for transactions at all if `--skip-simulation` is passed. However, most of the metadata can't be obtained without simulation. I've updated logic to only use simulated `ScriptResult` to fill `tx.gas` and `additional_contracts`

Also added a warning + prompt in cases when script attempts to broadcast a zero-value transaction to address without code. It should provide protection for cases when contract was deployed outside of `broadcast` block
