### PR TITLE
chore: make environment variable error nicer

### DIFF
--- a/crates/config/src/resolve.rs
+++ b/crates/config/src/resolve.rs
@@ -23,15 +23,23 @@ impl UnresolvedEnvVarError {
     pub fn try_resolve(&self) -> Result<String, Self> {
         interpolate(&self.unresolved)
     }
+
+    fn is_simple(&self) -> bool {
+        RE_PLACEHOLDER.captures_iter(&self.unresolved).count() <= 1
+    }
 }
 
 impl fmt::Display for UnresolvedEnvVarError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Failed to resolve env var `{}` in `{}`: {}",
-            self.var, self.unresolved, self.source
-        )
+        write!(f, "environment variable `{}` ", self.var)?;
+        f.write_str(match self.source {
+            VarError::NotPresent => "not found",
+            VarError::NotUnicode(_) => "is not valid unicode",
+        })?;
+        if !self.is_simple() {
+            write!(f, " in `{}`", self.unresolved)?;
+        }
+        Ok(())
     }
 }
 

--- a/testdata/default/cheats/RpcUrls.t.sol
+++ b/testdata/default/cheats/RpcUrls.t.sol
@@ -22,9 +22,7 @@ contract RpcUrlTest is DSTest {
     // can set env and return correct url
     function testCanSetAndGetURLAndAllUrls() public {
         // this will fail because alias is not set
-        vm._expectCheatcodeRevert(
-            "Failed to resolve env var `RPC_ENV_ALIAS` in `${RPC_ENV_ALIAS}`: environment variable not found"
-        );
+        vm._expectCheatcodeRevert("environment variable `RPC_ENV_ALIAS` not found");
         string[2][] memory _urls = vm.rpcUrls();
 
         string memory url = vm.rpcUrl("mainnet");


### PR DESCRIPTION
Before: ``[FAIL: setup failed: vm.createSelectFork: Failed to resolve env var `ETH_NODE_URI_MAINNET` in `${ETH_NODE_URI_MAINNET}`: environment variable not found] setUp() (gas: 0)``

After: ``[FAIL: setup failed: vm.createSelectFork: environment variable `ETH_NODE_URI_MAINNET` not found] setUp() (gas: 0)``