### PR TITLE
fix: #8759, default (low) gas limit set even when disabled, use custom gas_limit on forks

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1291,7 +1291,7 @@ latest block number: {latest_block}"
         u64::MAX as u128
     }
 
-    /// Returns the gas limit to use for the fork
+    /// Returns the gas limit for a non forked anvil instance
     ///
     /// Checks the config for the `disable_block_gas_limit` flag
     pub(crate) fn gas_limit(&self) -> u128 {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -312,7 +312,8 @@ Gas Limit
                 } else {
                     self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT).to_string()
                 }
-            }.green()
+            }
+            .green()
         );
 
         let _ = write!(
@@ -1175,7 +1176,7 @@ latest block number: {latest_block}"
                     gas_limit,
                     block.header.base_fee_per_gas.unwrap_or_default(),
                 );
-                
+
                 // update next base fee
                 fees.set_base_fee(next_block_base_fee);
             }
@@ -1275,12 +1276,12 @@ latest block number: {latest_block}"
                 return block.header.gas_limit;
             }
         }
-        
+
         u64::MAX as u128
     }
 
     /// Returns the gas limit to use for the fork
-    /// 
+    ///
     /// Checks the config for the `disable_block_gas_limit` flag
     pub(crate) fn gas_limit(&self) -> u128 {
         if self.disable_block_gas_limit {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -579,7 +579,6 @@ impl NodeConfig {
     #[must_use]
     pub fn disable_block_gas_limit(mut self, disable_block_gas_limit: bool) -> Self {
         self.disable_block_gas_limit = disable_block_gas_limit;
-
         self
     }
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -356,11 +356,9 @@ Genesis Timestamp
 
         let gas_limit = match self.gas_limit {
             // if we have a disabled flag we should max out the limit
-            Some(_) | None if self.disable_block_gas_limit => {
-                serde_json::Value::String(u64::MAX.to_string())
-            }
-            Some(limit) => serde_json::Value::String(limit.to_string()),
-            _ => serde_json::Value::Null,
+            Some(_) | None if self.disable_block_gas_limit => Some(u64::MAX.to_string()),
+            Some(limit) => Some(limit.to_string()),
+            _ => None,
         };
 
         if let Some(fork) = fork {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -570,7 +570,6 @@ impl NodeConfig {
     #[must_use]
     pub fn with_gas_limit(mut self, gas_limit: Option<u128>) -> Self {
         self.gas_limit = gas_limit;
-
         self
     }
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -19,7 +19,8 @@ use alloy_genesis::Genesis;
 use alloy_network::AnyNetwork;
 use alloy_primitives::{hex, utils::Unit, BlockNumber, TxHash, U256};
 use alloy_provider::Provider;
-use alloy_rpc_types::{BlockNumberOrTag, Transaction};
+use alloy_rpc_types::{Block, BlockNumberOrTag, Transaction};
+use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_signer_local::{
     coins_bip39::{English, Mnemonic},
@@ -59,6 +60,8 @@ use yansi::Paint;
 pub const NODE_PORT: u16 = 8545;
 /// Default chain id of the node
 pub const CHAIN_ID: u64 = 31337;
+/// The default gas limit for all transactions
+pub const DEFAULT_GAS_LIMIT: u128 = 30_000_000;
 /// Default mnemonic for dev accounts
 pub const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
 
@@ -90,7 +93,7 @@ pub struct NodeConfig {
     /// Chain ID of the EVM chain
     pub chain_id: Option<u64>,
     /// Default gas limit for all txs
-    pub gas_limit: u128,
+    pub gas_limit: Option<u128>,
     /// If set to `true`, disables the block gas limit
     pub disable_block_gas_limit: bool,
     /// Default gas price for all txs
@@ -303,7 +306,13 @@ Gas Limit
 
 {}
 "#,
-            self.gas_limit.green()
+            {
+                if self.disable_block_gas_limit {
+                    "Disabled".to_string()
+                } else {
+                    self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT).to_string()
+                }
+            }.green()
         );
 
         let _ = write!(
@@ -349,7 +358,7 @@ Genesis Timestamp
               "wallet": wallet_description,
               "base_fee": format!("{}", self.get_base_fee()),
               "gas_price": format!("{}", self.get_gas_price()),
-              "gas_limit": format!("{}", self.gas_limit),
+              "gas_limit": format!("{}", self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT)),
             })
         } else {
             json!({
@@ -358,7 +367,7 @@ Genesis Timestamp
               "wallet": wallet_description,
               "base_fee": format!("{}", self.get_base_fee()),
               "gas_price": format!("{}", self.get_gas_price()),
-              "gas_limit": format!("{}", self.gas_limit),
+              "gas_limit": format!("{}", self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT)),
               "genesis_timestamp": format!("{}", self.get_genesis_timestamp()),
             })
         }
@@ -390,7 +399,7 @@ impl Default for NodeConfig {
         let genesis_accounts = AccountGenerator::new(10).phrase(DEFAULT_MNEMONIC).gen();
         Self {
             chain_id: None,
-            gas_limit: 30_000_000,
+            gas_limit: None,
             disable_block_gas_limit: false,
             gas_price: None,
             hardfork: None,
@@ -546,9 +555,8 @@ impl NodeConfig {
     /// Sets the gas limit
     #[must_use]
     pub fn with_gas_limit(mut self, gas_limit: Option<u128>) -> Self {
-        if let Some(gas_limit) = gas_limit {
-            self.gas_limit = gas_limit;
-        }
+        self.gas_limit = gas_limit;
+
         self
     }
 
@@ -558,6 +566,7 @@ impl NodeConfig {
     #[must_use]
     pub fn disable_block_gas_limit(mut self, disable_block_gas_limit: bool) -> Self {
         self.disable_block_gas_limit = disable_block_gas_limit;
+
         self
     }
 
@@ -962,7 +971,7 @@ impl NodeConfig {
         let env = revm::primitives::Env {
             cfg: cfg.cfg_env,
             block: BlockEnv {
-                gas_limit: U256::from(self.gas_limit),
+                gas_limit: U256::from(self.gas_limit()),
                 basefee: U256::from(self.get_base_fee()),
                 ..Default::default()
             },
@@ -1140,15 +1149,7 @@ latest block number: {latest_block}"
             panic!("Failed to get block for block number: {fork_block_number}")
         };
 
-        // we only use the gas limit value of the block if it is non-zero and the block gas
-        // limit is enabled, since there are networks where this is not used and is always
-        // `0x0` which would inevitably result in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
-        let gas_limit = if self.disable_block_gas_limit || block.header.gas_limit == 0 {
-            u64::MAX as u128
-        } else {
-            block.header.gas_limit
-        };
-
+        let gas_limit = self.fork_gas_limit(&block);
         env.block = BlockEnv {
             number: U256::from(fork_block_number),
             timestamp: U256::from(block.header.timestamp),
@@ -1171,9 +1172,10 @@ latest block number: {latest_block}"
                 // the next block
                 let next_block_base_fee = fees.get_next_block_base_fee_per_gas(
                     block.header.gas_used,
-                    block.header.gas_limit,
+                    gas_limit,
                     block.header.base_fee_per_gas.unwrap_or_default(),
                 );
+                
                 // update next base fee
                 fees.set_base_fee(next_block_base_fee);
             }
@@ -1260,6 +1262,32 @@ latest block number: {latest_block}"
         db.insert_block_hash(U256::from(config.block_number), config.block_hash);
 
         (db, config)
+    }
+
+    /// we only use the gas limit value of the block if it is non-zero and the block gas
+    /// limit is enabled, since there are networks where this is not used and is always
+    /// `0x0` which would inevitably result in `OutOfGas` errors as soon as the evm is about to record gas, See also <https://github.com/foundry-rs/foundry/issues/3247>
+    pub(crate) fn fork_gas_limit(&self, block: &Block<WithOtherFields<Transaction>>) -> u128 {
+        if !self.disable_block_gas_limit {
+            if let Some(gas_limit) = self.gas_limit {
+                return gas_limit;
+            } else if block.header.gas_limit > 0 {
+                return block.header.gas_limit;
+            }
+        }
+        
+        u64::MAX as u128
+    }
+
+    /// Returns the gas limit to use for the fork
+    /// 
+    /// Checks the config for the `disable_block_gas_limit` flag
+    pub(crate) fn gas_limit(&self) -> u128 {
+        if self.disable_block_gas_limit {
+            return u64::MAX as u128;
+        }
+
+        self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT)
     }
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -441,8 +441,7 @@ impl Backend {
                     *self.fork.write() = Some(fork);
                     *self.env.write() = env;
                 } else {
-                    let gas_limit =
-                        self.node_config.read().await.clone().fork_gas_limit(&fork_block);
+                    let gas_limit = self.node_config.read().await.fork_gas_limit(&fork_block);
                     let mut env = self.env.write();
 
                     env.cfg.chain_id = fork.chain_id();

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -441,12 +441,14 @@ impl Backend {
                     *self.fork.write() = Some(fork);
                     *self.env.write() = env;
                 } else {
+                    let gas_limit = self.node_config.read().await.clone().fork_gas_limit(&fork_block);
                     let mut env = self.env.write();
+
                     env.cfg.chain_id = fork.chain_id();
                     env.block = BlockEnv {
                         number: U256::from(fork_block_number),
                         timestamp: U256::from(fork_block.header.timestamp),
-                        gas_limit: U256::from(fork_block.header.gas_limit),
+                        gas_limit: U256::from(gas_limit),
                         difficulty: fork_block.header.difficulty,
                         prevrandao: Some(fork_block.header.mix_hash.unwrap_or_default()),
                         // Keep previous `coinbase` and `basefee` value
@@ -459,7 +461,7 @@ impl Backend {
                     // the next block
                     let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
                         fork_block.header.gas_used,
-                        fork_block.header.gas_limit,
+                        gas_limit,
                         fork_block.header.base_fee_per_gas.unwrap_or_default(),
                     );
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -441,7 +441,8 @@ impl Backend {
                     *self.fork.write() = Some(fork);
                     *self.env.write() = env;
                 } else {
-                    let gas_limit = self.node_config.read().await.clone().fork_gas_limit(&fork_block);
+                    let gas_limit =
+                        self.node_config.read().await.clone().fork_gas_limit(&fork_block);
                     let mut env = self.env.write();
 
                     env.cfg.chain_id = fork.chain_id();

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -45,7 +45,9 @@ use tokio::{
 mod service;
 
 mod config;
-pub use config::{AccountGenerator, ForkChoice, NodeConfig, CHAIN_ID, VERSION_MESSAGE, DEFAULT_GAS_LIMIT};
+pub use config::{
+    AccountGenerator, ForkChoice, NodeConfig, CHAIN_ID, DEFAULT_GAS_LIMIT, VERSION_MESSAGE,
+};
 
 mod hardfork;
 pub use hardfork::EthereumHardfork;

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -45,7 +45,7 @@ use tokio::{
 mod service;
 
 mod config;
-pub use config::{AccountGenerator, ForkChoice, NodeConfig, CHAIN_ID, VERSION_MESSAGE};
+pub use config::{AccountGenerator, ForkChoice, NodeConfig, CHAIN_ID, VERSION_MESSAGE, DEFAULT_GAS_LIMIT};
 
 mod hardfork;
 pub use hardfork::EthereumHardfork;

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -69,10 +69,26 @@ async fn test_fork_gas_limit_applied_from_config() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_gas_limit_disabled_from_config() {
-    let (api, _handle) = spawn(fork_config().disable_block_gas_limit(true)).await;
+    let (api, handle) = spawn(fork_config().disable_block_gas_limit(true)).await;
 
     // see https://github.com/foundry-rs/foundry/pull/8933
     assert_eq!(api.gas_limit(), U256::from(U64::MAX));
+
+    // try to mine a couple blocks
+    let provider = handle.http_provider();
+    let tx = TransactionRequest::default()
+        .to(Address::random())
+        .value(U256::from(1337u64))
+        .from(handle.dev_wallets().next().unwrap().address());
+    let tx = WithOtherFields::new(tx);
+    let _ = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+
+    let tx = TransactionRequest::default()
+        .to(Address::random())
+        .value(U256::from(1337u64))
+        .from(handle.dev_wallets().next().unwrap().address());
+    let tx = WithOtherFields::new(tx);
+    let _ = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -2,13 +2,28 @@
 
 use crate::utils::http_provider_with_signer;
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{uint, Address, U256, U64};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use anvil::{eth::fees::INITIAL_BASE_FEE, spawn, NodeConfig};
 
 const GAS_TRANSFER: u128 = 21_000;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gas_limit_applied_from_config() {
+    let (api, _handle) = spawn(NodeConfig::test().with_gas_limit(Some(10_000_000))).await;
+
+    assert_eq!(api.gas_limit(), uint!(10_000_000_U256));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gas_limit_disabled_from_config() {
+    let (api, _handle) = spawn(NodeConfig::test().disable_block_gas_limit(true)).await;
+
+    // see https://github.com/foundry-rs/foundry/pull/8933
+    assert_eq!(api.gas_limit(), U256::from(U64::MAX));
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_full_block() {

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -230,14 +230,14 @@ async fn can_reject_too_high_gas_limits() {
 // <https://github.com/foundry-rs/foundry/issues/8094>
 #[tokio::test(flavor = "multi_thread")]
 async fn can_mine_large_gas_limit() {
-    let (api, handle) = spawn(NodeConfig::test().disable_block_gas_limit(true)).await;
+    let (_, handle) = spawn(NodeConfig::test().disable_block_gas_limit(true)).await;
     let provider = handle.http_provider();
 
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
     let from = accounts[0].address();
     let to = accounts[1].address();
 
-    let gas_limit = api.gas_limit().to::<u128>();
+    let gas_limit = anvil::DEFAULT_GAS_LIMIT;
     let amount = handle.genesis_balance().checked_div(U256::from(3u64)).unwrap();
 
     let tx =

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -135,6 +135,10 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
 
     let key = if is_infura { INFURA_KEYS[idx] } else { ALCHEMY_KEYS[idx - INFURA_KEYS.len()] };
 
+    if matches!(chain, NamedChain::Base) {
+        return "https://mainnet.base.org".to_string();
+    }
+
     // Nowhere near complete.
     let prefix = if is_infura {
         match chain {

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -130,14 +130,14 @@ pub fn next_mainnet_etherscan_api_key() -> String {
 fn next_url(is_ws: bool, chain: NamedChain) -> String {
     use NamedChain::*;
 
+    if matches!(chain, NamedChain::Base) {
+        return "https://mainnet.base.org".to_string();
+    }
+
     let idx = next() % num_keys();
     let is_infura = idx < INFURA_KEYS.len();
 
     let key = if is_infura { INFURA_KEYS[idx] } else { ALCHEMY_KEYS[idx - INFURA_KEYS.len()] };
-
-    if matches!(chain, NamedChain::Base) {
-        return "https://mainnet.base.org".to_string();
-    }
 
     // Nowhere near complete.
     let prefix = if is_infura {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

#8759 and others I believe were mostly afflicted by the fact that most eth_call requests do not typically fill out the `gas` field on call requests (including alloy bindings), and if you weren't in forking mode, with `disable_block_gas_limit`, any incoming call without this field would be limited to 30M gas, 

as you can see on line 1209 we try to get the requests gas field to setup the tx env, but its likely not there https://github.com/foundry-rs/foundry/blob/a592f7a9b93c7cc099341e6e9dfee3f2bb0b8748/crates/anvil/src/eth/backend/mem/mod.rs#L1205-L1231

so on line 1230 we set the tx.env.gas_limit to the block gas limit, however even when we set the`disable_block_gas_limit` flag, this block gas limit defaults to `30_000_000` as seen [here](https://github.com/foundry-rs/foundry/blob/a592f7a9b93c7cc099341e6e9dfee3f2bb0b8748/crates/anvil/src/config.rs#L965) and [here](https://github.com/foundry-rs/foundry/blob/a592f7a9b93c7cc099341e6e9dfee3f2bb0b8748/crates/anvil/src/config.rs#L393), which can make it seem like the flag is not working if the call youre testing is over 30M gas

Lastly, the fork mode appeared to work (as mentioned in #8759) because we branch if we have a fork, and in that branch we explicitly set the env block gas limit high if the flag is set , which would transitively apply to incoming calls.

https://github.com/foundry-rs/foundry/blob/a592f7a9b93c7cc099341e6e9dfee3f2bb0b8748/crates/anvil/src/config.rs#L1145-L1160

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

In this PR there is breaking change (gas_limit is now an option on `NodeConfig`) to allow for using custom gas limits in forks, if we dont care about that then it doesnt need to breaking.

If the `disable_block_gas_limit` flag is set, make sure the block gas limit is high to ensure we dont limit incoming calls (without explicit gas_limit) to the default (low) limit

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
