### PR TITLE
chore(deps): bump alloy-core 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b499852e1d0e9b8c6db0f24c48998e647c0d5762a01090f955106a7700e4611"
+checksum = "1109c57718022ac84c194f775977a534e1b3969b405e55693a61c42187cc0612"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a438d4486b5d525df3b3004188f9d5cd1d65cd30ecc41e5a3ccef6f6342e8af9"
+checksum = "c4cc0e59c803dd44d14fc0cfa9fea1f74cfa8fd9fb60ca303ced390c58c28d4e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
+checksum = "a289ffd7448036f2f436b377f981c79ce0b2090877bad938d43387dc09931877"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -314,8 +314,9 @@ dependencies = [
  "const-hex",
  "derive_arbitrary",
  "derive_more 1.0.0",
+ "foldhash",
  "getrandom",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "hex-literal",
  "indexmap 2.6.0",
  "itoa",
@@ -680,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e7f6e8fe5b443f82b3f1e15abfa191128f71569148428e49449d01f6f49e8b"
+checksum = "0409e3ba5d1de409997a7db8b8e9d679d52088c1dee042a85033affd3cadeab4"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
+checksum = "a18372ef450d59f74c7a64a738f546ba82c92f816597fed1802ef559304c81f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -713,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
+checksum = "f7bad89dd0d5f109e8feeaf787a9ed7a05a91a9a0efc6687d147a70ebca8eff7"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -730,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc85178909a49c8827ffccfc9103a7ce1767ae66a801b69bdc326913870bf8e6"
+checksum = "dbd3548d5262867c2c4be6223fe4f2583e21ade0ca1c307fd23bc7f28fca479e"
 dependencies = [
  "serde",
  "winnow",
@@ -740,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
+checksum = "4aa666f1036341b46625e72bd36878bf45ad0185f1b88601223e1ec6ed4b72b1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1994,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d9e0b4957f635b8d3da819d0db5603620467ecf1f692d22a8c2717ce27e6d8"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -3304,6 +3305,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
@@ -4740,6 +4747,10 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -8411,9 +8422,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab661c8148c2261222a4d641ad5477fd4bea79406a99056096a0b41b35617a5"
+checksum = "f3a850d65181df41b83c6be01a7d91f5e9377c43d48faa5af7d95816f437f5a3"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,7 +3393,6 @@ dependencies = [
  "regex",
  "reqwest",
  "revm-inspectors",
- "rustc-hash",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3673,7 +3672,6 @@ dependencies = [
  "proptest",
  "rand",
  "revm",
- "rustc-hash",
  "semver 1.0.23",
  "serde_json",
  "thiserror",
@@ -3761,7 +3759,6 @@ dependencies = [
  "foundry-macros",
  "num-format",
  "reqwest",
- "rustc-hash",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -3994,7 +3991,6 @@ dependencies = [
  "foundry-macros",
  "foundry-test-utils",
  "itertools 0.13.0",
- "rustc-hash",
 ]
 
 [[package]]
@@ -4023,7 +4019,6 @@ dependencies = [
  "parking_lot",
  "revm",
  "revm-inspectors",
- "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
@@ -4042,7 +4037,6 @@ dependencies = [
  "foundry-evm-core",
  "rayon",
  "revm",
- "rustc-hash",
  "semver 1.0.23",
  "tracing",
 ]
@@ -4093,7 +4087,6 @@ dependencies = [
  "rayon",
  "revm",
  "revm-inspectors",
- "rustc-hash",
  "serde",
  "solang-parser",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ alloy-json-abi = "0.8.5"
 alloy-primitives = { version = "0.8.5", features = [
     "getrandom",
     "rand",
-    "map-fxhash",
+    "map-foldhash",
 ] }
 alloy-sol-macro-expander = "0.8.5"
 alloy-sol-macro-input = "0.8.5"
@@ -249,7 +249,6 @@ k256 = "0.13"
 parking_lot = "0.12"
 mesc = "0.3"
 rand = "0.8"
-rustc-hash = "2.0"
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -8,12 +8,9 @@ use crate::{
     mem::state::state_root,
     revm::{db::DbAccount, primitives::AccountInfo},
 };
-use alloy_primitives::{Address, B256, U256, U64};
+use alloy_primitives::{map::HashMap, Address, B256, U256, U64};
 use alloy_rpc_types::BlockId;
-use foundry_evm::{
-    backend::{BlockchainDb, DatabaseResult, StateSnapshot},
-    hashbrown::HashMap,
-};
+use foundry_evm::backend::{BlockchainDb, DatabaseResult, StateSnapshot};
 
 // reexport for convenience
 pub use foundry_evm::{backend::MemDb, revm::db::DatabaseRef};

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -581,9 +581,8 @@ pub struct MinedTransactionReceipt {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
     use crate::eth::backend::db::Db;
     use alloy_primitives::{hex, Address};

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -1,17 +1,13 @@
 use crate::eth::{error::PoolError, util::hex_fmt_many};
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    Address, TxHash,
+};
 use alloy_rpc_types::Transaction as RpcTransaction;
 use alloy_serde::WithOtherFields;
 use anvil_core::eth::transaction::{PendingTransaction, TypedTransaction};
 use parking_lot::RwLock;
-use std::{
-    cmp::Ordering,
-    collections::{BTreeSet, HashMap, HashSet},
-    fmt,
-    str::FromStr,
-    sync::Arc,
-    time::Instant,
-};
+use std::{cmp::Ordering, collections::BTreeSet, fmt, str::FromStr, sync::Arc, time::Instant};
 
 /// A unique identifying marker for a transaction
 pub type TxMarker = Vec<u8>;

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -58,7 +58,6 @@ p256 = "0.13.2"
 ecdsa = "0.16"
 rand = "0.8"
 revm.workspace = true
-rustc-hash.workspace = true
 semver.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_consensus::TxEnvelope;
 use alloy_genesis::{Genesis, GenesisAccount};
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{map::HashMap, Address, Bytes, B256, U256};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolValue;
 use foundry_common::fs::{read_json_file, write_json_file};
@@ -16,10 +16,7 @@ use foundry_evm_core::{
 };
 use rand::Rng;
 use revm::primitives::{Account, Bytecode, SpecId, KECCAK_EMPTY};
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::Path,
-};
+use std::{collections::BTreeMap, path::Path};
 
 mod fork;
 pub(crate) mod mapping;

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -4,7 +4,7 @@ use super::string::parse;
 use crate::{Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*};
 use alloy_dyn_abi::DynSolType;
 use alloy_json_abi::ContractObject;
-use alloy_primitives::{hex, Bytes, U256};
+use alloy_primitives::{hex, map::Entry, Bytes, U256};
 use alloy_sol_types::SolValue;
 use dialoguer::{Input, Password};
 use foundry_common::fs;
@@ -12,7 +12,6 @@ use foundry_config::fs_permissions::FsAccessKind;
 use revm::interpreter::CreateInputs;
 use semver::Version;
 use std::{
-    collections::hash_map::Entry,
     io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::Command,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -49,7 +49,6 @@ use revm::{
     primitives::{BlockEnv, CreateScheme, EVMError, EvmStorageSlot, SpecId, EOF_MAGIC_BYTES},
     EvmContext, InnerEvmContext, Inspector,
 };
-use rustc_hash::FxHashMap;
 use serde_json::Value;
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -413,7 +412,7 @@ pub struct Cheatcodes {
     pub expected_emits: VecDeque<ExpectedEmit>,
 
     /// Map of context depths to memory offset ranges that may be written to within the call depth.
-    pub allowed_mem_writes: FxHashMap<u64, Vec<Range<u64>>>,
+    pub allowed_mem_writes: HashMap<u64, Vec<Range<u64>>>,
 
     /// Current broadcasting information
     pub broadcast: Option<Broadcast>,

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -1,5 +1,9 @@
 use crate::{Cheatcode, Cheatcodes, CheatsCtxt, Error, Result, Vm::*};
-use alloy_primitives::{address, hex, Address, Bytes, LogData as RawLog, U256};
+use alloy_primitives::{
+    address, hex,
+    map::{hash_map::Entry, HashMap},
+    Address, Bytes, LogData as RawLog, U256,
+};
 use alloy_sol_types::{SolError, SolValue};
 use foundry_common::ContractsByArtifact;
 use foundry_evm_core::decode::RevertDecoder;
@@ -7,7 +11,6 @@ use revm::interpreter::{
     return_ok, InstructionResult, Interpreter, InterpreterAction, InterpreterResult,
 };
 use spec::Vm;
-use std::collections::{hash_map::Entry, HashMap};
 
 /// For some cheatcodes we may internally change the status of the call, i.e. in `expectRevert`.
 /// Solidity will see a successful call and attempt to decode the return data. Therefore, we need

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -52,7 +52,6 @@ dunce.workspace = true
 eyre.workspace = true
 num-format.workspace = true
 reqwest.workspace = true
-rustc-hash.workspace = true
 semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -1,5 +1,6 @@
-//! cli arguments for configuring the evm settings
-use alloy_primitives::{Address, B256, U256};
+//! CLI arguments for configuring the EVM settings.
+
+use alloy_primitives::{map::HashMap, Address, B256, U256};
 use clap::{ArgAction, Parser};
 use eyre::ContextCompat;
 use foundry_config::{
@@ -11,11 +12,10 @@ use foundry_config::{
     },
     Chain, Config,
 };
-use rustc_hash::FxHashMap;
 use serde::Serialize;
 
 /// Map keyed by breakpoints char to their location (contract address, pc)
-pub type Breakpoints = FxHashMap<char, (Address, usize)>;
+pub type Breakpoints = HashMap<char, (Address, usize)>;
 
 /// `EvmArgs` and `EnvArgs` take the highest precedence in the Config/Figment hierarchy.
 ///

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -579,9 +579,8 @@ pub fn parse_signatures(tokens: Vec<String>) -> ParsedSignatures {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/evm/abi/Cargo.toml
+++ b/crates/evm/abi/Cargo.toml
@@ -22,7 +22,6 @@ alloy-sol-types = { workspace = true, features = ["json"] }
 
 derive_more.workspace = true
 itertools.workspace = true
-rustc-hash.workspace = true
 
 [dev-dependencies]
 foundry-test-utils.workspace = true

--- a/crates/evm/abi/src/console/hardhat.rs
+++ b/crates/evm/abi/src/console/hardhat.rs
@@ -1,8 +1,7 @@
-use alloy_primitives::Selector;
+use alloy_primitives::{map::HashMap, Selector};
 use alloy_sol_types::sol;
 use foundry_common_fmt::*;
 use foundry_macros::ConsoleFmt;
-use rustc_hash::FxHashMap;
 use std::sync::LazyLock;
 
 sol!(
@@ -39,8 +38,8 @@ pub fn hh_console_selector(input: &[u8]) -> Option<&'static Selector> {
 /// `hardhat/console.log` logs its events manually, and in functions that accept integers they're
 /// encoded as `abi.encodeWithSignature("log(int)", p0)`, which is not the canonical ABI encoding
 /// for `int` that Solidity and [`sol!`] use.
-pub static HARDHAT_CONSOLE_SELECTOR_PATCHES: LazyLock<FxHashMap<[u8; 4], [u8; 4]>> =
-    LazyLock::new(|| FxHashMap::from_iter(include!("./patches.rs")));
+pub static HARDHAT_CONSOLE_SELECTOR_PATCHES: LazyLock<HashMap<[u8; 4], [u8; 4]>> =
+    LazyLock::new(|| HashMap::from_iter(include!("./patches.rs")));
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -54,7 +54,6 @@ eyre.workspace = true
 futures.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1960,9 +1960,8 @@ fn apply_state_changeset(
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use crate::{backend::Backend, fork::CreateFork, opts::EvmOpts};
     use alloy_primitives::{Address, U256};
     use alloy_provider::Provider;

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -3,12 +3,11 @@
 use crate::abi::{Console, Vm};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Error, JsonAbi};
-use alloy_primitives::{hex, Log, Selector};
+use alloy_primitives::{hex, map::HashMap, Log, Selector};
 use alloy_sol_types::{SolEventInterface, SolInterface, SolValue};
 use foundry_common::SELECTOR_LEN;
 use itertools::Itertools;
 use revm::interpreter::InstructionResult;
-use rustc_hash::FxHashMap;
 use std::{fmt, sync::OnceLock};
 
 /// A skip reason.
@@ -60,7 +59,7 @@ pub fn decode_console_log(log: &Log) -> Option<String> {
 #[derive(Clone, Debug, Default)]
 pub struct RevertDecoder {
     /// The custom errors to use for decoding.
-    pub errors: FxHashMap<Selector, Vec<Error>>,
+    pub errors: HashMap<Selector, Vec<Error>>,
 }
 
 impl Default for &RevertDecoder {

--- a/crates/evm/core/src/fork/database.rs
+++ b/crates/evm/core/src/fork/database.rs
@@ -262,9 +262,8 @@ impl DatabaseRef for ForkDbStateSnapshot {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
     use crate::backend::BlockchainDbMeta;
     use foundry_common::provider::get_http_provider;

--- a/crates/evm/core/src/ic.rs
+++ b/crates/evm/core/src/ic.rs
@@ -1,12 +1,12 @@
+use alloy_primitives::map::HashMap;
 use revm::interpreter::opcode::{PUSH0, PUSH1, PUSH32};
-use rustc_hash::FxHashMap;
 
 /// Maps from program counter to instruction counter.
 ///
 /// Inverse of [`IcPcMap`].
 #[derive(Debug, Clone)]
 pub struct PcIcMap {
-    pub inner: FxHashMap<usize, usize>,
+    pub inner: HashMap<usize, usize>,
 }
 
 impl PcIcMap {
@@ -35,7 +35,7 @@ impl PcIcMap {
 ///
 /// Inverse of [`PcIcMap`].
 pub struct IcPcMap {
-    pub inner: FxHashMap<usize, usize>,
+    pub inner: HashMap<usize, usize>,
 }
 
 impl IcPcMap {
@@ -60,8 +60,8 @@ impl IcPcMap {
     }
 }
 
-fn make_map<const PC_FIRST: bool>(code: &[u8]) -> FxHashMap<usize, usize> {
-    let mut map = FxHashMap::default();
+fn make_map<const PC_FIRST: bool>(code: &[u8]) -> HashMap<usize, usize> {
+    let mut map = HashMap::default();
 
     let mut pc = 0;
     let mut cumulative_push_size = 0;

--- a/crates/evm/coverage/Cargo.toml
+++ b/crates/evm/coverage/Cargo.toml
@@ -23,5 +23,4 @@ eyre.workspace = true
 revm.workspace = true
 semver.workspace = true
 tracing.workspace = true
-rustc-hash.workspace = true
 rayon.workspace = true

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -1,8 +1,8 @@
 use super::{CoverageItem, CoverageItemKind, SourceLocation};
+use alloy_primitives::map::HashMap;
 use foundry_common::TestFunctionExt;
 use foundry_compilers::artifacts::ast::{self, Ast, Node, NodeType};
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 /// A visitor that walks the AST of a single contract and finds coverage items.
@@ -583,7 +583,7 @@ impl<'a> SourceAnalyzer<'a> {
 #[derive(Debug, Default)]
 pub struct SourceFiles<'a> {
     /// The versioned sources.
-    pub sources: FxHashMap<usize, SourceFile<'a>>,
+    pub sources: HashMap<usize, SourceFile<'a>>,
 }
 
 /// The source code and AST of a file.

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -1,9 +1,9 @@
 use super::{CoverageItem, CoverageItemKind, ItemAnchor, SourceLocation};
+use alloy_primitives::map::{DefaultHashBuilder, HashMap, HashSet};
 use eyre::ensure;
 use foundry_compilers::artifacts::sourcemap::{SourceElement, SourceMap};
 use foundry_evm_core::utils::IcPcMap;
 use revm::interpreter::opcode;
-use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Attempts to find anchors for the given items using the given source map and bytecode.
 pub fn find_anchors(
@@ -11,9 +11,9 @@ pub fn find_anchors(
     source_map: &SourceMap,
     ic_pc_map: &IcPcMap,
     items: &[CoverageItem],
-    items_by_source_id: &FxHashMap<usize, Vec<usize>>,
+    items_by_source_id: &HashMap<usize, Vec<usize>>,
 ) -> Vec<ItemAnchor> {
-    let mut seen = FxHashSet::default();
+    let mut seen = HashSet::with_hasher(DefaultHashBuilder::default());
     source_map
         .iter()
         .filter_map(|element| items_by_source_id.get(&(element.index()? as usize)))

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -8,12 +8,12 @@
 #[macro_use]
 extern crate tracing;
 
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::{map::HashMap, Bytes, B256};
 use eyre::{Context, Result};
 use foundry_compilers::artifacts::sourcemap::SourceMap;
 use semver::Version;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fmt::Display,
     ops::{AddAssign, Deref, DerefMut},
     path::{Path, PathBuf},

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -19,9 +19,3 @@ pub use foundry_evm_traces as traces;
 // TODO: We should probably remove these, but it's a pretty big breaking change.
 #[doc(hidden)]
 pub use revm;
-
-#[doc(hidden)]
-#[deprecated = "use `{hash_map, hash_set, HashMap, HashSet}` in `std::collections` or `revm::primitives` instead"]
-pub mod hashbrown {
-    pub use revm::primitives::{hash_map, hash_set, HashMap, HashSet};
-}

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -1,7 +1,7 @@
 use crate::invariant::{BasicTxDetails, FuzzRunIdentifiedContracts};
 use alloy_dyn_abi::{DynSolType, DynSolValue, EventExt, FunctionExt};
 use alloy_json_abi::{Function, JsonAbi};
-use alloy_primitives::{Address, Bytes, Log, B256, U256};
+use alloy_primitives::{map::HashMap, Address, Bytes, Log, B256, U256};
 use foundry_config::FuzzDictionaryConfig;
 use foundry_evm_core::utils::StateChangeset;
 use indexmap::IndexSet;
@@ -11,11 +11,7 @@ use revm::{
     interpreter::opcode,
     primitives::AccountInfo,
 };
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 type AIndexSet<T> = IndexSet<T, std::hash::BuildHasherDefault<ahash::AHasher>>;
 

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -38,7 +38,6 @@ itertools.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["time", "macros"] }
 tracing.workspace = true
-rustc-hash.workspace = true
 tempfile.workspace = true
 rayon.workspace = true
 solang-parser.workspace = true

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -11,7 +11,6 @@ use foundry_compilers::{
 use foundry_evm_core::utils::PcIcMap;
 use foundry_linking::Linker;
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
 use solang_parser::pt::SourceUnitPart;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -117,7 +116,7 @@ impl ArtifactData {
 #[derive(Clone, Debug, Default)]
 pub struct ContractSources {
     /// Map over build_id -> file_id -> (source code, language)
-    pub sources_by_id: HashMap<String, FxHashMap<u32, Arc<SourceData>>>,
+    pub sources_by_id: HashMap<String, HashMap<u32, Arc<SourceData>>>,
     /// Map over contract name -> Vec<(bytecode, build_id, file_id)>
     pub artifacts_by_name: HashMap<String, Vec<ArtifactData>>,
 }

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
-use alloy_primitives::{Address, LogData, Selector, B256};
+use alloy_primitives::{
+    map::{hash_map::Entry, HashMap},
+    Address, LogData, Selector, B256,
+};
 use foundry_common::{
     abi::get_indexed_event, fmt::format_token, get_contract_name, ContractsByArtifact, SELECTOR_LEN,
 };
@@ -25,11 +28,7 @@ use foundry_evm_core::{
 };
 use itertools::Itertools;
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
-use rustc_hash::FxHashMap;
-use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap},
-    sync::OnceLock,
-};
+use std::{collections::BTreeMap, sync::OnceLock};
 
 mod precompiles;
 
@@ -124,7 +123,7 @@ pub struct CallTraceDecoder {
     pub receive_contracts: Vec<Address>,
 
     /// All known functions.
-    pub functions: FxHashMap<Selector, Vec<Function>>,
+    pub functions: HashMap<Selector, Vec<Function>>,
     /// All known events.
     pub events: BTreeMap<(B256, usize), Vec<Event>>,
     /// Revert decoder. Contains all known custom errors.
@@ -171,7 +170,7 @@ impl CallTraceDecoder {
 
         Self {
             contracts: Default::default(),
-            labels: [
+            labels: HashMap::from_iter([
                 (CHEATCODE_ADDRESS, "VM".to_string()),
                 (HARDHAT_CONSOLE_ADDRESS, "console".to_string()),
                 (DEFAULT_CREATE2_DEPLOYER, "Create2Deployer".to_string()),
@@ -187,8 +186,7 @@ impl CallTraceDecoder {
                 (EC_PAIRING, "ECPairing".to_string()),
                 (BLAKE_2F, "Blake2F".to_string()),
                 (POINT_EVALUATION, "PointEvaluation".to_string()),
-            ]
-            .into(),
+            ]),
             receive_contracts: Default::default(),
 
             functions: hh_funcs()

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -1,16 +1,12 @@
 use alloy_json_abi::{Event, Function};
-use alloy_primitives::hex;
+use alloy_primitives::{hex, map::HashSet};
 use foundry_common::{
     abi::{get_event, get_func},
     fs,
     selectors::{OpenChainClient, SelectorType},
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, HashSet},
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 
 pub type SingleSignaturesIdentifier = Arc<RwLock<SignaturesIdentifier>>;
@@ -161,9 +157,8 @@ impl Drop for SignaturesIdentifier {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -98,7 +98,6 @@ watchexec-events = "3.0"
 watchexec-signals = "3.0"
 clearscreen = "3.0"
 evm-disassembler.workspace = true
-rustc-hash.workspace = true
 
 # doc server
 axum = { workspace = true, features = ["ws"] }

--- a/crates/forge/bin/cmd/clone.rs
+++ b/crates/forge/bin/cmd/clone.rs
@@ -608,9 +608,8 @@ impl EtherscanClient for Client {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
     use alloy_primitives::hex;
     use foundry_compilers::Artifact;

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -1,5 +1,5 @@
 use super::{install, test::TestArgs};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{map::HashMap, Address, Bytes, U256};
 use clap::{Parser, ValueEnum, ValueHint};
 use eyre::{Context, Result};
 use forge::{
@@ -24,10 +24,8 @@ use foundry_compilers::{
 };
 use foundry_config::{Config, SolcReq};
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
 use semver::Version;
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -150,7 +148,7 @@ impl CoverageArgs {
 
         // Collect source files.
         let project_paths = &project.paths;
-        let mut versioned_sources = HashMap::<Version, SourceFiles<'_>>::new();
+        let mut versioned_sources = HashMap::<Version, SourceFiles<'_>>::default();
         for (path, source_file, version) in output.output().sources.sources_with_version() {
             report.add_source(version.clone(), source_file.id as usize, path.clone());
 
@@ -191,7 +189,7 @@ impl CoverageArgs {
             let source_analysis = SourceAnalyzer::new(sources).analyze()?;
 
             // Build helper mapping used by `find_anchors`
-            let mut items_by_source_id = FxHashMap::<_, Vec<_>>::with_capacity_and_hasher(
+            let mut items_by_source_id = HashMap::<_, Vec<_>>::with_capacity_and_hasher(
                 source_analysis.items.len(),
                 Default::default(),
             );
@@ -410,7 +408,7 @@ impl BytecodeData {
     pub fn find_anchors(
         &self,
         source_analysis: &SourceAnalysis,
-        items_by_source_id: &FxHashMap<usize, Vec<usize>>,
+        items_by_source_id: &HashMap<usize, Vec<usize>>,
     ) -> Vec<ItemAnchor> {
         find_anchors(
             &self.bytecode,

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -1,14 +1,16 @@
 //! Coverage reports.
 
+use alloy_primitives::map::HashMap;
 use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, Color, Row, Table};
 use evm_disassembler::disassemble_bytes;
 use foundry_common::fs;
-pub use foundry_evm::coverage::*;
 use std::{
-    collections::{hash_map, HashMap},
+    collections::hash_map,
     io::Write,
     path::{Path, PathBuf},
 };
+
+pub use foundry_evm::coverage::*;
 
 /// A coverage reporter.
 pub trait CoverageReporter {

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -4,14 +4,12 @@ use crate::{
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS},
     traces::{CallTraceArena, CallTraceDecoder, CallTraceNode, DecodedCallData},
 };
+use alloy_primitives::map::HashSet;
 use comfy_table::{presets::ASCII_MARKDOWN, *};
 use foundry_common::{calc, TestFunctionExt};
 use foundry_evm::traces::CallKind;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, HashSet},
-    fmt::Display,
-};
+use std::{collections::BTreeMap, fmt::Display};
 use yansi::Paint;
 
 /// Represents the gas report for a set of contracts.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_dyn_abi::DynSolValue;
 use alloy_json_abi::Function;
-use alloy_primitives::{address, Address, Bytes, U256};
+use alloy_primitives::{address, map::HashMap, Address, Bytes, U256};
 use eyre::Result;
 use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
@@ -35,12 +35,7 @@ use foundry_evm::{
 };
 use proptest::test_runner::TestRunner;
 use rayon::prelude::*;
-use std::{
-    borrow::Cow,
-    cmp::min,
-    collections::{BTreeMap, HashMap},
-    time::Instant,
-};
+use std::{borrow::Cow, cmp::min, collections::BTreeMap, time::Instant};
 
 /// When running tests, we deploy all external libraries present in the project. To avoid additional
 /// libraries affecting nonces of senders used in tests, we are using separate address to

--- a/crates/script/src/providers.rs
+++ b/crates/script/src/providers.rs
@@ -1,12 +1,9 @@
+use alloy_primitives::map::{hash_map::Entry, HashMap};
 use alloy_provider::{utils::Eip1559Estimation, Provider};
 use eyre::{Result, WrapErr};
 use foundry_common::provider::{get_http_provider, RetryProvider};
 use foundry_config::Chain;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    ops::Deref,
-    sync::Arc,
-};
+use std::{ops::Deref, sync::Arc};
 
 /// Contains a map of RPC urls to single instances of [`ProviderInfo`].
 #[derive(Default)]

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -13,7 +13,7 @@ use crate::{
     ScriptArgs, ScriptConfig, ScriptResult,
 };
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{utils::format_units, Address, Bytes, TxKind, U256};
+use alloy_primitives::{map::HashMap, utils::format_units, Address, Bytes, TxKind, U256};
 use dialoguer::Confirm;
 use eyre::{Context, Result};
 use foundry_cheatcodes::ScriptWallets;
@@ -23,7 +23,7 @@ use foundry_evm::traces::{decode_trace_arena, render_trace_arena};
 use futures::future::{join_all, try_join_all};
 use parking_lot::RwLock;
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, VecDeque},
     sync::Arc,
 };
 use yansi::Paint;

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -177,9 +177,8 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
     use alloy_primitives::address;
     use foundry_config::Chain;

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -451,9 +451,8 @@ async fn ensure_solc_build_metadata(version: Version) -> Result<Version> {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use super::*;
     use clap::Parser;
     use foundry_common::fs;

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -8,7 +8,6 @@ use eyre::Result;
 use foundry_common::{fs, retry::Retry};
 use futures::FutureExt;
 use reqwest::Url;
-use revm_primitives::map::FxBuildHasher;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -114,8 +113,7 @@ impl SourcifyVerificationProvider {
         let metadata = context.get_target_metadata()?;
         let imports = context.get_target_imports()?;
 
-        let mut files =
-            HashMap::with_capacity_and_hasher(2 + imports.len(), FxBuildHasher::default());
+        let mut files = HashMap::with_capacity_and_hasher(2 + imports.len(), Default::default());
 
         let metadata = serde_json::to_string_pretty(&metadata)?;
         files.insert("metadata.json".to_string(), metadata);

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -148,9 +148,8 @@ impl From<RawWalletOpts> for WalletOpts {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 mod tests {
-    #![allow(clippy::needless_return)]
-
     use alloy_signer::Signer;
     use std::{path::Path, str::FromStr};
 

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,7 @@ allow = [
     "0BSD",
     "MPL-2.0",
     "CDDL-1.0",
+    "Zlib",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses


### PR DESCRIPTION
```
    Updating alloy-dyn-abi v0.8.5 -> v0.8.6
    Updating alloy-json-abi v0.8.5 -> v0.8.6
    Updating alloy-primitives v0.8.5 -> v0.8.6
    Updating alloy-sol-macro v0.8.5 -> v0.8.6
    Updating alloy-sol-macro-expander v0.8.5 -> v0.8.6
    Updating alloy-sol-macro-input v0.8.5 -> v0.8.6
    Updating alloy-sol-type-parser v0.8.5 -> v0.8.6
    Updating alloy-sol-types v0.8.5 -> v0.8.6
    Updating cc v1.1.25 -> v1.1.28
      Adding foldhash v0.1.3
    Updating syn-solidity v0.8.5 -> v0.8.6
```