### PR TITLE
ci(release): fix workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,7 @@ jobs:
             svm_target_platform: windows-amd64
             platform: win32
             arch: amd64
-    env:
-      SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
-      PLATFORM_NAME: ${{ matrix.platform }}
-      TARGET: ${{ matrix.target }}
-      PROFILE: maxperf
-      OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
-      VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -134,6 +128,10 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build binaries
+        env:
+          TARGET: ${{ matrix.target }}
+          PROFILE: maxperf
+          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
         shell: bash
         run: |
           set -eo pipefail
@@ -161,6 +159,12 @@ jobs:
 
       - name: Archive binaries
         id: artifacts
+        env:
+          SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
+          PLATFORM_NAME: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+          PROFILE: maxperf
+          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
@@ -181,6 +185,10 @@ jobs:
       - name: Build man page
         id: man
         if: matrix.target == 'x86_64-unknown-linux-gnu'
+        env:
+          TARGET: ${{ matrix.target }}
+          PROFILE: maxperf
+          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
         shell: bash
         run: |
           sudo apt-get -y install help2man

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
           PLATFORM_NAME: ${{ matrix.platform }}
           OUT_DIR: target/${{ matrix.target }}/${{ env.PROFILE }}
           VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
+          ARCH: ${{ matrix.arch }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: Build binaries
         env:
+          SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
           OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  PROFILE: maxperf
 
 jobs:
   prepare:
@@ -103,7 +104,6 @@ jobs:
             svm_target_platform: windows-amd64
             platform: win32
             arch: amd64
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -129,8 +129,8 @@ jobs:
 
       - name: Build binaries
         env:
+          PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
-          PROFILE: maxperf
           OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
         shell: bash
         run: |
@@ -160,11 +160,9 @@ jobs:
       - name: Archive binaries
         id: artifacts
         env:
-          SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           PLATFORM_NAME: ${{ matrix.platform }}
-          TARGET: ${{ matrix.target }}
-          PROFILE: maxperf
-          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
+          OUT_DIR: target/${{ matrix.target }}/${{ env.PROFILE }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
         shell: bash
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
@@ -186,9 +184,8 @@ jobs:
         id: man
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         env:
-          TARGET: ${{ matrix.target }}
-          PROFILE: maxperf
-          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
+          OUT_DIR: target/${{ matrix.target }}/${{ env.PROFILE }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
         shell: bash
         run: |
           sudo apt-get -y install help2man

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           SVM_TARGET_PLATFORM: ${{ matrix.svm_target_platform }}
           PLATFORM_NAME: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
-          OUT_DIR: target/${{ env.TARGET }}/${{ env.PROFILE }}
+          OUT_DIR: target/${{ matrix.target }}/${{ env.PROFILE }}
         shell: bash
         run: |
           set -eo pipefail


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes: https://github.com/foundry-rs/foundry/issues/8887
Fixes: https://github.com/foundry-rs/foundry/pull/8888

Reference test release: https://github.com/foundry-rs/foundry/actions/runs/10925357538 (note it doesn't include the last fixes in regards to `env.` variables)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Github workflow apparently does not permit `env` at this indentation
- `env.` variables set inside of same block above are not directly available (`env.TARGET`)
- Adds back`$ARCH` environment variable