### PR TITLE
feat(forge): allow `--verifier custom` option

### DIFF
--- a/crates/common/src/retry.rs
+++ b/crates/common/src/retry.rs
@@ -83,6 +83,7 @@ impl Retry {
 
     fn handle_err(&mut self, err: Error) {
         self.retries -= 1;
-        warn!("erroneous attempt ({} tries remaining): {}", self.retries, err.root_cause());
+        let _ =
+            sh_warn!("erroneous attempt ({} tries remaining): {}", self.retries, err.root_cause());
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -124,6 +124,7 @@ impl FromStr for VerificationProviderType {
             "s" | "sourcify" => Ok(Self::Sourcify),
             "b" | "blockscout" => Ok(Self::Blockscout),
             "o" | "oklink" => Ok(Self::Oklink),
+            "c" | "custom" => Ok(Self::Custom),
             _ => Err(format!("Unknown provider: {s}")),
         }
     }
@@ -144,6 +145,9 @@ impl fmt::Display for VerificationProviderType {
             Self::Oklink => {
                 write!(f, "oklink")?;
             }
+            Self::Custom => {
+                write!(f, "custom")?;
+            }
         };
         Ok(())
     }
@@ -156,6 +160,7 @@ pub enum VerificationProviderType {
     Sourcify,
     Blockscout,
     Oklink,
+    Custom,
 }
 
 impl VerificationProviderType {
@@ -171,6 +176,7 @@ impl VerificationProviderType {
             Self::Sourcify => Ok(Box::<SourcifyVerificationProvider>::default()),
             Self::Blockscout => Ok(Box::<EtherscanVerificationProvider>::default()),
             Self::Oklink => Ok(Box::<EtherscanVerificationProvider>::default()),
+            Self::Custom => Ok(Box::<EtherscanVerificationProvider>::default()),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9220 

- allows custom verifiers to be defined
- could be passed as cli arg, e.g.
```bash
forge create \
  --rpc-url http://localhost:8545 \
  --private-key 0x12345.... \
  src/Counter.sol:Counter \
  --verify \
  --verifier custom \
  --verifier-url http://localhost:8888/api
```
or
```bash
forge verify-contract \
  0x59b670e9fA9D0A427751Af201D676719a970857b \
  --rpc-url http://localhost:8545 \
  --verifier custom \
  --verifier-url http://localhost:8888/api
```

- or defined and implicitly taken from `foundry.toml` config, e.g.
```toml
[etherscan]
anvil-hardhat = { key = "1234", url = "http://localhost:8888/api" }
```
and calling as
```bash
forge create \
  --rpc-url http://localhost:8545 \
  --private-key 0x12345.... \
  src/Counter.sol:Counter \
  --verify
```
or
```bash
forge verify-contract \
  0x59b670e9fA9D0A427751Af201D676719a970857b \
  --rpc-url http://localhost:8545
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- better user feedback for retry error handle, print console warning
![image](https://github.com/user-attachments/assets/94ad0899-f1ce-4322-8edd-996d666747f1)
