### PR TITLE
fix: use `Debug` when formatting errors

### DIFF
--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -39,7 +39,7 @@ pub enum AnvilSubcommand {
 
 fn main() {
     if let Err(err) = run() {
-        let _ = foundry_common::Shell::get().error(&err);
+        let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }
 }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -39,7 +39,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
     if let Err(err) = run() {
-        let _ = foundry_common::Shell::get().error(&err);
+        let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }
 }

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -108,7 +108,7 @@ pub enum ChiselSubcommand {
 
 fn main() {
     if let Err(err) = run() {
-        let _ = foundry_common::Shell::get().error(&err);
+        let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }
 }

--- a/crates/cli/src/handler.rs
+++ b/crates/cli/src/handler.rs
@@ -15,7 +15,6 @@ impl EyreHandler for Handler {
         if f.alternate() {
             return core::fmt::Debug::fmt(error, f)
         }
-        writeln!(f)?;
         write!(f, "{}", error.red())?;
 
         if let Some(cause) = error.source() {

--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -321,9 +321,9 @@ impl Shell {
     /// This will render a message in [ERROR] style with a bold `Error: ` prefix.
     ///
     /// **Note**: will log regardless of the verbosity level.
-    pub fn error(&mut self, message: impl fmt::Display) -> Result<()> {
+    pub fn error(&mut self, message: impl fmt::Debug) -> Result<()> {
         self.maybe_err_erase_line();
-        self.output.message_stderr(&"Error", &ERROR, Some(&message), false)
+        self.output.message_stderr(&"Error", &ERROR, Some(&format!("{message:?}")), false)
     }
 
     /// Prints an amber 'warning' message. Use the [`sh_warn!`] macro instead.

--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -321,9 +321,9 @@ impl Shell {
     /// This will render a message in [ERROR] style with a bold `Error: ` prefix.
     ///
     /// **Note**: will log regardless of the verbosity level.
-    pub fn error(&mut self, message: impl fmt::Debug) -> Result<()> {
+    pub fn error(&mut self, message: impl fmt::Display) -> Result<()> {
         self.maybe_err_erase_line();
-        self.output.message_stderr(&"Error", &ERROR, Some(&format!("{message:?}")), false)
+        self.output.message_stderr(&"Error", &ERROR, Some(&message), false)
     }
 
     /// Prints an amber 'warning' message. Use the [`sh_warn!`] macro instead.

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -22,7 +22,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
     if let Err(err) = run() {
-        let _ = foundry_common::Shell::get().error(&err);
+        let _ = foundry_common::sh_err!("{err:?}");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

`Display` might not include complete context for errors. e.g eyre's `wrap_err` only includes top-level message in `Display` impl. `cargo run` uses `Debug` when formatting errors from `main` as well



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
