### PR TITLE
chore: do not print anvil port if silent

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -295,17 +295,19 @@ impl NodeHandle {
     /// Prints the launch info.
     pub(crate) fn print(&self, fork: Option<&ClientFork>) {
         self.config.print(fork);
-        if let Some(ipc_path) = self.ipc_path() {
-            let _ = sh_println!("IPC path: {ipc_path}");
+        if !self.config.silent {
+            if let Some(ipc_path) = self.ipc_path() {
+                let _ = sh_println!("IPC path: {ipc_path}");
+            }
+            let _ = sh_println!(
+                "Listening on {}",
+                self.addresses
+                    .iter()
+                    .map(|addr| { addr.to_string() })
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            );
         }
-        let _ = sh_println!(
-            "Listening on {}",
-            self.addresses
-                .iter()
-                .map(|addr| { addr.to_string() })
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
     }
 
     /// The address of the launched server.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Do not pring anvil port if silent (tests), same as old behavior
https://github.com/foundry-rs/foundry/blob/3ff3d0562215bca620e07c5c4c154eec8da0f04b/crates/anvil/src/lib.rs#L292-L308

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
