### PR TITLE
perf: cap default poll interval

### DIFF
--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -270,6 +270,9 @@ impl ProviderBuilder {
             client.set_poll_interval(
                 chain
                     .average_blocktime_hint()
+                    // we cap the poll interval because if not provided, chain would default to
+                    // mainnet
+                    .map(|hint| hint.min(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME))
                     .unwrap_or(DEFAULT_UNKNOWN_CHAIN_BLOCK_TIME)
                     .mul_f32(POLL_INTERVAL_BLOCK_TIME_SCALE_FACTOR),
             );


### PR DESCRIPTION
when we create the provider for cast, we don't necessarily know the chain (no foundry.toml) in which case we'd default to mainnet settings.

so for cast send this would always set a poll interval of ~7s which is not useful.

this now caps to `3s * 0.6` which should improve UX for all chains ~3s blocktime