### PR TITLE
chore(`common::shell`): finish implementation + enforce  in `clippy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,6 +3424,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "forge-fmt",
+ "foundry-common",
  "foundry-compilers",
  "foundry-config",
  "itertools 0.13.0",
@@ -3901,7 +3902,6 @@ dependencies = [
  "toml_edit",
  "tracing",
  "walkdir",
- "yansi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,6 +3902,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "walkdir",
+ "yansi",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,10 +3,10 @@ msrv = "1.80"
 # so it is safe to ignore it as well
 ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]
 
-# disallowed-macros = [
-#     # See `foundry_common::shell`
-#     { path = "std::print", reason = "use `sh_print` or similar macros instead" },
-#     { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
-#     { path = "std::println", reason = "use `sh_println` or similar macros instead" },
-#     { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
-# ]
+disallowed-macros = [
+    # See `foundry_common::shell`
+    { path = "std::print", reason = "use `sh_print` or similar macros instead" },
+    { path = "std::eprint", reason = "use `sh_eprint` or similar macros instead" },
+    { path = "std::println", reason = "use `sh_println` or similar macros instead" },
+    { path = "std::eprintln", reason = "use `sh_eprintln` or similar macros instead" },
+]

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -205,6 +205,7 @@ async fn can_check_blob_fields_on_genesis() {
     assert_eq!(block.header.excess_blob_gas, Some(0));
 }
 
+#[allow(clippy::disallowed_macros)]
 #[tokio::test(flavor = "multi_thread")]
 async fn can_correctly_estimate_blob_gas_with_recommended_fillers() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
@@ -247,6 +248,7 @@ async fn can_correctly_estimate_blob_gas_with_recommended_fillers() {
     );
 }
 
+#[allow(clippy::disallowed_macros)]
 #[tokio::test(flavor = "multi_thread")]
 async fn can_correctly_estimate_blob_gas_with_recommended_fillers_with_signer() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));

--- a/crates/anvil/tests/it/pubsub.rs
+++ b/crates/anvil/tests/it/pubsub.rs
@@ -247,6 +247,7 @@ async fn test_subscriptions() {
     assert_eq!(blocks, vec![1, 2, 3])
 }
 
+#[allow(clippy::disallowed_macros)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sub_new_heads_fast() {
     let (api, handle) = spawn(NodeConfig::test()).await;

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -12,7 +12,7 @@ use foundry_cli::{handler, utils};
 use foundry_common::{
     abi::get_event,
     ens::{namehash, ProviderEnsExt},
-    fmt::{format_uint_exp, print_tokens},
+    fmt::{format_tokens, format_tokens_raw, format_uint_exp},
     fs,
     selectors::{
         decode_calldata, decode_event_topic, decode_function_selector, decode_selectors,
@@ -135,11 +135,11 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::ParseUnits { value, unit } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::parse_units(&value, unit)?);
+            sh_println!("{}", SimpleCast::parse_units(&value, unit)?)?;
         }
         CastSubcommand::FormatUnits { value, unit } => {
             let value = stdin::unwrap_line(value)?;
-            println!("{}", SimpleCast::format_units(&value, unit)?);
+            sh_println!("{}", SimpleCast::format_units(&value, unit)?)?;
         }
         CastSubcommand::FromWei { value, unit } => {
             let value = stdin::unwrap_line(value)?;
@@ -189,7 +189,15 @@ async fn main_args(args: CastArgs) -> Result<()> {
         // ABI encoding & decoding
         CastSubcommand::AbiDecode { sig, calldata, input } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
-            print_tokens(&tokens, shell::is_json())
+            if shell::is_json() {
+                let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+                sh_println!("{}", serde_json::to_string_pretty(&tokens).unwrap())?;
+            } else {
+                let tokens = format_tokens(&tokens);
+                tokens.for_each(|t| {
+                    let _ = sh_println!("{t}");
+                });
+            }
         }
         CastSubcommand::AbiEncode { sig, packed, args } => {
             if !packed {
@@ -200,14 +208,30 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::CalldataDecode { sig, calldata } => {
             let tokens = SimpleCast::calldata_decode(&sig, &calldata, true)?;
-            print_tokens(&tokens, shell::is_json())
+            if shell::is_json() {
+                let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+                sh_println!("{}", serde_json::to_string_pretty(&tokens).unwrap())?;
+            } else {
+                let tokens = format_tokens(&tokens);
+                tokens.for_each(|t| {
+                    let _ = sh_println!("{t}");
+                });
+            }
         }
         CastSubcommand::CalldataEncode { sig, args } => {
             sh_println!("{}", SimpleCast::calldata_encode(sig, &args)?)?;
         }
         CastSubcommand::StringDecode { data } => {
             let tokens = SimpleCast::calldata_decode("Any(string)", &data, true)?;
-            print_tokens(&tokens, shell::is_json())
+            if shell::is_json() {
+                let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+                sh_println!("{}", serde_json::to_string_pretty(&tokens).unwrap())?;
+            } else {
+                let tokens = format_tokens(&tokens);
+                tokens.for_each(|t| {
+                    let _ = sh_println!("{t}");
+                });
+            }
         }
         CastSubcommand::Interface(cmd) => cmd.run().await?,
         CastSubcommand::CreationCode(cmd) => cmd.run().await?,
@@ -482,7 +506,15 @@ async fn main_args(args: CastArgs) -> Result<()> {
             };
 
             let tokens = SimpleCast::calldata_decode(sig, &calldata, true)?;
-            print_tokens(&tokens, shell::is_json())
+            if shell::is_json() {
+                let tokens: Vec<String> = format_tokens_raw(&tokens).collect();
+                sh_println!("{}", serde_json::to_string_pretty(&tokens).unwrap())?;
+            } else {
+                let tokens = format_tokens(&tokens);
+                tokens.for_each(|t| {
+                    let _ = sh_println!("{t}");
+                });
+            }
         }
         CastSubcommand::FourByteEvent { topic } => {
             let topic = stdin::unwrap_line(topic)?;

--- a/crates/cheatcodes/spec/src/lib.rs
+++ b/crates/cheatcodes/spec/src/lib.rs
@@ -103,6 +103,7 @@ impl Cheatcodes<'static> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     use super::*;
     use std::{fs, path::Path};

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -620,11 +620,11 @@ fn prompt(
 
     match rx.recv_timeout(timeout) {
         Ok(res) => res.map_err(|err| {
-            println!();
+            let _ = sh_println!();
             err.to_string().into()
         }),
         Err(_) => {
-            println!();
+            let _ = sh_eprintln!();
             Err("Prompt timed out".into())
         }
     }

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -7,7 +7,11 @@
 #![allow(elided_lifetimes_in_paths)] // Cheats context uses 3 lifetimes
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 pub extern crate foundry_cheatcodes_spec as spec;
+
 #[macro_use]
 extern crate tracing;
 

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -128,9 +128,8 @@ pub fn needs_setup(abi: &JsonAbi) -> bool {
 
     for setup_fn in setup_fns.iter() {
         if setup_fn.name != "setUp" {
-            println!(
-                "{} Found invalid setup function \"{}\" did you mean \"setUp()\"?",
-                "Warning:".yellow().bold(),
+            let _ = sh_warn!(
+                "Found invalid setup function \"{}\" did you mean \"setUp()\"?",
                 setup_fn.signature()
             );
         }
@@ -450,19 +449,19 @@ pub async fn print_traces(
 ) -> Result<()> {
     let traces = result.traces.as_mut().expect("No traces found");
 
-    println!("Traces:");
+    sh_println!("Traces:")?;
     for (_, arena) in traces {
         decode_trace_arena(arena, decoder).await?;
-        println!("{}", render_trace_arena_with_bytecodes(arena, verbose));
+        sh_println!("{}", render_trace_arena_with_bytecodes(arena, verbose))?;
     }
-    println!();
+    sh_println!()?;
 
     if result.success {
-        println!("{}", "Transaction successfully executed.".green());
+        sh_println!("{}", "Transaction successfully executed.".green())?;
     } else {
-        println!("{}", "Transaction failed.".red());
+        sh_err!("Transaction failed.")?;
     }
 
-    println!("Gas used: {}", result.gas_used);
+    sh_println!("Gas used: {}", result.gas_used)?;
     Ok(())
 }

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -132,18 +132,6 @@ pub fn format_tokens_raw(tokens: &[DynSolValue]) -> impl Iterator<Item = String>
     tokens.iter().map(format_token_raw)
 }
 
-/// Prints slice of tokens using [`format_tokens`] or [`format_tokens_raw`] depending on `json`
-/// parameter.
-pub fn print_tokens(tokens: &[DynSolValue], json: bool) {
-    if json {
-        let tokens: Vec<String> = format_tokens_raw(tokens).collect();
-        println!("{}", serde_json::to_string_pretty(&tokens).unwrap());
-    } else {
-        let tokens = format_tokens(tokens);
-        tokens.for_each(|t| println!("{t}"));
-    }
-}
-
 /// Pretty-prints the given value into a string suitable for user output.
 pub fn format_token(value: &DynSolValue) -> String {
     DynValueDisplay::new(value, false).to_string()

--- a/crates/common/fmt/src/lib.rs
+++ b/crates/common/fmt/src/lib.rs
@@ -4,9 +4,7 @@ mod console;
 pub use console::{console_format, ConsoleFmt, FormatSpec};
 
 mod dynamic;
-pub use dynamic::{
-    format_token, format_token_raw, format_tokens, format_tokens_raw, parse_tokens, print_tokens,
-};
+pub use dynamic::{format_token, format_token_raw, format_tokens, format_tokens_raw, parse_tokens};
 
 mod exp;
 pub use exp::{format_int_exp, format_uint_exp, to_exp_notation};

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -146,9 +146,9 @@ pub fn find_source(
             Ok(source)
         } else {
             let implementation = metadata.implementation.unwrap();
-            println!(
+            sh_println!(
                 "Contract at {address} is a proxy, trying to fetch source at {implementation}..."
-            );
+            )?;
             match find_source(client, implementation).await {
                 impl_source @ Ok(_) => impl_source,
                 Err(e) => {

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -127,7 +127,7 @@ impl ProjectCompiler {
     pub fn compile<C: Compiler>(mut self, project: &Project<C>) -> Result<ProjectCompileOutput<C>> {
         // TODO: Avoid process::exit
         if !project.paths.has_input_files() && self.files.is_empty() {
-            println!("Nothing to compile");
+            sh_println!("Nothing to compile")?;
             // nothing to do here
             std::process::exit(0);
         }
@@ -182,10 +182,10 @@ impl ProjectCompiler {
 
         if !quiet {
             if output.is_unchanged() {
-                println!("No files changed, compilation skipped");
+                sh_println!("No files changed, compilation skipped")?;
             } else {
                 // print the compiler output / warnings
-                println!("{output}");
+                sh_println!("{output}")?;
             }
 
             self.handle_output(&output);
@@ -206,12 +206,14 @@ impl ProjectCompiler {
                 artifacts.entry(version).or_default().push(name);
             }
             for (version, names) in artifacts {
-                println!(
+                let _ = sh_println!(
                     "  compiler version: {}.{}.{}",
-                    version.major, version.minor, version.patch
+                    version.major,
+                    version.minor,
+                    version.patch
                 );
                 for name in names {
-                    println!("    - {name}");
+                    let _ = sh_println!("    - {name}");
                 }
             }
         }
@@ -219,7 +221,7 @@ impl ProjectCompiler {
         if print_sizes {
             // add extra newline if names were already printed
             if print_names {
-                println!();
+                let _ = sh_println!();
             }
 
             let mut size_report = SizeReport { contracts: BTreeMap::new() };
@@ -252,7 +254,7 @@ impl ProjectCompiler {
                     .insert(name, ContractInfo { runtime_size, init_size, is_dev_contract });
             }
 
-            println!("{size_report}");
+            let _ = sh_println!("{size_report}");
 
             // TODO: avoid process::exit
             // exit with error if any contract exceeds the size limit, excluding test contracts.

--- a/crates/common/src/ens.rs
+++ b/crates/common/src/ens.rs
@@ -123,7 +123,9 @@ pub trait ProviderEnsExt<T: Transport + Clone, N: Network, P: Provider<T, N>> {
             .call()
             .await
             .map_err(EnsError::Resolve)
-            .inspect_err(|e| eprintln!("{e:?}"))?
+            .inspect_err(|e| {
+                let _ = sh_eprintln!("{e:?}");
+            })?
             ._0;
         Ok(addr)
     }

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -492,24 +492,20 @@ pub struct SelectorImportResponse {
 impl SelectorImportResponse {
     /// Print info about the functions which were uploaded or already known
     pub fn describe(&self) {
-        self.result
-            .function
-            .imported
-            .iter()
-            .for_each(|(k, v)| println!("Imported: Function {k}: {v}"));
-        self.result.event.imported.iter().for_each(|(k, v)| println!("Imported: Event {k}: {v}"));
-        self.result
-            .function
-            .duplicated
-            .iter()
-            .for_each(|(k, v)| println!("Duplicated: Function {k}: {v}"));
-        self.result
-            .event
-            .duplicated
-            .iter()
-            .for_each(|(k, v)| println!("Duplicated: Event {k}: {v}"));
+        self.result.function.imported.iter().for_each(|(k, v)| {
+            let _ = sh_println!("Imported: Function {k}: {v}");
+        });
+        self.result.event.imported.iter().for_each(|(k, v)| {
+            let _ = sh_println!("Imported: Event {k}: {v}");
+        });
+        self.result.function.duplicated.iter().for_each(|(k, v)| {
+            let _ = sh_println!("Duplicated: Function {k}: {v}");
+        });
+        self.result.event.duplicated.iter().for_each(|(k, v)| {
+            let _ = sh_println!("Duplicated: Event {k}: {v}");
+        });
 
-        println!("Selectors successfully uploaded to OpenChain");
+        let _ = sh_println!("Selectors successfully uploaded to OpenChain");
     }
 }
 
@@ -579,6 +575,7 @@ pub fn parse_signatures(tokens: Vec<String>) -> ParsedSignatures {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 #[allow(clippy::needless_return)]
 mod tests {
     use super::*;

--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -72,7 +72,7 @@ impl Spinner {
 
         let indicator = self.indicator[self.idx % self.indicator.len()].green();
         let indicator = Paint::new(format!("[{indicator}]")).bold();
-        print!("\r\x33[2K\r{indicator} {}", self.message);
+        let _ = sh_print!("\r\x33[2K\r{indicator} {}", self.message);
         io::stdout().flush().unwrap();
 
         self.idx = self.idx.wrapping_add(1);
@@ -112,11 +112,11 @@ impl SpinnerReporter {
                         Ok(SpinnerMsg::Msg(msg)) => {
                             spinner.message(msg);
                             // new line so past messages are not overwritten
-                            println!();
+                            let _ = sh_println!();
                         }
                         Ok(SpinnerMsg::Shutdown(ack)) => {
                             // end with a newline
-                            println!();
+                            let _ = sh_println!();
                             let _ = ack.send(());
                             break
                         }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -43,6 +43,7 @@ toml = { version = "0.8", features = ["preserve_order"] }
 toml_edit = "0.22.4"
 tracing.workspace = true
 walkdir.workspace = true
+yansi.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.2.1"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -43,7 +43,6 @@ toml = { version = "0.8", features = ["preserve_order"] }
 toml_edit = "0.22.4"
 tracing.workspace = true
 walkdir.workspace = true
-yansi.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 path-slash = "0.2.1"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -957,12 +957,7 @@ impl Config {
             return match rx.recv_timeout(Duration::from_secs(1)) {
                 Ok(res) => res,
                 Err(RecvTimeoutError::Timeout) => {
-                    eprintln!(
-                        "{}",
-                        yansi::Paint::yellow(
-                            "Pulling Docker image for eof-solc, this might take some time..."
-                        )
-                    );
+                    // sh_warn!("Pulling Docker image for eof-solc, this might take some time...");
                     rx.recv().expect("sender dropped")
                 }
                 Err(RecvTimeoutError::Disconnected) => panic!("sender dropped"),
@@ -4897,6 +4892,7 @@ mod tests {
     }
 
     // a test to print the config, mainly used to update the example config in the README
+    #[allow(clippy::disallowed_macros)]
     #[test]
     #[ignore]
     fn print_config() {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -933,6 +933,7 @@ impl Config {
     /// it's missing, unless the `offline` flag is enabled, in which case an error is thrown.
     ///
     /// If `solc` is [`SolcReq::Local`] then this will ensure that the path exists.
+    #[allow(clippy::disallowed_macros)]
     fn ensure_solc(&self) -> Result<Option<Solc>, SolcError> {
         if self.eof {
             let (tx, rx) = mpsc::channel();
@@ -957,7 +958,14 @@ impl Config {
             return match rx.recv_timeout(Duration::from_secs(1)) {
                 Ok(res) => res,
                 Err(RecvTimeoutError::Timeout) => {
-                    // sh_warn!("Pulling Docker image for eof-solc, this might take some time...");
+                    // `sh_warn!` is a circular dependency, preventing us from using it here.
+                    eprintln!(
+                        "{}",
+                        yansi::Paint::yellow(
+                            "Pulling Docker image for eof-solc, this might take some time..."
+                        )
+                    );
+
                     rx.recv().expect("sender dropped")
                 }
                 Err(RecvTimeoutError::Disconnected) => panic!("sender dropped"),

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -48,7 +48,7 @@ impl Debugger {
         let code = match self.try_run_tui() {
             Ok(ExitReason::CharExit) => 0,
             Err(e) => {
-                println!("{e}");
+                let _ = sh_eprintln!("{e}");
                 1
             }
         };

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 extern crate tracing;
 
 mod op;

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 forge-fmt.workspace = true
+foundry-common.workspace = true
 foundry-compilers.workspace = true
 foundry-config.workspace = true
 

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -105,7 +105,7 @@ impl DocBuilder {
             .collect::<Vec<_>>();
 
         if sources.is_empty() {
-            println!("No sources detected at {}", self.sources.display());
+            sh_println!("No sources detected at {}", self.sources.display())?;
             return Ok(())
         }
 

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 extern crate tracing;
 
 mod builder;

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 extern crate tracing;
 
 use alloy_primitives::{map::HashMap, Bytes, B256};
@@ -237,7 +240,7 @@ impl HitMap {
         if let (Some(len1), Some(len2)) = (len1, len2) {
             let len = std::cmp::max(len1.0, len2.0);
             let ok = hm1.bytecode.0[..*len] == hm2.bytecode.0[..*len];
-            println!("consistent_bytecode: {}, {}, {}, {}", ok, len1.0, len2.0, len);
+            let _ = sh_println!("consistent_bytecode: {}, {}, {}, {}", ok, len1.0, len2.0, len);
             return ok;
         }
         true

--- a/crates/evm/traces/src/identifier/etherscan.rs
+++ b/crates/evm/traces/src/identifier/etherscan.rs
@@ -65,7 +65,7 @@ impl EtherscanIdentifier {
             // filter out vyper files
             .filter(|(_, metadata)| !metadata.is_vyper())
             .map(|(address, metadata)| async move {
-                println!("Compiling: {} {address}", metadata.contract_name);
+                sh_println!("Compiling: {} {address}", metadata.contract_name)?;
                 let root = tempfile::tempdir()?;
                 let root_path = root.path();
                 let project = etherscan_project(metadata, root_path)?;

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 extern crate tracing;
 
 use foundry_common::contracts::{ContractsByAddress, ContractsByArtifact};

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -97,10 +97,8 @@ impl DependencyInstallOpts {
             let _ = sh_println!("Missing dependencies found. Installing now...\n");
             self.no_commit = true;
             if self.install(config, Vec::new()).is_err() {
-                let _ = sh_warn!(
-                    "{}",
-                    "Your project has missing dependencies that could not be installed."
-                );
+                let _ =
+                    sh_warn!("Your project has missing dependencies that could not be installed.");
             }
             true
         } else {

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -908,7 +908,7 @@ fn list(runner: MultiContractRunner, filter: &ProjectPathsAwareFilter) -> Result
     let results = runner.list(filter);
 
     if shell::is_json() {
-        println!("{}", serde_json::to_string(&results)?);
+        sh_println!("{}", serde_json::to_string(&results)?)?;
     } else {
         for (file, contracts) in results.iter() {
             sh_println!("{file}")?;

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -255,7 +255,7 @@ For more information, please see https://eips.ethereum.org/EIPS/eip-3855",
                     .map(|(_, chain)| *chain as u64)
                     .format(", ")
             );
-            sh_warn!("{}", msg)?;
+            sh_warn!("{msg}")?;
         }
         Ok(())
     }

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -13,7 +13,6 @@ use foundry_evm::{
     traces::{TraceKind, Traces},
 };
 use std::collections::VecDeque;
-use yansi::Paint;
 
 /// Drives script execution
 #[derive(Debug)]
@@ -248,7 +247,7 @@ impl ScriptRunner {
                 Ok(DeployResult { address, raw }) => (address, raw),
                 Err(EvmError::Execution(err)) => {
                     let ExecutionErr { raw, reason } = *err;
-                    println!("{}", format!("\nFailed with `{reason}`:\n").red());
+                    sh_err!("Failed with `{reason}`:\n")?;
                     (Address::ZERO, raw)
                 }
                 Err(e) => eyre::bail!("Failed deploying contract: {e:?}"),

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -151,8 +151,8 @@ impl PreSimulationState {
             .collect::<Vec<_>>();
 
         if self.script_config.evm_opts.verbosity > 3 {
-            println!("==========================");
-            println!("Simulated On-chain Traces:\n");
+            sh_println!("==========================")?;
+            sh_println!("Simulated On-chain Traces:\n")?;
         }
 
         let mut abort = false;
@@ -163,7 +163,7 @@ impl PreSimulationState {
             if tx.is_none() || self.script_config.evm_opts.verbosity > 3 {
                 for (_, trace) in &mut traces {
                     decode_trace_arena(trace, &self.execution_artifacts.decoder).await?;
-                    println!("{}", render_trace_arena(trace));
+                    sh_println!("{}", render_trace_arena(trace))?;
                 }
             }
 

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -12,7 +12,6 @@ use foundry_common::ContractsByArtifact;
 use foundry_compilers::{info::ContractInfo, Project};
 use foundry_config::{Chain, Config};
 use semver::Version;
-use yansi::Paint;
 
 /// State after we have broadcasted the script.
 /// It is assumed that at this point [BroadcastedState::sequence] contains receipts for all
@@ -218,13 +217,15 @@ async fn verify_contracts(
 
         let num_verifications = future_verifications.len();
         let mut num_of_successful_verifications = 0;
-        println!("##\nStart verification for ({num_verifications}) contracts");
+        sh_println!("##\nStart verification for ({num_verifications}) contracts")?;
         for verification in future_verifications {
             match verification.await {
                 Ok(_) => {
                     num_of_successful_verifications += 1;
                 }
-                Err(err) => eprintln!("Error during verification: {err:#}"),
+                Err(err) => {
+                    sh_err!("Failed to verify contract: {err:#}")?;
+                }
             }
         }
 
@@ -232,7 +233,7 @@ async fn verify_contracts(
             return Err(eyre!("Not all ({num_of_successful_verifications} / {num_verifications}) contracts were verified!"))
         }
 
-        println!("All ({num_verifications}) contracts were verified!");
+        sh_println!("All ({num_verifications}) contracts were verified!")?;
     }
 
     Ok(())
@@ -244,15 +245,9 @@ fn check_unverified(
     verify: VerifyBundle,
 ) {
     if !unverifiable_contracts.is_empty() {
-        println!(
-            "\n{}",
-            format!(
-                "We haven't found any matching bytecode for the following contracts: {:?}.\n\n{}",
-                unverifiable_contracts,
-                "This may occur when resuming a verification, but the underlying source code or compiler version has changed."
-            )
-            .yellow()
-            .bold(),
+        let _ = sh_warn!(
+            "We haven't found any matching bytecode for the following contracts: {:?}.\n\nThis may occur when resuming a verification, but the underlying source code or compiler version has changed.",
+            unverifiable_contracts
         );
 
         if let Some(commit) = &sequence.commit {
@@ -263,7 +258,9 @@ fn check_unverified(
                 .unwrap_or_default();
 
             if &current_commit != commit {
-                println!("\tScript was broadcasted on commit `{commit}`, but we are at `{current_commit}`.");
+                let _ = sh_warn!(
+                    "Script was broadcasted on commit `{commit}`, but we are at `{current_commit}`."
+                );
             }
         }
     }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
+extern crate foundry_common;
+
+#[macro_use]
 extern crate tracing;
 
 // Macros useful for testing.

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -177,7 +177,7 @@ fn next_url(is_ws: bool, chain: NamedChain) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::needless_return)]
+#[allow(clippy::needless_return, clippy::disallowed_macros)]
 mod tests {
     use super::*;
     use alloy_primitives::address;
@@ -190,7 +190,7 @@ mod tests {
         let mut first_abi = None;
         let mut failed = Vec::new();
         for (i, &key) in ETHERSCAN_MAINNET_KEYS.iter().enumerate() {
-            eprintln!("trying key {i} ({key})");
+            println!("trying key {i} ({key})");
 
             let client = foundry_block_explorers::Client::builder()
                 .chain(Chain::mainnet())

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -141,7 +141,7 @@ impl ExtTester {
     pub fn run(&self) {
         // Skip fork tests if the RPC url is not set.
         if self.fork_block.is_some() && std::env::var_os("ETH_RPC_URL").is_none() {
-            eprintln!("ETH_RPC_URL is not set; skipping");
+            let _ = sh_eprintln!("ETH_RPC_URL is not set; skipping");
             return;
         }
 
@@ -159,7 +159,7 @@ impl ExtTester {
         if self.rev.is_empty() {
             let mut git = Command::new("git");
             git.current_dir(root).args(["log", "-n", "1"]);
-            eprintln!("$ {git:?}");
+            let _ = sh_println!("$ {git:?}");
             let output = git.output().unwrap();
             if !output.status.success() {
                 panic!("git log failed: {output:?}");
@@ -170,7 +170,7 @@ impl ExtTester {
         } else {
             let mut git = Command::new("git");
             git.current_dir(root).args(["checkout", self.rev]);
-            eprintln!("$ {git:?}");
+            let _ = sh_println!("$ {git:?}");
             let status = git.status().unwrap();
             if !status.success() {
                 panic!("git checkout failed: {status}");
@@ -181,15 +181,17 @@ impl ExtTester {
         for install_command in &self.install_commands {
             let mut install_cmd = Command::new(&install_command[0]);
             install_cmd.args(&install_command[1..]).current_dir(root);
-            eprintln!("cd {root}; {install_cmd:?}");
+            let _ = sh_println!("cd {root}; {install_cmd:?}");
             match install_cmd.status() {
                 Ok(s) => {
-                    eprintln!("\n\n{install_cmd:?}: {s}");
+                    let _ = sh_println!("\n\n{install_cmd:?}: {s}");
                     if s.success() {
                         break;
                     }
                 }
-                Err(e) => eprintln!("\n\n{install_cmd:?}: {e}"),
+                Err(e) => {
+                    let _ = sh_eprintln!("\n\n{install_cmd:?}: {e}");
+                }
             }
         }
 
@@ -223,7 +225,7 @@ impl ExtTester {
 /// runs each test in a separate process. Instead, we use a global lock file to ensure that only one
 /// test can initialize the template at a time.
 pub fn initialize(target: &Path) {
-    eprintln!("initializing {}", target.display());
+    let _ = sh_println!("initializing {}", target.display());
 
     let tpath = TEMPLATE_PATH.as_path();
     pretty_err(tpath, fs::create_dir_all(tpath));
@@ -251,7 +253,7 @@ pub fn initialize(target: &Path) {
         if data != "1" {
             // Initialize and build.
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
-            eprintln!("- initializing template dir in {}", prj.root().display());
+            let _ = sh_println!("- initializing template dir in {}", prj.root().display());
 
             cmd.args(["init", "--force"]).assert_success();
             // checkout forge-std
@@ -281,7 +283,7 @@ pub fn initialize(target: &Path) {
         _read = Some(lock.read().unwrap());
     }
 
-    eprintln!("- copying template dir from {}", tpath.display());
+    let _ = sh_println!("- copying template dir from {}", tpath.display());
     pretty_err(target, fs::create_dir_all(target));
     pretty_err(target, copy_dir(tpath, target));
 }
@@ -291,12 +293,12 @@ pub fn clone_remote(repo_url: &str, target_dir: &str) {
     let mut cmd = Command::new("git");
     cmd.args(["clone", "--no-tags", "--recursive", "--shallow-submodules"]);
     cmd.args([repo_url, target_dir]);
-    eprintln!("{cmd:?}");
+    let _ = sh_println!("{cmd:?}");
     let status = cmd.status().unwrap();
     if !status.success() {
         panic!("git clone failed: {status}");
     }
-    eprintln!();
+    let _ = sh_println!();
 }
 
 /// Setup an empty test project and return a command pointing to the forge
@@ -922,7 +924,7 @@ impl TestCommand {
 
     #[track_caller]
     pub fn try_execute(&mut self) -> std::io::Result<Output> {
-        eprintln!("executing {:?}", self.cmd);
+        let _ = sh_println!("executing {:?}", self.cmd);
         let mut child =
             self.cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::piped()).spawn()?;
         if let Some(fun) = self.stdin_fun.take() {

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -21,7 +21,6 @@ use foundry_config::{figment, impl_figment_convert, Config};
 use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, utils::configure_tx_env};
 use revm_primitives::AccountInfo;
 use std::path::PathBuf;
-use yansi::Paint;
 
 impl_figment_convert!(VerifyBytecodeArgs);
 
@@ -145,11 +144,11 @@ impl VerifyBytecodeArgs {
         }
 
         if !self.json {
-            println!(
+            sh_println!(
                 "Verifying bytecode for contract {} at address {}",
-                self.contract.name.clone().green(),
-                self.address.green()
-            );
+                self.contract.name,
+                self.address
+            )?;
         }
 
         let mut json_results: Vec<JsonResult> = vec![];
@@ -215,12 +214,10 @@ impl VerifyBytecodeArgs {
 
         if maybe_predeploy {
             if !self.json {
-                println!(
-                    "{}",
-                    format!("Attempting to verify predeployed contract at {:?}. Ignoring creation code verification.", self.address)
-                        .yellow()
-                        .bold()
-                )
+                sh_warn!(
+                    "Attempting to verify predeployed contract at {:?}. Ignoring creation code verification.",
+                    self.address
+                )?;
             }
 
             // Append constructor args to the local_bytecode.

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -40,11 +40,11 @@ impl VerificationProvider for SourcifyVerificationProvider {
         let resp = retry
             .run_async(|| {
                 async {
-                    println!(
+                    sh_println!(
                         "\nSubmitting verification for [{}] {:?}.",
                         context.target_name,
                         args.address.to_string()
-                    );
+                    )?;
                     let response = client
                         .post(args.verifier.verifier_url.as_deref().unwrap_or(SOURCIFY_URL))
                         .header("Content-Type", "application/json")
@@ -145,15 +145,15 @@ impl SourcifyVerificationProvider {
         match response.status.as_str() {
             "perfect" => {
                 if let Some(ts) = &response.storage_timestamp {
-                    println!("Contract source code already verified. Storage Timestamp: {ts}");
+                    sh_println!("Contract source code already verified. Storage Timestamp: {ts}")?;
                 } else {
-                    println!("Contract successfully verified");
+                    sh_println!("Contract successfully verified")?;
                 }
             }
             "partial" => {
-                println!("The recompiled contract partially matches the deployed version");
+                sh_println!("The recompiled contract partially matches the deployed version")?;
             }
-            "false" => println!("Contract source code is not verified"),
+            "false" => sh_println!("Contract source code is not verified")?,
             s => eyre::bail!("Unknown status from sourcify. Status: {s:?}"),
         }
         Ok(())

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -146,7 +146,7 @@ pub fn print_result(
 ) {
     if let Some(res) = res {
         if !args.json {
-            println!(
+            let _ = sh_println!(
                 "{} with status {}",
                 format!("{bytecode_type:?} code matched").green().bold(),
                 res.green().bold()
@@ -156,17 +156,12 @@ pub fn print_result(
             json_results.push(json_res);
         }
     } else if !args.json {
-        println!(
-            "{}",
-            format!(
-                "{bytecode_type:?} code did not match - this may be due to varying compiler settings"
-            )
-            .red()
-            .bold()
+        let _ = sh_err!(
+            "{bytecode_type:?} code did not match - this may be due to varying compiler settings"
         );
         let mismatches = find_mismatch_in_settings(etherscan_config, config);
         for mismatch in mismatches {
-            println!("{}", mismatch.red().bold());
+            let _ = sh_eprintln!("{}", mismatch.red().bold());
         }
     } else {
         let json_res = JsonResult {

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -197,12 +197,12 @@ impl VerifyArgs {
             let args = EtherscanVerificationProvider::default()
                 .create_verify_request(&self, &context)
                 .await?;
-            println!("{}", args.source);
+            sh_println!("{}", args.source)?;
             return Ok(())
         }
 
         let verifier_url = self.verifier.verifier_url.clone();
-        println!("Start verifying contract `{}` deployed on {chain}", self.address);
+        sh_println!("Start verifying contract `{}` deployed on {chain}", self.address)?;
         self.verifier.verifier.client(&self.etherscan.key())?.verify(self, context).await.map_err(|err| {
             if let Some(verifier_url) = verifier_url {
                  match Url::parse(&verifier_url) {
@@ -333,7 +333,10 @@ impl_figment_convert_cast!(VerifyCheckArgs);
 impl VerifyCheckArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(self) -> Result<()> {
-        println!("Checking verification status on {}", self.etherscan.chain.unwrap_or_default());
+        sh_println!(
+            "Checking verification status on {}",
+            self.etherscan.chain.unwrap_or_default()
+        )?;
         self.verifier.verifier.client(&self.etherscan.key())?.check(self).await
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Enforces `common::shell` now in `clippy` and adds the final implementation of it

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We still allow the use of `print` without the common shell in tests. In some cases you may need to add a `#[allow(clippy::disallowed_macros)]` if not using the test macros.

Some minor inlining was required / preferred to work around a circular dependency in `fmt`

Note: there are still some places that use `Yansi::paint`, I think these generally make sense contextually (for example to visually differentiate between success / pending / failure in test results).