### PR TITLE
fix(remappings): check if remapping to add starts with existing remapping name

### DIFF
--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -49,11 +49,13 @@ impl Remappings {
     pub fn push(&mut self, remapping: Remapping) {
         if !self.remappings.iter().any(|existing| {
             // What we're doing here is filtering for ambiguous paths. For example, if we have
-            // @prb/math/=node_modules/@prb/math/src/ as existing, and
-            // @prb/=node_modules/@prb/  as the one being checked,
+            // @prb/=node_modules/@prb/ as existing, and
+            // @prb/math/=node_modules/@prb/math/src/  as the one being checked,
             // we want to keep the already existing one, which is the first one. This way we avoid
             // having to deal with ambiguous paths which is unwanted when autodetecting remappings.
-            existing.name.starts_with(&remapping.name) && existing.context == remapping.context
+            // Remappings are added from root of the project down to libraries, so
+            // we want to exclude any conflicting remappings added from libraries.
+            remapping.name.starts_with(&existing.name) && existing.context == remapping.context
         }) {
             self.remappings.push(remapping)
         }

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -46,7 +46,7 @@ impl Remappings {
     }
 
     /// Push an element to the remappings vector, but only if it's not already present.
-    pub fn push(&mut self, remapping: Remapping) {
+    fn push(&mut self, remapping: Remapping) {
         if !self.remappings.iter().any(|existing| {
             // What we're doing here is filtering for ambiguous paths. For example, if we have
             // @prb/=node_modules/@prb/ as existing, and

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -614,8 +614,10 @@ forgetest_init!(test_root_remappings_priority, |prj, cmd| {
     let nested = prj.paths().libraries[0].join("dep1");
     pretty_err(&nested, fs::create_dir_all(&nested));
     let mut lib_config = Config::load_with_root(&nested);
-    lib_config.remappings = vec![Remapping::from_str("@utils/libraries/=src/").unwrap().into()];
-    lib_config.remappings = vec![Remapping::from_str("@another-utils/=src/").unwrap().into()];
+    lib_config.remappings = vec![
+        Remapping::from_str("@utils/libraries/=src/").unwrap().into(),
+        Remapping::from_str("@another-utils/=src/").unwrap().into(),
+    ];
     let lib_toml_file = nested.join("foundry.toml");
     pretty_err(&lib_toml_file, fs::write(&lib_toml_file, lib_config.to_string_pretty().unwrap()));
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -595,6 +595,42 @@ forgetest_init!(can_prioritise_closer_lib_remappings, |prj, cmd| {
     );
 });
 
+// Test that remappings within root of the project have priority over remappings of sub-projects.
+// E.g. `@utils/libraries` mapping from library shouldn't be added if project already has `@utils`
+// remapping.
+// See <https://github.com/foundry-rs/foundry/issues/9146>
+forgetest_init!(test_root_remappings_priority, |prj, cmd| {
+    let mut config = cmd.config();
+    // Add `@utils/` remapping in project config.
+    config.remappings = vec![
+        Remapping::from_str("@utils/=src/").unwrap().into(),
+        Remapping::from_str("@another-utils/libraries/=src/").unwrap().into(),
+    ];
+    let proj_toml_file = prj.paths().root.join("foundry.toml");
+    pretty_err(&proj_toml_file, fs::write(&proj_toml_file, config.to_string_pretty().unwrap()));
+
+    // Create a new lib in the `lib` folder with conflicting `@utils/libraries` remapping.
+    // This should be filtered out from final remappings as root project already has `@utils/`.
+    let nested = prj.paths().libraries[0].join("dep1");
+    pretty_err(&nested, fs::create_dir_all(&nested));
+    let mut lib_config = Config::load_with_root(&nested);
+    lib_config.remappings = vec![Remapping::from_str("@utils/libraries/=src/").unwrap().into()];
+    lib_config.remappings = vec![Remapping::from_str("@another-utils/=src/").unwrap().into()];
+    let lib_toml_file = nested.join("foundry.toml");
+    pretty_err(&lib_toml_file, fs::write(&lib_toml_file, lib_config.to_string_pretty().unwrap()));
+
+    cmd.args(["remappings", "--pretty"]).assert_success().stdout_eq(str![[r#"
+Global:
+- @utils/=src/
+- @another-utils/libraries/=src/
+- @another-utils/=lib/dep1/src/
+- dep1/=lib/dep1/src/
+- forge-std/=lib/forge-std/src/
+
+
+"#]]);
+});
+
 // test to check that foundry.toml libs section updates on install
 forgetest!(can_update_libs_section, |prj, cmd| {
     cmd.git_init();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9146 

check if name of new remapping to be added starts with existing remapping name instead the other way around
e.g. if `@utils` remapping is already added in proj root then `@utils/libraries` from lib should not be added

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
