### PR TITLE
fix(`invariant`): replay should not fail for magic assume

### DIFF
--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -5,6 +5,7 @@ use crate::executors::{
     Executor,
 };
 use alloy_primitives::{Address, Bytes, U256};
+use foundry_evm_core::constants::MAGIC_ASSUME;
 use foundry_evm_fuzz::invariant::BasicTxDetails;
 use indicatif::ProgressBar;
 use proptest::bits::{BitSetLike, VarBitSet};
@@ -160,7 +161,7 @@ pub fn check_sequence(
             tx.call_details.calldata.clone(),
             U256::ZERO,
         )?;
-        if call_result.reverted && fail_on_revert {
+        if call_result.reverted && fail_on_revert && call_result.result.as_ref() != MAGIC_ASSUME {
             // Candidate sequence fails test.
             // We don't have to apply remaining calls to check sequence.
             return Ok((false, false));

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -161,6 +161,9 @@ pub fn check_sequence(
             tx.call_details.calldata.clone(),
             U256::ZERO,
         )?;
+        // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed scenarios that
+        // are replayed with a modified version of test driver (that use new `vm.assume`
+        // cheatcodes).
         if call_result.reverted && fail_on_revert && call_result.result.as_ref() != MAGIC_ASSUME {
             // Candidate sequence fails test.
             // We don't have to apply remaining calls to check sequence.

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -3,7 +3,8 @@
 use crate::{config::*, test_helpers::TEST_DATA_DEFAULT};
 use alloy_primitives::U256;
 use forge::fuzz::CounterExample;
-use foundry_test_utils::Filter;
+use foundry_config::{Config, InvariantConfig};
+use foundry_test_utils::{forgetest_init, str, Filter};
 use std::collections::BTreeMap;
 
 macro_rules! get_counterexample {
@@ -700,3 +701,71 @@ async fn test_no_reverts_in_counterexample() {
         }
     };
 }
+
+// Tests that a persisted failure doesn't fail due to assume revert if test driver is changed.
+forgetest_init!(should_not_fail_replay_assume, |prj, cmd| {
+    let config = Config {
+        invariant: {
+            InvariantConfig { fail_on_revert: true, max_assume_rejects: 10, ..Default::default() }
+        },
+        ..Default::default()
+    };
+    prj.write_config(config);
+
+    // Add initial test that breaks invariant.
+    prj.add_test(
+        "AssumeTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract AssumeHandler is Test {
+    function fuzzMe(uint256 a) public {
+        require(false, "Invariant failure");
+    }
+}
+
+contract AssumeTest is Test {
+    function setUp() public {
+        AssumeHandler handler = new AssumeHandler();
+    }
+    function invariant_assume() public {}
+}
+     "#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "--mt", "invariant_assume"]).assert_failure().stdout_eq(str![[r#"
+...
+[FAIL: revert: Invariant failure]
+...
+"#]]);
+
+    // Change test to use assume instead require. Same test should fail with too many inputs
+    // rejected message instead persisted failure revert.
+    prj.add_test(
+        "AssumeTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract AssumeHandler is Test {
+    function fuzzMe(uint256 a) public {
+        vm.assume(false);
+    }
+}
+
+contract AssumeTest is Test {
+    function setUp() public {
+        AssumeHandler handler = new AssumeHandler();
+    }
+    function invariant_assume() public {}
+}
+     "#,
+    )
+    .unwrap();
+
+    cmd.assert_failure().stdout_eq(str![[r#"
+...
+[FAIL: `vm.assume` rejected too many inputs (10 allowed)] invariant_assume() (runs: 0, calls: 0, reverts: 0)
+...
+"#]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- fuzzed inputs rejected by `assume` are discarded during fuzz runs so they cannot end up in a failed sequence
https://github.com/foundry-rs/foundry/blob/9dbfb2f1115466b28f2697e158131f90df6b2590/crates/evm/evm/src/executors/invariant/mod.rs#L336-L338
- when a failed sequence is identified, it is shrunken and persisted to be replayed (by using the `check_sequence` fn)
- if a failed sequence is persisted and then replayed by a changed test driver (which introduce a new assume) then replay will fail in assume revert (and show up in traces) which is not desirable. Instead the sequence should be replayed and if no failure then move forward with new campaign.

Reproducible sample, starting from
```Solidity
contract ReplHandler is Test {
    function fuzzMe(uint256 a) public {
        require(a > 500, "failed");
    }
}

contract ReplTest is Test {
    function setUp() public {
        ReplHandler handler = new ReplHandler();
    }

    function invariant_repl() public {}
}
```
fails with
```bash
[FAIL: revert: failed]
        [Sequence]
                sender=0x000000000000000000000000000000001ed7831C addr=[test/Repl.t.sol:ReplHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=fuzzMe(uint256) args=[3]
```

then if `fuzzMe` changed to
```Solidity
    function fuzzMe(uint256 a) public {
        vm.assume(false);
        require(a > 500, "failed");
    }
```

replay fails with following traces
```bash
[FAIL: invariant_repl persisted failure revert]
        [Sequence]
                sender=0x000000000000000000000000000000001ed7831C addr=[test/Repl.t.sol:ReplHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=fuzzMe(uint256) args=[3]
 invariant_repl() (runs: 1, calls: 1, reverts: 1)
Traces:
  [802250] ReplTest::setUp()
    ├─ [769223] → new ReplHandler@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
    │   └─ ← [Return] 3621 bytes of code
    └─ ← [Stop] 

  [3114] ReplHandler::fuzzMe(3)
    ├─ [0] VM::assume(false) [staticcall]
    │   └─ ← [Revert] FOUNDRY::ASSUME
    └─ ← [Revert] FOUNDRY::ASSUME

  [144] ReplTest::invariant_repl()
    └─ ← [Stop] 
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- do not revert replay if magic assume
- unit test