### PR TITLE
feat: implement `parseTomlType` cheats

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6473,6 +6473,66 @@
     },
     {
       "func": {
+        "id": "parseTomlTypeArray",
+        "description": "Parses a string of TOML data at `key` and coerces it to type array corresponding to `typeDescription`.",
+        "declaration": "function parseTomlTypeArray(string calldata toml, string calldata key, string calldata typeDescription) external pure returns (bytes memory);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "parseTomlTypeArray(string,string,string)",
+        "selector": "0x49be3743",
+        "selectorBytes": [
+          73,
+          190,
+          55,
+          67
+        ]
+      },
+      "group": "toml",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "parseTomlType_0",
+        "description": "Parses a string of TOML data and coerces it to type corresponding to `typeDescription`.",
+        "declaration": "function parseTomlType(string calldata toml, string calldata typeDescription) external pure returns (bytes memory);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "parseTomlType(string,string)",
+        "selector": "0x47fa5e11",
+        "selectorBytes": [
+          71,
+          250,
+          94,
+          17
+        ]
+      },
+      "group": "toml",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "parseTomlType_1",
+        "description": "Parses a string of TOML data at `key` and coerces it to type corresponding to `typeDescription`.",
+        "declaration": "function parseTomlType(string calldata toml, string calldata key, string calldata typeDescription) external pure returns (bytes memory);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "parseTomlType(string,string,string)",
+        "selector": "0xf9fa5cdb",
+        "selectorBytes": [
+          249,
+          250,
+          92,
+          219
+        ]
+      },
+      "group": "toml",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "parseTomlUint",
         "description": "Parses a string of TOML data at `key` and coerces it to `uint256`.",
         "declaration": "function parseTomlUint(string calldata toml, string calldata key) external pure returns (uint256);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2134,6 +2134,19 @@ interface Vm {
         pure
         returns (bytes32[] memory);
 
