### PR TITLE
fix: bump `revm-inspectors` to 0.7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ solang-parser = "=0.3.3"
 # no default features to avoid c-kzg
 revm = { version = "14.0.1", default-features = false }
 revm-primitives = { version = "9.0.1", default-features = false }
-revm-inspectors = { version = "0.6", features = ["serde"] }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", tag = "v0.7.4", features = ["serde"] }
 
 ## ethers
 ethers-contract-abigen = { version = "2.0.14", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fixes #8895. Upstream semver issue in `alloy` caused downstream issues in `proof-of-sql` which uses `forge-script` which requires us to bump `revm-inspectors` to 0.7.4.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
See above.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
