### PR TITLE
chore(`cast`): enforce `common::shell` for cast binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ fmt: ## Run all formatters.
 	cargo +nightly fmt
 	./.github/scripts/format.sh --check
 
-lint-clippy:
+lint-foundry:
 	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --all-features
 
 lint-codespell: ensure-codespell
@@ -52,19 +52,19 @@ ensure-codespell:
 
 lint: ## Run all linters.
 	make fmt && \
-	make lint-clippy && \
+	make lint-foundry && \
 	make lint-codespell
 
 ## Testing
 
-test-unit:
+test-foundry:
 	cargo nextest run -E 'kind(test) & !test(/issue|forge_std|ext_integration/)'
 
 test-doc:
 	cargo test --doc --workspace
 
 test: ## Run all tests.
-	make test-unit && \
+	make test-foundry && \
 	make test-doc
 
 pr: ## Run all tests and linters in preparation for a PR.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ fmt: ## Run all formatters.
 	cargo +nightly fmt
 	./.github/scripts/format.sh --check
 
-lint-foundry:
+lint-clippy:
 	RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --all-features
 
 lint-codespell: ensure-codespell
@@ -52,19 +52,19 @@ ensure-codespell:
 
 lint: ## Run all linters.
 	make fmt && \
-	make lint-foundry && \
+	make lint-clippy && \
 	make lint-codespell
 
 ## Testing
 
-test-foundry:
+test-unit:
 	cargo nextest run -E 'kind(test) & !test(/issue|forge_std|ext_integration/)'
 
 test-doc:
 	cargo test --doc --workspace
 
 test: ## Run all tests.
-	make test-foundry && \
+	make test-unit && \
 	make test-doc
 
 pr: ## Run all tests and linters in preparation for a PR.

--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -67,7 +67,7 @@ impl AccessListArgs {
 
         let access_list: String = cast.access_list(&tx, block, to_json).await?;
 
-        println!("{access_list}");
+        sh_println!("{access_list}")?;
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -205,7 +205,7 @@ impl CallArgs {
             return Ok(());
         }
 
-        println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, json).await?);
+        sh_println!("{}", Cast::new(provider).call(&tx, func.as_ref(), block, json).await?)?;
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -124,7 +124,7 @@ impl Create2Args {
         if let Some(salt) = salt {
             let salt = hex::FromHex::from_hex(salt)?;
             let address = deployer.create2(salt, init_code_hash);
-            println!("{address}");
+            sh_println!("{address}")?;
             return Ok(Create2Output { address, salt });
         }
 
@@ -191,11 +191,13 @@ impl Create2Args {
             rng.fill_bytes(remaining);
         }
 
-        println!("Configuration:");
-        println!("Init code hash: {init_code_hash}");
-        println!("Regex patterns: {:?}", regex.patterns());
-        println!();
-        println!("Starting to generate deterministic contract address with {n_threads} threads...");
+        sh_println!("Configuration:")?;
+        sh_println!("Init code hash: {init_code_hash}")?;
+        sh_println!("Regex patterns: {:?}", regex.patterns())?;
+        sh_println!()?;
+        sh_println!(
+            "Starting to generate deterministic contract address with {n_threads} threads..."
+        )?;
         let mut handles = Vec::with_capacity(n_threads);
         let found = Arc::new(AtomicBool::new(false));
         let timer = Instant::now();
@@ -249,9 +251,9 @@ impl Create2Args {
 
         let results = handles.into_iter().filter_map(|h| h.join().unwrap()).collect::<Vec<_>>();
         let (address, salt) = results.into_iter().next().unwrap();
-        println!("Successfully found contract address in {:?}", timer.elapsed());
-        println!("Address: {address}");
-        println!("Salt: {salt} ({})", U256::from_be_bytes(salt.0));
+        sh_println!("Successfully found contract address in {:?}", timer.elapsed())?;
+        sh_println!("Address: {address}")?;
+        sh_println!("Salt: {salt} ({})", U256::from_be_bytes(salt.0))?;
 
         Ok(Create2Output { address, salt })
     }

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -100,7 +100,7 @@ impl EstimateArgs {
             .await?;
 
         let gas = provider.estimate_gas(&tx).block(block.unwrap_or_default()).await?;
-        println!("{gas}");
+        sh_println!("{gas}")?;
         Ok(())
     }
 }

--- a/crates/cast/bin/cmd/find_block.rs
+++ b/crates/cast/bin/cmd/find_block.rs
@@ -77,7 +77,7 @@ impl FindBlockArgs {
             }
             matching_block.unwrap_or(low_block)
         };
-        println!("{block_num}");
+        sh_println!("{block_num}")?;
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/interface.rs
+++ b/crates/cast/bin/cmd/interface.rs
@@ -93,9 +93,9 @@ impl InterfaceArgs {
                 fs::create_dir_all(parent)?;
             }
             fs::write(&loc, res)?;
-            println!("Saved interface at {}", loc.display());
+            sh_println!("Saved interface at {}", loc.display())?;
         } else {
-            print!("{res}");
+            sh_print!("{res}")?;
         }
 
         Ok(())

