### PR TITLE
feat: add support for test skip reasons

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -8113,8 +8113,8 @@
     },
     {
       "func": {
-        "id": "skip",
-        "description": "Marks a test as skipped. Must be called at the top of the test.",
+        "id": "skip_0",
+        "description": "Marks a test as skipped. Must be called at the top level of a test.",
         "declaration": "function skip(bool skipTest) external;",
         "visibility": "external",
         "mutability": "",
@@ -8125,6 +8125,26 @@
           130,
           209,
           62
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "skip_1",
+        "description": "Marks a test as skipped with a reason. Must be called at the top level of a test.",
+        "declaration": "function skip(bool skipTest, string calldata reason) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "skip(bool,string)",
+        "selector": "0xc42a80a7",
+        "selectorBytes": [
+          196,
+          42,
+          128,
+          167
         ]
       },
       "group": "testing",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -843,9 +843,13 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
 
-    /// Marks a test as skipped. Must be called at the top of the test.
+    /// Marks a test as skipped. Must be called at the top level of a test.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function skip(bool skipTest) external;
+
+    /// Marks a test as skipped with a reason. Must be called at the top level of a test.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function skip(bool skipTest, string calldata reason) external;
 
     /// Asserts that the given condition is true.
     #[cheatcode(group = Testing, safety = Safe)]

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -70,14 +70,21 @@ impl Cheatcode for sleepCall {
     }
 }
 
-impl Cheatcode for skipCall {
+impl Cheatcode for skip_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { skipTest } = *self;
-        if skipTest {
+        skip_1Call { skipTest, reason: String::new() }.apply_stateful(ccx)
+    }
+}
+
+impl Cheatcode for skip_1Call {
+    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+        let Self { skipTest, reason } = self;
+        if *skipTest {
             // Skip should not work if called deeper than at test level.
             // Since we're not returning the magic skip bytes, this will cause a test failure.
             ensure!(ccx.ecx.journaled_state.depth() <= 1, "`skip` can only be used at test level");
-            Err(MAGIC_SKIP.into())
+            Err([MAGIC_SKIP, reason.as_bytes()].concat().into())
         } else {
             Ok(Default::default())
         }

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -34,7 +34,7 @@ pub const TEST_CONTRACT_ADDRESS: Address = address!("b4c79daB8f259C7Aee6E5b2Aa72
 /// Magic return value returned by the `assume` cheatcode.
 pub const MAGIC_ASSUME: &[u8] = b"FOUNDRY::ASSUME";
 
-/// Magic return value returned by the `skip` cheatcode.
+/// Magic return value returned by the `skip` cheatcode. Optionally appended with a reason.
 pub const MAGIC_SKIP: &[u8] = b"FOUNDRY::SKIP";
 
 /// The address that deploys the default CREATE2 deployer contract.

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -9,7 +9,39 @@ use foundry_common::SELECTOR_LEN;
 use itertools::Itertools;
 use revm::interpreter::InstructionResult;
 use rustc_hash::FxHashMap;
-use std::sync::OnceLock;
+use std::{fmt, sync::OnceLock};
+
+/// A skip reason.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkipReason(pub Option<String>);
+
+impl SkipReason {
+    /// Decodes a skip reason, if any.
+    pub fn decode(raw_result: &[u8]) -> Option<Self> {
+        raw_result.strip_prefix(crate::constants::MAGIC_SKIP).map(|reason| {
+            let reason = String::from_utf8_lossy(reason).into_owned();
+            Self((!reason.is_empty()).then_some(reason))
+        })
+    }
+
+    /// Decodes a skip reason from a string that was obtained by formatting `Self`.
+    ///
+    /// This is a hack to support re-decoding a skip reason in proptest.
+    pub fn decode_self(s: &str) -> Option<Self> {
+        s.strip_prefix("skipped").map(|rest| Self(rest.strip_prefix(": ").map(ToString::to_string)))
+    }
+}
+
+impl fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("skipped")?;
+        if let Some(reason) = &self.0 {
+            f.write_str(": ")?;
+            f.write_str(reason)?;
+        }
+        Ok(())
+    }
+}
 
 /// Decode a set of logs, only returning logs from DSTest logging events and Hardhat's `console.log`
 pub fn decode_console_logs(logs: &[Log]) -> Vec<String> {
@@ -120,9 +152,8 @@ impl RevertDecoder {
             };
         }
 
