### PR TITLE
chore(`anvil`): use op-alloy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,28 +85,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
-dependencies = [
- "alloy-eips 0.3.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.3.6",
- "c-kzg",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705687d5bfd019fee57cf9e206b27b30a9a9617535d5590a02b171e813208f8e"
 dependencies = [
- "alloy-eips 0.4.2",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "auto_impl",
  "c-kzg",
  "derive_more 1.0.0",
@@ -122,11 +108,11 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
- "alloy-network-primitives 0.4.2",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-types-eth 0.4.2",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -136,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b499852e1d0e9b8c6db0f24c48998e647c0d5762a01090f955106a7700e4611"
+checksum = "1109c57718022ac84c194f775977a534e1b3969b405e55693a61c42187cc0612"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -184,24 +170,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.3.6",
- "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
- "serde",
- "sha2",
-]
-
-[[package]]
-name = "alloy-eips"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ffb906284a1e1f63c4607da2068c8197458a352d0b3e9796e67353d72a9be85"
@@ -210,7 +178,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -225,15 +193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8429cf4554eed9b40feec7f4451113e76596086447550275e3def933faf47ce3"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a438d4486b5d525df3b3004188f9d5cd1d65cd30ecc41e5a3ccef6f6342e8af9"
+checksum = "c4cc0e59c803dd44d14fc0cfa9fea1f74cfa8fd9fb60ca303ced390c58c28d4e"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -261,13 +229,13 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fa23a6a9d612b52e402c995f2d582c25165ec03ac6edf64c861a76bc5b87cd"
 dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-json-rpc",
- "alloy-network-primitives 0.4.2",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.4.2",
- "alloy-serde 0.4.2",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -278,34 +246,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
-dependencies = [
- "alloy-eips 0.3.6",
- "alloy-primitives",
- "alloy-serde 0.3.6",
- "serde",
-]
-
-[[package]]
-name = "alloy-network-primitives"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801492711d4392b2ccf5fc0bc69e299fa1aab15167d74dcaa9aab96a54f684bd"
 dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
+checksum = "a289ffd7448036f2f436b377f981c79ce0b2090877bad938d43387dc09931877"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -314,8 +270,9 @@ dependencies = [
  "const-hex",
  "derive_arbitrary",
  "derive_more 1.0.0",
+ "foldhash",
  "getrandom",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "hex-literal",
  "indexmap 2.6.0",
  "itoa",
@@ -339,15 +296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcfaa4ffec0af04e3555686b8aacbcdf7d13638133a0672749209069750f78a6"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-network-primitives 0.4.2",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 0.4.2",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-transport",
@@ -446,10 +403,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 0.4.2",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "serde",
 ]
 
@@ -460,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d780adaa5d95b07ad92006b2feb68ecfa7e2015f7d5976ceaac4c906c73ebd07"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "serde",
 ]
 
@@ -470,11 +427,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0285c4c09f838ab830048b780d7f4a4f460f309aa1194bb049843309524c64c"
 dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "derive_more 1.0.0",
  "jsonwebtoken",
  "rand",
