### PR TITLE
feat(cheatcodes): string format

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5213,6 +5213,206 @@
     },
     {
       "func": {
+        "id": "format_0",
+        "description": "Return the formatted string with one `uint256` argument.",
+        "declaration": "function format(string calldata input, uint256 p0) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,uint256)",
+        "selector": "0x05c2acc4",
+        "selectorBytes": [
+          5,
+          194,
+          172,
+          196
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_1",
+        "description": "Return the formatted string with one `bool` argument.",
+        "declaration": "function format(string calldata input, bool p0) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,bool)",
+        "selector": "0x2702efd1",
+        "selectorBytes": [
+          39,
+          2,
+          239,
+          209
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_2",
+        "description": "Return the formatted string with two `uint256` arguments.",
+        "declaration": "function format(string calldata input, uint256 p0, uint256 p1) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,uint256,uint256)",
+        "selector": "0x510eeba1",
+        "selectorBytes": [
+          81,
+          14,
+          235,
+          161
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_3",
+        "description": "Return the formatted string with two `bool` arguments.",
+        "declaration": "function format(string calldata input, bool p0, bool p1) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,bool,bool)",
+        "selector": "0xa6bb978e",
+        "selectorBytes": [
+          166,
+          187,
+          151,
+          142
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_4",
+        "description": "Return the formatted string with one `uint256` argument and one `bool` argument.",
+        "declaration": "function format(string calldata input, uint256 p0, bool p1) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,uint256,bool)",
+        "selector": "0x37fab47f",
+        "selectorBytes": [
+          55,
+          250,
+          180,
+          127
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_5",
+        "description": "Return the formatted string with one `bool` argument and one `uint256` argument.",
+        "declaration": "function format(string calldata input, bool p0, uint256 p1) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,bool,uint256)",
+        "selector": "0x34dcd281",
+        "selectorBytes": [
+          52,
+          220,
+          210,
+          129
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_6",
+        "description": "Return the formatted string with three `uint256` arguments.",
+        "declaration": "function format(string calldata input, uint256 p0, uint256 p1, uint256 p2) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,uint256,uint256,uint256)",
+        "selector": "0xb67c2b93",
+        "selectorBytes": [
+          182,
+          124,
+          43,
+          147
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_7",
+        "description": "Return the formatted string with three `bool` arguments.",
+        "declaration": "function format(string calldata input, bool p0, bool p1, bool p2) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,bool,bool,bool)",
+        "selector": "0xf534ab85",
+        "selectorBytes": [
+          245,
+          52,
+          171,
+          133
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_8",
+        "description": "Return the formatted string with four `uint256` arguments.",
+        "declaration": "function format(string calldata input, uint256 p0, uint256 p1, uint256 p2, uint256 p3) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,uint256,uint256,uint256,uint256)",
+        "selector": "0x50734fce",
+        "selectorBytes": [
+          80,
+          115,
+          79,
+          206
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "format_9",
+        "description": "Return the formatted string with four `bool` arguments.",
+        "declaration": "function format(string calldata input, bool p0, bool p1, bool p2, bool p3) external pure returns (string memory output);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "format(string,bool,bool,bool,bool)",
+        "selector": "0x12ba5c43",
+        "selectorBytes": [
+          18,
+          186,
+          92,
+          67
+        ]
+      },
+      "group": "string",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "fsMetadata",
         "description": "Given a path, query the file system to get information about a file, directory, etc.",
         "declaration": "function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2116,6 +2116,40 @@ interface Vm {
     #[cheatcode(group = String)]
     function contains(string calldata subject, string calldata search) external returns (bool result);
 
+    /// Return the formatted string with one `uint256` argument.
+    #[cheatcode(group = String)]
+    function format(string calldata input, uint256 p0) external pure returns (string memory output);
+    /// Return the formatted string with one `bool` argument.
+    #[cheatcode(group = String)]
+    function format(string calldata input, bool p0) external pure returns (string memory output);
+
+    /// Return the formatted string with two `uint256` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, uint256 p0, uint256 p1) external pure returns (string memory output);
+    /// Return the formatted string with two `bool` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, bool p0, bool p1) external pure returns (string memory output);
+    /// Return the formatted string with one `uint256` argument and one `bool` argument.
+    #[cheatcode(group = String)]
+    function format(string calldata input, uint256 p0, bool p1) external pure returns (string memory output);
+    /// Return the formatted string with one `bool` argument and one `uint256` argument.
+    #[cheatcode(group = String)]
+    function format(string calldata input, bool p0, uint256 p1) external pure returns (string memory output);
+
+    /// Return the formatted string with three `uint256` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, uint256 p0, uint256 p1, uint256 p2) external pure returns (string memory output);
+    /// Return the formatted string with three `bool` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, bool p0, bool p1, bool p2) external pure returns (string memory output);
+
+    /// Return the formatted string with four `uint256` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, uint256 p0, uint256 p1, uint256 p2, uint256 p3) external pure returns (string memory output);
+    /// Return the formatted string with four `bool` arguments.
+    #[cheatcode(group = String)]
+    function format(string calldata input, bool p0, bool p1, bool p2, bool p3) external pure returns (string memory output);
+
     // ======== JSON Parsing and Manipulation ========
 
     // -------- Reading --------

--- a/crates/cheatcodes/src/string.rs
+++ b/crates/cheatcodes/src/string.rs
@@ -4,6 +4,7 @@ use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{hex, U256};
 use alloy_sol_types::SolValue;
+use foundry_common::fmt::console_format;
 
 // address
 impl Cheatcode for toString_0Call {
@@ -149,6 +150,74 @@ impl Cheatcode for containsCall {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { subject, search } = self;
         Ok(subject.contains(search).abi_encode())
+    }
+}
+
+// format with one argument
+impl Cheatcode for format_0Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0 } = self;
+        Ok(console_format(input, &[p0]).abi_encode())
+    }
+}
+impl Cheatcode for format_1Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0 } = self;
+        Ok(console_format(input, &[p0]).abi_encode())
+    }
+}
+
+// format with two arguments
+impl Cheatcode for format_2Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 } = self;
+        Ok(console_format(input, &[p0, p1]).abi_encode())
+    }
+}
+impl Cheatcode for format_3Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 } = self;
+        Ok(console_format(input, &[p0, p1]).abi_encode())
+    }
+}
+impl Cheatcode for format_4Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 } = self;
+        Ok(console_format(input, &[p0, p1]).abi_encode())
+    }
+}
+impl Cheatcode for format_5Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 } = self;
+        Ok(console_format(input, &[p0, p1]).abi_encode())
+    }
+}
+
+// format with three arguments
+impl Cheatcode for format_6Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1, p2 } = self;
+        Ok(console_format(input, &[p0, p1, p2]).abi_encode())
+    }
+}
+impl Cheatcode for format_7Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1, p2 } = self;
+        Ok(console_format(input, &[p0, p1, p2]).abi_encode())
+    }
+}
+
+// format with four arguments
+impl Cheatcode for format_8Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 , p2, p3} = self;
+        Ok(console_format(input, &[p0, p1, p2, p3]).abi_encode())
+    }
+}
+impl Cheatcode for format_9Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { input, p0, p1 , p2, p3} = self;
+        Ok(console_format(input, &[p0, p1, p2, p3]).abi_encode())
     }
 }
 

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -254,6 +254,16 @@ interface Vm {
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
     function fee(uint256 newBasefee) external;
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
+    function format(string calldata input, uint256 p0) external pure returns (string memory output);
+    function format(string calldata input, bool p0) external pure returns (string memory output);
+    function format(string calldata input, uint256 p0, uint256 p1) external pure returns (string memory output);
+    function format(string calldata input, bool p0, bool p1) external pure returns (string memory output);
+    function format(string calldata input, uint256 p0, bool p1) external pure returns (string memory output);
+    function format(string calldata input, bool p0, uint256 p1) external pure returns (string memory output);
+    function format(string calldata input, uint256 p0, uint256 p1, uint256 p2) external pure returns (string memory output);
+    function format(string calldata input, bool p0, bool p1, bool p2) external pure returns (string memory output);
+    function format(string calldata input, uint256 p0, uint256 p1, uint256 p2, uint256 p3) external pure returns (string memory output);
+    function format(string calldata input, bool p0, bool p1, bool p2, bool p3) external pure returns (string memory output);
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
     function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);
     function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);

