### PR TITLE
feat(`cheatcodes`): vm.rememberKeys

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -7515,6 +7515,46 @@
     },
     {
       "func": {
+        "id": "rememberKeys_0",
+        "description": "Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rememberKeys(string,string,uint32)",
+        "selector": "0x97cb9189",
+        "selectorBytes": [
+          151,
+          203,
+          145,
+          137
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "rememberKeys_1",
+        "description": "Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.\nThe respective private keys are saved to the local forge wallet for later use and their addresses are returned.",
+        "declaration": "function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count) external returns (address[] memory keyAddrs);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rememberKeys(string,string,string,uint32)",
+        "selector": "0xf8d58eaf",
+        "selectorBytes": [
+          248,
+          213,
+          142,
+          175
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "removeDir",
         "description": "Removes a directory at the provided path.\nThis cheatcode will revert in the following situations, but is not limited to just these cases:\n- `path` doesn't exist.\n- `path` isn't a directory.\n- User lacks permissions to modify `path`.\n- The directory is not empty and `recursive` is false.\n`path` is relative to the project root.",
         "declaration": "function removeDir(string calldata path, bool recursive) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2404,6 +2404,10 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
 
+    /// Adds private key
+    #[cheatcode(group = Crypto)]
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external;
+
     // -------- Uncategorized Utilities --------
 
     /// Labels an address in call traces.

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2404,9 +2404,10 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
 
-    /// Adds private key
+    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.
+    /// Derived wallets are saved to the local forge wallet for later use and their addresses are returned.
     #[cheatcode(group = Crypto)]
-    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external;
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external returns (address[] memory keyAddrs);
 
     // -------- Uncategorized Utilities --------
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2404,10 +2404,17 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
 
-    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.
-    /// Derived wallets are saved to the local forge wallet for later use and their addresses are returned.
+    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`,
+    /// the wallets are saved to the local forge wallet for later use and their addresses are returned.
     #[cheatcode(group = Crypto)]
-    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external returns (address[] memory keyAddrs);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
+
+    /// Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`,
+    /// the wallets are saved to the local forge wallet for later use and their addresses are returned.
+    #[cheatcode(group = Crypto)]
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count)
+        external
+        returns (address[] memory keyAddrs);
 
     // -------- Uncategorized Utilities --------
 

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2404,13 +2404,15 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
 
-    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`,
-    /// the wallets are saved to the local forge wallet for later use and their addresses are returned.
+    /// Derive a set number of wallets from a mnemonic at the derivation path `m/44'/60'/0'/0/{0..count}`.
+    ///
+    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
     #[cheatcode(group = Crypto)]
     function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
 
-    /// Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`,
-    /// the wallets are saved to the local forge wallet for later use and their addresses are returned.
+    /// Derive a set number of wallets from a mnemonic in the specified language at the derivation path `m/44'/60'/0'/0/{0..count}`.
+    ///
+    /// The respective private keys are saved to the local forge wallet for later use and their addresses are returned.
     #[cheatcode(group = Crypto)]
     function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count)
         external

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -101,13 +101,15 @@ impl Cheatcode for rememberKeysCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { mnemonic, derivationPath, count } = self;
         let wallets = derive_wallets::<English>(mnemonic, derivationPath, *count)?;
+        let mut addresses = Vec::<Address>::with_capacity(wallets.len());
         for wallet in wallets {
             if let Some(script_wallets) = state.script_wallets() {
+                addresses.push(wallet.address());
                 script_wallets.add_local_signer(wallet);
             }
         }
 
-        Ok(Default::default())
+        Ok(addresses.abi_encode())
     }
 }
 
