### PR TITLE
chore: more fixes for --all-features tests

### DIFF
--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -667,7 +667,7 @@ async fn can_remove_pool_transactions() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reorg() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
+    let (api, mut handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider();
 
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
@@ -792,4 +792,8 @@ async fn test_reorg() {
         })
         .await;
     assert!(res.is_err());
+
+    if let Some(signal) = handle.shutdown_signal_mut().take() {
+        signal.fire().unwrap();
+    }
 }

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -175,7 +175,7 @@ async fn test_tip_above_fee_cap() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_use_fee_history() {
     let base_fee = 50u128;
-    let (_api, handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee))).await;
+    let (_api, mut handle) = spawn(NodeConfig::test().with_base_fee(Some(base_fee))).await;
     let provider = handle.http_provider();
 
     for _ in 0..10 {
@@ -199,5 +199,9 @@ async fn test_can_use_fee_history() {
 
         assert_eq!(latest_block.header.base_fee_per_gas.unwrap(), *latest_fee_history_fee);
         assert_eq!(latest_fee_history_fee, next_base_fee);
+    }
+
+    if let Some(signal) = handle.shutdown_signal_mut().take() {
+        signal.fire().unwrap();
     }
 }

--- a/crates/anvil/tests/it/proof.rs
+++ b/crates/anvil/tests/it/proof.rs
@@ -122,12 +122,16 @@ async fn test_storage_proof() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_random_account_proofs() {
-    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let (api, mut handle) = spawn(NodeConfig::test()).await;
 
     for acc in std::iter::repeat_with(Address::random).take(10) {
         let _ = api
             .get_proof(acc, Vec::new(), None)
             .await
             .unwrap_or_else(|_| panic!("Failed to get proof for {acc:?}"));
+    }
+
+    if let Some(signal) = handle.shutdown_signal_mut().take() {
+        signal.fire().unwrap();
     }
 }

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -722,7 +722,7 @@ async fn test_trace_address_fork2() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_trace_filter() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
+    let (api, mut handle) = spawn(NodeConfig::test()).await;
     let provider = handle.ws_provider();
 
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
@@ -859,4 +859,8 @@ async fn test_trace_filter() {
 
     let traces = api.trace_filter(tracer).await.unwrap();
     assert_eq!(traces.len(), 5);
+
+    if let Some(signal) = handle.shutdown_signal_mut().take() {
+        signal.fire().unwrap();
+    }
 }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1022,6 +1022,7 @@ casttest!(storage, |_prj, cmd| {
 
 "#]]);
 
+    let rpc = next_http_rpc_endpoint();
     cmd.cast_fuse()
         .args(["storage", usdt, total_supply_slot, "--rpc-url", &rpc, "--block", block_after])
         .assert_success()

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -205,6 +205,7 @@ forgetest_init!(can_override_config, |prj, cmd| {
     );
 
     // env vars work
+    std::env::remove_var("DAPP_REMAPPINGS");
     std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/forge-std/lib/ds-test/from-env/");
     let config = forge_utils::load_config_with_root(Some(prj.root()));
     assert_eq!(
@@ -517,6 +518,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
     );
 
     // create a new lib directly in the `lib` folder with a remapping
+    std::env::remove_var("DAPP_REMAPPINGS");
     let mut config = config;
     config.remappings = vec![Remapping::from_str("nested/=lib/nested").unwrap().into()];
     let nested = prj.paths().libraries[0].join("nested-lib");
@@ -524,6 +526,7 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
     let toml_file = nested.join("foundry.toml");
     pretty_err(&toml_file, fs::write(&toml_file, config.to_string_pretty().unwrap()));
 
+    std::env::remove_var("DAPP_REMAPPINGS");
     let config = cmd.config();
     let remappings = config.remappings.iter().cloned().map(Remapping::from).collect::<Vec<_>>();
     similar_asserts::assert_eq!(

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -33,6 +33,7 @@ fn test_verify_bytecode(
     prj.add_source(contract_name, &source_code).unwrap();
     prj.write_config(config);
 
+    let etherscan_key = next_mainnet_etherscan_api_key();
     let mut args = vec![
         "verify-bytecode",
         addr,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
more fixes for `cargo test --all --all-features` clean run
- send shutdown signal for long running tests that spawns anvil, fixing
```
failed to spawn node: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
- avoid RPC URL rate limit for storage test
- avoid etherscan rate limit for `verify_bytecode` tests, fixing
```
Error: 
Received error response: status=0,message=NOTOK, result=Some("Max calls per sec rate limit reached (5/sec)")
failures:
    verify_bytecode::can_verify_bytecode_with_metadata
```
- remove `DAPP_REMAPPINGS` env var from `can_override_config` test, fixing
```
thread 'config::can_override_config' panicked at crates/forge/tests/cli/config.rs:210:5:
assertion failed: `(left == right)`'
  left: `"ds-test/=/tmp/can_override_config-68Zsmm2o/lib/forge-std/lib/ds-test/from-env/"`
 right: `"ds-test/=/tmp/can_override_config-68Zsmm2o/lib/forge-std/lib/ds-test/from-file/"`

Differences (-left|+right):
-ds-test/=/tmp/can_override_config-68Zsmm2o/lib/forge-std/lib/ds-test/from-env/
+ds-test/=/tmp/can_override_config-68Zsmm2o/lib/forge-std/lib/ds-test/from-file/
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
