### PR TITLE
fix: include `traces` field when running `forge test -vvvv --json`

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -499,6 +499,7 @@ impl TestArgs {
             runner.decode_internal = InternalTraceMode::Full;
         }
 
+        // Run tests in a non-streaming fashion and collect results for serialization.
         if self.json {
             let results = runner.test_collect(filter);
             println!("{}", serde_json::to_string(&results)?);
@@ -516,7 +517,7 @@ impl TestArgs {
 
         let libraries = runner.libraries.clone();
 
-        // Run tests.
+        // Run tests in a streaming fashion.
         let (tx, rx) = channel::<(String, SuiteResult)>();
         let timer = Instant::now();
         let show_progress = config.show_progress;

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -393,7 +393,6 @@ pub struct TestResult {
     pub kind: TestKind,
 
     /// Traces
-    #[serde(skip)]
     pub traces: Traces,
 
     /// Additional traces to use for gas report.

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -320,7 +320,7 @@ forgetest_init!(can_run_test_with_json_output_non_verbose, |prj, cmd| {
     // Assert that without verbose output the json output does not include the traces
     cmd.args(["test", "--json"])
         .assert_success()
-        .stdout_eq(file!["../fixtures/SimpleContractTestNonVerbose.json"]);
+        .stdout_eq(file!["../fixtures/SimpleContractTestNonVerbose.json"; Json]);
 });
 
 // tests that `forge test` will pick up tests that are stored in the `test = <path>` config value

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -274,6 +274,55 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+const SIMPLE_CONTRACT: &str = r#"
+import {Test} from "forge-std/Test.sol";
+
+contract SimpleContract {
+    uint256 public num;
+
+    function setValues(uint256 _num) public {
+        num = _num;
+    }
+}
+
+contract SimpleContractTest is Test {
+    function test() public {
+        SimpleContract c = new SimpleContract();
+        c.setValues(100);
+    }
+}
+   "#;
+
+forgetest_init!(can_run_test_with_json_output_verbose, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.clear();
+
+    // Disable optimizer because for simple contract most functions will get inlined.
+    prj.write_config(Config { optimizer: false, ..Default::default() });
+
+    prj.add_test("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
+
+    // Assert that with verbose output the json output includes the traces
+    cmd.args(["test", "-vvv", "--json"])
+        .assert_success()
+        .stdout_eq(file!["../fixtures/SimpleContractTestVerbose.json"]);
+});
+
+forgetest_init!(can_run_test_with_json_output_non_verbose, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.clear();
+
+    // Disable optimizer because for simple contract most functions will get inlined.
+    prj.write_config(Config { optimizer: false, ..Default::default() });
+
+    prj.add_test("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
+
+    // Assert that without verbose output the json output does not include the traces
+    cmd.args(["test", "--json"])
+        .assert_success()
+        .stdout_eq(file!["../fixtures/SimpleContractTestNonVerbose.json"]);
+});
+
 // tests that `forge test` will pick up tests that are stored in the `test = <path>` config value
 forgetest!(can_run_test_in_custom_test_folder, |prj, cmd| {
     prj.insert_ds_test();

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -275,7 +275,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 });
 
 const SIMPLE_CONTRACT: &str = r#"
-import {Test} from "forge-std/Test.sol";
+import "./test.sol";
 
 contract SimpleContract {
     uint256 public num;
@@ -285,7 +285,7 @@ contract SimpleContract {
     }
 }
 
-contract SimpleContractTest is Test {
+contract SimpleContractTest is DSTest {
     function test() public {
         SimpleContract c = new SimpleContract();
         c.setValues(100);
@@ -293,34 +293,26 @@ contract SimpleContractTest is Test {
 }
    "#;
 
-forgetest_init!(can_run_test_with_json_output_verbose, |prj, cmd| {
-    prj.wipe_contracts();
-    prj.clear();
+forgetest!(can_run_test_with_json_output_verbose, |prj, cmd| {
+    prj.insert_ds_test();
 
-    // Disable optimizer because for simple contract most functions will get inlined.
-    prj.write_config(Config { optimizer: false, ..Default::default() });
-
-    prj.add_test("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
+    prj.add_source("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
 
     // Assert that with verbose output the json output includes the traces
     cmd.args(["test", "-vvv", "--json"])
         .assert_success()
-        .stdout_eq(file!["../fixtures/SimpleContractTestVerbose.json"; Json]);
+        .stdout_eq(file!["../fixtures/SimpleContractTestVerbose.json": Json]);
 });
 
-forgetest_init!(can_run_test_with_json_output_non_verbose, |prj, cmd| {
-    prj.wipe_contracts();
-    prj.clear();
+forgetest!(can_run_test_with_json_output_non_verbose, |prj, cmd| {
+    prj.insert_ds_test();
 
-    // Disable optimizer because for simple contract most functions will get inlined.
-    prj.write_config(Config { optimizer: false, ..Default::default() });
-
-    prj.add_test("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
+    prj.add_source("Simple.t.sol", SIMPLE_CONTRACT).unwrap();
 
     // Assert that without verbose output the json output does not include the traces
     cmd.args(["test", "--json"])
         .assert_success()
-        .stdout_eq(file!["../fixtures/SimpleContractTestNonVerbose.json"; Json]);
+        .stdout_eq(file!["../fixtures/SimpleContractTestNonVerbose.json": Json]);
 });
 
 // tests that `forge test` will pick up tests that are stored in the `test = <path>` config value

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -305,7 +305,7 @@ forgetest_init!(can_run_test_with_json_output_verbose, |prj, cmd| {
     // Assert that with verbose output the json output includes the traces
     cmd.args(["test", "-vvv", "--json"])
         .assert_success()
-        .stdout_eq(file!["../fixtures/SimpleContractTestVerbose.json"]);
+        .stdout_eq(file!["../fixtures/SimpleContractTestVerbose.json"; Json]);
 });
 
 forgetest_init!(can_run_test_with_json_output_non_verbose, |prj, cmd| {

--- a/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
@@ -1,0 +1,27 @@
+{
+    "test/Simple.t.sol:SimpleContractTest": {
+        "duration": "{...}",
+        "test_results": {
+            "test()": {
+                "status": "Success",
+                "reason": null,
+                "counterexample": null,
+                "logs": [],
+                "kind": {
+                    "Unit": {
+                        "gas": "{...}"
+                    }
+                },
+                "traces": [],
+                "labeled_addresses": {},
+                "duration": {
+                    "secs": "{...}",
+                    "nanos": "{...}"
+                },
+                "breakpoints": {},
+                "gas_snapshots": {}
+            }
+        },
+        "warnings": []
+    }
+}

--- a/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestNonVerbose.json
@@ -1,5 +1,5 @@
 {
-    "test/Simple.t.sol:SimpleContractTest": {
+    "src/Simple.t.sol:SimpleContractTest": {
         "duration": "{...}",
         "test_results": {
             "test()": {

--- a/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
@@ -1,5 +1,5 @@
 {
-    "test/Simple.t.sol:SimpleContractTest": {
+    "src/Simple.t.sol:SimpleContractTest": {
         "duration": "{...}",
         "test_results": {
             "test()": {
@@ -141,8 +141,8 @@
                                         "value": "0x0",
                                         "data": "0xe26d14740000000000000000000000000000000000000000000000000000000000000064",
                                         "output": "0x",
-                                        "gas_used": 22520,
-                                        "gas_limit": 1056850875,
+                                        "gas_used": "{...}",
+                                        "gas_limit": "{...}",
                                         "status": "Stop",
                                         "steps": [],
                                         "decoded": {

--- a/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
+++ b/crates/forge/tests/fixtures/SimpleContractTestVerbose.json
@@ -1,0 +1,172 @@
+{
+    "test/Simple.t.sol:SimpleContractTest": {
+        "duration": "{...}",
+        "test_results": {
+            "test()": {
+                "status": "Success",
+                "reason": null,
+                "counterexample": null,
+                "logs": [],
+                "kind": {
+                    "Unit": {
+                        "gas": "{...}"
+                    }
+                },
+                "traces": [
+                    [
+                        "Deployment",
+                        {
+                            "arena": [
+                                {
+                                    "parent": null,
+                                    "children": [],
+                                    "idx": 0,
+                                    "trace": {
+                                        "depth": 0,
+                                        "success": true,
+                                        "caller": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+                                        "address": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                                        "maybe_precompile": false,
+                                        "selfdestruct_address": null,
+                                        "selfdestruct_refund_target": null,
+                                        "selfdestruct_transferred_value": null,
+                                        "kind": "CREATE",
+                                        "value": "0x0",
+                                        "data": "{...}",
+                                        "output": "{...}",
+                                        "gas_used": "{...}",
+                                        "gas_limit": "{...}",
+                                        "status": "Return",
+                                        "steps": [],
+                                        "decoded": {
+                                            "label": null,
+                                            "return_data": null,
+                                            "call_data": null
+                                        }
+                                    },
+                                    "logs": [],
+                                    "ordering": []
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        "Execution",
+                        {
+                            "arena": [
+                                {
+                                    "parent": null,
+                                    "children": [
+                                        1,
+                                        2
+                                    ],
+                                    "idx": 0,
+                                    "trace": {
+                                        "depth": 0,
+                                        "success": true,
+                                        "caller": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+                                        "address": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                                        "maybe_precompile": null,
+                                        "selfdestruct_address": null,
+                                        "selfdestruct_refund_target": null,
+                                        "selfdestruct_transferred_value": null,
+                                        "kind": "CALL",
+                                        "value": "0x0",
+                                        "data": "0xf8a8fd6d",
+                                        "output": "0x",
+                                        "gas_used": "{...}",
+                                        "gas_limit": "{...}",
+                                        "status": "Stop",
+                                        "steps": [],
+                                        "decoded": {
+                                            "label": null,
+                                            "return_data": null,
+                                            "call_data": null
+                                        }
+                                    },
+                                    "logs": [],
+                                    "ordering": [
+                                        {
+                                            "Call": 0
+                                        },
+                                        {
+                                            "Call": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "parent": 0,
+                                    "children": [],
+                                    "idx": 1,
+                                    "trace": {
+                                        "depth": 1,
+                                        "success": true,
+                                        "caller": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                                        "address": "0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f",
+                                        "maybe_precompile": false,
+                                        "selfdestruct_address": null,
+                                        "selfdestruct_refund_target": null,
+                                        "selfdestruct_transferred_value": null,
+                                        "kind": "CREATE",
+                                        "value": "0x0",
+                                        "data": "{...}",
+                                        "output": "{...}",
+                                        "gas_used": "{...}",
+                                        "gas_limit": "{...}",
+                                        "status": "Return",
+                                        "steps": [],
+                                        "decoded": {
+                                            "label": null,
+                                            "return_data": null,
+                                            "call_data": null
+                                        }
+                                    },
+                                    "logs": [],
+                                    "ordering": []
+                                },
+                                {
+                                    "parent": 0,
+                                    "children": [],
+                                    "idx": 2,
+                                    "trace": {
+                                        "depth": 1,
+                                        "success": true,
+                                        "caller": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                                        "address": "0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f",
+                                        "maybe_precompile": null,
+                                        "selfdestruct_address": null,
+                                        "selfdestruct_refund_target": null,
+                                        "selfdestruct_transferred_value": null,
+                                        "kind": "CALL",
+                                        "value": "0x0",
+                                        "data": "0xe26d14740000000000000000000000000000000000000000000000000000000000000064",
+                                        "output": "0x",
+                                        "gas_used": 22520,
+                                        "gas_limit": 1056850875,
+                                        "status": "Stop",
+                                        "steps": [],
+                                        "decoded": {
+                                            "label": null,
+                                            "return_data": null,
+                                            "call_data": null
+                                        }
+                                    },
+                                    "logs": [],
+                                    "ordering": []
+                                }
+                            ]
+                        }
+                    ]
+                ],
+                "labeled_addresses": {},
+                "duration": {
+                    "secs": "{...}",
+                    "nanos": "{...}"
+                },
+                "breakpoints": {},
+                "gas_snapshots": {}
+            }
+        },
+        "warnings": []
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/6922

Part of a larger meta-ticket: https://github.com/foundry-rs/foundry/issues/8794

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Enable and includes traces in JSON output when `forge test` is ran with `--json` enabled (and verbosity >= 3)

Includes Snapbox tests

Future improvements could include making `TraceWriter` in `revm-inspectors` JSON compatible so we return decoded traces and well as https://github.com/foundry-rs/foundry/issues/7813 once that is added.

This should not impact the JUnit XML reports as that follows a strict schema already