### PR TITLE
chore: bump max allowed verification delay

### DIFF
--- a/crates/verify/src/retry.rs
+++ b/crates/verify/src/retry.rs
@@ -23,7 +23,7 @@ pub struct RetryArgs {
     /// Optional delay to apply in between verification attempts, in seconds.
     #[arg(
         long,
-        value_parser = RangedU64ValueParser::<u32>::new().range(0..=30),
+        value_parser = RangedU64ValueParser::<u32>::new().range(0..=180),
         default_value = "5",
     )]
     pub delay: u32,


### PR DESCRIPTION
bumps to 3mins, there's probably an argument to leave this uncapped, but 3min should be reasonable