### PR TITLE
chore: alias wallet_sendTransaction

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -776,7 +776,14 @@ pub enum EthRequest {
     WalletGetCapabilities(()),
 
     /// Wallet send_tx
-    #[cfg_attr(feature = "serde", serde(rename = "wallet_sendTransaction", with = "sequence"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            rename = "wallet_sendTransaction",
+            alias = "odyssey_sendTransaction",
+            with = "sequence"
+        )
+    )]
     WalletSendTransaction(Box<WithOtherFields<TransactionRequest>>),
 
     /// Add an address to the [`DelegationCapability`] of the wallet


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`wallet_sendTransaction` is not part of the EIP-5792 spec. 


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Alias it as `odyssey_sendTransaction`, preparing `wallet_sendTransaction` for removal soon 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
