### PR TITLE
chore: use alloy-chains' `is_arbitrum`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3013,5 +3013,8 @@ pub fn prove_storage(storage: &HashMap<U256, U256>, keys: &[B256]) -> Vec<Vec<By
 }
 
 pub fn is_arbitrum(chain_id: u64) -> bool {
-    NamedChain::try_from(chain_id).map_or(false, |chain| chain.is_arbitrum())
+    if let Ok(chain) = NamedChain::try_from(chain_id) {
+        return chain.is_arbitrum()
+    }
+    false
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3013,11 +3013,5 @@ pub fn prove_storage(storage: &HashMap<U256, U256>, keys: &[B256]) -> Vec<Vec<By
 }
 
 pub fn is_arbitrum(chain_id: u64) -> bool {
-    matches!(
-        NamedChain::try_from(chain_id),
-        Ok(NamedChain::Arbitrum |
-            NamedChain::ArbitrumTestnet |
-            NamedChain::ArbitrumGoerli |
-            NamedChain::ArbitrumNova)
-    )
+    NamedChain::try_from(chain_id).map_or(false, |chain| chain.is_arbitrum())
 }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -159,15 +159,15 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
+        if chain.is_arbitrum() {
+            return true;
+        }
+
         return matches!(
             chain,
             NamedChain::Acala |
                 NamedChain::AcalaMandalaTestnet |
                 NamedChain::AcalaTestnet |
-                NamedChain::Arbitrum |
-                NamedChain::ArbitrumGoerli |
-                NamedChain::ArbitrumSepolia |
-                NamedChain::ArbitrumTestnet |
                 NamedChain::Etherlink |
                 NamedChain::EtherlinkTestnet |
                 NamedChain::Karura |
@@ -187,13 +187,7 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
 /// True if it supports broadcasting in batches.
 pub fn has_batch_support(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
-        return !matches!(
-            chain,
-            NamedChain::Arbitrum |
-                NamedChain::ArbitrumTestnet |
-                NamedChain::ArbitrumGoerli |
-                NamedChain::ArbitrumSepolia
-        );
+        return !chain.is_arbitrum();
     }
     true
 }

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -159,27 +159,24 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 /// True if the network calculates gas costs differently.
 pub fn has_different_gas_calc(chain_id: u64) -> bool {
     if let Some(chain) = Chain::from(chain_id).named() {
-        if chain.is_arbitrum() {
-            return true;
-        }
-
-        return matches!(
-            chain,
-            NamedChain::Acala |
-                NamedChain::AcalaMandalaTestnet |
-                NamedChain::AcalaTestnet |
-                NamedChain::Etherlink |
-                NamedChain::EtherlinkTestnet |
-                NamedChain::Karura |
-                NamedChain::KaruraTestnet |
-                NamedChain::Mantle |
-                NamedChain::MantleSepolia |
-                NamedChain::MantleTestnet |
-                NamedChain::Moonbase |
-                NamedChain::Moonbeam |
-                NamedChain::MoonbeamDev |
-                NamedChain::Moonriver
-        );
+        return chain.is_arbitrum() ||
+            matches!(
+                chain,
+                NamedChain::Acala |
+                    NamedChain::AcalaMandalaTestnet |
+                    NamedChain::AcalaTestnet |
+                    NamedChain::Etherlink |
+                    NamedChain::EtherlinkTestnet |
+                    NamedChain::Karura |
+                    NamedChain::KaruraTestnet |
+                    NamedChain::Mantle |
+                    NamedChain::MantleSepolia |
+                    NamedChain::MantleTestnet |
+                    NamedChain::Moonbase |
+                    NamedChain::Moonbeam |
+                    NamedChain::MoonbeamDev |
+                    NamedChain::Moonriver
+            );
     }
     false
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Follow-up for https://github.com/foundry-rs/foundry/pull/9430, can be merged before or after

Use the `alloy-chains` `is_arbitrum` built-in

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Follow-up for https://github.com/foundry-rs/foundry/pull/9430/files#diff-a0d1dbafd7eaf82b3fd4d30722d2c7e369394883a704e8b41554d0a31b43629f to use `is_arbitrum` consistently