+    /// Parses a string of TOML data and coerces it to type corresponding to `typeDescription`.
+    #[cheatcode(group = Toml)]
+    function parseTomlType(string calldata toml, string calldata typeDescription) external pure returns (bytes memory);
+    /// Parses a string of TOML data at `key` and coerces it to type corresponding to `typeDescription`.
+    #[cheatcode(group = Toml)]
+    function parseTomlType(string calldata toml, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
+    /// Parses a string of TOML data at `key` and coerces it to type array corresponding to `typeDescription`.
+    #[cheatcode(group = Toml)]
+    function parseTomlTypeArray(string calldata toml, string calldata key, string calldata typeDescription)
+        external
+        pure
+        returns (bytes memory);
+
     /// Returns an array of all the keys in a TOML table.
     #[cheatcode(group = Toml)]
     function parseTomlKeys(string calldata toml, string calldata key) external pure returns (string[] memory keys);

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -654,7 +654,7 @@ fn serialize_json(
 }
 
 /// Resolves a [DynSolType] from user input.
-fn resolve_type(type_description: &str) -> Result<DynSolType> {
+pub(super) fn resolve_type(type_description: &str) -> Result<DynSolType> {
     if let Ok(ty) = DynSolType::parse(type_description) {
         return Ok(ty);
     };

--- a/crates/cheatcodes/src/toml.rs
+++ b/crates/cheatcodes/src/toml.rs
@@ -3,12 +3,13 @@
 use crate::{
     json::{
         canonicalize_json_path, check_json_key_exists, parse_json, parse_json_coerce,
-        parse_json_keys,
+        parse_json_keys, resolve_type,
     },
     Cheatcode, Cheatcodes, Result,
     Vm::*,
 };
 use alloy_dyn_abi::DynSolType;
+use alloy_sol_types::SolValue;
 use foundry_common::fs;
 use foundry_config::fs_permissions::FsAccessKind;
 use serde_json::Value as JsonValue;
@@ -130,6 +131,28 @@ impl Cheatcode for parseTomlBytes32ArrayCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { toml, key } = self;
         parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(DynSolType::FixedBytes(32))))
+    }
+}
+
+impl Cheatcode for parseTomlType_0Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { toml, typeDescription } = self;
+        parse_toml_coerce(toml, "$", &resolve_type(typeDescription)?).map(|v| v.abi_encode())
+    }
+}
+
+impl Cheatcode for parseTomlType_1Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { toml, key, typeDescription } = self;
+        parse_toml_coerce(toml, key, &resolve_type(typeDescription)?).map(|v| v.abi_encode())
+    }
+}
+
+impl Cheatcode for parseTomlTypeArrayCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { toml, key, typeDescription } = self;
+        let ty = resolve_type(typeDescription)?;
+        parse_toml_coerce(toml, key, &DynSolType::Array(Box::new(ty))).map(|v| v.abi_encode())
     }
 }
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -319,6 +319,9 @@ interface Vm {
     function parseTomlKeys(string calldata toml, string calldata key) external pure returns (string[] memory keys);
     function parseTomlString(string calldata toml, string calldata key) external pure returns (string memory);
     function parseTomlStringArray(string calldata toml, string calldata key) external pure returns (string[] memory);
+    function parseTomlTypeArray(string calldata toml, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
+    function parseTomlType(string calldata toml, string calldata typeDescription) external pure returns (bytes memory);
+    function parseTomlType(string calldata toml, string calldata key, string calldata typeDescription) external pure returns (bytes memory);
     function parseTomlUint(string calldata toml, string calldata key) external pure returns (uint256);
     function parseTomlUintArray(string calldata toml, string calldata key) external pure returns (uint256[] memory);
     function parseToml(string calldata toml) external pure returns (bytes memory abiEncodedData);

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -334,36 +334,36 @@ contract ParseTomlTest is DSTest {
 contract WriteTomlTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
-    string toml1;
-    string toml2;
+    string json1;
+    string json2;
 
     function setUp() public {
-        toml1 = "example";
-        toml2 = "example2";
+        json1 = "example";
+        json2 = "example2";
     }
 
-    struct simpleToml {
+    struct simpleStruct {
         uint256 a;
         string b;
     }
 
-    struct notSimpleToml {
+    struct nestedStruct {
         uint256 a;
         string b;
-        simpleToml c;
+        simpleStruct c;
     }
 
-    function test_serializeNotSimpleToml() public {
-        string memory toml3 = "toml3";
+    function test_serializeNestedStructToml() public {
+        string memory json3 = "json3";
         string memory path = "fixtures/Toml/write_complex_test.toml";
-        vm.serializeUint(toml3, "a", uint256(123));
-        string memory semiFinal = vm.serializeString(toml3, "b", "test");
-        string memory finalToml = vm.serializeString(toml3, "c", semiFinal);
-        console.log(finalToml);
-        vm.writeToml(finalToml, path);
+        vm.serializeUint(json3, "a", uint256(123));
+        string memory semiFinal = vm.serializeString(json3, "b", "test");
+        string memory finalJson = vm.serializeString(json3, "c", semiFinal);
+        console.log(finalJson);
+        vm.writeToml(finalJson, path);
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml);
-        notSimpleToml memory decodedData = abi.decode(data, (notSimpleToml));
+        nestedStruct memory decodedData = abi.decode(data, (nestedStruct));
         console.log(decodedData.a);
         assertEq(decodedData.a, 123);
     }
@@ -372,7 +372,7 @@ contract WriteTomlTest is DSTest {
         string memory path = "fixtures/Toml/write_complex_test.toml";
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml, ".");
-        notSimpleToml memory decodedData = abi.decode(data, (notSimpleToml));
+        nestedStruct memory decodedData = abi.decode(data, (nestedStruct));
         console.log(decodedData.a);
         assertEq(decodedData.a, 123);
     }
@@ -392,24 +392,24 @@ contract WriteTomlTest is DSTest {
     }
 
     function test_writeToml() public {
-        string memory toml3 = "toml3";
+        string memory json3 = "json3";
         string memory path = "fixtures/Toml/write_test.toml";
-        vm.serializeUint(toml3, "a", uint256(123));
-        string memory finalToml = vm.serializeString(toml3, "b", "test");
-        vm.writeToml(finalToml, path);
+        vm.serializeUint(json3, "a", uint256(123));
+        string memory finalJson = vm.serializeString(json3, "b", "test");
+        vm.writeToml(finalJson, path);
 
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml);
-        simpleToml memory decodedData = abi.decode(data, (simpleToml));
+        simpleStruct memory decodedData = abi.decode(data, (simpleStruct));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 
         // write toml3 to key b
-        vm.writeToml(finalToml, path, ".b");
+        vm.writeToml(finalJson, path, ".b");
         // read again
         toml = vm.readFile(path);
         data = vm.parseToml(toml, ".b");
-        decodedData = abi.decode(data, (simpleToml));
+        decodedData = abi.decode(data, (simpleStruct));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -243,14 +243,14 @@ contract ParseTomlTest is DSTest {
         assertEq(bytesArray[1], hex"02");
     }
 
-    struct Nested {
+    struct NestedStruct {
         uint256 number;
         string str;
     }
 
     function test_nestedObject() public {
         bytes memory data = vm.parseToml(toml, ".nestedObject");
-        Nested memory nested = abi.decode(data, (Nested));
+        NestedStruct memory nested = abi.decode(data, (NestedStruct));
         assertEq(nested.number, 9223372036854775807); // TOML is limited to 64-bit integers
         assertEq(nested.str, "NEST");
     }

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -6,7 +6,7 @@ import "cheats/Vm.sol";
 import "../logs/console.sol";
 
 library TomlStructs {
-        address constant HEVM_ADDRESS = address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+    address constant HEVM_ADDRESS = address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
     Vm constant vm = Vm(HEVM_ADDRESS);
 
     // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^FlatToml
@@ -307,7 +307,6 @@ contract ParseTomlTest is DSTest {
     // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^NestedToml
     string constant schema_NestedToml =
         "NestedToml(FlatToml[] members,AnotherFlatToml inner,string name)AnotherFlatToml(bytes4 fixedBytes)FlatToml(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";
-
 
     function test_parseTomlType() public {
         string memory readToml = vm.readFile("fixtures/Toml/nested_toml_struct.toml");

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -5,7 +5,81 @@ import "ds-test/test.sol";
 import "cheats/Vm.sol";
 import "../logs/console.sol";
 
+library TomlStructs {
+        address constant HEVM_ADDRESS = address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^FlatToml
+    string constant schema_FlatToml =
+        "FlatToml(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";
+
+    // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^NestedToml
+    string constant schema_NestedToml =
+        "NestedToml(FlatToml[] members,AnotherFlatToml inner,string name)AnotherFlatToml(bytes4 fixedBytes)FlatToml(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";
+
+    function deserializeFlatToml(string memory toml) internal pure returns (ParseTomlTest.FlatToml memory) {
+        return abi.decode(vm.parseTomlType(toml, schema_FlatToml), (ParseTomlTest.FlatToml));
+    }
+
+    function deserializeFlatToml(string memory toml, string memory path)
+        internal
+        pure
+        returns (ParseTomlTest.FlatToml memory)
+    {
+        return abi.decode(vm.parseTomlType(toml, path, schema_FlatToml), (ParseTomlTest.FlatToml));
+    }
+
+    function deserializeFlatTomlArray(string memory toml, string memory path)
+        internal
+        pure
+        returns (ParseTomlTest.FlatToml[] memory)
+    {
+        return abi.decode(vm.parseTomlTypeArray(toml, path, schema_FlatToml), (ParseTomlTest.FlatToml[]));
+    }
+
+    function deserializeNestedToml(string memory toml) internal pure returns (ParseTomlTest.NestedToml memory) {
+        return abi.decode(vm.parseTomlType(toml, schema_NestedToml), (ParseTomlTest.NestedToml));
+    }
+
+    function deserializeNestedToml(string memory toml, string memory path)
+        internal
+        pure
+        returns (ParseTomlTest.NestedToml memory)
+    {
+        return abi.decode(vm.parseTomlType(toml, path, schema_NestedToml), (ParseTomlTest.NestedToml));
+    }
+
+    function deserializeNestedTomlArray(string memory toml, string memory path)
+        internal
+        pure
+        returns (ParseTomlTest.NestedToml[] memory)
+    {
+        return abi.decode(vm.parseTomlType(toml, path, schema_NestedToml), (ParseTomlTest.NestedToml[]));
+    }
+}
+
 contract ParseTomlTest is DSTest {
+    using TomlStructs for *;
+
+    struct FlatToml {
+        uint256 a;
+        int24[][] arr;
+        string str;
+        bytes b;
+        address addr;
+        bytes32 fixedBytes;
+    }
+
+    struct AnotherFlatToml {
+        bytes4 fixedBytes;
+    }
+
+    struct NestedToml {
+        FlatToml[] members;
+        AnotherFlatToml inner;
+        string name;
+    }
+
     Vm constant vm = Vm(HEVM_ADDRESS);
     string toml;
 
@@ -181,8 +255,8 @@ contract ParseTomlTest is DSTest {
         assertEq(nested.str, "NEST");
     }
 
-    function test_advancedJsonPath() public {
-        bytes memory data = vm.parseToml(toml, ".advancedJsonPath[*].id");
+    function test_advancedTomlPath() public {
+        bytes memory data = vm.parseToml(toml, ".advancedTomlPath[*].id");
         uint256[] memory numbers = abi.decode(data, (uint256[]));
         assertEq(numbers[0], 1);
         assertEq(numbers[1], 2);
@@ -225,48 +299,81 @@ contract ParseTomlTest is DSTest {
         vm._expectCheatcodeRevert("key \".*\" must return exactly one JSON object");
         vm.parseTomlKeys(tomlString, ".*");
     }
+
+    // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^FlatToml
+    string constant schema_FlatToml =
+        "FlatToml(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";
+
+    // forge eip712 testdata/default/cheats/Toml.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^NestedToml
+    string constant schema_NestedToml =
+        "NestedToml(FlatToml[] members,AnotherFlatToml inner,string name)AnotherFlatToml(bytes4 fixedBytes)FlatToml(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";
+
+
+    function test_parseTomlType() public {
+        string memory readToml = vm.readFile("fixtures/Toml/nested_toml_struct.toml");
+        NestedToml memory data = readToml.deserializeNestedToml();
+        assertEq(data.members.length, 2);
+
+        FlatToml memory expected = FlatToml({
+            a: 200,
+            arr: new int24[][](0),
+            str: "some other string",
+            b: hex"0000000000000000000000000000000000000000",
+            addr: 0x167D91deaEEE3021161502873d3bcc6291081648,
+            fixedBytes: 0xed1c7beb1f00feaaaec5636950d6edb25a8d4fedc8deb2711287b64c4d27719d
+        });
+
+        assertEq(keccak256(abi.encode(data.members[1])), keccak256(abi.encode(expected)));
+        assertEq(bytes32(data.inner.fixedBytes), bytes32(bytes4(0x12345678)));
+
+        FlatToml[] memory members = TomlStructs.deserializeFlatTomlArray(readToml, ".members");
+
+        assertEq(keccak256(abi.encode(members)), keccak256(abi.encode(data.members)));
+    }
 }
 
 contract WriteTomlTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
-    string json1;
-    string json2;
+    string toml1;
+    string toml2;
 
     function setUp() public {
-        json1 = "example";
-        json2 = "example2";
+        toml1 = "example";
+        toml2 = "example2";
     }
 
-    struct simpleJson {
+    struct simpleToml {
         uint256 a;
         string b;
     }
 
-    struct notSimpleJson {
+    struct notSimpleToml {
         uint256 a;
         string b;
-        simpleJson c;
+        simpleToml c;
     }
 
     function test_serializeNotSimpleToml() public {
-        string memory json3 = "json3";
+        string memory toml3 = "toml3";
         string memory path = "fixtures/Toml/write_complex_test.toml";
-        vm.serializeUint(json3, "a", uint256(123));
-        string memory semiFinal = vm.serializeString(json3, "b", "test");
-        string memory finalJson = vm.serializeString(json3, "c", semiFinal);
-        console.log(finalJson);
-        vm.writeToml(finalJson, path);
+        vm.serializeUint(toml3, "a", uint256(123));
+        string memory semiFinal = vm.serializeString(toml3, "b", "test");
+        string memory finalToml = vm.serializeString(toml3, "c", semiFinal);
+        console.log(finalToml);
+        vm.writeToml(finalToml, path);
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml);
-        notSimpleJson memory decodedData = abi.decode(data, (notSimpleJson));
+        notSimpleToml memory decodedData = abi.decode(data, (notSimpleToml));
+        console.log(decodedData.a);
+        assertEq(decodedData.a, 123);
     }
 
     function test_retrieveEntireToml() public {
         string memory path = "fixtures/Toml/write_complex_test.toml";
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml, ".");
-        notSimpleJson memory decodedData = abi.decode(data, (notSimpleJson));
+        notSimpleToml memory decodedData = abi.decode(data, (notSimpleToml));
         console.log(decodedData.a);
         assertEq(decodedData.a, 123);
     }
@@ -286,24 +393,24 @@ contract WriteTomlTest is DSTest {
     }
 
     function test_writeToml() public {
-        string memory json3 = "json3";
+        string memory toml3 = "toml3";
         string memory path = "fixtures/Toml/write_test.toml";
-        vm.serializeUint(json3, "a", uint256(123));
-        string memory finalJson = vm.serializeString(json3, "b", "test");
-        vm.writeToml(finalJson, path);
+        vm.serializeUint(toml3, "a", uint256(123));
+        string memory finalToml = vm.serializeString(toml3, "b", "test");
+        vm.writeToml(finalToml, path);
 
         string memory toml = vm.readFile(path);
         bytes memory data = vm.parseToml(toml);
-        simpleJson memory decodedData = abi.decode(data, (simpleJson));
+        simpleToml memory decodedData = abi.decode(data, (simpleToml));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 
-        // write json3 to key b
-        vm.writeToml(finalJson, path, ".b");
+        // write toml3 to key b
+        vm.writeToml(finalToml, path, ".b");
         // read again
         toml = vm.readFile(path);
         data = vm.parseToml(toml, ".b");
-        decodedData = abi.decode(data, (simpleJson));
+        decodedData = abi.decode(data, (simpleToml));
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 

--- a/testdata/default/cheats/Toml.t.sol
+++ b/testdata/default/cheats/Toml.t.sol
@@ -404,7 +404,7 @@ contract WriteTomlTest is DSTest {
         assertEq(decodedData.a, 123);
         assertEq(decodedData.b, "test");
 
-        // write toml3 to key b
+        // write json3 to key b
         vm.writeToml(finalJson, path, ".b");
         // read again
         toml = vm.readFile(path);

--- a/testdata/fixtures/Toml/nested_toml_struct.toml
+++ b/testdata/fixtures/Toml/nested_toml_struct.toml
@@ -1,0 +1,23 @@
+name = "test"
+
+[[members]]
+a = 100
+arr = [
+    [1, -2, -5],
+    [1000, 2000, 0]
+]
+str = "some string"
+b = "0x"
+addr = "0x0000000000000000000000000000000000000000"
+fixedBytes = "0x8ae3fc6bd1b150a73ec4afe3ef136fa2f88e9c96131c883c5e4a4714811c1598"
+
+[[members]]
+a = 200
+arr = []
+str = "some other string"
+b = "0x0000000000000000000000000000000000000000"
+addr = "0x167D91deaEEE3021161502873d3bcc6291081648"
+fixedBytes = "0xed1c7beb1f00feaaaec5636950d6edb25a8d4fedc8deb2711287b64c4d27719d"
+
+[inner]
+fixedBytes = "0x12345678"

--- a/testdata/fixtures/Toml/test.toml
+++ b/testdata/fixtures/Toml/test.toml
@@ -43,8 +43,8 @@ bytesStringArray = ["0x01", "0x02"]
 number = 9223372036854775807 # TOML is limited to 64-bit integers
 str = "NEST"
 
-[[advancedJsonPath]]
+[[advancedTomlPath]]
 id = 1
 
-[[advancedJsonPath]]
+[[advancedTomlPath]]
 id = 2


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #8810 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Mostly a copy/paste of #8345.

Minor: removal of references of `json` in `testdata/default/cheats/Toml.t.sol` and use of `toml` instead. 
