### PR TITLE
fix(`anvil`): set `storage.best_number` correctly

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -739,7 +739,7 @@ impl ForkedStorage {
         accounts: BTreeMap<Address, SerializableAccountRecord>,
         block_number: u64,
     ) {
-        accounts.into_iter().map(|(k, v)| {
+        accounts.into_iter().for_each(|(k, v)| {
             let info = AccountInfo {
                 balance: v.balance,
                 nonce: v.nonce,
@@ -747,7 +747,7 @@ impl ForkedStorage {
                 code: if v.code.is_empty() { None } else { Some(Bytecode::new_raw(v.code)) },
             };
 
-            self.account_at.insert((k, block_number), info)
+            self.account_at.insert((k, block_number), info);
         });
     }
 }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -29,9 +29,11 @@ use parking_lot::{
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
     RawRwLock, RwLock,
 };
-use revm::primitives::BlobExcessGasAndPrice;
-use std::{sync::Arc, time::Duration};
+use revm::primitives::{AccountInfo, BlobExcessGasAndPrice, Bytecode, KECCAK_EMPTY};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tokio::sync::RwLock as AsyncRwLock;
+
+use super::db::{SerializableAccountRecord, SerializableState};
 
 /// Represents a fork of a remote client
 ///
@@ -270,11 +272,19 @@ impl ClientFork {
         blocknumber: u64,
     ) -> Result<U256, TransportError> {
         trace!(target: "backend::fork", "get_balance={:?}", address);
+        if let Some(account) = self.storage_read().account_at.get(&(address, blocknumber)).cloned()
+        {
+            return Ok(account.balance);
+        }
+
         self.provider().get_balance(address).block_id(blocknumber.into()).await
     }
 
     pub async fn get_nonce(&self, address: Address, block: u64) -> Result<u64, TransportError> {
         trace!(target: "backend::fork", "get_nonce={:?}", address);
+        if let Some(account) = self.storage_read().account_at.get(&(address, block)).cloned() {
+            return Ok(account.nonce);
+        }
         self.provider().get_transaction_count(address).block_id(block.into()).await
     }
 
@@ -284,6 +294,16 @@ impl ClientFork {
         blocknumber: u64,
     ) -> Result<Account, TransportError> {
         trace!(target: "backend::fork", "get_account={:?}", address);
+        if let Some(account) = self.storage_read().account_at.get(&(address, blocknumber)).cloned()
+        {
+            let acc = Account {
+                balance: account.balance,
+                nonce: account.nonce,
+                code_hash: account.code_hash,
+                storage_root: Default::default(),
+            };
+            return Ok(acc);
+        }
         self.provider().get_account(address).block_id(blocknumber.into()).await
     }
 
@@ -601,6 +621,14 @@ impl ClientFork {
 
         block
     }
+
+    pub fn load_state(&mut self, state: SerializableState) {
+        let mut storage = self.storage_write();
+
+        if let Some(block) = state.block {
+            storage.load_accounts(state.accounts, block.number.to());
+        }
+    }
 }
 
 /// Contains all fork metadata
@@ -695,6 +723,7 @@ pub struct ForkedStorage {
     pub block_traces: HashMap<u64, Vec<Trace>>,
     pub block_receipts: HashMap<u64, Vec<ReceiptResponse>>,
     pub code_at: HashMap<(Address, u64), Bytes>,
+    pub account_at: HashMap<(Address, u64), AccountInfo>,
 }
 
 impl ForkedStorage {
@@ -702,5 +731,23 @@ impl ForkedStorage {
     pub fn clear(&mut self) {
         // simply replace with a completely new, empty instance
         *self = Self::default()
+    }
+
+    /// Load the accounts.
+    pub fn load_accounts(
+        &mut self,
+        accounts: BTreeMap<Address, SerializableAccountRecord>,
+        block_number: u64,
+    ) {
+        accounts.into_iter().map(|(k, v)| {
+            let info = AccountInfo {
+                balance: v.balance,
+                nonce: v.nonce,
+                code_hash: KECCAK_EMPTY,
+                code: if v.code.is_empty() { None } else { Some(Bytecode::new_raw(v.code)) },
+            };
+
+            self.account_at.insert((k, block_number), info)
+        });
     }
 }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -739,7 +739,7 @@ impl ForkedStorage {
         accounts: BTreeMap<Address, SerializableAccountRecord>,
         block_number: u64,
     ) {
-        accounts.into_iter().for_each(|(k, v)| {
+        accounts.into_iter().map(|(k, v)| {
             let info = AccountInfo {
                 balance: v.balance,
                 nonce: v.nonce,
@@ -747,7 +747,7 @@ impl ForkedStorage {
                 code: if v.code.is_empty() { None } else { Some(Bytecode::new_raw(v.code)) },
             };
 
-            self.account_at.insert((k, block_number), info);
+            self.account_at.insert((k, block_number), info)
         });
     }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -929,6 +929,10 @@ impl Backend {
             .into());
         }
 
+        if let Some(mut fork) = self.get_fork() {
+            fork.load_state(state.clone());
+        }
+
         if let Some(historical_states) = state.historical_states {
             self.states.write().load_states(historical_states);
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -937,10 +937,6 @@ impl Backend {
             .into());
         }
 
-        if let Some(mut fork) = self.get_fork() {
-            fork.load_state(state.clone());
-        }
-
         if let Some(historical_states) = state.historical_states {
             self.states.write().load_states(historical_states);
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -911,7 +911,7 @@ impl Backend {
 
             if let Some((number, hash)) = fork_num_and_hash {
                 // If loading state file on a fork, set best number to the fork block number.
-                // Ref:
+                // Ref: https://github.com/foundry-rs/foundry/pull/9215#issue-2618681838
                 self.blockchain.storage.write().best_number = U64::from(number);
                 self.blockchain.storage.write().best_hash = hash;
             } else {

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -159,6 +159,7 @@ async fn can_preserve_historical_states_between_dump_and_load() {
     assert_eq!(greeting_after_change, "World!");
 }
 
+// <https://github.com/foundry-rs/foundry/issues/9053>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_load_state() {
     let (api, handle) = spawn(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9053 + Closes https://github.com/foundry-rs/foundry/issues/8493

This arises when `--fork-url` and `--load-state` are used together.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- ~Introduce `account_at` in `ForkedStorage` which stores the state of accounts at specific block numbers.~
- ~Populate `account_at` using the provided state file.~ 

Solution is a lot simpler.

- We are correctly loading the data to the db: https://github.com/foundry-rs/foundry/blob/4012adefd376bd618d1348398c1da07224d2dace/crates/anvil/src/eth/backend/mem/mod.rs#L925
- However, the `storage.best_number` i.e head of the chain is not correctly set when `--load-state` is used with `--fork-url`. We continue to set `storage.best_number = state.block.number` which is incorrect as the `best_number` should be `fork_block_number`. 
- This issue is observed when `fork_block_number` > `state.block_number`. In this case while all state data has been correctly loaded to the db, we fetch via the provider due to this check. https://github.com/foundry-rs/foundry/blob/4012adefd376bd618d1348398c1da07224d2dace/crates/anvil/src/eth/api.rs#L683
- Setting `storage.best_number = fork_block_number` fixes this

- [x] Test

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