-        if err == crate::constants::MAGIC_SKIP {
-            // Also used in forge fuzz runner
-            return Some("SKIPPED".to_string());
+        if let Some(reason) = SkipReason::decode(err) {
+            return Some(reason.to_string());
         }
 
         // Solidity's `Error(string)` or `Panic(uint256)`
@@ -177,11 +208,17 @@ impl RevertDecoder {
         }
 
         // Generic custom error.
-        Some(format!(
-            "custom error {}:{}",
-            hex::encode(selector),
-            std::str::from_utf8(data).map_or_else(|_| trimmed_hex(data), String::from)
-        ))
+        Some({
+            let mut s = format!("custom error {}", hex::encode_prefixed(selector));
+            if !data.is_empty() {
+                s.push_str(": ");
+                match std::str::from_utf8(data) {
+                    Ok(data) => s.push_str(data),
+                    Err(_) => s.push_str(&trimmed_hex(data)),
+                }
+            }
+            s
+        })
     }
 }
 
@@ -194,7 +231,7 @@ fn trimmed_hex(s: &[u8]) -> String {
             "{}…{} ({} bytes)",
             &hex::encode(&s[..n / 2]),
             &hex::encode(&s[s.len() - n / 2..]),
-            s.len()
+            s.len(),
         )
     }
 }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -5,7 +5,10 @@ use alloy_primitives::{Address, Bytes, Log, U256};
 use eyre::Result;
 use foundry_common::evm::Breakpoints;
 use foundry_config::FuzzConfig;
-use foundry_evm_core::{constants::MAGIC_ASSUME, decode::RevertDecoder};
+use foundry_evm_core::{
+    constants::MAGIC_ASSUME,
+    decode::{RevertDecoder, SkipReason},
+};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
     strategies::{fuzz_calldata, fuzz_calldata_from_state, EvmFuzzState},
