### PR TITLE
fix(fmt): multiline single param only if func definition is multiline for `all_params`

### DIFF
--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1638,13 +1638,17 @@ impl<'a, W: Write> Formatter<'a, W> {
                             &params,
                             ",",
                         )?;
-                    // Write new line if we have only one parameter and params first all multi set.
+                    // Write new line if we have only one parameter and params first set,
+                    // or if the function definition is multiline and all params set.
                     if params.len() == 1 &&
-                        matches!(
+                        (matches!(
                             fmt.config.multiline_func_header,
-                            MultilineFuncHeaderStyle::ParamsFirst |
+                            MultilineFuncHeaderStyle::ParamsFirst
+                        ) || params_multiline &&
+                            matches!(
+                                fmt.config.multiline_func_header,
                                 MultilineFuncHeaderStyle::AllParams
-                        )
+                            ))
                     {
                         writeln!(fmt.buf())?;
                     }

--- a/crates/fmt/src/formatter.rs
+++ b/crates/fmt/src/formatter.rs
@@ -1640,16 +1640,15 @@ impl<'a, W: Write> Formatter<'a, W> {
                         )?;
                     // Write new line if we have only one parameter and params first set,
                     // or if the function definition is multiline and all params set.
-                    if params.len() == 1 &&
-                        (matches!(
+                    let single_param_multiline = matches!(
+                        fmt.config.multiline_func_header,
+                        MultilineFuncHeaderStyle::ParamsFirst
+                    ) || params_multiline &&
+                        matches!(
                             fmt.config.multiline_func_header,
-                            MultilineFuncHeaderStyle::ParamsFirst
-                        ) || params_multiline &&
-                            matches!(
-                                fmt.config.multiline_func_header,
-                                MultilineFuncHeaderStyle::AllParams
-                            ))
-                    {
+                            MultilineFuncHeaderStyle::AllParams
+                        );
+                    if params.len() == 1 && single_param_multiline {
                         writeln!(fmt.buf())?;
                     }
                     fmt.write_chunks_separated(&params, ",", params_multiline)?;

--- a/crates/fmt/testdata/FunctionDefinition/all-params.fmt.sol
+++ b/crates/fmt/testdata/FunctionDefinition/all-params.fmt.sol
@@ -3,9 +3,7 @@
 interface FunctionInterfaces {
     function noParamsNoModifiersNoReturns();
 
-    function oneParam(
-        uint256 x
-    );
+    function oneParam(uint256 x);
 
     function oneModifier() modifier1;
 
@@ -345,9 +343,7 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function oneParam(
-        uint256 x
-    ) {
+    function oneParam(uint256 x) {
         a = 1;
     }
 


### PR DESCRIPTION
## Motivation

Follow-up for #9176. Spec is defined in https://github.com/foundry-rs/foundry/pull/9176#discussion_r1814710251

## Solution

- When `all_params` is selected, multiline the single parameter only when the full function definition takes more than a single line (i.e. multilined).