### PR TITLE
fix(forge): generate `evm.legacyAssembly` extra output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d91e510bd537970f68f8462dea0e8df0a2302d4749fb57bc8e10bbd32a283e2"
+checksum = "588bc1dd21020966a255a578433016d4637c810ed76127997a469bc4a3311e7f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9971eefe4eae1cf2ac707beb4d40f63304b34c81c0961d299e461c14a23b1e7"
+checksum = "3b12c7a7ab554fde7521428b040205569c187995b817481720e99adf524bf7f8"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3759,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-solc"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde3d12776c295ad85bcdbbae18f4601e384f40a62b0e3371d880bbcd91c65c"
+checksum = "4654933ab983928d8e33e7fdf425bb60553e8a4ac415a6014f1f2e56a5b3741d"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3783,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569a769f6105248816c253715ec39977d61d369e9c67e4774d6870da8f64dffc"
+checksum = "2271a6689d27f42ffe1259f587196f56251508c6c9e362c585ccf234f5919f96"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3798,15 +3798,14 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-core"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f10ade77fa0eab75e142a76711c42a258781bad0c4516ad64aa413297ebb72e"
+checksum = "eb71494112126e7ecb92748913403c35ef949f18734e3ff4566a782ce2c8b986"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
  "dunce",
  "fs_extra",
- "memmap2",
  "once_cell",
  "path-slash",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ foundry-linking = { path = "crates/linking" }
 
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.7.3", default-features = false }
-foundry-compilers = { version = "0.11.1", default-features = false }
+foundry-compilers = { version = "0.11.3", default-features = false }
 foundry-fork-db = "0.3.2"
 solang-parser = "=0.3.3"
 

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -101,6 +101,9 @@ impl InspectArgs {
             ContractArtifactField::Assembly | ContractArtifactField::AssemblyOptimized => {
                 print_json_str(&artifact.assembly, None)?;
             }
+            ContractArtifactField::LegacyAssembly => {
+                print_json_str(&artifact.legacy_assembly, None)?;
+            }
             ContractArtifactField::MethodIdentifiers => {
                 print_json(&artifact.method_identifiers)?;
             }
@@ -210,6 +213,7 @@ pub enum ContractArtifactField {
     DeployedBytecode,
     Assembly,
     AssemblyOptimized,
+    LegacyAssembly,
     MethodIdentifiers,
     GasEstimates,
     StorageLayout,
@@ -292,6 +296,7 @@ impl_value_enum! {
         DeployedBytecode  => "deployedBytecode" | "deployed_bytecode" | "deployed-bytecode"
                              | "deployed" | "deployedbytecode",
         Assembly          => "assembly" | "asm",
+        LegacyAssembly    => "legacyAssembly" | "legacyassembly" | "legacy_assembly",
         AssemblyOptimized => "assemblyOptimized" | "asmOptimized" | "assemblyoptimized"
                              | "assembly_optimized" | "asmopt" | "assembly-optimized"
                              | "asmo" | "asm-optimized" | "asmoptimized" | "asm_optimized",
@@ -324,6 +329,7 @@ impl From<ContractArtifactField> for ContractOutputSelection {
                 DeployedBytecodeOutputSelection::All,
             )),
             Caf::Assembly | Caf::AssemblyOptimized => Self::Evm(EvmOutputSelection::Assembly),
+            Caf::LegacyAssembly => Self::Evm(EvmOutputSelection::LegacyAssembly),
             Caf::MethodIdentifiers => Self::Evm(EvmOutputSelection::MethodIdentifiers),
             Caf::GasEstimates => Self::Evm(EvmOutputSelection::GasEstimates),
             Caf::StorageLayout => Self::StorageLayout,
@@ -354,6 +360,7 @@ impl PartialEq<ContractOutputSelection> for ContractArtifactField {
                 (Self::Bytecode, Cos::Evm(Eos::ByteCode(_))) |
                 (Self::DeployedBytecode, Cos::Evm(Eos::DeployedByteCode(_))) |
                 (Self::Assembly | Self::AssemblyOptimized, Cos::Evm(Eos::Assembly)) |
+                (Self::LegacyAssembly, Cos::Evm(Eos::LegacyAssembly)) |
                 (Self::MethodIdentifiers, Cos::Evm(Eos::MethodIdentifiers)) |
                 (Self::GasEstimates, Cos::Evm(Eos::GasEstimates)) |
                 (Self::StorageLayout, Cos::StorageLayout) |

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -740,9 +740,17 @@ Compiler run successful!
 
 // checks that extra output works
 forgetest_init!(can_emit_multiple_extra_output, |prj, cmd| {
-    cmd.args(["build", "--extra-output", "metadata", "ir-optimized", "--extra-output", "ir"])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.args([
+        "build",
+        "--extra-output",
+        "metadata",
+        "legacyAssembly",
+        "ir-optimized",
+        "--extra-output",
+        "ir",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -753,6 +761,7 @@ Compiler run successful!
     let artifact: ConfigurableContractArtifact =
         foundry_compilers::utils::read_json_file(&artifact_path).unwrap();
     assert!(artifact.metadata.is_some());
+    assert!(artifact.legacy_assembly.is_some());
     assert!(artifact.ir.is_some());
     assert!(artifact.ir_optimized.is_some());
 
@@ -763,6 +772,7 @@ Compiler run successful!
             "metadata",
             "ir-optimized",
             "evm.bytecode.sourceMap",
+            "evm.legacyAssembly",
             "--force",
         ])
         .root_arg()
@@ -784,6 +794,12 @@ Compiler run successful!
     let sourcemap =
         prj.paths().artifacts.join(format!("{TEMPLATE_CONTRACT_ARTIFACT_BASE}.sourcemap"));
     std::fs::read_to_string(sourcemap).unwrap();
+
+    let legacy_assembly = prj
+        .paths()
+        .artifacts
+        .join(format!("{TEMPLATE_CONTRACT_ARTIFACT_BASE}.legacyAssembly.json"));
+    std::fs::read_to_string(legacy_assembly).unwrap();
 });
 
 forgetest!(can_print_warnings, |prj, cmd| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #8977 
Bump foundry compilers, add test for extra output (and file) check
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
