### PR TITLE
fix(forge test): install missing dependencies before creating `Project`

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -904,6 +904,9 @@ impl Config {
     ) -> Result<BTreeMap<PathBuf, RestrictionsWithVersion<MultiCompilerRestrictions>>, SolcError>
     {
         let mut map = BTreeMap::new();
+        if self.compilation_restrictions.is_empty() {
+            return Ok(BTreeMap::new());
+        }
 
         let graph = Graph::<MultiCompilerParsedSource>::resolve(paths)?;
         let (sources, _) = graph.into_sources();

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -291,15 +291,14 @@ impl TestArgs {
             config.invariant.gas_report_samples = 0;
         }
 
-        // Set up the project.
-        let mut project = config.project()?;
-
         // Install missing dependencies.
         if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
             // need to re-configure here to also catch additional remappings
             config = self.load_config();
-            project = config.project()?;
         }
+
+        // Set up the project.
+        let project = config.project()?;
 
         let mut filter = self.filter(&config);
         trace!(target: "forge::test", ?filter, "using filter");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes https://github.com/foundry-rs/foundry/issues/9375

With #8668 we now resolve the `Graph` when creating project as we need data about all sources for restrictions. This caused `forge test` to fail in CI if there are any missing dependencies which were being installed only after call to `config.project()`

This PR changes order of operations so that we always install dependencies first. Also I've added an optimization to skip graph resolution if user did not specify any restrictions
