### PR TITLE
fix(`forge eip712`): fix handling of subtypes

### DIFF
--- a/crates/forge/bin/cmd/bind_json.rs
+++ b/crates/forge/bin/cmd/bind_json.rs
@@ -309,10 +309,7 @@ impl CompiledState {
         for ((path, id), (def, contract_name)) in structs {
             // For some structs there's no schema (e.g. if they contain a mapping), so we just skip
             // those.
-            let Some(schema) = resolver.resolve_struct_eip712(id, &mut Default::default(), true)?
-            else {
-                continue
-            };
+            let Some(schema) = resolver.resolve_struct_eip712(id)? else { continue };
 
             if !include.is_empty() {
                 if !include.iter().any(|matcher| matcher.is_match(path)) {

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -168,7 +168,8 @@ impl Resolver {
             if subtype_id == id {
                 continue
             }
-            let Some(encoded_subtype) = self.resolve_eip712_inner(subtype_id, subtypes, false, Some(&subtype_name))?
+            let Some(encoded_subtype) =
+                self.resolve_eip712_inner(subtype_id, subtypes, false, Some(&subtype_name))?
             else {
                 return Ok(None)
             };

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -11,7 +11,7 @@ use foundry_compilers::{
     },
     CompilerSettings,
 };
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, fmt::Write, path::PathBuf};
 
 foundry_config::impl_figment_convert!(Eip712Args, opts);
 
@@ -62,9 +62,7 @@ impl Eip712Args {
         };
 
         for (id, _) in structs_in_target {
-            if let Some(resolved) =
-                resolver.resolve_struct_eip712(id, &mut Default::default(), true)?
-            {
+            if let Some(resolved) = resolver.resolve_struct_eip712(id)? {
                 println!("{resolved}");
                 println!();
             }
@@ -128,14 +126,19 @@ impl Resolver {
     ///
     /// Returns `None` if struct contains any fields that are not supported by EIP-712 (e.g.
     /// mappings or function pointers).
-    pub fn resolve_struct_eip712(
+    pub fn resolve_struct_eip712(&self, id: usize) -> Result<Option<String>> {
+        self.resolve_eip712_inner(id, &mut Default::default(), true, None)
+    }
+
+    fn resolve_eip712_inner(
         &self,
         id: usize,
         subtypes: &mut BTreeMap<String, usize>,
         append_subtypes: bool,
+        rename: Option<&str>,
     ) -> Result<Option<String>> {
         let def = &self.structs[&id];
-        let mut result = format!("{}(", def.name);
+        let mut result = format!("{}(", rename.unwrap_or(&def.name));
 
         for (idx, member) in def.members.iter().enumerate() {
             let Some(ty) = self.resolve_type(
@@ -146,9 +149,7 @@ impl Resolver {
                 return Ok(None)
             };
 
-            result.push_str(&ty);
-            result.push(' ');
-            result.push_str(&member.name);
+            write!(result, "{ty} {name}", name = member.name)?;
 
             if idx < def.members.len() - 1 {
                 result.push(',');
@@ -161,11 +162,13 @@ impl Resolver {
             return Ok(Some(result))
         }
 
-        for subtype_id in subtypes.values().copied().collect::<Vec<_>>() {
+        for (subtype_name, subtype_id) in
+            subtypes.iter().map(|(name, id)| (name.clone(), *id)).collect::<Vec<_>>()
+        {
             if subtype_id == id {
                 continue
             }
-            let Some(encoded_subtype) = self.resolve_struct_eip712(subtype_id, subtypes, false)?
+            let Some(encoded_subtype) = self.resolve_eip712_inner(subtype_id, subtypes, false, Some(&subtype_name))?
             else {
                 return Ok(None)
             };
@@ -204,6 +207,17 @@ impl Resolver {
                             name.clone()
                         // Otherwise, try assigning a new name.
                         } else {
+                            // iterate over members to check if they are resolvable and to populate subtypes
+                            for member in &def.members {
+                                if self.resolve_type(
+                                    member.type_name.as_ref().ok_or_eyre("missing type name")?,
+                                    subtypes,
+                                )?
+                                .is_none()
+                                {
+                                    return Ok(None)
+                                }
+                            }
                             let mut i = 0;
                             let mut name = def.name.clone();
                             while subtypes.contains_key(&name) {

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -32,7 +32,7 @@ library Structs2 {
         .unwrap();
 
     cmd.forge_fuse()
-        .args(["eip712", path.to_string_lossy().to_string()])
+        .args(["eip712", path.to_string_lossy().as_ref()])
         .assert_success()
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -1,0 +1,53 @@
+forgetest!(test_eip712, |prj, cmd| {
+    let path = prj
+        .add_source(
+            "Structs",
+            r#"
+library Structs {
+    struct Foo {
+        Bar bar;
+    }
+
+    struct Bar {
+        Art art;
+    }
+
+    struct Art {
+        uint256 id;
+    }
+
+    struct Complex {
+        Structs2.Foo foo2;
+        Foo[] foos;
+    }
+}
+
+library Structs2 {
+    struct Foo {
+        uint256 id;
+    }
+}
+"#,
+        )
+        .unwrap();
+
+    cmd.forge_fuse()
+        .args(["eip712", &path.to_string_lossy().to_string()])
+        .assert_success()
+        .stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+No files changed, compilation skipped
+Foo(Bar bar)Art(uint256 id)Bar(Art art)
+
+Bar(Art art)Art(uint256 id)
+
+Art(uint256 id)
+
+Complex(Foo foo2,Foo_1[] foos)Art(uint256 id)Bar(Art art)Foo(uint256 id)Foo_1(Bar bar)
+
+Foo(uint256 id)
+
+
+"#]]);
+});

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -32,7 +32,7 @@ library Structs2 {
         .unwrap();
 
     cmd.forge_fuse()
-        .args(["eip712", &path.to_string_lossy().to_string()])
+        .args(["eip712", path.to_string_lossy().to_string()])
         .assert_success()
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -31,10 +31,8 @@ library Structs2 {
         )
         .unwrap();
 
-    cmd.forge_fuse()
-        .args(["eip712", path.to_string_lossy().as_ref()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.forge_fuse().args(["eip712", path.to_string_lossy().as_ref()]).assert_success().stdout_eq(
+        str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 No files changed, compilation skipped
@@ -49,5 +47,6 @@ Complex(Foo foo2,Foo_1[] foos)Art(uint256 id)Bar(Art art)Foo(uint256 id)Foo_1(Ba
 Foo(uint256 id)
 
 
-"#]]);
+"#]],
+    );
 });

--- a/crates/forge/tests/cli/main.rs
+++ b/crates/forge/tests/cli/main.rs
@@ -15,6 +15,7 @@ mod coverage;
 mod create;
 mod debug;
 mod doc;
+mod eip712;
 mod multi_script;
 mod script;
 mod soldeer;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/9027

We didn't account for subtypes deeper than depth 1. Also, renames weren't applied correctly to struct names when appending subtypes to resulted string.

## Solution
