### PR TITLE
fix(forge): record gas for nested deployed contracts

### DIFF
--- a/crates/forge/src/gas_report.rs
+++ b/crates/forge/src/gas_report.rs
@@ -7,7 +7,6 @@ use crate::{
 use alloy_primitives::map::HashSet;
 use comfy_table::{presets::ASCII_MARKDOWN, *};
 use foundry_common::{calc, TestFunctionExt};
-use foundry_evm::traces::CallKind;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{collections::BTreeMap, fmt::Display};
@@ -91,17 +90,6 @@ impl GasReport {
         let trace = &node.trace;
 
         if trace.address == CHEATCODE_ADDRESS || trace.address == HARDHAT_CONSOLE_ADDRESS {
-            return;
-        }
-
-        // Only include top-level calls which account for calldata and base (21.000) cost.
-        // Only include Calls and Creates as only these calls are isolated in inspector.
-        if trace.depth > 1 &&
-            (trace.kind == CallKind::Call ||
-                trace.kind == CallKind::Create ||
-                trace.kind == CallKind::Create2 ||
-                trace.kind == CallKind::EOFCreate)
-        {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9300 
Atm the gas reports are not collected for Calls and Creates if not the top level call (comment says `// Only include Calls and Creates as only these calls are isolated in inspector.` but check returns if one of these kinds, so they're not added)

https://github.com/foundry-rs/foundry/blob/4817280d96e0e33a2e96cf169770da60514d1764/crates/forge/src/gas_report.rs#L97-L106

E.g. for a `Parent` contract that creates `Child` which in turn creates `AnotherChild`, running tests with traces and gas report will look like

```bash
[PASS] test_gas() (gas: 314505)
Traces:
  [314505] NestedDeploy::test_gas()
    ├─ [254857] → new Parent@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
    │   ├─ [125076] → new Child@0x104fBc016F4bb334D775a19E8A6510109AC63E00
    │   │   ├─ [20275] → new AnotherChild@0x41C3c259514f88211c4CA2fd805A93F8F9A57504
    │   │   │   └─ ← [Return] 101 bytes of code
    │   │   └─ ← [Return] 252 bytes of code
    │   └─ ← [Return] 165 bytes of code
...

Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 2.34ms (1.49ms CPU time)
| src/Counter.sol:Child contract |                 |       |        |       |         |
|--------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                | Deployment Size |       |        |       |         |
| 0                              | 0               |       |        |       |         |
| Function Name                  | min             | avg   | median | max   | # calls |
| w                              | 26256           | 26256 | 26256  | 26256 | 1       |


| src/Counter.sol:Parent contract |                 |     |        |     |         |
|---------------------------------|-----------------|-----|--------|-----|---------|
| Deployment Cost                 | Deployment Size |     |        |     |         |
| 254857                          | 770             |     |        |     |         |
| Function Name                   | min             | avg | median | max | # calls |
| child                           | 182             | 182 | 182    | 182 | 1       |
```

All contracts and gas are displayed in traces but deployment cost and size for `Child` and `AnotherChild` reports are missing (one more thing that is not inline between traces and gas reports is that in traces the creation bytecode size is shown whereas in gas report the deployment bytecode size)

@klkvr tests are passing but probably there's a good reason for the check, please advise 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- include all calls at all depths in gas reports