### PR TITLE
chore: do not trim decoded generic custom error

### DIFF
--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -191,7 +191,7 @@ impl RevertDecoder {
                 s.push_str(": ");
                 match std::str::from_utf8(data) {
                     Ok(data) => s.push_str(data),
-                    Err(_) => s.push_str(&trimmed_hex(data)),
+                    Err(_) => s.push_str(&hex::encode(data)),
                 }
             }
             s


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref https://t.me/foundry_rs/37822
Don't think custom errors data could be too big for needed to be trimmed and this could be helpful in cases like attached ref, e.g.

![image](https://github.com/user-attachments/assets/ebf253ef-0f34-4d8d-a948-60f433c01840)

instead

![image](https://github.com/user-attachments/assets/b4ca6743-ce6b-4ab2-88c7-a14d7fd54bf1)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