@@ -131,9 +134,8 @@ impl FuzzedExecutor {
                 }) => {
                     // We cannot use the calldata returned by the test runner in `TestError::Fail`,
                     // since that input represents the last run case, which may not correspond with
-                    // our failure - when a fuzz case fails, proptest will try
-                    // to run at least one more case to find a minimal failure
-                    // case.
+                    // our failure - when a fuzz case fails, proptest will try to run at least one
+                    // more case to find a minimal failure case.
                     let reason = rd.maybe_decode(&outcome.1.result, Some(status));
                     execution_data.borrow_mut().logs.extend(outcome.1.logs.clone());
                     execution_data.borrow_mut().counterexample = outcome;
@@ -157,6 +159,7 @@ impl FuzzedExecutor {
             first_case: fuzz_result.first_case.unwrap_or_default(),
             gas_by_case: fuzz_result.gas_by_case,
             success: run_result.is_ok(),
+            skipped: false,
             reason: None,
             counterexample: None,
             logs: fuzz_result.logs,
@@ -168,20 +171,22 @@ impl FuzzedExecutor {
         };
 
         match run_result {
-            // Currently the only operation that can trigger proptest global rejects is the
-            // `vm.assume` cheatcode, thus we surface this info to the user when the fuzz test
-            // aborts due to too many global rejects, making the error message more actionable.
-            Err(TestError::Abort(reason)) if reason.message() == "Too many global rejects" => {
-                result.reason = Some(
-                    FuzzError::TooManyRejects(self.runner.config().max_global_rejects).to_string(),
-                );
-            }
+            Ok(()) => {}
             Err(TestError::Abort(reason)) => {
-                result.reason = Some(reason.to_string());
+                let msg = reason.message();
+                // Currently the only operation that can trigger proptest global rejects is the
+                // `vm.assume` cheatcode, thus we surface this info to the user when the fuzz test
+                // aborts due to too many global rejects, making the error message more actionable.
+                result.reason = if msg == "Too many global rejects" {
+                    let error = FuzzError::TooManyRejects(self.runner.config().max_global_rejects);
+                    Some(error.to_string())
+                } else {
+                    Some(msg.to_string())
+                };
             }
             Err(TestError::Fail(reason, _)) => {
                 let reason = reason.to_string();
-                result.reason = if reason.is_empty() { None } else { Some(reason) };
+                result.reason = (!reason.is_empty()).then_some(reason);
 
                 let args = if let Some(data) = calldata.get(4..) {
                     func.abi_decode_input(data, false).unwrap_or_default()
@@ -193,7 +198,13 @@ impl FuzzedExecutor {
                     BaseCounterExample::from_fuzz_call(calldata, args, call.traces),
                 ));
             }
-            _ => {}
+        }
+
+        if let Some(reason) = &result.reason {
+            if let Some(reason) = SkipReason::decode_self(reason) {
+                result.skipped = true;
+                result.reason = reason.0;
+            }
         }
 
         state.log_stats();
@@ -212,9 +223,9 @@ impl FuzzedExecutor {
         let mut call = self
             .executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
-            .map_err(|_| TestCaseError::fail(FuzzError::FailedContractCall))?;
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
 
-        // When the `assume` cheatcode is called it returns a special string
+        // Handle `vm.assume`.
         if call.result.as_ref() == MAGIC_ASSUME {
             return Err(TestCaseError::reject(FuzzError::AssumeReject))
         }

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -40,9 +40,9 @@ impl InvariantFuzzError {
             Self::BrokenInvariant(case_data) | Self::Revert(case_data) => {
                 (!case_data.revert_reason.is_empty()).then(|| case_data.revert_reason.clone())
             }
-            Self::MaxAssumeRejects(allowed) => Some(format!(
-                "The `vm.assume` cheatcode rejected too many inputs ({allowed} allowed)"
-            )),
+            Self::MaxAssumeRejects(allowed) => {
+                Some(format!("`vm.assume` rejected too many inputs ({allowed} allowed)"))
+            }
         }
     }
 }

--- a/crates/evm/fuzz/src/error.rs
+++ b/crates/evm/fuzz/src/error.rs
@@ -1,16 +1,13 @@
-//! errors related to fuzz tests
+//! Errors related to fuzz tests.
+
 use proptest::test_runner::Reason;
 
 /// Possible errors when running fuzz tests
 #[derive(Debug, thiserror::Error)]
 pub enum FuzzError {
-    #[error("Couldn't call unknown contract")]
-    UnknownContract,
-    #[error("Failed contract call")]
-    FailedContractCall,
     #[error("`vm.assume` reject")]
     AssumeReject,
-    #[error("The `vm.assume` cheatcode rejected too many inputs ({0} allowed)")]
+    #[error("`vm.assume` rejected too many inputs ({0} allowed)")]
     TooManyRejects(u32),
 }
 

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -151,6 +151,8 @@ pub struct FuzzTestResult {
     /// properly, or that there was a revert and that the test was expected to fail
     /// (prefixed with `testFail`)
     pub success: bool,
+    /// Whether the test case was skipped. `reason` will contain the skip reason, if any.
+    pub skipped: bool,
 
     /// If there was a revert, this field will be populated. Note that the test can
     /// still be successful (i.e self.success == true) when it's expected to fail.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -9,6 +9,7 @@ use eyre::Report;
 use foundry_common::{evm::Breakpoints, get_contract_name, get_file_name, shell};
 use foundry_evm::{
     coverage::HitMaps,
+    decode::SkipReason,
     executors::{EvmError, RawCallResult},
     fuzz::{CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
@@ -53,17 +54,17 @@ impl TestOutcome {
 
     /// Returns an iterator over all individual succeeding tests and their names.
     pub fn successes(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Success)
+        self.tests().filter(|(_, t)| t.status.is_success())
     }
 
     /// Returns an iterator over all individual skipped tests and their names.
     pub fn skips(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Skipped)
+        self.tests().filter(|(_, t)| t.status.is_skipped())
     }
 
     /// Returns an iterator over all individual failing tests and their names.
     pub fn failures(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Failure)
+        self.tests().filter(|(_, t)| t.status.is_failure())
     }
 
     /// Returns an iterator over all individual tests and their names.
@@ -221,17 +222,17 @@ impl SuiteResult {
 
     /// Returns an iterator over all individual succeeding tests and their names.
     pub fn successes(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Success)
+        self.tests().filter(|(_, t)| t.status.is_success())
     }
 
     /// Returns an iterator over all individual skipped tests and their names.
     pub fn skips(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Skipped)
+        self.tests().filter(|(_, t)| t.status.is_skipped())
     }
 
     /// Returns an iterator over all individual failing tests and their names.
     pub fn failures(&self) -> impl Iterator<Item = (&String, &TestResult)> {
-        self.tests().filter(|(_, t)| t.status == TestStatus::Failure)
+        self.tests().filter(|(_, t)| t.status.is_failure())
     }
 
     /// Returns the number of tests that passed.
@@ -395,29 +396,39 @@ impl fmt::Display for TestResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.status {
             TestStatus::Success => "[PASS]".green().fmt(f),
-            TestStatus::Skipped => "[SKIP]".yellow().fmt(f),
+            TestStatus::Skipped => {
+                let mut s = String::from("[SKIP");
+                if let Some(reason) = &self.reason {
+                    write!(s, ": {reason}").unwrap();
+                }
+                s.push(']');
+                s.yellow().fmt(f)
+            }
             TestStatus::Failure => {
-                let mut s = String::from("[FAIL. Reason: ");
+                let mut s = String::from("[FAIL");
+                if self.reason.is_some() || self.counterexample.is_some() {
+                    if let Some(reason) = &self.reason {
+                        write!(s, ": {reason}").unwrap();
+                    }
 
-                let reason = self.reason.as_deref().unwrap_or("assertion failed");
-                s.push_str(reason);
-
-                if let Some(counterexample) = &self.counterexample {
-                    match counterexample {
-                        CounterExample::Single(ex) => {
-                            write!(s, "; counterexample: {ex}]").unwrap();
-                        }
-                        CounterExample::Sequence(sequence) => {
-                            s.push_str("]\n\t[Sequence]\n");
-                            for ex in sequence {
-                                writeln!(s, "\t\t{ex}").unwrap();
+                    if let Some(counterexample) = &self.counterexample {
+                        match counterexample {
+                            CounterExample::Single(ex) => {
+                                write!(s, "; counterexample: {ex}]").unwrap();
+                            }
+                            CounterExample::Sequence(sequence) => {
+                                s.push_str("]\n\t[Sequence]\n");
+                                for ex in sequence {
+                                    writeln!(s, "\t\t{ex}").unwrap();
+                                }
                             }
                         }
+                    } else {
+                        s.push(']');
                     }
                 } else {
                     s.push(']');
                 }
-
                 s.red().fmt(f)
             }
         }
@@ -455,8 +466,9 @@ impl TestResult {
     }
 
     /// Returns the skipped result for single test (used in skipped fuzz test too).
-    pub fn single_skip(mut self) -> Self {
+    pub fn single_skip(mut self, reason: SkipReason) -> Self {
         self.status = TestStatus::Skipped;
+        self.reason = reason.0;
         self
     }
 
@@ -511,22 +523,27 @@ impl TestResult {
         self.traces.extend(result.traces.map(|traces| (TraceKind::Execution, traces)));
         self.merge_coverages(result.coverage);
 
-        self.status = match result.success {
-            true => TestStatus::Success,
-            false => TestStatus::Failure,
+        self.status = if result.skipped {
+            TestStatus::Skipped
+        } else if result.success {
+            TestStatus::Success
+        } else {
+            TestStatus::Failure
         };
         self.reason = result.reason;
         self.counterexample = result.counterexample;
         self.duration = Duration::default();
         self.gas_report_traces = result.gas_report_traces.into_iter().map(|t| vec![t]).collect();
         self.breakpoints = result.breakpoints.unwrap_or_default();
+
         self
     }
 
     /// Returns the skipped result for invariant test.
-    pub fn invariant_skip(mut self) -> Self {
+    pub fn invariant_skip(mut self, reason: SkipReason) -> Self {
         self.kind = TestKind::Invariant { runs: 1, calls: 1, reverts: 1 };
         self.status = TestStatus::Skipped;
+        self.reason = reason.0;
         self
     }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -443,7 +443,7 @@ impl<'a> ContractRunner<'a> {
         ) {
             Ok(res) => (res.raw, None),
             Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
-            Err(EvmError::SkipError) => return test_result.single_skip(),
+            Err(EvmError::Skip(reason)) => return test_result.single_skip(reason),
             Err(err) => return test_result.single_fail(Some(err.to_string())),
         };
 
@@ -467,7 +467,7 @@ impl<'a> ContractRunner<'a> {
         let mut test_result = TestResult::new(setup);
 
         // First, run the test normally to see if it needs to be skipped.
-        if let Err(EvmError::SkipError) = self.executor.call(
+        if let Err(EvmError::Skip(reason)) = self.executor.call(
             self.sender,
             address,
             func,
@@ -475,7 +475,7 @@ impl<'a> ContractRunner<'a> {
             U256::ZERO,
             Some(self.revert_decoder),
         ) {
-            return test_result.invariant_skip()
+            return test_result.invariant_skip(reason);
         };
 
         let mut evm = InvariantExecutor::new(
@@ -661,12 +661,6 @@ impl<'a> ContractRunner<'a> {
             self.revert_decoder,
             progress.as_ref(),
         );
-
-        // Check the last test result and skip the test
-        // if it's marked as so.
-        if let Some("SKIPPED") = result.reason.as_deref() {
-            return test_result.single_skip()
-        }
         test_result.fuzz_result(result)
     }
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -215,20 +215,15 @@ contract DeployScript is Script {
         "--slow",
         "--broadcast",
         "--unlocked",
+        "--ignored-error-codes=2018", // `wasteGas` can be restricted to view
     ])
     .assert_success()
     .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-Compiler run successful with warnings:
-Warning (2018): Function state mutability can be restricted to view
- [FILE]:7:5:
-  |
-7 |     function wasteGas(uint256 minGas) public {
-  |     ^ (Relevant source part starts here and spans across multiple lines).
-
+Compiler run successful!
 Traces:
-  [81040] DeployScript::run()
+  [81034] DeployScript::run()
     ├─ [0] VM::startBroadcast()
     │   └─ ← [Return] 
     ├─ [45299] → new GasWaster@[..]
@@ -336,7 +331,7 @@ Warning (2018): Function state mutability can be restricted to view
   |     ^ (Relevant source part starts here and spans across multiple lines).
 
 Traces:
-  [81040] DeployScript::run()
+  [81034] DeployScript::run()
     ├─ [0] VM::startBroadcast()
     │   └─ ← [Return] 
     ├─ [45299] → new GasWaster@[..]

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -529,7 +529,7 @@ Compiler run successful!
 Ran 1 test for test/Contract.t.sol:USDTCallingTest
 [PASS] test() ([GAS])
 Traces:
-  [9537] USDTCallingTest::test()
+  [9516] USDTCallingTest::test()
     ├─ [0] VM::createSelectFork("[..]")
     │   └─ ← [Return] 0
     ├─ [3110] 0xdAC17F958D2ee523a2206206994597C13D831ec7::name() [staticcall]
@@ -573,7 +573,7 @@ contract CustomTypesTest is Test {
 Compiler run successful!
 
 Ran 2 tests for test/Contract.t.sol:CustomTypesTest
-[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
+[FAIL: PoolNotInitialized()] testErr() ([GAS])
 Traces:
   [254] CustomTypesTest::testErr()
     └─ ← [Revert] PoolNotInitialized()
@@ -590,7 +590,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 1 failed, 0 skipped (2 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/Contract.t.sol:CustomTypesTest
-[FAIL. Reason: PoolNotInitialized()] testErr() ([GAS])
+[FAIL: PoolNotInitialized()] testErr() ([GAS])
 
 Encountered a total of 1 failing tests, 1 tests succeeded
 
@@ -632,7 +632,8 @@ forgetest_init!(can_test_transient_storage_with_isolation, |prj, cmd| {
 
     prj.add_test(
         "Contract.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
+pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 
 contract TransientTester {
@@ -687,7 +688,7 @@ forgetest_init!(can_disable_block_gas_limit, |prj, cmd| {
 
     prj.add_test(
         "Contract.t.sol",
-        &r#"pragma solidity 0.8.24;
+        &r#"
 import {Test} from "forge-std/Test.sol";
 
 contract C is Test {}
@@ -743,7 +744,7 @@ forgetest_init!(should_not_shrink_fuzz_failure, |prj, cmd| {
 
     prj.add_test(
         "CounterFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract Counter {
@@ -776,14 +777,14 @@ contract CounterTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
+[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterFuzz.t.sol:CounterTest
-[FAIL. Reason: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
+[FAIL: panic: arithmetic underflow or overflow (0x11); counterexample: calldata=0xa76d58f5ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 [1.157e77]]] testAddOne(uint256) (runs: 61, [AVG_GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -794,7 +795,7 @@ forgetest_init!(should_exit_early_on_invariant_failure, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(
         "CounterInvariant.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract Counter {
@@ -827,14 +828,14 @@ contract CounterTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/CounterInvariant.t.sol:CounterTest
-[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/CounterInvariant.t.sol:CounterTest
-[FAIL. Reason: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
+[FAIL: failed to set up invariant testing environment: wrong count] invariant_early_exit() (runs: 0, calls: 0, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -845,7 +846,7 @@ forgetest_init!(should_replay_failures_only, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(
         "ReplayFailures.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Test} from "forge-std/Test.sol";
 
 contract ReplayFailuresTest is Test {
@@ -876,17 +877,17 @@ Compiler run successful!
 
 Ran 4 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
 [PASS] testA() ([GAS])
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
 [PASS] testC() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 Suite result: FAILED. 2 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 2 failed, 0 skipped (4 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 2 tests succeeded
 
@@ -900,16 +901,16 @@ Encountered a total of 2 failing tests, 2 tests succeeded
 No files changed, compilation skipped
 
 Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 2 failed, 0 skipped (2 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL. Reason: revert: testB failed] testB() ([GAS])
-[FAIL. Reason: revert: testD failed] testD() ([GAS])
+[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: revert: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 0 tests succeeded
 
@@ -924,6 +925,7 @@ forgetest_init!(should_show_precompile_labels, |prj, cmd| {
         "Contract.t.sol",
         r#"
 import {Test} from "forge-std/Test.sol";
+
 contract PrecompileLabelsTest is Test {
     function testPrecompileLabels() public {
         vm.deal(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D), 1 ether);
@@ -1011,14 +1013,15 @@ forgetest_init!(should_show_logs_when_fuzz_test, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+        r#"
+import {Test, console} from "forge-std/Test.sol";
+
+contract ContractFuzz is Test {
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
-     "#,
+}
+    "#,
     )
     .unwrap();
     cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
@@ -1054,16 +1057,16 @@ forgetest_init!(should_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
-      /// forge-config: default.fuzz.show-logs = true
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+contract ContractFuzz is Test {
+    /// forge-config: default.fuzz.show-logs = true
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
-     "#,
+}
+    "#,
     )
     .unwrap();
     cmd.args(["test", "-vv"]).assert_success().stdout_eq(str![[r#"
@@ -1101,12 +1104,12 @@ forgetest_init!(should_not_show_logs_when_fuzz_test, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
+        r#"
+        import {Test, console} from "forge-std/Test.sol";
     contract ContractFuzz is Test {
 
       function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
+        console.log("inside fuzz test, x is:", x);
       }
     }
      "#,
@@ -1140,15 +1143,15 @@ forgetest_init!(should_not_show_logs_when_fuzz_test_inline_config, |prj, cmd| {
 
     prj.add_test(
         "ContractFuzz.t.sol",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
-    contract ContractFuzz is Test {
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
-      /// forge-config: default.fuzz.show-logs = false
-      function testFuzzConsoleLog(uint256 x) public pure {
-        console2.log("inside fuzz test, x is:", x);
-      }
+contract ContractFuzz is Test {
+    /// forge-config: default.fuzz.show-logs = false
+    function testFuzzConsoleLog(uint256 x) public pure {
+        console.log("inside fuzz test, x is:", x);
     }
+}
      "#,
     )
     .unwrap();
@@ -1177,8 +1180,9 @@ forgetest_init!(internal_functions_trace, |prj, cmd| {
 
     prj.add_test(
         "Simple",
-        r#"pragma solidity 0.8.24;
-        import {Test, console2} from "forge-std/Test.sol";
+        r#"
+import {Test, console} from "forge-std/Test.sol";
+
 contract SimpleContract {
     uint256 public num;
     address public addr;
@@ -1254,8 +1258,8 @@ forgetest_init!(internal_functions_trace_memory, |prj, cmd| {
 
     prj.add_test(
         "Simple",
-        r#"pragma solidity 0.8.24;
-import {Test, console2} from "forge-std/Test.sol";
+        r#"
+import {Test, console} from "forge-std/Test.sol";
 
 contract SimpleContract {
     string public str = "initial value";
@@ -1283,7 +1287,7 @@ contract SimpleContractTest is Test {
         r#"
 ...
 Traces:
-  [421960] SimpleContractTest::test()
+  [421947] SimpleContractTest::test()
     ├─ [385978] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
     │   └─ ← [Return] 1814 bytes of code
     ├─ [2534] SimpleContract::setStr("new value")
@@ -1506,7 +1510,7 @@ Logs:
 });
 
 // https://github.com/foundry-rs/foundry/issues/4370
-forgetest_init!(repro_4370, |prj, cmd| {
+forgetest_init!(pause_gas_metering_with_delete, |prj, cmd| {
     prj.wipe_contracts();
 
     prj.add_test(
@@ -1543,7 +1547,7 @@ forgetest_init!(pause_tracing, |prj, cmd| {
 
     prj.add_source(
         "Pause.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract TraceGenerator is DSTest {
@@ -1628,7 +1632,7 @@ forgetest_init!(gas_metering_reset, |prj, cmd| {
 
     prj.add_source(
         "ATest.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract B {
@@ -1780,8 +1784,8 @@ contract CounterTest is Test {
 
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL. Reason: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
-[FAIL. Reason: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
+[FAIL: Error != expected error: NumberNotEven(1) != RandomError()] test_decode() ([GAS])
+[FAIL: Error != expected error: NumberNotEven(1) != NumberNotEven(2)] test_decode_with_args() ([GAS])
 ...
 "#]]);
 });
@@ -1795,7 +1799,7 @@ forgetest_init!(test_expect_partial_revert, |prj, cmd| {
 
     prj.add_source(
         "Counter.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract Counter {
@@ -1830,7 +1834,7 @@ contract CounterTest is DSTest {
 ...
 [PASS] testExpectPartialRevertWith4Bytes() ([GAS])
 [PASS] testExpectPartialRevertWithSelector() ([GAS])
-[FAIL. Reason: Error != expected error: WrongNumber(0) != custom error 238ace70:] testExpectRevert() ([GAS])
+[FAIL: Error != expected error: WrongNumber(0) != custom error 0x238ace70] testExpectRevert() ([GAS])
 ...
 "#]]);
 });
@@ -1849,7 +1853,7 @@ forgetest_init!(test_assume_no_revert, |prj, cmd| {
 
     prj.add_source(
         "Counter.t.sol",
-        r#"pragma solidity 0.8.24;
+        r#"
 import {Vm} from "./Vm.sol";
 import {DSTest} from "./test.sol";
 contract CounterWithRevert {
@@ -1912,10 +1916,66 @@ contract CounterRevertTest is DSTest {
 
     cmd.args(["test"]).with_no_redact().assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL. Reason: assertion failed; counterexample: [..]] test_assume_no_revert_fail_assert(uint256) [..]
-[FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_2nd_call(uint256) [..]
-[FAIL. Reason: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_3rd_call(uint256) [..]
+[FAIL; counterexample: [..]] test_assume_no_revert_fail_assert(uint256) [..]
+[FAIL: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_2nd_call(uint256) [..]
+[FAIL: CheckError(); counterexample: [..]] test_assume_no_revert_fail_in_3rd_call(uint256) [..]
 [PASS] test_assume_no_revert_pass(uint256) [..]
 ...
+"#]]);
+});
+
+forgetest_init!(skip_output, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.insert_ds_test();
+    prj.insert_vm();
+    prj.clear();
+
+    prj.add_source(
+        "Counter.t.sol",
+        r#"
+        import {Vm} from "./Vm.sol";
+        import {DSTest} from "./test.sol";
+
+        contract Skips is DSTest {
+            Vm constant vm = Vm(HEVM_ADDRESS);
+
+            function test_skipUnit() public {
+                vm.skip(true);
+            }
+            function test_skipUnitReason() public {
+                vm.skip(true, "unit");
+            }
+
+            function test_skipFuzz(uint) public {
+                vm.skip(true);
+            }
+            function test_skipFuzzReason(uint) public {
+                vm.skip(true, "fuzz");
+            }
+
+            function invariant_skipInvariant() public {
+                vm.skip(true);
+            }
+            function invariant_skipInvariantReason() public {
+                vm.skip(true, "invariant");
+            }
+        }
+    "#,
+    )
+    .unwrap();
+
+    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+...
+Ran 6 tests for src/Counter.t.sol:Skips
+[SKIP] invariant_skipInvariant() (runs: 1, calls: 1, reverts: 1)
+[SKIP: invariant] invariant_skipInvariantReason() (runs: 1, calls: 1, reverts: 1)
+[SKIP] test_skipFuzz(uint256) (runs: 0, [AVG_GAS])
+[SKIP: fuzz] test_skipFuzzReason(uint256) (runs: 0, [AVG_GAS])
+[SKIP] test_skipUnit() ([GAS])
+[SKIP: unit] test_skipUnitReason() ([GAS])
+Suite result: ok. 0 passed; 0 failed; 6 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 0 failed, 6 skipped (6 total tests)
+
 "#]]);
 });

--- a/crates/forge/tests/fixtures/ScriptVerify.sol
+++ b/crates/forge/tests/fixtures/ScriptVerify.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Unique} from "./unique.sol";
 

--- a/crates/forge/tests/it/fuzz.rs
+++ b/crates/forge/tests/it/fuzz.rs
@@ -198,7 +198,7 @@ contract InlineMaxRejectsTest is Test {
 
     cmd.args(["test"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL. Reason: The `vm.assume` cheatcode rejected too many inputs (1 allowed)] test_fuzz_bound(uint256) (runs: 0, [AVG_GAS])
+[FAIL: `vm.assume` rejected too many inputs (1 allowed)] test_fuzz_bound(uint256) (runs: 0, [AVG_GAS])
 ...
 "#]]);
 });

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -479,7 +479,7 @@ async fn test_invariant_assume_respects_restrictions() {
             vec![(
                 "invariant_dummy()",
                 false,
-                Some("The `vm.assume` cheatcode rejected too many inputs (1 allowed)".into()),
+                Some("`vm.assume` rejected too many inputs (1 allowed)".into()),
                 None,
                 None,
             )],

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -47,11 +47,11 @@ static TEMPLATE_LOCK: LazyLock<PathBuf> =
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// The default Solc version used when compiling tests.
-pub const SOLC_VERSION: &str = "0.8.23";
+pub const SOLC_VERSION: &str = "0.8.27";
 
 /// Another Solc version used when compiling tests. Necessary to avoid downloading multiple
 /// versions.
-pub const OTHER_SOLC_VERSION: &str = "0.8.22";
+pub const OTHER_SOLC_VERSION: &str = "0.8.26";
 
 /// External test builder
 #[derive(Clone, Debug)]

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -402,6 +402,7 @@ interface Vm {
     function sign(bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function sign(address signer, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function skip(bool skipTest) external;
+    function skip(bool skipTest, string calldata reason) external;
     function sleep(uint256 duration) external;
     function snapshot() external returns (uint256 snapshotId);
     function split(string calldata input, string calldata delimiter) external pure returns (string[] memory outputs);


### PR DESCRIPTION
Adds `vm.skip(bool,string)` for an optional string reason which shows up in the output.

Unfortunately not super straight forward for fuzz tests because we have to decode the encoded reason again to properly propagate it 

\+ tweaks to a few error messages and cleanups

Can be added to https://github.com/foundry-rs/foundry/pull/8852