--- a/crates/cast/bin/cmd/logs.rs
+++ b/crates/cast/bin/cmd/logs.rs
@@ -90,7 +90,7 @@ impl LogsArgs {
         if !subscribe {
             let logs = cast.filter_logs(filter, json).await?;
             sh_println!("{logs}")?;
-            return Ok(());
+            return Ok(())
         }
 
         // FIXME: this is a hotfix for <https://github.com/foundry-rs/foundry/issues/7682>

--- a/crates/cast/bin/cmd/logs.rs
+++ b/crates/cast/bin/cmd/logs.rs
@@ -89,10 +89,8 @@ impl LogsArgs {
 
         if !subscribe {
             let logs = cast.filter_logs(filter, json).await?;
-
-            println!("{logs}");
-
-            return Ok(())
+            sh_println!("{logs}")?;
+            return Ok(());
         }
 
         // FIXME: this is a hotfix for <https://github.com/foundry-rs/foundry/issues/7682>

--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -105,7 +105,7 @@ impl MakeTxArgs {
         let tx = tx.build(&EthereumWallet::new(signer)).await?;
 
         let signed_tx = hex::encode(tx.encoded_2718());
-        println!("0x{signed_tx}");
+        sh_println!("0x{signed_tx}")?;
 
         Ok(())
     }

--- a/crates/cast/bin/cmd/rpc.rs
+++ b/crates/cast/bin/cmd/rpc.rs
@@ -53,7 +53,7 @@ impl RpcArgs {
         } else {
             serde_json::Value::Array(params.into_iter().map(value_or_string).collect())
         };
-        println!("{}", Cast::new(provider).rpc(&method, params).await?);
+        sh_println!("{}", Cast::new(provider).rpc(&method, params).await?)?;
         Ok(())
     }
 }

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -177,7 +177,7 @@ impl RunArgs {
                 pb.set_position(0);
 
                 let BlockTransactions::Full(ref txs) = block.transactions else {
-                    return Err(eyre::eyre!("Could not get block txs"));
+                    return Err(eyre::eyre!("Could not get block txs"))
                 };
 
                 for (index, tx) in txs.iter().enumerate() {

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -170,14 +170,14 @@ impl RunArgs {
 
         // Set the state to the moment right before the transaction
         if !self.quick {
-            println!("Executing previous transactions from the block.");
+            sh_println!("Executing previous transactions from the block.")?;
 
             if let Some(block) = block {
                 let pb = init_progress(block.transactions.len() as u64, "tx");
                 pb.set_position(0);
 
                 let BlockTransactions::Full(ref txs) = block.transactions else {
-                    return Err(eyre::eyre!("Could not get block txs"))
+                    return Err(eyre::eyre!("Could not get block txs"));
                 };
 
                 for (index, tx) in txs.iter().enumerate() {

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -197,12 +197,12 @@ async fn cast_send<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
     let tx_hash = pending_tx.inner().tx_hash();
 
     if cast_async {
-        println!("{tx_hash:#x}");
+        sh_println!("{tx_hash:#x}")?;
     } else {
         let receipt = cast
             .receipt(format!("{tx_hash:#x}"), None, confs, Some(timeout), false, to_json)
             .await?;
-        println!("{receipt}");
+        sh_println!("{receipt}")?;
     }
 
     Ok(())

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -92,7 +92,7 @@ impl StorageArgs {
         // Slot was provided, perform a simple RPC call
         if let Some(slot) = slot {
             let cast = Cast::new(provider);
-            println!("{}", cast.storage(address, slot, block).await?);
+            sh_println!("{}", cast.storage(address, slot, block).await?)?;
             return Ok(());
         }
 
@@ -120,7 +120,7 @@ impl StorageArgs {
 
         // Not a forge project or artifact not found
         // Get code from Etherscan
-        eprintln!("No matching artifacts found, fetching source code from Etherscan...");
+        sh_warn!("No matching artifacts found, fetching source code from Etherscan...")?;
 
         if !self.etherscan.has_key() {
             eyre::bail!("You must provide an Etherscan API key if you're fetching a remote contract's storage.");
@@ -161,7 +161,7 @@ impl StorageArgs {
 
             if is_storage_layout_empty(&artifact.storage_layout) && auto_detect {
                 // try recompiling with the minimum version
-                eprintln!("The requested contract was compiled with {version} while the minimum version for storage layouts is {MIN_SOLC} and as a result the output may be empty.");
+                sh_warn!("The requested contract was compiled with {version} while the minimum version for storage layouts is {MIN_SOLC} and as a result the output may be empty.")?;
                 let solc = Solc::find_or_install(&MIN_SOLC)?;
                 project.compiler = SolcCompiler::Specific(solc);
                 if let Ok(output) = ProjectCompiler::new().quiet(true).compile(&project) {
@@ -223,7 +223,7 @@ async fn fetch_and_print_storage<P: Provider<T, AnyNetwork>, T: Transport + Clon
     pretty: bool,
 ) -> Result<()> {
     if is_storage_layout_empty(&artifact.storage_layout) {
-        eprintln!("Storage layout is empty.");
+        sh_warn!("Storage layout is empty.")?;
         Ok(())
     } else {
         let layout = artifact.storage_layout.as_ref().unwrap().clone();
@@ -255,8 +255,8 @@ async fn fetch_storage_slots<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
 
 fn print_storage(layout: StorageLayout, values: Vec<StorageValue>, pretty: bool) -> Result<()> {
     if !pretty {
-        println!("{}", serde_json::to_string_pretty(&serde_json::to_value(layout)?)?);
-        return Ok(())
+        sh_println!("{}", serde_json::to_string_pretty(&serde_json::to_value(layout)?)?)?;
+        return Ok(());
     }
 
     let mut table = Table::new();
@@ -281,7 +281,7 @@ fn print_storage(layout: StorageLayout, values: Vec<StorageValue>, pretty: bool)
         ]);
     }
 
-    println!("{table}");
+    sh_println!("{table}")?;
 
     Ok(())
 }

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -256,7 +256,7 @@ async fn fetch_storage_slots<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
 fn print_storage(layout: StorageLayout, values: Vec<StorageValue>, pretty: bool) -> Result<()> {
     if !pretty {
         sh_println!("{}", serde_json::to_string_pretty(&serde_json::to_value(layout)?)?)?;
-        return Ok(());
+        return Ok(())
     }
 
     let mut table = Table::new();

--- a/crates/cast/bin/cmd/wallet/list.rs
+++ b/crates/cast/bin/cmd/wallet/list.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use eyre::Result;
 
-use foundry_common::fs;
+use foundry_common::{fs, sh_err, sh_println};
 use foundry_config::Config;
 use foundry_wallets::multi_wallet::MultiWalletOptsBuilder;
 
@@ -61,12 +61,14 @@ impl ListArgs {
                                 .available_senders(self.max_senders.unwrap())
                                 .await?
                                 .iter()
-                                .for_each(|sender| println!("{} ({})", sender, $label));
+                                .for_each(|sender| {
+                                    let _ = sh_println!("{} ({})", sender, $label);
+                                })
                         }
                     }
                     Err(e) => {
                         if !self.all {
-                            println!("{}", e)
+                            sh_err!("{}", e)?;
                         }
                     }
                 }
@@ -97,7 +99,7 @@ impl ListArgs {
             if path.is_file() {
                 if let Some(file_name) = path.file_name() {
                     if let Some(name) = file_name.to_str() {
-                        println!("{name} (Local)");
+                        sh_println!("{name} (Local)")?;
                     }
                 }
             }

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -11,7 +11,7 @@ use cast::revm::primitives::Authorization;
 use clap::Parser;
 use eyre::{Context, Result};
 use foundry_cli::{opts::RpcOpts, utils};
-use foundry_common::fs;
+use foundry_common::{fs, sh_println};
 use foundry_config::Config;
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
 use rand::thread_rng;
@@ -259,16 +259,16 @@ impl WalletSubcommands {
                             }
                             ));
                         } else {
-                            println!(
+                            sh_println!(
                                 "Created new encrypted keystore file: {}",
                                 path.join(uuid).display()
-                            );
-                            println!("Address: {}", wallet.address().to_checksum(None));
+                            )?;
+                            sh_println!("Address: {}", wallet.address().to_checksum(None))?;
                         }
                     }
 
                     if let Some(json) = json_values.as_ref() {
-                        println!("{}", serde_json::to_string_pretty(json)?);
+                        sh_println!("{}", serde_json::to_string_pretty(json)?)?;
                     }
                 } else {
                     for _ in 0..number {
@@ -280,17 +280,17 @@ impl WalletSubcommands {
                                 "private_key": format!("0x{}", hex::encode(wallet.credential().to_bytes())),
                             }))
                         } else {
-                            println!("Successfully created new keypair.");
-                            println!("Address:     {}", wallet.address().to_checksum(None));
-                            println!(
+                            sh_println!("Successfully created new keypair.")?;
+                            sh_println!("Address:     {}", wallet.address().to_checksum(None))?;
+                            sh_println!(
                                 "Private key: 0x{}",
                                 hex::encode(wallet.credential().to_bytes())
-                            );
+                            )?;
                         }
                     }
 
                     if let Some(json) = json_values.as_ref() {
-                        println!("{}", serde_json::to_string_pretty(json)?);
+                        sh_println!("{}", serde_json::to_string_pretty(json)?)?;
                     }
                 }
             }
@@ -304,7 +304,7 @@ impl WalletSubcommands {
                 };
 
                 if !json {
-                    println!("{}", "Generating mnemonic from provided entropy...".yellow());
+                    sh_println!("{}", "Generating mnemonic from provided entropy...".yellow())?;
                 }
 
                 let builder = MnemonicBuilder::<English>::default().phrase(phrase.as_str());
@@ -316,9 +316,9 @@ impl WalletSubcommands {
                     wallets.into_iter().map(|b| b.build()).collect::<Result<Vec<_>, _>>()?;
 
                 if !json {
-                    println!("{}", "Successfully generated a new mnemonic.".green());
-                    println!("Phrase:\n{phrase}");
-                    println!("\nAccounts:");
+                    sh_println!("{}", "Successfully generated a new mnemonic.".green())?;
+                    sh_println!("Phrase:\n{phrase}")?;
+                    sh_println!("\nAccounts:")?;
                 }
 
                 let mut accounts = json!([]);
@@ -330,9 +330,9 @@ impl WalletSubcommands {
                             "private_key": format!("0x{}", private_key),
                         }));
                     } else {
-                        println!("- Account {i}:");
-                        println!("Address:     {}", wallet.address());
-                        println!("Private key: 0x{private_key}\n");
+                        sh_println!("- Account {i}:")?;
+                        sh_println!("Address:     {}", wallet.address())?;
+                        sh_println!("Private key: 0x{private_key}\n")?;
                     }
                 }
 
