### PR TITLE
feat(forge): add max supported EVM version in compiler -vv

### DIFF
--- a/crates/forge/bin/cmd/compiler.rs
+++ b/crates/forge/bin/cmd/compiler.rs
@@ -33,10 +33,11 @@ pub enum CompilerSubcommands {
 struct ResolvedCompiler {
     /// Compiler version.
     version: Version,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Max supported EVM version of compiler.
+    #[serde(skip_serializing_if = "Option::is_none")]
     evm_version: Option<EvmVersion>,
     /// Source paths.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     paths: Vec<String>,
 }
 
@@ -56,7 +57,9 @@ pub struct ResolveArgs {
     /// Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
     ///
     /// Verbosity levels:
-    /// - 2: Print source paths.
+    /// - 0: Print compiler versions.
+    /// - 1: Print compiler version and source paths.
+    /// - 2: Print compiler version, source paths and max supported EVM version of the compiler.
     #[arg(long, short, verbatim_doc_comment, action = ArgAction::Count, help_heading = "Display options")]
     pub verbosity: u8,
 
@@ -127,6 +130,12 @@ impl ResolveArgs {
 
             // Skip language if no paths are found after filtering.
             if !versions_with_paths.is_empty() {
+                // Clear paths if verbosity is 0, performed only after filtering to avoid being
+                // skipped.
+                if verbosity == 0 {
+                    versions_with_paths.iter_mut().for_each(|version| version.paths.clear());
+                }
+
                 output.insert(language.to_string(), versions_with_paths);
             }
         }

--- a/crates/forge/bin/cmd/compiler.rs
+++ b/crates/forge/bin/cmd/compiler.rs
@@ -125,8 +125,15 @@ impl ResolveArgs {
             }
 
             for (version, evm_version, paths) in versions {
-                if verbosity >= 1 {
-                    println!("{version} [Max supported EVM version: {evm_version}]:");
+                if verbosity == 0 {
+                    println!("- {version}");
+                } else {
+                    if verbosity == 1 {
+                        println!("{version}:");
+                    } else {
+                        println!("{version} (<= {evm_version}):")
+                    }
+
                     for (idx, path) in paths.iter().enumerate() {
                         if idx == paths.len() - 1 {
                             println!("└── {path}\n");
@@ -134,12 +141,10 @@ impl ResolveArgs {
                             println!("├── {path}");
                         }
                     }
-                } else {
-                    println!("- {version}");
                 }
             }
 
-            if verbosity < 1 {
+            if verbosity == 0 {
                 println!();
             }
         }

--- a/crates/forge/bin/cmd/compiler.rs
+++ b/crates/forge/bin/cmd/compiler.rs
@@ -118,22 +118,19 @@ impl ResolveArgs {
         }
 
         for (language, versions) in &output {
-            if verbosity < 1 {
-                println!("{language}:");
-            } else {
-                println!("{language}:\n");
+            match verbosity {
+                0 => println!("{language}:"),
+                _ => println!("{language}:\n"),
             }
 
             for (version, evm_version, paths) in versions {
-                if verbosity == 0 {
-                    println!("- {version}");
-                } else {
-                    if verbosity == 1 {
-                        println!("{version}:");
-                    } else {
-                        println!("{version} (<= {evm_version}):")
-                    }
+                match verbosity {
+                    0 => println!("- {version}"),
+                    1 => println!("{version}:"),
+                    _ => println!("{version} (<= {evm_version}):"),
+                }
 
+                if verbosity > 0 {
                     for (idx, path) in paths.iter().enumerate() {
                         if idx == paths.len() - 1 {
                             println!("└── {path}\n");

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -220,13 +220,13 @@ Solidity:
 0.8.11 (<= london):
 └── src/ContractB.sol
 
-0.8.27 (<= cancun):
+0.8.27 (<= [..]):
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
 Vyper:
 
-0.4.0 (<= cancun):
+0.4.0 (<= [..]):
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -262,7 +262,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_json, |prj, cmd| {
     },
     {
       "version": "0.8.27",
-      "evm_version": "Cancun",
+      "evm_version": "[..]",
       "paths": [
         "src/ContractC.sol",
         "src/ContractD.sol"
@@ -272,7 +272,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_json, |prj, cmd| {
   "Vyper": [
     {
       "version": "0.4.0",
-      "evm_version": "Cancun",
+      "evm_version": "[..]",
       "paths": [
         "src/Counter.vy",
         "src/ICounter.vyi"

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -108,7 +108,18 @@ forgetest!(can_list_resolved_compiler_versions_json, |prj, cmd| {
 
     cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
         str![[r#"
-{"Solidity":[["0.8.27","[..]",["src/ContractC.sol","src/ContractD.sol"]]]}"#]]
+{
+  "Solidity": [
+    {
+      "version": "0.8.27",
+      "paths": [
+        "src/ContractC.sol",
+        "src/ContractD.sol"
+      ]
+    }
+  ]
+}
+"#]]
         .is_json(),
     );
 });
@@ -164,10 +175,32 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
     prj.add_raw_source("Counter.vy", VYPER_CONTRACT).unwrap();
 
     cmd.args(["compiler", "resolve", "--skip", "Contract(A|B|C)", "--json"])
-            .assert_success()
-            .stdout_eq(str![[r#"
-{"Solidity":[["0.8.27","[..]",["src/ContractD.sol"]]],"Vyper":[["0.4.0","[..]",["src/Counter.vy","src/ICounter.vyi"]]]}
-"#]].is_json());
+        .assert_success()
+        .stdout_eq(
+            str![[r#"
+{
+  "Solidity": [
+    {
+      "version": "0.8.27",
+      "paths": [
+        "src/ContractD.sol"
+      ]
+    }
+  ],
+  "Vyper": [
+    {
+      "version": "0.4.0",
+      "paths": [
+        "src/Counter.vy",
+        "src/ICounter.vyi"
+      ]
+    }
+  ]
+}
+
+"#]]
+            .is_json(),
+        );
 });
 
 forgetest!(can_list_resolved_multiple_compiler_versions_verbose, |prj, cmd| {
@@ -209,9 +242,44 @@ forgetest!(can_list_resolved_multiple_compiler_versions_json, |prj, cmd| {
     prj.add_raw_source("ICounter.vyi", VYPER_INTERFACE).unwrap();
     prj.add_raw_source("Counter.vy", VYPER_CONTRACT).unwrap();
 
-    cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
+    cmd.args(["compiler", "resolve", "--json", "-vv"]).assert_success().stdout_eq(
         str![[r#"
-{"Solidity":[["0.8.4","Istanbul",["src/ContractA.sol"]],["0.8.11","London",["src/ContractB.sol"]],["0.8.27","[..]",["src/ContractC.sol","src/ContractD.sol"]]],"Vyper":[["0.4.0","Cancun",["src/Counter.vy","src/ICounter.vyi"]]]}
+{
+  "Solidity": [
+    {
+      "version": "0.8.4",
+      "evm_version": "Istanbul",
+      "paths": [
+        "src/ContractA.sol"
+      ]
+    },
+    {
+      "version": "0.8.11",
+      "evm_version": "London",
+      "paths": [
+        "src/ContractB.sol"
+      ]
+    },
+    {
+      "version": "0.8.27",
+      "evm_version": "Cancun",
+      "paths": [
+        "src/ContractC.sol",
+        "src/ContractD.sol"
+      ]
+    }
+  ],
+  "Vyper": [
+    {
+      "version": "0.4.0",
+      "evm_version": "Cancun",
+      "paths": [
+        "src/Counter.vy",
+        "src/ICounter.vyi"
+      ]
+    }
+  ]
+}
 "#]]
         .is_json(),
     );

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -94,7 +94,7 @@ forgetest!(can_list_resolved_compiler_versions_verbose, |prj, cmd| {
     cmd.args(["compiler", "resolve", "-v"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.27 [Max supported EVM version: [..]]:
+0.8.27:
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
@@ -146,7 +146,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped, |prj, cmd| {
         r#"
 Vyper:
 
-0.4.0 [Max supported EVM version: [..]]:
+0.4.0:
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -178,22 +178,22 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose, |prj, cmd| {
     prj.add_raw_source("ICounter.vyi", VYPER_INTERFACE).unwrap();
     prj.add_raw_source("Counter.vy", VYPER_CONTRACT).unwrap();
 
-    cmd.args(["compiler", "resolve", "-v"]).assert_success().stdout_eq(str![[r#"
+    cmd.args(["compiler", "resolve", "-vv"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.4 [Max supported EVM version: istanbul]:
+0.8.4 (<= istanbul):
 └── src/ContractA.sol
 
-0.8.11 [Max supported EVM version: london]:
+0.8.11 (<= london):
 └── src/ContractB.sol
 
-0.8.27 [Max supported EVM version: [..]]:
+0.8.27 (<= cancun):
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
 Vyper:
 
-0.4.0 [Max supported EVM version: [..]]:
+0.4.0 (<= cancun):
 ├── src/Counter.vy
 └── src/ICounter.vyi
 

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -31,7 +31,7 @@ contract ContractD {}
 "#;
 
 const VYPER_INTERFACE: &str = r#"
-# pragma version 0.4.0
+# pragma version >=0.4.0
 
 @external
 @view
@@ -94,7 +94,7 @@ forgetest!(can_list_resolved_compiler_versions_verbose, |prj, cmd| {
     cmd.args(["compiler", "resolve", "-v"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.27:
+0.8.27 [Max supported EVM version: [..]]:
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
@@ -108,7 +108,7 @@ forgetest!(can_list_resolved_compiler_versions_json, |prj, cmd| {
 
     cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
         str![[r#"
-{"Solidity":[["0.8.27",["src/ContractC.sol","src/ContractD.sol"]]]}"#]]
+{"Solidity":[["0.8.27","[..]",["src/ContractC.sol","src/ContractD.sol"]]]}"#]]
         .is_json(),
     );
 });
@@ -146,7 +146,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped, |prj, cmd| {
         r#"
 Vyper:
 
-0.4.0:
+0.4.0 [Max supported EVM version: [..]]:
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -166,7 +166,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
     cmd.args(["compiler", "resolve", "--skip", "Contract(A|B|C)", "--json"])
             .assert_success()
             .stdout_eq(str![[r#"
-{"Solidity":[["0.8.27",["src/ContractD.sol"]]],"Vyper":[["0.4.0",["src/Counter.vy","src/ICounter.vyi"]]]}
+{"Solidity":[["0.8.27","[..]",["src/ContractD.sol"]]],"Vyper":[["0.4.0","[..]",["src/Counter.vy","src/ICounter.vyi"]]]}
 "#]].is_json());
 });
 
@@ -181,19 +181,19 @@ forgetest!(can_list_resolved_multiple_compiler_versions_verbose, |prj, cmd| {
     cmd.args(["compiler", "resolve", "-v"]).assert_success().stdout_eq(str![[r#"
 Solidity:
 
-0.8.4:
+0.8.4 [Max supported EVM version: istanbul]:
 └── src/ContractA.sol
 
-0.8.11:
+0.8.11 [Max supported EVM version: london]:
 └── src/ContractB.sol
 
-0.8.27:
+0.8.27 [Max supported EVM version: [..]]:
 ├── src/ContractC.sol
 └── src/ContractD.sol
 
 Vyper:
 
-0.4.0:
+0.4.0 [Max supported EVM version: [..]]:
 ├── src/Counter.vy
 └── src/ICounter.vyi
 
@@ -211,7 +211,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_json, |prj, cmd| {
 
     cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
         str![[r#"
-{"Solidity":[["0.8.4",["src/ContractA.sol"]],["0.8.11",["src/ContractB.sol"]],["0.8.27",["src/ContractC.sol","src/ContractD.sol"]]],"Vyper":[["0.4.0",["src/Counter.vy","src/ICounter.vyi"]]]}
+{"Solidity":[["0.8.4","Istanbul",["src/ContractA.sol"]],["0.8.11","London",["src/ContractB.sol"]],["0.8.27","[..]",["src/ContractC.sol","src/ContractD.sol"]]],"Vyper":[["0.4.0","Cancun",["src/Counter.vy","src/ICounter.vyi"]]]}
 "#]]
         .is_json(),
     );

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -87,6 +87,23 @@ Solidity:
 "#]]);
 });
 
+forgetest!(can_list_resolved_compiler_versions_json, |prj, cmd| {
+    prj.add_source("ContractA", CONTRACT_A).unwrap();
+
+    cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
+        str![[r#"
+{
+   "Solidity":[
+      {
+         "version":"0.8.4"
+      }
+   ]
+}
+"#]]
+        .is_json(),
+    );
+});
+
 forgetest!(can_list_resolved_compiler_versions_verbose, |prj, cmd| {
     prj.add_source("ContractC", CONTRACT_C).unwrap();
     prj.add_source("ContractD", CONTRACT_D).unwrap();
@@ -102,11 +119,11 @@ Solidity:
 "#]]);
 });
 
-forgetest!(can_list_resolved_compiler_versions_json, |prj, cmd| {
+forgetest!(can_list_resolved_compiler_versions_verbose_json, |prj, cmd| {
     prj.add_source("ContractC", CONTRACT_C).unwrap();
     prj.add_source("ContractD", CONTRACT_D).unwrap();
 
-    cmd.args(["compiler", "resolve", "--json"]).assert_success().stdout_eq(
+    cmd.args(["compiler", "resolve", "--json", "-v"]).assert_success().stdout_eq(
         str![[r#"
 {
   "Solidity": [
@@ -174,7 +191,7 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
     prj.add_raw_source("ICounter.vyi", VYPER_INTERFACE).unwrap();
     prj.add_raw_source("Counter.vy", VYPER_CONTRACT).unwrap();
 
-    cmd.args(["compiler", "resolve", "--skip", "Contract(A|B|C)", "--json"])
+    cmd.args(["compiler", "resolve", "--skip", "Contract(A|B|C)", "--json", "-v"])
         .assert_success()
         .stdout_eq(
             str![[r#"
@@ -197,7 +214,6 @@ forgetest!(can_list_resolved_multiple_compiler_versions_skipped_json, |prj, cmd|
     }
   ]
 }
-
 "#]]
             .is_json(),
         );
@@ -234,7 +250,7 @@ Vyper:
 "#]]);
 });
 
-forgetest!(can_list_resolved_multiple_compiler_versions_json, |prj, cmd| {
+forgetest!(can_list_resolved_multiple_compiler_versions_verbose_json, |prj, cmd| {
     prj.add_source("ContractA", CONTRACT_A).unwrap();
     prj.add_source("ContractB", CONTRACT_B).unwrap();
     prj.add_source("ContractC", CONTRACT_C).unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #9125 
- show max supported EVM version when running `forge compiler resolve -v` 
- start from default and normalize on solc version
- for vyper will always show default evm version
- tests redacted as evm default version is a moving target
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
