### PR TITLE
fix(test): increment nonce for calls too when isolate

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -993,12 +993,12 @@ impl Cheatcodes {
                     });
                     debug!(target: "cheatcodes", tx=?self.broadcastable_transactions.back().unwrap(), "broadcastable call");
 
-                    let prev = account.info.nonce;
-
-                    // Touch account to ensure that incremented nonce is committed
-                    account.mark_touch();
-                    account.info.nonce += 1;
-                    debug!(target: "cheatcodes", address=%broadcast.new_origin, nonce=prev+1, prev, "incremented nonce");
+                    // Explicitly increment nonce if calls are not isolated.
+                    if !self.config.evm_opts.isolate {
+                        let prev = account.info.nonce;
+                        account.info.nonce += 1;
+                        debug!(target: "cheatcodes", address=%broadcast.new_origin, nonce=prev+1, prev, "incremented nonce");
+                    }
                 } else if broadcast.single_call {
                     let msg =
                     "`staticcall`s are not allowed after `broadcast`; use `startBroadcast` instead";

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -257,15 +257,8 @@ pub struct InspectorData {
 /// non-isolated mode. For descriptions and workarounds for those changes see: <https://github.com/foundry-rs/foundry/pull/7186#issuecomment-1959102195>
 #[derive(Debug, Clone)]
 pub struct InnerContextData {
-    /// The sender of the inner EVM context.
-    /// It is also an origin of the transaction that created the inner EVM context.
-    sender: Address,
-    /// Nonce of the sender before invocation of the inner EVM context.
-    original_sender_nonce: u64,
     /// Origin of the transaction in the outer EVM context.
     original_origin: Address,
-    /// Whether the inner context was created by a CREATE transaction.
-    is_create: bool,
 }
 
 /// An inspector that calls multiple inspectors in sequence.
@@ -490,14 +483,6 @@ impl<'a> InspectorStackRefMut<'a> {
     fn adjust_evm_data_for_inner_context<DB: DatabaseExt>(&mut self, ecx: &mut EvmContext<DB>) {
         let inner_context_data =
             self.inner_context_data.as_ref().expect("should be called in inner context");
-        let sender_acc = ecx
-            .journaled_state
-            .state
-            .get_mut(&inner_context_data.sender)
-            .expect("failed to load sender");
-        if !inner_context_data.is_create {
-            sender_acc.info.nonce = inner_context_data.original_sender_nonce;
-        }
         ecx.env.tx.caller = inner_context_data.original_origin;
     }
 
@@ -541,13 +526,6 @@ impl<'a> InspectorStackRefMut<'a> {
 
         ecx.db.commit(ecx.journaled_state.state.clone());
 
-        let nonce = ecx
-            .journaled_state
-            .load_account(caller, &mut ecx.db)
-            .expect("failed to load caller")
-            .info
-            .nonce;
-
         let cached_env = ecx.env.clone();
 
         ecx.env.block.basefee = U256::ZERO;
@@ -555,7 +533,6 @@ impl<'a> InspectorStackRefMut<'a> {
         ecx.env.tx.transact_to = transact_to;
         ecx.env.tx.data = input;
         ecx.env.tx.value = value;
-        ecx.env.tx.nonce = Some(nonce);
         // Add 21000 to the gas limit to account for the base cost of transaction.
         ecx.env.tx.gas_limit = gas_limit + 21000;
         // If we haven't disabled gas limit checks, ensure that transaction gas limit will not
@@ -566,12 +543,7 @@ impl<'a> InspectorStackRefMut<'a> {
         }
         ecx.env.tx.gas_price = U256::ZERO;
 
-        self.inner_context_data = Some(InnerContextData {
-            sender: ecx.env.tx.caller,
-            original_origin: cached_env.tx.caller,
-            original_sender_nonce: nonce,
-            is_create: matches!(transact_to, TxKind::Create),
-        });
+        self.inner_context_data = Some(InnerContextData { original_origin: cached_env.tx.caller });
         self.in_inner_context = true;
 
         let env = EnvWithHandlerCfg::new_with_spec_id(ecx.env.clone(), ecx.spec_id());

--- a/testdata/default/cheats/Nonce.t.sol
+++ b/testdata/default/cheats/Nonce.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Counter {
+    uint256 public count;
+
+    function increment() public {
+        count += 1;
+    }
+}
+
+contract NonceIsolatedTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testIncrementNonce() public {
+        address bob = address(14);
+        vm.startPrank(bob);
+        Counter counter = new Counter();
+        assertEq(vm.getNonce(bob), 1);
+        counter.increment();
+        assertEq(vm.getNonce(bob), 2);
+        new Counter();
+        assertEq(vm.getNonce(bob), 3);
+        counter.increment();
+        assertEq(vm.getNonce(bob), 4);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #8811 take2
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- do not reset account nonce when running with isolate
- explicitly increment nonce in cheatcode inspector only if calls are not isolated
- `cargo test --all --features=isolate-by-default` pass
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
