### PR TITLE
docs: clarify keystore path should point to a filename

### DIFF
--- a/crates/wallets/src/multi_wallet.rs
+++ b/crates/wallets/src/multi_wallet.rs
@@ -162,7 +162,7 @@ pub struct MultiWalletOpts {
     )]
     pub mnemonic_indexes: Option<Vec<u32>>,
 
-    /// Use the keystore in the given folder or file.
+    /// Use the keystore by its filename in the given folder.
     #[arg(
         long = "keystore",
         visible_alias = "keystores",
@@ -173,7 +173,7 @@ pub struct MultiWalletOpts {
     #[builder(default = "None")]
     pub keystore_paths: Option<Vec<String>>,
 
-    /// Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+    /// Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename.
     #[arg(
         long = "account",
         visible_alias = "accounts",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #9001 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Clarify that you should point to a keystore by its filename but it can be in a custom directory