### PR TITLE
anvil: Correctly set HF fields for Genesis block

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -230,8 +230,10 @@ impl Backend {
             trace!(target: "backend", "using forked blockchain at {}", fork.block_number());
             Blockchain::forked(fork.block_number(), fork.block_hash(), fork.total_difficulty())
         } else {
+            let env = env.read();
             Blockchain::new(
-                &env.read(),
+                &env,
+                env.handler_cfg.spec_id,
                 fees.is_eip1559().then(|| fees.base_fee()),
                 genesis.timestamp,
             )


### PR DESCRIPTION
Some fields were missing for some HF, leading to an invalid Genesis block hash.

This is linked to https://github.com/foundry-rs/foundry/pull/9202