@@ -341,7 +341,7 @@ impl WalletSubcommands {
                         "mnemonic": phrase,
                         "accounts": accounts,
                     });
-                    println!("{}", serde_json::to_string_pretty(&obj)?);
+                    sh_println!("{}", serde_json::to_string_pretty(&obj)?)?;
                 }
             }
             Self::Vanity(cmd) => {
@@ -357,7 +357,7 @@ impl WalletSubcommands {
                     .signer()
                     .await?;
                 let addr = wallet.address();
-                println!("{}", addr.to_checksum(None));
+                sh_println!("{}", addr.to_checksum(None))?;
             }
             Self::Sign { message, data, from_file, no_hash, wallet } => {
                 let wallet = wallet.signer().await?;
@@ -375,7 +375,7 @@ impl WalletSubcommands {
                 } else {
                     wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
                 };
-                println!("0x{}", hex::encode(sig.as_bytes()));
+                sh_println!("0x{}", hex::encode(sig.as_bytes()))?;
             }
             Self::SignAuth { rpc, nonce, chain, wallet, address } => {
                 let wallet = wallet.signer().await?;
@@ -393,12 +393,12 @@ impl WalletSubcommands {
                 let auth = Authorization { chain_id, address, nonce };
                 let signature = wallet.sign_hash(&auth.signature_hash()).await?;
                 let auth = auth.into_signed(signature);
-                println!("{}", hex::encode_prefixed(alloy_rlp::encode(&auth)));
+                sh_println!("{}", hex::encode_prefixed(alloy_rlp::encode(&auth)))?;
             }
             Self::Verify { message, signature, address } => {
                 let recovered_address = Self::recover_address_from_message(&message, &signature)?;
                 if address == recovered_address {
-                    println!("Validation succeeded. Address {address} signed this message.");
+                    sh_println!("Validation succeeded. Address {address} signed this message.")?;
                 } else {
                     eyre::bail!("Validation failed. Address {address} did not sign this message.");
                 }
@@ -459,7 +459,7 @@ flag to set your key via:
                     "`{}` keystore was saved successfully. Address: {:?}",
                     &account_name, address,
                 );
-                println!("{}", success_message.green());
+                sh_println!("{}", success_message.green())?;
             }
             Self::List(cmd) => {
                 cmd.run().await?;
@@ -492,13 +492,13 @@ flag to set your key via:
                 match wallet {
                     WalletSigner::Local(wallet) => {
                         if verbose {
-                            println!("Address:     {}", wallet.address());
-                            println!(
+                            sh_println!("Address:     {}", wallet.address())?;
+                            sh_println!(
                                 "Private key: 0x{}",
                                 hex::encode(wallet.credential().to_bytes())
-                            );
+                            )?;
                         } else {
-                            println!("0x{}", hex::encode(wallet.credential().to_bytes()));
+                            sh_println!("0x{}", hex::encode(wallet.credential().to_bytes()))?;
                         }
                     }
                     _ => {
@@ -536,7 +536,7 @@ flag to set your key via:
                 let success_message =
                     format!("{}'s private key is: {}", &account_name, private_key);
 
-                println!("{}", success_message.green());
+                sh_println!("{}", success_message.green())?;
             }
         };
 

--- a/crates/cast/bin/cmd/wallet/vanity.rs
+++ b/crates/cast/bin/cmd/wallet/vanity.rs
@@ -3,6 +3,7 @@ use alloy_signer::{k256::ecdsa::SigningKey, utils::secret_key_to_address};
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
 use eyre::Result;
+use foundry_common::sh_println;
 use itertools::Either;
 use rayon::iter::{self, ParallelIterator};
 use regex::Regex;
@@ -99,7 +100,7 @@ impl VanityArgs {
             };
         }
 
-        println!("Starting to generate vanity address...");
+        sh_println!("Starting to generate vanity address...")?;
         let timer = Instant::now();
 
         let wallet = match (left_exact_hex, left_regex, right_exact_hex, right_regex) {
@@ -144,7 +145,7 @@ impl VanityArgs {
             save_wallet_to_file(&wallet, &save_path)?;
         }
 
-        println!(
+        sh_println!(
             "Successfully found vanity address in {:.3} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
             timer.elapsed().as_secs_f64(),
             if nonce.is_some() { "\nContract address: " } else { "" },
@@ -155,7 +156,7 @@ impl VanityArgs {
             },
             wallet.address().to_checksum(None),
             hex::encode(wallet.credential().to_bytes()),
-        );
+        )?;
 
         Ok(wallet)
     }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -59,54 +59,44 @@ fn run() -> Result<()> {
 async fn main_args(args: CastArgs) -> Result<()> {
     match args.cmd {
         // Constants
-        CastSubcommand::MaxInt { r#type } => {
-            println!("{}", SimpleCast::max_int(&r#type)?);
-        }
-        CastSubcommand::MinInt { r#type } => {
-            println!("{}", SimpleCast::min_int(&r#type)?);
-        }
-        CastSubcommand::MaxUint { r#type } => {
-            println!("{}", SimpleCast::max_int(&r#type)?);
-        }
-        CastSubcommand::AddressZero => {
-            println!("{:?}", Address::ZERO);
-        }
-        CastSubcommand::HashZero => {
-            println!("{:?}", B256::ZERO);
-        }
+        CastSubcommand::MaxInt { r#type } => sh_println!("{}", SimpleCast::max_int(&r#type)?)?,
+        CastSubcommand::MinInt { r#type } => sh_println!("{}", SimpleCast::min_int(&r#type)?)?,
+        CastSubcommand::MaxUint { r#type } => sh_println!("{}", SimpleCast::max_int(&r#type)?)?,
+        CastSubcommand::AddressZero => sh_println!("{:?}", Address::ZERO)?,
+        CastSubcommand::HashZero => sh_println!("{:?}", B256::ZERO)?,
 
         // Conversions & transformations
         CastSubcommand::FromUtf8 { text } => {
             let value = stdin::unwrap(text, false)?;
-            println!("{}", SimpleCast::from_utf8(&value));
+            sh_println!("{}", SimpleCast::from_utf8(&value))?
         }
         CastSubcommand::ToAscii { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_ascii(value.trim())?);
+            sh_println!("{}", SimpleCast::to_ascii(value.trim())?)?
         }
         CastSubcommand::ToUtf8 { hexdata } => {
             let value = stdin::unwrap(hexdata, false)?;
-            println!("{}", SimpleCast::to_utf8(&value)?);
+            sh_println!("{}", SimpleCast::to_utf8(&value)?)?
         }
         CastSubcommand::FromFixedPoint { value, decimals } => {
             let (value, decimals) = stdin::unwrap2(value, decimals)?;
-            println!("{}", SimpleCast::from_fixed_point(&value, &decimals)?);
+            sh_println!("{}", SimpleCast::from_fixed_point(&value, &decimals)?)?
         }
         CastSubcommand::ToFixedPoint { value, decimals } => {
             let (value, decimals) = stdin::unwrap2(value, decimals)?;
-            println!("{}", SimpleCast::to_fixed_point(&value, &decimals)?);
+            sh_println!("{}", SimpleCast::to_fixed_point(&value, &decimals)?)?
         }
         CastSubcommand::ConcatHex { data } => {
             if data.is_empty() {
                 let s = stdin::read(true)?;
-                println!("{}", SimpleCast::concat_hex(s.split_whitespace()))
+                sh_println!("{}", SimpleCast::concat_hex(s.split_whitespace()))?
             } else {
-                println!("{}", SimpleCast::concat_hex(data))
+                sh_println!("{}", SimpleCast::concat_hex(data))?
             }
         }
         CastSubcommand::FromBin => {
             let hex = stdin::read_bytes(false)?;
-            println!("{}", hex::encode_prefixed(hex));
+            sh_println!("{}", hex::encode_prefixed(hex))?
         }
         CastSubcommand::ToHexdata { input } => {
             let value = stdin::unwrap_line(input)?;
@@ -115,67 +105,67 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 s if s.starts_with('/') => hex::encode(fs::read(s)?),
                 s => s.split(':').map(|s| s.trim_start_matches("0x").to_lowercase()).collect(),
             };
-            println!("0x{output}");
+            sh_println!("0x{output}")?
         }
         CastSubcommand::ToCheckSumAddress { address } => {
             let value = stdin::unwrap_line(address)?;
-            println!("{}", value.to_checksum(None));
+            sh_println!("{}", value.to_checksum(None))?
         }
         CastSubcommand::ToUint256 { value } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_uint256(&value)?);
+            sh_println!("{}", SimpleCast::to_uint256(&value)?)?
         }
         CastSubcommand::ToInt256 { value } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_int256(&value)?);
+            sh_println!("{}", SimpleCast::to_int256(&value)?)?
         }
         CastSubcommand::ToUnit { value, unit } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_unit(&value, &unit)?);
+            sh_println!("{}", SimpleCast::to_unit(&value, &unit)?)?
         }
         CastSubcommand::FromWei { value, unit } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::from_wei(&value, &unit)?);
+            sh_println!("{}", SimpleCast::from_wei(&value, &unit)?)?
         }
         CastSubcommand::ToWei { value, unit } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_wei(&value, &unit)?);
+            sh_println!("{}", SimpleCast::to_wei(&value, &unit)?)?
         }
         CastSubcommand::FromRlp { value } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::from_rlp(value)?);
