### PR TITLE
feat(forge): support junit xml test reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,6 +3261,7 @@ dependencies = [
  "anvil",
  "async-trait",
  "axum",
+ "chrono",
  "clap",
  "clap_complete",
  "clap_complete_fig",
@@ -3300,6 +3301,7 @@ dependencies = [
  "paste",
  "path-slash",
  "proptest",
+ "quick-junit",
  "rayon",
  "regex",
  "reqwest",
@@ -5718,6 +5720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "newtype-uuid"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526cb7c660872e401beaf3297f95f548ce3b4b4bdd8121b7c0713771d7c4a6e"
+dependencies = [
+ "uuid 1.10.0",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +6821,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-junit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ffd2f9a162cfae131bed6d9d1ed60adced33be340a94f96952897d7cb0c240"
+dependencies = [
+ "chrono",
+ "indexmap 2.5.0",
+ "newtype-uuid",
+ "quick-xml 0.36.1",
+ "strip-ansi-escapes",
+ "thiserror",
+ "uuid 1.10.0",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6823,6 +6849,15 @@ name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
 ]
@@ -8186,6 +8221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9157,6 +9201,26 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/crates/common/src/shell.rs
+++ b/crates/common/src/shell.rs
@@ -75,8 +75,8 @@ impl Shell {
         Self { output, verbosity }
     }
 
-    /// Returns a new shell that conforms to the specified verbosity arguments, where `json` takes
-    /// higher precedence
+    /// Returns a new shell that conforms to the specified verbosity arguments, where `json`
+    /// or `junit` takes higher precedence.
     pub fn from_args(silent: bool, json: bool) -> Self {
         match (silent, json) {
             (_, true) => Self::json(),

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -46,6 +46,7 @@ serde.workspace = true
 tracing.workspace = true
 yansi.workspace = true
 humantime-serde = "1.1.1"
+chrono.workspace = true
 
 # bin
 forge-doc.workspace = true
@@ -107,6 +108,7 @@ opener = "0.7"
 
 # soldeer
 soldeer.workspace = true
+quick-junit = "0.5.0"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -844,7 +844,9 @@ fn junit_xml_report(results: &BTreeMap<String, SuiteResult>, verbosity: u8) -> R
                 TestStatus::Failure => TestCaseStatus::non_success(NonSuccessKind::Failure),
                 TestStatus::Skipped => TestCaseStatus::skipped(),
             };
-            test_status.set_message(test_result.reason.clone().unwrap_or_default());
+            if let Some(reason) = &test_result.reason {
+                test_status.set_message(reason);
+            }
 
             let mut test_case = TestCase::new(test_name, test_status);
             test_case.set_time(test_result.duration);

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -839,15 +839,12 @@ fn junit_xml_report(results: &BTreeMap<String, SuiteResult>, verbosity: u8) -> R
         test_suite.set_time(suite_result.duration);
         test_suite.set_system_out(suite_result.summary());
         for (test_name, test_result) in &suite_result.test_results {
-            let test_status = if test_result.status.is_failure() {
-                let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
-                status.set_message(test_result.reason.clone().unwrap_or_default());
-                status
-            } else if test_result.status.is_skipped() {
-                TestCaseStatus::skipped()
-            } else {
-                TestCaseStatus::success()
+            let mut test_status = match test_result.status {
+                TestStatus::Success => TestCaseStatus::success(),
+                TestStatus::Failure => TestCaseStatus::non_success(NonSuccessKind::Failure),
+                TestStatus::Skipped => TestCaseStatus::skipped(),
             };
+            test_status.set_message(test_result.reason.clone().unwrap_or_default());
 
             let mut test_case = TestCase::new(test_name, test_status);
             test_case.set_time(test_result.duration);

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -503,7 +503,7 @@ impl TestArgs {
 
         if self.junit {
             let results = runner.test_collect(filter);
-            println!("{}", junit_xml_report(&results, verbosity).to_string().unwrap());
+            println!("{}", junit_xml_report(&results, verbosity).to_string()?);
             return Ok(TestOutcome::new(results, self.allow_failure));
         }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -835,7 +835,7 @@ fn junit_xml_report(results: &BTreeMap<String, SuiteResult>, verbosity: u8) -> R
     junit_report.set_timestamp(Utc::now());
     for (suite_name, suite_result) in results {
         let mut test_suite = TestSuite::new(suite_name);
-        total_duration = total_duration + suite_result.duration;
+        total_duration += suite_result.duration;
         test_suite.set_time(suite_result.duration);
         test_suite.set_system_out(suite_result.summary());
         for (test_name, test_result) in &suite_result.test_results {

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2045,7 +2045,7 @@ forgetest_init!(should_generate_junit_xml_report, |prj, cmd| {
             <system-out>[PASS] test_junit_pass_fuzz(uint256) (runs: 256, [AVG_GAS])</system-out>
         </testcase>
         <testcase name="test_junit_skip()" time="[..]">
-            <skipped message=""/>
+            <skipped/>
             <system-out>[SKIP] test_junit_skip() ([GAS])</system-out>
         </testcase>
         <testcase name="test_junit_skip_with_message()" time="[..]">

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1927,25 +1927,25 @@ forgetest_init!(should_generate_junit_xml_report, |prj, cmd| {
         r#"
 import "forge-std/Test.sol";
 contract AJunitReportTest is Test {
-    function test_junit1() public {
+    function test_junit_assert_fail() public {
         assert(1 > 2);
     }
 
-    function test_junit2() public {
+    function test_junit_revert_fail() public {
         require(1 > 2, "Revert");
     }
 }
 
 contract BJunitReportTest is Test {
-    function test_junit3() public {
+    function test_junit_pass() public {
         require(1 < 2, "Revert");
     }
 
-    function test_junit4() public {
+    function test_junit_skip() public {
         vm.skip(true);
     }
 
-    function test_junit5(uint256 a) public {
+    function test_junit_pass_fuzz(uint256 a) public {
     }
 }
    "#,
@@ -1954,33 +1954,34 @@ contract BJunitReportTest is Test {
 
     cmd.args(["test", "--junit"]).assert_failure().stdout_eq(str![[r#"
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Test run" tests="5" failures="2" errors="0" timestamp="[..]">
-    <testsuite name="src/JunitReportTest.t.sol:AJunitReportTest" tests="2" disabled="0" errors="0" failures="2">
-        <testcase name="test_junit1()" time="[..]">
+<testsuites name="Test run" tests="5" failures="2" errors="0" timestamp="[..]" time="[..]">
+    <testsuite name="src/JunitReportTest.t.sol:AJunitReportTest" tests="2" disabled="0" errors="0" failures="2" time="[..]">
+        <testcase name="test_junit_assert_fail()" time="[..]">
             <failure message="panic: assertion failed (0x01)"/>
-            <system-err>[FAIL. Reason: panic: assertion failed (0x01)] test_junit1() ([GAS])</system-err>
+            <system-out>[FAIL. Reason: panic: assertion failed (0x01)] test_junit_assert_fail() ([GAS])</system-out>
         </testcase>
-        <testcase name="test_junit2()" time="[..]">
+        <testcase name="test_junit_revert_fail()" time="[..]">
             <failure message="revert: Revert"/>
-            <system-err>[FAIL. Reason: revert: Revert] test_junit2() ([GAS])</system-err>
+            <system-out>[FAIL. Reason: revert: Revert] test_junit_revert_fail() ([GAS])</system-out>
         </testcase>
         <system-out>Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]</system-out>
     </testsuite>
-    <testsuite name="src/JunitReportTest.t.sol:BJunitReportTest" tests="3" disabled="1" errors="0" failures="0">
-        <testcase name="test_junit3()" time="[..]">
-            <system-out>[PASS] test_junit3() ([GAS])</system-out>
+    <testsuite name="src/JunitReportTest.t.sol:BJunitReportTest" tests="3" disabled="1" errors="0" failures="0" time="[..]">
+        <testcase name="test_junit_pass()" time="[..]">
+            <system-out>[PASS] test_junit_pass() ([GAS])</system-out>
         </testcase>
-        <testcase name="test_junit4()" time="[..]">
+        <testcase name="test_junit_pass_fuzz(uint256)" time="[..]">
+            <system-out>[PASS] test_junit_pass_fuzz(uint256) (runs: 256, [AVG_GAS])</system-out>
+        </testcase>
+        <testcase name="test_junit_skip()" time="[..]">
             <skipped/>
-            <system-out>[SKIP] test_junit4() ([GAS])</system-out>
-        </testcase>
-        <testcase name="test_junit5(uint256)" time="[..]">
-            <system-out>[PASS] test_junit5(uint256) (runs: 256, [AVG_GAS])</system-out>
+            <system-out>[SKIP] test_junit_skip() ([GAS])</system-out>
         </testcase>
         <system-out>Suite result: ok. 2 passed; 0 failed; 1 skipped; [ELAPSED]</system-out>
     </testsuite>
 </testsuites>
-...
+
+
 "#]]);
 });
 
@@ -1991,7 +1992,7 @@ forgetest_init!(should_generate_junit_xml_report_with_logs, |prj, cmd| {
         r#"
 import "forge-std/Test.sol";
 contract JunitReportTest is Test {
-    function test_junit1() public {
+    function test_junit_with_logs() public {
         console.log("Step1");
         console.log("Step2");
         console.log("Step3");
@@ -2004,14 +2005,15 @@ contract JunitReportTest is Test {
 
     cmd.args(["test", "--junit", "-vvvv"]).assert_success().stdout_eq(str![[r#"
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Test run" tests="1" failures="0" errors="0" timestamp="[..]">
-    <testsuite name="src/JunitReportTest.t.sol:JunitReportTest" tests="1" disabled="0" errors="0" failures="0">
-        <testcase name="test_junit1()" time="[..]">
-            <system-out>[PASS] test_junit1() ([GAS])/nLogs:/n  Step1/n  Step2/n  Step3/n</system-out>
+<testsuites name="Test run" tests="1" failures="0" errors="0" timestamp="[..]" time="[..]">
+    <testsuite name="src/JunitReportTest.t.sol:JunitReportTest" tests="1" disabled="0" errors="0" failures="0" time="[..]">
+        <testcase name="test_junit_with_logs()" time="[..]">
+            <system-out>[PASS] test_junit_with_logs() ([GAS])/nLogs:/n  Step1/n  Step2/n  Step3/n</system-out>
         </testcase>
         <system-out>Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]</system-out>
     </testsuite>
 </testsuites>
-...
+
+
 "#]]);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #7004 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add junit xml report support using quick-junit crate
- testsuites timestamp is UTC at the moment report generated; for passed test the test output is added in `<system-out>`, for failed in `<system-err>`; currently only logs displayed if running with verbosity > 2(traces not decoded, will be added with refactoring code and reusing code for json output as well)
- tests covering pass, fail, and skip tests