### PR TITLE
fix: redact RPC URLs in traces if URL is passed in directly

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -516,6 +516,24 @@ impl CallTraceDecoder {
                     Some(decoded.iter().map(format_token).collect())
                 }
             }
+            "createFork" |
+            "createSelectFork" |
+            "rpc" => {
+                let mut decoded = func.abi_decode_input(&data[SELECTOR_LEN..], false).ok()?;
+
+                // Redact RPC URL except if referenced by an alias
+                if !decoded.is_empty() && func.inputs[0].ty == "string" {
+                    let url_or_alias = decoded[0].as_str().unwrap_or_default();
+
+                    if url_or_alias.starts_with("http") || url_or_alias.starts_with("ws") {
+                        decoded[0] = DynSolValue::String("<rpc url>".to_string());
+                    }
+                } else {
+                    return None;
+                }
+
+                Some(decoded.iter().map(format_token).collect())
+            }
             _ => None,
         }
     }
@@ -558,6 +576,7 @@ impl CallTraceDecoder {
             "promptSecret" | "promptSecretUint" => Some("<secret>"),
             "parseJson" if self.verbosity < 5 => Some("<encoded JSON value>"),
             "readFile" if self.verbosity < 5 => Some("<file>"),
+            "rpcUrl" | "rpcUrls" | "rpcUrlStructs" => Some("<rpc url>"),
             _ => None,
         }
         .map(Into::into)
