### PR TITLE
fix(cast): do not strip 0x / hex decode message before EIP-191 hashing

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -533,10 +533,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::HashMessage { message } => {
             let message = stdin::unwrap_line(message)?;
-            let input = match message.strip_prefix("0x") {
-                Some(hex_str) => hex::decode(hex_str)?,
-                None => message.as_bytes().to_vec(),
-            };
+            let input = message.as_bytes().to_vec();
             println!("{}", eip191_hash_message(input));
         }
         CastSubcommand::SigEvent { event_string } => {

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -533,8 +533,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::HashMessage { message } => {
             let message = stdin::unwrap_line(message)?;
-            let input = message.as_bytes().to_vec();
-            println!("{}", eip191_hash_message(input));
+            println!("{}", eip191_hash_message(message));
         }
         CastSubcommand::SigEvent { event_string } => {
             let event_string = stdin::unwrap_line(event_string)?;

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1322,7 +1322,7 @@ casttest!(hash_message, |_prj, cmd| {
 "#]]);
 
     cmd.cast_fuse().args(["hash-message", "0x68656c6c6f"]).assert_success().stdout_eq(str![[r#"
-0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750
+0x83a0870b6c63a71efdd3b2749ef700653d97454152c4b53fa9b102dc430c7c32
 
 "#]]);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- attempts to use `cast hm` to create flashbot sig failed, eventually used `chisel eval` to generate such
```bash
chisel eval 'keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n66","'$payload_keccak'"))'
```
https://github.com/pcaversaccio/white-hat-frontrunning/blob/main/go.sh#L62
- fix cast to not hex decode message to hash but use it as it is to create EIP-191 final message `"\x19Ethereum Signed Message:\n" + message. length + message` which is then hashed
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
