### PR TITLE
fix(coverage): better find of loc start byte position

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -470,12 +470,14 @@ impl<'a> ContractVisitor<'a> {
     }
 
     fn source_location_for(&self, loc: &ast::LowFidelitySourceLocation) -> SourceLocation {
+        let loc_start =
+            self.source.char_indices().map(|(i, _)| i).nth(loc.start).unwrap_or_default();
         SourceLocation {
             source_id: self.source_id,
             contract_name: self.contract_name.clone(),
             start: loc.start as u32,
             length: loc.length.map(|x| x as u32),
-            line: self.source[..loc.start].lines().count(),
+            line: self.source[..loc_start].lines().count(),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
potentially fix for #8957 (wasn't able to reproduce locally): determine source location start by using char_indices and avoid panic when slicing source
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
