### PR TITLE
fix(`anvil`): use header.number not best_number

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1917,7 +1917,7 @@ impl Backend {
         ) = NamedChain::try_from(self.env.read().env.cfg.chain_id)
         {
             // Block number is the best number.
-            block.header.number = self.best_number();
+            block.header.number = number;
             // Set `l1BlockNumber` field.
             block.other.insert("l1BlockNumber".to_string(), number.into());
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9143 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

While applying arb chain specifics in `convert_block`, we use the `self.best_number()` to set `header.number`. This is wrong as best_number keeps increasing as the chain progresses. 

Hence, RPC call such as eth_getBlockByNumber would return the incorrect number field. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
