### PR TITLE
chore: add Makefile and `codespell`

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,target,Cargo.toml,Cargo.lock,*.sol
+skip = .git,target,testdata,Cargo.toml,Cargo.lock
 ignore-words-list = crate,ser,ratatui,Caf,froms

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,target,testdata,Cargo.toml,Cargo.lock
-ignore-words-list = crate,ser,ratatui,Caf,froms
+ignore-words-list = crate,ser,ratatui,Caf,froms,strat

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,target,Cargo.toml,Cargo.lock,*.sol
+ignore-words-list = crate,ser,ratatui,Caf

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,target,Cargo.toml,Cargo.lock,*.sol
-ignore-words-list = crate,ser,ratatui,Caf
+ignore-words-list = crate,ser,ratatui,Caf,froms

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,15 @@ jobs:
           cache-on-failure: true
       - run: cargo test --workspace --doc
 
+  codespell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: codespell-project/actions-codespell@v2
+        with:
+          skip: "*.json"
+
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -107,6 +116,7 @@ jobs:
       - nextest
       - docs
       - doctest
+      - codespell
       - clippy
       - rustfmt
       - forge-fmt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# Heavily inspired by Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/Makefile
+.DEFAULT_GOAL := help
+
+# Cargo profile for builds. Default is for local builds, CI uses an override.
+PROFILE ?= release
+
+# List of features to use when building. Can be overridden via the environment.
+# No jemalloc on Windows
+ifeq ($(OS),Windows_NT)
+    FEATURES ?= rustls aws-kms cli asm-keccak
+else
+    FEATURES ?= jemalloc rustls aws-kms cli asm-keccak
+endif
+
+##@ Help
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Build
+
+.PHONY: build
+build: ## Perform a `cargo` build
+	cargo build --features "$(FEATURES)" --profile "$(PROFILE)"
+
+##@ Other
+
+.PHONY: clean
+clean:
+	cargo clean
+
+fmt: ## Run the formatter
+	cargo +nightly fmt
+
+lint-foundry:
+	cargo clippy --workspace --all-targets --all-features
+
+lint-codespell: ensure-codespell
+	codespell --skip "*.json"
+
+ensure-codespell:
+	@if ! command -v codespell &> /dev/null; then \
+		echo "codespell not found. Please install it by running the command `pip install codespell` or refer to the following link for more information: https://github.com/codespell-project/codespell" \
+		exit 1; \
+    fi
+
+lint: ## Run all linters
+	make fmt && \
+	make lint-foundry && \
+	make lint-codespell
+
+test-doc:
+	cargo test --doc --workspace
+
+test: ## Run all tests
+	make test && \
+	make test-doc
+
+pr: ## Run all tests and linters for a PR
+	make lint && \
+	make test

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,9 @@ clean: ## Clean the project.
 
 ## Linting
 
-fmt: ## Run the formatter.
+fmt: ## Run all formatters.
 	cargo +nightly fmt
+	./.github/scripts/format.sh --check
 
 lint-foundry:
 	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --all-features

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .DEFAULT_GOAL := help
 
 # Cargo profile for builds.
-PROFILE ?= release
+PROFILE ?= dev
 
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-# Heavily inspired by Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/Makefile
+# Heavily inspired by:
+# - Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/Makefile
+# - Reth: https://github.com/paradigmxyz/reth/blob/1f642353ca083b374851ab355b5d80207b36445c/Makefile
 .DEFAULT_GOAL := help
 
-# Cargo profile for builds. Default is for local builds, CI uses an override.
+# Cargo profile for builds.
 PROFILE ?= release
 
 # List of features to use when building. Can be overridden via the environment.
@@ -21,20 +23,22 @@ help: ## Display this help.
 ##@ Build
 
 .PHONY: build
-build: ## Perform a `cargo` build
+build: ## Build the project.
 	cargo build --features "$(FEATURES)" --profile "$(PROFILE)"
 
 ##@ Other
 
 .PHONY: clean
-clean:
+clean: ## Clean the project.
 	cargo clean
 
-fmt: ## Run the formatter
+## Linting
+
+fmt: ## Run the formatter.
 	cargo +nightly fmt
 
 lint-foundry:
