### PR TITLE
fix(chisel): on edit fail command only if execution failed

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -719,18 +719,20 @@ impl ChiselDispatcher {
                                 }
                             }
 
-                            // If the contract execution failed, continue on without
-                            // updating the source.
-                            DispatchResult::CommandFailed(Self::make_error(
-                                "Failed to execute edited contract!",
-                            ))
-                        } else {
-                            // the code could be compiled, save it
-                            *self.source_mut() = new_session_source;
-                            DispatchResult::CommandSuccess(Some(String::from(
-                                "Successfully edited `run()` function's body!",
-                            )))
+                            if failed {
+                                // If the contract execution failed, continue on without
+                                // updating the source.
+                                return DispatchResult::CommandFailed(Self::make_error(
+                                    "Failed to execute edited contract!",
+                                ));
+                            }
                         }
+
+                        // the code could be compiled, save it
+                        *self.source_mut() = new_session_source;
+                        DispatchResult::CommandSuccess(Some(String::from(
+                            "Successfully edited `run()` function's body!",
+                        )))
                     }
                     Err(_) => {
                         DispatchResult::CommandFailed("The code could not be compiled".to_string())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #4393 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- exit with command failed only on failures: show traces and failed are handled in same branch 
https://github.com/foundry-rs/foundry/blob/2044faec64f99a21f0e5f0094458a973612d0712/crates/chisel/src/dispatcher.rs#L704
and both results now in command failed as `failed` bool is not checked
https://github.com/foundry-rs/foundry/blob/2044faec64f99a21f0e5f0094458a973612d0712/crates/chisel/src/dispatcher.rs#L722-L726