### PR TITLE
fix(cli): etherlink needs eth_estimateGas for gas calculation

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -171,6 +171,8 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                 NamedChain::ArbitrumGoerli |
                 NamedChain::ArbitrumSepolia |
                 NamedChain::ArbitrumTestnet |
+                NamedChain::Etherlink |
+                NamedChain::EtherlinkTestnet |
                 NamedChain::Karura |
                 NamedChain::KaruraTestnet |
                 NamedChain::Mantle |


### PR DESCRIPTION
## Motivation

Etherlink is an EVM-compatible L2 running on Tezos. As some other EVM-compatible chains, it has a specific gas computation, hence `forge script` will fail to inject transactions as they gas computed internally is different (and generally not enough).

## Solution

Following other chains that have a different gas calculation, `Etherlink` and `EtherlinkTestnet` are added as exception to force gas estimation from the node.
