### PR TITLE
chore(`forge`): enforce `common::shell` for `forge` crate

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,10 +3,10 @@ msrv = "1.80"
 # so it is safe to ignore it as well
 ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]
 
-# disallowed-macros = [
-#     # See `foundry_common::shell`
-#     { path = "std::print", reason = "use `sh_print` or similar macros instead" },
-#     { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
-#     { path = "std::println", reason = "use `sh_println` or similar macros instead" },
-#     { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
-# ]
+disallowed-macros = [
+    # See `foundry_common::shell`
+    { path = "std::print", reason = "use `sh_print` or similar macros instead" },
+    { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
+    { path = "std::println", reason = "use `sh_println` or similar macros instead" },
+    { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,10 +3,10 @@ msrv = "1.80"
 # so it is safe to ignore it as well
 ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]
 
-disallowed-macros = [
-    # See `foundry_common::shell`
-    { path = "std::print", reason = "use `sh_print` or similar macros instead" },
-    { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
-    { path = "std::println", reason = "use `sh_println` or similar macros instead" },
-    { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
-]
+# disallowed-macros = [
+#     # See `foundry_common::shell`
+#     { path = "std::print", reason = "use `sh_print` or similar macros instead" },
+#     { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
+#     { path = "std::println", reason = "use `sh_println` or similar macros instead" },
+#     { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
+# ]

--- a/crates/cast/bin/cmd/create2.rs
+++ b/crates/cast/bin/cmd/create2.rs
@@ -193,8 +193,7 @@ impl Create2Args {
 
         sh_println!("Configuration:")?;
         sh_println!("Init code hash: {init_code_hash}")?;
-        sh_println!("Regex patterns: {:?}", regex.patterns())?;
-        sh_println!()?;
+        sh_println!("Regex patterns: {:?}\n", regex.patterns())?;
         sh_println!(
             "Starting to generate deterministic contract address with {n_threads} threads..."
         )?;

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -106,10 +106,9 @@ impl BindArgs {
         }
 
         if self.ethers {
-            eprintln!(
-                "Warning: `--ethers` bindings are deprecated and will be removed in the future. \
-                 Consider using `--alloy` (default) instead."
-            );
+            sh_warn!(
+                "`--ethers` bindings are deprecated and will be removed in the future. Consider using `--alloy` (default) instead."
+            )?;
         }
 
         let config = self.try_load_config_emit_warnings()?;
@@ -118,7 +117,7 @@ impl BindArgs {
 
         if bindings_root.exists() {
             if !self.overwrite {
-                println!("Bindings found. Checking for consistency.");
+                sh_println!("Bindings found. Checking for consistency.")?;
                 return self.check_existing_bindings(&artifacts, &bindings_root);
             }
 
@@ -128,7 +127,7 @@ impl BindArgs {
 
         self.generate_bindings(&artifacts, &bindings_root)?;
 
-        println!("Bindings have been generated to {}", bindings_root.display());
+        sh_println!("Bindings have been generated to {}", bindings_root.display())?;
         Ok(())
     }
 
@@ -274,7 +273,7 @@ impl BindArgs {
 
     fn check_ethers(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let bindings = self.get_multi(artifacts)?.build()?;
-        println!("Checking bindings for {} contracts.", bindings.len());
+        sh_println!("Checking bindings for {} contracts.", bindings.len())?;
         if !self.module {
             bindings
                 .ensure_consistent_crate(
@@ -294,14 +293,14 @@ impl BindArgs {
         } else {
             bindings.ensure_consistent_module(bindings_root, self.single_file)?;
         }
-        println!("OK.");
+        sh_println!("OK.")?;
         Ok(())
     }
 
     fn check_alloy(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let mut bindings = self.get_solmacrogen(artifacts)?;
         bindings.generate_bindings()?;
-        println!("Checking bindings for {} contracts", bindings.instances.len());
+        sh_println!("Checking bindings for {} contracts", bindings.instances.len())?;
         bindings.check_consistency(
             &self.crate_name,
             &self.crate_version,
@@ -311,7 +310,7 @@ impl BindArgs {
             self.module,
             self.alloy_version.clone(),
         )?;
-        println!("OK.");
+        sh_println!("OK.")?;
         Ok(())
     }
 
@@ -326,7 +325,7 @@ impl BindArgs {
 
     fn generate_ethers(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let mut bindings = self.get_multi(artifacts)?.build()?;
-        println!("Generating bindings for {} contracts", bindings.len());
+        sh_println!("Generating bindings for {} contracts", bindings.len())?;
         if !self.module {
             trace!(single_file = self.single_file, "generating crate");
             if !self.skip_extra_derives {
@@ -346,7 +345,7 @@ impl BindArgs {
 
     fn generate_alloy(&self, artifacts: &Path, bindings_root: &Path) -> Result<()> {
         let mut solmacrogen = self.get_solmacrogen(artifacts)?;
-        println!("Generating bindings for {} contracts", solmacrogen.instances.len());
+        sh_println!("Generating bindings for {} contracts", solmacrogen.instances.len())?;
 
         if !self.module {
             trace!(single_file = self.single_file, "generating crate");

--- a/crates/forge/bin/cmd/bind_json.rs
+++ b/crates/forge/bin/cmd/bind_json.rs
@@ -439,7 +439,7 @@ impl ResolvedState {
         }
         fs::write(&self.target_path, &result)?;
 
-        println!("Bindings written to {}", self.target_path.display());
+        sh_println!("Bindings written to {}", self.target_path.display())?;
 
         Ok(result)
     }

--- a/crates/forge/bin/cmd/cache.rs
+++ b/crates/forge/bin/cmd/cache.rs
@@ -101,7 +101,7 @@ impl LsArgs {
                 ChainOrAll::All => cache = Config::list_foundry_cache()?,
             }
         }
-        print!("{cache}");
+        sh_print!("{cache}")?;
         Ok(())
     }
 }

--- a/crates/forge/bin/cmd/clone.rs
+++ b/crates/forge/bin/cmd/clone.rs
@@ -616,6 +616,7 @@ mod tests {
     use foundry_test_utils::rpc::next_mainnet_etherscan_api_key;
     use std::collections::BTreeMap;
 
+    #[allow(clippy::disallowed_macros)]
     fn assert_successful_compilation(root: &PathBuf) -> ProjectCompileOutput {
         println!("project_root: {root:#?}");
         compile_project(root).expect("compilation failure")

--- a/crates/forge/bin/cmd/compiler.rs
+++ b/crates/forge/bin/cmd/compiler.rs
@@ -141,25 +141,25 @@ impl ResolveArgs {
         }
 
         if json {
-            println!("{}", serde_json::to_string(&output)?);
+            sh_println!("{}", serde_json::to_string(&output)?)?;
             return Ok(());
         }
 
         for (language, compilers) in &output {
             match verbosity {
-                0 => println!("{language}:"),
-                _ => println!("{language}:\n"),
+                0 => sh_println!("{language}:")?,
+                _ => sh_println!("{language}:\n")?,
             }
 
             for resolved_compiler in compilers {
                 let version = &resolved_compiler.version;
                 match verbosity {
-                    0 => println!("- {version}"),
+                    0 => sh_println!("- {version}")?,
                     _ => {
                         if let Some(evm) = &resolved_compiler.evm_version {
-                            println!("{version} (<= {evm}):")
+                            sh_println!("{version} (<= {evm}):")?
                         } else {
-                            println!("{version}:")
+                            sh_println!("{version}:")?
                         }
                     }
                 }
@@ -168,16 +168,16 @@ impl ResolveArgs {
                     let paths = &resolved_compiler.paths;
                     for (idx, path) in paths.iter().enumerate() {
                         if idx == paths.len() - 1 {
-                            println!("└── {path}\n");
+                            sh_println!("└── {path}\n")?
                         } else {
-                            println!("├── {path}");
+                            sh_println!("├── {path}")?
                         }
                     }
                 }
             }
 
             if verbosity == 0 {
-                println!();
+                sh_println!()?
             }
         }
 

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -321,18 +321,18 @@ impl CreateArgs {
                 "deployedTo": address.to_string(),
                 "transactionHash": receipt.transaction_hash
             });
-            println!("{output}");
+            sh_println!("{output}")?;
         } else {
-            println!("Deployer: {deployer_address}");
-            println!("Deployed to: {address}");
-            println!("Transaction hash: {:?}", receipt.transaction_hash);
+            sh_println!("Deployer: {deployer_address}")?;
+            sh_println!("Deployed to: {address}")?;
+            sh_println!("Transaction hash: {:?}", receipt.transaction_hash)?;
         };
 
         if !self.verify {
             return Ok(());
         }
 
-        println!("Starting contract verification...");
+        sh_println!("Starting contract verification...")?;
 
         let num_of_optimizations = if self.opts.compiler.optimize.unwrap_or_default() {
             self.opts.compiler.optimizer_runs
@@ -361,7 +361,7 @@ impl CreateArgs {
             show_standard_json_input: self.show_standard_json_input,
             guess_constructor_args: false,
         };
-        println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier);
+        sh_println!("Waiting for {} to detect contract deployment...", verify.verifier.verifier)?;
         verify.run().await
     }
 

--- a/crates/forge/bin/cmd/doc/server.rs
+++ b/crates/forge/bin/cmd/doc/server.rs
@@ -75,7 +75,7 @@ impl Server {
         let file_404 = get_404_output_file(&input_404);
 
         let serving_url = format!("http://{address}");
-        println!("Serving on: {serving_url}");
+        sh_println!("Serving on: {serving_url}")?;
 
         let thread_handle = std::thread::spawn(move || serve(build_dir, sockaddr, &file_404));
 

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -63,8 +63,8 @@ impl Eip712Args {
 
         for (id, _) in structs_in_target {
             if let Some(resolved) = resolver.resolve_struct_eip712(id)? {
-                sh_println!("{resolved}");
-                sh_println!();
+                sh_println!("{resolved}")?;
+                sh_println!()?;
             }
         }
 

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -63,8 +63,8 @@ impl Eip712Args {
 
         for (id, _) in structs_in_target {
             if let Some(resolved) = resolver.resolve_struct_eip712(id)? {
-                println!("{resolved}");
-                println!();
+                sh_println!("{resolved}");
+                sh_println!();
             }
         }
 

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -63,8 +63,7 @@ impl Eip712Args {
 
         for (id, _) in structs_in_target {
             if let Some(resolved) = resolver.resolve_struct_eip712(id)? {
-                sh_println!("{resolved}")?;
-                sh_println!()?;
+                sh_println!("{resolved}\n")?;
             }
         }
 

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -64,9 +64,9 @@ impl FlattenArgs {
             Some(output) => {
                 fs::create_dir_all(output.parent().unwrap())?;
                 fs::write(&output, flattened)?;
-                println!("Flattened file written at {}", output.display());
+                sh_println!("Flattened file written at {}", output.display())?;
             }
-            None => println!("{flattened}"),
+            None => sh_println!("{flattened}")?,
         };
 
         Ok(())

--- a/crates/forge/bin/cmd/fmt.rs
+++ b/crates/forge/bin/cmd/fmt.rs
@@ -129,7 +129,7 @@ impl FmtArgs {
             let new_format = diff.ratio() < 1.0;
             if self.check || path.is_none() {
                 if self.raw {
-                    print!("{output}");
+                    sh_print!("{output}")?;
                 }
 
                 // If new format then compute diff summary.

--- a/crates/forge/bin/cmd/geiger/mod.rs
+++ b/crates/forge/bin/cmd/geiger/mod.rs
@@ -95,7 +95,7 @@ impl GeigerArgs {
         let sources = self.sources(&config).wrap_err("Failed to resolve files")?;
 
         if config.ffi {
-            eprintln!("{}\n", "ffi enabled".red());
+            sh_warn!("FFI enabled")?;
         }
 
         let root = config.root.0;
@@ -112,7 +112,7 @@ impl GeigerArgs {
                     len
                 }
                 Err(err) => {
-                    eprintln!("{err}");
+                    let _ = sh_err!("{err}");
                     0
                 }
             })

--- a/crates/forge/bin/cmd/geiger/mod.rs
+++ b/crates/forge/bin/cmd/geiger/mod.rs
@@ -94,7 +94,7 @@ impl GeigerArgs {
         let sources = self.sources(&config).wrap_err("Failed to resolve files")?;
 
         if config.ffi {
-            sh_warn!("FFI enabled")?;
+            sh_warn!("FFI enabled\n")?;
         }
 
         let root = config.root.0;

--- a/crates/forge/bin/cmd/geiger/mod.rs
+++ b/crates/forge/bin/cmd/geiger/mod.rs
@@ -6,7 +6,6 @@ use foundry_config::{impl_figment_convert_basic, Config};
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::path::PathBuf;
-use yansi::Paint;
 
 mod error;
 

--- a/crates/forge/bin/cmd/geiger/mod.rs
+++ b/crates/forge/bin/cmd/geiger/mod.rs
@@ -106,7 +106,7 @@ impl GeigerArgs {
                     let len = metrics.cheatcodes.len();
                     let printer = SolFileMetricsPrinter { metrics: &metrics, root: &root };
                     if self.full || len == 0 {
-                        eprint!("{printer}");
+                        let _ = sh_eprint!("{printer}");
                     }
                     len
                 }

--- a/crates/forge/bin/cmd/generate/mod.rs
+++ b/crates/forge/bin/cmd/generate/mod.rs
@@ -44,7 +44,7 @@ impl GenerateTestArgs {
         // Write the test content to the test file.
         fs::write(&test_file_path, test_content)?;
 
-        println!("{} test file: {}", "Generated".green(), test_file_path.to_str().unwrap());
+        sh_println!("{} test file: {}", "Generated".green(), test_file_path.to_str().unwrap())?;
         Ok(())
     }
 }

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -87,7 +87,7 @@ impl InspectArgs {
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
                 if pretty {
                     let source = foundry_cli::utils::abi_to_solidity(abi, &contract.name)?;
-                    println!("{source}");
+                    sh_println!("{source}")?;
                 } else {
                     print_json(abi)?;
                 }
@@ -201,7 +201,7 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>, pretty: bool
         ]);
     }
 
-    println!("{table}");
+    sh_println!("{table}")?;
     Ok(())
 }
 
@@ -390,12 +390,12 @@ impl ContractArtifactField {
 }
 
 fn print_json(obj: &impl serde::Serialize) -> Result<()> {
-    println!("{}", serde_json::to_string_pretty(obj)?);
+    sh_println!("{}", serde_json::to_string_pretty(obj)?)?;
     Ok(())
 }
 
 fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> {
-    println!("{}", get_json_str(obj, key)?);
+    sh_println!("{}", get_json_str(obj, key)?)?;
     Ok(())
 }
 
@@ -408,9 +408,9 @@ fn print_yul(yul: Option<&str>, pretty: bool) -> Result<()> {
         LazyLock::new(|| Regex::new(r"(///.*\n\s*)|(\s*/\*\*.*\*/)").unwrap());
 
     if pretty {
-        println!("{}", YUL_COMMENTS.replace_all(yul, ""));
+        sh_println!("{}", YUL_COMMENTS.replace_all(yul, ""))?;
     } else {
-        println!("{yul}");
+        sh_println!("{yul}")?;
     }
 
     Ok(())
@@ -450,7 +450,7 @@ fn print_eof(bytecode: Option<CompactBytecode>) -> Result<()> {
 
     let eof = Eof::decode(bytecode).wrap_err("Failed to decode EOF")?;
 
-    println!("{}", pretty_eof(&eof)?);
+    sh_println!("{}", pretty_eof(&eof)?)?;
 
     Ok(())
 }

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -412,9 +412,9 @@ impl Installer<'_> {
 
         // multiple candidates, ask the user to choose one or skip
         candidates.insert(0, String::from("SKIP AND USE ORIGINAL TAG"));
-        println!("There are multiple matching tags:");
+        sh_println!("There are multiple matching tags:")?;
         for (i, candidate) in candidates.iter().enumerate() {
-            println!("[{i}] {candidate}");
+            sh_println!("[{i}] {candidate}")?;
         }
 
         let n_candidates = candidates.len();
@@ -429,7 +429,7 @@ impl Installer<'_> {
                 Ok(0) => return Ok(tag.into()),
                 Ok(i) if (1..=n_candidates).contains(&i) => {
                     let c = &candidates[i];
-                    println!("[{i}] {c} selected");
+                    sh_println!("[{i}] {c} selected")?;
                     return Ok(c.clone())
                 }
                 _ => continue,
@@ -474,9 +474,9 @@ impl Installer<'_> {
 
         // multiple candidates, ask the user to choose one or skip
         candidates.insert(0, format!("{tag} (original branch)"));
-        println!("There are multiple matching branches:");
+        sh_println!("There are multiple matching branches:")?;
         for (i, candidate) in candidates.iter().enumerate() {
-            println!("[{i}] {candidate}");
+            sh_println!("[{i}] {candidate}")?;
         }
 
         let n_candidates = candidates.len();
@@ -488,7 +488,7 @@ impl Installer<'_> {
 
         // default selection, return None
         if input.is_empty() {
-            println!("Canceled branch matching");
+            sh_println!("Canceled branch matching")?;
             return Ok(None)
         }
 
@@ -497,7 +497,7 @@ impl Installer<'_> {
             Ok(0) => Ok(Some(tag.into())),
             Ok(i) if (1..=n_candidates).contains(&i) => {
                 let c = &candidates[i];
-                println!("[{i}] {c} selected");
+                sh_println!("[{i}] {c} selected")?;
                 Ok(Some(c.clone()))
             }
             _ => Ok(None),

--- a/crates/forge/bin/cmd/remappings.rs
+++ b/crates/forge/bin/cmd/remappings.rs
@@ -30,20 +30,20 @@ impl RemappingArgs {
             }
             for (group, remappings) in groups {
                 if let Some(group) = group {
-                    println!("Context: {group}");
+                    sh_println!("Context: {group}")?;
                 } else {
-                    println!("Global:");
+                    sh_println!("Global:")?;
                 }
 
                 for mut remapping in remappings {
                     remapping.context = None; // avoid writing context twice
-                    println!("- {remapping}");
+                    sh_println!("- {remapping}")?;
                 }
-                println!();
+                sh_println!()?;
             }
         } else {
             for remapping in config.remappings {
-                println!("{remapping}");
+                sh_println!("{remapping}")?;
             }
         }
 

--- a/crates/forge/bin/cmd/remove.rs
+++ b/crates/forge/bin/cmd/remove.rs
@@ -38,7 +38,7 @@ impl RemoveArgs {
 
         // remove all the dependencies from .git/modules
         for (Dependency { name, url, tag, .. }, path) in self.dependencies.iter().zip(&paths) {
-            println!("Removing '{name}' in {}, (url: {url:?}, tag: {tag:?})", path.display());
+            sh_println!("Removing '{name}' in {}, (url: {url:?}, tag: {tag:?})", path.display())?;
             std::fs::remove_dir_all(git_modules.join(path))?;
         }
 

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -340,12 +340,10 @@ impl SelectorsSubcommands {
                 }
 
                 if table.row_count() > 0 {
-                    sh_println!()?;
-                    sh_println!("Found {} instance(s)...", table.row_count())?;
+                    sh_println!("\nFound {} instance(s)...", table.row_count())?;
                     sh_println!("{table}")?;
                 } else {
-                    sh_println!()?;
-                    return Err(eyre::eyre!("Selector not found in the project."));
+                    return Err(eyre::eyre!("\nSelector not found in the project."));
                 }
             }
         }

--- a/crates/forge/bin/cmd/selectors.rs
+++ b/crates/forge/bin/cmd/selectors.rs
@@ -120,13 +120,13 @@ impl SelectorsSubcommands {
                         continue
                     }
 
-                    println!("Uploading selectors for {contract}...");
+                    sh_println!("Uploading selectors for {contract}...")?;
 
                     // upload abi to selector database
                     import_selectors(SelectorImportData::Abi(vec![abi])).await?.describe();
 
                     if artifacts.peek().is_some() {
-                        println!()
+                        sh_println!()?
                     }
                 }
             }
@@ -171,7 +171,7 @@ impl SelectorsSubcommands {
                     .collect();
 
                 if colliding_methods.is_empty() {
-                    println!("No colliding method selectors between the two contracts.");
+                    sh_println!("No colliding method selectors between the two contracts.")?;
                 } else {
                     let mut table = Table::new();
                     table.set_header([
@@ -182,12 +182,12 @@ impl SelectorsSubcommands {
                     for method in colliding_methods.iter() {
                         table.add_row([method.0, method.1, method.2]);
                     }
-                    println!("{} collisions found:", colliding_methods.len());
-                    println!("{table}");
+                    sh_println!("{} collisions found:", colliding_methods.len())?;
+                    sh_println!("{table}")?;
                 }
             }
             Self::List { contract, project_paths } => {
-                println!("Listing selectors for contracts in the project...");
+                sh_println!("Listing selectors for contracts in the project...")?;
                 let build_args = CoreBuildArgs {
                     project_paths,
                     compiler: CompilerArgs {
@@ -240,7 +240,7 @@ impl SelectorsSubcommands {
                         continue
                     }
 
-                    println!("{contract}");
+                    sh_println!("{contract}")?;
 
                     let mut table = Table::new();
 
@@ -264,16 +264,16 @@ impl SelectorsSubcommands {
                         table.add_row(["Error", &sig, &hex::encode_prefixed(selector)]);
                     }
 
-                    println!("{table}");
+                    sh_println!("{table}")?;
 
                     if artifacts.peek().is_some() {
-                        println!()
+                        sh_println!()?
                     }
                 }
             }
 
             Self::Find { selector, project_paths } => {
-                println!("Searching for selector {selector:?} in the project...");
+                sh_println!("Searching for selector {selector:?} in the project...")?;
 
                 let build_args = CoreBuildArgs {
                     project_paths,
@@ -340,11 +340,11 @@ impl SelectorsSubcommands {
                 }
 
                 if table.row_count() > 0 {
-                    println!();
-                    println!("Found {} instance(s)...", table.row_count());
-                    println!("{table}");
+                    sh_println!()?;
+                    sh_println!("Found {} instance(s)...", table.row_count())?;
+                    sh_println!("{table}")?;
                 } else {
-                    println!();
+                    sh_println!()?;
                     return Err(eyre::eyre!("Selector not found in the project."));
                 }
             }

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -331,7 +331,7 @@ fn check(
         {
             let source_gas = test.result.kind.report();
             if !within_tolerance(source_gas.gas(), target_gas.gas(), tolerance) {
-                eprintln!(
+                let _ = sh_println!(
                     "Diff in \"{}::{}\": consumed \"{}\" gas, expected \"{}\" gas ",
                     test.contract_name(),
                     test.signature,
@@ -341,7 +341,7 @@ fn check(
                 has_diff = true;
             }
         } else {
-            eprintln!(
+            let _ = sh_println!(
                 "No matching snapshot entry found for \"{}::{}\" in snapshot file",
                 test.contract_name(),
                 test.signature
@@ -382,20 +382,20 @@ fn diff(tests: Vec<SuiteTestResult>, snaps: Vec<GasSnapshotEntry>) -> Result<()>
         overall_gas_change += gas_change;
         overall_gas_used += diff.target_gas_used.gas() as i128;
         let gas_diff = diff.gas_diff();
-        println!(
+        sh_println!(
             "{} (gas: {} ({})) ",
             diff.signature,
             fmt_change(gas_change),
             fmt_pct_change(gas_diff)
-        );
+        )?;
     }
 
     let overall_gas_diff = overall_gas_change as f64 / overall_gas_used as f64;
-    println!(
+    sh_println!(
         "Overall gas change: {} ({})",
         fmt_change(overall_gas_change),
         fmt_pct_change(overall_gas_diff)
-    );
+    )?;
     Ok(())
 }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -236,7 +236,7 @@ impl TestArgs {
                 )?;
             } else {
                 sh_println!("No tests match the provided pattern:")?;
-                print!("{filter}");
+                sh_print!("{filter}")?;
 
                 // Try to suggest a test when there's no match
                 if let Some(test_pattern) = &filter.args().test_pattern {

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -750,13 +750,13 @@ impl TestArgs {
                                 .collect();
 
                             if !diff.is_empty() {
-                                let _ = sh_err!(
+                                let _ = sh_eprintln!(
                                     "{}",
                                     format!("\n[{group}] Failed to match snapshots:").red().bold()
                                 );
 
                                 for (key, (previous_snapshot, snapshot)) in &diff {
-                                    let _ = sh_println!(
+                                    let _ = sh_eprintln!(
                                         "{}",
                                         format!("- [{key}] {previous_snapshot} → {snapshot}").red()
                                     );

--- a/crates/forge/bin/cmd/test/summary.rs
+++ b/crates/forge/bin/cmd/test/summary.rs
@@ -92,7 +92,7 @@ impl TestSummaryReporter {
             self.table.add_row(row);
         }
 
-        println!("\n{}", self.table);
+        let _ = sh_println!("\n{}", self.table);
     }
 }
 
@@ -126,6 +126,6 @@ pub(crate) fn print_invariant_metrics(test_metrics: &HashMap<String, InvariantMe
             }
         }
 
-        println!("{table}\n");
+        let _ = sh_println!("{table}\n");
     }
 }

--- a/crates/forge/bin/cmd/watch.rs
+++ b/crates/forge/bin/cmd/watch.rs
@@ -108,7 +108,9 @@ impl WatchArgs {
     ) -> Result<watchexec::Config> {
         let config = watchexec::Config::default();
 
-        config.on_error(|err| eprintln!("[[{err:?}]]"));
+        config.on_error(|err| {
+            let _ = sh_eprintln!("[[{err:?}]]");
+        });
 
         if let Some(delay) = &self.watch_delay {
             config.throttle(utils::parse_delay(delay)?);
@@ -149,7 +151,7 @@ impl WatchArgs {
             let quit = |mut action: ActionHandler| {
                 match quit_again.fetch_add(1, Ordering::Relaxed) {
                     0 => {
-                        eprintln!(
+                        let _ = sh_eprintln!(
                             "[Waiting {stop_timeout:?} for processes to exit before stopping... \
                              Ctrl-C again to exit faster]"
                         );
@@ -228,7 +230,7 @@ fn end_of_process(state: &CommandState) {
 
     let quiet = false;
     if !quiet {
-        eprintln!("{}", format!("[{msg}]").paint(fg.foreground()));
+        let _ = sh_eprintln!("{}", format!("[{msg}]").paint(fg.foreground()));
     }
 }
 

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -55,7 +55,7 @@ impl CoverageReporter for SummaryReporter {
         }
 
         self.add_row("Total", self.total.clone());
-        println!("{}", self.table);
+        sh_println!("{}", self.table)?;
         Ok(())
     }
 }
@@ -139,7 +139,7 @@ impl CoverageReporter for LcovReporter<'_> {
             writeln!(self.destination, "end_of_record")?;
         }
 
-        println!("Wrote LCOV report.");
+        sh_println!("Wrote LCOV report.")?;
 
         Ok(())
     }
@@ -151,30 +151,30 @@ pub struct DebugReporter;
 impl CoverageReporter for DebugReporter {
     fn report(self, report: &CoverageReport) -> eyre::Result<()> {
         for (path, items) in report.items_by_source() {
-            println!("Uncovered for {}:", path.display());
+            sh_println!("Uncovered for {}:", path.display())?;
             items.iter().for_each(|item| {
                 if item.hits == 0 {
-                    println!("- {item}");
+                    let _ = sh_println!("- {item}");
                 }
             });
-            println!();
+            sh_println!()?;
         }
 
         for (contract_id, anchors) in &report.anchors {
-            println!("Anchors for {contract_id}:");
+            sh_println!("Anchors for {contract_id}:")?;
             anchors
                 .0
                 .iter()
                 .map(|anchor| (false, anchor))
                 .chain(anchors.1.iter().map(|anchor| (true, anchor)))
                 .for_each(|(is_deployed, anchor)| {
-                    println!("- {anchor}");
+                    let _ = sh_println!("- {anchor}");
                     if is_deployed {
-                        println!("- Creation code");
+                        let _ = sh_println!("- Creation code");
                     } else {
-                        println!("- Runtime code");
+                        let _ = sh_println!("- Runtime code");
                     }
-                    println!(
+                    let _ = sh_println!(
                         "  - Refers to item: {}",
                         report
                             .items
@@ -183,7 +183,7 @@ impl CoverageReporter for DebugReporter {
                             .map_or("None".to_owned(), |item| item.to_string())
                     );
                 });
-            println!();
+            sh_println!()?;
         }
 
         Ok(())

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -65,10 +65,8 @@ impl GasReport {
                 // list. This is addressed this way because getting a report you don't expect is
                 // preferable than not getting one you expect. A warning is printed to stderr
                 // indicating the "double listing".
-                eprintln!(
-                    "{}: {} is listed in both 'gas_reports' and 'gas_reports_ignore'.",
-                    "warning".yellow().bold(),
-                    contract_name
+                let _ = sh_warn!(
+                    "{contract_name} is listed in both 'gas_reports' and 'gas_reports_ignore'."
                 );
             }
             return contains_anyway;

--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -11,7 +11,6 @@ use foundry_evm::traces::CallKind;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{collections::BTreeMap, fmt::Display};
-use yansi::Paint;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum GasReportKind {

--- a/crates/forge/src/progress.rs
+++ b/crates/forge/src/progress.rs
@@ -48,7 +48,7 @@ impl TestsProgressState {
     pub fn end_suite_progress(&mut self, suite_name: &String, result_summary: String) {
         if let Some(suite_progress) = self.suites_progress.remove(suite_name) {
             self.multi.suspend(|| {
-                println!("{suite_name}\n  ↪ {result_summary}");
+                let _ = sh_println!("{suite_name}\n  ↪ {result_summary}");
             });
             suite_progress.finish_and_clear();
             // Increment test progress bar to reflect completed test suite.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -163,8 +163,7 @@ impl TestOutcome {
             std::process::exit(1);
         }
 
-        sh_println!()?;
-        sh_println!("Failing tests:")?;
+        sh_println!("\nFailing tests:")?;
         for (suite_name, suite) in outcome.results.iter() {
             let failed = suite.failed();
             if failed == 0 {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -2213,7 +2213,7 @@ forgetest!(gas_report_ignore_some_contracts, |prj, cmd| {
 "#]])
         .stderr_eq(str![[r#"
 ...
-warning: ContractThree is listed in both 'gas_reports' and 'gas_reports_ignore'.
+Warning: ContractThree is listed in both 'gas_reports' and 'gas_reports_ignore'.
 ...
 "#]]);
     cmd.forge_fuse()
@@ -2278,7 +2278,7 @@ warning: ContractThree is listed in both 'gas_reports' and 'gas_reports_ignore'.
         )
         .stderr_eq(str![[r#"
 ...
-warning: ContractThree is listed in both 'gas_reports' and 'gas_reports_ignore'.
+Warning: ContractThree is listed in both 'gas_reports' and 'gas_reports_ignore'.
 ...
 "#]]);
 });

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -73,6 +73,7 @@ contract Verify is Unique {
     .unwrap();
 }
 
+#[allow(clippy::disallowed_macros)]
 fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Result<()> {
     // give etherscan some time to verify the contract
     let retry = Retry::new(retries, Some(Duration::from_secs(30)));
@@ -124,6 +125,7 @@ fn await_verification_response(info: EnvExternalities, mut cmd: TestCommand) {
     parse_verification_result(&mut cmd, 6).expect("Failed to verify check")
 }
 
+#[allow(clippy::disallowed_macros)]
 fn verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: TestCommand) {
     // only execute if keys present
     if let Some(info) = info {
@@ -157,6 +159,7 @@ fn verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: Te
     }
 }
 
+#[allow(clippy::disallowed_macros)]
 fn guess_constructor_args(info: Option<EnvExternalities>, prj: TestProject, mut cmd: TestCommand) {
     // only execute if keys present
     if let Some(info) = info {
@@ -197,6 +200,7 @@ fn guess_constructor_args(info: Option<EnvExternalities>, prj: TestProject, mut 
     }
 }
 
+#[allow(clippy::disallowed_macros)]
 /// Executes create --verify on the given chain
 fn create_verify_on_chain(info: Option<EnvExternalities>, prj: TestProject, mut cmd: TestCommand) {
     // only execute if keys present

--- a/crates/test-utils/src/macros.rs
+++ b/crates/test-utils/src/macros.rs
@@ -37,6 +37,7 @@ macro_rules! forgetest {
         $crate::forgetest!($(#[$attr])* $test, $crate::foundry_compilers::PathStyle::Dapptools, |$prj, $cmd| $e);
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[test]
         $(#[$attr])*
         fn $test() {
@@ -52,6 +53,7 @@ macro_rules! forgetest_async {
         $crate::forgetest_async!($(#[$attr])* $test, $crate::foundry_compilers::PathStyle::Dapptools, |$prj, $cmd| $e);
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[tokio::test(flavor = "multi_thread")]
         $(#[$attr])*
         async fn $test() {
@@ -67,6 +69,7 @@ macro_rules! casttest {
         $crate::casttest!($(#[$attr])* $test, $crate::foundry_compilers::PathStyle::Dapptools, $($async)? |$prj, $cmd| $e);
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[test]
         $(#[$attr])*
         fn $test() {
@@ -75,6 +78,7 @@ macro_rules! casttest {
         }
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, async |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[tokio::test(flavor = "multi_thread")]
         $(#[$attr])*
         async fn $test() {
@@ -86,11 +90,13 @@ macro_rules! casttest {
 
 /// Same as `forgetest` but returns an already initialized project workspace (`forge init`)
 #[macro_export]
+#[allow(clippy::disallowed_macros)]
 macro_rules! forgetest_init {
     ($(#[$attr:meta])* $test:ident, |$prj:ident, $cmd:ident| $e:expr) => {
         $crate::forgetest_init!($(#[$attr])* $test, $crate::foundry_compilers::PathStyle::Dapptools, |$prj, $cmd| $e);
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[test]
         $(#[$attr])*
         fn $test() {
@@ -103,11 +109,13 @@ macro_rules! forgetest_init {
 
 /// Setup forge soldeer
 #[macro_export]
+#[allow(clippy::disallowed_macros)]
 macro_rules! forgesoldeer {
     ($(#[$attr:meta])* $test:ident, |$prj:ident, $cmd:ident| $e:expr) => {
         $crate::forgesoldeer!($(#[$attr])* $test, $crate::foundry_compilers::PathStyle::Dapptools, |$prj, $cmd| $e);
     };
     ($(#[$attr:meta])* $test:ident, $style:expr, |$prj:ident, $cmd:ident| $e:expr) => {
+        #[allow(clippy::disallowed_macros)]
         #[test]
         $(#[$attr])*
         fn $test() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Enforces `common::shell` as added in https://github.com/foundry-rs/foundry/pull/9109 for the `forge` crate

Includes minor fix preferring prepending / appending `\n` in favor of an empty `sh_println!()`

Adds `#[allow(clippy::disallowed_macros)]` to test macros as preparation for enabled clippy enforcement allow you to still use `println`, etc.. in tests. In some specific cases you may need to add  `#[allow(clippy::disallowed_macros)]` above helpers.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Splits out the enforcement of the common shell per binary / large crate to avoid huge diffs making reviews easier