### PR TITLE
feat(cheatcodes): add vm.cloneAccount() cheatcode

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3193,6 +3193,26 @@
     },
     {
       "func": {
+        "id": "cloneAccount",
+        "description": "Load a genesis JSON file's `allocs` into the in-memory revm state.",
+        "declaration": "function cloneAccount(address source, address target) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "cloneAccount(address,address)",
+        "selector": "0x533d61c9",
+        "selectorBytes": [
+          83,
+          61,
+          97,
+          201
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "closeFile",
         "description": "Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.\n`path` is relative to the project root.",
         "declaration": "function closeFile(string calldata path) external;",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3194,7 +3194,7 @@
     {
       "func": {
         "id": "cloneAccount",
-        "description": "Clones a source account code, state, balance and nonce to a target account and updates in-memory revm state.",
+        "description": "Clones a source account code, state, balance and nonce to a target account and updates in-memory EVM state.",
         "declaration": "function cloneAccount(address source, address target) external;",
         "visibility": "external",
         "mutability": "",
@@ -5620,7 +5620,7 @@
     {
       "func": {
         "id": "loadAllocs",
-        "description": "Load a genesis JSON file's `allocs` into the in-memory revm state.",
+        "description": "Load a genesis JSON file's `allocs` into the in-memory EVM state.",
         "declaration": "function loadAllocs(string calldata pathToAllocsJson) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3194,7 +3194,7 @@
     {
       "func": {
         "id": "cloneAccount",
-        "description": "Load a genesis JSON file's `allocs` into the in-memory revm state.",
+        "description": "Clones a source account code, state, balance and nonce to a target account and updates in-memory revm state.",
         "declaration": "function cloneAccount(address source, address target) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -287,6 +287,10 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function loadAllocs(string calldata pathToAllocsJson) external;
 
+    /// Clones a source account code, state, balance and nonce to a target account and updates in-memory revm state.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function cloneAccount(address source, address target) external;
+
     // -------- Record Storage --------
 
     /// Records all storage reads and writes.

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -283,11 +283,11 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Safe)]
     function load(address target, bytes32 slot) external view returns (bytes32 data);
 
-    /// Load a genesis JSON file's `allocs` into the in-memory revm state.
+    /// Load a genesis JSON file's `allocs` into the in-memory EVM state.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function loadAllocs(string calldata pathToAllocsJson) external;
 
-    /// Clones a source account code, state, balance and nonce to a target account and updates in-memory revm state.
+    /// Clones a source account code, state, balance and nonce to a target account and updates in-memory EVM state.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function cloneAccount(address source, address target) external;
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -161,7 +161,7 @@ impl Cheatcode for cloneAccountCall {
         let Self { source, target } = self;
 
         let account = ccx.ecx.journaled_state.load_account(*source, &mut ccx.ecx.db)?;
-        ccx.ecx.db.copy_account(
+        ccx.ecx.db.clone_account(
             &genesis_account(account.data),
             target,
             &mut ccx.ecx.journaled_state,
@@ -959,7 +959,7 @@ fn get_state_diff(state: &mut Cheatcodes) -> Result {
 }
 
 /// Helper function that creates a `GenesisAccount` from a regular `Account`.
-fn genesis_account(account: &mut Account) -> GenesisAccount {
+fn genesis_account(account: &Account) -> GenesisAccount {
     GenesisAccount {
         nonce: Some(account.info.nonce),
         balance: account.info.balance,

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -159,6 +159,22 @@ impl Cheatcode for loadAllocsCall {
     }
 }
 
+impl Cheatcode for cloneAccountCall {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { source, target } = self;
+
+        let account = ccx.ecx.journaled_state.load_account(*source, &mut ccx.ecx.db)?;
+        ccx.ecx.db.copy_account(
+            &genesis_account(account.data),
+            target,
+            &mut ccx.ecx.journaled_state,
+        )?;
+        // Cloned account should persist in forked envs.
+        ccx.ecx.db.add_persistent_account(*target);
+        Ok(Default::default())
+    }
+}
+
 impl Cheatcode for dumpStateCall {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { pathToStateJson } = self;
@@ -181,23 +197,7 @@ impl Cheatcode for dumpStateCall {
             .state()
             .iter_mut()
             .filter(|(key, val)| !skip(key, val))
-            .map(|(key, val)| {
-                (
-                    key,
-                    GenesisAccount {
-                        nonce: Some(val.info.nonce),
-                        balance: val.info.balance,
-                        code: val.info.code.as_ref().map(|o| o.original_bytes()),
-                        storage: Some(
-                            val.storage
-                                .iter()
-                                .map(|(k, v)| (B256::from(*k), B256::from(v.present_value())))
-                                .collect(),
-                        ),
-                        private_key: None,
-                    },
-                )
-            })
+            .map(|(key, val)| (key, genesis_account(val)))
             .collect::<BTreeMap<_, _>>();
 
         write_json_file(path, &alloc)?;
@@ -959,4 +959,21 @@ fn get_state_diff(state: &mut Cheatcodes) -> Result {
         .flatten()
         .collect::<Vec<_>>();
     Ok(res.abi_encode())
+}
+
+/// Helper function that creates a `GenesisAccount` from a regular `Account`.
+fn genesis_account(account: &mut Account) -> GenesisAccount {
+    GenesisAccount {
+        nonce: Some(account.info.nonce),
+        balance: account.info.balance,
+        code: account.info.code.as_ref().map(|o| o.original_bytes()),
+        storage: Some(
+            account
+                .storage
+                .iter()
+                .map(|(k, v)| (B256::from(*k), B256::from(v.present_value())))
+                .collect(),
+        ),
+        private_key: None,
+    }
 }

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -233,13 +233,13 @@ impl DatabaseExt for CowBackend<'_> {
         self.backend_mut(&Env::default()).load_allocs(allocs, journaled_state)
     }
 
-    fn copy_account(
+    fn clone_account(
         &mut self,
         source: &GenesisAccount,
         target: &Address,
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError> {
-        self.backend_mut(&Env::default()).copy_account(source, target, journaled_state)
+        self.backend_mut(&Env::default()).clone_account(source, target, journaled_state)
     }
 
     fn is_persistent(&self, acc: &Address) -> bool {

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -233,6 +233,15 @@ impl DatabaseExt for CowBackend<'_> {
         self.backend_mut(&Env::default()).load_allocs(allocs, journaled_state)
     }
 
+    fn copy_account(
+        &mut self,
+        source: &GenesisAccount,
+        target: &Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        self.backend_mut(&Env::default()).copy_account(source, target, journaled_state)
+    }
+
     fn is_persistent(&self, acc: &Address) -> bool {
         self.backend.is_persistent(acc)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -279,6 +279,10 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit {
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError>;
 
+    /// Copies bytecode, storage, nonce and balance from the given genesis account to the target
+    /// address.
+    ///
+    /// Returns [Ok] if data was successfully inserted into the journal, [Err] otherwise.
     fn copy_account(
         &mut self,
         source: &GenesisAccount,
@@ -1380,7 +1384,8 @@ impl DatabaseExt for Backend {
         Ok(())
     }
 
-    /// Copies bytecode, storage, nonce and balance from the given genesis account to the target address.
+    /// Copies bytecode, storage, nonce and balance from the given genesis account to the target
+    /// address.
     ///
     /// Returns [Ok] if data was successfully inserted into the journal, [Err] otherwise.
     fn copy_account(

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -283,7 +283,7 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit {
     /// address.
     ///
     /// Returns [Ok] if data was successfully inserted into the journal, [Err] otherwise.
-    fn copy_account(
+    fn clone_account(
         &mut self,
         source: &GenesisAccount,
         target: &Address,
@@ -1378,7 +1378,7 @@ impl DatabaseExt for Backend {
     ) -> Result<(), BackendError> {
         // Loop through all of the allocs defined in the map and commit them to the journal.
         for (addr, acc) in allocs.iter() {
-            self.copy_account(acc, addr, journaled_state)?;
+            self.clone_account(acc, addr, journaled_state)?;
         }
 
         Ok(())
@@ -1388,7 +1388,7 @@ impl DatabaseExt for Backend {
     /// address.
     ///
     /// Returns [Ok] if data was successfully inserted into the journal, [Err] otherwise.
-    fn copy_account(
+    fn clone_account(
         &mut self,
         source: &GenesisAccount,
         target: &Address,

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -279,6 +279,13 @@ pub trait DatabaseExt: Database<Error = DatabaseError> + DatabaseCommit {
         journaled_state: &mut JournaledState,
     ) -> Result<(), BackendError>;
 
+    fn copy_account(
+        &mut self,
+        source: &GenesisAccount,
+        target: &Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError>;
+
     /// Returns true if the given account is currently marked as persistent.
     fn is_persistent(&self, acc: &Address) -> bool;
 
@@ -1367,44 +1374,58 @@ impl DatabaseExt for Backend {
     ) -> Result<(), BackendError> {
         // Loop through all of the allocs defined in the map and commit them to the journal.
         for (addr, acc) in allocs.iter() {
-            // Fetch the account from the journaled state. Will create a new account if it does
-            // not already exist.
-            let mut state_acc = journaled_state.load_account(*addr, self)?;
-
-            // Set the account's bytecode and code hash, if the `bytecode` field is present.
-            if let Some(bytecode) = acc.code.as_ref() {
-                state_acc.info.code_hash = keccak256(bytecode);
-                let bytecode = Bytecode::new_raw(bytecode.0.clone().into());
-                state_acc.info.code = Some(bytecode);
-            }
-
-            // Set the account's storage, if the `storage` field is present.
-            if let Some(storage) = acc.storage.as_ref() {
-                state_acc.storage = storage
-                    .iter()
-                    .map(|(slot, value)| {
-                        let slot = U256::from_be_bytes(slot.0);
-                        (
-                            slot,
-                            EvmStorageSlot::new_changed(
-                                state_acc
-                                    .storage
-                                    .get(&slot)
-                                    .map(|s| s.present_value)
-                                    .unwrap_or_default(),
-                                U256::from_be_bytes(value.0),
-                            ),
-                        )
-                    })
-                    .collect();
-            }
-            // Set the account's nonce and balance.
-            state_acc.info.nonce = acc.nonce.unwrap_or_default();
-            state_acc.info.balance = acc.balance;
-
-            // Touch the account to ensure the loaded information persists if called in `setUp`.
-            journaled_state.touch(addr);
+            self.copy_account(acc, addr, journaled_state)?;
         }
+
+        Ok(())
+    }
+
+    /// Copies bytecode, storage, nonce and balance from the given genesis account to the target address.
+    ///
+    /// Returns [Ok] if data was successfully inserted into the journal, [Err] otherwise.
+    fn copy_account(
+        &mut self,
+        source: &GenesisAccount,
+        target: &Address,
+        journaled_state: &mut JournaledState,
+    ) -> Result<(), BackendError> {
+        // Fetch the account from the journaled state. Will create a new account if it does
+        // not already exist.
+        let mut state_acc = journaled_state.load_account(*target, self)?;
+
+        // Set the account's bytecode and code hash, if the `bytecode` field is present.
+        if let Some(bytecode) = source.code.as_ref() {
+            state_acc.info.code_hash = keccak256(bytecode);
+            let bytecode = Bytecode::new_raw(bytecode.0.clone().into());
+            state_acc.info.code = Some(bytecode);
+        }
+
+        // Set the account's storage, if the `storage` field is present.
+        if let Some(storage) = source.storage.as_ref() {
+            state_acc.storage = storage
+                .iter()
+                .map(|(slot, value)| {
+                    let slot = U256::from_be_bytes(slot.0);
+                    (
+                        slot,
+                        EvmStorageSlot::new_changed(
+                            state_acc
+                                .storage
+                                .get(&slot)
+                                .map(|s| s.present_value)
+                                .unwrap_or_default(),
+                            U256::from_be_bytes(value.0),
+                        ),
+                    )
+                })
+                .collect();
+        }
+        // Set the account's nonce and balance.
+        state_acc.info.nonce = source.nonce.unwrap_or_default();
+        state_acc.info.balance = source.balance;
+
+        // Touch the account to ensure the loaded information persists if called in `setUp`.
+        journaled_state.touch(target);
 
         Ok(())
     }

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -155,6 +155,7 @@ interface Vm {
     function broadcast(uint256 privateKey) external;
     function chainId(uint256 newChainId) external;
     function clearMockedCalls() external;
+    function cloneAccount(address source, address target) external;
     function closeFile(string calldata path) external;
     function coinbase(address newCoinbase) external;
     function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer) external pure returns (address);

--- a/testdata/default/cheats/CloneAccount.t.sol
+++ b/testdata/default/cheats/CloneAccount.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.18;
+
+import "ds-test/test.sol";
+import "cheats/Vm.sol";
+
+contract Source {
+    uint256 public a;
+    address public b;
+    uint256[3] public c;
+    bool public d;
+
+    constructor() {
+        a = 100;
+        b = address(111);
+        c[0] = 222;
+        c[1] = 333;
+        c[2] = 444;
+        d = true;
+    }
+
+    function getC(uint256 index) public returns (uint256 val) {
+        val = c[index];
+    }
+}
+
+contract CloneAccountTest is DSTest {
+    Vm vm = Vm(HEVM_ADDRESS);
+
+    address clone = address(777);
+
+    function setUp() public {
+        Source src = new Source();
+        vm.deal(address(src), 0.123 ether);
+        vm.cloneAccount(address(src), clone);
+    }
+
+    function test_clone_account() public {
+        // Check clone balance.
+        assertEq(clone.balance, 0.123 ether);
+        // Check clone storage.
+        assertEq(Source(clone).a(), 100);
+        assertEq(Source(clone).b(), address(111));
+        assertEq(Source(clone).getC(0), 222);
+        assertEq(Source(clone).getC(1), 333);
+        assertEq(Source(clone).getC(2), 444);
+        assertEq(Source(clone).d(), true);
+    }
+}

--- a/testdata/default/cheats/CloneAccount.t.sol
+++ b/testdata/default/cheats/CloneAccount.t.sol
@@ -18,10 +18,6 @@ contract Source {
         c[2] = 444;
         d = true;
     }
-
-    function getC(uint256 index) public returns (uint256 val) {
-        val = c[index];
-    }
 }
 
 contract CloneAccountTest is DSTest {
@@ -41,9 +37,9 @@ contract CloneAccountTest is DSTest {
         // Check clone storage.
         assertEq(Source(clone).a(), 100);
         assertEq(Source(clone).b(), address(111));
-        assertEq(Source(clone).getC(0), 222);
-        assertEq(Source(clone).getC(1), 333);
-        assertEq(Source(clone).getC(2), 444);
+        assertEq(Source(clone).c(0), 222);
+        assertEq(Source(clone).c(1), 333);
+        assertEq(Source(clone).c(2), 444);
         assertEq(Source(clone).d(), true);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4893 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- add `copy_account` to `DatabaseExt` trait and reuse impl in `load_allocs`
- `cloneAccountCall` to copy account and mark target as persistent