+            sh_println!("{}", SimpleCast::from_rlp(value)?)?
         }
         CastSubcommand::ToRlp { value } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_rlp(&value)?);
+            sh_println!("{}", SimpleCast::to_rlp(&value)?)?
         }
         CastSubcommand::ToHex(ToBaseArgs { value, base_in }) => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), "hex")?);
+            sh_println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), "hex")?)?
         }
         CastSubcommand::ToDec(ToBaseArgs { value, base_in }) => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), "dec")?);
+            sh_println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), "dec")?)?
         }
         CastSubcommand::ToBase { base: ToBaseArgs { value, base_in }, base_out } => {
             let (value, base_out) = stdin::unwrap2(value, base_out)?;
-            println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), &base_out)?);
+            sh_println!("{}", SimpleCast::to_base(&value, base_in.as_deref(), &base_out)?)?
         }
         CastSubcommand::ToBytes32 { bytes } => {
             let value = stdin::unwrap_line(bytes)?;
-            println!("{}", SimpleCast::to_bytes32(&value)?);
+            sh_println!("{}", SimpleCast::to_bytes32(&value)?)?
         }
         CastSubcommand::FormatBytes32String { string } => {
             let value = stdin::unwrap_line(string)?;
-            println!("{}", SimpleCast::format_bytes32_string(&value)?);
+            sh_println!("{}", SimpleCast::format_bytes32_string(&value)?)?
         }
         CastSubcommand::ParseBytes32String { bytes } => {
             let value = stdin::unwrap_line(bytes)?;
-            println!("{}", SimpleCast::parse_bytes32_string(&value)?);
+            sh_println!("{}", SimpleCast::parse_bytes32_string(&value)?)?
         }
         CastSubcommand::ParseBytes32Address { bytes } => {
             let value = stdin::unwrap_line(bytes)?;
-            println!("{}", SimpleCast::parse_bytes32_address(&value)?);
+            sh_println!("{}", SimpleCast::parse_bytes32_address(&value)?)?
         }
 
         // ABI encoding & decoding