@@ -670,7 +689,7 @@ mod tests {
     use alloy_primitives::hex;
 
     #[test]
-    fn test_should_redact_pk() {
+    fn test_should_redact() {
         let decoder = CallTraceDecoder::new();
 
         // [function_signature, data, expected]
@@ -726,6 +745,275 @@ mod tests {
                         .to_string(),
                 ]),
             ),
+            (
+                // cast calldata "createFork(string)" "https://eth-mainnet.g.alchemy.com/v2/api_key"
+                "createFork(string)",
+                hex!(
+                    "
+                    31ba3498
+                    0000000000000000000000000000000000000000000000000000000000000020
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                    "
+                )
+                .to_vec(),
+                Some(vec!["\"<rpc url>\"".to_string()]),
+            ),
+            (
+                // cast calldata "createFork(string)" "wss://eth-mainnet.g.alchemy.com/v2/api_key"
+                "createFork(string)",
+                hex!(
+                    "
+                    31ba3498
+                    0000000000000000000000000000000000000000000000000000000000000020
+                    000000000000000000000000000000000000000000000000000000000000002a
+                    7773733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f6d2f
+                    76322f6170695f6b657900000000000000000000000000000000000000000000
+                    "
+                )
+                .to_vec(),
+                Some(vec!["\"<rpc url>\"".to_string()]),
+            ),
+            (
+                // cast calldata "createFork(string)" "mainnet"
+                "createFork(string)",
+                hex!(
+                    "
+                    31ba3498
+                    0000000000000000000000000000000000000000000000000000000000000020
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                    "
+                )
+                .to_vec(),
+                Some(vec!["\"mainnet\"".to_string()]),
+            ),
+            (
+                // cast calldata "createFork(string,uint256)" "https://eth-mainnet.g.alchemy.com/v2/api_key" 1
+                "createFork(string,uint256)",
+                hex!(
+                    "
+                    6ba3ba2b
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    0000000000000000000000000000000000000000000000000000000000000001
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec!["\"<rpc url>\"".to_string(), "1".to_string()]),
+            ),
+            (
+                // cast calldata "createFork(string,uint256)" "mainnet" 1
+                "createFork(string,uint256)",
+                hex!(
+                    "
+                    6ba3ba2b
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    0000000000000000000000000000000000000000000000000000000000000001
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec!["\"mainnet\"".to_string(), "1".to_string()]),
+            ),
+            (
+                // cast calldata "createFork(string,bytes32)" "https://eth-mainnet.g.alchemy.com/v2/api_key" 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                "createFork(string,bytes32)",
+                hex!(
+                    "
+                    7ca29682
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"<rpc url>\"".to_string(),
+                    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                        .to_string(),
+                ]),
+            ),
+            (
+                // cast calldata "createFork(string,bytes32)" "mainnet"
+                // 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                "createFork(string,bytes32)",
+                hex!(
+                    "
+                    7ca29682
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"mainnet\"".to_string(),
+                    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                        .to_string(),
+                ]),
+            ),
+            (
+                // cast calldata "createSelectFork(string)" "https://eth-mainnet.g.alchemy.com/v2/api_key"
+                "createSelectFork(string)",
+                hex!(
+                    "
+                    98680034
+                    0000000000000000000000000000000000000000000000000000000000000020
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                    "
+                )
+                .to_vec(),
+                Some(vec!["\"<rpc url>\"".to_string()]),
+            ),
+            (
+                // cast calldata "createSelectFork(string)" "mainnet"
+                "createSelectFork(string)",
+                hex!(
+                    "
+                    98680034
+                    0000000000000000000000000000000000000000000000000000000000000020
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                    "
+                )
+                .to_vec(),
+                Some(vec!["\"mainnet\"".to_string()]),
+            ),
+            (
+                // cast calldata "createSelectFork(string,uint256)" "https://eth-mainnet.g.alchemy.com/v2/api_key" 1
+                "createSelectFork(string,uint256)",
+                hex!(
+                    "
+                    71ee464d
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    0000000000000000000000000000000000000000000000000000000000000001
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec!["\"<rpc url>\"".to_string(), "1".to_string()]),
+            ),
+            (
+                // cast calldata "createSelectFork(string,uint256)" "mainnet" 1
+                "createSelectFork(string,uint256)",
+                hex!(
+                    "
+                    71ee464d
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    0000000000000000000000000000000000000000000000000000000000000001
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec!["\"mainnet\"".to_string(), "1".to_string()]),
+            ),
+            (
+                // cast calldata "createSelectFork(string,bytes32)" "https://eth-mainnet.g.alchemy.com/v2/api_key" 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                "createSelectFork(string,bytes32)",
+                hex!(
+                    "
+                    84d52b7a
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"<rpc url>\"".to_string(),
+                    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                        .to_string(),
+                ]),
+            ),
+            (
+                // cast calldata "createSelectFork(string,bytes32)" "mainnet"
+                // 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                "createSelectFork(string,bytes32)",
+                hex!(
+                    "
+                    84d52b7a
+                    0000000000000000000000000000000000000000000000000000000000000040
+                    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"mainnet\"".to_string(),
+                    "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                        .to_string(),
+                ]),
+            ),
+            (
+                // cast calldata "rpc(string,string,string)" "https://eth-mainnet.g.alchemy.com/v2/api_key" "eth_getBalance" "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]"
+                "rpc(string,string,string)",
+                hex!(
+                    "
+                    0199a220
+                    0000000000000000000000000000000000000000000000000000000000000060
+                    00000000000000000000000000000000000000000000000000000000000000c0
+                    0000000000000000000000000000000000000000000000000000000000000100
+                    000000000000000000000000000000000000000000000000000000000000002c
+                    68747470733a2f2f6574682d6d61696e6e65742e672e616c6368656d792e636f
+                    6d2f76322f6170695f6b65790000000000000000000000000000000000000000
+                    000000000000000000000000000000000000000000000000000000000000000e
+                    6574685f67657442616c616e6365000000000000000000000000000000000000
+                    0000000000000000000000000000000000000000000000000000000000000034
+                    5b22307835353165373738343737386566386530343865343935646634396632
+                    363134663834613466316463222c22307830225d000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"<rpc url>\"".to_string(),
+                    "\"eth_getBalance\"".to_string(),
+                    "\"[\\\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\\\",\\\"0x0\\\"]\""
+                        .to_string(),
+                ]),
+            ),
+            (
+                // cast calldata "rpc(string,string,string)" "mainnet" "eth_getBalance"
+                // "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]"
+                "rpc(string,string,string)",
+                hex!(
+                    "
+                    0199a220
+                    0000000000000000000000000000000000000000000000000000000000000060
+                    00000000000000000000000000000000000000000000000000000000000000a0
+                    00000000000000000000000000000000000000000000000000000000000000e0
+                    0000000000000000000000000000000000000000000000000000000000000007
+                    6d61696e6e657400000000000000000000000000000000000000000000000000
+                    000000000000000000000000000000000000000000000000000000000000000e
+                    6574685f67657442616c616e6365000000000000000000000000000000000000
+                    0000000000000000000000000000000000000000000000000000000000000034
+                    5b22307835353165373738343737386566386530343865343935646634396632
+                    363134663834613466316463222c22307830225d000000000000000000000000
+                "
+                )
+                .to_vec(),
+                Some(vec![
+                    "\"mainnet\"".to_string(),
+                    "\"eth_getBalance\"".to_string(),
+                    "\"[\\\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\\\",\\\"0x0\\\"]\""
+                        .to_string(),
+                ]),
+            ),
         ];
 
         // [function_signature, expected]
