### PR TITLE
chore: add comments for alloy-core patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,18 @@ proptest = "1"
 comfy-table = "7"
 
 # [patch.crates-io]
+## alloy-core
+# alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
+# alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }
+# alloy-primitives = { path = "../../alloy-rs/core/crates/primitives" }
+# alloy-sol-macro = { path = "../../alloy-rs/core/crates/sol-macro" }
+# alloy-sol-macro-expander = { path = "../../alloy-rs/core/crates/sol-macro-expander" }
+# alloy-sol-macro-input = { path = "../../alloy-rs/core/crates/sol-macro-input" }
+# alloy-sol-type-parser = { path = "../../alloy-rs/core/crates/sol-type-parser" }
+# alloy-sol-types = { path = "../../alloy-rs/core/crates/sol-types" }
+# syn-solidity = { path = "../../alloy-rs/core/crates/syn-solidity" }
+
+## alloy
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }


### PR DESCRIPTION
Happens often enough that we should keep the patches commented out. This was also done for ethers since there's a lot of crates and they generally all must be patched together or it won't compile.