### PR TITLE
fix(`anvil`): arb fork mining

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2955,15 +2955,11 @@ pub fn prove_storage(storage: &HashMap<U256, U256>, keys: &[B256]) -> Vec<Vec<By
 }
 
 pub fn is_arbitrum(chain_id: u64) -> bool {
-    if let Ok(
-        NamedChain::Arbitrum |
-        NamedChain::ArbitrumGoerli |
-        NamedChain::ArbitrumNova |
-        NamedChain::ArbitrumTestnet,
-    ) = NamedChain::try_from(chain_id)
-    {
-        true
-    } else {
-        false
-    }
+    matches!(
+        NamedChain::try_from(chain_id),
+        Ok(NamedChain::Arbitrum |
+            NamedChain::ArbitrumTestnet |
+            NamedChain::ArbitrumGoerli |
+            NamedChain::ArbitrumNova)
+    )
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1916,8 +1916,6 @@ impl Backend {
             NamedChain::ArbitrumTestnet,
         ) = NamedChain::try_from(self.env.read().env.cfg.chain_id)
         {
-            // Block number is the best number.
-            block.header.number = number;
             // Set `l1BlockNumber` field.
             block.other.insert("l1BlockNumber".to_string(), number.into());
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1098,8 +1098,17 @@ impl Backend {
                 env.cfg.disable_base_fee = true;
             }
 
+            let block_number =
+                self.blockchain.storage.read().best_number.saturating_add(U64::from(1));
+
             // increase block number for this block
-            env.block.number = env.block.number.saturating_add(U256::from(1));
+            if is_arbitrum(env.cfg.chain_id) {
+                // Temporary set `env.block.number` to `block_number` for Arbitrum chains.
+                env.block.number = block_number.to();
+            } else {
+                env.block.number = env.block.number.saturating_add(U256::from(1));
+            }
+
             env.block.basefee = U256::from(current_base_fee);
             env.block.blob_excess_gas_and_price = current_excess_blob_gas_and_price;
 
@@ -1149,9 +1158,7 @@ impl Backend {
             let ExecutedTransactions { block, included, invalid } = executed_tx;
             let BlockInfo { block, transactions, receipts } = block;
 
-            let mut storage = self.blockchain.storage.write();
             let header = block.header.clone();
-            let block_number = storage.best_number.saturating_add(U64::from(1));
 
             trace!(
                 target: "backend",
@@ -1160,7 +1167,7 @@ impl Backend {
                 transactions.len(),
                 transactions.iter().map(|tx| tx.transaction_hash).collect::<Vec<_>>()
             );
-
+            let mut storage = self.blockchain.storage.write();
             // update block metadata
             storage.best_number = block_number;
             storage.best_hash = block_hash;
@@ -1909,13 +1916,7 @@ impl Backend {
         let mut block = WithOtherFields::new(block);
 
         // If Arbitrum, apply chain specifics to converted block.
-        if let Ok(
-            NamedChain::Arbitrum |
-            NamedChain::ArbitrumGoerli |
-            NamedChain::ArbitrumNova |
-            NamedChain::ArbitrumTestnet,
-        ) = NamedChain::try_from(self.env.read().env.cfg.chain_id)
-        {
+        if is_arbitrum(self.env.read().cfg.chain_id) {
             // Set `l1BlockNumber` field.
             block.other.insert("l1BlockNumber".to_string(), number.into());
         }
@@ -2951,4 +2952,18 @@ pub fn prove_storage(storage: &HashMap<U256, U256>, keys: &[B256]) -> Vec<Vec<By
     }
 
     proofs
+}
+
+pub fn is_arbitrum(chain_id: u64) -> bool {
+    if let Ok(
+        NamedChain::Arbitrum |
+        NamedChain::ArbitrumGoerli |
+        NamedChain::ArbitrumNova |
+        NamedChain::ArbitrumTestnet,
+    ) = NamedChain::try_from(chain_id)
+    {
+        true
+    } else {
+        false
+    }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1917,7 +1917,7 @@ impl Backend {
         ) = NamedChain::try_from(self.env.read().env.cfg.chain_id)
         {
             // Block number is the best number.
-            block.header.number = self.best_number();
+            block.header.number = number;
             // Set `l1BlockNumber` field.
             block.other.insert("l1BlockNumber".to_string(), number.into());
         }

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -871,3 +871,20 @@ async fn can_set_executor() {
 
     assert_eq!(executor, expected_addr);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arb_get_block() {
+    let (api, _handle) = spawn(NodeConfig::test().with_chain_id(Some(421611u64))).await;
+
+    // Mine two blocks
+    api.mine_one().await;
+    api.mine_one().await;
+
+    let best_number = api.block_number().unwrap().to::<u64>();
+
+    assert_eq!(best_number, 2);
+
+    let block = api.block_by_number(1.into()).await.unwrap().unwrap();
+
+    assert_eq!(block.header.number, 1);
+}

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1218,7 +1218,6 @@ async fn test_arbitrum_fork_dev_balance() {
 
 // <https://github.com/foundry-rs/foundry/issues/6749>
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_arbitrum_fork_block_number() {
     // fork to get initial block for test
     let (_, handle) = spawn(

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1218,6 +1218,7 @@ async fn test_arbitrum_fork_dev_balance() {
 
 // <https://github.com/foundry-rs/foundry/issues/6749>
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_arbitrum_fork_block_number() {
     // fork to get initial block for test
     let (_, handle) = spawn(

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1216,6 +1216,27 @@ async fn test_arbitrum_fork_dev_balance() {
     }
 }
 
+// <https://github.com/foundry-rs/foundry/issues/9152>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_arb_fork_mining() {
+    let fork_block_number = 266137031u64;
+    let fork_rpc = next_rpc_endpoint(NamedChain::Arbitrum);
+    let (api, _handle) = spawn(
+        fork_config()
+            .with_fork_block_number(Some(fork_block_number))
+            .with_eth_rpc_url(Some(fork_rpc)),
+    )
+    .await;
+
+    let init_blk_num = api.block_number().unwrap().to::<u64>();
+
+    // Mine one
+    api.mine_one().await;
+    let mined_blk_num = api.block_number().unwrap().to::<u64>();
+
+    assert_eq!(mined_blk_num, init_blk_num + 1);
+}
+
 // <https://github.com/foundry-rs/foundry/issues/6749>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_arbitrum_fork_block_number() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9152 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

While mining blocks on arbitrum forks set the `env.block.number` using `storage.best_number` as `env.block.number` actually represents `l1BlockNumber` and not the arbitrum block number. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
