### PR TITLE
fix(`forge`): detect invalid inline config keys

### DIFF
--- a/crates/config/src/inline/error.rs
+++ b/crates/config/src/inline/error.rs
@@ -5,6 +5,9 @@ pub enum InlineConfigParserError {
     /// The property cannot be mapped to the configuration object
     #[error("'{0}' is an invalid config property")]
     InvalidConfigProperty(String),
+    /// An invalid config key has been provided
+    #[error("'{0}' is an invalid config key. Available config keys are: {1}")]
+    InvalidConfigKey(String, String),
     /// An invalid profile has been provided
     #[error("'{0}' specifies an invalid profile. Available profiles are: {1}")]
     InvalidProfile(String, String),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -108,7 +108,10 @@ mod invariant;
 pub use invariant::InvariantConfig;
 
 mod inline;
-pub use inline::{validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser, NatSpec, InlineConfigParserError};
+pub use inline::{
+    validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser,
+    InlineConfigParserError, NatSpec,
+};
 
 pub mod soldeer;
 use soldeer::{SoldeerConfig, SoldeerDependencyConfig};

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -108,7 +108,7 @@ mod invariant;
 pub use invariant::InvariantConfig;
 
 mod inline;
-pub use inline::{validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser, NatSpec};
+pub use inline::{validate_profiles, InlineConfig, InlineConfigError, InlineConfigParser, NatSpec, InlineConfigParserError};
 
 pub mod soldeer;
 use soldeer::{SoldeerConfig, SoldeerDependencyConfig};

--- a/crates/forge/tests/it/inline.rs
+++ b/crates/forge/tests/it/inline.rs
@@ -118,7 +118,7 @@ forgetest_init!(tests_invalid_config_key, |prj, cmd| {
     )
     .unwrap();
 
-    cmd.args(&["test", "--mt", "testInvalidInlineConf"]).assert_failure().stderr_eq(
+    cmd.args(["test", "--mt", "testInvalidInlineConf"]).assert_failure().stderr_eq(
         r#"Error: Inline config error detected at forge-config:default.invalid.runs=1024
 
 Context:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5371 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Introduce `const VALID_CONFIG_KEYS` 
- Parse the config lines and see if it contains any keys that are outside `VALID_CONFIG_KEYS`.
- Throw `InvalidConfigKey` error if it does.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
