### PR TITLE
feat: use `dyn DatabaseExt`

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -397,6 +397,7 @@ fn build_logs_bloom(logs: Vec<Log>, bloom: &mut Bloom) {
     }
 }
 
+/// Creates a database with given database and inspector, optionally enabling alphanet features.
 pub fn new_evm_with_inspector<DB: revm::Database>(
     db: DB,
     env: EnvWithHandlerCfg,

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -28,8 +28,9 @@ use foundry_evm::{
         },
     },
     traces::CallTraceNode,
+    utils::alphanet_handler_register,
 };
-use revm::primitives::MAX_BLOB_GAS_PER_BLOCK;
+use revm::{db::WrapDatabaseRef, primitives::MAX_BLOB_GAS_PER_BLOCK};
 use std::sync::Arc;
 
 /// Represents an executed transaction (transacted on the DB)
@@ -303,7 +304,7 @@ impl<'a, 'b, DB: Db + ?Sized, V: TransactionValidator> Iterator
         let nonce = account.nonce;
 
         // records all call and step traces
-        let mut inspector = Inspector::default().with_tracing().with_alphanet(self.alphanet);
+        let mut inspector = Inspector::default().with_tracing();
         if self.enable_steps_tracing {
             inspector = inspector.with_steps_tracing();
         }
@@ -312,8 +313,7 @@ impl<'a, 'b, DB: Db + ?Sized, V: TransactionValidator> Iterator
         }
 
         let exec_result = {
-            let mut evm =
-                foundry_evm::utils::new_evm_with_inspector(&mut *self.db, env, &mut inspector);
+            let mut evm = new_evm_with_inspector(&mut *self.db, env, &mut inspector, self.alphanet);
             if let Some(factory) = &self.precompile_factory {
                 inject_precompiles(&mut evm, factory.precompiles());
             }
@@ -395,4 +395,37 @@ fn build_logs_bloom(logs: Vec<Log>, bloom: &mut Bloom) {
             bloom.accrue(BloomInput::Raw(&topic[..]));
         }
     }
+}
+
+pub fn new_evm_with_inspector<DB: revm::Database>(
+    db: DB,
+    env: EnvWithHandlerCfg,
+    inspector: &mut dyn revm::Inspector<DB>,
+    alphanet: bool,
+) -> revm::Evm<'_, &mut dyn revm::Inspector<DB>, DB> {
+    let EnvWithHandlerCfg { env, handler_cfg } = env;
+
+    let mut handler = revm::Handler::new(handler_cfg);
+
+    handler.append_handler_register_plain(revm::inspector_handle_register);
+    if alphanet {
+        handler.append_handler_register_plain(alphanet_handler_register);
+    }
+
+    let context = revm::Context::new(revm::EvmContext::new_with_env(db, env), inspector);
+
+    revm::Evm::new(context, handler)
+}
+
+/// Creates a new EVM with the given inspector and wraps the database in a `WrapDatabaseRef`.
+pub fn new_evm_with_inspector_ref<'a, DB>(
+    db: DB,
+    env: EnvWithHandlerCfg,
+    inspector: &mut dyn revm::Inspector<WrapDatabaseRef<DB>>,
+    alphanet: bool,
+) -> revm::Evm<'a, &mut dyn revm::Inspector<WrapDatabaseRef<DB>>, WrapDatabaseRef<DB>>
+where
+    DB: revm::DatabaseRef,
+{
+    new_evm_with_inspector(WrapDatabaseRef(db), env, inspector, alphanet)
 }

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -14,7 +14,6 @@ use foundry_evm::{
         EvmContext,
     },
     traces::TracingInspectorConfig,
-    InspectorExt,
 };
 
 /// The [`revm::Inspector`] used when transacting in the evm
@@ -23,8 +22,6 @@ pub struct Inspector {
     pub tracer: Option<TracingInspector>,
     /// collects all `console.sol` logs
     pub log_collector: Option<LogCollector>,
-    /// Whether to enable Alphanet support
-    pub alphanet: bool,
 }
 
 impl Inspector {
@@ -57,12 +54,6 @@ impl Inspector {
     /// Configures the `Tracer` [`revm::Inspector`]
     pub fn with_log_collector(mut self) -> Self {
         self.log_collector = Some(Default::default());
-        self
-    }
-
-    /// Enables Alphanet features
-    pub fn with_alphanet(mut self, yes: bool) -> Self {
-        self.alphanet = yes;
         self
     }
 }
@@ -173,16 +164,6 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
         if let Some(tracer) = &mut self.tracer {
             revm::Inspector::<DB>::selfdestruct(tracer, contract, target, value);
         }
-    }
-}
-
-impl InspectorExt<'_> for Inspector {
-    fn is_alphanet(&self) -> bool {
-        self.alphanet
-    }
-
-    fn get_inspector<'a>(&mut self) -> &mut dyn revm::Inspector<&'a mut DB> {
-        self
     }
 }
 

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -176,9 +176,13 @@ impl<DB: Database> revm::Inspector<DB> for Inspector {
     }
 }
 