@@ -185,9 +175,9 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::AbiEncode { sig, packed, args } => {
             if !packed {
-                println!("{}", SimpleCast::abi_encode(&sig, &args)?);
+                sh_println!("{}", SimpleCast::abi_encode(&sig, &args)?)?
             } else {
-                println!("{}", SimpleCast::abi_encode_packed(&sig, &args)?);
+                sh_println!("{}", SimpleCast::abi_encode_packed(&sig, &args)?)?
             }
         }
         CastSubcommand::CalldataDecode { sig, calldata, json } => {
@@ -195,26 +185,26 @@ async fn main_args(args: CastArgs) -> Result<()> {
             print_tokens(&tokens, json)
         }
         CastSubcommand::CalldataEncode { sig, args } => {
-            println!("{}", SimpleCast::calldata_encode(sig, &args)?);
+            sh_println!("{}", SimpleCast::calldata_encode(sig, &args)?)?;
         }
         CastSubcommand::Interface(cmd) => cmd.run().await?,
         CastSubcommand::Bind(cmd) => cmd.run().await?,
         CastSubcommand::PrettyCalldata { calldata, offline } => {
             let calldata = stdin::unwrap_line(calldata)?;
-            println!("{}", pretty_calldata(&calldata, offline).await?);
+            sh_println!("{}", pretty_calldata(&calldata, offline).await?)?;
         }
         CastSubcommand::Sig { sig, optimize } => {
             let sig = stdin::unwrap_line(sig)?;
             match optimize {
                 Some(opt) => {
-                    println!("Starting to optimize signature...");
+                    sh_println!("Starting to optimize signature...")?;
                     let start_time = Instant::now();
                     let (selector, signature) = SimpleCast::get_selector(&sig, opt)?;
-                    println!("Successfully generated in {:?}", start_time.elapsed());
-                    println!("Selector: {selector}");
-                    println!("Optimized signature: {signature}");
+                    sh_println!("Successfully generated in {:?}", start_time.elapsed())?;
+                    sh_println!("Selector: {selector}")?;
+                    sh_println!("Optimized signature: {signature}")?;
                 }
-                None => println!("{}", SimpleCast::get_selector(&sig, 0)?.0),
+                None => sh_println!("{}", SimpleCast::get_selector(&sig, 0)?.0)?,
             }
         }
 
@@ -223,10 +213,10 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::Age { block, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!(
+            sh_println!(
                 "{}",
                 Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
-            );
+            )?
         }
         CastSubcommand::Balance { block, who, ether, rpc, erc20 } => {
             let config = Config::from(&rpc);
@@ -237,14 +227,14 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 Some(token) => {
                     let balance =
                         Cast::new(&provider).erc20_balance(token, account_addr, block).await?;
-                    println!("{}", format_uint_exp(balance));
+                    sh_println!("{}", format_uint_exp(balance))?
                 }
                 None => {
                     let value = Cast::new(&provider).balance(account_addr, block).await?;
                     if ether {
-                        println!("{}", SimpleCast::from_wei(&value.to_string(), "eth")?);
+                        sh_println!("{}", SimpleCast::from_wei(&value.to_string(), "eth")?)?
                     } else {
-                        println!("{value}");
+                        sh_println!("{value}")?
                     }
                 }
             }
@@ -252,20 +242,20 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::BaseFee { block, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!(
+            sh_println!(
                 "{}",
                 Cast::new(provider).base_fee(block.unwrap_or(BlockId::Number(Latest))).await?
-            );
+            )?
         }
         CastSubcommand::Block { block, full, field, json, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!(
+            sh_println!(
                 "{}",
                 Cast::new(provider)
                     .block(block.unwrap_or(BlockId::Number(Latest)), full, field, json)
                     .await?
-            );
+            )?
         }
         CastSubcommand::BlockNumber { rpc, block } => {
             let config = Config::from(&rpc);
@@ -281,34 +271,34 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 }
                 None => Cast::new(provider).block_number().await?,
             };
