### PR TITLE
fix(anvil): Apply state overrides in debug_traceCall

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1438,7 +1438,8 @@ impl Backend {
             let block_number = block.number;
 
             let state = if let Some(overrides) = state_overrides {
-                Box::new(state::apply_state_override(overrides, state)?) as Box<dyn MaybeFullDatabase>
+                Box::new(state::apply_state_override(overrides, state)?)
+                    as Box<dyn MaybeFullDatabase>
             } else {
                 state
             };

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1430,12 +1430,18 @@ impl Backend {
         block_request: Option<BlockRequest>,
         opts: GethDebugTracingCallOptions,
     ) -> Result<GethTrace, BlockchainError> {
-        let GethDebugTracingCallOptions { tracing_options, block_overrides: _, state_overrides: _ } =
+        let GethDebugTracingCallOptions { tracing_options, block_overrides: _, state_overrides } =
             opts;
         let GethDebugTracingOptions { config, tracer, tracer_config, .. } = tracing_options;
 
         self.with_database_at(block_request, |state, block| {
             let block_number = block.number;
+
+            let state = if let Some(overrides) = state_overrides {
+                Box::new(state::apply_state_override(overrides, state)?) as Box<dyn MaybeFullDatabase>
+            } else {
+                state
+            };
 
             if let Some(tracer) = tracer {
                 return match tracer {

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -5,12 +5,16 @@ use crate::{
 };
 use alloy_eips::BlockId;
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{hex, Address, Bytes, U256};
+use alloy_primitives::{
+    hex::{self, FromHex},
+    Address, Bytes, U256,
+};
 use alloy_provider::{
     ext::{DebugApi, TraceApi},
     Provider,
 };
 use alloy_rpc_types::{
+    state::StateOverride,
     trace::{
         filter::{TraceFilter, TraceFilterMode},
         geth::{
@@ -252,6 +256,50 @@ async fn test_call_tracer_debug_trace_call() {
             assert!(call_frame.calls.is_empty());
             assert!(call_frame.to.unwrap() == *simple_storage_contract.address());
             assert!(call_frame.logs.len() == 1);
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_debug_trace_call_state_override() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+
+    let tx = TransactionRequest::default()
+        .from(wallets[1].address())
+        .to("0x1234567890123456789012345678901234567890".parse().unwrap());
+
+    let override_json = r#"{
+            "0x1234567890123456789012345678901234567890": {
+                "balance": "0x01",
+                "code": "0x30315f5260205ff3"
+            }
+        }"#;
+
+    let state_override: StateOverride = serde_json::from_str(override_json).unwrap();
+
+    let tx_traces = handle
+        .http_provider()
+        .debug_trace_call(
+            tx.clone(),
+            BlockId::latest(),
+            GethDebugTracingCallOptions::default()
+                .with_tracing_options(GethDebugTracingOptions::default())
+                .with_state_overrides(state_override),
+        )
+        .await
+        .unwrap();
+
+    match tx_traces {
+        GethTrace::Default(trace_res) => {
+            assert_eq!(
+                trace_res.return_value,
+                Bytes::from_hex("0000000000000000000000000000000000000000000000000000000000000001")
+                    .unwrap()
+            );
         }
         _ => {
             unreachable!()


### PR DESCRIPTION
## Motivation
State overrides are very useful when trying to simulate transactions. However, the `debug_traceCall` implementation did not apply the provided state overrides.

## Solution

The solution was to apply the state overrides similarly to the `eth_call` logic. I've also included a small test to verify that the patch is effective.