### PR TITLE
fix(`anvil`): handle OP deposit txs in `TypedTransaction` and `PoolTransaction` conversion

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1015,7 +1015,7 @@ impl TryFrom<WithOtherFields<RpcTransaction>> for TypedTransaction {
                 .cloned()
                 .map(|v| {
                     serde_json::from_value::<U256>(v)
-                        .map_err(|_| ConversionError::Custom(format!("Cannot deserialize mint")))
+                        .map_err(|_| ConversionError::Custom("Cannot deserialize mint".to_string()))
                 })?;
 
             let source_hash = tx
@@ -1025,7 +1025,7 @@ impl TryFrom<WithOtherFields<RpcTransaction>> for TypedTransaction {
                 .cloned()
                 .map(|v| {
                     serde_json::from_value::<B256>(v).map_err(|_| {
-                        ConversionError::Custom(format!("Cannot deserialize source hash"))
+                        ConversionError::Custom("Cannot deserialize source hash".to_string())
                     })
                 })?;
 

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1010,23 +1010,16 @@ impl TryFrom<WithOtherFields<RpcTransaction>> for TypedTransaction {
         if tx.transaction_type.is_some_and(|t| t == 0x7E) {
             let mint = tx
                 .other
-                .get("mint")
-                .ok_or(ConversionError::Custom("MissingMint".to_string()))
-                .cloned()
-                .map(|v| {
-                    serde_json::from_value::<U256>(v)
-                        .map_err(|_| ConversionError::Custom("Cannot deserialize mint".to_string()))
-                })?;
+                .get_deserialized::<U256>("mint")
+                .ok_or(ConversionError::Custom("MissingMint".to_string()))?
+                .map_err(|_| ConversionError::Custom("Cannot deserialize mint".to_string()))?;
 
             let source_hash = tx
                 .other
-                .get("sourceHash")
-                .ok_or(ConversionError::Custom("MissingSourceHash".to_string()))
-                .cloned()
-                .map(|v| {
-                    serde_json::from_value::<B256>(v).map_err(|_| {
-                        ConversionError::Custom("Cannot deserialize source hash".to_string())
-                    })
+                .get_deserialized::<B256>("sourceHash")
+                .ok_or(ConversionError::Custom("MissingSourceHash".to_string()))?
+                .map_err(|_| {
+                    ConversionError::Custom("Cannot deserialize source hash".to_string())
                 })?;
 
             let deposit = DepositTransaction {
@@ -1037,8 +1030,8 @@ impl TryFrom<WithOtherFields<RpcTransaction>> for TypedTransaction {
                 value: tx.value,
                 gas_limit: tx.gas,
                 input: tx.input.clone(),
-                mint: mint?,
-                source_hash: source_hash?,
+                mint,
+                source_hash,
             };
 
             return Ok(Self::Deposit(deposit));

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1281,11 +1281,23 @@ async fn derive_block_and_transactions(
                 .ok_or(eyre::eyre!("Failed to get fork transaction by hash"))?;
             let transaction_block_number = transaction.block_number.unwrap();
 
+            tracing::info!(
+                "Forking from transaction hash: {transaction_hash} in block number: {transaction_block_number}"
+            );
+
             // Get the block pertaining to the fork transaction
             let transaction_block = provider
                 .get_block_by_number(transaction_block_number.into(), true)
                 .await?
                 .ok_or(eyre::eyre!("Failed to get fork block by number"))?;
+
+            tracing::info!(
+                "Forking from block number: {transaction_block_number} with hash: {transaction_block_hash}",
+                transaction_block_number = transaction_block_number,
+                transaction_block_hash = transaction_block.header.hash
+            );
+
+            tracing::info!("Block has {} transactions", transaction_block.transactions.len());
 
             // Filter out transactions that are after the fork transaction
             let filtered_transactions: Vec<&alloy_serde::WithOtherFields<Transaction>> =
@@ -1297,11 +1309,27 @@ async fn derive_block_and_transactions(
                     .take_while_inclusive(|&transaction| transaction.hash != transaction_hash.0)
                     .collect();
 
+            tracing::info!(
+                "Filtered transactions: {filtered_transactions}",
+                filtered_transactions = filtered_transactions.len()
+            );
+
             // Convert the transactions to PoolTransactions
             let force_transactions = filtered_transactions
                 .iter()
-                .map(|&transaction| PoolTransaction::try_from(transaction.clone().inner))
-                .collect::<Result<Vec<_>, _>>()?;
+                .map(|&transaction| {
+                    tracing::info!(
+                        "Converting transaction {} to pool transaction",
+                        transaction.hash
+                    );
+                    let pool_tx = PoolTransaction::try_from(transaction.clone());
+
+                    tracing::info!("Conversion result: {pool_tx:?}");
+
+                    pool_tx
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| eyre::eyre!("Err converting to pool transactions {e}"))?;
             Ok((transaction_block_number.saturating_sub(1), Some(force_transactions)))
         }
     }

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -1,6 +1,7 @@
 use crate::eth::{error::PoolError, util::hex_fmt_many};
 use alloy_primitives::{Address, TxHash};
 use alloy_rpc_types::Transaction as RpcTransaction;
+use alloy_serde::WithOtherFields;
 use anvil_core::eth::transaction::{PendingTransaction, TypedTransaction};
 use parking_lot::RwLock;
 use std::{
@@ -116,11 +117,13 @@ impl fmt::Debug for PoolTransaction {
     }
 }
 
-impl TryFrom<RpcTransaction> for PoolTransaction {
+impl TryFrom<WithOtherFields<RpcTransaction>> for PoolTransaction {
     type Error = eyre::Error;
-    fn try_from(transaction: RpcTransaction) -> Result<Self, Self::Error> {
+    fn try_from(transaction: WithOtherFields<RpcTransaction>) -> Result<Self, Self::Error> {
         let typed_transaction = TypedTransaction::try_from(transaction)?;
+        tracing::info!("Converted to typed transaction!");
         let pending_transaction = PendingTransaction::new(typed_transaction)?;
+        tracing::info!("Converted to pending transaction!");
         Ok(Self {
             pending_transaction,
             requires: vec![],

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -121,9 +121,7 @@ impl TryFrom<WithOtherFields<RpcTransaction>> for PoolTransaction {
     type Error = eyre::Error;
     fn try_from(transaction: WithOtherFields<RpcTransaction>) -> Result<Self, Self::Error> {
         let typed_transaction = TypedTransaction::try_from(transaction)?;
-        tracing::info!("Converted to typed transaction!");
         let pending_transaction = PendingTransaction::new(typed_transaction)?;
-        tracing::info!("Converted to pending transaction!");
         Ok(Self {
             pending_transaction,
             requires: vec![],

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -167,6 +167,26 @@ async fn test_fork_eth_get_nonce() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_optimism_with_transaction_hash() {
+    use std::str::FromStr;
+
+    // Fork to a block with a specific transaction
+    let fork_tx_hash =
+        TxHash::from_str("fcb864b5a50f0f0b111dbbf9e9167b2cb6179dfd6270e1ad53aac6049c0ec038")
+            .unwrap();
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(rpc::next_rpc_endpoint(NamedChain::Optimism)))
+            .with_fork_transaction_hash(Some(fork_tx_hash)),
+    )
+    .await;
+
+    // Make sure the fork starts from previous block
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, 125777954 - 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_eth_fee_history() {
     let (api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #8940 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Change `TryFrom` implementations of `PoolTransaction` and `TypedTransaction` to use `WithOtherFields<RpcTransaction>` instead of `RpcTransaction`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
