### PR TITLE
feat(cast): add contract creation bytecodes to traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6762,7 +6762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -7161,9 +7161,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48294aab02ed5d1940ad9b06f2a3230c3f0d98db6eacd618878cf143e204f6b0"
+checksum = "b57b33a24b5b8b8efa1da3f60d44f02d6e649f06ef925d7780723ff14ff55321"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9430,7 +9430,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -200,7 +200,7 @@ impl CallArgs {
                 ),
             };
 
-            handle_traces(trace, &config, chain, labels, debug, decode_internal).await?;
+            handle_traces(trace, &config, chain, labels, debug, decode_internal, false).await?;
 
             return Ok(());
         }

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -242,7 +242,16 @@ impl RunArgs {
             }
         };
 
-        handle_traces(result, &config, chain, self.label, self.debug, self.decode_internal).await?;
+        handle_traces(
+            result,
+            &config,
+            chain,
+            self.label,
+            self.debug,
+            self.decode_internal,
+            self.verbose,
+        )
+        .await?;
 
         Ok(())
     }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -17,7 +17,8 @@ use foundry_evm::{
         debug::DebugTraceIdentifier,
         decode_trace_arena,
         identifier::{EtherscanIdentifier, SignaturesIdentifier},
-        render_trace_arena, CallTraceDecoder, CallTraceDecoderBuilder, TraceKind, Traces,
+        render_trace_arena_with_bytecodes, CallTraceDecoder, CallTraceDecoderBuilder, TraceKind,
+        Traces,
     },
 };
 use std::{
@@ -361,6 +362,7 @@ pub async fn handle_traces(
     labels: Vec<String>,
     debug: bool,
     decode_internal: bool,
+    verbose: bool,
 ) -> Result<()> {
     let labels = labels.iter().filter_map(|label_str| {
         let mut iter = label_str.split(':');
@@ -410,19 +412,23 @@ pub async fn handle_traces(
             .build();
         debugger.try_run()?;
     } else {
-        print_traces(&mut result, &decoder).await?;
+        print_traces(&mut result, &decoder, verbose).await?;
     }
 
     Ok(())
 }
 
-pub async fn print_traces(result: &mut TraceResult, decoder: &CallTraceDecoder) -> Result<()> {
+pub async fn print_traces(
+    result: &mut TraceResult,
+    decoder: &CallTraceDecoder,
+    verbose: bool,
+) -> Result<()> {
     let traces = result.traces.as_mut().expect("No traces found");
 
     println!("Traces:");
     for (_, arena) in traces {
         decode_trace_arena(arena, decoder).await?;
-        println!("{}", render_trace_arena(arena));
+        println!("{}", render_trace_arena_with_bytecodes(arena, verbose));
     }
     println!();
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -178,7 +178,15 @@ pub async fn decode_trace_arena(
 
 /// Render a collection of call traces to a string.
 pub fn render_trace_arena(arena: &SparsedTraceArena) -> String {
-    let mut w = TraceWriter::new(Vec::<u8>::new());
+    render_trace_arena_with_bytecodes(arena, false)
+}
+
+/// Render a collection of call traces to a string optionally including contract creation bytecodes.
+pub fn render_trace_arena_with_bytecodes(
+    arena: &SparsedTraceArena,
+    with_bytecodes: bool,
+) -> String {
+    let mut w = TraceWriter::new(Vec::<u8>::new()).write_bytecodes(with_bytecodes);
     w.write_arena(&arena.resolve_arena()).expect("Failed to write traces");
     String::from_utf8(w.into_writer()).expect("trace writer wrote invalid UTF-8")
 }


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8906.

## Solution

Prints the contract creation bytecodes in the trace when `--verbose` is passed to `cast run`.

I'm not sure if there are tests for this parts of the code, so I haven't added or changed any.

Formatting was a big mystery to me, I did my best manually, but I don't understand what's the correct approach. I haven't found any guide in `.md` files, but there is a `rustfmt.toml` file and the code seems formatted, but running `cargo fmt` alters dozens of files across the whole project, which apparently are not automatically formatted.