### PR TITLE
fix: disable optimizations when `--decode-internal` is set

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -14,6 +14,7 @@ use foundry_compilers::{
     solc::SolcSettings,
     Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
 };
+use foundry_config::SolcReq;
 use num_format::{Locale, ToFormattedString};
 use std::{
     collections::BTreeMap,
@@ -430,4 +431,15 @@ pub fn with_compilation_reporter<O>(quiet: bool, f: impl FnOnce() -> O) -> O {
     };
 
     foundry_compilers::report::with_scoped(&reporter, f)
+}
+
+/// Returns whether the compiler version supports `via-ir` compilation.
+pub fn supports_via_ir(solc: &Option<SolcReq>) -> bool {
+    if let Some(SolcReq::Version(version)) = &solc {
+        if *version < semver::Version::new(0, 8, 13) {
+            return false;
+        }
+    }
+
+    true
 }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -132,7 +132,7 @@ impl CoverageArgs {
                 project.settings.solc.settings.with_via_ir_minimum_optimization()
         } else {
             let msg =
-                "Warning! Disabling optimizer as it is required for accurate source mappings."
+                "Warning! Disabling optimizer as it is required for accurate source mappings.\n"
                     .yellow();
             p_println!(!self.test.build_args().silent => "{msg}");
 

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -116,11 +116,11 @@ impl CoverageArgs {
 
             // print warning message
             let msg = concat!(
-                "Warning! \"--ir-minimum\" flag enables viaIR with minimum optimization, \
+                "Warning! \"--ir-minimum\" flag enables viaIR with minimum optimization \
                  which can result in inaccurate source mappings.\n",
                 "Only use this flag as a workaround if you are experiencing \"stack too deep\" errors.\n",
                 "Note that \"viaIR\" is only available in Solidity 0.8.13 and above.\n",
-                "See more: https://github.com/foundry-rs/foundry/issues/3357",
+                "See more: https://github.com/foundry-rs/foundry/issues/3357\n",
             ).yellow();
             p_println!(!self.test.build_args().silent => "{msg}");
 
@@ -132,7 +132,7 @@ impl CoverageArgs {
                 project.settings.solc.settings.with_via_ir_minimum_optimization()
         } else {
             let msg =
-                "Warning! Disabling optimizer as it is required for accurate source mappings.\n"
+                "Warning! Disabling optimizer as it is a requirement for accurate source mappings.\n"
                     .yellow();
             p_println!(!self.test.build_args().silent => "{msg}");
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -335,7 +335,7 @@ impl TestArgs {
                     project.settings.solc.settings.with_via_ir_minimum_optimization()
             } else {
                 let msg =
-                    "Warning! Disabling optimizer as it is required for accurate source mappings."
+                    "Warning! Disabling optimizer as it is required for accurate source mappings.\n"
                         .yellow();
                 p_println!(!self.opts.silent => "{msg}");
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -325,17 +325,19 @@ impl TestArgs {
                 }
 
                 let msg = concat!(
-                    "Warning! Using \"--ir-minimum\" flag to enable viaIR with minimum optimization, \
-                    which can result in inaccurate source mappings.\n",
-                )
-                .yellow();
+                    "Warning! Uses \"--ir-minimum\" flag to use viaIR with minimum optimization \
+                     which can result in inaccurate source mappings.\n",
+                    "Only use this flag as a workaround if you are experiencing \"stack too deep\" errors.\n",
+                    "Note that \"viaIR\" is only available in Solidity 0.8.13 and above.\n",
+                    "See more: https://github.com/foundry-rs/foundry/issues/3357\n",
+                ).yellow();
                 p_println!(!self.opts.silent => "{msg}");
 
                 project.settings.solc.settings =
                     project.settings.solc.settings.with_via_ir_minimum_optimization()
             } else {
                 let msg =
-                    "Warning! Disabling optimizer as it is required for accurate source mappings.\n"
+                    "Warning! Disabling optimizer as it is a requirement for accurate source mappings.\n"
                         .yellow();
                 p_println!(!self.opts.silent => "{msg}");
 

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1230,13 +1230,13 @@ Traces:
     ├─ [22638] SimpleContract::increment()
     │   ├─ [20150] SimpleContract::_setNum(1)
     │   │   └─ ← 0
-    │   └─ ← [Stop]
+    │   └─ ← [Stop] 
     ├─ [23219] SimpleContract::setValues(100, 0x0000000000000000000000000000000000000123)
     │   ├─ [250] SimpleContract::_setNum(100)
     │   │   └─ ← 1
     │   ├─ [22339] SimpleContract::_setAddr(0x0000000000000000000000000000000000000123)
     │   │   └─ ← 0x0000000000000000000000000000000000000000
-    │   └─ ← [Stop]
+    │   └─ ← [Stop] 
     └─ ← [Stop] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1214,7 +1214,7 @@ forgetest_init!(internal_functions_trace, |prj, cmd| {
     // The optimizer is disabled internally.
     prj.add_test("Simple", SIMPLE_CONTRACT).unwrap();
     cmd.args(["test", "-vvvv", "--decode-internal"]).assert_success().stdout_eq(str![[r#"
-Warning! Disabling optimizer as it is required for accurate source mappings.
+Warning! Disabling optimizer as it is a requirement for accurate source mappings.
 
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
@@ -1256,7 +1256,10 @@ forgetest_init!(internal_functions_trace_via_ir_minimum, |prj, cmd| {
     cmd.args(["test", "-vvvv", "--decode-internal", "--via-ir"])
         .assert_success()
         .stdout_eq(str![[r#"
-Warning! Using "--ir-minimum" flag to enable viaIR with minimum optimization, which can result in inaccurate source mappings.
+Warning! Uses "--ir-minimum" flag to use viaIR with minimum optimization which can result in inaccurate source mappings.
+Only use this flag as a workaround if you are experiencing "stack too deep" errors.
+Note that "viaIR" is only available in Solidity 0.8.13 and above.
+See more: https://github.com/foundry-rs/foundry/issues/3357
 
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
@@ -1269,20 +1272,20 @@ Traces:
     ├─ [288869] SimpleContractTest::test()
     │   ├─ [256331] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
     │   │   └─ ← [Return] 1280 bytes of code
-    │   └─ ←
+    │   └─ ← 
     ├─ [23484] SimpleContract::increment()
     │   ├─ [2189] SimpleContract::increment()
-    │   │   └─ ←
+    │   │   └─ ← 
     │   ├─ [20654] SimpleContract::_setNum(1)
     │   │   └─ ← 0
-    │   └─ ← [Return]
+    │   └─ ← [Return] 
     ├─ [24177] SimpleContract::setValues(100, 0x0000000000000000000000000000000000000123)
     │   ├─ [245] SimpleContract::setValues(291, 0x0000000000000000000000000000000000000064)
-    │   │   └─ ←
+    │   │   └─ ← 
     │   ├─ [22786] SimpleContract::_setAddr(0x0000000000000000000000000000000000000123)
     │   │   └─ ← 0x0000000000000000000000000000000000000000
-    │   └─ ← [Return]
-    └─ ← [Return]
+    │   └─ ← [Return] 
+    └─ ← [Return] 
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -1169,6 +1169,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+#[cfg(not(feature = "isolate-by-default"))]
 const SIMPLE_CONTRACT: &str = r#"
 import {Test, console} from "forge-std/Test.sol";
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: #8986 
Closes: #8840, added warning that optimizations are disabled to both `coverage` and `test`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Automatically disables optimization settings when running with the `--decode-internal` flag (incl. flamecharts / flamegraphs), with same settings used by `forge coverage`

Now emits a warning that the optimizer is disabled

When using `--via-ir` it switches to use the `--ir-minimum` flag, also emitting a warning

cc @klkvr 