### PR TITLE
fix: normalize EVM version in chisel

### DIFF
--- a/crates/chisel/src/session_source.rs
+++ b/crates/chisel/src/session_source.rs
@@ -106,16 +106,6 @@ impl SessionSourceConfig {
 
         match solc_req {
             SolcReq::Version(version) => {
-                // Validate that the requested evm version is supported by the solc version
-                let req_evm_version = self.foundry_config.evm_version;
-                if let Some(compat_evm_version) = req_evm_version.normalize_version_solc(&version) {
-                    if req_evm_version > compat_evm_version {
-                        eyre::bail!(
-                            "The set evm version, {req_evm_version}, is not supported by solc {version}. Upgrade to a newer solc version."
-                        );
-                    }
-                }
-
                 let solc = if let Some(solc) = Solc::find_svm_installed_version(&version)? {
                     solc
                 } else {
@@ -322,7 +312,11 @@ impl SessionSource {
 
         let settings = Settings {
             remappings,
-            evm_version: Some(self.config.foundry_config.evm_version),
+            evm_version: self
+                .config
+                .foundry_config
+                .evm_version
+                .normalize_version_solc(&self.solc.version),
             ..Default::default()
         };
 

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -1,7 +1,6 @@
 use chisel::session::ChiselSession;
 use foundry_compilers::artifacts::EvmVersion;
-use foundry_config::{Config, SolcReq};
-use semver::Version;
+use foundry_config::Config;
 use serial_test::serial;
 use std::path::Path;
 
@@ -220,28 +219,4 @@ fn test_load_latest_cache() {
     // Validate the session
     assert_eq!(new_env.id.unwrap(), "1");
     assert_eq!(new_env.session_source.to_repl_source(), env.session_source.to_repl_source());
-}
-
-#[test]
-#[serial]
-fn test_solc_evm_configuration_mismatch() {
-    // Create and clear the cache directory
-    ChiselSession::create_cache_dir().unwrap();
-    ChiselSession::clear_cache().unwrap();
-
-    // Force the solc version to be 0.8.13 which does not support Paris
-    let foundry_config = Config {
-        evm_version: EvmVersion::Paris,
-        solc: Some(SolcReq::Version(Version::new(0, 8, 13))),
-        ..Default::default()
-    };
-
-    // Create a new session that is expected to fail
-    let error = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config,
-        ..Default::default()
-    })
-    .unwrap_err();
-
-    assert_eq!(error.to_string(), "The set evm version, paris, is not supported by solc 0.8.13. Upgrade to a newer solc version.");
 }

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -1,6 +1,6 @@
 use chisel::session::ChiselSession;
 use foundry_compilers::artifacts::EvmVersion;
-use semver::Version;
+use foundry_config::Config;
 use serial_test::serial;
 use std::path::Path;
 
@@ -219,4 +219,28 @@ fn test_load_latest_cache() {
     // Validate the session
     assert_eq!(new_env.id.unwrap(), "1");
     assert_eq!(new_env.session_source.to_repl_source(), env.session_source.to_repl_source());
+}
+
+#[test]
+#[serial]
+fn test_solc_evm_configuration_mismatch() {
+    // Create and clear the cache directory
+    ChiselSession::create_cache_dir().unwrap();
+    ChiselSession::clear_cache().unwrap();
+
+    // Force the solc version to be 0.8.13 which does not support Paris
+    let foundry_config = Config {
+        evm_version: EvmVersion::Paris,
+        solc: Some(SolcReq::Version(Version::new(0, 8, 13))),
+        ..Default::default()
+    };
+
+    // Create a new session that is expected to fail
+    let error = ChiselSession::new(chisel::session_source::SessionSourceConfig {
+        foundry_config,
+        ..Default::default()
+    })
+    .unwrap_err();
+
+    assert_eq!(error.to_string(), "The set evm version, paris, is not supported by solc 0.8.13. Upgrade to a newer solc version.");
 }

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -221,27 +221,3 @@ fn test_load_latest_cache() {
     assert_eq!(new_env.id.unwrap(), "1");
     assert_eq!(new_env.session_source.to_repl_source(), env.session_source.to_repl_source());
 }
-
-#[test]
-#[serial]
-fn test_solc_evm_configuration_mismatch() {
-    // Create and clear the cache directory
-    ChiselSession::create_cache_dir().unwrap();
-    ChiselSession::clear_cache().unwrap();
-
-    // Force the solc version to be 0.8.13 which does not support Paris
-    let foundry_config = Config {
-        evm_version: EvmVersion::Paris,
-        solc: Some(SolcReq::Version(Version::new(0, 8, 13))),
-        ..Default::default()
-    };
-
-    // Create a new session that is expected to fail
-    let error = ChiselSession::new(chisel::session_source::SessionSourceConfig {
-        foundry_config,
-        ..Default::default()
-    })
-    .unwrap_err();
-
-    assert_eq!(error.to_string(), "The set evm version, paris, is not supported by solc 0.8.13. Upgrade to a newer solc version.");
-}

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -1,6 +1,7 @@
 use chisel::session::ChiselSession;
 use foundry_compilers::artifacts::EvmVersion;
-use foundry_config::Config;
+use foundry_config::{Config, SolcReq};
+use semver::Version;
 use serial_test::serial;
 use std::path::Path;
 

--- a/crates/chisel/tests/cache.rs
+++ b/crates/chisel/tests/cache.rs
@@ -1,6 +1,5 @@
 use chisel::session::ChiselSession;
 use foundry_compilers::artifacts::EvmVersion;
-use foundry_config::{Config, SolcReq};
 use semver::Version;
 use serial_test::serial;
 use std::path::Path;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/8978

Currently if latest installed solc is <0.8.18, running `chisel` would result in an error unless `chisel --evm-version london` is specified

## Solution

There's no need in throwing this error. We already silently normalize EVM version during usual compilation, so for chisel this should be fine too