-	cargo clippy --workspace --all-targets --all-features
+	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --all-features
 
 lint-codespell: ensure-codespell
 	codespell --skip "*.json"
@@ -45,18 +49,23 @@ ensure-codespell:
 		exit 1; \
     fi
 
-lint: ## Run all linters
+lint: ## Run all linters.
 	make fmt && \
 	make lint-foundry && \
 	make lint-codespell
 
+## Testing
+
+test-foundry:
+	cargo nextest run -E 'kind(test) & !test(/issue|forge_std|ext_integration/)'
+
 test-doc:
 	cargo test --doc --workspace
 
-test: ## Run all tests
-	make test && \
+test: ## Run all tests.
+	make test-foundry && \
 	make test-doc
 
-pr: ## Run all tests and linters for a PR
+pr: ## Run all tests and linters in preparation for a PR.
 	make lint && \
 	make test

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ By default `forge config` shows the currently selected foundry profile and its v
 
 ### DappTools Compatibility
 
-You can re-use your `.dapprc` environment variables by running `source .dapprc` before using a Foundry tool.
+You can reuse your `.dapprc` environment variables by running `source .dapprc` before using a Foundry tool.
 
 ### Additional Configuration
 

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -522,7 +522,7 @@ pub enum EthRequest {
     EvmSetTime(U256),
 
     /// Serializes the current state (including contracts code, contract's storage, accounts
-    /// properties, etc.) into a savable data blob
+    /// properties, etc.) into a saveable data blob
     #[cfg_attr(feature = "serde", serde(rename = "anvil_dumpState", alias = "hardhat_dumpState"))]
     DumpState(#[cfg_attr(feature = "serde", serde(default))] Option<Params<Option<bool>>>),
 

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -672,7 +672,7 @@ pub enum TypedTransaction {
 /// This is a function that demotes TypedTransaction to TransactionRequest for greater flexibility
 /// over the type.
 ///
-/// This function is purely for convience and specific use cases, e.g. RLP encoded transactions
+/// This function is purely for convenience and specific use cases, e.g. RLP encoded transactions
 /// decode to TypedTransactions where the API over TypedTransctions is quite strict.
 impl TryFrom<TypedTransaction> for TransactionRequest {
     type Error = ConversionError;

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1360,7 +1360,7 @@ impl PruneStateHistoryConfig {
         !self.enabled || self.max_memory_history.is_some()
     }
 
-    /// Returns tru if this setting was enabled.
+    /// Returns true if this setting was enabled.
     pub fn is_config_enabled(&self) -> bool {
         self.enabled
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1936,7 +1936,7 @@ impl EthApi {
         Ok(())
     }
 
-    /// Reorg the chain to a specific depth and mine new blocks back to the cannonical height.
+    /// Reorg the chain to a specific depth and mine new blocks back to the canonical height.
     ///
     /// e.g depth = 3
     ///     A  -> B  -> C  -> D  -> E
@@ -2566,7 +2566,7 @@ impl EthApi {
                     // current midpoint, as spending any less gas would make no
                     // sense (as the TX would still revert due to lack of gas).
                     //
-                    // We don't care about the reason here, as we known that trasaction is correct
+                    // We don't care about the reason here, as we known that transaction is correct
                     // as it succeeded earlier
                     lowest_gas_limit = mid_gas_limit;
                 }

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -24,7 +24,7 @@ impl CheatsManager {
         let mut state = self.state.write();
         // When somebody **explicitly** impersonates an account we need to store it so we are able
         // to return it from `eth_accounts`. That's why we do not simply call `is_impersonated()`
-        // which does not check that list when auto impersonation is enabeld.
+        // which does not check that list when auto impersonation is enabled.
         if state.impersonated_accounts.contains(&addr) {
             // need to check if already impersonated, so we don't overwrite the code
             return true

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -149,7 +149,7 @@ pub struct Backend {
     /// which the write-lock is active depends on whether the `ForkDb` can provide all requested
     /// data from memory or whether it has to retrieve it via RPC calls first. This means that it
     /// potentially blocks for some time, even taking into account the rate limits of RPC
-    /// endpoints. Therefor the `Db` is guarded by a `tokio::sync::RwLock` here so calls that
+    /// endpoints. Therefore the `Db` is guarded by a `tokio::sync::RwLock` here so calls that
     /// need to read from it, while it's currently written to, don't block. E.g. a new block is
     /// currently mined and a new [`Self::set_storage_at()`] request is being executed.
     db: Arc<AsyncRwLock<Box<dyn Db>>>,

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -569,7 +569,7 @@ impl MinedTransaction {
 pub struct MinedTransactionReceipt {
     /// The actual json rpc receipt object
     pub inner: ReceiptResponse,
-    /// Output data fo the transaction
+    /// Output data for the transaction
     pub out: Option<Bytes>,
 }
 

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -20,7 +20,7 @@
 //! used to determine whether it can be included in a block (transaction is ready) or whether it
 //! still _requires_ other transactions to be mined first (transaction is pending).
 //! A transaction is associated with the nonce of the account it's sent from. A unique identifying
-//! marker for a transaction is therefor the pair `(nonce + account)`. An incoming transaction with
+//! marker for a transaction is therefore the pair `(nonce + account)`. An incoming transaction with
 //! a `nonce > nonce on chain` will _require_ `(nonce -1, account)` first, before it is ready to be
 //! included in a block.
 //!

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3634,7 +3634,7 @@
     {
       "func": {
         "id": "deployCode_1",
-        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionaly accepts abi-encoded constructor arguments.",
+        "description": "Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.\nAdditionally accepts abi-encoded constructor arguments.",
         "declaration": "function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1544,7 +1544,7 @@ interface Vm {
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
     /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
     ///
-    /// Additionaly accepts abi-encoded constructor arguments.
+    /// Additionally accepts abi-encoded constructor arguments.
     #[cheatcode(group = Filesystem)]
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs) external returns (address deployedAddress);
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -222,7 +222,7 @@ pub struct BroadcastableTransaction {
 pub struct GasMetering {
     /// True if gas metering is paused.
     pub paused: bool,
-    /// True if gas metering was resumed or reseted during the test.
+    /// True if gas metering was resumed or reset during the test.
     /// Used to reconcile gas when frame ends (if spent less than refunded).
     pub touched: bool,
     /// True if gas metering should be reset to frame limit.
@@ -1196,7 +1196,7 @@ impl<DB: DatabaseExt> Inspector<DB> for Cheatcodes {
             call.target_address == HARDHAT_CONSOLE_ADDRESS;
 
         // Clean up pranks/broadcasts if it's not a cheatcode call end. We shouldn't do
-        // it for cheatcode calls because they are not appplied for cheatcodes in the `call` hook.
+        // it for cheatcode calls because they are not applied for cheatcodes in the `call` hook.
         // This should be placed before the revert handling, because we might exit early there
         if !cheatcode_call {
             // Clean up pranks

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -594,7 +594,7 @@ fn serialize_value_as_json(value: DynSolValue) -> Result<Value> {
     match value {
         DynSolValue::Bool(b) => Ok(Value::Bool(b)),
         DynSolValue::String(s) => {
-            // Strings are allowed to contain strigified JSON objects, so we try to parse it like
+            // Strings are allowed to contain stringified JSON objects, so we try to parse it like
             // one first.
             if let Ok(map) = serde_json::from_str(&s) {
                 Ok(Value::Object(map))

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -1161,7 +1161,7 @@ impl Type {
         Self::ethabi(&return_parameter.ty, Some(intermediate)).map(|p| (contract_expr.unwrap(), p))
     }
 
-    /// Inverts Int to Uint and viceversa.
+    /// Inverts Int to Uint and vice-versa.
     fn invert_int(self) -> Self {
         match self {
             Self::Builtin(DynSolType::Uint(n)) => Self::Builtin(DynSolType::Int(n)),

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -163,7 +163,7 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
 
 /// Conditionally print a message
 ///
-/// This macro accepts a predicate and the message to print if the predicate is tru
+/// This macro accepts a predicate and the message to print if the predicate is true
 ///
 /// ```ignore
 /// let quiet = true;

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -100,7 +100,7 @@ model_checker = { contracts = { 'a.sol' = [
 ], timeout = 10000 }
 verbosity = 0
 eth_rpc_url = "https://example.com/"
-# Setting this option enables decoding of error traces from mainnet deployed / verfied contracts via etherscan
+# Setting this option enables decoding of error traces from mainnet deployed / verified contracts via etherscan
 etherscan_api_key = "YOURETHERSCANAPIKEY"
 # ignore solc warnings for missing license and exceeded contract size
 # known error codes are: ["unreachable", "unused-return", "unused-param", "unused-var", "code-size", "shadowing", "func-mutability", "license", "pragma-solidity", "virtual-interfaces", "same-varname", "too-many-warnings", "constructor-visibility", "init-code-size", "missing-receive-ether", "unnamed-return", "transient-storage"]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2717,7 +2717,7 @@ impl<P: Provider> Provider for OptionalStrictProfileProvider<P> {
         figment.data().map_err(|err| {
             // figment does tag metadata and tries to map metadata to an error, since we use a new
             // figment in this provider this new figment does not know about the metadata of the
-            // provider and can't map the metadata to the error. Therefor we return the root error
+            // provider and can't map the metadata to the error. Therefore we return the root error
             // if this error originated in the provider's data.
             if let Err(root_err) = self.provider.data() {
                 return root_err;

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -119,7 +119,7 @@ fn get_create2_factory_call_inputs(salt: U256, inputs: CreateInputs) -> CallInpu
 /// Used for routing certain CREATE2 invocations through [DEFAULT_CREATE2_DEPLOYER].
 ///
 /// Overrides create hook with CALL frame if [InspectorExt::should_use_create2_factory] returns
-/// true. Keeps track of overriden frames and handles outcome in the overriden insert_call_outcome
+/// true. Keeps track of overridden frames and handles outcome in the overridden insert_call_outcome
 /// hook by inserting decoded address directly into interpreter.
 ///
 /// Should be installed after [revm::inspector_handle_register] and before any other registers.

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -71,7 +71,7 @@ pub fn find_anchor_simple(
 
     Ok(ItemAnchor {
         instruction: ic_pc_map.get(instruction).ok_or_else(|| {
-            eyre::eyre!("We found an anchor, but we cant translate it to a program counter")
+            eyre::eyre!("We found an anchor, but we can't translate it to a program counter")
         })?,
         item_id,
     })

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -88,7 +88,7 @@ impl FuzzedExecutor {
         let execution_data = RefCell::new(FuzzTestData::default());
         let state = self.build_fuzz_state();
         let dictionary_weight = self.config.dictionary.dictionary_weight.min(100);
-        let strat = proptest::prop_oneof![
+        let strategy = proptest::prop_oneof![
             100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
             dictionary_weight => fuzz_calldata_from_state(func.clone(), &state),
         ];
@@ -96,7 +96,7 @@ impl FuzzedExecutor {
         let max_traces_to_collect = std::cmp::max(1, self.config.gas_report_samples) as usize;
         let show_logs = self.config.show_logs;
 
-        let run_result = self.runner.clone().run(&strat, |calldata| {
+        let run_result = self.runner.clone().run(&strategy, |calldata| {
             let fuzz_res = self.single_fuzz(address, should_fail, calldata)?;
 
             // If running with progress then increment current run.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -243,7 +243,7 @@ impl InvariantTestRun {
     }
 }
 
-/// Wrapper around any [`Executor`] implementor which provides fuzzing support using [`proptest`].
+/// Wrapper around any [`Executor`] implementer which provides fuzzing support using [`proptest`].
 ///
 /// After instantiation, calling `invariant_fuzz` will proceed to hammer the deployed smart
 /// contracts with inputs, until it finds a counterexample sequence. The provided [`TestRunner`]
@@ -463,7 +463,7 @@ impl<'a> InvariantExecutor<'a> {
             EvmFuzzState::new(self.executor.backend().mem_db(), self.config.dictionary);
 
         // Creates the invariant strategy.
-        let strat = invariant_strat(
+        let strategy = invariant_strat(
             fuzz_state.clone(),
             targeted_senders,
             targeted_contracts.clone(),
@@ -519,7 +519,7 @@ impl<'a> InvariantExecutor<'a> {
                 last_call_results,
                 self.runner.clone(),
             ),
-            strat,
+            strategy,
         ))
     }
 

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -21,13 +21,13 @@ struct Shrink {
 /// If the failure is not reproducible then restore removed call and moves to next one.
 #[derive(Debug)]
 struct CallSequenceShrinker {
-    /// Length of call sequence to be shrinked.
+    /// Length of call sequence to be shrunk.
     call_sequence_len: usize,
-    /// Call ids contained in current shrinked sequence.
+    /// Call ids contained in current shrunk sequence.
     included_calls: VarBitSet,
-    /// Current shrinked call id.
+    /// Current shrunk call id.
     shrink: Shrink,
-    /// Previous shrinked call id.
+    /// Previous shrunk call id.
     prev_shrink: Option<Shrink>,
 }
 
@@ -82,7 +82,7 @@ impl CallSequenceShrinker {
 /// Maximal shrinkage is guaranteed if the shrink_run_limit is not set to a value lower than the
 /// length of failed call sequence.
 ///
-/// The shrinked call sequence always respect the order failure is reproduced as it is tested
+/// The shrunk call sequence always respect the order failure is reproduced as it is tested
 /// top-down.
 pub(crate) fn shrink_sequence(
     failed_case: &FailedInvariantCaseData,

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -576,7 +576,7 @@ impl Executor {
     /// Creates the environment to use when executing a transaction in a test context
     ///
     /// If using a backend with cheatcodes, `tx.gas_price` and `block.number` will be overwritten by
-    /// the cheatcode state inbetween calls.
+    /// the cheatcode state in between calls.
     fn build_test_env(
         &self,
         caller: Address,

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -218,12 +218,12 @@ mod tests {
         let func = get_func(f).unwrap();
         let db = CacheDB::new(EmptyDB::default());
         let state = EvmFuzzState::new(&db, FuzzDictionaryConfig::default());
-        let strat = proptest::prop_oneof![
+        let strategy = proptest::prop_oneof![
             60 => fuzz_calldata(func.clone(), &FuzzFixtures::default()),
             40 => fuzz_calldata_from_state(func, &state),
         ];
         let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
         let mut runner = proptest::test_runner::TestRunner::new(cfg);
-        let _ = runner.run(&strat, |_| Ok(()));
+        let _ = runner.run(&strategy, |_| Ok(()));
     }
 }

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -110,7 +110,7 @@ impl<'a> DebugStepsWalker<'a> {
             loc.index() == other_loc.index()
     }
 
-    /// Invoked when current step is a JUMPDEST preceeded by a JUMP marked as [Jump::In].
+    /// Invoked when current step is a JUMPDEST preceded by a JUMP marked as [Jump::In].
     fn jump_in(&mut self) {
         // This usually means that this is a jump into the external function which is an
         // entrypoint for the current frame. We don't want to include this to avoid
@@ -128,7 +128,7 @@ impl<'a> DebugStepsWalker<'a> {
         }
     }
 
-    /// Invoked when current step is a JUMPDEST preceeded by a JUMP marked as [Jump::Out].
+    /// Invoked when current step is a JUMPDEST preceded by a JUMP marked as [Jump::Out].
     fn jump_out(&mut self) {
         let Some((i, _)) = self.stack.iter().enumerate().rfind(|(_, (_, step_idx))| {
             self.is_same_loc(*step_idx, self.current_step) ||

--- a/crates/fmt/src/buffer.rs
+++ b/crates/fmt/src/buffer.rs
@@ -173,7 +173,7 @@ impl<W: Write> FormatBuffer<W> {
         let mut comment_state = self.state.comment_state();
         while let Some(line) = lines.next() {
             // remove the whitespace that covered by the base indent length (this is normally the
-            // case with temporary buffers as this will be readded by the underlying IndentWriter
+            // case with temporary buffers as this will be re-added by the underlying IndentWriter
             // later on
             let (new_comment_state, line_start) = line
                 .comment_state_char_indices()

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -3244,7 +3244,7 @@ impl<'a, W: Write> Visitor for Formatter<'a, W> {
                 let is_constructor = self.context.is_constructor_function();
                 // we can't make any decisions here regarding trailing `()` because we'd need to
                 // find out if the `base` is a solidity modifier or an
-                // interface/contract therefor we we its raw content.
+                // interface/contract therefore we we its raw content.
 
                 // we can however check if the contract `is` the `base`, this however also does
                 // not cover all cases

--- a/crates/fmt/src/visit.rs
+++ b/crates/fmt/src/visit.rs
@@ -5,7 +5,7 @@ use crate::solang_ext::pt::*;
 /// A trait that is invoked while traversing the Solidity Parse Tree.
 /// Each method of the [Visitor] trait is a hook that can be potentially overridden.
 ///
-/// Currently the main implementor of this trait is the [`Formatter`](crate::Formatter<'_>) struct.
+/// Currently the main implementer of this trait is the [`Formatter`](crate::Formatter<'_>) struct.
 pub trait Visitor {
     type Error: std::error::Error;
 

--- a/crates/forge/README.md
+++ b/crates/forge/README.md
@@ -206,7 +206,7 @@ contract MyTest {
 
     function testBarExpectedRevert() public {
         vm.expectRevert("My expected revert string");
-        // This would fail *if* we didnt expect revert. Since we expect the revert,
+        // This would fail *if* we didn't expect revert. Since we expect the revert,
         // it doesn't, unless the revert string is wrong.
         foo.bar(101);
     }

--- a/crates/forge/bin/cmd/bind_json.rs
+++ b/crates/forge/bin/cmd/bind_json.rs
@@ -187,7 +187,7 @@ struct StructToWrite {
 }
 
 impl StructToWrite {
-    /// Returns the name of the imported item. If struct is definied at the file level, returns the
+    /// Returns the name of the imported item. If struct is defined at the file level, returns the
     /// struct name, otherwise returns the parent contract name.
     fn struct_or_contract_name(&self) -> &str {
         self.contract_name.as_deref().unwrap_or(&self.name)

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -187,7 +187,7 @@ impl TestArgs {
 
     /// Returns sources which include any tests to be executed.
     /// If no filters are provided, sources are filtered by existence of test/invariant methods in
-    /// them, If filters are provided, sources are additionaly filtered by them.
+    /// them, If filters are provided, sources are additionally filtered by them.
     pub fn get_sources_to_compile(
         &self,
         config: &Config,

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -79,7 +79,7 @@ impl GasReport {
             return;
         }
 
-        // Only include top-level calls which accout for calldata and base (21.000) cost.
+        // Only include top-level calls which account for calldata and base (21.000) cost.
         // Only include Calls and Creates as only these calls are isolated in inspector.
         if trace.depth > 1 &&
             (trace.kind == CallKind::Call ||

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -984,7 +984,7 @@ Warning: SPDX license identifier not provided in source file. Before publishing,
 "#]]);
 });
 
-// test that `forge build` does not print `(with warnings)` if there arent any
+// test that `forge build` does not print `(with warnings)` if there aren't any
 forgetest!(can_compile_without_warnings, |prj, cmd| {
     let config = Config {
         ignored_error_codes: vec![SolidityErrorCode::SpdxLicenseNotProvided],

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -930,7 +930,7 @@ forgetest_async!(check_broadcast_log, |prj, cmd| {
 
     // Check broadcast logs
     // Ignore timestamp, blockHash, blockNumber, cumulativeGasUsed, effectiveGasPrice,
-    // transactionIndex and logIndex values since they can change inbetween runs
+    // transactionIndex and logIndex values since they can change in between runs
     let re = Regex::new(r#"((timestamp":).[0-9]*)|((blockHash":).*)|((blockNumber":).*)|((cumulativeGasUsed":).*)|((effectiveGasPrice":).*)|((transactionIndex":).*)|((logIndex":).*)"#).unwrap();
 
     let fixtures_log = std::fs::read_to_string(
@@ -954,7 +954,7 @@ forgetest_async!(check_broadcast_log, |prj, cmd| {
     // );
 
     // Check sensitive logs
-    // Ignore port number since it can change inbetween runs
+    // Ignore port number since it can change in between runs
     let re = Regex::new(r":[0-9]+").unwrap();
 
     let fixtures_log = std::fs::read_to_string(

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -295,7 +295,7 @@ impl BundledState {
 
                                 tx.set_chain_id(sequence.chain);
 
-                                // Set TxKind::Create explicitly to satify `check_reqd_fields` in
+                                // Set TxKind::Create explicitly to satisfy `check_reqd_fields` in
                                 // alloy
                                 if tx.to.is_none() {
                                     tx.set_create();

--- a/crates/script/src/progress.rs
+++ b/crates/script/src/progress.rs
@@ -16,7 +16,7 @@ use yansi::Paint;
 /// State of [ProgressBar]s displayed for the given [ScriptSequence].
 #[derive(Debug)]
 pub struct SequenceProgressState {
-    /// The top spinner with containt of the format "Sequence #{id} on {network} | {status}""
+    /// The top spinner with content of the format "Sequence #{id} on {network} | {status}""
     top_spinner: ProgressBar,
     /// Progress bar with the count of transactions.
     txs: ProgressBar,

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -89,7 +89,7 @@ impl VerifyBundle {
 
     /// Configures the chain and sets the etherscan key, if available
     pub fn set_chain(&mut self, config: &Config, chain: Chain) {
-        // If dealing with multiple chains, we need to be able to change inbetween the config
+        // If dealing with multiple chains, we need to be able to change in between the config
         // chain_id.
         self.etherscan.key = config.get_etherscan_api_key(Some(chain));
         self.etherscan.chain = Some(chain);

--- a/crates/sol-macro-gen/src/lib.rs
+++ b/crates/sol-macro-gen/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate constains the logic for Rust bindings generating from Solidity contracts
+//! This crate contains the logic for Rust bindings generating from Solidity contracts
 
 pub mod sol_macro_gen;
 

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -468,7 +468,7 @@ impl VerifyBytecodeArgs {
                 &transaction,
             )?;
 
-            // State commited using deploy_with_env, now get the runtime bytecode from the db.
+            // State committed using deploy_with_env, now get the runtime bytecode from the db.
             let (fork_runtime_code, onchain_runtime_code) = crate::utils::get_runtime_codes(
                 &mut executor,
                 &provider,

--- a/crates/verify/src/retry.rs
+++ b/crates/verify/src/retry.rs
@@ -20,7 +20,7 @@ pub struct RetryArgs {
     )]
     pub retries: u32,
 
-    /// Optional delay to apply inbetween verification attempts, in seconds.
+    /// Optional delay to apply in between verification attempts, in seconds.
     #[arg(
         long,
         value_parser = RangedU64ValueParser::<u32>::new().range(0..=30),

--- a/testdata/default/repros/Issue6634.t.sol
+++ b/testdata/default/repros/Issue6634.t.sol
@@ -58,7 +58,7 @@ contract Issue6634Test is DSTest {
 
         assertEq(called.length, 2, "incorrect length");
         assertEq(uint256(called[0].kind), uint256(Vm.AccountAccessKind.Call), "first AccountAccess is incorrect kind");
-        assertEq(called[0].account, CREATE2_DEPLOYER, "first AccountAccess accout is incorrect");
+        assertEq(called[0].account, CREATE2_DEPLOYER, "first AccountAccess account is incorrect");
         assertEq(called[0].accessor, accessor, "first AccountAccess accessor is incorrect");
         assertEq(
             uint256(called[1].kind), uint256(Vm.AccountAccessKind.Create), "second AccountAccess is incorrect kind"
@@ -84,7 +84,7 @@ contract Issue6634Test is DSTest {
 
         assertEq(called.length, 2, "incorrect length");
         assertEq(uint256(called[0].kind), uint256(Vm.AccountAccessKind.Call), "first AccountAccess is incorrect kind");
-        assertEq(called[0].account, CREATE2_DEPLOYER, "first AccountAccess accout is incorrect");
+        assertEq(called[0].account, CREATE2_DEPLOYER, "first AccountAccess account is incorrect");
         assertEq(called[0].accessor, accessor, "first AccountAccess accessor is incorrect");
         assertEq(
             uint256(called[1].kind), uint256(Vm.AccountAccessKind.Create), "second AccountAccess is incorrect kind"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Adds a Makefile to help run the various command locally more easily

`$ make` yields:

```
Usage:
  make <target>

Help
  help             Display this help.

Build
  build            Build the project.

Other
  clean            Clean the project.
  fmt              Run all formatters.
  lint             Run all linters.
  test             Run all tests.
  pr               Run all tests and linters in preparation for a PR.
```

Includes common tasks focused on commands you would run for a PR

Adds `codespell` to Makefile and CI (also used by Reth) to enforce spell checking

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

No breaking changes, fixes spelling issues raised by codespell