### PR TITLE
fix(`anvil`): tag newly created legacy transactions on shadow fork as `Some(0)` (`0x0`) rather than `None`

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -755,7 +755,7 @@ impl TypedTransaction {
     /// Returns the transaction type
     pub fn r#type(&self) -> Option<u8> {
         match self {
-            Self::Legacy(_) => None,
+            Self::Legacy(_) => Some(0),
             Self::EIP2930(_) => Some(1),
             Self::EIP1559(_) => Some(2),
             Self::EIP4844(_) => Some(3),

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -755,7 +755,7 @@ impl TypedTransaction {
     /// Returns the transaction type
     pub fn r#type(&self) -> Option<u8> {
         match self {
-            Self::Legacy(_) => Some(0),
+            Self::Legacy(_) => None,
             Self::EIP2930(_) => Some(1),
             Self::EIP1559(_) => Some(2),
             Self::EIP4844(_) => Some(3),
@@ -1564,7 +1564,7 @@ impl Decodable for TypedReceipt {
 impl Encodable2718 for TypedReceipt {
     fn type_flag(&self) -> Option<u8> {
         match self {
-            Self::Legacy(_) => Some(0),
+            Self::Legacy(_) => None,
             Self::EIP2930(_) => Some(1),
             Self::EIP1559(_) => Some(2),
             Self::EIP4844(_) => Some(3),

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -300,7 +300,7 @@ pub fn to_alloy_transaction_with_hash_and_sender(
                 y_parity: None,
             }),
             access_list: None,
-            transaction_type: None,
+            transaction_type: Some(0),
             max_fee_per_blob_gas: None,
             blob_versioned_hashes: None,
             authorization_list: None,
@@ -1564,7 +1564,7 @@ impl Decodable for TypedReceipt {
 impl Encodable2718 for TypedReceipt {
     fn type_flag(&self) -> Option<u8> {
         match self {
-            Self::Legacy(_) => None,
+            Self::Legacy(_) => Some(0),
             Self::EIP2930(_) => Some(1),
             Self::EIP1559(_) => Some(2),
             Self::EIP4844(_) => Some(3),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/9194

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Mark legacy transaction type as `0x0` or `Some(0)` rather than `None`

This is in line with how Alloy marks legacy transactions

Steps to test:

```
1. make build
2. ./target/debug/anvil --block-time 12 --port 8545 --fork-url <SEPOLIA_API_KEY>
```

In other window send a new transaction w/ default Anvil keys):

```
3. cast send 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 0x --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --legacy
4. cast tx <TX_HASH> --json | jq
```

To verify the fix run step 2 with latest `anvil` install

Will now correctly yield:

```json
{
  "hash": "0x4dd5234b264e33221ef96a782163da179dcdc86a33f36f368aff8464ff17baa8",
  "nonce": "0x2f9a",
  "blockHash": "0x85ee456c35a65eccbd00ce99071a7aa79779770a52257cbaef4ef267f27254d8",
  "blockNumber": "0x69ed48",
  "transactionIndex": "0x0",
  "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
  "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
  "value": "0x0",
  "gasPrice": "0xe7f2d0db",
  "gas": "0x5209",
  "input": "0x",
  "r": "0xfe3f4a9323506eb34d6e38d15eebdfee9999d9355a40de7107cb19ad652623ae",
  "s": "0xdb65c223098cd4b7c8a032cc3958eb609fc1d0db7b64e83cacde5ace2217e99",
  "v": "0x1546d72",
  "chainId": "0xaa36a7",
  "type": "0x0"
}
```

as opposed to

```json
{
  "hash": "0xe29dedc1f322c74923c409e5a4c66db6a9106d4ba765c7ba35c63bbdd826346e",
  "nonce": "0x2f9a",
  "blockHash": "0xf5836152445dc0421b15e0e3a4de9f37a0e85361fe6d9913497c2b7181876e88",
  "blockNumber": "0x69ed4e",
  "transactionIndex": "0x0",
  "from": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
  "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
  "value": "0x0",
  "gasPrice": "0x10abcce5d",
  "gas": "0x5209",
  "input": "0x",
  "r": "0x950a20008eb86b40c582ed1b909e30cea67a887bf04202507213000efef99ea8",
  "s": "0x7f3e167a3281e08823d5900847236505627bbf590fe8c9b45a61a78e3c4b2a68",
  "v": "0x1546d72",
  "chainId": "0xaa36a7"
}
```

When querying existing legacy transactions the `transaction_type` is already correctly marked as `0x0`.