### PR TITLE
feat(`anvil`): optionally preserve historical states on dump_state

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -525,9 +525,9 @@ pub enum EthRequest {
     /// properties, etc.) into a savable data blob
     #[cfg_attr(
         feature = "serde",
-        serde(rename = "anvil_dumpState", alias = "hardhat_dumpState", with = "empty_params")
+        serde(rename = "anvil_dumpState", alias = "hardhat_dumpState", with = "sequence")
     )]
-    DumpState(()),
+    DumpState(bool),
 
     /// Adds state previously dumped with `DumpState` to the current chain
     #[cfg_attr(

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1210,7 +1210,7 @@ mod tests {
 
     #[test]
     fn test_serde_custom_dump_state() {
-        let s = r#"{"method": "anvil_dumpState", "params": [] }"#;
+        let s = r#"{"method": "anvil_dumpState", "params": [false] }"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -523,11 +523,8 @@ pub enum EthRequest {
 
     /// Serializes the current state (including contracts code, contract's storage, accounts
     /// properties, etc.) into a savable data blob
-    #[cfg_attr(
-        feature = "serde",
-        serde(rename = "anvil_dumpState", alias = "hardhat_dumpState", with = "sequence")
-    )]
-    DumpState(bool),
+    #[cfg_attr(feature = "serde", serde(rename = "anvil_dumpState", alias = "hardhat_dumpState"))]
+    DumpState(#[cfg_attr(feature = "serde", serde(default))] Option<Params<Option<bool>>>),
 
     /// Adds state previously dumped with `DumpState` to the current chain
     #[cfg_attr(
@@ -1210,9 +1207,19 @@ mod tests {
 
     #[test]
     fn test_serde_custom_dump_state() {
-        let s = r#"{"method": "anvil_dumpState", "params": [false] }"#;
+        let s = r#"{"method": "anvil_dumpState", "params": [true]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "anvil_dumpState"}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let req = serde_json::from_value::<EthRequest>(value).unwrap();
+        match req {
+            EthRequest::DumpState(param) => {
+                assert!(param.is_none());
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[test]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -149,12 +149,11 @@ pub struct NodeArgs {
     #[arg(long, value_name = "PATH", conflicts_with = "init")]
     pub dump_state: Option<PathBuf>,
 
-    /// Preserve historical state snapshots when dumping the state on shutdown.
+    /// Preserve historical state snapshots when dumping the state.
     ///
-    /// This will save the in-memory states of the chain at particular block hashes not just the
-    /// state at the tip.
+    /// This will save the in-memory states of the chain at particular block hashes.
     ///
-    /// These historical states will be loaded into the memory if called with `--load-state`, and
+    /// These historical states will be loaded into the memory when `--load-state` / `--state`, and
     /// aids in RPC calls beyond the block at which state was dumped.
     #[arg(long, conflicts_with = "init", default_value = "false")]
     pub preserve_historical_states: bool,

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -695,7 +695,7 @@ impl StateFile {
         Ok(state)
     }
 }
-
+ 
 /// Represents the input URL for a fork with an optional trailing block number:
 /// `http://localhost:8545@1000000`
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -351,7 +351,9 @@ impl EthApi {
             EthRequest::SetNextBlockBaseFeePerGas(gas) => {
                 self.anvil_set_next_block_base_fee_per_gas(gas).await.to_rpc_result()
             }
-            EthRequest::DumpState(_) => self.anvil_dump_state().await.to_rpc_result(),
+            EthRequest::DumpState(preserve_historical_states) => {
+                self.anvil_dump_state(preserve_historical_states).await.to_rpc_result()
+            }
             EthRequest::LoadState(buf) => self.anvil_load_state(buf).await.to_rpc_result(),
             EthRequest::NodeInfo(_) => self.anvil_node_info().await.to_rpc_result(),
             EthRequest::AnvilMetadata(_) => self.anvil_metadata().await.to_rpc_result(),
@@ -1839,14 +1841,17 @@ impl EthApi {
     /// process by calling `anvil_loadState`
     ///
     /// Handler for RPC call: `anvil_dumpState`
-    pub async fn anvil_dump_state(&self) -> Result<Bytes> {
+    pub async fn anvil_dump_state(&self, preserve_historical_states: bool) -> Result<Bytes> {
         node_info!("anvil_dumpState");
-        self.backend.dump_state().await
+        self.backend.dump_state(preserve_historical_states).await
     }
 
     /// Returns the current state
-    pub async fn serialized_state(&self) -> Result<SerializableState> {
-        self.backend.serialized_state().await
+    pub async fn serialized_state(
+        &self,
+        preserve_historical_states: bool,
+    ) -> Result<SerializableState> {
+        self.backend.serialized_state(preserve_historical_states).await
     }
 
     /// Append chain state buffer to current chain. Will overwrite any conflicting addresses or

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -351,9 +351,10 @@ impl EthApi {
             EthRequest::SetNextBlockBaseFeePerGas(gas) => {
                 self.anvil_set_next_block_base_fee_per_gas(gas).await.to_rpc_result()
             }
-            EthRequest::DumpState(preserve_historical_states) => {
-                self.anvil_dump_state(preserve_historical_states).await.to_rpc_result()
-            }
+            EthRequest::DumpState(preserve_historical_states) => self
+                .anvil_dump_state(preserve_historical_states.and_then(|s| s.params))
+                .await
+                .to_rpc_result(),
             EthRequest::LoadState(buf) => self.anvil_load_state(buf).await.to_rpc_result(),
             EthRequest::NodeInfo(_) => self.anvil_node_info().await.to_rpc_result(),
             EthRequest::AnvilMetadata(_) => self.anvil_metadata().await.to_rpc_result(),
@@ -1841,9 +1842,12 @@ impl EthApi {
     /// process by calling `anvil_loadState`
     ///
     /// Handler for RPC call: `anvil_dumpState`
-    pub async fn anvil_dump_state(&self, preserve_historical_states: bool) -> Result<Bytes> {
+    pub async fn anvil_dump_state(
+        &self,
+        preserve_historical_states: Option<bool>,
+    ) -> Result<Bytes> {
         node_info!("anvil_dumpState");
-        self.backend.dump_state(preserve_historical_states).await
+        self.backend.dump_state(preserve_historical_states.unwrap_or(false)).await
     }
 
     /// Returns the current state

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -124,7 +124,7 @@ pub trait Db:
         best_number: U64,
         blocks: Vec<SerializableBlock>,
         transactions: Vec<SerializableTransaction>,
-        historical_states: SerializableHistoricalStates,
+        historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>>;
 
     /// Deserialize and add all chain data to the backend storage
@@ -199,7 +199,7 @@ impl<T: DatabaseRef<Error = DatabaseError> + Send + Sync + Clone + fmt::Debug> D
         _best_number: U64,
         _blocks: Vec<SerializableBlock>,
         _transaction: Vec<SerializableTransaction>,
-        _historical_states: SerializableHistoricalStates,
+        _historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>> {
         Ok(None)
     }

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -457,4 +457,19 @@ impl From<SerializableTransaction> for MinedTransaction {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct SerializableHistoricalStates(pub Vec<(B256, StateSnapshot)>);
+pub struct SerializableHistoricalStates(Vec<(B256, StateSnapshot)>);
+
+impl SerializableHistoricalStates {
+    pub const fn new(states: Vec<(B256, StateSnapshot)>) -> Self {
+        Self(states)
+    }
+}
+
+impl IntoIterator for SerializableHistoricalStates {
+    type Item = (B256, StateSnapshot);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -1,7 +1,7 @@
 use crate::{
     eth::backend::db::{
         Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
-        SerializableState, SerializableTransaction, StateDb,
+        SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
     },
     revm::primitives::AccountInfo,
 };
@@ -38,6 +38,7 @@ impl Db for ForkedDatabase {
         best_number: U64,
         blocks: Vec<SerializableBlock>,
         transactions: Vec<SerializableTransaction>,
+        historical_states: SerializableHistoricalStates,
     ) -> DatabaseResult<Option<SerializableState>> {
         let mut db = self.database().clone();
         let accounts = self
@@ -68,6 +69,7 @@ impl Db for ForkedDatabase {
             best_block_number: Some(best_number),
             blocks,
             transactions,
+            historical_states: Some(historical_states),
         }))
     }
 

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -95,6 +95,14 @@ impl MaybeFullDatabase for ForkedDatabase {
         StateSnapshot { accounts, storage, block_hashes }
     }
 
+    fn read_as_snapshot(&self) -> StateSnapshot {
+        let db = self.inner().db();
+        let accounts = db.accounts.read().clone();
+        let storage = db.storage.read().clone();
+        let block_hashes = db.block_hashes.read().clone();
+        StateSnapshot { accounts, storage, block_hashes }
+    }
+
     fn clear(&mut self) {
         self.flush_cache();
         self.clear_into_snapshot();
@@ -112,6 +120,10 @@ impl MaybeFullDatabase for ForkedDatabase {
 impl MaybeFullDatabase for ForkDbSnapshot {
     fn clear_into_snapshot(&mut self) -> StateSnapshot {
         std::mem::take(&mut self.snapshot)
+    }
+
+    fn read_as_snapshot(&self) -> StateSnapshot {
+        self.snapshot.clone()
     }
 
     fn clear(&mut self) {

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -38,7 +38,7 @@ impl Db for ForkedDatabase {
         best_number: U64,
         blocks: Vec<SerializableBlock>,
         transactions: Vec<SerializableTransaction>,
-        historical_states: SerializableHistoricalStates,
+        historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>> {
         let mut db = self.database().clone();
         let accounts = self
@@ -69,7 +69,7 @@ impl Db for ForkedDatabase {
             best_block_number: Some(best_number),
             blocks,
             transactions,
-            historical_states: Some(historical_states),
+            historical_states,
         }))
     }
 

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -38,7 +38,7 @@ impl Db for MemDb {
         best_number: U64,
         blocks: Vec<SerializableBlock>,
         transactions: Vec<SerializableTransaction>,
-        historical_states: SerializableHistoricalStates,
+        historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>> {
         let accounts = self
             .inner
@@ -69,7 +69,7 @@ impl Db for MemDb {
             best_block_number: Some(best_number),
             blocks,
             transactions,
-            historical_states: Some(historical_states),
+            historical_states,
         }))
     }
 

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -3,7 +3,7 @@
 use crate::{
     eth::backend::db::{
         Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
-        SerializableState, SerializableTransaction, StateDb,
+        SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
     },
     mem::state::state_root,
     revm::{db::DbAccount, primitives::AccountInfo},
@@ -38,6 +38,7 @@ impl Db for MemDb {
         best_number: U64,
         blocks: Vec<SerializableBlock>,
         transactions: Vec<SerializableTransaction>,
+        historical_states: SerializableHistoricalStates,
     ) -> DatabaseResult<Option<SerializableState>> {
         let accounts = self
             .inner
@@ -68,6 +69,7 @@ impl Db for MemDb {
             best_block_number: Some(best_number),
             blocks,
             transactions,
+            historical_states: Some(historical_states),
         }))
     }
 
@@ -163,7 +165,7 @@ mod tests {
 
         // blocks dumping/loading tested in storage.rs
         let state = dump_db
-            .dump_state(Default::default(), U64::ZERO, Vec::new(), Vec::new())
+            .dump_state(Default::default(), U64::ZERO, Vec::new(), Vec::new(), Default::default())
             .unwrap()
             .unwrap();
 

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -112,6 +112,10 @@ impl MaybeFullDatabase for MemDb {
         self.inner.clear_into_snapshot()
     }
 
+    fn read_as_snapshot(&self) -> StateSnapshot {
+        self.inner.read_as_snapshot()
+    }
+
     fn clear(&mut self) {
         self.inner.clear();
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -809,6 +809,10 @@ impl Backend {
         self.blockchain.storage.write().load_blocks(state.blocks.clone());
         self.blockchain.storage.write().load_transactions(state.transactions.clone());
 
+        if let Some(historical_states) = state.historical_states {
+            self.states.write().load_states(historical_states);
+        }
+
         Ok(true)
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -763,7 +763,14 @@ impl Backend {
         let best_number = self.blockchain.storage.read().best_number;
         let blocks = self.blockchain.storage.read().serialized_blocks();
         let transactions = self.blockchain.storage.read().serialized_transactions();
-        let state = self.db.read().await.dump_state(at, best_number, blocks, transactions)?;
+        let historical_states = self.states.write().serialized_states();
+        let state = self.db.read().await.dump_state(
+            at,
+            best_number,
+            blocks,
+            transactions,
+            historical_states,
+        )?;
         state.ok_or_else(|| {
             RpcError::invalid_params("Dumping state not supported with the current configuration")
                 .into()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -758,12 +758,20 @@ impl Backend {
     }
 
     /// Get the current state.
-    pub async fn serialized_state(&self) -> Result<SerializableState, BlockchainError> {
+    pub async fn serialized_state(
+        &self,
+        preserve_historical_states: bool,
+    ) -> Result<SerializableState, BlockchainError> {
         let at = self.env.read().block.clone();
         let best_number = self.blockchain.storage.read().best_number;
         let blocks = self.blockchain.storage.read().serialized_blocks();
         let transactions = self.blockchain.storage.read().serialized_transactions();
-        let historical_states = self.states.write().serialized_states();
+        let historical_states = if preserve_historical_states {
+            Some(self.states.write().serialized_states())
+        } else {
+            None
+        };
+
         let state = self.db.read().await.dump_state(
             at,
             best_number,
@@ -778,8 +786,11 @@ impl Backend {
     }
 
     /// Write all chain data to serialized bytes buffer
-    pub async fn dump_state(&self) -> Result<Bytes, BlockchainError> {
-        let state = self.serialized_state().await?;
+    pub async fn dump_state(
+        &self,
+        preserve_historical_states: bool,
+    ) -> Result<Bytes, BlockchainError> {
+        let state = self.serialized_state(preserve_historical_states).await?;
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder
             .write_all(&serde_json::to_vec(&state).unwrap_or_default())

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -196,7 +196,7 @@ impl InMemoryBlockStates {
     /// Serialize all states to a list of serializable historical states
     pub fn serialized_states(&mut self) -> SerializableHistoricalStates {
         // Get in-memory states and serialized them
-        let mut in_memory_states = self
+        let mut states = self
             .states
             .iter_mut()
             .map(|(hash, state)| (*hash, state.serialize_state()))
@@ -209,14 +209,14 @@ impl InMemoryBlockStates {
             .collect::<Vec<_>>();
 
         // Join the two lists
-        in_memory_states.extend(disk_states);
+        states.extend(disk_states);
 
-        SerializableHistoricalStates(in_memory_states)
+        SerializableHistoricalStates::new(states)
     }
 
     /// Load states from serialized data
     pub fn load_states(&mut self, states: SerializableHistoricalStates) {
-        for (hash, snapshot) in states.0 {
+        for (hash, snapshot) in states {
             let mut state_db = StateDb::new(MemDb::default());
             state_db.init_from_snapshot(snapshot);
             self.insert(hash, state_db);

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -14,7 +14,7 @@ async fn can_load_state() {
 
     let num = api.block_number().unwrap();
 
-    let state = api.serialized_state().await.unwrap();
+    let state = api.serialized_state(false).await.unwrap();
     foundry_common::fs::write_json_file(&state_file, &state).unwrap();
 
     let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -1,6 +1,9 @@
 //! general eth api tests
 
+use crate::abi::Greeter;
 use alloy_primitives::Uint;
+use alloy_provider::Provider;
+use alloy_rpc_types::BlockId;
 use anvil::{spawn, NodeConfig};
 
 #[tokio::test(flavor = "multi_thread")]
@@ -41,4 +44,55 @@ async fn can_load_existing_state() {
 
     let block_number = api.block_number().unwrap();
     assert_eq!(block_number, Uint::from(2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_preserve_historical_states_between_dump_and_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state_file = tmp.path().join("state.json");
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    let provider = handle.http_provider();
+
+    let greeter = Greeter::deploy(&provider, "Hello".to_string()).await.unwrap();
+
+    let address = greeter.address();
+
+    let deploy_blk_num = provider.get_block_number().await.unwrap();
+
+    let tx = greeter
+        .setGreeting("World!".to_string())
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let change_greeting_blk_num = tx.block_number.unwrap();
+
+    api.mine_one().await;
+
+    let ser_state = api.serialized_state(true).await.unwrap();
+    foundry_common::fs::write_json_file(&state_file, &ser_state).unwrap();
+
+    let (api, handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;
+
+    let block_number = api.block_number().unwrap();
+    assert_eq!(block_number, Uint::from(3));
+
+    let provider = handle.http_provider();
+
+    let greeter = Greeter::new(*address, provider);
+
+    let greeting_at_init =
+        greeter.greet().block(BlockId::number(deploy_blk_num)).call().await.unwrap()._0;
+
+    assert_eq!(greeting_at_init, "Hello");
+
+    let greeting_after_change =
+        greeter.greet().block(BlockId::number(change_greeting_blk_num)).call().await.unwrap()._0;
+
+    assert_eq!(greeting_after_change, "World!");
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref #8518

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a new flag `--preserve-historical-states` (default: false) to be used with `--dump-state`. If this flag is enabled anvil will dump `InMemoryBlockStates` into the state file. 

Behind the scenes it uses `StateSnapshot` of corresponding `StateDb` and serializes it for dumping. 

This brings a breaking change to the anvil API `anvil_dump_state(&self)` -> `anvil_dump_state(&self, preserve_historical_states: bool)` 

These `historical_states` are then loaded into `InMemoryBlockStates` when called with `--load-state`

This enables users to make RPC calls at a particular `block` (preceding the state dump block) that existed in the previous anvil instance.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
