### PR TITLE
fix: identification of contracts in scripts

### DIFF
--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -205,9 +205,8 @@ impl PreSimulationState {
             .contracts
             .iter()
             .filter_map(move |(addr, contract_id)| {
-                let contract_name = get_contract_name(contract_id);
                 if let Ok(Some((_, data))) =
-                    self.build_data.known_contracts.find_by_name_or_identifier(contract_name)
+                    self.build_data.known_contracts.find_by_name_or_identifier(contract_id)
                 {
                     return Some((*addr, data));
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Right now this would fail if there're any contracts with the same name in project due to
https://github.com/foundry-rs/foundry/blob/2dcc84fdc4188a3a5dffce7a6b2d7fabb9aca8d9/crates/common/src/contracts.rs#L255

## Solution

Use complete identifier when getting artifact
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
