### PR TITLE
chore(traces): remove unreachable decoding of expectRevert

### DIFF
--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::Vm::ForgeContext;
 use alloy_sol_types::sol;
 use foundry_macros::Cheatcode;
+use std::fmt;
 
 sol! {
 // Cheatcodes are marked as view/pure/none using the following rules:
@@ -2403,6 +2404,20 @@ impl PartialEq for ForgeContext {
             (Self::ScriptResume, Self::ScriptResume) |
             (Self::Unknown, Self::Unknown) => true,
             _ => false,
+        }
+    }
+}
+
+impl fmt::Display for Vm::CheatcodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl fmt::Display for Vm::VmErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CheatcodeError(err) => err.fmt(f),
         }
     }
 }

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -4,7 +4,7 @@ use crate::abi::{Console, Vm};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Error, JsonAbi};
 use alloy_primitives::{hex, Log, Selector};
-use alloy_sol_types::{SolCall, SolError, SolEventInterface, SolInterface, SolValue};
+use alloy_sol_types::{SolError, SolEventInterface, SolInterface, SolValue};
 use foundry_common::SELECTOR_LEN;
 use itertools::Itertools;
 use revm::interpreter::InstructionResult;
@@ -169,36 +169,6 @@ impl RevertDecoder {
             Vm::CheatcodeError::SELECTOR => {
                 let e = Vm::CheatcodeError::abi_decode_raw(data, false).ok()?;
                 return Some(e.message);
-            }
-            // `expectRevert(bytes)`
-            Vm::expectRevert_2Call::SELECTOR => {
-                let e = Vm::expectRevert_2Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
-            }
-            // `expectRevert(bytes,address)`
-            Vm::expectRevert_5Call::SELECTOR => {
-                let e = Vm::expectRevert_5Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
-            }
-            // `expectRevert(bytes4)`
-            Vm::expectRevert_1Call::SELECTOR => {
-                let e = Vm::expectRevert_1Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
-            }
-            // `expectRevert(bytes4,address)`
-            Vm::expectRevert_4Call::SELECTOR => {
-                let e = Vm::expectRevert_4Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
-            }
-            // `expectPartialRevert(bytes4)`
-            Vm::expectPartialRevert_0Call::SELECTOR => {
-                let e = Vm::expectPartialRevert_0Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
-            }
-            // `expectPartialRevert(bytes4,address)`
-            Vm::expectPartialRevert_1Call::SELECTOR => {
-                let e = Vm::expectPartialRevert_1Call::abi_decode_raw(data, false).ok()?;
-                return self.maybe_decode(&e.revertData[..], status);
             }
             _ => {}
         }

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -4,7 +4,7 @@ use crate::abi::{Console, Vm};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Error, JsonAbi};
 use alloy_primitives::{hex, Log, Selector};
-use alloy_sol_types::{SolError, SolEventInterface, SolInterface, SolValue};
+use alloy_sol_types::{SolEventInterface, SolInterface, SolValue};
 use foundry_common::SELECTOR_LEN;
 use itertools::Itertools;
 use revm::interpreter::InstructionResult;
@@ -139,7 +139,7 @@ impl RevertDecoder {
     ///
     /// See [`decode`](Self::decode) for more information.
     pub fn maybe_decode(&self, err: &[u8], status: Option<InstructionResult>) -> Option<String> {
-        if err.len() < SELECTOR_LEN {
+        let Some((selector, data)) = err.split_first_chunk::<SELECTOR_LEN>() else {
             if let Some(status) = status {
                 if !status.is_ok() {
                     return Some(format!("EvmError: {status:?}"));
@@ -150,27 +150,15 @@ impl RevertDecoder {
             } else {
                 Some(format!("custom error bytes {}", hex::encode_prefixed(err)))
             };
-        }
+        };
 
         if let Some(reason) = SkipReason::decode(err) {
             return Some(reason.to_string());
         }
 
-        // Solidity's `Error(string)` or `Panic(uint256)`
-        if let Ok(e) = alloy_sol_types::GenericContractError::abi_decode(err, false) {
+        // Solidity's `Error(string)` or `Panic(uint256)`, or `Vm`'s custom errors.
+        if let Ok(e) = alloy_sol_types::ContractError::<Vm::VmErrors>::abi_decode(err, false) {
             return Some(e.to_string());
-        }
-
-        let (selector, data) = err.split_at(SELECTOR_LEN);
-        let selector: &[u8; 4] = selector.try_into().unwrap();
-
-        match *selector {
-            // `CheatcodeError(string)`
-            Vm::CheatcodeError::SELECTOR => {
-                let e = Vm::CheatcodeError::abi_decode_raw(data, false).ok()?;
-                return Some(e.message);
-            }
-            _ => {}
         }
 
         // Custom errors.


### PR DESCRIPTION
These are unreachable because `expectRevert*` selectors never appear in return data, so there is no point in checking for them.