-            println!("{number}");
+            sh_println!("{number}")?
         }
         CastSubcommand::Chain { rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", Cast::new(provider).chain().await?);
+            sh_println!("{}", Cast::new(provider).chain().await?)?
         }
         CastSubcommand::ChainId { rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", Cast::new(provider).chain_id().await?);
+            sh_println!("{}", Cast::new(provider).chain_id().await?)?
         }
         CastSubcommand::Client { rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", provider.get_client_version().await?);
+            sh_println!("{}", provider.get_client_version().await?)?
         }
         CastSubcommand::Code { block, who, disassemble, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).code(who, block, disassemble).await?);
+            sh_println!("{}", Cast::new(provider).code(who, block, disassemble).await?)?
         }
         CastSubcommand::Codesize { block, who, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).codesize(who, block).await?);
+            sh_println!("{}", Cast::new(provider).codesize(who, block).await?)?
         }
         CastSubcommand::ComputeAddress { address, nonce, rpc } => {
             let config = Config::from(&rpc);
@@ -316,10 +306,10 @@ async fn main_args(args: CastArgs) -> Result<()> {
 
             let address: Address = stdin::unwrap_line(address)?.parse()?;
             let computed = Cast::new(provider).compute_address(address, nonce).await?;
-            println!("Computed Address: {}", computed.to_checksum(None));
+            sh_println!("Computed Address: {}", computed.to_checksum(None))?
         }
         CastSubcommand::Disassemble { bytecode } => {
-            println!("{}", SimpleCast::disassemble(&hex::decode(bytecode)?)?);
+            sh_println!("{}", SimpleCast::disassemble(&hex::decode(bytecode)?)?)?
         }
         CastSubcommand::Selectors { bytecode, resolve } => {
             let functions = SimpleCast::extract_functions(&bytecode)?;
@@ -337,9 +327,9 @@ async fn main_args(args: CastArgs) -> Result<()> {
             {
                 if resolve {
                     let resolved = &resolve_results[pos];
-                    println!("{selector}\t{arguments:max_args_len$}\t{state_mutability:max_mutability_len$}\t{resolved}");
+                    sh_println!("{selector}\t{arguments:max_args_len$}\t{state_mutability:max_mutability_len$}\t{resolved}")?
                 } else {
-                    println!("{selector}\t{arguments:max_args_len$}\t{state_mutability}");
+                    sh_println!("{selector}\t{arguments:max_args_len$}\t{state_mutability}")?
                 }
             }
         }
@@ -347,45 +337,45 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::GasPrice { rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!("{}", Cast::new(provider).gas_price().await?);
+            sh_println!("{}", Cast::new(provider).gas_price().await?)?;
         }
         CastSubcommand::Index { key_type, key, slot_number } => {
-            println!("{}", SimpleCast::index(&key_type, &key, &slot_number)?);
+            sh_println!("{}", SimpleCast::index(&key_type, &key, &slot_number)?)?;
         }
         CastSubcommand::IndexErc7201 { id, formula_id } => {
             eyre::ensure!(formula_id == "erc7201", "unsupported formula ID: {formula_id}");
             let id = stdin::unwrap_line(id)?;
-            println!("{}", foundry_common::erc7201(&id));
+            sh_println!("{}", foundry_common::erc7201(&id))?;
         }
         CastSubcommand::Implementation { block, who, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).implementation(who, block).await?);
+            sh_println!("{}", Cast::new(provider).implementation(who, block).await?)?;
         }
         CastSubcommand::Admin { block, who, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).admin(who, block).await?);
