### PR TITLE
fix(`forge doc`): display custom natspec tag

### DIFF
--- a/crates/doc/src/parser/comment.rs
+++ b/crates/doc/src/parser/comment.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::map::HashMap;
-use derive_more::{Deref, DerefMut};
+use derive_more::{derive::Display, Deref, DerefMut};
 use solang_parser::doccomment::DocCommentTag;
 
 /// The natspec comment tag explaining the purpose of the comment.
 /// See: <https://docs.soliditylang.org/en/v0.8.17/natspec-format.html#tags>.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 pub enum CommentTag {
     /// A title that should describe the contract/interface
     Title,

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -64,8 +64,9 @@ impl AsDoc for CommentsRef<'_> {
             writer.write_bold(&format!("Note{}:", if customs.len() == 1 { "" } else { "s" }))?;
             for c in customs.iter() {
                 writer.writeln_raw(format!(
-                    "{}{}",
+                    "{}{}: {}",
                     if customs.len() == 1 { "" } else { "- " },
+                    &c.tag,
                     &c.value
                 ))?;
                 writer.writeln()?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Display custom natspec tag when generating documentation with `forge doc`.

- Follow up of #9075.
- Address this [comment](https://github.com/foundry-rs/foundry/pull/9075#issuecomment-2451451919).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Custom natspec comments are now preceded by their tag.

<img width="2471" alt="Screenshot 2024-11-04 at 10 10 34" src="https://github.com/user-attachments/assets/0787821b-fc9f-4a85-86e4-5cc69ecf5889">

