### PR TITLE
fix: use regular `println` in internal test utils to avoid interfering with `cargo test` runner

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -2447,22 +2447,6 @@ contract GasReportFallbackTest is Test {
         .assert_success()
         .stdout_eq(str![[r#"
 ...
-Ran 1 test for test/DelegateProxyTest.sol:GasReportFallbackTest
-[PASS] test_fallback_gas_report() ([GAS])
-Traces:
-  [331067] GasReportFallbackTest::test_fallback_gas_report()
-    ├─ [106511] → new ProxiedContract@[..]
-    │   └─ ← [Return] 246 bytes of code
-    ├─ [108698] → new DelegateProxy@[..]
-    │   └─ ← [Return] 143 bytes of code
-    ├─ [29396] DelegateProxy::fallback(100)
-    │   ├─ [3320] ProxiedContract::deposit(100) [delegatecall]
-    │   │   └─ ← [Stop] 
-    │   └─ ← [Return] 
-    ├─ [21160] DelegateProxy::deposit()
-    │   └─ ← [Stop] 
-    └─ ← [Stop] 
-
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 | test/DelegateProxyTest.sol:DelegateProxy contract |                 |       |        |       |         |
 |---------------------------------------------------|-----------------|-------|--------|-------|---------|

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -2447,6 +2447,22 @@ contract GasReportFallbackTest is Test {
         .assert_success()
         .stdout_eq(str![[r#"
 ...
+Ran 1 test for test/DelegateProxyTest.sol:GasReportFallbackTest
+[PASS] test_fallback_gas_report() ([GAS])
+Traces:
+  [331067] GasReportFallbackTest::test_fallback_gas_report()
+    ├─ [106511] → new ProxiedContract@[..]
+    │   └─ ← [Return] 246 bytes of code
+    ├─ [108698] → new DelegateProxy@[..]
+    │   └─ ← [Return] 143 bytes of code
+    ├─ [29396] DelegateProxy::fallback(100)
+    │   ├─ [3320] ProxiedContract::deposit(100) [delegatecall]
+    │   │   └─ ← [Stop] 
+    │   └─ ← [Return] 
+    ├─ [21160] DelegateProxy::deposit()
+    │   └─ ← [Stop] 
+    └─ ← [Stop] 
+
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
 | test/DelegateProxyTest.sol:DelegateProxy contract |                 |       |        |       |         |
 |---------------------------------------------------|-----------------|-------|--------|-------|---------|

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -72,7 +72,7 @@ pub fn format_receipt(chain: Chain, receipt: &AnyTransactionReceipt) -> String {
     let gas_used = receipt.gas_used;
     let gas_price = receipt.effective_gas_price;
     format!(
-        "\n##### {chain}\n{status}Hash: {tx_hash:?}{caddr}\nBlock: {bn}\n{gas}\n\n",
+        "\n##### {chain}\n{status} Hash: {tx_hash:?}{caddr}\nBlock: {bn}\n{gas}\n\n",
         status = if !receipt.inner.inner.inner.receipt.status.coerce_status() {
             "❌  [Failed]"
         } else {

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -224,8 +224,9 @@ impl ExtTester {
 /// This used to use a `static` `Lazy`, but this approach does not with `cargo-nextest` because it
 /// runs each test in a separate process. Instead, we use a global lock file to ensure that only one
 /// test can initialize the template at a time.
+#[allow(clippy::disallowed_macros)]
 pub fn initialize(target: &Path) {
-    let _ = sh_println!("initializing {}", target.display());
+    println!("initializing {}", target.display());
 
     let tpath = TEMPLATE_PATH.as_path();
     pretty_err(tpath, fs::create_dir_all(tpath));
@@ -253,7 +254,7 @@ pub fn initialize(target: &Path) {
         if data != "1" {
             // Initialize and build.
             let (prj, mut cmd) = setup_forge("template", foundry_compilers::PathStyle::Dapptools);
-            let _ = sh_println!("- initializing template dir in {}", prj.root().display());
+            println!("- initializing template dir in {}", prj.root().display());
 
             cmd.args(["init", "--force"]).assert_success();
             // checkout forge-std
@@ -283,7 +284,7 @@ pub fn initialize(target: &Path) {
         _read = Some(lock.read().unwrap());
     }
 
-    let _ = sh_println!("- copying template dir from {}", tpath.display());
+    println!("- copying template dir from {}", tpath.display());
     pretty_err(target, fs::create_dir_all(target));
     pretty_err(target, copy_dir(tpath, target));
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `common::shell` interferes with `cargo test`. In internals like this it is fine to add an exception. Instead of rendering to `stderr` we render to regular `stdout` as this is collected and presented to the user at the end as a built-in.

Previously:

```
initializing /tmp/gas_report_with_fallback-0HtVf2k
- initializing template dir in /tmp/template-1hIkWtV
executing cd "/tmp/template-1hIkWtV" && NO_COLOR="1" "/home/george/work/foundry/target/debug/forge" "init" "--force"
executing cd "/tmp/template-1hIkWtV" && NO_COLOR="1" "/home/george/work/foundry/target/debug/forge" "build" "--use" "0.8.27"
- copying template dir from /tmp/foundry-forge-test-template
executing cd "/tmp/gas_report_with_fallback-0HtVf2k" && NO_COLOR="1" "/home/george/work/foundry/target/debug/forge" "test" "--mt" "test_fallback_gas_report" "-vvvv" "--gas-report"
executing cd "/tmp/gas_report_with_fallback-0HtVf2k" && NO_COLOR="1" "/home/george/work/foundry/target/debug/forge" "test" "--mt" "test_fallback_gas_report" "--gas-report" "--json"
test cmd::gas_report_with_fallback ... ok
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Now yields:

```
running 1 test
executing cd "/tmp/gas_report_with_fallback-0UmDEvA" && NO_COLOR="1" "/home/zerosnacks/Projects/foundry/target/debug/forge" "test" "--mt" "test_fallback_gas_report" "-vvvv" "--gas-report"
executing cd "/tmp/gas_report_with_fallback-0UmDEvA" && NO_COLOR="1" "/home/zerosnacks/Projects/foundry/target/debug/forge" "test" "--mt" "test_fallback_gas_report" "--gas-report" "--json"
test cmd::gas_report_with_fallback ... ok

successes:

---- cmd::gas_report_with_fallback stdout ----
initializing /tmp/gas_report_with_fallback-0UmDEvA
- copying template dir from /tmp/foundry-forge-test-template


successes:
    cmd::gas_report_with_fallback

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 298 filtered out; finished in 1.36s
```

- `sh_println!` -> `println!` for specific test internals
- Render `{status} Hash:` with a space in between previously it would render as `[Success]Hash:`