+            sh_println!("{}", Cast::new(provider).admin(who, block).await?)?;
         }
         CastSubcommand::Nonce { block, who, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).nonce(who, block).await?);
+            sh_println!("{}", Cast::new(provider).nonce(who, block).await?)?;
         }
         CastSubcommand::Codehash { block, who, slots, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).codehash(who, slots, block).await?);
+            sh_println!("{}", Cast::new(provider).codehash(who, slots, block).await?)?;
         }
         CastSubcommand::StorageRoot { block, who, slots, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
-            println!("{}", Cast::new(provider).storage_root(who, slots, block).await?);
+            sh_println!("{}", Cast::new(provider).storage_root(who, slots, block).await?)?;
         }
         CastSubcommand::Proof { address, slots, rpc, block } => {
             let config = Config::from(&rpc);
@@ -395,7 +385,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 .get_proof(address, slots.into_iter().collect())
                 .block_id(block.unwrap_or_default())
                 .await?;
-            println!("{}", serde_json::to_string(&value)?);
+            sh_println!("{}", serde_json::to_string(&value)?)?;
         }
         CastSubcommand::Rpc(cmd) => cmd.run().await?,
         CastSubcommand::Storage(cmd) => cmd.run().await?,
@@ -412,21 +402,21 @@ async fn main_args(args: CastArgs) -> Result<()> {
             let tx_hash = pending_tx.inner().tx_hash();
 
             if cast_async {
-                println!("{tx_hash:#x}");
+                sh_println!("{tx_hash:#x}")?;
             } else {
                 let receipt = pending_tx.get_receipt().await?;
-                println!("{}", serde_json::json!(receipt));
+                sh_println!("{}", serde_json::json!(receipt))?;
             }
         }
         CastSubcommand::Receipt { tx_hash, field, json, cast_async, confirmations, rpc } => {
             let config = Config::from(&rpc);
             let provider = utils::get_provider(&config)?;
-            println!(
+            sh_println!(
                 "{}",
                 Cast::new(provider)
                     .receipt(tx_hash, field, confirmations, None, cast_async, json)
                     .await?
-            );
+            )?
         }
         CastSubcommand::Run(cmd) => cmd.run().await?,
         CastSubcommand::SendTx(cmd) => cmd.run().await?,
@@ -437,7 +427,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             // Can use either --raw or specify raw as a field
             let raw = raw || field.as_ref().is_some_and(|f| f == "raw");
 
-            println!("{}", Cast::new(&provider).transaction(tx_hash, field, raw, json).await?)
+            sh_println!("{}", Cast::new(&provider).transaction(tx_hash, field, raw, json).await?)?
         }
 
         // 4Byte
@@ -448,13 +438,15 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 eyre::bail!("No matching function signatures found for selector `{selector}`");
             }
             for sig in sigs {
-                println!("{sig}");
+                sh_println!("{sig}")?
             }
         }
         CastSubcommand::FourByteDecode { calldata, json } => {
             let calldata = stdin::unwrap_line(calldata)?;
             let sigs = decode_calldata(&calldata).await?;
-            sigs.iter().enumerate().for_each(|(i, sig)| println!("{}) \"{sig}\"", i + 1));
+            sigs.iter().enumerate().for_each(|(i, sig)| {
+                let _ = sh_println!("{}) \"{sig}\"", i + 1);
+            });
 
             let sig = match sigs.len() {
                 0 => eyre::bail!("No signatures found"),
@@ -475,7 +467,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 eyre::bail!("No matching event signatures found for topic `{topic}`");
             }
             for sig in sigs {
-                println!("{sig}");
+                sh_println!("{sig}")?
             }
         }
         CastSubcommand::UploadSignature { signatures } => {
@@ -492,7 +484,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         // ENS
         CastSubcommand::Namehash { name } => {
             let name = stdin::unwrap_line(name)?;
-            println!("{}", namehash(&name));
+            sh_println!("{}", namehash(&name))?
         }
         CastSubcommand::LookupAddress { who, rpc, verify } => {
             let config = Config::from(&rpc);
@@ -507,7 +499,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                     "Reverse lookup verification failed: got `{address}`, expected `{who}`"
                 );
             }
-            println!("{name}");
+            sh_println!("{name}")?
         }
         CastSubcommand::ResolveName { who, rpc, verify } => {
             let config = Config::from(&rpc);
@@ -522,7 +514,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                     "Forward lookup verification failed: got `{name}`, expected `{who}`"
                 );
             }
-            println!("{address}");
+            sh_println!("{address}")?
         }
 
         // Misc
