### PR TITLE
fix(forge): warn if script is executed with cbor metadata disabled

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1986,3 +1986,28 @@ forgetest_async!(can_deploy_library_create2_different_sender, |prj, cmd| {
         .assert_nonce_increment(&[(2, 2)])
         .await;
 });
+
+// Tests that the `run` command works correctly
+forgetest!(should_warn_if_no_metadata, |prj, cmd| {
+    let script = prj
+        .add_source(
+            "Foo",
+            r#"
+contract Demo {
+    function run() external {
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.arg("script").arg(script).args(["--no-metadata"]).assert_success().stdout_eq(str![[r#"
+Warning! Running "forge script" with "--no-metadata" flag or with "cbor_metadata" set to false can result in deployment failures.
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Script ran successfully.
+[GAS]
+
+"#]]);
+});

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1987,7 +1987,8 @@ forgetest_async!(can_deploy_library_create2_different_sender, |prj, cmd| {
         .await;
 });
 
-// Tests that the `run` command works correctly
+// Tests that the `forge script` command warns if metadata disabled.
+// <https://github.com/foundry-rs/foundry/issues/8995>
 forgetest!(should_warn_if_no_metadata, |prj, cmd| {
     let script = prj
         .add_source(
@@ -2002,7 +2003,7 @@ contract Demo {
         .unwrap();
 
     cmd.arg("script").arg(script).args(["--no-metadata"]).assert_success().stdout_eq(str![[r#"
-Warning! Running "forge script" with "--no-metadata" flag or with "cbor_metadata" set to false can result in deployment failures.
+Warning! "--no-metadata" flag or "cbor_metadata" set to false can result in deployment failures.
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -212,11 +212,7 @@ impl ScriptArgs {
         let (config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
 
         // print warning message if `cbor_metadata` is disabled
-        let msg = concat!(
-            "Warning! Running \"forge script\" with \"--no-metadata\" flag \
-             or with \"cbor_metadata\" set to false can result in deployment failures.",
-        )
-        .yellow();
+        let msg = "Warning! \"--no-metadata\" flag or \"cbor_metadata\" set to false can result in deployment failures.".yellow();
         p_println!(!config.cbor_metadata => "{msg}");
 
         if let Some(sender) = self.maybe_load_private_key()? {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -23,7 +23,7 @@ use clap::{Parser, ValueHint};
 use dialoguer::Confirm;
 use eyre::{ContextCompat, Result};
 use forge_verify::RetryArgs;
-use foundry_cli::{opts::CoreBuildArgs, utils::LoadConfig};
+use foundry_cli::{opts::CoreBuildArgs, p_println, utils::LoadConfig};
 use foundry_common::{
     abi::{encode_function_args, get_func},
     evm::{Breakpoints, EvmArgs},
@@ -210,6 +210,14 @@ impl ScriptArgs {
             ScriptWallets::new(self.wallets.get_multi_wallet().await?, self.evm_opts.sender);
 
         let (config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
+
+        // print warning message if `cbor_metadata` is disabled
+        let msg = concat!(
+            "Warning! Running \"forge script\" with \"--no-metadata\" flag \
+             or with \"cbor_metadata\" set to false can result in deployment failures.",
+        )
+        .yellow();
+        p_println!(!config.cbor_metadata => "{msg}");
 
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8995 

Added warn message inline with coverage warn if cbor metadata disabled when using forge script
![image](https://github.com/user-attachments/assets/539ed05d-0237-4d4a-8895-789db108fb75)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
