### PR TITLE
fix: remove duplicate `gas_limit` / `block_gas_limit` field, declare as alias

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -196,11 +196,6 @@ impl Provider for EvmArgs {
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 #[command(next_help_heading = "Executor environment config")]
 pub struct EnvArgs {
-    /// The block gas limit.
-    #[arg(long, value_name = "GAS_LIMIT")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gas_limit: Option<u64>,
-
     /// EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
     /// default, it is 0x6000 (~25kb).
     #[arg(long, value_name = "CODE_SIZE")]
@@ -253,7 +248,7 @@ pub struct EnvArgs {
     pub block_prevrandao: Option<B256>,
 
     /// The block gas limit.
-    #[arg(long, value_name = "GAS_LIMIT")]
+    #[arg(long, visible_alias = "gas-limit", value_name = "GAS_LIMIT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_gas_limit: Option<u64>,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/4693

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Declared as visible alias for backwards compatibility

Also mirrors 

```rust
    #[arg(long, visible_alias = "no-gas-limit")]
    pub disable_block_gas_limit: bool,
```