### PR TITLE
chore: fixes for --all-features tests

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -702,6 +702,8 @@ to                      0x91da5bf3F8Eb72724E6f50Ec6C3D199C6355c59c
 
 "#]]);
 
+    let rpc = next_http_rpc_endpoint();
+
     // <https://etherscan.io/tx/0x0e07d8b53ed3d91314c80e53cf25bcde02084939395845cbb625b029d568135c>
     cmd.cast_fuse()
         .args([
@@ -879,6 +881,8 @@ casttest!(mktx_requires_to, |_prj, cmd| {
         "mktx",
         "--private-key",
         "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
     ]);
     cmd.assert_failure().stderr_eq(str![[r#"
 Error: 
@@ -967,6 +971,8 @@ casttest!(send_requires_to, |_prj, cmd| {
         "send",
         "--private-key",
         "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "--chain",
+        "1",
     ]);
     cmd.assert_failure().stderr_eq(str![[r#"
 Error: 

--- a/crates/forge/tests/it/inline.rs
+++ b/crates/forge/tests/it/inline.rs
@@ -1,6 +1,6 @@
 //! Inline configuration tests.
 
-use crate::test_helpers::TEST_DATA_DEFAULT;
+use crate::test_helpers::{ForgeTestData, ForgeTestProfile, TEST_DATA_DEFAULT};
 use forge::{result::TestKind, TestOptionsBuilder};
 use foundry_config::{FuzzConfig, InvariantConfig};
 use foundry_test_utils::Filter;
@@ -8,7 +8,8 @@ use foundry_test_utils::Filter;
 #[tokio::test(flavor = "multi_thread")]
 async fn inline_config_run_fuzz() {
     let filter = Filter::new(".*", ".*", ".*inline/FuzzInlineConf.t.sol");
-    let mut runner = TEST_DATA_DEFAULT.runner();
+    // Fresh runner to make sure there's no persisted failure from previous tests.
+    let mut runner = ForgeTestData::new(ForgeTestProfile::Default).runner();
     let result = runner.test_collect(&filter);
     let results = result
         .into_iter()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
more fixes in the effort to make `cargo test --all --all-features` run clean
- cast `receipt_revert_reason`: use next http endpoint for 2nd call to avoid rate limits
- cast `send_requires_to` and `mktx_requires_to`: panicd `error sending request for url (http://localhost:8545/)`, pass `--chain=1` to avoid such
- `inline_config_run_fuzz`: make sure fresh runner so there's no failed fuzz persisted / needed to rerun

TBD: there's still occasionally failing tests (seen in cast and soldeer) e.g.
```
thread 'storage' panicked at crates/cast/tests/cli/main.rs:1021:10:
Expected success, was 101
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
