### PR TITLE
fix(anvil): correctly set hardfork-specific block fields

### DIFF
--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -8,9 +8,7 @@ use crate::{
     mem::inspector::Inspector,
     PrecompileFactory,
 };
-use alloy_consensus::{
-    constants::EMPTY_WITHDRAWALS, Receipt, ReceiptWithBloom,
-};
+use alloy_consensus::{constants::EMPTY_WITHDRAWALS, Receipt, ReceiptWithBloom};
 use alloy_eips::{eip2718::Encodable2718, eip7685::EMPTY_REQUESTS_HASH};
 use alloy_primitives::{Bloom, BloomInput, Log, B256};
 use anvil_core::eth::{

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -8,8 +8,10 @@ use crate::{
     mem::inspector::Inspector,
     PrecompileFactory,
 };
-use alloy_consensus::{Header, Receipt, ReceiptWithBloom};
-use alloy_eips::eip2718::Encodable2718;
+use alloy_consensus::{
+    constants::EMPTY_WITHDRAWALS, Receipt, ReceiptWithBloom,
+};
+use alloy_eips::{eip2718::Encodable2718, eip7685::EMPTY_REQUESTS_HASH};
 use alloy_primitives::{Bloom, BloomInput, Log, B256};
 use anvil_core::eth::{
     block::{Block, BlockInfo, PartialHeader},
@@ -134,7 +136,9 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
             None
         };
 
+        let is_shanghai = self.cfg_env.handler_cfg.spec_id >= SpecId::SHANGHAI;
         let is_cancun = self.cfg_env.handler_cfg.spec_id >= SpecId::CANCUN;
+        let is_prague = self.cfg_env.handler_cfg.spec_id >= SpecId::PRAGUE;
         let excess_blob_gas = if is_cancun { self.block_env.get_blob_excess_gas() } else { None };
         let mut cumulative_blob_gas_used = if is_cancun { Some(0u64) } else { None };
 
@@ -208,7 +212,6 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
             transactions.push(transaction.pending_transaction.transaction.clone());
         }
 
-        let ommers: Vec<Header> = Vec::new();
         let receipts_root =
             trie::ordered_trie_root(receipts.iter().map(Encodable2718::encoded_2718));
 
@@ -227,12 +230,14 @@ impl<DB: Db + ?Sized, V: TransactionValidator> TransactionExecutor<'_, DB, V> {
             mix_hash: Default::default(),
             nonce: Default::default(),
             base_fee,
-            parent_beacon_block_root: Default::default(),
+            parent_beacon_block_root: is_cancun.then_some(Default::default()),
             blob_gas_used: cumulative_blob_gas_used,
             excess_blob_gas,
+            withdrawals_root: is_shanghai.then_some(EMPTY_WITHDRAWALS),
+            requests_hash: is_prague.then_some(EMPTY_REQUESTS_HASH),
         };
 
-        let block = Block::new(partial_header, transactions.clone(), ommers);
+        let block = Block::new(partial_header, transactions.clone());
         let block = BlockInfo { block, transactions: transaction_infos, receipts };
         ExecutedTransactions { block, included, invalid }
     }

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -693,10 +693,8 @@ mod tests {
         let bytes_first = &mut &hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap()[..];
         let tx: MaybeImpersonatedTransaction =
             TypedTransaction::decode(&mut &bytes_first[..]).unwrap().into();
-        let block = Block::new::<MaybeImpersonatedTransaction>(
-            partial_header.clone(),
-            vec![tx.clone()],
-        );
+        let block =
+            Block::new::<MaybeImpersonatedTransaction>(partial_header.clone(), vec![tx.clone()]);
         let block_hash = block.header.hash_slow();
         dump_storage.blocks.insert(block_hash, block);
 

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -274,7 +274,7 @@ impl BlockchainStorage {
             excess_blob_gas: env.block.get_blob_excess_gas(),
             ..Default::default()
         };
-        let block = Block::new::<MaybeImpersonatedTransaction>(partial_header, vec![], vec![]);
+        let block = Block::new::<MaybeImpersonatedTransaction>(partial_header, vec![]);
         let genesis_hash = block.header.hash_slow();
         let best_hash = genesis_hash;
         let best_number: U64 = U64::from(0u64);
@@ -696,7 +696,6 @@ mod tests {
         let block = Block::new::<MaybeImpersonatedTransaction>(
             partial_header.clone(),
             vec![tx.clone()],
-            vec![],
         );
         let block_hash = block.header.hash_slow();
         dump_storage.blocks.insert(block_hash, block);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

ref https://github.com/foundry-rs/foundry/issues/9198#issuecomment-2439707092

Right now `parent_beacon_block_root`, `withdrawals_root` and `requests_hash` are always being set to `None`. They are indeed always empty but we should set empty values if corresponding hardfork is enabled.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
