### PR TITLE
chore: remove redundant 'setup failed' in setup errors

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -157,15 +157,9 @@ impl ContractRunner<'_> {
                         raw: RawCallResult { traces, labels, logs, coverage, .. },
                         reason,
                     } = *err;
-                    (logs, traces, labels, Some(format!("setup failed: {reason}")), coverage)
+                    (logs, traces, labels, Some(reason), coverage)
                 }
-                Err(err) => (
-                    Vec::new(),
-                    None,
-                    HashMap::default(),
-                    Some(format!("setup failed: {err}")),
-                    None,
-                ),
+                Err(err) => (Vec::new(), None, HashMap::default(), Some(err.to_string()), None),
             };
             traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
             logs.extend(setup_logs);

--- a/crates/forge/tests/it/core.rs
+++ b/crates/forge/tests/it/core.rs
@@ -23,7 +23,7 @@ async fn test_core() {
                 vec![(
                     "setUp()",
                     false,
-                    Some("setup failed: revert: setup failed predictably".to_string()),
+                    Some("revert: setup failed predictably".to_string()),
                     None,
                     None,
                 )],
@@ -70,13 +70,7 @@ async fn test_core() {
             ),
             (
                 "default/core/FailingTestAfterFailedSetup.t.sol:FailingTestAfterFailedSetupTest",
-                vec![(
-                    "setUp()",
-                    false,
-                    Some("setup failed: execution error".to_string()),
-                    None,
-                    None,
-                )],
+                vec![("setUp()", false, Some("execution error".to_string()), None, None)],
             ),
             (
                 "default/core/MultipleAfterInvariant.t.sol:MultipleAfterInvariant",


### PR DESCRIPTION
These errors are shown as part of `setUp` in the logs anyway