@@ -534,30 +526,32 @@ async fn main_args(args: CastArgs) -> Result<()> {
             match String::from_utf8(bytes) {
                 Ok(s) => {
                     let s = SimpleCast::keccak(&s)?;
-                    println!("{s}");
+                    sh_println!("{s}")?
                 }
                 Err(e) => {
                     let hash = keccak256(e.as_bytes());
                     let s = hex::encode(hash);
-                    println!("0x{s}");
+                    sh_println!("0x{s}")?
                 }
             };
         }
         CastSubcommand::HashMessage { message } => {
             let message = stdin::unwrap_line(message)?;
-            println!("{}", eip191_hash_message(message));
+            sh_println!("{}", eip191_hash_message(message))?
         }
         CastSubcommand::SigEvent { event_string } => {
             let event_string = stdin::unwrap_line(event_string)?;
             let parsed_event = get_event(&event_string)?;
-            println!("{:?}", parsed_event.selector());
+            sh_println!("{:?}", parsed_event.selector())?
         }
-        CastSubcommand::LeftShift { value, bits, base_in, base_out } => {
-            println!("{}", SimpleCast::left_shift(&value, &bits, base_in.as_deref(), &base_out)?);
-        }
-        CastSubcommand::RightShift { value, bits, base_in, base_out } => {
-            println!("{}", SimpleCast::right_shift(&value, &bits, base_in.as_deref(), &base_out)?);
-        }
+        CastSubcommand::LeftShift { value, bits, base_in, base_out } => sh_println!(
+            "{}",
+            SimpleCast::left_shift(&value, &bits, base_in.as_deref(), &base_out)?
+        )?,
+        CastSubcommand::RightShift { value, bits, base_in, base_out } => sh_println!(
+            "{}",
+            SimpleCast::right_shift(&value, &bits, base_in.as_deref(), &base_out)?
+        )?,
         CastSubcommand::EtherscanSource { address, directory, etherscan, flatten } => {
             let config = Config::from(&etherscan);
             let chain = config.chain.unwrap_or_default();
@@ -568,7 +562,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                         .await?
                 }
                 (None, false) => {
-                    println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?);
+                    sh_println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?)?
                 }
                 (dir, true) => {
                     SimpleCast::etherscan_source_flatten(chain, address, api_key, dir).await?;
@@ -593,11 +587,11 @@ async fn main_args(args: CastArgs) -> Result<()> {
             let tx = stdin::unwrap_line(tx)?;
             let tx = SimpleCast::decode_raw_transaction(&tx)?;
 
-            println!("{}", serde_json::to_string_pretty(&tx)?);
+            sh_println!("{}", serde_json::to_string_pretty(&tx)?)?
         }
         CastSubcommand::DecodeEof { eof } => {
             let eof = stdin::unwrap_line(eof)?;
-            println!("{}", SimpleCast::decode_eof(&eof)?);
+            sh_println!("{}", SimpleCast::decode_eof(&eof)?)?
         }
     };
     Ok(())

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -59,11 +59,21 @@ fn run() -> Result<()> {
 async fn main_args(args: CastArgs) -> Result<()> {
     match args.cmd {
         // Constants
-        CastSubcommand::MaxInt { r#type } => sh_println!("{}", SimpleCast::max_int(&r#type)?)?,
-        CastSubcommand::MinInt { r#type } => sh_println!("{}", SimpleCast::min_int(&r#type)?)?,
-        CastSubcommand::MaxUint { r#type } => sh_println!("{}", SimpleCast::max_int(&r#type)?)?,
-        CastSubcommand::AddressZero => sh_println!("{:?}", Address::ZERO)?,
-        CastSubcommand::HashZero => sh_println!("{:?}", B256::ZERO)?,
+        CastSubcommand::MaxInt { r#type } => {
+            sh_println!("{}", SimpleCast::max_int(&r#type)?)?;
+        }
+        CastSubcommand::MinInt { r#type } => {
+            sh_println!("{}", SimpleCast::min_int(&r#type)?)?;
+        }
+        CastSubcommand::MaxUint { r#type } => {
+            sh_println!("{}", SimpleCast::max_int(&r#type)?)?;
+        }
+        CastSubcommand::AddressZero => {
+            sh_println!("{:?}", Address::ZERO)?;
+        }
+        CastSubcommand::HashZero => {
+            sh_println!("{:?}", B256::ZERO)?;
+        }
 
         // Conversions & transformations
         CastSubcommand::FromUtf8 { text } => {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -56,6 +56,9 @@ mod rlp_converter;
 
 use rlp_converter::Item;
 
+#[macro_use]
+extern crate foundry_common;
+
 // TODO: CastContract with common contract initializers? Same for CastProviders?
 
 sol! {
@@ -1947,9 +1950,9 @@ impl SimpleCast {
         if let Some(path) = output_path {
             fs::create_dir_all(path.parent().unwrap())?;
             fs::write(&path, flattened)?;
-            println!("Flattened file written at {}", path.display());
+            sh_println!("Flattened file written at {}", path.display())?
         } else {
-            println!("{flattened}");
+            sh_println!("{flattened}")?
         }
 
         Ok(())

--- a/crates/cast/src/rlp_converter.rs
+++ b/crates/cast/src/rlp_converter.rs
@@ -108,6 +108,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::disallowed_macros)]
     fn encode_decode_test() -> alloy_rlp::Result<()> {
         let parameters = vec![
             (1, b"\xc0".to_vec(), Item::Array(vec![])),
@@ -149,6 +150,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::disallowed_macros)]
     fn deserialize_from_str_test_hex() -> JsonResult<()> {
         let parameters = vec![
             (1, "[\"\"]", Item::Array(vec![Item::Data(vec![])])),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Enforces `common::shell` as added in https://github.com/foundry-rs/foundry/pull/9109 for the `cast` binary

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Splits out the enforcement of the common shell per binary / large crate to avoid huge diffs making reviews easier