### PR TITLE
fix: remove steps after steps tracing cheatcodes are done

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -771,7 +771,7 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
         // Free up memory by clearing the steps if they are not recorded outside of cheatcode usage.
         if !record_info.original_tracer_config.record_steps {
             tracer.traces_mut().nodes_mut().iter_mut().for_each(|node| {
-                node.trace.steps.clear();
+                node.trace.steps = Vec::new();
             });
         }
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -761,6 +761,13 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
             return Err(Error::from("nothing recorded"))
         };
 
+        // Use the trace nodes to flatten the call trace
+        let root = tracer.traces();
+        let steps = flatten_call_trace(0, root, record_info.start_node_idx);
+
+        let debug_steps: Vec<DebugStep> =
+            steps.iter().map(|&step| convert_call_trace_to_debug_step(step)).collect();
+
         // Free up memory by clearing the steps if they are not recorded outside of cheatcode usage.
         if !record_info.original_tracer_config.record_steps {
             tracer.traces_mut().nodes_mut().iter_mut().for_each(|node| {
@@ -770,13 +777,6 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
 
         // Revert the tracer config to the one before recording
         tracer.update_config(|_config| record_info.original_tracer_config);
-
-        // Use the trace nodes to flatten the call trace
-        let root = tracer.traces();
-        let steps = flatten_call_trace(0, root, record_info.start_node_idx);
-
-        let debug_steps: Vec<DebugStep> =
-            steps.iter().map(|&step| convert_call_trace_to_debug_step(step)).collect();
 
         // Clean up the recording info
         ccx.state.record_debug_steps_info = None;

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -761,6 +761,13 @@ impl Cheatcode for stopAndReturnDebugTraceRecordingCall {
             return Err(Error::from("nothing recorded"))
         };
 
+        // Free up memory by clearing the steps if they are not recorded outside of cheatcode usage.
+        if !record_info.original_tracer_config.record_steps {
+            tracer.traces_mut().nodes_mut().iter_mut().for_each(|node| {
+                node.trace.steps.clear();
+            });
+        }
+
         // Revert the tracer config to the one before recording
         tracer.update_config(|_config| record_info.original_tracer_config);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

ref https://t.me/foundry_support/57540

right now all recorded steps stay in memory until the end of tests execution which is not neccesarry

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
