### PR TITLE
fix(`cheatcodes`): apply_stateful in mockCallRevert

### DIFF
--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,6 +1,6 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, DatabaseExt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
-use revm::{interpreter::InstructionResult, primitives::Bytecode};
+use revm::{interpreter::InstructionResult, primitives::Bytecode, InnerEvmContext};
 use std::cmp::Ordering;
 
 /// Mocked call data.
@@ -49,15 +49,7 @@ impl Cheatcode for clearMockedCallsCall {
 impl Cheatcode for mockCall_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { callee, data, returnData } = self;
-        let acc = ccx.ecx.load_account(*callee)?;
-
-        // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
-        // check Solidity might perform.
-        let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
-        if empty_bytecode {
-            let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
-            ccx.ecx.journaled_state.set_code(*callee, code);
-        }
+        let _ = make_acc_non_empty(callee, ccx.ecx)?;
 
         mock_call(ccx.state, callee, data, None, returnData, InstructionResult::Return);
         Ok(Default::default())
@@ -76,15 +68,7 @@ impl Cheatcode for mockCall_1Call {
 impl Cheatcode for mockCallRevert_0Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { callee, data, revertData } = self;
-        let acc = ccx.ecx.load_account(*callee)?;
-
-        // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
-        // check Solidity might perform.
-        let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
-        if empty_bytecode {
-            let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
-            ccx.ecx.journaled_state.set_code(*callee, code);
-        }
+        let _ = make_acc_non_empty(callee, ccx.ecx)?;
 
         mock_call(ccx.state, callee, data, None, revertData, InstructionResult::Revert);
         Ok(Default::default())
@@ -94,15 +78,7 @@ impl Cheatcode for mockCallRevert_0Call {
 impl Cheatcode for mockCallRevert_1Call {
     fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
         let Self { callee, msgValue, data, revertData } = self;
-        let acc = ccx.ecx.load_account(*callee)?;
-
-        // Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
-        // check Solidity might perform.
-        let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
-        if empty_bytecode {
-            let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
-            ccx.ecx.journaled_state.set_code(*callee, code);
-        }
+        let _ = make_acc_non_empty(callee, ccx.ecx)?;
 
         mock_call(ccx.state, callee, data, Some(msgValue), revertData, InstructionResult::Revert);
         Ok(Default::default())
@@ -131,4 +107,18 @@ fn mock_call(
         MockCallDataContext { calldata: Bytes::copy_from_slice(cdata), value: value.copied() },
         MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) },
     );
+}
+
+// Etches a single byte onto the account if it is empty to circumvent the `extcodesize`
+// check Solidity might perform.
+fn make_acc_non_empty<DB: DatabaseExt>(callee: &Address, ecx: &mut InnerEvmContext<DB>) -> Result {
+    let acc = ecx.load_account(*callee)?;
+
+    let empty_bytecode = acc.info.code.as_ref().map_or(true, Bytecode::is_empty);
+    if empty_bytecode {
+        let code = Bytecode::new_raw(Bytes::from_static(&[0u8]));
+        ecx.journaled_state.set_code(*callee, code);
+    }
+
+    Ok(Default::default())
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #8556

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `apply_stateful` to access and update `acc.code` in case empty. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