-impl<DB: Database> InspectorExt<DB> for Inspector {
+impl InspectorExt<'_> for Inspector {
     fn is_alphanet(&self) -> bool {
         self.alphanet
+    }
+
+    fn get_inspector<'a>(&mut self) -> &mut dyn revm::Inspector<&'a mut DB> {
+        self
     }
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1,6 +1,7 @@
 //! In-memory blockchain backend.
 
 use self::state::trie_storage;
+use super::executor::new_evm_with_inspector_ref;
 use crate::{
     config::PruneStateHistoryConfig,
     eth::{
@@ -32,6 +33,7 @@ use crate::{
     revm::{db::DatabaseRef, primitives::AccountInfo},
     ForkChoice, NodeConfig, PrecompileFactory,
 };
+use alloy_chains::NamedChain;
 use alloy_consensus::{Account, Header, Receipt, ReceiptWithBloom};
 use alloy_eips::eip4844::MAX_BLOBS_PER_BLOCK;
 use alloy_primitives::{keccak256, Address, Bytes, TxHash, TxKind, B256, U256, U64};
@@ -64,8 +66,6 @@ use anvil_core::eth::{
     utils::meets_eip155,
 };
 use anvil_rpc::error::RpcError;
-
-use alloy_chains::NamedChain;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use foundry_evm::{
     backend::{DatabaseError, DatabaseResult, RevertStateSnapshotAction},
@@ -98,8 +98,6 @@ use std::{
 };
 use storage::{Blockchain, MinedTransaction, DEFAULT_HISTORY_LIMIT};
 use tokio::sync::RwLock as AsyncRwLock;
-
-use super::executor::new_evm_with_inspector_ref;
 
 pub mod cache;
 pub mod fork_db;

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -744,10 +744,7 @@ fn inner_revert_to_state(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
     Ok(result.abi_encode())
 }
 
-fn inner_revert_to_state_and_delete(
-    ccx: &mut CheatsCtxt,
-    snapshot_id: U256,
-) -> Result {
+fn inner_revert_to_state_and_delete(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
     let result = if let Some(journaled_state) = ccx.ecx.db.revert_state(
         snapshot_id,
         &ccx.ecx.journaled_state,
@@ -763,10 +760,7 @@ fn inner_revert_to_state_and_delete(
     Ok(result.abi_encode())
 }
 
-fn inner_delete_state_snapshot(
-    ccx: &mut CheatsCtxt,
-    snapshot_id: U256,
-) -> Result {
+fn inner_delete_state_snapshot(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
     let result = ccx.ecx.db.delete_state_snapshot(snapshot_id);
     Ok(result.abi_encode())
 }

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -518,21 +518,21 @@ impl Cheatcode for readCallersCall {
 }
 
 impl Cheatcode for snapshotValue_0Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name, value } = self;
         inner_value_snapshot(ccx, None, Some(name.clone()), value.to_string())
     }
 }
 
 impl Cheatcode for snapshotValue_1Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { group, name, value } = self;
         inner_value_snapshot(ccx, Some(group.clone()), Some(name.clone()), value.to_string())
     }
 }
 
 impl Cheatcode for snapshotGasLastCall_0Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -542,7 +542,7 @@ impl Cheatcode for snapshotGasLastCall_0Call {
 }
 
 impl Cheatcode for snapshotGasLastCall_1Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name, group } = self;
         let Some(last_call_gas) = &ccx.state.gas_metering.last_call_gas else {
             bail!("no external call was made yet");
@@ -557,35 +557,35 @@ impl Cheatcode for snapshotGasLastCall_1Call {
 }
 
 impl Cheatcode for startSnapshotGas_0Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name } = self;
         inner_start_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
 impl Cheatcode for startSnapshotGas_1Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { group, name } = self;
         inner_start_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
 }
 
 impl Cheatcode for stopSnapshotGas_0Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
         inner_stop_gas_snapshot(ccx, None, None)
     }
 }
 
 impl Cheatcode for stopSnapshotGas_1Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { name } = self;
         inner_stop_gas_snapshot(ccx, None, Some(name.clone()))
     }
 }
 
 impl Cheatcode for stopSnapshotGas_2Call {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { group, name } = self;
         inner_stop_gas_snapshot(ccx, Some(group.clone()), Some(name.clone()))
     }
@@ -600,7 +600,7 @@ impl Cheatcode for snapshotCall {
 }
 
 impl Cheatcode for snapshotStateCall {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
         inner_snapshot_state(ccx)
     }
@@ -615,7 +615,7 @@ impl Cheatcode for revertToCall {
 }
 
 impl Cheatcode for revertToStateCall {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state(ccx, *snapshotId)
     }
@@ -630,7 +630,7 @@ impl Cheatcode for revertToAndDeleteCall {
 }
 
 impl Cheatcode for revertToStateAndDeleteCall {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { snapshotId } = self;
         inner_revert_to_state_and_delete(ccx, *snapshotId)
     }
@@ -645,7 +645,7 @@ impl Cheatcode for deleteSnapshotCall {
 }
 
 impl Cheatcode for deleteStateSnapshotCall {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { snapshotId } = self;
         inner_delete_state_snapshot(ccx, *snapshotId)
     }
