### PR TITLE
[wip] fix(anvil): prevent panic in ots

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1676,6 +1676,7 @@ impl Backend {
 
     pub fn get_block_by_hash(&self, hash: B256) -> Option<Block> {
         self.blockchain.get_block_by_hash(&hash)
+        // TODO: Fix https://github.com/foundry-rs/foundry/issues/8822 by fetching from fork.
     }
 
     pub fn mined_block_by_number(&self, number: BlockNumber) -> Option<AnyNetworkBlock> {

--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -424,8 +424,12 @@ impl EthApi {
             .into_iter()
             .map(|r| match r {
                 Ok(Some(r)) => {
-                    let timestamp =
-                        self.backend.get_block(r.block_number.unwrap()).unwrap().header.timestamp;
+                    let timestamp = self
+                        .backend
+                        .get_block(r.block_number.unwrap())
+                        .ok_or(BlockchainError::BlockNotFound)?
+                        .header
+                        .timestamp;
                     let receipt = r.map_inner(OtsReceipt::from);
                     let res = OtsTransactionReceipt { receipt, timestamp: Some(timestamp) };
                     Ok(res)
@@ -466,7 +470,7 @@ impl EthApi {
                     let timestamp = self
                         .backend
                         .get_block(receipt.block_number.unwrap())
-                        .unwrap()
+                        .ok_or(BlockchainError::BlockNotFound)?
                         .header
                         .timestamp;
                     let receipt = receipt.map_inner(OtsReceipt::from);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #8822.

Unwrapping None value. 

Core issues is that we're fetching from blockchain storage even though we're on a fork and should be fetching from ForkedDB which contains the data.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Avoid `unwrap()` and use `ok_or()`. 

Use `block_by_hash()` which fetches from fork in case `backend.get_block_by_hash` returns `None`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
