### PR TITLE
fix: configure initial blob gas and price correctly

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -493,7 +493,8 @@ impl NodeConfig {
         {
             BlobExcessGasAndPrice::new(excess_blob_gas as u64)
         } else {
-            BlobExcessGasAndPrice { blob_gasprice: 0, excess_blob_gas: 0 }
+            // if no excess blob gas is configured, default to 0
+            BlobExcessGasAndPrice::new(0)
         }
     }
 


### PR DESCRIPTION
we previously configured the initial BlobExcessGasAndPrice incorrectly with 0

ref https://github.com/foundry-rs/foundry/pull/8963