@@ -733,6 +1021,10 @@ mod tests {
             // Should redact private key on output in all cases:
             ("createWallet(string)", Some("<pk>".to_string())),
             ("deriveKey(string,uint32)", Some("<pk>".to_string())),
+            // Should redact RPC URL if defined, except if referenced by an alias:
+            ("rpcUrl(string)", Some("<rpc url>".to_string())),
+            ("rpcUrls()", Some("<rpc url>".to_string())),
+            ("rpcUrlStructs()", Some("<rpc url>".to_string())),
         ];
 
         for (function_signature, data, expected) in cheatcode_input_test_cases {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Whilst it is generally recommended and easier to configure aliases in `foundry.toml` w/ an `.env` and reference by alias in the tests it can occur that a user directly passes an RPC URL. 

```toml
[rpc_endpoints]
mainnet = "${MAINNET_RPC_URL}"
```

```solidity
vm.createSelectFork("mainnet");
```

Like private keys we should redact these fields if not referenced by alias to prevent leaking API keys in CIs

```solidity
vm.createSelectFork("https://eth-mainnet.g.alchemy.com/v2/api-key");
```

should render as

```
<rpc url>
```

Closes: https://github.com/foundry-rs/foundry/issues/9069

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Example output (redacted by API key):

```solidity
    function test_rpc_urls() public {
        vm.createFork("https://eth-mainnet.g.alchemy.com/v2/api-key");
        vm.createFork("https://eth-mainnet.g.alchemy.com/v2/api-key", 15_977_624);
        vm.createFork(
            "https://eth-mainnet.g.alchemy.com/v2/api-key",
            hex"b0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb"
        );

        vm.createFork("mainnet");
        vm.createFork("mainnet", 15_977_624);
        vm.createFork("mainnet", hex"b0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb");

        vm.createSelectFork("https://eth-mainnet.g.alchemy.com/v2/api-key");
        vm.createSelectFork("https://eth-mainnet.g.alchemy.com/v2/api-key", 15_977_624);
        vm.createSelectFork(
            "https://eth-mainnet.g.alchemy.com/v2/api-key",
            hex"b0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb"
        );

        vm.createSelectFork("mainnet");
        vm.createSelectFork("mainnet", 15_977_624);
        vm.createSelectFork("mainnet", hex"b0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb");

        string memory url = vm.rpcUrl("mainnet");
        Vm.Rpc[] memory rpcs = vm.rpcUrlStructs();
        string[2][] memory urls = vm.rpcUrls();

        bytes memory a = vm.rpc("eth_getBalance", "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]");
        bytes memory b = vm.rpc(
            "https://eth-mainnet.g.alchemy.com/v2/api-key",
            "eth_getBalance",
            "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]"
        );
    }
```

```
  [17592] ForkTest::test_rpc_urls()
    ├─ [0] VM::createFork("<rpc url>")
    │   └─ ← [Return] 0
    ├─ [0] VM::createFork("<rpc url>", 15977624 [1.597e7])
    │   └─ ← [Return] 1
    ├─ [0] VM::createFork("<rpc url>", 0xb0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb)
    │   └─ ← [Return] 2
    ├─ [0] VM::createFork("mainnet")
    │   └─ ← [Return] 3
    ├─ [0] VM::createFork("mainnet", 15977624 [1.597e7])
    │   └─ ← [Return] 4
    ├─ [0] VM::createFork("mainnet", 0xb0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb)
    │   └─ ← [Return] 5
    ├─ [0] VM::createSelectFork("<rpc url>")
    │   └─ ← [Return] 6
    ├─ [0] VM::createSelectFork("<rpc url>", 15977624 [1.597e7])
    │   └─ ← [Return] 7
    ├─ [0] VM::createSelectFork("<rpc url>", 0xb0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb)
    │   └─ ← [Return] 8
    ├─ [0] VM::createSelectFork("mainnet")
    │   └─ ← [Return] 9
    ├─ [0] VM::createSelectFork("mainnet", 15977624 [1.597e7])
    │   └─ ← [Return] 10
    ├─ [0] VM::createSelectFork("mainnet", 0xb0403b2e1d30a497806d46d4c355ea54a67c4f1e587824904427220b5b9eefdb)
    │   └─ ← [Return] 11
    ├─ [0] VM::rpcUrl("mainnet") [staticcall]
    │   └─ ← [Return] <rpc url>
    ├─ [0] VM::rpcUrlStructs() [staticcall]
    │   └─ ← [Return] <rpc url>
    ├─ [0] VM::rpcUrls() [staticcall]
    │   └─ ← [Return] <rpc url>
    ├─ [0] VM::rpc("eth_getBalance", "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]")
    │   └─ ← [Return] 0x2086ac351052600000
    ├─ [0] VM::rpc("<rpc url>", "eth_getBalance", "[\"0x551e7784778ef8e048e495df49f2614f84a4f1dc\",\"0x0\"]")
    │   └─ ← [Return] 0x2086ac351052600000
    └─ ← [Stop] 
```

Includes tests to check this and makes sure only the RPC url is redacted if it is not an alias for readability sake. The tests also check that only the RPC url field is redacted, not the entire output.