### PR TITLE
fix: respect `--auth` in `cast call` and `cast estimate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,9 +3659,11 @@ version = "0.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
+ "alloy-eips",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rlp",
  "alloy-transport",
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "indicatif",
  "regex",
  "serde",
+ "serde_json",
  "strsim",
  "strum",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { workspace = true, features = ["macros"] }
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 tracing.workspace = true
 yansi.workspace = true
+serde_json.workspace = true
 
 tracing-tracy = { version = "0.11", optional = true }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,10 +22,12 @@ foundry-wallets.workspace = true
 
 foundry-compilers = { workspace = true, features = ["full"] }
 
+alloy-eips.workspace = true
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
+alloy-rlp.workspace = true
 alloy-transport.workspace = true
 alloy-chains.workspace = true
 

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use crate::utils::parse_ether_value;
-use alloy_eips::eip7702::SignedAuthorization;
+use crate::utils::{parse_ether_value, parse_json};
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{hex, Address, U256, U64};
 use alloy_rlp::Decodable;
 use clap::Parser;
@@ -95,8 +95,8 @@ pub struct TransactionOpts {
     /// Accepts either a JSON-encoded access list or an empty value to create the access list
     /// via an RPC call to `eth_createAccessList`. To retrieve only the access list portion, use
     /// the `cast access-list` command.
-    #[arg(long)]
-    pub access_list: Option<Option<String>>,
+    #[arg(long, value_parser = parse_json::<AccessList>)]
+    pub access_list: Option<Option<AccessList>>,
 }
 
 #[cfg(test)]

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -1,9 +1,36 @@
-use crate::utils::parse_ether_value;
-use alloy_primitives::{U256, U64};
-use clap::Parser;
-use serde::Serialize;
+use std::str::FromStr;
 
-#[derive(Clone, Debug, Serialize, Parser)]
+use crate::utils::parse_ether_value;
+use alloy_eips::eip7702::SignedAuthorization;
+use alloy_primitives::{hex, Address, U256, U64};
+use alloy_rlp::Decodable;
+use clap::Parser;
+
+/// CLI helper to parse a EIP-7702 authorization list.
+/// Can be either a hex-encoded signed authorization or an address.
+#[derive(Clone, Debug)]
+pub enum CliAuthorizationList {
+    /// If an address is provided, we sign the authorization delegating to provided address.
+    Address(Address),
+    /// If RLP-encoded authorization is provided, we decode it and attach to transaction.
+    Signed(SignedAuthorization),
+}
+
+impl FromStr for CliAuthorizationList {
+    type Err = eyre::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(addr) = Address::from_str(s) {
+            Ok(Self::Address(addr))
+        } else if let Ok(auth) = SignedAuthorization::decode(&mut hex::decode(s)?.as_ref()) {
+            Ok(Self::Signed(auth))
+        } else {
+            eyre::bail!("Failed to decode authorization")
+        }
+    }
+}
+
+#[derive(Clone, Debug, Parser)]
 #[command(next_help_heading = "Transaction options")]
 pub struct TransactionOpts {
     /// Gas limit for the transaction.
@@ -61,7 +88,7 @@ pub struct TransactionOpts {
     ///
     /// Can be either a hex-encoded signed authorization or an address.
     #[arg(long, conflicts_with_all = &["legacy", "blob"])]
-    pub auth: Option<String>,
+    pub auth: Option<CliAuthorizationList>,
 
     /// EIP-2930 access list.
     ///

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -5,6 +5,7 @@ use alloy_transport::Transport;
 use eyre::{ContextCompat, Result};
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
 use foundry_config::{Chain, Config};
+use serde::de::DeserializeOwned;
 use std::{
     ffi::OsStr,
     future::Future,
@@ -131,6 +132,11 @@ pub fn parse_ether_value(value: &str) -> Result<U256> {
             .wrap_err("Could not parse ether value from string")?
             .0
     })
+}
+
+/// Parses a `T` from a string using [`serde_json::from_str`].
+pub fn parse_json<T: DeserializeOwned>(value: &str) -> serde_json::Result<T> {
+    serde_json::from_str(value)
 }
 
 /// Parses a `Duration` from a &str


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Right now for read-only requests we skip both `--access-list` and `--auth` making it impossible to call `eth_call` or `eth_estimateGas` with those

## Solution

Reorder things a bit and respect those flags. Also moved the parsing logic to cli crate.