### PR TITLE
fix: better error handling when waiting for receipt

### DIFF
--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -2,7 +2,7 @@ use alloy_chains::Chain;
 use alloy_primitives::{utils::format_units, TxHash, U256};
 use alloy_provider::{PendingTransactionBuilder, PendingTransactionError, Provider, WatchTxError};
 use alloy_rpc_types::AnyTransactionReceipt;
-use eyre::{Result};
+use eyre::Result;
 use foundry_common::provider::RetryProvider;
 use std::time::Duration;
 
@@ -47,7 +47,7 @@ pub async fn check_tx_status(
             {
                 Ok(receipt) => return Ok(receipt.into()),
                 // do nothing on timeout, we will check whether tx is dropped below
-                Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout)) => {},
+                Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout)) => {}
                 // treat other errors as fatal
                 Err(e) => return Err(e.into()),
             }

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -1,8 +1,8 @@
 use alloy_chains::Chain;
 use alloy_primitives::{utils::format_units, TxHash, U256};
-use alloy_provider::{PendingTransactionBuilder, Provider};
+use alloy_provider::{PendingTransactionBuilder, PendingTransactionError, Provider, WatchTxError};
 use alloy_rpc_types::AnyTransactionReceipt;
-use eyre::Result;
+use eyre::{Result};
 use foundry_common::provider::RetryProvider;
 use std::time::Duration;
 
@@ -40,12 +40,16 @@ pub async fn check_tx_status(
         }
 
         loop {
-            if let Ok(receipt) = PendingTransactionBuilder::new(provider.clone(), hash)
+            match PendingTransactionBuilder::new(provider.clone(), hash)
                 .with_timeout(Some(Duration::from_secs(timeout)))
                 .get_receipt()
                 .await
             {
-                return Ok(receipt.into())
+                Ok(receipt) => return Ok(receipt.into()),
+                // do nothing on timeout, we will check whether tx is dropped below
+                Err(PendingTransactionError::TxWatcher(WatchTxError::Timeout)) => {},
+                // treat other errors as fatal
+                Err(e) => return Err(e.into()),
             }
 
             if provider.get_transaction_by_hash(hash).await?.is_some() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

ref https://github.com/foundry-rs/foundry/issues/9239

we should only continue trying if we've got a timeout, all other errors (like deser error) should be fatal

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