--- a/testdata/default/cheats/StringUtils.t.sol
+++ b/testdata/default/cheats/StringUtils.t.sol
@@ -57,4 +57,21 @@ contract StringManipulationTest is DSTest {
         assert(vm.contains(subject, "test"));
         assert(!vm.contains(subject, "foundry"));
     }
+
+    function testFormat() public {
+        string memory input1 = "test: %d %d %d %d";
+        assertEq(vm.format(input1, 1), "test: 1 %d %d %d");
+        assertEq(vm.format(input1, 1, 2), "test: 1 2 %d %d");
+        assertEq(vm.format(input1, 1, 2, 3), "test: 1 2 3 %d");
+        assertEq(vm.format(input1, 1, 2, 3, 4), "test: 1 2 3 4");
+
+        string memory input2 = "test: %s %s %s %s";
+        assertEq(vm.format(input2, true), "test: true %s %s %s");
+        assertEq(vm.format(input2, true, false), "test: true false %s %s");
+        assertEq(vm.format(input2, true, false, true), "test: true false true %s");
+        assertEq(vm.format(input2, true, false, true, true), "test: true false true true");
+    
+        assertEq(vm.format("test: %d %s", 1, true), "test: 1 true");
+        assertEq(vm.format("test: %s %d", true, 1), "test: true 1");
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5002

Implement `format` cheatcode to format strings with specifiers like `%s` and `%d`, similar to console logging.

This is just a first iteration, I'd like to see if it's aligned with what's needed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
