### PR TITLE
fix(anvil): set auto-unlock an alias of auto-impersonate

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -561,7 +561,8 @@ pub struct AnvilEvmArgs {
     #[arg(long, visible_alias = "no-console-log")]
     pub disable_console_log: bool,
 
-    /// Enable autoImpersonate on startup
+    /// Enables automatic impersonation on startup. This allows any transaction sender to be
+    /// simulated as different accounts, which is useful for testing contract behavior.
     #[arg(long, visible_alias = "auto-unlock")]
     pub auto_impersonate: bool,
 

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -562,7 +562,7 @@ pub struct AnvilEvmArgs {
     pub disable_console_log: bool,
 
     /// Enable autoImpersonate on startup
-    #[arg(long, visible_alias = "auto-impersonate")]
+    #[arg(long, visible_alias = "auto-unlock")]
     pub auto_impersonate: bool,
 
     /// Run an Optimism chain


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The alias of `auto-impersonate` is no diff of the original value:

```bash
$ anvil --help 
      --auto-impersonate
          Enable autoImpersonate on startup

          [aliases: auto-impersonate]
```

And as `--unlocked` has different meanings in `cast`(ref https://github.com/foundry-rs/foundry/pull/5335#discussion_r1257186166)

So let's add `auto-unlock` as an alias of this argument.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
