### PR TITLE
 feat(`cast run`): add `--etherscan-api-key`  to resolve contract names

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -58,6 +58,10 @@ pub struct RunArgs {
     #[arg(long, short)]
     label: Vec<String>,
 
+    /// Etherscan API key.
+    #[arg(long)]
+    pub etherscan_api_key: Option<String>,
+
     #[command(flatten)]
     rpc: RpcOpts,
 
@@ -98,6 +102,7 @@ impl RunArgs {
         let figment = Into::<Figment>::into(&self.rpc).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;
         let mut config = Config::try_from(figment)?.sanitized();
+        config.etherscan_api_key = self.etherscan_api_key;
 
         let compute_units_per_second =
             if self.no_rate_limit { Some(u64::MAX) } else { self.compute_units_per_second };

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1505,10 +1505,11 @@ casttest!(fetch_constructor_args_from_etherscan, |_prj, cmd| {
 });
 
 // <https://github.com/foundry-rs/foundry/issues/3473>
-casttest!(test_non_mainnet_traces, |_prj, cmd| {
+casttest!(test_non_mainnet_traces, |prj, cmd| {
+    prj.clear();
     cmd.args([
         "run",
-        "0x8346762a8c1d7ce70be23c1b68ff920ffb6bca8fd62323e6c1d108f209e0b45d",
+        "0xa003e419e2d7502269eb5eda56947b580120e00abfd5b5460d08f8af44a0c24f",
         "--rpc-url",
         next_rpc_endpoint(NamedChain::Optimism).as_str(),
         "--etherscan-api-key",
@@ -1518,14 +1519,11 @@ casttest!(test_non_mainnet_traces, |_prj, cmd| {
     .stdout_eq(str![[r#"
 Executing previous transactions from the block.
 Traces:
-  [429891] FuturesMarket::modifyPositionWithTracking(79573547589616810 [7.957e16], 0x4b57454e54410000000000000000000000000000000000000000000000000000)
-    ├─ [9111] SystemStatus::requireFuturesMarketActive(0x7345544800000000000000000000000000000000000000000000000000000000) [staticcall]
-    │   └─ ← [Stop] 
-    ├─ [2789] SystemStatus::requireSynthActive(0x7345544800000000000000000000000000000000000000000000000000000000) [staticcall]
-    │   └─ ← [Stop] 
-    ├─ [70705] ExchangeCircuitBreaker::rateWithBreakCircuit(0x7345544800000000000000000000000000000000000000000000000000000000)
-    │   ├─ [399] SystemStatus::systemSuspended() [staticcall]
-    │   │   └─ ← [Return] false
+  [33841] FiatTokenProxy::fallback(0x111111125421cA6dc452d289314280a0f8842A65, 164054805 [1.64e8])
+    ├─ [26673] FiatTokenV2_2::approve(0x111111125421cA6dc452d289314280a0f8842A65, 164054805 [1.64e8]) [delegatecall]
+    │   ├─ emit Approval(owner: 0x9a95Af47C51562acfb2107F44d7967DF253197df, spender: 0x111111125421cA6dc452d289314280a0f8842A65, value: 164054805 [1.64e8])
+    │   └─ ← [Return] true
+    └─ ← [Return] true
 ...
 
 "#]]);

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6,8 +6,8 @@ use anvil::{EthereumHardfork, NodeConfig};
 use foundry_test_utils::{
     casttest, file,
     rpc::{
-        next_http_rpc_endpoint, next_mainnet_etherscan_api_key, next_rpc_endpoint,
-        next_ws_rpc_endpoint,
+        next_etherscan_api_key, next_http_rpc_endpoint, next_mainnet_etherscan_api_key,
+        next_rpc_endpoint, next_ws_rpc_endpoint,
     },
     str,
     util::OutputExt,
@@ -1500,6 +1500,33 @@ casttest!(fetch_constructor_args_from_etherscan, |_prj, cmd| {
     .assert_success()
     .stdout_eq(str![[r#"
 0x00000000000000000000000000000000000014bddab3e51a57cff87a50000000 → Uint(420690000000000000000000000000000, 256)
+
+"#]]);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/3473>
+casttest!(test_non_mainnet_traces, |_prj, cmd| {
+    cmd.args([
+        "run",
+        "0x8346762a8c1d7ce70be23c1b68ff920ffb6bca8fd62323e6c1d108f209e0b45d",
+        "--rpc-url",
+        next_rpc_endpoint(NamedChain::Optimism).as_str(),
+        "--etherscan-api-key",
+        next_etherscan_api_key(NamedChain::Optimism).as_str(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Executing previous transactions from the block.
+Traces:
+  [429891] FuturesMarket::modifyPositionWithTracking(79573547589616810 [7.957e16], 0x4b57454e54410000000000000000000000000000000000000000000000000000)
+    ├─ [9111] SystemStatus::requireFuturesMarketActive(0x7345544800000000000000000000000000000000000000000000000000000000) [staticcall]
+    │   └─ ← [Stop] 
+    ├─ [2789] SystemStatus::requireSynthActive(0x7345544800000000000000000000000000000000000000000000000000000000) [staticcall]
+    │   └─ ← [Stop] 
+    ├─ [70705] ExchangeCircuitBreaker::rateWithBreakCircuit(0x7345544800000000000000000000000000000000000000000000000000000000)
+    │   ├─ [399] SystemStatus::systemSuspended() [staticcall]
+    │   │   └─ ← [Return] false
+...
 
 "#]]);
 });

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -1,6 +1,6 @@
 //! RPC API keys utilities.
 
-use foundry_config::NamedChain;
+use foundry_config::{NamedChain, NamedChain::Optimism};
 use rand::seq::SliceRandom;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -75,6 +75,10 @@ static ETHERSCAN_MAINNET_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
     keys
 });
 
+// List of etherscan keys for Optimism.
+static ETHERSCAN_OPTIMISM_KEYS: LazyLock<Vec<&'static str>> =
+    LazyLock::new(|| vec!["JQNGFHINKS1W7Y5FRXU4SPBYF43J3NYK46"]);
+
 /// Returns the next index to use.
 fn next() -> usize {
     static NEXT_INDEX: AtomicUsize = AtomicUsize::new(0);
@@ -125,6 +129,16 @@ pub fn next_ws_archive_rpc_endpoint() -> String {
 pub fn next_mainnet_etherscan_api_key() -> String {
     let idx = next() % ETHERSCAN_MAINNET_KEYS.len();
     ETHERSCAN_MAINNET_KEYS[idx].to_string()
+}
+
+/// Returns the next etherscan api key for given chain.
+pub fn next_etherscan_api_key(chain: NamedChain) -> String {
+    let keys = match chain {
+        Optimism => &ETHERSCAN_OPTIMISM_KEYS,
+        _ => &ETHERSCAN_MAINNET_KEYS,
+    };
+    let idx = next() % keys.len();
+    keys[idx].to_string()
 }
 
 fn next_url(is_ws: bool, chain: NamedChain) -> String {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #3473 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- fix `get_remote_chain_id`: do not assume mainnet chain if `mainnet` in RPC URL (Alchemy has `opt-mainnet`, `arb-mainnet` etc.)
- add `--etherscan-api-key` for `cast run`
- test

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
