### PR TITLE
fix(`CI`): update Avalache Fuji RPC

### DIFF
--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -364,7 +364,7 @@ pub fn rpc_endpoints() -> RpcEndpoints {
         ("optimism", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Optimism))),
         ("arbitrum", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Arbitrum))),
         ("polygon", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Polygon))),
-        ("avaxTestnet", RpcEndpoint::Url("https://api.avax-test.network/ext/bc/C/rpc".into())),
+        ("avaxTestnet", RpcEndpoint::Url("https://rpc.ankr.com/avalanche_fuji".into())),
         ("rpcEnvAlias", RpcEndpoint::Env("${RPC_ENV_ALIAS}".into())),
     ])
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Broken CI, flaky RPC endpoint: https://api.avax-test.network/ext/bc/C/rpc

Related: https://github.com/foundry-rs/foundry/actions/runs/11330396435/job/31508145615
Related: https://github.com/foundry-rs/foundry/actions/runs/11330706488/job/31509127194?pr=7909

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Replaces RPC URL with ANKR, as listed in the documentation, as the default RPC https://avalanche-fuji-c-chain-rpc.publicnode.com does not include archive data

See: https://docs.avax.network/tooling/rpc-providers
