### PR TITLE
refactor: adapt to CompilerContract trait type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,8 +3788,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6131af72175c55aa531c4851290d9cf67af7a82b03f20a8a9d28dba81b9fd3"
+source = "git+https://github.com/elfedy/compilers.git?branch=elfedy-compiler-output#7ddf90557f3e50acaa60d4acd54a50d6addb6166"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3826,8 +3825,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c522c473e7a111b81f0d47f8a65ca1ef0642c8c8d1ca2d1e230338210d16bb02"
+source = "git+https://github.com/elfedy/compilers.git?branch=elfedy-compiler-output#7ddf90557f3e50acaa60d4acd54a50d6addb6166"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3836,8 +3834,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cd569a0c38d232244932e71933b54e418cddcc8f0c16fd8af96dd844b27788"
+source = "git+https://github.com/elfedy/compilers.git?branch=elfedy-compiler-output#7ddf90557f3e50acaa60d4acd54a50d6addb6166"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3860,8 +3857,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b80563ba10981ec4a9667fda9318d02721a81f248ae73303603388580150a35"
+source = "git+https://github.com/elfedy/compilers.git?branch=elfedy-compiler-output#7ddf90557f3e50acaa60d4acd54a50d6addb6166"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3875,8 +3871,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a840a87cb4845d208df3390a12d3724e6d1cc1268a51ac334a01f80f9b6419b"
+source = "git+https://github.com/elfedy/compilers.git?branch=elfedy-compiler-output#7ddf90557f3e50acaa60d4acd54a50d6addb6166"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
@@ -7035,7 +7030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -8488,7 +8483,7 @@ dependencies = [
  "const-hex",
  "derive_builder",
  "dunce",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "itoa",
  "lasso",
  "match_cfg",
@@ -8524,7 +8519,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.6.0",
  "bumpalo",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "memchr",
  "num-bigint",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,3 +330,5 @@ yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 # alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 # alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
+foundry-compilers = { git = "https://github.com/elfedy/compilers.git", branch = "elfedy-compiler-output"}
+

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -20,7 +20,7 @@ use foundry_common::{
     shell,
 };
 use foundry_compilers::{
-    artifacts::{ConfigurableContractArtifact, StorageLayout},
+    artifacts::{ConfigurableContractArtifact, Contract, StorageLayout},
     compilers::{
         solc::{Solc, SolcCompiler},
         Compiler,
@@ -284,7 +284,7 @@ fn print_storage(layout: StorageLayout, values: Vec<StorageValue>, pretty: bool)
             "{}",
             serde_json::to_string_pretty(&serde_json::to_value(StorageReport { layout, values })?)?
         )?;
-        return Ok(())
+        return Ok(());
     }
 
     let mut table = Table::new();
@@ -314,7 +314,7 @@ fn print_storage(layout: StorageLayout, values: Vec<StorageValue>, pretty: bool)
     Ok(())
 }
 
