### PR TITLE
fix(invariant): do not commit state if assume returns

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -317,10 +317,11 @@ impl<'a> InvariantExecutor<'a> {
                     TestCaseError::fail("No input generated to call fuzzed target.")
                 })?;
 
-                // Execute call from the randomly generated sequence and commit state changes.
-                let call_result = current_run
+                // Execute call from the randomly generated sequence without committing state.
+                // State is committed only if call is not a magic assume.
+                let mut call_result = current_run
                     .executor
-                    .transact_raw(
+                    .call_raw(
                         tx.sender,
                         tx.call_details.target,
                         tx.call_details.calldata.clone(),
@@ -343,9 +344,11 @@ impl<'a> InvariantExecutor<'a> {
                         return Err(TestCaseError::fail("Max number of vm.assume rejects reached."))
                     }
                 } else {
+                    // Commit executed call result.
+                    current_run.executor.commit(&mut call_result);
+
                     // Collect data for fuzzing from the state changeset.
                     let mut state_changeset = call_result.state_changeset.clone();
-
                     if !call_result.reverted {
                         collect_data(
                             &invariant_test,
@@ -369,13 +372,13 @@ impl<'a> InvariantExecutor<'a> {
                     {
                         warn!(target: "forge::test", "{error}");
                     }
-
                     current_run.fuzz_runs.push(FuzzCase {
                         calldata: tx.call_details.calldata.clone(),
                         gas: call_result.gas_used,
                         stipend: call_result.stipend,
                     });
 
+                    // Determine if test can continue or should exit.
                     let result = can_continue(
                         &invariant_contract,
                         &invariant_test,
@@ -385,11 +388,9 @@ impl<'a> InvariantExecutor<'a> {
                         &state_changeset,
                     )
                     .map_err(|e| TestCaseError::fail(e.to_string()))?;
-
                     if !result.can_continue || current_run.depth == self.config.depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
-
                     // If test cannot continue then stop current run and exit test suite.
                     if !result.can_continue {
                         return Err(TestCaseError::fail("Test cannot continue."))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9054 
- atm in invariant tests we're committing the state of fuzzed selector, regardless it is a magic assume result
- assume rejections should discard the current fuzzed input and increment rejection counter but without modifying state (similar with a call that doesn't happen). Further more the assume input is popped from call sequence, so won't be available in a failed call sequence (still could change state)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- do not commit state if call result is MAGIC_ASSUME