### PR TITLE
chore: rename the arg name of EvmOpts from evm_opts to evm_args

### DIFF
--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -35,7 +35,7 @@ extern crate foundry_common;
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 // Loads project's figment and merges the build cli arguments into it
-foundry_config::merge_impl_figment_convert!(Chisel, opts, evm_opts);
+foundry_config::merge_impl_figment_convert!(Chisel, opts, evm_args);
 
 const VERSION_MESSAGE: &str = concat!(
     env!("CARGO_PKG_VERSION"),
@@ -76,7 +76,7 @@ pub struct Chisel {
     pub opts: CoreBuildArgs,
 
     #[command(flatten)]
-    pub evm_opts: EvmArgs,
+    pub evm_args: EvmArgs,
 }
 
 /// Chisel binary subcommands

--- a/crates/forge/bin/cmd/config.rs
+++ b/crates/forge/bin/cmd/config.rs
@@ -5,7 +5,7 @@ use foundry_cli::utils::LoadConfig;
 use foundry_common::{evm::EvmArgs, shell};
 use foundry_config::fix::fix_tomls;
 
-foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
+foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_args);
 
 /// CLI arguments for `forge config`.
 #[derive(Clone, Debug, Parser)]
@@ -23,7 +23,7 @@ pub struct ConfigArgs {
     opts: BuildArgs,
 
     #[command(flatten)]
-    evm_opts: EvmArgs,
+    evm_args: EvmArgs,
 }
 
 impl ConfigArgs {

--- a/crates/forge/bin/cmd/debug.rs
+++ b/crates/forge/bin/cmd/debug.rs
@@ -6,7 +6,7 @@ use foundry_common::evm::EvmArgs;
 use std::path::PathBuf;
 
 // Loads project's figment and merges the build cli arguments into it
-foundry_config::impl_figment_convert!(DebugArgs, opts, evm_opts);
+foundry_config::impl_figment_convert!(DebugArgs, opts, evm_args);
 
 /// CLI arguments for `forge debug`.
 #[derive(Clone, Debug, Parser)]
@@ -46,7 +46,7 @@ pub struct DebugArgs {
     pub opts: CoreBuildArgs,
 
     #[command(flatten)]
-    pub evm_opts: EvmArgs,
+    pub evm_args: EvmArgs,
 }
 
 impl DebugArgs {
@@ -58,7 +58,7 @@ impl DebugArgs {
             sig: self.sig,
             gas_estimate_multiplier: 130,
             opts: self.opts,
-            evm_args: self.evm_opts,
+            evm_args: self.evm_args,
             debug: true,
             dump: self.dump,
             retry: RETRY_VERIFY_ON_CREATE,

--- a/crates/forge/bin/cmd/debug.rs
+++ b/crates/forge/bin/cmd/debug.rs
@@ -58,7 +58,7 @@ impl DebugArgs {
             sig: self.sig,
             gas_estimate_multiplier: 130,
             opts: self.opts,
-            evm_opts: self.evm_opts,
+            evm_args: self.evm_opts,
             debug: true,
             dump: self.dump,
             retry: RETRY_VERIFY_ON_CREATE,

--- a/crates/forge/bin/cmd/mod.rs
+++ b/crates/forge/bin/cmd/mod.rs
@@ -24,7 +24,7 @@
 //! #[derive(Clone, Debug, Parser)]
 //! pub struct MyArgs {
 //!     #[command(flatten)]
-//!     evm_opts: EvmArgs,
+//!     evm_args: EvmArgs,
 //!     #[command(flatten)]
 //!     opts: BuildArgs,
 //! }

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -59,7 +59,7 @@ pub use filter::FilterArgs;
 use forge::{result::TestKind, traces::render_trace_arena_inner};
 
 // Loads project's figment and merges the build cli arguments into it
-foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_opts);
+foundry_config::merge_impl_figment_convert!(TestArgs, opts, evm_args);
 
 /// CLI arguments for `forge test`.
 #[derive(Clone, Debug, Parser)]
@@ -162,7 +162,7 @@ pub struct TestArgs {
     pub rerun: bool,
 
     #[command(flatten)]
-    evm_opts: EvmArgs,
+    evm_args: EvmArgs,
 
     #[command(flatten)]
     opts: CoreBuildArgs,
@@ -1007,7 +1007,7 @@ mod tests {
     fn extract_chain() {
         let test = |arg: &str, expected: Chain| {
             let args = TestArgs::parse_from(["foundry-cli", arg]);
-            assert_eq!(args.evm_opts.env.chain, Some(expected));
+            assert_eq!(args.evm_args.env.chain, Some(expected));
             let (config, evm_opts) = args.load_config_and_evm_opts().unwrap();
             assert_eq!(config.chain, Some(expected));
             assert_eq!(evm_opts.env.chain_id, Some(expected.id()));

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -189,7 +189,7 @@ impl PreExecutionState {
         if let Some(txs) = transactions {
             // If the user passed a `--sender` don't check anything.
             if self.build_data.predeploy_libraries.libraries_count() > 0 &&
-                self.args.evm_opts.sender.is_none()
+                self.args.evm_args.sender.is_none()
             {
                 for tx in txs.iter() {
                     if tx.transaction.to().is_none() {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -73,7 +73,7 @@ mod transaction;
 mod verify;
 
 // Loads project's figment and merges the build cli arguments into it
-foundry_config::merge_impl_figment_convert!(ScriptArgs, opts, evm_opts);
+foundry_config::merge_impl_figment_convert!(ScriptArgs, opts, evm_args);
 
 /// CLI arguments for `forge script`.
 #[derive(Clone, Debug, Default, Parser)]
@@ -210,7 +210,7 @@ pub struct ScriptArgs {
     pub wallets: MultiWalletOpts,
 
     #[command(flatten)]
-    pub evm_opts: EvmArgs,
+    pub evm_args: EvmArgs,
 
     #[command(flatten)]
     pub verifier: forge_verify::VerifierArgs,
@@ -222,7 +222,7 @@ pub struct ScriptArgs {
 impl ScriptArgs {
     pub async fn preprocess(self) -> Result<PreprocessedState> {
         let script_wallets =
-            Wallets::new(self.wallets.get_multi_wallet().await?, self.evm_opts.sender);
+            Wallets::new(self.wallets.get_multi_wallet().await?, self.evm_args.sender);
 
         let (config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
 
@@ -411,7 +411,7 @@ impl ScriptArgs {
         }
 
         let mut prompt_user = false;
-        let max_size = match self.evm_opts.env.code_size_limit {
+        let max_size = match self.evm_args.env.code_size_limit {
             Some(size) => size,
             None => CONTRACT_MAX_SIZE,
         };
@@ -723,7 +723,7 @@ mod tests {
             "--code-size-limit",
             "50000",
         ]);
-        assert_eq!(args.evm_opts.env.code_size_limit, Some(50000));
+        assert_eq!(args.evm_args.env.code_size_limit, Some(50000));
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We have `EvmArgs` and `EvmOpts` struct, so rename `evm_opts: EvmArgs` to `evm_args: EvmArgs`, make the code more readable.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
