### PR TITLE
chore: pick provider urls by next index

### DIFF
--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -142,7 +142,8 @@ fn next_archive_endpoint(is_ws: bool) -> String {
     let rpc_env_vars = env::var(env_urls).unwrap_or_default();
     if !rpc_env_vars.is_empty() {
         let urls = rpc_env_vars.split(',').collect::<Vec<&str>>();
-        urls.choose(&mut rand::thread_rng()).unwrap().to_string()
+        let idx = next() % urls.len();
+        urls[idx].to_string()
     } else if is_ws {
         let idx = next() % ALCHEMY_KEYS.len();
         format!("wss://eth-mainnet.g.alchemy.com/v2/{}", ALCHEMY_KEYS[idx])


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- use `next()` fn to pick up a provider url by index
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