@@ -660,7 +660,7 @@ impl Cheatcode for deleteSnapshotsCall {
 }
 
 impl Cheatcode for deleteStateSnapshotsCall {
-    fn apply_stateful<DB: DatabaseExt>(&self, ccx: &mut CheatsCtxt<DB>) -> Result {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
         inner_delete_state_snapshots(ccx)
     }
@@ -724,11 +724,11 @@ pub(super) fn get_nonce(ccx: &mut CheatsCtxt, address: &Address) -> Result {
     Ok(account.info.nonce.abi_encode())
 }
 
-fn inner_snapshot_state<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>) -> Result {
+fn inner_snapshot_state(ccx: &mut CheatsCtxt) -> Result {
     Ok(ccx.ecx.db.snapshot_state(&ccx.ecx.journaled_state, &ccx.ecx.env).abi_encode())
 }
 
-fn inner_revert_to_state<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>, snapshot_id: U256) -> Result {
+fn inner_revert_to_state(ccx: &mut CheatsCtxt, snapshot_id: U256) -> Result {
     let result = if let Some(journaled_state) = ccx.ecx.db.revert_state(
         snapshot_id,
         &ccx.ecx.journaled_state,
@@ -744,8 +744,8 @@ fn inner_revert_to_state<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>, snapshot_id:
     Ok(result.abi_encode())
 }
 
-fn inner_revert_to_state_and_delete<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_revert_to_state_and_delete(
+    ccx: &mut CheatsCtxt,
     snapshot_id: U256,
 ) -> Result {
     let result = if let Some(journaled_state) = ccx.ecx.db.revert_state(
@@ -763,21 +763,21 @@ fn inner_revert_to_state_and_delete<DB: DatabaseExt>(
     Ok(result.abi_encode())
 }
 
-fn inner_delete_state_snapshot<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_delete_state_snapshot(
+    ccx: &mut CheatsCtxt,
     snapshot_id: U256,
 ) -> Result {
     let result = ccx.ecx.db.delete_state_snapshot(snapshot_id);
     Ok(result.abi_encode())
 }
 
-fn inner_delete_state_snapshots<DB: DatabaseExt>(ccx: &mut CheatsCtxt<DB>) -> Result {
+fn inner_delete_state_snapshots(ccx: &mut CheatsCtxt) -> Result {
     ccx.ecx.db.delete_state_snapshots();
     Ok(Default::default())
 }
 
-fn inner_value_snapshot<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_value_snapshot(
+    ccx: &mut CheatsCtxt,
     group: Option<String>,
     name: Option<String>,
     value: String,
@@ -789,8 +789,8 @@ fn inner_value_snapshot<DB: DatabaseExt>(
     Ok(Default::default())
 }
 
-fn inner_last_gas_snapshot<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_last_gas_snapshot(
+    ccx: &mut CheatsCtxt,
     group: Option<String>,
     name: Option<String>,
     value: u64,
@@ -802,8 +802,8 @@ fn inner_last_gas_snapshot<DB: DatabaseExt>(
     Ok(value.abi_encode())
 }
 
-fn inner_start_gas_snapshot<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_start_gas_snapshot(
+    ccx: &mut CheatsCtxt,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -829,8 +829,8 @@ fn inner_start_gas_snapshot<DB: DatabaseExt>(
     Ok(Default::default())
 }
 
-fn inner_stop_gas_snapshot<DB: DatabaseExt>(
-    ccx: &mut CheatsCtxt<DB>,
+fn inner_stop_gas_snapshot(
+    ccx: &mut CheatsCtxt,
     group: Option<String>,
     name: Option<String>,
 ) -> Result {
@@ -880,8 +880,8 @@ fn inner_stop_gas_snapshot<DB: DatabaseExt>(
 }
 
 // Derives the snapshot group and name from the provided group and name or the running contract.
-fn derive_snapshot_name<DB: DatabaseExt>(
-    ccx: &CheatsCtxt<DB>,
+fn derive_snapshot_name(
+    ccx: &CheatsCtxt,
     group: Option<String>,
     name: Option<String>,
 ) -> (String, String) {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -73,10 +73,10 @@ pub type InnerEcx<'a, 'b, 'c> = &'a mut InnerEvmContext<&'b mut (dyn DatabaseExt
 pub trait CheatcodesExecutor {
     /// Core trait method accepting mutable reference to [Cheatcodes] and returning
     /// [revm::Inspector].
-    fn get_inspector<'a>(
+    fn get_inspector<'a, 'db>(
         &'a mut self,
         cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt<&'a mut dyn DatabaseExt> + 'a>;
+    ) -> Box<dyn InspectorExt<'db> + 'a>;
 
     /// Obtains [revm::Evm] instance and executes the given CREATE frame.
     fn exec_create(
@@ -144,7 +144,7 @@ where
     F: for<'a, 'b> FnOnce(
         &mut revm::Evm<
             '_,
-            &'b mut dyn InspectorExt<&'a mut dyn DatabaseExt>,
+            &'b mut dyn InspectorExt<'a>,
             &'a mut dyn DatabaseExt,
         >,
     ) -> Result<O, EVMError<DatabaseError>>,
@@ -164,7 +164,7 @@ where
         l1_block_info,
     };
 
-    let mut evm = new_evm_with_existing_context(inner, &mut *inspector as _);
+    let mut evm = new_evm_with_existing_context(inner, inspector.get_inspector());
 
     let res = f(&mut evm)?;
 
@@ -182,11 +182,11 @@ where
 struct TransparentCheatcodesExecutor;
 
 impl CheatcodesExecutor for TransparentCheatcodesExecutor {
-    fn get_inspector<'a>(
-        &'a mut self,
-        cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt<&'a mut dyn DatabaseExt> + 'a> {
-        Box::new(cheats as &mut dyn InspectorExt<&mut dyn DatabaseExt>)
+    fn get_inspector<'a, 'db>(
+            &'a mut self,
+            cheats: &'a mut Cheatcodes,
+        ) -> Box<dyn InspectorExt<'db> + 'a> {
+        Box::new(cheats)
     }
 }
 
@@ -1523,7 +1523,7 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
     }
 }
 
-impl InspectorExt<&mut dyn DatabaseExt> for Cheatcodes {
+impl<'a> InspectorExt<'a> for Cheatcodes {
     fn should_use_create2_factory(&mut self, ecx: Ecx, inputs: &mut CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme {
             let target_depth = if let Some(prank) = &self.prank {
@@ -1539,6 +1539,10 @@ impl InspectorExt<&mut dyn DatabaseExt> for Cheatcodes {
         } else {
             false
         }
+    }
+
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
+        self
     }
 }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -73,10 +73,7 @@ pub type InnerEcx<'a, 'b, 'c> = &'a mut InnerEvmContext<&'b mut (dyn DatabaseExt
 pub trait CheatcodesExecutor {
     /// Core trait method accepting mutable reference to [Cheatcodes] and returning
     /// [revm::Inspector].
-    fn get_inspector<'a, 'db>(
-        &'a mut self,
-        cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt + 'a>;
+    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a>;
 
     /// Obtains [revm::Evm] instance and executes the given CREATE frame.
     fn exec_create(
@@ -178,10 +175,7 @@ where
 struct TransparentCheatcodesExecutor;
 
 impl CheatcodesExecutor for TransparentCheatcodesExecutor {
-    fn get_inspector<'a, 'db>(
-        &'a mut self,
-        cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt + 'a> {
+    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
         Box::new(cheats)
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -142,11 +142,7 @@ fn with_evm<E, F, O>(
 where
     E: CheatcodesExecutor + ?Sized,
     F: for<'a, 'b> FnOnce(
-        &mut revm::Evm<
-            '_,
-            &'b mut dyn InspectorExt<'a>,
-            &'a mut dyn DatabaseExt,
-        >,
+        &mut revm::Evm<'_, &'b mut dyn InspectorExt<'a>, &'a mut dyn DatabaseExt>,
     ) -> Result<O, EVMError<DatabaseError>>,
 {
     let mut inspector = executor.get_inspector(ccx.state);
@@ -183,9 +179,9 @@ struct TransparentCheatcodesExecutor;
 
 impl CheatcodesExecutor for TransparentCheatcodesExecutor {
     fn get_inspector<'a, 'db>(
-            &'a mut self,
-            cheats: &'a mut Cheatcodes,
-        ) -> Box<dyn InspectorExt<'db> + 'a> {
+        &'a mut self,
+        cheats: &'a mut Cheatcodes,
+    ) -> Box<dyn InspectorExt<'db> + 'a> {
         Box::new(cheats)
     }
 }
@@ -1523,7 +1519,7 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
     }
 }
 
-impl<'a> InspectorExt<'a> for Cheatcodes {
+impl InspectorExt<'_> for Cheatcodes {
     fn should_use_create2_factory(&mut self, ecx: Ecx, inputs: &mut CreateInputs) -> bool {
         if let CreateScheme::Create2 { .. } = inputs.scheme {
             let target_depth = if let Some(prank) = &self.prank {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1555,11 +1555,7 @@ impl Cheatcodes {
     }
 
     #[cold]
-    fn meter_gas_record<DB: DatabaseExt>(
-        &mut self,
-        interpreter: &mut Interpreter,
-        ecx: &mut EvmContext<DB>,
-    ) {
+    fn meter_gas_record(&mut self, interpreter: &mut Interpreter, ecx: Ecx) {
         if matches!(interpreter.instruction_result, InstructionResult::Continue) {
             self.gas_metering.gas_records.iter_mut().for_each(|record| {
                 if ecx.journaled_state.depth() == record.depth {

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -1,11 +1,13 @@
 //! Implementations of [`Utilities`](spec::Group::Utilities) cheatcodes.
 
 use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
+use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::ens::namehash;
 use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
-use rand::Rng;
+use proptest::prelude::Strategy;
+use rand::{Rng, RngCore};
 use std::collections::HashMap;
 
 /// Contains locations of traces ignored via cheatcodes.
@@ -17,7 +19,7 @@ use std::collections::HashMap;
 pub struct IgnoredTraces {
     /// Mapping from (start_node_idx, start_item_idx) to (end_node_idx, end_item_idx) representing
     /// ranges of trace nodes to ignore.
-    pub ignored: HashMap<(usize, usize), (usize, usize)>,
+    pub ignored: alloy_primitives::map::HashMap<(usize, usize), (usize, usize)>,
     /// Keeps track of (start_node_idx, start_item_idx) of the last `vm.pauseTracing` call.
     pub last_pause_call: Option<(usize, usize)>,
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -2,7 +2,7 @@
 
 use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
-use alloy_primitives::U256;
+use alloy_primitives::{map::HashMap, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::ens::namehash;
 use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
@@ -18,7 +18,7 @@ use rand::{Rng, RngCore};
 pub struct IgnoredTraces {
     /// Mapping from (start_node_idx, start_item_idx) to (end_node_idx, end_item_idx) representing
     /// ranges of trace nodes to ignore.
-    pub ignored: alloy_primitives::map::HashMap<(usize, usize), (usize, usize)>,
+    pub ignored: HashMap<(usize, usize), (usize, usize)>,
     /// Keeps track of (start_node_idx, start_item_idx) of the last `vm.pauseTracing` call.
     pub last_pause_call: Option<(usize, usize)>,
 }

--- a/crates/cheatcodes/src/utils.rs
+++ b/crates/cheatcodes/src/utils.rs
@@ -2,13 +2,12 @@
 
 use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::U256;
 use alloy_sol_types::SolValue;
 use foundry_common::ens::namehash;
 use foundry_evm_core::constants::DEFAULT_CREATE2_DEPLOYER;
 use proptest::prelude::Strategy;
 use rand::{Rng, RngCore};
-use std::collections::HashMap;
 
 /// Contains locations of traces ignored via cheatcodes.
 ///

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -184,23 +184,23 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         self.backend_mut(env).roll_fork_to_transaction(id, transaction, env, journaled_state)
     }
 
-    fn transact<'b>(
+    fn transact(
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'b>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()> {
         self.backend_mut(env).transact(id, transaction, env, journaled_state, inspector)
     }
 
-    fn transact_from_tx<'b>(
+    fn transact_from_tx(
         &mut self,
         transaction: TransactionRequest,
         env: &Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'b>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()> {
         self.backend_mut(env).transact_from_tx(transaction, env, journaled_state, inspector)
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -62,10 +62,10 @@ impl<'a> CowBackend<'a> {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'b, I: InspectorExt<'b>>(
+    pub fn inspect<'b>(
         &'b mut self,
         env: &mut EnvWithHandlerCfg,
-        mut inspector: I,
+        inspector: &'b mut dyn InspectorExt<'b>,
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
@@ -74,7 +74,7 @@ impl<'a> CowBackend<'a> {
         let mut evm = crate::utils::new_evm_with_inspector(
             self as &mut dyn DatabaseExt,
             env.clone(),
-            inspector.get_inspector(),
+            inspector,
         );
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -65,7 +65,7 @@ impl<'a> CowBackend<'a> {
     pub fn inspect<'b>(
         &'b mut self,
         env: &mut EnvWithHandlerCfg,
-        inspector: &'b mut dyn InspectorExt<'b>,
+        inspector: &'b mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
@@ -190,7 +190,7 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'_>,
+        inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
         self.backend_mut(env).transact(id, transaction, env, journaled_state, inspector)
     }
@@ -200,7 +200,7 @@ impl<'a> DatabaseExt for CowBackend<'a> {
         transaction: TransactionRequest,
         env: &Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'_>,
+        inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<()> {
         self.backend_mut(env).transact_from_tx(transaction, env, journaled_state, inspector)
     }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -62,20 +62,16 @@ impl<'a> CowBackend<'a> {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'b>(
-        &'b mut self,
+    pub fn inspect(
+        &mut self,
         env: &mut EnvWithHandlerCfg,
-        inspector: &'b mut dyn InspectorExt,
+        inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState> {
         // this is a new call to inspect with a new env, so even if we've cloned the backend
         // already, we reset the initialized state
         self.is_initialized = false;
         self.spec_id = env.handler_cfg.spec_id;
-        let mut evm = crate::utils::new_evm_with_inspector(
-            self as &mut dyn DatabaseExt,
-            env.clone(),
-            inspector,
-        );
+        let mut evm = crate::utils::new_evm_with_inspector(self, env.clone(), inspector);
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -194,22 +194,22 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit {
     ) -> eyre::Result<()>;
 
     /// Fetches the given transaction for the fork and executes it, committing the state in the DB
-    fn transact<'a>(
+    fn transact(
         &mut self,
         id: Option<LocalForkId>,
         transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'a>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()>;
 
     /// Executes a given TransactionRequest, commits the new state to the DB
-    fn transact_from_tx<'a>(
+    fn transact_from_tx(
         &mut self,
         transaction: TransactionRequest,
         env: &Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'a>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()>;
 
     /// Returns the `ForkId` that's currently used in the database, if fork mode is on
@@ -1223,13 +1223,13 @@ impl DatabaseExt for Backend {
         Ok(())
     }
 
-    fn transact<'a>(
+    fn transact(
         &mut self,
         maybe_id: Option<LocalForkId>,
         transaction: B256,
         env: &mut Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'a>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()> {
         trace!(?maybe_id, ?transaction, "execute transaction");
         let persistent_accounts = self.inner.persistent_accounts.clone();
@@ -1265,12 +1265,12 @@ impl DatabaseExt for Backend {
         )
     }
 
-    fn transact_from_tx<'a>(
+    fn transact_from_tx(
         &mut self,
         tx: TransactionRequest,
         env: &Env,
         journaled_state: &mut JournaledState,
-        inspector: &mut dyn InspectorExt<'a>,
+        inspector: &mut dyn InspectorExt<'_>,
     ) -> eyre::Result<()> {
         trace!(?tx, "execute signed transaction");
 
@@ -1914,14 +1914,14 @@ fn update_env_block<T>(env: &mut Env, block: &Block<T>) {
 
 /// Executes the given transaction and commits state changes to the database _and_ the journaled
 /// state, with an inspector.
-fn commit_transaction<'a>(
+fn commit_transaction(
     tx: &Transaction,
     mut env: EnvWithHandlerCfg,
     journaled_state: &mut JournaledState,
     fork: &mut Fork,
     fork_id: &ForkId,
     persistent_accounts: &HashSet<Address>,
-    inspector: &mut dyn InspectorExt<'a>,
+    inspector: &mut dyn InspectorExt<'_>,
 ) -> eyre::Result<()> {
     configure_tx_env(&mut env.env, tx);
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -751,17 +751,13 @@ impl Backend {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'a>(
-        &'a mut self,
+    pub fn inspect(
+        &mut self,
         env: &mut EnvWithHandlerCfg,
-        inspector: &'a mut dyn InspectorExt,
+        inspector: &mut dyn InspectorExt,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(env);
-        let mut evm = crate::utils::new_evm_with_inspector(
-            self as &mut dyn DatabaseExt,
-            env.clone(),
-            inspector,
-        );
+        let mut evm = crate::utils::new_evm_with_inspector(self, env.clone(), inspector);
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;
 
@@ -1296,7 +1292,7 @@ impl DatabaseExt for Backend {
         let res = {
             let mut db = self.clone();
             let env = self.env_with_handler_cfg(env);
-            let mut evm = new_evm_with_inspector(&mut db as _, env, inspector);
+            let mut evm = new_evm_with_inspector(&mut db, env, inspector);
             evm.context.evm.journaled_state.depth = journaled_state.depth + 1;
             evm.transact()?
         };

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -751,16 +751,16 @@ impl Backend {
     /// Note: in case there are any cheatcodes executed that modify the environment, this will
     /// update the given `env` with the new values.
     #[instrument(name = "inspect", level = "debug", skip_all)]
-    pub fn inspect<'a, 'db, I: InspectorExt<'db> + 'a>(
+    pub fn inspect<'a>(
         &'a mut self,
         env: &mut EnvWithHandlerCfg,
-        mut inspector: I,
+        inspector: &'a mut dyn InspectorExt<'a>,
     ) -> eyre::Result<ResultAndState> {
         self.initialize(env);
         let mut evm = crate::utils::new_evm_with_inspector(
             self as &mut dyn DatabaseExt,
             env.clone(),
-            inspector.get_inspector(),
+            inspector,
         );
 
         let res = evm.transact().wrap_err("backend: failed while inspecting")?;

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -6,7 +6,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use auto_impl::auto_impl;
-use revm::{inspectors::NoOpInspector, interpreter::CreateInputs, Database, EvmContext, Inspector};
+use backend::DatabaseExt;
+use revm::{inspectors::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
 use revm_inspectors::access_list::AccessListInspector;
 
 #[macro_use]
@@ -32,14 +33,14 @@ pub mod utils;
 /// An extension trait that allows us to add additional hooks to Inspector for later use in
 /// handlers.
 #[auto_impl(&mut, Box)]
-pub trait InspectorExt<DB: Database>: Inspector<DB> {
+pub trait InspectorExt<'a>: Inspector<&'a mut dyn DatabaseExt> {
     /// Determines whether the `DEFAULT_CREATE2_DEPLOYER` should be used for a CREATE2 frame.
     ///
     /// If this function returns true, we'll replace CREATE2 frame with a CALL frame to CREATE2
     /// factory.
     fn should_use_create2_factory(
         &mut self,
-        _context: &mut EvmContext<DB>,
+        _context: &mut EvmContext<&'a mut dyn DatabaseExt>,
         _inputs: &mut CreateInputs,
     ) -> bool {
         false
@@ -52,7 +53,18 @@ pub trait InspectorExt<DB: Database>: Inspector<DB> {
     fn is_alphanet(&self) -> bool {
         false
     }
+
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b>;
 }
 
-impl<DB: Database> InspectorExt<DB> for NoOpInspector {}
-impl<DB: Database> InspectorExt<DB> for AccessListInspector {}
+impl<'a> InspectorExt<'a> for NoOpInspector {
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
+        self
+    }
+}
+
+impl<'a> InspectorExt<'a> for AccessListInspector {
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
+        self
+    }
+}

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -33,14 +33,14 @@ pub mod utils;
 /// An extension trait that allows us to add additional hooks to Inspector for later use in
 /// handlers.
 #[auto_impl(&mut, Box)]
-pub trait InspectorExt<'a>: Inspector<&'a mut dyn DatabaseExt> {
+pub trait InspectorExt: for<'a> Inspector<&'a mut dyn DatabaseExt> {
     /// Determines whether the `DEFAULT_CREATE2_DEPLOYER` should be used for a CREATE2 frame.
     ///
     /// If this function returns true, we'll replace CREATE2 frame with a CALL frame to CREATE2
     /// factory.
     fn should_use_create2_factory(
         &mut self,
-        _context: &mut EvmContext<&'a mut dyn DatabaseExt>,
+        _context: &mut EvmContext<&mut dyn DatabaseExt>,
         _inputs: &mut CreateInputs,
     ) -> bool {
         false
@@ -53,19 +53,8 @@ pub trait InspectorExt<'a>: Inspector<&'a mut dyn DatabaseExt> {
     fn is_alphanet(&self) -> bool {
         false
     }
-
-    /// Casts this [`InspectorExt`] to a an instance with a different lifetime.
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b>;
 }
 
-impl InspectorExt<'_> for NoOpInspector {
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
-        self
-    }
-}
+impl InspectorExt for NoOpInspector {}
 
-impl InspectorExt<'_> for AccessListInspector {
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
-        self
-    }
-}
+impl InspectorExt for AccessListInspector {}

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -54,6 +54,7 @@ pub trait InspectorExt<'a>: Inspector<&'a mut dyn DatabaseExt> {
         false
     }
 
+    /// Casts this [`InspectorExt`] to a an instance with a different lifetime.
     fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b>;
 }
 

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -57,13 +57,13 @@ pub trait InspectorExt<'a>: Inspector<&'a mut dyn DatabaseExt> {
     fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b>;
 }
 
-impl<'a> InspectorExt<'a> for NoOpInspector {
+impl InspectorExt<'_> for NoOpInspector {
     fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
         self
     }
 }
 
-impl<'a> InspectorExt<'a> for AccessListInspector {
+impl InspectorExt<'_> for AccessListInspector {
     fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
         self
     }

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -126,8 +126,8 @@ fn get_create2_factory_call_inputs(salt: U256, inputs: CreateInputs) -> CallInpu
 /// hook by inserting decoded address directly into interpreter.
 ///
 /// Should be installed after [revm::inspector_handle_register] and before any other registers.
-pub fn create2_handler_register<'a, I: InspectorExt>(
-    handler: &mut EvmHandler<'_, I, &'a mut dyn DatabaseExt>,
+pub fn create2_handler_register<I: InspectorExt>(
+    handler: &mut EvmHandler<'_, I, &mut dyn DatabaseExt>,
 ) {
     let create2_overrides = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
 

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -234,11 +234,11 @@ pub fn alphanet_handler_register<EXT, DB: revm::Database>(handler: &mut EvmHandl
 }
 
 /// Creates a new EVM with the given inspector.
-pub fn new_evm_with_inspector<'a>(
-    db: &'a mut dyn DatabaseExt,
+pub fn new_evm_with_inspector<'evm, 'i, 'db>(
+    db: &'db mut dyn DatabaseExt,
     env: revm::primitives::EnvWithHandlerCfg,
-    inspector: &'a mut dyn InspectorExt,
-) -> revm::Evm<'a, &'a mut dyn InspectorExt, &'a mut dyn DatabaseExt> {
+    inspector: &'i mut dyn InspectorExt,
+) -> revm::Evm<'evm, &'i mut dyn InspectorExt, &'db mut dyn DatabaseExt> {
     let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
 
     // NOTE: We could use `revm::Evm::builder()` here, but on the current patch it has some

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -236,14 +236,11 @@ pub fn alphanet_handler_register<'a, I: InspectorExt<'a>>(
 }
 
 /// Creates a new EVM with the given inspector.
-pub fn new_evm_with_inspector<'a, I>(
+pub fn new_evm_with_inspector<'a>(
     db: &'a mut dyn DatabaseExt,
     env: revm::primitives::EnvWithHandlerCfg,
-    inspector: I,
-) -> revm::Evm<'a, I, &'a mut dyn DatabaseExt>
-where
-    I: InspectorExt<'a>,
-{
+    inspector: &'a mut dyn InspectorExt<'a>,
+) -> revm::Evm<'a, &'a mut dyn InspectorExt<'a>, &'a mut dyn DatabaseExt> {
     let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
 
     // NOTE: We could use `revm::Evm::builder()` here, but on the current patch it has some
@@ -285,13 +282,10 @@ where
     new_evm_with_inspector(WrapDatabaseRef(db), env, inspector)
 }
 
-pub fn new_evm_with_existing_context<'a, I>(
+pub fn new_evm_with_existing_context<'a>(
     inner: revm::InnerEvmContext<&'a mut dyn DatabaseExt>,
-    inspector: I,
-) -> revm::Evm<'a, I, &'a mut dyn DatabaseExt>
-where
-    I: InspectorExt<'a>,
-{
+    inspector: &'a mut dyn InspectorExt<'a>,
+) -> revm::Evm<'a, &'a mut dyn InspectorExt<'a>, &'a mut dyn DatabaseExt> {
     let handler_cfg = HandlerCfg::new(inner.spec_id());
 
     let mut handler = revm::Handler::new(handler_cfg);

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -126,7 +126,7 @@ fn get_create2_factory_call_inputs(salt: U256, inputs: CreateInputs) -> CallInpu
 /// hook by inserting decoded address directly into interpreter.
 ///
 /// Should be installed after [revm::inspector_handle_register] and before any other registers.
-pub fn create2_handler_register<'a, I: InspectorExt<'a>>(
+pub fn create2_handler_register<'a, I: InspectorExt>(
     handler: &mut EvmHandler<'_, I, &'a mut dyn DatabaseExt>,
 ) {
     let create2_overrides = Rc::<RefCell<Vec<_>>>::new(RefCell::new(Vec::new()));
@@ -237,8 +237,8 @@ pub fn alphanet_handler_register<EXT, DB: revm::Database>(handler: &mut EvmHandl
 pub fn new_evm_with_inspector<'a>(
     db: &'a mut dyn DatabaseExt,
     env: revm::primitives::EnvWithHandlerCfg,
-    inspector: &'a mut dyn InspectorExt<'a>,
-) -> revm::Evm<'a, &'a mut dyn InspectorExt<'a>, &'a mut dyn DatabaseExt> {
+    inspector: &'a mut dyn InspectorExt,
+) -> revm::Evm<'a, &'a mut dyn InspectorExt, &'a mut dyn DatabaseExt> {
     let revm::primitives::EnvWithHandlerCfg { env, handler_cfg } = env;
 
     // NOTE: We could use `revm::Evm::builder()` here, but on the current patch it has some
@@ -268,8 +268,8 @@ pub fn new_evm_with_inspector<'a>(
 
 pub fn new_evm_with_existing_context<'a>(
     inner: revm::InnerEvmContext<&'a mut dyn DatabaseExt>,
-    inspector: &'a mut dyn InspectorExt<'a>,
-) -> revm::Evm<'a, &'a mut dyn InspectorExt<'a>, &'a mut dyn DatabaseExt> {
+    inspector: &'a mut dyn InspectorExt,
+) -> revm::Evm<'a, &'a mut dyn InspectorExt, &'a mut dyn DatabaseExt> {
     let handler_cfg = HandlerCfg::new(inner.spec_id());
 
     let mut handler = revm::Handler::new(handler_cfg);

--- a/crates/evm/evm/src/inspectors/logs.rs
+++ b/crates/evm/evm/src/inspectors/logs.rs
@@ -60,7 +60,7 @@ impl<DB: Database> Inspector<DB> for LogCollector {
                         gas: Gas::new(inputs.gas_limit),
                     },
                     memory_offset: inputs.return_memory_offset.clone(),
-                })
+                });
             }
         }
 
@@ -68,7 +68,7 @@ impl<DB: Database> Inspector<DB> for LogCollector {
     }
 }
 
-impl<'a> InspectorExt<'a> for LogCollector {
+impl InspectorExt<'_> for LogCollector {
     fn console_log(&mut self, input: String) {
         self.logs.push(Log::new_unchecked(
             HARDHAT_CONSOLE_ADDRESS,
@@ -77,7 +77,7 @@ impl<'a> InspectorExt<'a> for LogCollector {
         ));
     }
 
-    fn get_inspector<'b>(&mut self) ->  &mut dyn InspectorExt<'b> {
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
         self
     }
 }

--- a/crates/evm/evm/src/inspectors/logs.rs
+++ b/crates/evm/evm/src/inspectors/logs.rs
@@ -68,17 +68,13 @@ impl<DB: Database> Inspector<DB> for LogCollector {
     }
 }
 
-impl InspectorExt<'_> for LogCollector {
+impl InspectorExt for LogCollector {
     fn console_log(&mut self, input: String) {
         self.logs.push(Log::new_unchecked(
             HARDHAT_CONSOLE_ADDRESS,
             vec![Console::log::SIGNATURE_HASH],
             input.abi_encode().into(),
         ));
-    }
-
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
-        self
     }
 }
 

--- a/crates/evm/evm/src/inspectors/logs.rs
+++ b/crates/evm/evm/src/inspectors/logs.rs
@@ -68,13 +68,17 @@ impl<DB: Database> Inspector<DB> for LogCollector {
     }
 }
 
-impl<DB: Database> InspectorExt<DB> for LogCollector {
+impl<'a> InspectorExt<'a> for LogCollector {
     fn console_log(&mut self, input: String) {
         self.logs.push(Log::new_unchecked(
             HARDHAT_CONSOLE_ADDRESS,
             vec![Console::log::SIGNATURE_HASH],
             input.abi_encode().into(),
         ));
+    }
+
+    fn get_inspector<'b>(&mut self) ->  &mut dyn InspectorExt<'b> {
+        self
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -307,7 +307,7 @@ impl CheatcodesExecutor for InspectorStackInner {
     fn get_inspector<'a, 'db>(
         &'a mut self,
         cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt<'db> + 'a> {
+    ) -> Box<dyn InspectorExt + 'a> {
         Box::new(InspectorStackRefMut { cheatcodes: Some(cheats), inner: self })
     }
 
@@ -933,10 +933,10 @@ impl<'a> Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'a> {
     }
 }
 
-impl<'a, 'db> InspectorExt<'db> for InspectorStackRefMut<'a> {
+impl InspectorExt for InspectorStackRefMut<'_> {
     fn should_use_create2_factory(
         &mut self,
-        ecx: &mut EvmContext<&'db mut dyn DatabaseExt>,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
         inputs: &mut CreateInputs,
     ) -> bool {
         call_inspectors_adjust_depth!(
@@ -958,10 +958,6 @@ impl<'a, 'db> InspectorExt<'db> for InspectorStackRefMut<'a> {
 
     fn is_alphanet(&self) -> bool {
         self.inner.alphanet
-    }
-
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
-        self
     }
 }
 
@@ -1053,7 +1049,7 @@ impl Inspector<&mut dyn DatabaseExt> for InspectorStack {
     }
 }
 
-impl InspectorExt<'_> for InspectorStack {
+impl InspectorExt for InspectorStack {
     fn should_use_create2_factory(
         &mut self,
         ecx: &mut EvmContext<&mut dyn DatabaseExt>,
@@ -1064,10 +1060,6 @@ impl InspectorExt<'_> for InspectorStack {
 
     fn is_alphanet(&self) -> bool {
         self.alphanet
-    }
-
-    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
-        self
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -631,7 +631,11 @@ impl<'a> InspectorStackRefMut<'a> {
 }
 
 impl<'a> Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'a> {
-    fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>) {
+    fn initialize_interp(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+    ) {
         call_inspectors_adjust_depth!(
             [&mut self.coverage, &mut self.tracer, &mut self.cheatcodes, &mut self.printer],
             |inspector| inspector.initialize_interp(interpreter, ecx),
@@ -655,7 +659,11 @@ impl<'a> Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'a> {
         );
     }
 
-    fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>) {
+    fn step_end(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+    ) {
         call_inspectors_adjust_depth!(
             [&mut self.tracer, &mut self.cheatcodes, &mut self.chisel_state, &mut self.printer],
             |inspector| inspector.step_end(interpreter, ecx),
@@ -664,7 +672,12 @@ impl<'a> Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'a> {
         );
     }
 
-    fn log(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>, log: &Log) {
+    fn log(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+        log: &Log,
+    ) {
         call_inspectors_adjust_depth!(
             [&mut self.tracer, &mut self.log_collector, &mut self.cheatcodes, &mut self.printer],
             |inspector| inspector.log(interpreter, ecx, log),
@@ -673,7 +686,11 @@ impl<'a> Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'a> {
         );
     }
 
-    fn call(&mut self, ecx: &mut EvmContext<&mut dyn DatabaseExt>, call: &mut CallInputs) -> Option<CallOutcome> {
+    fn call(
+        &mut self,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+        call: &mut CallInputs,
+    ) -> Option<CallOutcome> {
         if self.in_inner_context && ecx.journaled_state.depth == 0 {
             self.adjust_evm_data_for_inner_context(ecx);
             return None;
@@ -943,7 +960,7 @@ impl<'a, 'db> InspectorExt<'db> for InspectorStackRefMut<'a> {
         self.inner.alphanet
     }
 
-    fn get_inspector<'b>(&mut self) ->  &mut dyn InspectorExt<'b> {
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
         self
     }
 }
@@ -955,7 +972,11 @@ impl Inspector<&mut dyn DatabaseExt> for InspectorStack {
     }
 
     #[inline]
-    fn step_end(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>) {
+    fn step_end(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+    ) {
         self.as_mut().step_end(interpreter, ecx)
     }
 
@@ -1010,11 +1031,20 @@ impl Inspector<&mut dyn DatabaseExt> for InspectorStack {
         self.as_mut().eofcreate_end(context, call, outcome)
     }
 
-    fn initialize_interp(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>) {
+    fn initialize_interp(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+    ) {
         self.as_mut().initialize_interp(interpreter, ecx)
     }
 
-    fn log(&mut self, interpreter: &mut Interpreter, ecx: &mut EvmContext<&mut dyn DatabaseExt>, log: &Log) {
+    fn log(
+        &mut self,
+        interpreter: &mut Interpreter,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
+        log: &Log,
+    ) {
         self.as_mut().log(interpreter, ecx, log)
     }
 
@@ -1023,10 +1053,10 @@ impl Inspector<&mut dyn DatabaseExt> for InspectorStack {
     }
 }
 
-impl<'a> InspectorExt<'a> for InspectorStack {
+impl InspectorExt<'_> for InspectorStack {
     fn should_use_create2_factory(
         &mut self,
-        ecx: &mut EvmContext<&'a mut dyn DatabaseExt>,
+        ecx: &mut EvmContext<&mut dyn DatabaseExt>,
         inputs: &mut CreateInputs,
     ) -> bool {
         self.as_mut().should_use_create2_factory(ecx, inputs)
@@ -1036,7 +1066,7 @@ impl<'a> InspectorExt<'a> for InspectorStack {
         self.alphanet
     }
 
-    fn get_inspector<'b>(&mut self) ->  &mut dyn InspectorExt<'b> {
+    fn get_inspector<'b>(&mut self) -> &mut dyn InspectorExt<'b> {
         self
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -547,11 +547,7 @@ impl<'a> InspectorStackRefMut<'a> {
 
         let env = EnvWithHandlerCfg::new_with_spec_id(ecx.env.clone(), ecx.spec_id());
         let res = {
-            let mut evm = crate::utils::new_evm_with_inspector(
-                &mut ecx.db as &mut dyn DatabaseExt,
-                env,
-                &mut *self,
-            );
+            let mut evm = crate::utils::new_evm_with_inspector(&mut ecx.db, env, self);
             let res = evm.transact();
 
             // need to reset the env in case it was modified via cheatcodes during execution

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -304,10 +304,7 @@ pub struct InspectorStackRefMut<'a> {
 }
 
 impl CheatcodesExecutor for InspectorStackInner {
-    fn get_inspector<'a, 'db>(
-        &'a mut self,
-        cheats: &'a mut Cheatcodes,
-    ) -> Box<dyn InspectorExt + 'a> {
+    fn get_inspector<'a>(&'a mut self, cheats: &'a mut Cheatcodes) -> Box<dyn InspectorExt + 'a> {
         Box::new(InspectorStackRefMut { cheatcodes: Some(cheats), inner: self })
     }
 


### PR DESCRIPTION
## Motivation

Unblocks and finishes https://github.com/foundry-rs/foundry/pull/8924

Was working on a fix for https://github.com/foundry-rs/foundry/issues/8971 and ended up with lifetime issues which should be avoidable after this PR

## Solution

Looks like the main blocker is that when using `&mut dyn DatabaseExt` we end up needing to alter `'life` in `dyn InspectorExt<&'life mut dyn DatabaseExt>` in places where we recursively create EVMs. I don't think there's an easy way to express the covariance of inspector over DB lifetime via bounds, so we need some kind of trait which is able to produce inspectors for any db generic.

This PR adds a `get_inspector` fn to `InspectorExt` which allows to get `InspectorExt<&'b>` (basically just change the inner database lifetime). The impl is pretty much always just returns `self`
https://github.com/foundry-rs/foundry/blob/e170fca8d2ecef195eed05ae056ea1160258eceb/crates/evm/core/src/lib.rs#L57

This seems to solve the issue, allowing us to only use EVMs with `dyn DatabaseExt` and `dyn InspectorExt`: https://github.com/foundry-rs/foundry/blob/0ea74c1b02ce7919bf424c85e6b20b9d4bc21d99/crates/evm/core/src/utils.rs#L239-L243

This adds separate anvil EVM creation functions. anvil does not rely on `DatabaseExt` and `create2_handler_register`, thus it makes sense to separate forge and anvil EVMs at this point