### PR TITLE
fix(`coverage`): account for `build_id` in source identification 

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use foundry_common::TestFunctionExt;
 use foundry_compilers::artifacts::ast::{self, Ast, Node, NodeType};
 use rayon::prelude::*;
-use std::{borrow::Cow, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 /// A visitor that walks the AST of a single contract and finds coverage items.
 #[derive(Clone, Debug)]
@@ -591,26 +591,23 @@ pub struct SourceFiles<'a> {
 /// Serves as a unique identifier for sources across multiple compiler runs.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SourceIdentifier {
-    pub path: PathBuf,
+    /// Source ID is unique for each source file per compilation job but may not be across
+    /// different jobs.
     pub source_id: usize,
+    /// Artifact build id is same for all sources in a single compilation job. But always unique
+    /// across different jobs.
     pub build_id: String,
 }
 
 impl fmt::Display for SourceIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "source_id={} build_id={} path={}",
-            self.source_id,
-            self.build_id,
-            self.path.display()
-        )
+        write!(f, "source_id={} build_id={}", self.source_id, self.build_id,)
     }
 }
 
 impl SourceIdentifier {
-    pub fn new(source_id: usize, build_id: String, path: PathBuf) -> Self {
-        Self { path, source_id, build_id }
+    pub fn new(source_id: usize, build_id: String) -> Self {
+        Self { source_id, build_id }
     }
 }
 

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -539,7 +539,7 @@ impl<'a> SourceAnalyzer<'a> {
             .sources
             .sources
             .par_iter()
-            .flat_map_iter(|(source_id, SourceFile { source, ast, .. })| {
+            .flat_map_iter(|(source_id, SourceFile { source, ast })| {
                 ast.nodes.iter().map(move |node| {
                     if !matches!(node.node_type, NodeType::ContractDefinition) {
                         return Ok(vec![]);

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -1,3 +1,5 @@
+use crate::analysis::SourceIdentifier;
+
 use super::{CoverageItem, CoverageItemKind, ItemAnchor, SourceLocation};
 use alloy_primitives::map::{DefaultHashBuilder, HashMap, HashSet};
 use eyre::ensure;
@@ -11,12 +13,13 @@ pub fn find_anchors(
     source_map: &SourceMap,
     ic_pc_map: &IcPcMap,
     items: &[CoverageItem],
-    items_by_source_id: &HashMap<usize, Vec<usize>>,
+    items_by_source_id: &HashMap<SourceIdentifier, Vec<usize>>,
+    source_id: &SourceIdentifier,
 ) -> Vec<ItemAnchor> {
     let mut seen = HashSet::with_hasher(DefaultHashBuilder::default());
     source_map
         .iter()
-        .filter_map(|element| items_by_source_id.get(&(element.index()? as usize)))
+        .filter_map(|_element| items_by_source_id.get(source_id))
         .flatten()
         .filter_map(|&item_id| {
             if !seen.insert(item_id) {
@@ -171,7 +174,8 @@ pub fn find_anchor_branch(
 /// Calculates whether `element` is within the range of the target `location`.
 fn is_in_source_range(element: &SourceElement, location: &SourceLocation) -> bool {
     // Source IDs must match.
-    let source_ids_match = element.index().is_some_and(|a| a as usize == location.source_id);
+    let source_ids_match =
+        element.index().is_some_and(|a| a as usize == location.source_id.source_id);
     if !source_ids_match {
         return false;
     }

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -178,9 +178,8 @@ impl CoverageArgs {
                 continue;
             };
 
-            let file = project_paths.root.join(id.source.clone());
-            let identifier = SourceIdentifier::new(source_file.id as usize, build_id.clone(), file);
-            report.add_source(version.clone(), identifier, id.source.clone());
+            let identifier = SourceIdentifier::new(source_file.id as usize, build_id.clone());
+            report.add_source(version.clone(), identifier.clone(), id.source.clone());
 
             if let Some(ast) = source_file.ast {
                 let file = project_paths.root.join(id.source);
@@ -191,9 +190,6 @@ impl CoverageArgs {
                     source: fs::read_to_string(&file)
                         .wrap_err("Could not read source code for analysis")?,
                 };
-
-                let identifier =
-                    SourceIdentifier::new(source_file.id as usize, build_id.clone(), file);
 
                 versioned_sources
                     .entry(version.clone())

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -223,7 +223,6 @@ impl CoverageReporter for BytecodeReporter {
                     .unwrap_or("     ".to_owned());
                 let source_id = source_element.index();
                 let source_path = source_id.and_then(|_i| {
-                    // report.source_paths.get(&(contract_id.version.clone(), i as usize))
                     report
                         .source_paths
                         .get(&(contract_id.version.clone(), contract_id.source_id.clone()))

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -222,8 +222,11 @@ impl CoverageReporter for BytecodeReporter {
                     .map(|h| format!("[{h:03}]"))
                     .unwrap_or("     ".to_owned());
                 let source_id = source_element.index();
-                let source_path = source_id.and_then(|i| {
-                    report.source_paths.get(&(contract_id.version.clone(), i as usize))
+                let source_path = source_id.and_then(|_i| {
+                    // report.source_paths.get(&(contract_id.version.clone(), i as usize))
+                    report
+                        .source_paths
+                        .get(&(contract_id.version.clone(), contract_id.source_id.clone()))
                 });
 
                 let code = format!("{code:?}");

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1662,22 +1662,35 @@ forgetest!(test_coverage_multi_solc_versions, |prj, cmd| {
 });
 
 // checks that `clean` also works with the "out" value set in Config
-forgetest!(coverage_cache, |prj, cmd| {    
-    prj.add_source("A", r#"
+// this test verifies that the coverage is preserved across compiler runs that may result in files
+// with different source_id's
+forgetest!(coverage_cache_across_compiler_runs, |prj, cmd| {
+    prj.add_source(
+        "A",
+        r#"
 contract A {
     function f() public pure returns (uint) {
         return 1;
     }
-}"#).unwrap();
+}"#,
+    )
+    .unwrap();
 
-    prj.add_source("B", r#"
+    prj.add_source(
+        "B",
+        r#"
 contract B {
     function f() public pure returns (uint) {
         return 1;
     }
-}"#).unwrap();
+}"#,
+    )
+    .unwrap();
 
-    let a_test = prj.add_test("A.t.sol", r#"
+    let a_test = prj
+        .add_test(
+            "A.t.sol",
+            r#"
 import {A} from "../src/A.sol";
 
 contract ATest {
@@ -1686,9 +1699,13 @@ contract ATest {
         a.f();
     }
 }
-    "#).unwrap();
+    "#,
+        )
+        .unwrap();
 
-    prj.add_test("B.t.sol", r#"
+    prj.add_test(
+        "B.t.sol",
+        r#"
     import {B} from "../src/B.sol";
     
     contract BTest {
@@ -1697,8 +1714,10 @@ contract ATest {
             a.f();
         }
     }
-        "#).unwrap();
-    
+        "#,
+    )
+    .unwrap();
+
     cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 Ran 2 test suites [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
@@ -1718,7 +1737,8 @@ Ran 2 test suites [ELAPSED]: 2 tests passed, 0 failed, 0 skipped (2 total tests)
 | File      | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-----------|---------------|---------------|---------------|---------------|
 | src/A.sol | 100.00% (1/1) | 100.00% (1/1) | 100.00% (0/0) | 100.00% (1/1) |
-| Total     | 100.00% (1/1) | 100.00% (1/1) | 100.00% (0/0) | 100.00% (1/1) |
+| src/B.sol | 100.00% (1/1) | 100.00% (1/1) | 100.00% (0/0) | 100.00% (1/1) |
+| Total     | 100.00% (2/2) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
 
 "#]]);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref: https://github.com/foundry-rs/foundry/pull/9366#issuecomment-2498169059

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Introduces `SourceIdentifier` which wraps both `build_id` and `source_id`.
- `SourceIdentifier` replaces `source_id` as a key identifier for source files in report and analysis.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