@@ -338,7 +340,7 @@ fn derive_wallets<W: Wordlist>(
     for idx in 0..count {
         let wallet = MnemonicBuilder::<W>::default()
             .phrase(mnemonic)
-            .derivation_path(format!("{}{}", out, idx))?
+            .derivation_path(format!("{out}{idx}"))?
             .build()?;
         wallets.push(wallet);
     }

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2117,7 +2117,7 @@ forgetest_init!(can_remeber_keys, |prj, cmd| {
 import "forge-std/Script.sol";
 
 interface Vm {
-    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32clea count) external returns (address[] memory keyAddrs);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
 }
 
 contract WalletScript is Script {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2117,7 +2117,7 @@ forgetest_init!(can_remeber_keys, |prj, cmd| {
 import "forge-std/Script.sol";
 
 interface Vm {
-    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external returns (address[] memory keyAddrs);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32clea count) external returns (address[] memory keyAddrs);
 }
 
 contract WalletScript is Script {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3,7 +3,6 @@
 use crate::constants::TEMPLATE_CONTRACT;
 use alloy_primitives::{hex, Address, Bytes};
 use anvil::{spawn, NodeConfig};
-use foundry_compilers::output;
 use foundry_test_utils::{
     rpc,
     util::{OTHER_SOLC_VERSION, SOLC_VERSION},
@@ -2118,16 +2117,14 @@ forgetest_init!(can_remeber_keys, |prj, cmd| {
 import "forge-std/Script.sol";
 
 interface Vm {
-    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external;
-    function getScriptWallets() external returns (address[] memory wallets);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint8 count) external returns (address[] memory keyAddrs);
 }
 
 contract WalletScript is Script {
     function run() public {
         string memory mnemonic = "test test test test test test test test test test test junk";
         string memory derivationPath = "m/44'/60'/0'/0/";
-        Vm(address(vm)).rememberKeys(mnemonic, derivationPath, 10);
-        address[] memory wallets = Vm(address(vm)).getScriptWallets();
+        address[] memory wallets = Vm(address(vm)).rememberKeys(mnemonic, derivationPath, 3);
         for (uint256 i = 0; i < wallets.length; i++) {
             console.log(wallets[i]);
         }
@@ -2135,9 +2132,17 @@ contract WalletScript is Script {
 }"#,
         )
         .unwrap();
-    let output = cmd.arg("script").arg(script).assert_success();
+    cmd.arg("script").arg(script).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Script ran successfully.
+[GAS]
 
-    let output = output.get_output();
+== Logs ==
+  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
 
-    println!("{:#?}", output);
+"#]]);
 });

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2219,3 +2219,58 @@ warning: specifying argument for --decode-internal is deprecated and will be rem
 
 "#]]);
 });
+
+// Test a script that calls vm.rememberKeys
+forgetest_init!(script_testing, |prj, cmd| {
+    prj
+    .add_source(
+        "Foo",
+        r#"
+import "forge-std/Script.sol";
+
+interface Vm {
+function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
+}
+
+contract WalletScript is Script {
+function run() public {
+    string memory mnemonic = "test test test test test test test test test test test junk";
+    string memory derivationPath = "m/44'/60'/0'/0/";
+    address[] memory wallets = Vm(address(vm)).rememberKeys(mnemonic, derivationPath, 3);
+    for (uint256 i = 0; i < wallets.length; i++) {
+        console.log(wallets[i]);
+    }
+}
+}
+
+contract FooTest {
+    WalletScript public script;
+
+
+    function setUp() public {
+        script = new WalletScript();
+    }
+
+    function testWalletScript() public {
+        script.run();
+    }
+}
+
+"#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "--mt", "testWalletScript", "-vvv"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for src/Foo.sol:FooTest
+[PASS] testWalletScript() ([GAS])
+Logs:
+  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+...
+"#]]);
+});

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -370,6 +370,8 @@ interface Vm {
     function record() external;
     function recordLogs() external;
     function rememberKey(uint256 privateKey) external returns (address keyAddr);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
+    function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count) external returns (address[] memory keyAddrs);
     function removeDir(string calldata path, bool recursive) external;
     function removeFile(string calldata path) external;
     function replace(string calldata input, string calldata from, string calldata to) external pure returns (string memory output);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #8225 + Closes https://github.com/foundry-rs/foundry/issues/7950

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Introduces cheatcodes to derive and save multiple wallets/signers in the script env. 

```solidity
function rememberKeys(string calldata mnemonic, string calldata derivationPath, uint32 count) external returns (address[] memory keyAddrs);
function rememberKeys(string calldata mnemonic, string calldata derivationPath, string calldata language, uint32 count) external returns (address[] memory keyAddrs);
```


Under the hood these cheatcodes save the derived wallets in `ScriptWallets` such that they are persisted throughout the script environment.

Moreover, to aid in the testing of scripts (as in `forge test DeployScript.t.sol`) these cheatcodes will initialize `ScriptWallets` in the `CheatsConfig` if not already initialized
This is particularly useful for testing scripts that require unlocked accounts.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
