### PR TITLE
fix: only test `--eof` on linux

### DIFF
--- a/crates/forge/tests/cli/alphanet.rs
+++ b/crates/forge/tests/cli/alphanet.rs
@@ -1,5 +1,5 @@
 // Ensure we can run basic counter tests with EOF support.
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 forgetest_init!(test_eof_flag, |prj, cmd| {
     cmd.forge_fuse().args(["test", "--eof"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

looks like running docker inside of macos runners is not supported https://github.com/orgs/community/discussions/69211#discussioncomment-7242133

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
