### PR TITLE
fix(coverage): do not report empty constructors, enable reports for `receive`

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -50,15 +50,15 @@ impl<'a> ContractVisitor<'a> {
         let name: String =
             node.attribute("name").ok_or_else(|| eyre::eyre!("Function has no name"))?;
 
-        // TODO(onbjerg): Figure out why we cannot find anchors for the receive function
         let kind: String =
             node.attribute("kind").ok_or_else(|| eyre::eyre!("Function has no kind"))?;
-        if kind == "receive" {
-            return Ok(())
-        }
 
         match &node.body {
             Some(body) => {
+                // Do not add coverage item for constructors without statements.
+                if kind == "constructor" && !has_statements(body) {
+                    return Ok(())
+                }
                 self.push_item_kind(CoverageItemKind::Function { name }, &node.src);
                 self.visit_block(body)
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9270 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- do not count empty constructor as coverage function
- receive anchor can now properly found, enable coverage report for
- tests

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
