### PR TITLE
feat(script): support custom create2 deployer

### DIFF
--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -18,7 +18,11 @@ use foundry_config::{
     },
     Config,
 };
-use foundry_evm::{executors::TracingExecutor, opts::EvmOpts};
+use foundry_evm::{
+    executors::TracingExecutor,
+    opts::EvmOpts,
+    traces::{InternalTraceMode, TraceMode},
+};
 use std::str::FromStr;
 
 /// CLI arguments for `cast call`.
@@ -183,13 +187,19 @@ impl CallArgs {
             env.cfg.disable_block_gas_limit = true;
             env.block.gas_limit = U256::MAX;
 
+            let trace_mode = TraceMode::Call
+                .with_debug(debug)
+                .with_decode_internal(if decode_internal {
+                    InternalTraceMode::Full
+                } else {
+                    InternalTraceMode::None
+                })
+                .with_state_changes(shell::verbosity() > 4);
             let mut executor = TracingExecutor::new(
                 env,
                 fork,
                 evm_version,
-                debug,
-                decode_internal,
-                shell::verbosity() > 4,
+                trace_mode,
                 alphanet,
                 create2_deployer,
             );

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -175,6 +175,7 @@ impl CallArgs {
                 config.fork_block_number = Some(block_number);
             }
 
+            let create2_deployer = evm_opts.create2_deployer;
             let (mut env, fork, chain, alphanet) =
                 TracingExecutor::get_fork_material(&config, evm_opts).await?;
 

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -191,6 +191,7 @@ impl CallArgs {
                 decode_internal,
                 shell::verbosity() > 4,
                 alphanet,
+                create2_deployer,
             );
 
             let value = tx.value.unwrap_or_default();

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -23,6 +23,7 @@ use foundry_config::{
 use foundry_evm::{
     executors::{EvmError, TracingExecutor},
     opts::EvmOpts,
+    traces::{InternalTraceMode, TraceMode},
     utils::configure_tx_env,
 };
 
@@ -164,13 +165,19 @@ impl RunArgs {
             }
         }
 
+        let trace_mode = TraceMode::Call
+            .with_debug(self.debug)
+            .with_decode_internal(if self.decode_internal {
+                InternalTraceMode::Full
+            } else {
+                InternalTraceMode::None
+            })
+            .with_state_changes(shell::verbosity() > 4);
         let mut executor = TracingExecutor::new(
             env.clone(),
             fork,
             evm_version,
-            self.debug,
-            self.decode_internal,
-            shell::verbosity() > 4,
+            trace_mode,
             alphanet,
             create2_deployer,
         );

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -138,6 +138,7 @@ impl RunArgs {
         // we need to fork off the parent block
         config.fork_block_number = Some(tx_block_number - 1);
 
+        let create2_deployer = evm_opts.create2_deployer;
         let (mut env, fork, chain, alphanet) =
             TracingExecutor::get_fork_material(&config, evm_opts).await?;
 
@@ -171,6 +172,7 @@ impl RunArgs {
             self.decode_internal,
             shell::verbosity() > 4,
             alphanet,
+            create2_deployer,
         );
         let mut env =
             EnvWithHandlerCfg::new_with_spec_id(Box::new(env.clone()), executor.spec_id());

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1587,6 +1587,10 @@ impl InspectorExt for Cheatcodes {
             false
         }
     }
+
+    fn create2_deployer(&self) -> Address {
+        self.config.evm_opts.create2_deployer
+    }
 }
 
 impl Cheatcodes {

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -103,6 +103,10 @@ pub struct EvmArgs {
     #[serde(skip)]
     pub always_use_create_2_factory: bool,
 
+    /// The CREATE2 deployer address to use, this will override the one in the config.
+    #[arg(long, value_name = "ADDRESS")]
+    pub create2_deployer: Option<Address>,
+
     /// Sets the number of assumed available compute units per second for this provider
     ///
     /// default value: 330

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -105,6 +105,7 @@ pub struct EvmArgs {
 
     /// The CREATE2 deployer address to use, this will override the one in the config.
     #[arg(long, value_name = "ADDRESS")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub create2_deployer: Option<Address>,
 
     /// Sets the number of assumed available compute units per second for this provider

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -440,6 +440,9 @@ pub struct Config {
     /// CREATE2 salt to use for the library deployment in scripts.
     pub create2_library_salt: B256,
 
+    /// The CREATE2 deployer address to use.
+    pub create2_deployer: Address,
+
     /// Configuration for Vyper compiler
     pub vyper: VyperConfig,
 
@@ -474,10 +477,6 @@ pub struct Config {
 
     /// Whether to enable Alphanet features.
     pub alphanet: bool,
-
-    /// The CREATE2 deployer address to use.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub create2_deployer: Option<Address>,
 
     /// Timeout for transactions in seconds.
     pub transaction_timeout: u64,
@@ -556,6 +555,10 @@ impl Config {
 
     /// Default salt for create2 library deployments
     pub const DEFAULT_CREATE2_LIBRARY_SALT: FixedBytes<32> = FixedBytes::<32>::ZERO;
+
+    /// Default create2 deployer
+    pub const DEFAULT_CREATE2_DEPLOYER: Address =
+        address!("4e59b44847b379578588920ca78fbf26c0b4956c");
 
     /// Docker image with eof-enabled solc binary
     pub const EOF_SOLC_IMAGE: &'static str = "ghcr.io/paradigmxyz/forge-eof@sha256:46f868ce5264e1190881a3a335d41d7f42d6f26ed20b0c823609c715e38d603f";
@@ -2308,6 +2311,7 @@ impl Default for Config {
             labels: Default::default(),
             unchecked_cheatcode_artifacts: false,
             create2_library_salt: Self::DEFAULT_CREATE2_LIBRARY_SALT,
+            create2_deployer: Self::DEFAULT_CREATE2_DEPLOYER,
             skip: vec![],
             dependencies: Default::default(),
             soldeer: Default::default(),
@@ -2317,7 +2321,6 @@ impl Default for Config {
             extra_args: vec![],
             eof_version: None,
             alphanet: false,
-            create2_deployer: None,
             transaction_timeout: 120,
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -475,6 +475,10 @@ pub struct Config {
     /// Whether to enable Alphanet features.
     pub alphanet: bool,
 
+    /// The CREATE2 deployer address to use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create2_deployer: Option<Address>,
+
     /// Timeout for transactions in seconds.
     pub transaction_timeout: u64,
 
@@ -2313,6 +2317,7 @@ impl Default for Config {
             extra_args: vec![],
             eof_version: None,
             alphanet: false,
+            create2_deployer: None,
             transaction_timeout: 120,
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -1,5 +1,4 @@
-use alloy_primitives::{address, b256, hex, hex::FromHex, Address, B256};
-use std::sync::LazyLock;
+use alloy_primitives::{address, b256, hex, Address, B256};
 
 /// The cheatcode handler address.
 ///
@@ -47,23 +46,6 @@ pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920c
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE: &[u8] = &hex!("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
-
-/// The lazily initialized CREATE2 deployer address that can be configured via environment
-/// variable or the default one.
-pub static CREATE2_DEPLOYER: LazyLock<Address> = LazyLock::new(|| {
-    match std::env::var("FOUNDRY_CREATE2_DEPLOYER") {
-        Ok(addr) => Address::from_hex(addr).unwrap_or_else(|_| {
-            error!("env FOUNDRY_CREATE2_DEPLOYER is set, but not a valid Ethereum address, use {DEFAULT_CREATE2_DEPLOYER} instead");
-            DEFAULT_CREATE2_DEPLOYER
-        }),
-        Err(_) => DEFAULT_CREATE2_DEPLOYER,
-    }
-});
-
-/// The address that deploys the default CREATE2 deployer contract.
-pub fn get_create2_deployer() -> Address {
-    *CREATE2_DEPLOYER
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{address, b256, hex, Address, B256};
+use alloy_primitives::{address, b256, hex, hex::FromHex, Address, B256};
 
 /// The cheatcode handler address.
 ///
@@ -46,6 +46,17 @@ pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920c
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE: &[u8] = &hex!("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
+
+/// The address that deploys the default CREATE2 deployer contract.
+pub fn get_create2_deployer() -> Address {
+    match std::env::var("FOUNDRY_CREATE2_DEPLOYER") {
+        Ok(addr) => Address::from_hex(addr).unwrap_or_else(|_| {
+            error!("env FOUNDRY_CREATE2_DEPLOYER is set, but not a valid Ethereum address, use {DEFAULT_CREATE2_DEPLOYER} instead");
+            DEFAULT_CREATE2_DEPLOYER
+        }),
+        Err(_) => DEFAULT_CREATE2_DEPLOYER,
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{address, b256, hex, hex::FromHex, Address, B256};
+use std::sync::LazyLock;
 
 /// The cheatcode handler address.
 ///
@@ -47,8 +48,9 @@ pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f3
 /// The runtime code of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE: &[u8] = &hex!("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 
-/// The address that deploys the default CREATE2 deployer contract.
-pub fn get_create2_deployer() -> Address {
+/// The lazily initialized CREATE2 deployer address that can be configured via environment
+/// variable or the default one.
+pub static CREATE2_DEPLOYER: LazyLock<Address> = LazyLock::new(|| {
     match std::env::var("FOUNDRY_CREATE2_DEPLOYER") {
         Ok(addr) => Address::from_hex(addr).unwrap_or_else(|_| {
             error!("env FOUNDRY_CREATE2_DEPLOYER is set, but not a valid Ethereum address, use {DEFAULT_CREATE2_DEPLOYER} instead");
@@ -56,6 +58,11 @@ pub fn get_create2_deployer() -> Address {
         }),
         Err(_) => DEFAULT_CREATE2_DEPLOYER,
     }
+});
+
+/// The address that deploys the default CREATE2 deployer contract.
+pub fn get_create2_deployer() -> Address {
+    *CREATE2_DEPLOYER
 }
 
 #[cfg(test)]

--- a/crates/evm/core/src/constants.rs
+++ b/crates/evm/core/src/constants.rs
@@ -46,6 +46,11 @@ pub const DEFAULT_CREATE2_DEPLOYER: Address = address!("4e59b44847b379578588920c
 pub const DEFAULT_CREATE2_DEPLOYER_CODE: &[u8] = &hex!("604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
 /// The runtime code of the default CREATE2 deployer.
 pub const DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE: &[u8] = &hex!("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3");
+/// The hash of the default CREATE2 deployer code.
+///
+/// This is calculated as `keccak256([`DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE`])`.
+pub const DEFAULT_CREATE2_DEPLOYER_CODEHASH: B256 =
+    b256!("2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989");
 
 #[cfg(test)]
 mod tests {

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -5,6 +5,8 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use crate::constants::DEFAULT_CREATE2_DEPLOYER;
+use alloy_primitives::Address;
 use auto_impl::auto_impl;
 use backend::DatabaseExt;
 use revm::{inspectors::NoOpInspector, interpreter::CreateInputs, EvmContext, Inspector};
@@ -53,6 +55,11 @@ pub trait InspectorExt: for<'a> Inspector<&'a mut dyn DatabaseExt> {
     /// Returns `true` if the current network is Alphanet.
     fn is_alphanet(&self) -> bool {
         false
+    }
+
+    /// Returns the CREATE2 deployer address.
+    fn create2_deployer(&self) -> Address {
+        DEFAULT_CREATE2_DEPLOYER
     }
 }
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -73,7 +73,26 @@ pub struct EvmOpts {
 
 impl Default for EvmOpts {
     fn default() -> Self {
-        Self { create2_deployer: Config::DEFAULT_CREATE2_DEPLOYER, ..Default::default() }
+        Self {
+            env: Env::default(),
+            fork_url: None,
+            fork_block_number: None,
+            fork_retries: None,
+            fork_retry_backoff: None,
+            compute_units_per_second: None,
+            no_rpc_rate_limit: false,
+            no_storage_caching: false,
+            initial_balance: U256::default(),
+            sender: Address::default(),
+            ffi: false,
+            always_use_create_2_factory: false,
+            verbosity: 0,
+            memory_limit: 0,
+            isolate: false,
+            disable_block_gas_limit: false,
+            alphanet: false,
+            create2_deployer: Config::DEFAULT_CREATE2_DEPLOYER,
+        }
     }
 }
 

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -66,6 +66,9 @@ pub struct EvmOpts {
 
     /// whether to enable Alphanet features.
     pub alphanet: bool,
+
+    /// Optional CREATE2 deployer override
+    pub create2_deployer: Address,
 }
 
 impl EvmOpts {

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -9,7 +9,7 @@ use revm::primitives::{BlockEnv, CfgEnv, TxEnv};
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvmOpts {
     /// The EVM environment configuration.
     #[serde(flatten)]
@@ -67,8 +67,14 @@ pub struct EvmOpts {
     /// whether to enable Alphanet features.
     pub alphanet: bool,
 
-    /// Optional CREATE2 deployer override
+    /// The CREATE2 deployer's address.
     pub create2_deployer: Address,
+}
+
+impl Default for EvmOpts {
+    fn default() -> Self {
+        Self { create2_deployer: Config::DEFAULT_CREATE2_DEPLOYER, ..Default::default() }
+    }
 }
 
 impl EvmOpts {

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -1,5 +1,5 @@
 use super::fork::environment;
-use crate::fork::CreateFork;
+use crate::{constants::DEFAULT_CREATE2_DEPLOYER, fork::CreateFork};
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{network::AnyRpcBlock, Provider};
 use eyre::WrapErr;
@@ -91,7 +91,7 @@ impl Default for EvmOpts {
             isolate: false,
             disable_block_gas_limit: false,
             alphanet: false,
-            create2_deployer: Config::DEFAULT_CREATE2_DEPLOYER,
+            create2_deployer: DEFAULT_CREATE2_DEPLOYER,
         }
     }
 }

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -210,7 +210,7 @@ pub fn create2_handler_register<I: InspectorExt>(
                 return Ok(FrameOrResult::Result(FrameResult::Call(CallOutcome {
                     result: InterpreterResult {
                         result: InstructionResult::Revert,
-                        output: format!("missing CREATE2 deployer: {}", create2_deployer).into(),
+                        output: format!("missing CREATE2 deployer: {create2_deployer}").into(),
                         gas: Gas::new(gas_limit),
                     },
                     memory_offset: 0..0,

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -210,7 +210,7 @@ pub fn create2_handler_register<I: InspectorExt>(
                 return Ok(FrameOrResult::Result(FrameResult::Call(CallOutcome {
                     result: InterpreterResult {
                         result: InstructionResult::Revert,
-                        output: "missing CREATE2 deployer".into(),
+                        output: format!("missing CREATE2 deployer: {}", create2_deployer).into(),
                         gas: Gas::new(gas_limit),
                     },
                     memory_offset: 0..0,

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,7 +1,5 @@
 pub use crate::ic::*;
-use crate::{
-    backend::DatabaseExt, constants::get_create2_deployer, precompiles::ALPHANET_P256, InspectorExt,
-};
+use crate::{backend::DatabaseExt, precompiles::ALPHANET_P256, InspectorExt};
 use alloy_consensus::BlockHeader;
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::AnyTxEnvelope;
@@ -194,7 +192,7 @@ pub fn create2_handler_register<I: InspectorExt>(
             let gas_limit = inputs.gas_limit;
 
             // Get CREATE2 deployer.
-            let create2_deployer = get_create2_deployer();
+            let create2_deployer = ctx.external.create2_deployer();
             // Generate call inputs for CREATE2 factory.
             let mut call_inputs = get_create2_factory_call_inputs(salt, *inputs, create2_deployer);
 

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -168,7 +168,7 @@ fn get_create2_factory_call_inputs(
     }
 }
 
-/// Used for routing certain CREATE2 invocations through [DEFAULT_CREATE2_DEPLOYER].
+/// Used for routing certain CREATE2 invocations through CREATE2_DEPLOYER.
 ///
 /// Overrides create hook with CALL frame if [InspectorExt::should_use_create2_factory] returns
 /// true. Keeps track of overridden frames and handles outcome in the overridden insert_call_outcome

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -1,5 +1,8 @@
 pub use crate::ic::*;
-use crate::{backend::DatabaseExt, precompiles::ALPHANET_P256, InspectorExt};
+use crate::{
+    backend::DatabaseExt, constants::DEFAULT_CREATE2_DEPLOYER_CODEHASH, precompiles::ALPHANET_P256,
+    InspectorExt,
+};
 use alloy_consensus::BlockHeader;
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::AnyTxEnvelope;
@@ -211,6 +214,15 @@ pub fn create2_handler_register<I: InspectorExt>(
                     result: InterpreterResult {
                         result: InstructionResult::Revert,
                         output: format!("missing CREATE2 deployer: {create2_deployer}").into(),
+                        gas: Gas::new(gas_limit),
+                    },
+                    memory_offset: 0..0,
+                })))
+            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
+                return Ok(FrameOrResult::Result(FrameResult::Call(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 deployer bytecode".into(),
                         gas: Gas::new(gas_limit),
                     },
                     memory_offset: 0..0,

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -24,6 +24,7 @@ use foundry_evm_core::{
     },
     decode::{RevertDecoder, SkipReason},
     utils::StateChangeset,
+    InspectorExt,
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_traces::{SparsedTraceArena, TraceMode};
@@ -235,6 +236,17 @@ impl Executor {
     pub fn set_gas_limit(&mut self, gas_limit: u64) -> &mut Self {
         self.gas_limit = gas_limit;
         self
+    }
+
+    #[inline]
+    pub fn set_create2_deployer(&mut self, create2_deployer: Address) -> &mut Self {
+        self.inspector_mut().set_create2_deployer(create2_deployer);
+        self
+    }
+
+    #[inline]
+    pub fn create2_deployer(&self) -> Address {
+        self.inspector().create2_deployer()
     }
 
     /// Deploys a contract and commits the new state to the underlying database.

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -239,12 +239,6 @@ impl Executor {
     }
 
     #[inline]
-    pub fn set_create2_deployer(&mut self, create2_deployer: Address) -> &mut Self {
-        self.inspector_mut().set_create2_deployer(create2_deployer);
-        self
-    }
-
-    #[inline]
     pub fn create2_deployer(&self) -> Address {
         self.inspector().create2_deployer()
     }

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -1,4 +1,5 @@
 use crate::executors::{Executor, ExecutorBuilder};
+use alloy_primitives::Address;
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{utils::evm_spec_id, Chain, Config};
 use foundry_evm_core::{backend::Backend, fork::CreateFork, opts::EvmOpts};
@@ -20,6 +21,7 @@ impl TracingExecutor {
         decode_internal: bool,
         with_state_changes: bool,
         alphanet: bool,
+        create2_deployer: Address,
     ) -> Self {
         let db = Backend::spawn(fork);
         let trace_mode = TraceMode::Call
@@ -34,7 +36,12 @@ impl TracingExecutor {
             // configures a bare version of the evm executor: no cheatcode inspector is enabled,
             // tracing will be enabled only for the targeted transaction
             executor: ExecutorBuilder::new()
-                .inspectors(|stack| stack.trace_mode(trace_mode).alphanet(alphanet))
+                .inspectors(|stack| {
+                    stack
+                        .trace_mode(trace_mode)
+                        .alphanet(alphanet)
+                        .create2_deployer(create2_deployer)
+                })
                 .spec(evm_spec_id(&version.unwrap_or_default(), alphanet))
                 .build(env, db),
         }

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -3,7 +3,7 @@ use alloy_primitives::Address;
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{utils::evm_spec_id, Chain, Config};
 use foundry_evm_core::{backend::Backend, fork::CreateFork, opts::EvmOpts};
-use foundry_evm_traces::{InternalTraceMode, TraceMode};
+use foundry_evm_traces::TraceMode;
 use revm::primitives::{Env, SpecId};
 use std::ops::{Deref, DerefMut};
 
@@ -17,21 +17,11 @@ impl TracingExecutor {
         env: revm::primitives::Env,
         fork: Option<CreateFork>,
         version: Option<EvmVersion>,
-        debug: bool,
-        decode_internal: bool,
-        with_state_changes: bool,
+        trace_mode: TraceMode,
         alphanet: bool,
         create2_deployer: Address,
     ) -> Self {
         let db = Backend::spawn(fork);
-        let trace_mode = TraceMode::Call
-            .with_debug(debug)
-            .with_decode_internal(if decode_internal {
-                InternalTraceMode::Full
-            } else {
-                InternalTraceMode::None
-            })
-            .with_state_changes(with_state_changes);
         Self {
             // configures a bare version of the evm executor: no cheatcode inspector is enabled,
             // tracing will be enabled only for the targeted transaction

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -282,6 +282,7 @@ pub struct InspectorStackInner {
     pub tracer: Option<TracingInspector>,
     pub enable_isolation: bool,
     pub alphanet: bool,
+    pub create2_deployer: Address,
 
     /// Flag marking if we are in the inner EVM context.
     pub in_inner_context: bool,
@@ -396,6 +397,12 @@ impl InspectorStack {
     #[inline]
     pub fn alphanet(&mut self, yes: bool) {
         self.alphanet = yes;
+    }
+
+    /// Set the CREATE2 deployer address.
+    #[inline]
+    pub fn set_create2_deployer(&mut self, deployer: Address) {
+        self.create2_deployer = deployer;
     }
 
     /// Set whether to enable the log collector.
@@ -1123,6 +1130,10 @@ impl InspectorExt for InspectorStack {
 
     fn is_alphanet(&self) -> bool {
         self.alphanet
+    }
+
+    fn create2_deployer(&self) -> Address {
+        self.create2_deployer
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -59,6 +59,8 @@ pub struct InspectorStackBuilder {
     pub alphanet: bool,
     /// The wallets to set in the cheatcodes context.
     pub wallets: Option<Wallets>,
+    /// The CREATE2 deployer address.
+    pub create2_deployer: Address,
 }
 
 impl InspectorStackBuilder {
@@ -156,6 +158,12 @@ impl InspectorStackBuilder {
         self
     }
 
+    #[inline]
+    pub fn create2_deployer(mut self, create2_deployer: Address) -> Self {
+        self.create2_deployer = create2_deployer;
+        self
+    }
+
     /// Builds the stack of inspectors to use when transacting/committing on the EVM.
     pub fn build(self) -> InspectorStack {
         let Self {
@@ -171,6 +179,7 @@ impl InspectorStackBuilder {
             enable_isolation,
             alphanet,
             wallets,
+            create2_deployer,
         } = self;
         let mut stack = InspectorStack::new();
 
@@ -197,6 +206,7 @@ impl InspectorStackBuilder {
 
         stack.enable_isolation(enable_isolation);
         stack.alphanet(alphanet);
+        stack.set_create2_deployer(create2_deployer);
 
         // environment, must come after all of the inspectors
         if let Some(block) = block {
@@ -1028,6 +1038,10 @@ impl InspectorExt for InspectorStackRefMut<'_> {
 
     fn is_alphanet(&self) -> bool {
         self.inner.alphanet
+    }
+
+    fn create2_deployer(&self) -> Address {
+        self.inner.create2_deployer
     }
 }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -260,6 +260,7 @@ impl MultiContractRunner {
                     .coverage(self.coverage)
                     .enable_isolation(self.isolation)
                     .alphanet(self.alphanet)
+                    .create2_deployer(self.evm_opts.create2_deployer)
             })
             .spec(self.evm_spec)
             .gas_limit(self.evm_opts.gas_limit())

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -143,6 +143,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         isolate: true,
         unchecked_cheatcode_artifacts: false,
         create2_library_salt: Config::DEFAULT_CREATE2_LIBRARY_SALT,
+        create2_deployer: Config::DEFAULT_CREATE2_DEPLOYER,
         vyper: Default::default(),
         skip: vec![],
         dependencies: Default::default(),

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -873,7 +873,8 @@ forgetest_async!(can_deploy_with_custom_create2, |prj, cmd| {
         .load_private_keys(&[0])
         .await
         .add_create2_deployer(create2)
-        .add_sig("BroadcastTestNoLinking", "deployCreate2()")
+        .add_sig("BroadcastTestNoLinking", "deployCreate2(address)")
+        .arg(&create2.to_string())
         .simulate(ScriptOutcome::OkSimulation)
         .broadcast(ScriptOutcome::OkBroadcast)
         .assert_nonce_increment(&[(0, 2)])

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -880,6 +880,21 @@ forgetest_async!(can_deploy_with_custom_create2, |prj, cmd| {
         .await;
 });
 
+forgetest_async!(canot_deploy_with_nonexist_create2, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());
+    let create2 = Address::from_str("0x0000000000000000000000000000000000b4956c").unwrap();
+
+    tester
+        .add_deployer(0)
+        .load_private_keys(&[0])
+        .await
+        .add_create2_deployer(create2)
+        .add_sig("BroadcastTestNoLinking", "deployCreate2()")
+        .simulate(ScriptOutcome::ScriptFailed)
+        .broadcast(ScriptOutcome::ScriptFailed);
+});
+
 forgetest_async!(can_deploy_and_simulate_25_txes_concurrently, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let mut tester = ScriptTester::new_broadcast(cmd, &handle.http_endpoint(), prj.root());

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2002,7 +2002,7 @@ contract SimpleScript is Script {
     ]);
 
     cmd.assert_failure().stderr_eq(str![[r#"
-Error: script failed: missing CREATE2 deployer
+Error: script failed: missing CREATE2 deployer: 0x4e59b44847b379578588920cA78FbF26c0B4956C
 
 "#]]);
 });

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -17,7 +17,7 @@ use foundry_compilers::{
     utils::source_files_iter,
     ArtifactId, ProjectCompileOutput,
 };
-use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, traces::debug::ContractSources};
+use foundry_evm::traces::debug::ContractSources;
 use foundry_linking::Linker;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -17,7 +17,7 @@ use foundry_compilers::{
     utils::source_files_iter,
     ArtifactId, ProjectCompileOutput,
 };
-use foundry_evm::{constants::get_create2_deployer, traces::debug::ContractSources};
+use foundry_evm::traces::debug::ContractSources;
 use foundry_linking::Linker;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
@@ -40,7 +40,7 @@ impl BuildData {
     /// Links contracts. Uses CREATE2 linking when possible, otherwise falls back to
     /// default linking with sender nonce and address.
     pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
-        let create2_deployer = get_create2_deployer();
+        let create2_deployer = script_config.evm_opts.create2_deployer;
         let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
             let provider = try_get_http_provider(fork_url)?;
             let deployer_code = provider.get_code_at(create2_deployer).await?;

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -42,7 +42,7 @@ impl BuildData {
     pub async fn link(self, script_config: &ScriptConfig) -> Result<LinkedBuildData> {
         let can_use_create2 = if let Some(fork_url) = &script_config.evm_opts.fork_url {
             let provider = try_get_http_provider(fork_url)?;
-            let deployer_code = provider.get_code_at(DEFAULT_CREATE2_DEPLOYER).await?;
+            let deployer_code = provider.get_code_at(script_config.create2_deployer).await?;
 
             !deployer_code.is_empty()
         } else {
@@ -57,7 +57,7 @@ impl BuildData {
                 self.get_linker()
                     .link_with_create2(
                         known_libraries.clone(),
-                        DEFAULT_CREATE2_DEPLOYER,
+                        script_config.create2_deployer,
                         script_config.config.create2_library_salt,
                         &self.target,
                     )

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -229,10 +229,6 @@ impl ScriptArgs {
             evm_opts.sender = sender;
         }
 
-        if let Some(create2_deployer) = self.evm_opts.create2_deployer {
-            evm_opts.create2_deployer = create2_deployer;
-        }
-
         let script_config = ScriptConfig::new(config, evm_opts).await?;
 
         Ok(PreprocessedState { args: self, script_config, script_wallets })

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -45,8 +45,8 @@ use foundry_config::{
     Config,
 };
 use foundry_evm::{
-    constants::get_create2_deployer,
     backend::Backend,
+    constants::get_create2_deployer,
     executors::ExecutorBuilder,
     inspectors::{
         cheatcodes::{BroadcastableTransactions, Wallets},

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -624,6 +624,7 @@ impl ScriptConfig {
                 stack
                     .trace_mode(if debug { TraceMode::Debug } else { TraceMode::Call })
                     .alphanet(self.evm_opts.alphanet)
+                    .create2_deployer(self.evm_opts.create2_deployer)
             })
             .spec(self.config.evm_spec_id())
             .gas_limit(self.evm_opts.gas_limit())

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -46,7 +46,6 @@ use foundry_config::{
 };
 use foundry_evm::{
     backend::Backend,
-    constants::DEFAULT_CREATE2_DEPLOYER,
     executors::ExecutorBuilder,
     inspectors::{
         cheatcodes::{BroadcastableTransactions, Wallets},
@@ -233,9 +232,7 @@ impl ScriptArgs {
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
         }
-        evm_opts.create2_deployer = self
-            .create2_deployer
-            .unwrap_or_else(|| config.create2_deployer.unwrap_or(DEFAULT_CREATE2_DEPLOYER));
+        evm_opts.create2_deployer = self.create2_deployer.unwrap_or(config.create2_deployer);
 
         let script_config = ScriptConfig::new(config, evm_opts).await?;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -46,7 +46,7 @@ use foundry_config::{
 };
 use foundry_evm::{
     backend::Backend,
-    constants::get_create2_deployer,
+    constants::DEFAULT_CREATE2_DEPLOYER,
     executors::ExecutorBuilder,
     inspectors::{
         cheatcodes::{BroadcastableTransactions, Wallets},
@@ -199,6 +199,10 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
+    /// The CREATE2 deployer address to use
+    #[arg(long, value_name = "ADDRESS")]
+    pub create2_deployer: Option<Address>,
+
     /// Timeout to use for broadcasting transactions.
     #[arg(long, env = "ETH_TIMEOUT")]
     pub timeout: Option<u64>,
@@ -229,6 +233,9 @@ impl ScriptArgs {
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
         }
+        evm_opts.create2_deployer = self
+            .create2_deployer
+            .unwrap_or_else(|| config.create2_deployer.unwrap_or(DEFAULT_CREATE2_DEPLOYER));
 
         let script_config = ScriptConfig::new(config, evm_opts).await?;
 
@@ -239,7 +246,9 @@ impl ScriptArgs {
     pub async fn run_script(self) -> Result<()> {
         trace!(target: "script", "executing script command");
 
-        let compiled = self.preprocess().await?.compile()?;
+        let state = self.preprocess().await?;
+        let create2_deployer = state.script_config.evm_opts.create2_deployer;
+        let compiled = state.compile()?;
 
         // Move from `CompiledState` to `BundledState` either by resuming or executing and
         // simulating script.
@@ -294,6 +303,7 @@ impl ScriptArgs {
             pre_simulation.args.check_contract_sizes(
                 &pre_simulation.execution_result,
                 &pre_simulation.build_data.known_contracts,
+                create2_deployer,
             )?;
 
             pre_simulation.fill_metadata().await?.bundle().await?
@@ -384,6 +394,7 @@ impl ScriptArgs {
         &self,
         result: &ScriptResult,
         known_contracts: &ContractsByArtifact,
+        create2_deployer: Address,
     ) -> Result<()> {
         // (name, &init, &deployed)[]
         let mut bytecodes: Vec<(String, &[u8], &[u8])> = vec![];
@@ -416,7 +427,6 @@ impl ScriptArgs {
             None => CONTRACT_MAX_SIZE,
         };
 
-        let create2_deployer = get_create2_deployer();
         for (data, to) in result.transactions.iter().flat_map(|txes| {
             txes.iter().filter_map(|tx| {
                 tx.transaction
@@ -554,6 +564,7 @@ impl ScriptConfig {
             // dapptools compatibility
             1
         };
+
         Ok(Self { config, evm_opts, sender_nonce, backends: HashMap::default() })
     }
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -306,7 +306,7 @@ impl ScriptArgs {
                 create2_deployer,
             )?;
 
-            pre_simulation.fill_metadata().await?.bundle().await?
+            pre_simulation.fill_metadata(create2_deployer).await?.bundle().await?
         };
 
         // Exit early in case user didn't provide any broadcast/verify related flags.

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -302,7 +302,7 @@ impl ScriptArgs {
                 create2_deployer,
             )?;
 
-            pre_simulation.fill_metadata(create2_deployer).await?.bundle().await?
+            pre_simulation.fill_metadata().await?.bundle().await?
         };
 
         // Exit early in case user didn't provide any broadcast/verify related flags.

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -198,7 +198,7 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
-    /// The CREATE2 deployer address to use
+    /// The CREATE2 deployer address to use, this will override the one in the config.
     #[arg(long, value_name = "ADDRESS")]
     pub create2_deployer: Option<Address>,
 
@@ -232,7 +232,10 @@ impl ScriptArgs {
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
         }
-        evm_opts.create2_deployer = self.create2_deployer.unwrap_or(config.create2_deployer);
+
+        if let Some(create2_deployer) = self.create2_deployer {
+            evm_opts.create2_deployer = create2_deployer;
+        }
 
         let script_config = ScriptConfig::new(config, evm_opts).await?;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -198,10 +198,6 @@ pub struct ScriptArgs {
     )]
     pub with_gas_price: Option<U256>,
 
-    /// The CREATE2 deployer address to use, this will override the one in the config.
-    #[arg(long, value_name = "ADDRESS")]
-    pub create2_deployer: Option<Address>,
-
     /// Timeout to use for broadcasting transactions.
     #[arg(long, env = "ETH_TIMEOUT")]
     pub timeout: Option<u64>,
@@ -233,7 +229,7 @@ impl ScriptArgs {
             evm_opts.sender = sender;
         }
 
-        if let Some(create2_deployer) = self.create2_deployer {
+        if let Some(create2_deployer) = self.evm_opts.create2_deployer {
             evm_opts.create2_deployer = create2_deployer;
         }
 

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
 use foundry_config::Config;
 use foundry_evm::{
-    constants::{CALLER, DEFAULT_CREATE2_DEPLOYER},
+    constants::CALLER,
     executors::{DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
     opts::EvmOpts,
     revm::interpreter::{return_ok, InstructionResult},
@@ -20,11 +20,12 @@ use std::collections::VecDeque;
 pub struct ScriptRunner {
     pub executor: Executor,
     pub evm_opts: EvmOpts,
+    pub create2_deployer: Address,
 }
 
 impl ScriptRunner {
-    pub fn new(executor: Executor, evm_opts: EvmOpts) -> Self {
-        Self { executor, evm_opts }
+    pub fn new(executor: Executor, evm_opts: EvmOpts, create2_deployer: Address) -> Self {
+        Self { executor, evm_opts, create2_deployer }
     }
 
     /// Deploys the libraries and broadcast contract. Calls setUp method if requested.
@@ -84,8 +85,7 @@ impl ScriptRunner {
             }),
             ScriptPredeployLibraries::Create2(libraries, salt) => {
                 for library in libraries {
-                    let address =
-                        DEFAULT_CREATE2_DEPLOYER.create2_from_code(salt, library.as_ref());
+                    let address = self.create2_deployer.create2_from_code(salt, library.as_ref());
                     // Skip if already deployed
                     if !self.executor.is_empty_code(address)? {
                         continue;
@@ -95,7 +95,7 @@ impl ScriptRunner {
                         .executor
                         .transact_raw(
                             self.evm_opts.sender,
-                            DEFAULT_CREATE2_DEPLOYER,
+                            self.create2_deployer,
                             calldata.clone().into(),
                             U256::from(0),
                         )
@@ -111,7 +111,7 @@ impl ScriptRunner {
                             from: Some(self.evm_opts.sender),
                             input: calldata.into(),
                             nonce: Some(sender_nonce + library_transactions.len() as u64),
-                            to: Some(TxKind::Call(DEFAULT_CREATE2_DEPLOYER)),
+                            to: Some(TxKind::Call(self.create2_deployer)),
                             ..Default::default()
                         }
                         .into(),

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
 use foundry_config::Config;
 use foundry_evm::{
-    constants::{get_create2_deployer, CALLER},
+    constants::CALLER,
     executors::{DeployResult, EvmError, ExecutionErr, Executor, RawCallResult},
     opts::EvmOpts,
     revm::interpreter::{return_ok, InstructionResult},
@@ -83,7 +83,7 @@ impl ScriptRunner {
                 })
             }),
             ScriptPredeployLibraries::Create2(libraries, salt) => {
-                let create2_deployer = get_create2_deployer();
+                let create2_deployer = self.evm_opts.create2_deployer;
                 for library in libraries {
                     let address = create2_deployer.create2_from_code(salt, library.as_ref());
                     // Skip if already deployed

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -12,6 +12,7 @@ use foundry_evm::{
     opts::EvmOpts,
     revm::interpreter::{return_ok, InstructionResult},
     traces::{TraceKind, Traces},
+    InspectorExt,
 };
 use std::collections::VecDeque;
 
@@ -86,7 +87,7 @@ impl ScriptRunner {
                 })
             }),
             ScriptPredeployLibraries::Create2(libraries, salt) => {
-                let create2_deployer = self.evm_opts.create2_deployer;
+                let create2_deployer = self.executor.inspector().create2_deployer();
                 for library in libraries {
                     let address = create2_deployer.create2_from_code(salt, library.as_ref());
                     // Skip if already deployed

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -39,6 +39,9 @@ impl ScriptRunner {
     ) -> Result<(Address, ScriptResult)> {
         trace!(target: "script", "executing setUP()");
 
+        // set CREATE2 deployer from EvmOpts.
+        self.executor.inspector_mut().set_create2_deployer(self.evm_opts.create2_deployer);
+
         if !is_broadcast {
             if self.evm_opts.sender == Config::DEFAULT_SENDER {
                 // We max out their balance so that they can deploy and make calls.

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -50,9 +50,6 @@ impl ScriptRunner {
             }
         }
 
-        // set CREATE2 deployer from EvmOpts.
-        self.executor.set_create2_deployer(self.evm_opts.create2_deployer);
-
         self.executor.set_nonce(self.evm_opts.sender, sender_nonce)?;
 
         // We max out their balance so that they can deploy and make calls.

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -61,7 +61,11 @@ impl PreSimulationState {
                 let nonce = tx.transaction.nonce().expect("all transactions should have a sender");
                 let to = tx.transaction.to();
 
-                let mut builder = ScriptTransactionBuilder::new(tx.transaction, rpc);
+                let mut builder = ScriptTransactionBuilder::new(
+                    tx.transaction,
+                    rpc,
+                    self.script_config.create2_deployer.clone(),
+                );
 
                 if let Some(TxKind::Call(_)) = to {
                     builder.set_call(&address_to_abi, &self.execution_artifacts.decoder)?;

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -46,7 +46,7 @@ impl PreSimulationState {
     /// left empty.
     ///
     /// Both modes will panic if any of the transactions have None for the `rpc` field.
-    pub async fn fill_metadata(self) -> Result<FilledTransactionsState> {
+    pub async fn fill_metadata(self, create2_deployer: Address) -> Result<FilledTransactionsState> {
         let address_to_abi = self.build_address_to_abi_map();
 
         let mut transactions = self
@@ -64,7 +64,11 @@ impl PreSimulationState {
                 let mut builder = ScriptTransactionBuilder::new(tx.transaction, rpc);
 
                 if let Some(TxKind::Call(_)) = to {
-                    builder.set_call(&address_to_abi, &self.execution_artifacts.decoder)?;
+                    builder.set_call(
+                        &address_to_abi,
+                        &self.execution_artifacts.decoder,
+                        create2_deployer,
+                    )?;
                 } else {
                     builder.set_create(false, sender.create(nonce), &address_to_abi)?;
                 }

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -61,11 +61,7 @@ impl PreSimulationState {
                 let nonce = tx.transaction.nonce().expect("all transactions should have a sender");
                 let to = tx.transaction.to();
 
-                let mut builder = ScriptTransactionBuilder::new(
-                    tx.transaction,
-                    rpc,
-                    self.script_config.create2_deployer.clone(),
-                );
+                let mut builder = ScriptTransactionBuilder::new(tx.transaction, rpc);
 
                 if let Some(TxKind::Call(_)) = to {
                     builder.set_call(&address_to_abi, &self.execution_artifacts.decoder)?;

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -46,7 +46,7 @@ impl PreSimulationState {
     /// left empty.
     ///
     /// Both modes will panic if any of the transactions have None for the `rpc` field.
-    pub async fn fill_metadata(self, create2_deployer: Address) -> Result<FilledTransactionsState> {
+    pub async fn fill_metadata(self) -> Result<FilledTransactionsState> {
         let address_to_abi = self.build_address_to_abi_map();
 
         let mut transactions = self
@@ -67,7 +67,7 @@ impl PreSimulationState {
                     builder.set_call(
                         &address_to_abi,
                         &self.execution_artifacts.decoder,
-                        create2_deployer,
+                        self.script_config.evm_opts.create2_deployer,
                     )?;
                 } else {
                     builder.set_create(false, sender.create(nonce), &address_to_abi)?;

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{hex, Address, TxKind, B256};
 use eyre::Result;
 use forge_script_sequence::TransactionWithMetadata;
 use foundry_common::{fmt::format_token_raw, ContractData, TransactionMaybeSigned, SELECTOR_LEN};
-use foundry_evm::{constants::get_create2_deployer, traces::CallTraceDecoder};
+use foundry_evm::traces::CallTraceDecoder;
 use itertools::Itertools;
 use revm_inspectors::tracing::types::CallKind;
 use std::collections::BTreeMap;
@@ -29,9 +29,9 @@ impl ScriptTransactionBuilder {
         &mut self,
         local_contracts: &BTreeMap<Address, &ContractData>,
         decoder: &CallTraceDecoder,
+        create2_deployer: Address,
     ) -> Result<()> {
         if let Some(TxKind::Call(to)) = self.transaction.transaction.to() {
-            let create2_deployer = get_create2_deployer();
             if to == create2_deployer {
                 if let Some(input) = self.transaction.transaction.input() {
                     let (salt, init_code) = input.split_at(32);

--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -171,6 +171,10 @@ impl ScriptTester {
         self.args(&["--tc", contract_name, "--sig", sig])
     }
 
+    pub fn add_create2_deployer(&mut self, create2_deployer: Address) -> &mut Self {
+        self.args(&["--create2-deployer", create2_deployer.to_string().as_str()])
+    }
+
     /// Adds the `--unlocked` flag
     pub fn unlocked(&mut self) -> &mut Self {
         self.arg("--unlocked")

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -324,6 +324,7 @@ pub async fn get_tracing_executor(
 ) -> Result<(Env, TracingExecutor)> {
     fork_config.fork_block_number = Some(fork_blk_num);
     fork_config.evm_version = evm_version;
+    let create2_deployer = evm_opts.create2_deployer;
 
     let (env, fork, _chain, is_alphanet) =
         TracingExecutor::get_fork_material(fork_config, evm_opts).await?;
@@ -336,6 +337,7 @@ pub async fn get_tracing_executor(
         false,
         false,
         is_alphanet,
+        create2_deployer,
     );
 
     Ok((env, executor))

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -12,7 +12,10 @@ use foundry_block_explorers::{
 use foundry_common::{abi::encode_args, compile::ProjectCompiler, provider::RetryProvider, shell};
 use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
 use foundry_config::Config;
-use foundry_evm::{constants::DEFAULT_CREATE2_DEPLOYER, executors::TracingExecutor, opts::EvmOpts};
+use foundry_evm::{
+    constants::DEFAULT_CREATE2_DEPLOYER, executors::TracingExecutor, opts::EvmOpts,
+    traces::TraceMode,
+};
 use reqwest::Url;
 use revm_primitives::{
     db::Database,
@@ -333,9 +336,7 @@ pub async fn get_tracing_executor(
         env.clone(),
         fork,
         Some(fork_config.evm_version),
-        false,
-        false,
-        false,
+        TraceMode::Call,
         is_alphanet,
         create2_deployer,
     );

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -324,8 +324,8 @@ pub async fn get_tracing_executor(
 ) -> Result<(Env, TracingExecutor)> {
     fork_config.fork_block_number = Some(fork_blk_num);
     fork_config.evm_version = evm_version;
-    let create2_deployer = evm_opts.create2_deployer;
 
+    let create2_deployer = evm_opts.create2_deployer;
     let (env, fork, _chain, is_alphanet) =
         TracingExecutor::get_fork_material(fork_config, evm_opts).await?;
 

--- a/testdata/default/cheats/Broadcast.t.sol
+++ b/testdata/default/cheats/Broadcast.t.sol
@@ -219,6 +219,32 @@ contract BroadcastTestNoLinking is DSTest {
         vm.stopBroadcast();
     }
 
+    function deployCreate2(address deployer) public {
+        vm.startBroadcast();
+        bytes32 salt = bytes32(uint256(1338));
+        NoLink test_c2 = new NoLink{salt: salt}();
+        assert(test_c2.view_me() == 1337);
+
+        address expectedAddress = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff),
+                            deployer,
+                            salt,
+                            keccak256(abi.encodePacked(type(NoLink).creationCode, abi.encode()))
+                        )
+                    )
+                )
+            )
+        );
+        require(address(test_c2) == expectedAddress, "Create2 address mismatch");
+
+        NoLink test2 = new NoLink();
+        vm.stopBroadcast();
+    }
+
     function errorStaticCall() public {
         vm.broadcast();
         NoLink test11 = new NoLink();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Currently when deploy contracts using CREATE2 method, it is default to https://github.com/foundry-rs/foundry/blob/fcaa2a7dc4212c270e7c6a40e88948c42c136a5f/crates/evm/core/src/constants.rs#L44

But in some circumstances, we can't access or deploy the 0x4e59b44847b379578588920ca78fbf26c0b4956c contract, may be caused of not able to send the pre EIP155 raw transaction. So try to introduce a env to change the default create2 deployer.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. add `--create2-deployer` to the `forge script` argument
2. add `create2_deployer` to the `foundry.toml` config file