@@ -484,37 +441,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
-dependencies = [
- "alloy-consensus 0.3.6",
- "alloy-eips 0.3.6",
- "alloy-network-primitives 0.3.6",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.3.6",
- "alloy-sol-types",
- "cfg-if",
- "derive_more 1.0.0",
- "hashbrown 0.14.5",
- "itertools 0.13.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413f4aa3ccf2c3e4234a047c5fa4727916d7daf25a89f9b765df0ba09784fd87"
 dependencies = [
- "alloy-consensus 0.4.2",
- "alloy-eips 0.4.2",
- "alloy-network-primitives 0.4.2",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-sol-types",
  "derive_more 1.0.0",
  "itertools 0.13.0",
@@ -529,8 +465,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "017cad3e5793c5613588c1f9732bcbad77e820ba7d0feaba3527749f856fdbc5"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.4.2",
- "alloy-serde 0.4.2",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror",
@@ -543,20 +479,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b230e321c416be7f50530159392b4c41a45596d40d97e185575bcd0b545e521"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.4.2",
- "alloy-serde 0.4.2",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -592,7 +517,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417e19d9844350d11f7426d4920a5df777f8c2abbb7a70d9de6f1faf284db15b"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -610,7 +535,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fd12ae28e8330766821058ed9a6a06ae4f9b12c776e8a7cfb16e3a954f508e"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -628,7 +553,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a02400dea370022151f07581b73a836115c88ce4df350206653493bec024e2"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-network",
  "alloy-primitives",
@@ -648,7 +573,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494e0a256f3e99f2426f994bcd1be312c02cb8f88260088dacb33a8b8936475f"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -667,7 +592,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d91ddee2390b002148128e47902893deba353eb1b818a3afb6c960ebf4e42c"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -680,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e7f6e8fe5b443f82b3f1e15abfa191128f71569148428e49449d01f6f49e8b"
+checksum = "0409e3ba5d1de409997a7db8b8e9d679d52088c1dee042a85033affd3cadeab4"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -694,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
+checksum = "a18372ef450d59f74c7a64a738f546ba82c92f816597fed1802ef559304c81f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -713,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
+checksum = "f7bad89dd0d5f109e8feeaf787a9ed7a05a91a9a0efc6687d147a70ebca8eff7"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -730,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc85178909a49c8827ffccfc9103a7ce1767ae66a801b69bdc326913870bf8e6"
+checksum = "dbd3548d5262867c2c4be6223fe4f2583e21ade0ca1c307fd23bc7f28fca479e"
 dependencies = [
  "serde",
  "winnow",
@@ -740,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
+checksum = "4aa666f1036341b46625e72bd36878bf45ad0185f1b88601223e1ec6ed4b72b1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -927,10 +852,10 @@ name = "anvil"
 version = "0.2.0"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
- "alloy-eips 0.4.2",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -941,7 +866,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -995,17 +920,18 @@ dependencies = [
 name = "anvil-core"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 0.4.2",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-trie",
  "bytes",
  "foundry-common",
  "foundry-evm",
+ "op-alloy-consensus",
  "rand",
  "revm",
  "serde",
@@ -1994,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d9e0b4957f635b8d3da819d0db5603620467ecf1f692d22a8c2717ce27e6d8"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -3306,6 +3232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,14 +3257,14 @@ name = "forge"
 version = "0.2.0"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-macro-expander",
@@ -3455,15 +3387,15 @@ name = "forge-script"
 version = "0.2.0"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips 0.4.2",
+ "alloy-eips",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-signer",
  "alloy-transport",
  "async-recursion",
@@ -3576,7 +3508,7 @@ name = "foundry-cast"
 version = "0.2.0"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3586,7 +3518,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -3634,7 +3566,7 @@ dependencies = [
 name = "foundry-cheatcodes"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-genesis",
  "alloy-json-abi",
@@ -3726,7 +3658,7 @@ dependencies = [
 name = "foundry-common"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3736,7 +3668,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -3772,11 +3704,11 @@ dependencies = [
 name = "foundry-common-fmt"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "chrono",
  "comfy-table",
  "foundry-macros",
@@ -4000,7 +3932,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
  "auto_impl",
@@ -4103,7 +4035,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-serde 0.4.2",
+ "alloy-serde",
  "alloy-transport",
  "eyre",
  "futures",
@@ -4163,7 +4095,7 @@ dependencies = [
 name = "foundry-wallets"
 version = "0.2.0"
 dependencies = [
- "alloy-consensus 0.4.2",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-network",
  "alloy-primitives",
@@ -4732,7 +4664,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -4740,6 +4671,10 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -6091,15 +6026,15 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.2.12"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21aad1fbf80d2bcd7406880efc7ba109365f44bbb72896758ddcbfa46bf1592c"
+checksum = "c4f7f318f885db6e1455370ca91f74b7faed152c8142f6418f0936d606e582ff"
 dependencies = [
- "alloy-consensus 0.3.6",
- "alloy-eips 0.3.6",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.6",
+ "alloy-serde",
  "derive_more 1.0.0",
  "serde",
  "spin",
@@ -6107,17 +6042,16 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.2.12"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
+checksum = "547d29c5ab957ff32e14edddb93652dad748d2ef6cbe4b0fe8615ce06b0a3ddb"
 dependencies = [
- "alloy-eips 0.3.6",
- "alloy-network-primitives 0.3.6",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 0.3.6",
- "alloy-serde 0.3.6",
- "cfg-if",
- "hashbrown 0.14.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -7253,7 +7187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c44af0bf801f48d25f7baf25cf72aff4c02d610f83b428175228162fef0246"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 0.4.2",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -7699,9 +7633,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -8411,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab661c8148c2261222a4d641ad5477fd4bea79406a99056096a0b41b35617a5"
+checksum = "f3a850d65181df41b83c6be01a7d91f5e9377c43d48faa5af7d95816f437f5a3"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,8 +219,9 @@ alloy-chains = "0.1"
 alloy-rlp = "0.3"
 alloy-trie = "0.6.0"
 
-## op-alloy for tests in anvil
-op-alloy-rpc-types = "0.2.9"
+## op-alloy 
+op-alloy-rpc-types = "0.3.3"
+op-alloy-consensus = "0.3.3"
 
 ## misc
 async-trait = "0.1"

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -30,6 +30,7 @@ alloy-eips.workspace = true
 alloy-consensus = { workspace = true, features = ["k256", "kzg"] }
 alloy-dyn-abi = { workspace = true, features = ["std", "eip712"] }
 alloy-trie.workspace = true
+op-alloy-consensus.workspace = true
 
 serde = { workspace = true, optional = true }
 serde_json.workspace = true

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1,6 +1,6 @@
 //! Transaction related types
 
-use crate::eth::transaction::optimism::{DepositTransaction, DepositTransactionRequest};
+use crate::eth::transaction::optimism::DepositTransaction;
 use alloy_consensus::{
     transaction::{
         eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
@@ -21,6 +21,7 @@ use alloy_rpc_types::{
 use alloy_serde::{OtherFields, WithOtherFields};
 use bytes::BufMut;
 use foundry_evm::traces::CallTraceNode;
+use op_alloy_consensus::TxDeposit;
 use revm::{
     interpreter::InstructionResult,
     primitives::{OptimismFields, TxEnv},
@@ -59,14 +60,14 @@ pub fn transaction_request_to_typed(
 
     // Special case: OP-stack deposit tx
     if transaction_type == Some(0x7E) || has_optimism_fields(&other) {
-        return Some(TypedTransactionRequest::Deposit(DepositTransactionRequest {
+        return Some(TypedTransactionRequest::Deposit(TxDeposit {
             from: from.unwrap_or_default(),
             source_hash: other.get_deserialized::<B256>("sourceHash")?.ok()?,
-            kind: to.unwrap_or_default(),
-            mint: other.get_deserialized::<U256>("mint")?.ok()?,
+            to: to.unwrap_or_default(),
+            mint: Some(other.get_deserialized::<u128>("mint")?.ok()?),
             value: value.unwrap_or_default(),
             gas_limit: gas.unwrap_or_default(),
-            is_system_tx: other.get_deserialized::<bool>("isSystemTx")?.ok()?,
+            is_system_transaction: other.get_deserialized::<bool>("isSystemTx")?.ok()?,
             input: input.into_input().unwrap_or_default(),
         }));
     }
@@ -165,7 +166,7 @@ pub enum TypedTransactionRequest {
     EIP2930(TxEip2930),
     EIP1559(TxEip1559),
     EIP4844(TxEip4844Variant),
-    Deposit(DepositTransactionRequest),
+    Deposit(TxDeposit),
 }
 
 /// A wrapper for [TypedTransaction] that allows impersonating accounts.

--- a/crates/anvil/core/src/eth/transaction/optimism.rs
+++ b/crates/anvil/core/src/eth/transaction/optimism.rs
@@ -4,270 +4,264 @@ use alloy_rlp::{
     length_of_length, Decodable, Encodable, Error as DecodeError, Header as RlpHeader,
 };
 use bytes::BufMut;
+use op_alloy_consensus::TxDeposit;
 use serde::{Deserialize, Serialize};
 use std::mem;
 
 pub const DEPOSIT_TX_TYPE_ID: u8 = 0x7E;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DepositTransactionRequest {
-    pub source_hash: B256,
-    pub from: Address,
-    pub kind: TxKind,
-    pub mint: U256,
-    pub value: U256,
-    pub gas_limit: u64,
-    pub is_system_tx: bool,
-    pub input: Bytes,
-}
+// #[derive(Clone, Debug, PartialEq, Eq)]
+// pub struct DepositTransactionRequest {
+//     pub source_hash: B256,
+//     pub from: Address,
+//     pub kind: TxKind,
+//     pub mint: U256,
+//     pub value: U256,
+//     pub gas_limit: u64,
+//     pub is_system_tx: bool,
+//     pub input: Bytes,
+// }
 
-impl DepositTransactionRequest {
-    pub fn hash(&self) -> B256 {
-        let mut encoded = Vec::new();
-        encoded.put_u8(DEPOSIT_TX_TYPE_ID);
-        self.encode(&mut encoded);
+// impl DepositTransactionRequest {
+//     pub fn hash(&self) -> B256 {
+//         let mut encoded = Vec::new();
+//         encoded.put_u8(DEPOSIT_TX_TYPE_ID);
+//         self.encode(&mut encoded);
 
-        B256::from_slice(alloy_primitives::keccak256(encoded).as_slice())
-    }
+//         B256::from_slice(alloy_primitives::keccak256(encoded).as_slice())
+//     }
 
-    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
-    pub(crate) fn encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.source_hash.encode(out);
-        self.from.encode(out);
-        self.kind.encode(out);
-        self.mint.encode(out);
-        self.value.encode(out);
-        self.gas_limit.encode(out);
-        self.is_system_tx.encode(out);
-        self.input.encode(out);
-    }
+//     /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
+//     pub(crate) fn encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+//         self.source_hash.encode(out);
+//         self.from.encode(out);
+//         self.kind.encode(out);
+//         self.mint.encode(out);
+//         self.value.encode(out);
+//         self.gas_limit.encode(out);
+//         self.is_system_tx.encode(out);
+//         self.input.encode(out);
+//     }
 
-    /// Calculates the length of the RLP-encoded transaction's fields.
-    pub(crate) fn fields_len(&self) -> usize {
-        let mut len = 0;
-        len += self.source_hash.length();
-        len += self.from.length();
-        len += self.kind.length();
-        len += self.mint.length();
-        len += self.value.length();
-        len += self.gas_limit.length();
-        len += self.is_system_tx.length();
-        len += self.input.length();
-        len
-    }
+//     /// Calculates the length of the RLP-encoded transaction's fields.
+//     pub(crate) fn fields_len(&self) -> usize {
+//         let mut len = 0;
+//         len += self.source_hash.length();
+//         len += self.from.length();
+//         len += self.kind.length();
+//         len += self.mint.length();
+//         len += self.value.length();
+//         len += self.gas_limit.length();
+//         len += self.is_system_tx.length();
+//         len += self.input.length();
+//         len
+//     }
 
-    /// Decodes the inner [DepositTransactionRequest] fields from RLP bytes.
-    ///
-    /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the following
-    /// RLP fields in the following order:
-    ///
-    /// - `source_hash`
-    /// - `from`
-    /// - `kind`
-    /// - `mint`
-    /// - `value`
-    /// - `gas_limit`
-    /// - `is_system_tx`
-    /// - `input`
-    pub fn decode_inner(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self {
-            source_hash: Decodable::decode(buf)?,
-            from: Decodable::decode(buf)?,
-            kind: Decodable::decode(buf)?,
-            mint: Decodable::decode(buf)?,
-            value: Decodable::decode(buf)?,
-            gas_limit: Decodable::decode(buf)?,
-            is_system_tx: Decodable::decode(buf)?,
-            input: Decodable::decode(buf)?,
-        })
-    }
+//     /// Decodes the inner [DepositTransactionRequest] fields from RLP bytes.
+//     ///
+//     /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the
+// following     /// RLP fields in the following order:
+//     ///
+//     /// - `source_hash`
+//     /// - `from`
+//     /// - `kind`
+//     /// - `mint`
+//     /// - `value`
+//     /// - `gas_limit`
+//     /// - `is_system_tx`
+//     /// - `input`
+//     pub fn decode_inner(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+//         Ok(Self {
+//             source_hash: Decodable::decode(buf)?,
+//             from: Decodable::decode(buf)?,
+//             kind: Decodable::decode(buf)?,
+//             mint: Decodable::decode(buf)?,
+//             value: Decodable::decode(buf)?,
+//             gas_limit: Decodable::decode(buf)?,
+//             is_system_tx: Decodable::decode(buf)?,
+//             input: Decodable::decode(buf)?,
+//         })
+//     }
 
-    /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
-    /// hash that for eip2718 does not require rlp header
-    pub(crate) fn encode_with_signature(
-        &self,
-        signature: &Signature,
-        out: &mut dyn alloy_rlp::BufMut,
-    ) {
-        let payload_length = self.fields_len() + signature.rlp_vrs_len();
-        let header = alloy_rlp::Header { list: true, payload_length };
-        header.encode(out);
-        self.encode_fields(out);
-        signature.write_rlp_vrs(out);
-    }
+//     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
+//     /// hash that for eip2718 does not require rlp header
+//     pub(crate) fn encode_with_signature(
+//         &self,
+//         signature: &Signature,
+//         out: &mut dyn alloy_rlp::BufMut,
+//     ) {
+//         let payload_length = self.fields_len() + signature.rlp_vrs_len();
+//         let header = alloy_rlp::Header { list: true, payload_length };
+//         header.encode(out);
+//         self.encode_fields(out);
+//         signature.write_rlp_vrs(out);
+//     }
 
-    /// Output the length of the RLP signed transaction encoding, _without_ a RLP string header.
-    pub fn payload_len_with_signature_without_header(&self, signature: &Signature) -> usize {
-        let payload_length = self.fields_len() + signature.rlp_vrs_len();
-        // 'transaction type byte length' + 'header length' + 'payload length'
-        1 + length_of_length(payload_length) + payload_length
-    }
+//     /// Output the length of the RLP signed transaction encoding, _without_ a RLP string header.
+//     pub fn payload_len_with_signature_without_header(&self, signature: &Signature) -> usize {
+//         let payload_length = self.fields_len() + signature.rlp_vrs_len();
+//         // 'transaction type byte length' + 'header length' + 'payload length'
+//         1 + length_of_length(payload_length) + payload_length
+//     }
 
-    /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
-    pub fn payload_len_with_signature(&self, signature: &Signature) -> usize {
-        let len = self.payload_len_with_signature_without_header(signature);
-        length_of_length(len) + len
-    }
+//     /// Output the length of the RLP signed transaction encoding. This encodes with a RLP header.
+//     pub fn payload_len_with_signature(&self, signature: &Signature) -> usize {
+//         let len = self.payload_len_with_signature_without_header(signature);
+//         length_of_length(len) + len
+//     }
 
-    /// Get transaction type
-    pub(crate) const fn tx_type(&self) -> u8 {
-        DEPOSIT_TX_TYPE_ID
-    }
+//     /// Get transaction type
+//     pub(crate) const fn tx_type(&self) -> u8 {
+//         DEPOSIT_TX_TYPE_ID
+//     }
 
-    /// Calculates a heuristic for the in-memory size of the [DepositTransaction] transaction.
-    pub fn size(&self) -> usize {
-        mem::size_of::<B256>() + // source_hash
-        mem::size_of::<Address>() + // from
-        self.kind.size() + // to
-        mem::size_of::<U256>() + // mint
-        mem::size_of::<U256>() + // value
-        mem::size_of::<U256>() + // gas_limit
-        mem::size_of::<bool>() + // is_system_transaction
-        self.input.len() // input
-    }
+//     /// Calculates a heuristic for the in-memory size of the [DepositTransaction] transaction.
+//     pub fn size(&self) -> usize {
+//         mem::size_of::<B256>() + // source_hash
+//         mem::size_of::<Address>() + // from
+//         self.kind.size() + // to
+//         mem::size_of::<U256>() + // mint
+//         mem::size_of::<U256>() + // value
+//         mem::size_of::<U256>() + // gas_limit
+//         mem::size_of::<bool>() + // is_system_transaction
+//         self.input.len() // input
+//     }
 
-    /// Encodes the legacy transaction in RLP for signing.
-    pub(crate) fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
-        out.put_u8(self.tx_type());
-        alloy_rlp::Header { list: true, payload_length: self.fields_len() }.encode(out);
-        self.encode_fields(out);
-    }
+//     /// Encodes the legacy transaction in RLP for signing.
+//     pub(crate) fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
+//         out.put_u8(self.tx_type());
+//         alloy_rlp::Header { list: true, payload_length: self.fields_len() }.encode(out);
+//         self.encode_fields(out);
+//     }
 
-    /// Outputs the length of the signature RLP encoding for the transaction.
-    pub(crate) fn payload_len_for_signature(&self) -> usize {
-        let payload_length = self.fields_len();
-        // 'transaction type byte length' + 'header length' + 'payload length'
-        1 + length_of_length(payload_length) + payload_length
-    }
+//     /// Outputs the length of the signature RLP encoding for the transaction.
+//     pub(crate) fn payload_len_for_signature(&self) -> usize {
+//         let payload_length = self.fields_len();
+//         // 'transaction type byte length' + 'header length' + 'payload length'
+//         1 + length_of_length(payload_length) + payload_length
+//     }
 
-    fn encoded_len_with_signature(&self, signature: &Signature) -> usize {
-        // this counts the tx fields and signature fields
-        let payload_length = self.fields_len() + signature.rlp_vrs_len();
+//     fn encoded_len_with_signature(&self, signature: &Signature) -> usize {
+//         // this counts the tx fields and signature fields
+//         let payload_length = self.fields_len() + signature.rlp_vrs_len();
 
-        // this counts:
-        // * tx type byte
-        // * inner header length
-        // * inner payload length
-        1 + alloy_rlp::Header { list: true, payload_length }.length() + payload_length
-    }
-}
+//         // this counts:
+//         // * tx type byte
+//         // * inner header length
+//         // * inner payload length
+//         1 + alloy_rlp::Header { list: true, payload_length }.length() + payload_length
+//     }
+// }
 
-impl Transaction for DepositTransactionRequest {
-    fn input(&self) -> &[u8] {
-        &self.input
-    }
+// impl Transaction for DepositTransactionRequest {
+//     fn input(&self) -> &[u8] {
+//         &self.input
+//     }
 
-    /// Get `to`.
-    fn to(&self) -> TxKind {
-        self.kind
-    }
+//     /// Get `to`.
+//     fn to(&self) -> TxKind {
+//         self.kind
+//     }
 
-    /// Get `value`.
-    fn value(&self) -> U256 {
-        self.value
-    }
+//     /// Get `value`.
+//     fn value(&self) -> U256 {
+//         self.value
+//     }
 
-    /// Get `chain_id`.
-    fn chain_id(&self) -> Option<ChainId> {
-        None
-    }
+//     /// Get `chain_id`.
+//     fn chain_id(&self) -> Option<ChainId> {
+//         None
+//     }
 
-    /// Get `nonce`.
-    fn nonce(&self) -> u64 {
-        u64::MAX
-    }
+//     /// Get `nonce`.
+//     fn nonce(&self) -> u64 {
+//         u64::MAX
+//     }
 
-    /// Get `gas_limit`.
-    fn gas_limit(&self) -> u64 {
-        self.gas_limit
-    }
+//     /// Get `gas_limit`.
+//     fn gas_limit(&self) -> u64 {
+//         self.gas_limit
+//     }
 
-    /// Get `gas_price`.
-    fn gas_price(&self) -> Option<u128> {
-        None
-    }
+//     /// Get `gas_price`.
+//     fn gas_price(&self) -> Option<u128> {
+//         None
+//     }
 
-    fn ty(&self) -> u8 {
-        0x7E
-    }
+//     fn ty(&self) -> u8 {
+//         0x7E
+//     }
 
-    // Below fields are not found in a `DepositTransactionRequest`
+//     // Below fields are not found in a `DepositTransactionRequest`
 
-    fn access_list(&self) -> Option<&alloy_rpc_types::AccessList> {
-        None
-    }
+//     fn access_list(&self) -> Option<&alloy_rpc_types::AccessList> {
+//         None
+//     }
 
-    fn authorization_list(&self) -> Option<&[revm::primitives::SignedAuthorization]> {
-        None
-    }
+//     fn authorization_list(&self) -> Option<&[revm::primitives::SignedAuthorization]> {
+//         None
+//     }
 
-    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
-        None
-    }
+//     fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+//         None
+//     }
 
-    fn effective_tip_per_gas(&self, _base_fee: u64) -> Option<u128> {
-        None
-    }
+//     fn effective_tip_per_gas(&self, _base_fee: u64) -> Option<u128> {
+//         None
+//     }
 
-    fn max_fee_per_blob_gas(&self) -> Option<u128> {
-        None
-    }
+//     fn max_fee_per_blob_gas(&self) -> Option<u128> {
+//         None
+//     }
 
-    fn max_fee_per_gas(&self) -> u128 {
-        0
-    }
+//     fn max_fee_per_gas(&self) -> u128 {
+//         0
+//     }
 
-    fn max_priority_fee_per_gas(&self) -> Option<u128> {
-        None
-    }
+//     fn max_priority_fee_per_gas(&self) -> Option<u128> {
+//         None
+//     }
 
-    fn priority_fee_or_price(&self) -> u128 {
-        0
-    }
-}
+//     fn priority_fee_or_price(&self) -> u128 {
+//         0
+//     }
+// }
 
-impl SignableTransaction<Signature> for DepositTransactionRequest {
-    fn set_chain_id(&mut self, _chain_id: ChainId) {}
+// impl SignableTransaction<Signature> for TxDeposit {
+//     fn set_chain_id(&mut self, _chain_id: ChainId) {}
 
-    fn payload_len_for_signature(&self) -> usize {
-        self.payload_len_for_signature()
-    }
+//     fn payload_len_for_signature(&self) -> usize {
+//         self.payload_len_for_signature()
+//     }
 
-    fn into_signed(self, signature: Signature) -> Signed<Self> {
-        let mut buf = Vec::with_capacity(self.encoded_len_with_signature(&signature));
-        self.encode_with_signature(&signature, &mut buf);
-        let hash = keccak256(&buf);
+//     fn into_signed(self, signature: Signature) -> Signed<Self> {
+//         let mut buf = Vec::with_capacity(self.encoded_len_with_signature(&signature));
+//         self.encode_with_signature(&signature, &mut buf);
+//         let hash = keccak256(&buf);
 
-        // Drop any v chain id value to ensure the signature format is correct at the time of
-        // combination for an EIP-4844 transaction. V should indicate the y-parity of the
-        // signature.
-        Signed::new_unchecked(self, signature.with_parity_bool(), hash)
-    }
+//         // Drop any v chain id value to ensure the signature format is correct at the time of
+//         // combination for an EIP-4844 transaction. V should indicate the y-parity of the
+//         // signature.
+//         Signed::new_unchecked(self, signature.with_parity_bool(), hash)
+//     }
 
-    fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
-        self.encode_for_signing(out);
-    }
-}
+//     fn encode_for_signing(&self, out: &mut dyn alloy_rlp::BufMut) {
+//         self.encode_for_signing(out);
+//     }
+// }
 
-impl From<DepositTransaction> for DepositTransactionRequest {
+impl From<DepositTransaction> for TxDeposit {
     fn from(tx: DepositTransaction) -> Self {
         Self {
             from: tx.from,
             source_hash: tx.source_hash,
-            kind: tx.kind,
-            mint: tx.mint,
+            to: tx.kind,
+            mint: Some(tx.mint.to::<u128>()),
             value: tx.value,
             gas_limit: tx.gas_limit,
-            is_system_tx: tx.is_system_tx,
+            is_system_transaction: tx.is_system_tx,
             input: tx.input,
         }
-    }
-}
-
-impl Encodable for DepositTransactionRequest {
-    fn encode(&self, out: &mut dyn bytes::BufMut) {
-        RlpHeader { list: true, payload_length: self.fields_len() }.encode(out);
-        self.encode_fields(out);
     }
 }
 
@@ -442,24 +436,5 @@ mod tests {
         let decoded_tx = DepositTransaction::decode_2718(&mut encoded_tx.as_slice()).unwrap();
 
         assert_eq!(tx, decoded_tx);
-    }
-
-    #[test]
-    fn test_tx_request_hash_equals_tx_hash() {
-        let tx = DepositTransaction {
-            nonce: 0,
-            source_hash: B256::default(),
-            from: Address::default(),
-            kind: TxKind::Call(Address::default()),
-            mint: U256::from(100),
-            value: U256::from(100),
-            gas_limit: 50000,
-            is_system_tx: false,
-            input: Bytes::default(),
-        };
-
-        let tx_request = DepositTransactionRequest::from(tx.clone());
-
-        assert_eq!(tx.hash(), tx_request.hash());
     }
 }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2899,7 +2899,7 @@ fn determine_base_gas_by_kind(request: &WithOtherFields<TransactionRequest>) -> 
                 TxKind::Create => MIN_CREATE_GAS,
             },
             TypedTransactionRequest::EIP4844(_) => MIN_TRANSACTION_GAS,
-            TypedTransactionRequest::Deposit(req) => match req.kind {
+            TypedTransactionRequest::Deposit(req) => match req.to {
                 TxKind::Call(_) => MIN_TRANSACTION_GAS,
                 TxKind::Create => MIN_CREATE_GAS,
             },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Replaces the `DepositTransactionRequest` with `op-alloy-consensus::TxDeposit`. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

WIP

- [ ] `impl SignableTransaction<Signature> for TxDeposit` in op-alloy
- [ ] Remove `DepositTransaction` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
