### PR TITLE
chore: avoid unnecessary `mut`

### DIFF
--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -112,10 +112,10 @@ impl PreSimulationState {
         // Executes all transactions from the different forks concurrently.
         let futs = transactions
             .into_iter()
-            .map(|mut transaction| async {
+            .map(|transaction| async {
                 let mut runner = runners.get(&transaction.rpc).expect("invalid rpc url").write();
 
-                let tx = transaction.tx_mut();
+                let tx = transaction.tx();
                 let to = if let Some(TxKind::Call(to)) = tx.to() { Some(to) } else { None };
                 let result = runner
                     .simulate(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This small section seems to have some leftover unnecessary `mut`, even tho no field of `transaction` is changed. 
I believe this was not removed after [moving `ScriptSequence`](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Cleanup `mut` qualifier and related `tx_mut()` method usage in favor of `tx()`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
