### PR TITLE
Typo Update debugging.md

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -21,4 +21,4 @@ Filters are explained in detail in the [`env_logger` crate docs](https://docs.rs
 ### Compiler input and output
 
 You can get the compiler input JSON and output JSON by passing the `--build-info` flag.
-This will create two files: one for the input and one for the output.
+This will create two files: one for the input and one for the outputs.


### PR DESCRIPTION
**Description:**

In the documentation, there is a small typo that needs to be corrected for better clarity and accuracy.

### Original:
> "This will create two files: one for the input and one for the output."

### Fix:
> "This will create two files: one for the input and one for the outputs."

### Explanation:
The word "output" should be changed to "outputs" because, in this context, it makes more sense to refer to "outputs" in the plural form. The sentence describes the creation of a file for all compiler output data, not a single output. Using "outputs" better reflects this idea and improves the overall clarity of the documentation.

---

Thank you for reviewing this minor fix!

