### PR TITLE
feat(cast): add string-decode to decode string

### DIFF
--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -536,6 +536,19 @@ pub enum CastSubcommand {
         json: bool,
     },
 
+    /// Decode Error string
+    ///
+    /// Similar to `calldata-decode --input`, but function selector is `Error(string)`
+    #[command(visible_aliases = &["--error-decode", "ed"])]
+    ErrorDecode {
+        /// The ABI-encoded error string
+        error: String,
+
+        /// Print the decoded calldata as JSON.
+        #[arg(long, short, help_heading = "Display options")]
+        json: bool,
+    },
+
     /// Decode ABI-encoded input or output data.
     ///
     /// Defaults to decoding output data. To decode input data pass --input.

--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -523,7 +523,7 @@ pub enum CastSubcommand {
     ///
     /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata`
     /// string
-    #[command(visible_aliases = &["--calldata-decode","cdd"])]
+    #[command(visible_aliases = &["--calldata-decode", "cdd"])]
     CalldataDecode {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -536,13 +536,13 @@ pub enum CastSubcommand {
         json: bool,
     },
 
-    /// Decode Error string
+    /// Decode string
     ///
-    /// Similar to `calldata-decode --input`, but function selector is `Error(string)`
-    #[command(visible_aliases = &["--error-decode", "ed"])]
-    ErrorDecode {
-        /// The ABI-encoded error string
-        error: String,
+    /// Similar to `calldata-decode --input`, but the function argument is a `string`
+    #[command(visible_aliases = &["--string-decode", "sd"])]
+    StringDecode {
+        /// The ABI-encoded string
+        data: String,
 
         /// Print the decoded calldata as JSON.
         #[arg(long, short, help_heading = "Display options")]

--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -536,15 +536,15 @@ pub enum CastSubcommand {
         json: bool,
     },
 
-    /// Decode string
+    /// Decode ABI-encoded string.
     ///
     /// Similar to `calldata-decode --input`, but the function argument is a `string`
     #[command(visible_aliases = &["--string-decode", "sd"])]
     StringDecode {
-        /// The ABI-encoded string
+        /// The ABI-encoded string.
         data: String,
 
-        /// Print the decoded calldata as JSON.
+        /// Print the decoded string as JSON.
         #[arg(long, short, help_heading = "Display options")]
         json: bool,
     },

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -205,8 +205,8 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::CalldataEncode { sig, args } => {
             sh_println!("{}", SimpleCast::calldata_encode(sig, &args)?)?;
         }
-        CastSubcommand::ErrorDecode { error, json } => {
-            let tokens = SimpleCast::calldata_decode("Error(string)", &error, true)?;
+        CastSubcommand::StringDecode { data, json } => {
+            let tokens = SimpleCast::calldata_decode("Any(string)", &data, true)?;
             print_tokens(&tokens, json)
         }
         CastSubcommand::Interface(cmd) => cmd.run().await?,

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -205,6 +205,10 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::CalldataEncode { sig, args } => {
             sh_println!("{}", SimpleCast::calldata_encode(sig, &args)?)?;
         }
+        CastSubcommand::ErrorDecode { error, json } => {
+            let tokens = SimpleCast::calldata_decode("Error(string)", &error, true)?;
+            print_tokens(&tokens, json)
+        }
         CastSubcommand::Interface(cmd) => cmd.run().await?,
         CastSubcommand::CreationCode(cmd) => cmd.run().await?,
         CastSubcommand::ConstructorArgs(cmd) => cmd.run().await?,

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1417,6 +1417,13 @@ casttest!(parse_units, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(string_decode, |_prj, cmd| {
+    cmd.args(["string-decode", "0x88c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000054753303235000000000000000000000000000000000000000000000000000000"]).assert_success().stdout_eq(str![[r#"
+"GS025"
+
+"#]]);
+});
+
 casttest!(format_units, |_prj, cmd| {
     cmd.args(["format-units", "1000000", "6"]).assert_success().stdout_eq(str![[r#"
 1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When I'm debugging some transactions that we reverted, what I got from the tx's trace as below:

```json
{
  "from": "0x7567d83b7b8d80addcb281a71d54fc7b3364ffed",
  "gas": "0x0",
  "gasUsed": "0x0",
  "to": "0x5ff0bea4603b68c7e80b8a973a666b9840db248c",
  "input": "0x6a76120200000000000000000000000034053113b5ddc6fb368e4d028c1bbbcb85c14ef1...",
  "output": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000054753303235000000000000000000000000000000000000000000000000000000",
  "error": "execution reverted",
  "calls": [
    {
      "from": "0x5ff0bea4603b68c7e80b8a973a666b9840db248c",
      "gas": "0xbbf0",
      "gasUsed": "0x24cc",
      "to": "0x632cd990566bc2cc888f75c9bbe8b9185a91d24d",
      "input": "0x6a76120200000000000000000000000034053113b5ddc6fb368e4d028c1bbbcb85c14ef1...",
      "output": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000054753303235000000000000000000000000000000000000000000000000000000",
      "error": "execution reverted",
      "type": "DELEGATECALL"
    }
  ],
  "value": "0x0",
  "type": "CALL"
}
```

And this output is ABI-encode of `Error(string)`, so I think we can add a simple command to decode the ABI-string into human readable msg, for this case:

```bash
$ ./target/release/cast 
 string-decode 0x88c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000054753303235000000000000000000000000000000000000000000000000000000

"GS025"
```

Inspired from https://ethereum.stackexchange.com/a/77530


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
