### PR TITLE
chore(evm): use dyn DatabaseExt in inspect

### DIFF
--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -62,7 +62,7 @@ impl<'a> CowBackend<'a> {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'b, I: InspectorExt<&'b mut Self>>(
+    pub fn inspect<'b, I: InspectorExt<&'b mut dyn DatabaseExt>>(
         &'b mut self,
         env: &mut EnvWithHandlerCfg,
         inspector: I,
@@ -71,7 +71,11 @@ impl<'a> CowBackend<'a> {
         // already, we reset the initialized state
         self.is_initialized = false;
         self.spec_id = env.handler_cfg.spec_id;
-        let mut evm = crate::utils::new_evm_with_inspector(self, env.clone(), inspector);
+        let mut evm = crate::utils::new_evm_with_inspector(
+            self as &mut dyn DatabaseExt,
+            env.clone(),
+            inspector,
+        );
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -749,13 +749,17 @@ impl Backend {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'a, I: InspectorExt<&'a mut Self>>(
+    pub fn inspect<'a, I: InspectorExt<&'a mut dyn DatabaseExt>>(
         &'a mut self,
         env: &mut EnvWithHandlerCfg,
         inspector: I,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(env);
-        let mut evm = crate::utils::new_evm_with_inspector(self, env.clone(), inspector);
+        let mut evm = crate::utils::new_evm_with_inspector(
+            self as &mut dyn DatabaseExt,
+            env.clone(),
+            inspector,
+        );
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;
 


### PR DESCRIPTION
Gets rid of a few more revm monomorphizations (2/6 + 1 with https://github.com/foundry-rs/foundry/pull/8919)

Negligible perf impact since Db access is rare and cost of dynamic dispatch is minimal compared to hashmap lookups or network requests that the db does