### PR TITLE
feat: add `--broadcast` flag to forge create, default to dry run mode

### DIFF
--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -160,8 +160,6 @@ impl CreateArgs {
             provider.get_chain_id().await?
         };
 
-        let contract_name = self.contract.name.clone();
-
         // Whether to broadcast the transaction or not
         let dry_run = !self.broadcast;
 
@@ -169,7 +167,6 @@ impl CreateArgs {
             // Deploy with unlocked account
             let sender = self.eth.wallet.from.expect("required");
             self.deploy(
-                &contract_name,
                 abi,
                 bin,
                 params,
@@ -189,7 +186,6 @@ impl CreateArgs {
                 .wallet(EthereumWallet::new(signer))
                 .on_provider(provider);
             self.deploy(
-                &contract_name,
                 abi,
                 bin,
                 params,
@@ -266,7 +262,6 @@ impl CreateArgs {
     #[allow(clippy::too_many_arguments)]
     async fn deploy<P: Provider<T, AnyNetwork>, T: Transport + Clone>(
         self,
-        contract_name: &str,
         abi: JsonAbi,
         bin: BytecodeObject,
         args: Vec<DynSolValue>,
@@ -359,7 +354,7 @@ impl CreateArgs {
             if !shell::is_json() {
                 sh_warn!("Dry run enabled, not broadcasting transaction\n")?;
 
-                sh_println!("Contract: {contract_name}")?;
+                sh_println!("Contract: {}", self.contract.name)?;
                 sh_println!(
                     "Transaction: {}",
                     serde_json::to_string_pretty(&deployer.tx.clone())?
@@ -369,7 +364,7 @@ impl CreateArgs {
                 sh_warn!("To broadcast this transaction, add --broadcast to the previous command. See forge create --help for more.")?;
             } else {
                 let output = json!({
-                    "contract": contract_name,
+                    "contract": self.contract.name,
                     "transaction": &deployer.tx,
                     "abi":&abi
                 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/3356

In order to prevent accidental deployments this PR proposes to add a `--broadcast` flag to `forge create` as a requirement for actually deploying. If not passed the user is warned this is a dry run and asks them to explicitly pass it. This is in line with `forge script`.

If `--broadcast` not passed we configure the transaction and simulate right up to the point of actually deploying.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Note this is a breaking change but in my eyes a sensible one and hints the user