### PR TITLE
chore: format chained error for EvmError

### DIFF
--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -663,7 +663,7 @@ pub enum EvmError {
     Skip(SkipReason),
     /// Any other error.
     #[error(transparent)]
-    Eyre(#[from] eyre::Error),
+    Eyre(eyre::Error),
 }
 
 impl From<ExecutionErr> for EvmError {
@@ -675,6 +675,16 @@ impl From<ExecutionErr> for EvmError {
 impl From<alloy_sol_types::Error> for EvmError {
     fn from(err: alloy_sol_types::Error) -> Self {
         Self::Abi(err.into())
+    }
+}
+
+impl From<eyre::Error> for EvmError {
+    fn from(err: eyre::Report) -> Self {
+        let mut chained_cause = String::new();
+        for cause in err.chain() {
+            chained_cause.push_str(format!("{cause}; ").as_str());
+        }
+        Self::Eyre(eyre::format_err!("{chained_cause}"))
     }
 }
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2210,3 +2210,27 @@ Simulated On-chain Traces:
 ...
 "#]]);
 });
+
+// Tests that chained errors are properly displayed.
+// <https://github.com/foundry-rs/foundry/issues/9161>
+forgetest_init!(should_display_evm_chained_error, |prj, cmd| {
+    let script = prj
+        .add_source(
+            "Foo",
+            r#"
+import "forge-std/Script.sol";
+
+contract ContractScript is Script {
+    function run() public {
+    }
+}
+   "#,
+        )
+        .unwrap();
+    cmd.arg("script").arg(script).args(["--fork-url", "https://public-node.testnet.rsk.co"]).assert_failure().stderr_eq(str![[r#"
+Error: 
+Failed to deploy script:
+backend: failed while inspecting; header validation error: `prevrandao` not set; `prevrandao` not set; 
+
+"#]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
in #9161 message presented to user was
```
Error:
Failed to deploy script:
backend: failed while inspecting
```
then foundry code was looked up to figure out it was failing with `Header(PrevrandaoNotSet)`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- chain EvmError messages, add test