### PR TITLE
fix(cheatcodes): improve fork cheatcodes messages

### DIFF
--- a/crates/cheatcodes/src/error.rs
+++ b/crates/cheatcodes/src/error.rs
@@ -293,7 +293,6 @@ impl_from!(
     alloy_primitives::SignatureError,
     FsPathError,
     hex::FromHexError,
-    eyre::Error,
     BackendError,
     DatabaseError,
     jsonpath_lib::JsonPathError,
@@ -313,6 +312,17 @@ impl<T: Into<BackendError>> From<EVMError<T>> for Error {
     #[inline]
     fn from(err: EVMError<T>) -> Self {
         Self::display(BackendError::from(err))
+    }
+}
+
+impl From<eyre::Report> for Error {
+    #[inline]
+    fn from(err: eyre::Report) -> Self {
+        let mut chained_cause = String::new();
+        for cause in err.chain() {
+            chained_cause.push_str(format!(" {cause};").as_str());
+        }
+        Self::display(chained_cause)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8908 

follow up on https://github.com/foundry-rs/foundry/pull/8936#pullrequestreview-2321724224 not sure what's the best solution here but I hit this while doing some tests, the issue is with wrapped errors that are not displaying entirely when failed from cheatcodes and propagated to test result, https://github.com/foundry-rs/foundry/pull/8936 could be a better solution as will handle all other cases if any...

- with this approach:
![image](https://github.com/user-attachments/assets/0189d803-6928-46f4-aafb-e0d261088698)

- with https://github.com/foundry-rs/foundry/pull/8936 approach
![image](https://github.com/user-attachments/assets/41f5b226-33b9-4668-a542-3768e89fd1a2)

- current
![image](https://github.com/user-attachments/assets/a9674a94-fac1-46f8-8b6f-9cf030b3b89f)

@yash-atreya @mattsse @klkvr 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
