### PR TITLE
fix: support EOF opcodes in `cast da`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,6 @@ dependencies = [
  "comfy-table",
  "criterion",
  "dunce",
- "evm-disassembler",
  "evmole",
  "eyre",
  "foundry-block-explorers",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -54,7 +54,6 @@ alloy-sol-types.workspace = true
 alloy-transport.workspace = true
 
 chrono.workspace = true
-evm-disassembler.workspace = true
 eyre.workspace = true
 futures.workspace = true
 rand.workspace = true

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -307,7 +307,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             println!("Computed Address: {}", computed.to_checksum(None));
         }
         CastSubcommand::Disassemble { bytecode } => {
-            println!("{}", SimpleCast::disassemble(&bytecode)?);
+            println!("{}", SimpleCast::disassemble(&hex::decode(bytecode)?)?);
         }
         CastSubcommand::Selectors { bytecode, resolve } => {
             let functions = SimpleCast::extract_functions(&bytecode)?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1960,8 +1960,8 @@ impl SimpleCast {
     /// # Example
     ///
     /// ```
-    /// use cast::SimpleCast as Cast;
     /// use alloy_primitives::hex;
+    /// use cast::SimpleCast as Cast;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let bytecode = "0x608060405260043610603f57600035";

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1961,10 +1961,11 @@ impl SimpleCast {
     ///
     /// ```
     /// use cast::SimpleCast as Cast;
+    /// use alloy_primitives::hex;
     ///
     /// # async fn foo() -> eyre::Result<()> {
     /// let bytecode = "0x608060405260043610603f57600035";
-    /// let opcodes = Cast::disassemble(bytecode)?;
+    /// let opcodes = Cast::disassemble(&hex::decode(bytecode)?)?;
     /// println!("{}", opcodes);
     /// # Ok(())
     /// # }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

right now `cast disassemble` does not handle EOF opcodes and their immediate bytes

## Solution

Reuse `immediate_size` helper from revm-inspectors (should we move it to revm?), and implement a native helper for decoding bytecode.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
