### PR TITLE
fix(`anvil`): set `storage.best_hash` while loading state

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -817,8 +817,7 @@ impl Backend {
             let best_hash =
                 self.blockchain.storage.read().hash(best_number.into()).ok_or_else(|| {
                     BlockchainError::RpcError(RpcError::internal_error_with(format!(
-                        "Best hash not found for best number: {}",
-                        best_number
+                        "Best hash not found for best number {best_number}",
                     )))
                 })?;
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -800,14 +800,29 @@ impl Backend {
 
     /// Apply [SerializableState] data to the backend storage.
     pub async fn load_state(&self, state: SerializableState) -> Result<bool, BlockchainError> {
+        // load the blocks and transactions into the storage
+        self.blockchain.storage.write().load_blocks(state.blocks.clone());
+        self.blockchain.storage.write().load_transactions(state.transactions.clone());
         // reset the block env
         if let Some(block) = state.block.clone() {
             self.env.write().block = block.clone();
 
             // Set the current best block number.
             // Defaults to block number for compatibility with existing state files.
-            self.blockchain.storage.write().best_number =
-                state.best_block_number.unwrap_or(block.number.to::<U64>());
+
+            let best_number = state.best_block_number.unwrap_or(block.number.to::<U64>());
+            self.blockchain.storage.write().best_number = best_number;
+
+            // Set the current best block hash;
+            let best_hash =
+                self.blockchain.storage.read().hash(best_number.into()).ok_or_else(|| {
+                    BlockchainError::RpcError(RpcError::internal_error_with(format!(
+                        "Best hash not found for best number: {}",
+                        best_number
+                    )))
+                })?;
+
+            self.blockchain.storage.write().best_hash = best_hash;
         }
 
         if !self.db.write().await.load_state(state.clone())? {
@@ -816,9 +831,6 @@ impl Backend {
             )
             .into());
         }
-
-        self.blockchain.storage.write().load_blocks(state.blocks.clone());
-        self.blockchain.storage.write().load_transactions(state.transactions.clone());
 
         if let Some(historical_states) = state.historical_states {
             self.states.write().load_states(historical_states);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Fixes #9017 

We were not setting the `best_hash` in storage after setting `best_number` leading to invalid `eth_getBlockByNumber` responses but valid `eth_blockNumber` responses.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Load all blocks and transactions to storage first then sets the `best_hash` and `best_block_number` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