-fn add_storage_layout_output<C: Compiler>(project: &mut Project<C>) {
+fn add_storage_layout_output<C: Compiler<CompilerContract = Contract>>(project: &mut Project<C>) {
     project.artifacts.additional_values.storage_layout = true;
     project.update_output_selection(|selection| {
         selection.0.values_mut().for_each(|contract_selection| {

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -10,7 +10,7 @@ use comfy_table::{presets::ASCII_MARKDOWN, Attribute, Cell, CellAlignment, Color
 use eyre::Result;
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    artifacts::{remappings::Remapping, BytecodeObject, Source},
+    artifacts::{remappings::Remapping, BytecodeObject, Contract, Source},
     compilers::{
         solc::{Solc, SolcCompiler},
         Compiler,
@@ -129,7 +129,10 @@ impl ProjectCompiler {
     }
 
     /// Compiles the project.
-    pub fn compile<C: Compiler>(mut self, project: &Project<C>) -> Result<ProjectCompileOutput<C>> {
+    pub fn compile<C: Compiler<CompilerContract = Contract>>(
+        mut self,
+        project: &Project<C>,
+    ) -> Result<ProjectCompileOutput<C>> {
         // TODO: Avoid process::exit
         if !project.paths.has_input_files() && self.files.is_empty() {
             sh_println!("Nothing to compile")?;
@@ -163,7 +166,10 @@ impl ProjectCompiler {
     /// ProjectCompiler::new().compile_with(|| Ok(prj.compile()?)).unwrap();
     /// ```
     #[instrument(target = "forge::compile", skip_all)]
-    fn compile_with<C: Compiler, F>(self, f: F) -> Result<ProjectCompileOutput<C>>
+    fn compile_with<C: Compiler<CompilerContract = Contract>, F>(
+        self,
+        f: F,
+    ) -> Result<ProjectCompileOutput<C>>
     where
         F: FnOnce() -> Result<ProjectCompileOutput<C>>,
     {
@@ -202,7 +208,10 @@ impl ProjectCompiler {
     }
 
     /// If configured, this will print sizes or names
-    fn handle_output<C: Compiler>(&self, output: &ProjectCompileOutput<C>) {
+    fn handle_output<C: Compiler<CompilerContract = Contract>>(
+        &self,
+        output: &ProjectCompileOutput<C>,
+    ) {
         let print_names = self.print_names.unwrap_or(false);
         let print_sizes = self.print_sizes.unwrap_or(false);
 
@@ -257,8 +266,8 @@ impl ProjectCompiler {
                     .as_ref()
                     .map(|abi| {
                         abi.functions().any(|f| {
-                            f.test_function_kind().is_known() ||
-                                matches!(f.name.as_str(), "IS_TEST" | "IS_SCRIPT")
+                            f.test_function_kind().is_known()
+                                || matches!(f.name.as_str(), "IS_TEST" | "IS_SCRIPT")
                         })
                     })
                     .unwrap_or(false);
@@ -465,7 +474,7 @@ pub struct ContractInfo {
 /// If `verify` and it's a standalone script, throw error. Only allowed for projects.
 ///
 /// **Note:** this expects the `target_path` to be absolute
-pub fn compile_target<C: Compiler>(
+pub fn compile_target<C: Compiler<CompilerContract = Contract>>(
     target_path: &Path,
     project: &Project<C>,
     quiet: bool,

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -3,7 +3,7 @@ use foundry_common::compact_to_contract;
 use foundry_compilers::{
     artifacts::{
         sourcemap::{SourceElement, SourceMap},
-        Bytecode, ContractBytecodeSome, Libraries, Source,
+        Bytecode, Contract, ContractBytecodeSome, Libraries, Source,
     },
     multi::MultiCompilerLanguage,
     Artifact, Compiler, ProjectCompileOutput,
@@ -137,7 +137,7 @@ impl ContractSources {
         Ok(sources)
     }
 
-    pub fn insert<C: Compiler>(
+    pub fn insert<C: Compiler<CompilerContract = Contract>>(
         &mut self,
         output: &ProjectCompileOutput<C>,
         root: &Path,

--- a/crates/forge/bin/cmd/clone.rs
+++ b/crates/forge/bin/cmd/clone.rs
@@ -266,7 +266,7 @@ impl CloneArgs {
                 let remappings_txt_content =
                     config.remappings.iter().map(|r| r.to_string()).collect::<Vec<_>>().join("\n");
                 if fs::write(&remappings_txt, remappings_txt_content).is_err() {
-                    return false
+                    return false;
                 }
 
                 let profile = config.profile.as_str().as_str();
@@ -442,16 +442,16 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
     // * if there is any other directory other than `src`, `contracts`, `lib`, `hardhat`,
     //   `forge-std`,
     // or not started with `@`, we should not re-organize.
-    let to_reorg = !no_reorg &&
-        std::fs::read_dir(tmp_dump_dir.join(contract_name))?.all(|e| {
+    let to_reorg = !no_reorg
+        && std::fs::read_dir(tmp_dump_dir.join(contract_name))?.all(|e| {
             let Ok(e) = e else { return false };
             let folder_name = e.file_name();
-            folder_name == "src" ||
-                folder_name == "lib" ||
-                folder_name == "contracts" ||
-                folder_name == "hardhat" ||
-                folder_name == "forge-std" ||
-                folder_name.to_string_lossy().starts_with('@')
+            folder_name == "src"
+                || folder_name == "lib"
+                || folder_name == "contracts"
+                || folder_name == "hardhat"
+                || folder_name == "forge-std"
+                || folder_name.to_string_lossy().starts_with('@')
         });
 
     // ensure `src` and `lib` directories exist
@@ -484,9 +484,9 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
                 }
             } else {
                 assert!(
-                    folder_name == "hardhat" ||
-                        folder_name == "forge-std" ||
-                        folder_name.to_string_lossy().starts_with('@')
+                    folder_name == "hardhat"
+                        || folder_name == "forge-std"
+                        || folder_name.to_string_lossy().starts_with('@')
                 );
                 // move these other folders to lib
                 let dest = lib_dir.join(&folder_name);
@@ -527,9 +527,9 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
             // i.e., remove prefix `contracts` (if any) and add prefix `src`
             let new_path = if r.path.starts_with("contracts") {
                 PathBuf::from("src").join(PathBuf::from(&r.path).strip_prefix("contracts")?)
-            } else if r.path.starts_with('@') ||
-                r.path.starts_with("hardhat/") ||
-                r.path.starts_with("forge-std/")
+            } else if r.path.starts_with('@')
+                || r.path.starts_with("hardhat/")
+                || r.path.starts_with("forge-std/")
             {
                 PathBuf::from("lib").join(PathBuf::from(&r.path))
             } else {
@@ -612,7 +612,7 @@ impl EtherscanClient for Client {
 mod tests {
     use super::*;
     use alloy_primitives::hex;
-    use foundry_compilers::Artifact;
+    use foundry_compilers::CompilerContract;
     use foundry_test_utils::rpc::next_mainnet_etherscan_api_key;
     use std::collections::BTreeMap;
 
@@ -631,7 +631,7 @@ mod tests {
             contracts.iter().for_each(|(name, contract)| {
                 if name == contract_name {
                     let compiled_creation_code =
-                        contract.get_bytecode_object().expect("creation code not found");
+                        contract.bin_ref().expect("creation code not found");
                     assert!(
                         hex::encode(compiled_creation_code.as_ref())
                             .starts_with(stripped_creation_code),

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -9,7 +9,9 @@ use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_common::{get_contract_name, shell::verbosity, ContractsByArtifact, TestFunctionExt};
 use foundry_compilers::{
-    artifacts::Libraries, compilers::Compiler, Artifact, ArtifactId, ProjectCompileOutput,
+    artifacts::{Contract, Libraries},
+    compilers::Compiler,
+    Artifact, ArtifactId, ProjectCompileOutput,
 };
 use foundry_config::Config;
 use foundry_evm::{
@@ -394,7 +396,7 @@ impl MultiContractRunnerBuilder {
 
     /// Given an EVM, proceeds to return a runner which is able to execute all tests
     /// against that evm
-    pub fn build<C: Compiler>(
+    pub fn build<C: Compiler<CompilerContract = Contract>>(
         self,
         root: &Path,
         output: &ProjectCompileOutput<C>,
@@ -430,8 +432,8 @@ impl MultiContractRunnerBuilder {
             let Some(abi) = &contract.abi else { continue };
 
             // if it's a test, link it and add to deployable contracts
-            if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
-                abi.functions().any(|func| func.name.is_any_test())
+            if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
+                && abi.functions().any(|func| func.name.is_any_test())
             {
                 let Some(bytecode) =
                     contract.get_bytecode_bytes().map(|b| b.into_owned()).filter(|b| !b.is_empty())
@@ -469,8 +471,8 @@ impl MultiContractRunnerBuilder {
 }
 
 pub fn matches_contract(id: &ArtifactId, abi: &JsonAbi, filter: &dyn TestFilter) -> bool {
-    (filter.matches_path(&id.source) && filter.matches_contract(&id.name)) &&
-        abi.functions().any(|func| is_matching_test(func, filter))
+    (filter.matches_path(&id.source) && filter.matches_contract(&id.name))
+        && abi.functions().any(|func| is_matching_test(func, filter))
 }
 
 /// Returns `true` if the function is a test function that matches the given filter.

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -1,6 +1,7 @@
 use crate::init_tracing;
 use eyre::{Result, WrapErr};
 use foundry_compilers::{
+    artifacts::Contract,
     cache::CompilerCache,
     compilers::multi::MultiCompiler,
     error::Result as SolcResult,
@@ -420,7 +421,9 @@ pub fn setup_cast_project(test: TestProject) -> (TestProject, TestCommand) {
 ///
 /// Test projects are created from a global atomic counter to avoid duplicates.
 #[derive(Clone, Debug)]
-pub struct TestProject<T: ArtifactOutput = ConfigurableArtifacts> {
+pub struct TestProject<
+    T: ArtifactOutput<CompilerContract = Contract> + Default = ConfigurableArtifacts,
+> {
     /// The directory in which this test executable is running.
     exe_root: PathBuf,
     /// The project in which the test should run.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/foundry-rs/compilers/pull/224 would introduce a new type to compilers that involves breaking changes to the api.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adapt code to those changes. This is a naive way that hardcodes `CompilerContract` to be `Contract` most of the time. We could either adapt the code to be more generic (more desirable from a non evm perspective, but also might be better to delay it for further more targeted PRs) or to have `Contract` as the default `CompilerContract` in compilers and potentially remove some boilerplate
