### PR TITLE
fix(`anvil`): eth_gasPrice returned `1000000000` with `--block-base-fee-per-gas 0`, adds new `--disable-min-priority-fee` to return `0`

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -254,6 +254,7 @@ impl NodeArgs {
             .fork_compute_units_per_second(compute_units_per_second)
             .with_eth_rpc_url(self.evm_opts.fork_url.map(|fork| fork.url))
             .with_base_fee(self.evm_opts.block_base_fee_per_gas)
+            .disable_min_priority_fee(self.evm_opts.disable_min_priority_fee)
             .with_storage_caching(self.evm_opts.no_storage_caching)
             .with_server_config(self.server_config)
             .with_host(self.host)
@@ -546,6 +547,15 @@ pub struct AnvilEvmArgs {
         help_heading = "Environment config"
     )]
     pub block_base_fee_per_gas: Option<u64>,
+
+    /// Disable the enforcement of a minimum suggested priority fee.
+    #[arg(
+        long,
+        value_name = "DISABLE_MIN_PRIORITY_FEE",
+        visible_alias = "no-priority-fee",
+        help_heading = "Environment config"
+    )]
+    pub disable_min_priority_fee: bool,
 
     /// The chain ID.
     #[arg(long, alias = "chain", help_heading = "Environment config")]

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -549,12 +549,7 @@ pub struct AnvilEvmArgs {
     pub block_base_fee_per_gas: Option<u64>,
 
     /// Disable the enforcement of a minimum suggested priority fee.
-    #[arg(
-        long,
-        value_name = "DISABLE_MIN_PRIORITY_FEE",
-        visible_alias = "no-priority-fee",
-        help_heading = "Environment config"
-    )]
+    #[arg(long, visible_alias = "no-priority-fee", help_heading = "Environment config")]
     pub disable_min_priority_fee: bool,
 
     /// The chain ID.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -99,6 +99,8 @@ pub struct NodeConfig {
     pub gas_price: Option<u128>,
     /// Default base fee
     pub base_fee: Option<u64>,
+    /// If set to `true`, disables the minimum suggested priority fee
+    pub disable_min_priority_fee: bool,
     /// Default blob excess gas and price
     pub blob_excess_gas_and_price: Option<BlobExcessGasAndPrice>,
     /// The hardfork to use
@@ -432,6 +434,7 @@ impl Default for NodeConfig {
             fork_choice: None,
             account_generator: None,
             base_fee: None,
+            disable_min_priority_fee: false,
             blob_excess_gas_and_price: None,
             enable_tracing: true,
             enable_steps_tracing: false,
@@ -620,6 +623,13 @@ impl NodeConfig {
     #[must_use]
     pub fn with_base_fee(mut self, base_fee: Option<u64>) -> Self {
         self.base_fee = base_fee;
+        self
+    }
+
+    /// Disable minimum suggested priority fee
+    #[must_use]
+    pub fn disable_min_priority_fee(mut self, disable_min_priority_fee: bool) -> Self {
+        self.disable_min_priority_fee = disable_min_priority_fee;
         self
     }
 
@@ -994,6 +1004,7 @@ impl NodeConfig {
         let fees = FeeManager::new(
             cfg.handler_cfg.spec_id,
             self.get_base_fee(),
+            !self.disable_min_priority_fee,
             self.get_gas_price(),
             self.get_blob_excess_gas_and_price(),
         );

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -99,7 +99,7 @@ pub struct NodeConfig {
     pub gas_price: Option<u128>,
     /// Default base fee
     pub base_fee: Option<u64>,
-    /// If set to `true`, disables the minimum suggested priority fee
+    /// If set to `true`, disables the enforcement of a minimum suggested priority fee
     pub disable_min_priority_fee: bool,
     /// Default blob excess gas and price
     pub blob_excess_gas_and_price: Option<BlobExcessGasAndPrice>,
@@ -626,7 +626,7 @@ impl NodeConfig {
         self
     }
 
-    /// Disable minimum suggested priority fee
+    /// Disable the enforcement of a minimum suggested priority fee
     #[must_use]
     pub fn disable_min_priority_fee(mut self, disable_min_priority_fee: bool) -> Self {
         self.disable_min_priority_fee = disable_min_priority_fee;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -592,7 +592,11 @@ impl EthApi {
     /// Returns the current gas price
     pub fn gas_price(&self) -> u128 {
         if self.backend.is_eip1559() {
-            (self.backend.base_fee() as u128).saturating_add(self.lowest_suggestion_tip())
+            if self.backend.is_min_priority_fee_enforced() {
+                (self.backend.base_fee() as u128).saturating_add(self.lowest_suggestion_tip())
+            } else {
+                self.backend.base_fee() as u128
+            }
         } else {
             self.backend.fees().raw_gas_price()
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -668,6 +668,11 @@ impl Backend {
         self.fees.base_fee()
     }
 
+    /// Returns whether the minimum suggested priority fee is enforced
+    pub fn is_min_priority_fee_enforced(&self) -> bool {
+        self.fees.is_min_priority_fee_enforced()
+    }
+
     pub fn excess_blob_gas_and_price(&self) -> Option<BlobExcessGasAndPrice> {
         self.fees.excess_blob_gas_and_price()
     }

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -48,7 +48,7 @@ pub struct FeeManager {
     ///
     /// This value will be updated after a new block was mined
     base_fee: Arc<RwLock<u64>>,
-    /// Whether the minimum suggested priority fee should be used
+    /// Whether the minimum suggested priority fee is enforced
     is_min_priority_fee_enforced: bool,
     /// Tracks the excess blob gas, and the base fee, for the next block post Cancun
     ///

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -48,6 +48,8 @@ pub struct FeeManager {
     ///
     /// This value will be updated after a new block was mined
     base_fee: Arc<RwLock<u64>>,
+    /// Whether the minimum suggested priority fee should be used
+    is_min_priority_fee_enforced: bool,
     /// Tracks the excess blob gas, and the base fee, for the next block post Cancun
     ///
     /// This value will be updated after a new block was mined
@@ -63,12 +65,14 @@ impl FeeManager {
     pub fn new(
         spec_id: SpecId,
         base_fee: u64,
+        is_min_priority_fee_enforced: bool,
         gas_price: u128,
         blob_excess_gas_and_price: BlobExcessGasAndPrice,
     ) -> Self {
         Self {
             spec_id,
             base_fee: Arc::new(RwLock::new(base_fee)),
+            is_min_priority_fee_enforced,
             gas_price: Arc::new(RwLock::new(gas_price)),
             blob_excess_gas_and_price: Arc::new(RwLock::new(blob_excess_gas_and_price)),
             elasticity: Arc::new(RwLock::new(default_elasticity())),
@@ -103,6 +107,10 @@ impl FeeManager {
         } else {
             0
         }
+    }
+
+    pub fn is_min_priority_fee_enforced(&self) -> bool {
+        self.is_min_priority_fee_enforced
     }
 
     /// Raw base gas price


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/9033

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Prefers a simple boolean flag to disable the enforcement rather than allowing the user to pass a priority fee of 0

Adds a new flag to disable min suggested priority fee: `--disable-min-priority-fee`

```
anvil --gas-price 0 --block-base-fee-per-gas 0 --disable-min-priority-fee
```

```
cast gas-price
```

Now yields `0` when the `--disable-min-priority-fee` is set

Without it still yields the `MIN_SUGGESTED_PRIORITY_FEE`:

https://github.com/foundry-rs/foundry/blob/eb046653de4047a27b181394338732e597965257/crates/anvil/src/eth/fees.rs#L36