### PR TITLE
feat(cheatcodes): Add `vm.mockCalls` to mock different return data for multiple calls

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5779,6 +5779,46 @@
     },
     {
       "func": {
+        "id": "mockCalls_0",
+        "description": "Mocks multiple calls to an address, returning specified data for each call.",
+        "declaration": "function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "mockCalls(address,bytes,bytes[])",
+        "selector": "0x5c5c3de9",
+        "selectorBytes": [
+          92,
+          92,
+          61,
+          233
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "mockCalls_1",
+        "description": "Mocks multiple calls to an address with a specific `msg.value`, returning specified data for each call.",
+        "declaration": "function mockCalls(address callee, uint256 msgValue, bytes calldata data, bytes[] calldata returnData) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "mockCalls(address,uint256,bytes,bytes[])",
+        "selector": "0x08bcbae1",
+        "selectorBytes": [
+          8,
+          188,
+          186,
+          225
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "mockFunction",
         "description": "Whenever a call is made to `callee` with calldata `data`, this cheatcode instead calls\n`target` with the same calldata. This functionality is similar to a delegate call made to\n`target` contract from `callee`.\nCan be used to substitute a call to a function with another implementation that captures\nthe primary logic of the original function but is easier to reason about.\nIf calldata is not a strict match then partial match by selector is attempted.",
         "declaration": "function mockFunction(address callee, address target, bytes calldata data) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -465,6 +465,14 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function mockCall(address callee, uint256 msgValue, bytes calldata data, bytes calldata returnData) external;
 
+    /// Mocks multiple calls to an address, returning specified data for each call.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;
+
+    /// Mocks multiple calls to an address with a specific `msg.value`, returning specified data for each call.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function mockCalls(address callee, uint256 msgValue, bytes calldata data, bytes[] calldata returnData) external;
+
     /// Reverts a call to an address with specified revert data.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function mockCallRevert(address callee, bytes calldata data, bytes calldata revertData) external;

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -122,10 +122,7 @@ fn mock_call(
     rdata: &Bytes,
     ret_type: InstructionResult,
 ) {
-    state.mocked_calls.entry(*callee).or_default().insert(
-        MockCallDataContext { calldata: Bytes::copy_from_slice(cdata), value: value.copied() },
-        VecDeque::from(vec![MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) }]),
-    );
+    mock_calls(state, callee, cdata, value, &[rdata.clone()], ret_type)
 }
 
 #[allow(clippy::ptr_arg)] // Not public API, doesn't matter

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -1,7 +1,7 @@
 use crate::{inspector::InnerEcx, Cheatcode, Cheatcodes, CheatsCtxt, Result, Vm::*};
 use alloy_primitives::{Address, Bytes, U256};
 use revm::{interpreter::InstructionResult, primitives::Bytecode};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, collections::VecDeque};
 
 /// Mocked call data.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -105,7 +105,7 @@ fn mock_call(
 ) {
     state.mocked_calls.entry(*callee).or_default().insert(
         MockCallDataContext { calldata: Bytes::copy_from_slice(cdata), value: value.copied() },
-        MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) },
+        VecDeque::from(vec![MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) }]),
     );
 }
 

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -136,9 +136,10 @@ fn mock_calls(
 ) {
     state.mocked_calls.entry(*callee).or_default().insert(
         MockCallDataContext { calldata: Bytes::copy_from_slice(cdata), value: value.copied() },
-        rdata_vec.iter().map(|rdata|
-            MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) }
-        ).collect::<VecDeque<_>>(),
+        rdata_vec
+            .iter()
+            .map(|rdata| MockCallReturnData { ret_type, data: Bytes::copy_from_slice(rdata) })
+            .collect::<VecDeque<_>>(),
     );
 }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -402,7 +402,7 @@ pub struct Cheatcodes {
 
     /// Mocked calls
     // **Note**: inner must a BTreeMap because of special `Ord` impl for `MockCallDataContext`
-    pub mocked_calls: HashMap<Address, BTreeMap<MockCallDataContext, MockCallReturnData>>,
+    pub mocked_calls: HashMap<Address, BTreeMap<MockCallDataContext, VecDeque<MockCallReturnData>>>,
 
     /// Mocked functions. Maps target address to be mocked to pair of (calldata, mock address).
     pub mocked_functions: HashMap<Address, HashMap<Bytes, Address>>,
@@ -889,26 +889,36 @@ where {
         }
 
         // Handle mocked calls
-        if let Some(mocks) = self.mocked_calls.get(&call.bytecode_address) {
+        if let Some(mocks) = self.mocked_calls.get_mut(&call.bytecode_address) {
             let ctx =
                 MockCallDataContext { calldata: call.input.clone(), value: call.transfer_value() };
-            if let Some(return_data) = mocks.get(&ctx).or_else(|| {
-                mocks
-                    .iter()
+
+            if let Some(return_data_queue) = match mocks.get_mut(&ctx) {
+                Some(queue) => Some(queue),
+                None => mocks
+                    .iter_mut()
                     .find(|(mock, _)| {
                         call.input.get(..mock.calldata.len()) == Some(&mock.calldata[..]) &&
                             mock.value.map_or(true, |value| Some(value) == call.transfer_value())
                     })
                     .map(|(_, v)| v)
-            }) {
-                return Some(CallOutcome {
-                    result: InterpreterResult {
-                        result: return_data.ret_type,
-                        output: return_data.data.clone(),
-                        gas,
-                    },
-                    memory_offset: call.return_memory_offset.clone(),
-                });
+            } {
+                if let Some(return_data) = if return_data_queue.len() == 1 {
+                    // If the mocked calls stack has a single element in it, don't empty it
+                    return_data_queue.front().map(|x| x.to_owned())
+                } else {
+                    // Else, we pop the front element
+                    return_data_queue.pop_front()
+                } {
+                    return Some(CallOutcome {
+                        result: InterpreterResult {
+                            result: return_data.ret_type,
+                            output: return_data.data.clone(),
+                            gas,
+                        },
+                        memory_offset: call.return_memory_offset.clone(),
+                    });
+                }
             }
         }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -901,7 +901,7 @@ where {
                         call.input.get(..mock.calldata.len()) == Some(&mock.calldata[..]) &&
                             mock.value.map_or(true, |value| Some(value) == call.transfer_value())
                     })
-                    .map(|(_, v)| v)
+                    .map(|(_, v)| v),
             } {
                 if let Some(return_data) = if return_data_queue.len() == 1 {
                     // If the mocked calls stack has a single element in it, don't empty it
@@ -913,7 +913,7 @@ where {
                     return Some(CallOutcome {
                         result: InterpreterResult {
                             result: return_data.ret_type,
-                            output: return_data.data.clone(),
+                            output: return_data.data,
                             gas,
                         },
                         memory_offset: call.return_memory_offset.clone(),

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -284,6 +284,8 @@ interface Vm {
     function mockCallRevert(address callee, uint256 msgValue, bytes calldata data, bytes calldata revertData) external;
     function mockCall(address callee, bytes calldata data, bytes calldata returnData) external;
     function mockCall(address callee, uint256 msgValue, bytes calldata data, bytes calldata returnData) external;
+    function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;
+    function mockCalls(address callee, uint256 msgValue, bytes calldata data, bytes[] calldata returnData) external;
     function mockFunction(address callee, address target, bytes calldata data) external;
     function parseAddress(string calldata stringifiedValue) external pure returns (address parsedValue);
     function parseBool(string calldata stringifiedValue) external pure returns (bool parsedValue);

--- a/testdata/default/cheats/MockCalls.t.sol
+++ b/testdata/default/cheats/MockCalls.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract MockCallsTest is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testMockCalls() public {
+        address mockUser = vm.addr(vm.randomUint());
+        address mockErc20 = vm.addr(vm.randomUint());
+        bytes memory data = abi.encodeWithSignature('balanceOf(address)', mockUser);
+        bytes[] memory mocks = new bytes[](3);
+        mocks[0] = abi.encode(2 ether);
+        mocks[1] = abi.encode(1 ether);
+        mocks[2] = abi.encode(6.423 ether);
+        vm.mockCalls(mockErc20, data, mocks);
+        (, bytes memory ret1) = mockErc20.call(data);
+        assertEq(abi.decode(ret1, (uint)), 2 ether);
+        (, bytes memory ret2) = mockErc20.call(data);
+        assertEq(abi.decode(ret2, (uint)), 1 ether);
+        (, bytes memory ret3) = mockErc20.call(data);
+        assertEq(abi.decode(ret3, (uint)), 6.423 ether);
+    }
+}

--- a/testdata/default/cheats/MockCalls.t.sol
+++ b/testdata/default/cheats/MockCalls.t.sol
@@ -7,6 +7,23 @@ import "cheats/Vm.sol";
 contract MockCallsTest is DSTest {
     Vm constant vm = Vm(HEVM_ADDRESS);
 
+    function testMockCallsWithValue() public {
+        address mockUser = vm.addr(vm.randomUint());
+        address mockErc20 = vm.addr(vm.randomUint());
+        bytes memory data = abi.encodeWithSignature('balanceOf(address)', mockUser);
+        bytes[] memory mocks = new bytes[](3);
+        mocks[0] = abi.encode(2 ether);
+        mocks[1] = abi.encode(1 ether);
+        mocks[2] = abi.encode(6.423 ether);
+        vm.mockCalls(mockErc20, 1 ether, data, mocks);
+        (, bytes memory ret1) = mockErc20.call{ value: 1 ether }(data);
+        assertEq(abi.decode(ret1, (uint)), 2 ether);
+        (, bytes memory ret2) = mockErc20.call{ value: 1 ether }(data);
+        assertEq(abi.decode(ret2, (uint)), 1 ether);
+        (, bytes memory ret3) = mockErc20.call{ value: 1 ether }(data);
+        assertEq(abi.decode(ret3, (uint)), 6.423 ether);
+    }
+
     function testMockCalls() public {
         address mockUser = vm.addr(vm.randomUint());
         address mockErc20 = vm.addr(vm.randomUint());


### PR DESCRIPTION
This PR implements #7467 

## Motivation
Today, we can mock the return value of a function call by using `mockCall`. Sometimes, it is useful to mock the same call twice with different return values.

Consider the following function:
```solidity
function failsafeArb (IERC20 token, IERC20 arbToken) public {
    uint initialBalance = token.balanceOf(address(this));
    doArbitrage(token, arbToken);
    uint finalBalance = token.balanceOf(address(this));
    require(finalBalance > initialBalance, 'arbitrage failed');
}
```

Both invocations of `token.balanceOf()` have the same calldata. This means we cannot use two different `mockCall` to test this behavior.

With `mockCalls` we would test it like so:
```solidity
bytes[] retdata = new bytes[](2);
retdata[0] = abi.encode(100 ether);
retdata[1] = abi.encode(99 ether);
vm.mockCalls(
    address(token),
    abi.encodeWithSelector(
        IERC20.balanceOf.selector,
        address(testContract)
    ),
    retdata
);

vm.expectRevert('arbitrage failed');
testContract.failsafeArb(token, arbToken);
```

## Solution
I changed `Cheatcodes::mocked_calls` to have a type of `HashMap<Address, BTreeMap<MockCallDataContext, VecDeque<MockCallReturnData>>>`, note the `VecDeque<...>`.

I then went in `inspector.rs` and modified the part which handles the mocked calls, to pop the front mock return data as long as the stack has more than one element. This kept backward-compatibility in such a way which minimized the amount of necessary changes.

## Cheatcodes checklist
The checklist from the cheatcodes [development docs](https://github.com/foundry-rs/foundry/blob/master/docs/dev/cheatcodes.md):

- [x] Add its Solidity definition(s) in [cheatcodes/spec/src/vm.rs](https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/spec/src/vm.rs). Ensure that all structs and functions are documented, and that all function parameters are named. This will initially fail to compile because of the automatically generated match { ... } expression. This is expected, and will be fixed in the next step
- [x] Implement the cheatcode in [cheatcodes](https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes) in its category's respective module. Follow the existing implementations as a guide.
- [ ] ~~If a struct, enum, error, or event was added to Vm, update [spec::Cheatcodes::new](https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/spec/src/lib.rs#L74)~~
- [x] Update the JSON interface by running cargo cheats twice. This is expected to fail the first time that this is run after adding a new cheatcode; see [JSON interface](https://github.com/foundry-rs/foundry/blob/master/docs/dev/cheatcodes.md#json-interface)
- [x] Write an integration test for the cheatcode in [testdata/cheats/](https://github.com/foundry-rs/foundry/blob/master/testdata/default/cheats)
