### PR TITLE
feat(`forge build`): `--watch` flag now watches `foundry.toml` config…

### DIFF
--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -138,10 +138,12 @@ impl BuildArgs {
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
     pub(crate) fn watchexec_config(&self) -> Result<watchexec::Config> {
-        // use the path arguments or if none where provided the `src` dir
+        // Use the path arguments or if none where provided the `src`, `test` and `script`
+        // directories as well as the `foundry.toml` configuration file.
         self.watch.watchexec_config(|| {
             let config = Config::from(self);
-            [config.src, config.test, config.script]
+            let foundry_toml: PathBuf = config.root.0.join(Config::FILE_NAME);
+            [config.src, config.test, config.script, foundry_toml]
         })
     }
 }


### PR DESCRIPTION
… changes

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #9099 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Monitor `foundry.toml` on top of Solidity file changes when using `forge build --watch`.

Tested on a local project. When updating `foundry.toml`, `forge build --watch` will try to re-build the files as expected.
