### PR TITLE
fix(anvil): on anvil_mine jump to next timestamp before mine new block

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1697,12 +1697,12 @@ impl EthApi {
 
         // mine all the blocks
         for _ in 0..blocks.to::<u64>() {
-            self.mine_one().await;
-
             // If we have an interval, jump forwards in time to the "next" timestamp
             if let Some(interval) = interval {
                 self.backend.time().increase_time(interval);
             }
+
+            self.mine_one().await;
         }
 
         Ok(())

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1009,3 +1009,21 @@ async fn test_mine_blks_with_same_timestamp() {
     // timestamps should be equal
     assert_eq!(blks, vec![init_timestamp; 4]);
 }
+
+// <https://github.com/foundry-rs/foundry/issues/8962>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mine_first_block_with_interval() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let init_blk = provider.get_block(BlockId::latest(), false.into()).await.unwrap().unwrap();
+    let init_timestamp = init_blk.header.timestamp;
+
+    // Mine 2 blocks with interval of 60.
+    let _ = api.anvil_mine(Some(U256::from(2)), Some(U256::from(60))).await;
+
+    let first_block = api.block_by_number(1.into()).await.unwrap().unwrap();
+    assert_eq!(first_block.header.timestamp, init_timestamp + 60);
+
+    let second_block = api.block_by_number(2.into()).await.unwrap().unwrap();
+    assert_eq!(second_block.header.timestamp, init_timestamp + 120);
+}

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1013,10 +1013,10 @@ async fn test_mine_blks_with_same_timestamp() {
 // <https://github.com/foundry-rs/foundry/issues/8962>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mine_first_block_with_interval() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    let provider = handle.http_provider();
-    let init_blk = provider.get_block(BlockId::latest(), false.into()).await.unwrap().unwrap();
-    let init_timestamp = init_blk.header.timestamp;
+    let (api, _) = spawn(NodeConfig::test()).await;
+
+    let init_block = api.block_by_number(0.into()).await.unwrap().unwrap();
+    let init_timestamp = init_block.header.timestamp;
 
     // Mine 2 blocks with interval of 60.
     let _ = api.anvil_mine(Some(U256::from(2)), Some(U256::from(60))).await;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -128,7 +128,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn call<'a>(
+    pub async fn call(
         &self,
         req: &WithOtherFields<TransactionRequest>,
         func: Option<&Function>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #8962 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- when `anvil_mine` jump to next timestamp before mining new block so the timestamp of first block mined respect interval