### PR TITLE
fix(coverage): special functions have no name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4173,6 +4173,7 @@ dependencies = [
  "regex",
  "serde_json",
  "snapbox",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -310,9 +310,10 @@ impl CoverageArgs {
     }
 }
 
-// TODO: HTML
-#[derive(Clone, Debug, ValueEnum)]
+/// Coverage reports to generate.
+#[derive(Clone, Debug, Default, ValueEnum)]
 pub enum CoverageReportKind {
+    #[default]
     Summary,
     Lcov,
     Debug,

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -102,12 +102,13 @@ impl CoverageReporter for LcovReporter<'_> {
 
             for item in items {
                 let line = item.loc.lines.start;
-                let line_end = item.loc.lines.end - 1;
+                // `lines` is half-open, so we need to subtract 1 to get the last included line.
+                let end_line = item.loc.lines.end - 1;
                 let hits = item.hits;
                 match item.kind {
                     CoverageItemKind::Function { ref name } => {
                         let name = format!("{}.{name}", item.loc.contract_name);
-                        writeln!(self.out, "FN:{line},{line_end},{name}")?;
+                        writeln!(self.out, "FN:{line},{end_line},{name}")?;
                         writeln!(self.out, "FNDA:{hits},{name}")?;
                     }
                     CoverageItemKind::Line => {

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -70,7 +70,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 100% coverage (init function coverage called in setUp is accounted).
-    cmd.arg("coverage").arg("--summary").assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -243,7 +243,7 @@ contract AContractTest is DSTest {
     );
 
     // Assert 100% coverage (assert properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -319,7 +319,7 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% branch coverage.
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -625,7 +625,7 @@ contract FooTest is DSTest {
 "#]]);
 
     // Assert 100% coverage.
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches      | % Funcs       |
 |-------------|-----------------|-----------------|-----------------|---------------|
@@ -696,7 +696,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 100% coverage.
-    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------------|-----------------|---------------|---------------|---------------|
@@ -805,7 +805,7 @@ contract FooTest is DSTest {
 "#]]);
 
     // Assert 100% branch coverage (including clauses without body).
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches    | % Funcs       |
 |-------------|-----------------|-----------------|---------------|---------------|
@@ -908,7 +908,7 @@ contract FooTest is DSTest {
     )
     .unwrap();
 
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches    | % Funcs       |
 |-------------|-----------------|-----------------|---------------|---------------|
@@ -998,7 +998,7 @@ contract FooTest is DSTest {
     )
     .unwrap();
 
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------|-----------------|---------------|---------------|---------------|
@@ -1076,7 +1076,7 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% coverage (true/false branches properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -1160,7 +1160,7 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% coverage (true/false branches properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -1229,7 +1229,7 @@ contract AContractTest is DSTest {
     )
     .unwrap();
 
-    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------------|-----------------|---------------|---------------|---------------|
@@ -1279,7 +1279,7 @@ contract AContractTest is DSTest {
     )
     .unwrap();
 
-    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -1322,7 +1322,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert there's only one function (`increment`) reported.
-    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -32,7 +32,9 @@ Wrote LCOV report.
 
     let lcov = prj.root().join("lcov.info");
     assert!(lcov.exists(), "lcov.info was not created");
-    assert_data_eq!(Data::read_from(&lcov, None), str![[r#"
+    assert_data_eq!(
+        Data::read_from(&lcov, None),
+        str![[r#"
 TN:
 SF:script/Counter.s.sol
 DA:10,0
@@ -69,7 +71,8 @@ BRF:0
 BRH:0
 end_of_record
 
-"#]]);
+"#]]
+    );
 }
 
 forgetest_init!(basic_coverage, |prj, cmd| {

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -219,43 +219,38 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 50% branch coverage for assert failure.
-    cmd.arg("coverage")
-        .args(["--mt".to_string(), "testAssertRevertBranch".to_string()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--mt", "testAssertRevertBranch"]).assert_success().stdout_eq(str![
+        [r#"
 ...
 | File              | % Lines      | % Statements | % Branches   | % Funcs       |
 |-------------------|--------------|--------------|--------------|---------------|
 | src/AContract.sol | 66.67% (2/3) | 50.00% (1/2) | 50.00% (1/2) | 100.00% (1/1) |
 | Total             | 66.67% (2/3) | 50.00% (1/2) | 50.00% (1/2) | 100.00% (1/1) |
 
-"#]]);
+"#]
+    ]);
 
     // Assert 50% branch coverage for proper assert.
-    cmd.forge_fuse()
-        .arg("coverage")
-        .args(["--mt".to_string(), "testAssertBranch".to_string()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--mt", "testAssertBranch"]).assert_success().stdout_eq(
+        str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches   | % Funcs       |
 |-------------------|---------------|---------------|--------------|---------------|
 | src/AContract.sol | 100.00% (3/3) | 100.00% (2/2) | 50.00% (1/2) | 100.00% (1/1) |
 | Total             | 100.00% (3/3) | 100.00% (2/2) | 50.00% (1/2) | 100.00% (1/1) |
 
-"#]]);
+"#]],
+    );
 
     // Assert 100% coverage (assert properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
 | src/AContract.sol | 100.00% (3/3) | 100.00% (2/2) | 100.00% (2/2) | 100.00% (1/1) |
 | Total             | 100.00% (3/3) | 100.00% (2/2) | 100.00% (2/2) | 100.00% (1/1) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_require_coverage, |prj, cmd| {
@@ -300,10 +295,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 50% branch coverage if only revert tested.
-    cmd.arg("coverage")
-        .args(["--mt".to_string(), "testRequireRevert".to_string()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--mt", "testRequireRevert"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches   | % Funcs       |
 |-------------------|---------------|---------------|--------------|---------------|
@@ -315,7 +307,7 @@ contract AContractTest is DSTest {
     // Assert 50% branch coverage if only happy path tested.
     cmd.forge_fuse()
         .arg("coverage")
-        .args(["--mt".to_string(), "testRequireNoRevert".to_string()])
+        .args(["--mt", "testRequireNoRevert"])
         .assert_success()
         .stdout_eq(str![[r#"
 ...
@@ -327,16 +319,14 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% branch coverage.
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
 | src/AContract.sol | 100.00% (2/2) | 100.00% (1/1) | 100.00% (2/2) | 100.00% (1/1) |
 | Total             | 100.00% (2/2) | 100.00% (1/1) | 100.00% (2/2) | 100.00% (1/1) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_line_hit_not_doubled, |prj, cmd| {
@@ -609,10 +599,7 @@ contract FooTest is DSTest {
 
     // Assert no coverage for single path branch. 2 branches (parent and child) not covered.
     cmd.arg("coverage")
-        .args([
-            "--nmt".to_string(),
-            "test_single_path_child_branch|test_single_path_parent_branch".to_string(),
-        ])
+        .args(["--nmt", "test_single_path_child_branch|test_single_path_parent_branch"])
         .assert_success()
         .stdout_eq(str![[r#"
 ...
@@ -626,7 +613,7 @@ contract FooTest is DSTest {
     // Assert no coverage for single path child branch. 1 branch (child) not covered.
     cmd.forge_fuse()
         .arg("coverage")
-        .args(["--nmt".to_string(), "test_single_path_child_branch".to_string()])
+        .args(["--nmt", "test_single_path_child_branch"])
         .assert_success()
         .stdout_eq(str![[r#"
 ...
@@ -638,16 +625,14 @@ contract FooTest is DSTest {
 "#]]);
 
     // Assert 100% coverage.
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches      | % Funcs       |
 |-------------|-----------------|-----------------|-----------------|---------------|
 | src/Foo.sol | 100.00% (36/36) | 100.00% (30/30) | 100.00% (16/16) | 100.00% (9/9) |
 | Total       | 100.00% (36/36) | 100.00% (30/30) | 100.00% (16/16) | 100.00% (9/9) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_function_call_coverage, |prj, cmd| {
@@ -711,7 +696,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 100% coverage.
-    cmd.arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------------|-----------------|---------------|---------------|---------------|
@@ -810,28 +795,24 @@ contract FooTest is DSTest {
     .unwrap();
 
     // Assert coverage not 100% for happy paths only.
-    cmd.arg("coverage").args(["--mt".to_string(), "happy".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.arg("coverage").args(["--mt", "happy"]).assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines        | % Statements   | % Branches   | % Funcs       |
 |-------------|----------------|----------------|--------------|---------------|
 | src/Foo.sol | 75.00% (15/20) | 66.67% (14/21) | 83.33% (5/6) | 100.00% (5/5) |
 | Total       | 75.00% (15/20) | 66.67% (14/21) | 83.33% (5/6) | 100.00% (5/5) |
 
-"#]],
-    );
+"#]]);
 
     // Assert 100% branch coverage (including clauses without body).
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches    | % Funcs       |
 |-------------|-----------------|-----------------|---------------|---------------|
 | src/Foo.sol | 100.00% (20/20) | 100.00% (21/21) | 100.00% (6/6) | 100.00% (5/5) |
 | Total       | 100.00% (20/20) | 100.00% (21/21) | 100.00% (6/6) | 100.00% (5/5) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_yul_coverage, |prj, cmd| {
@@ -927,16 +908,14 @@ contract FooTest is DSTest {
     )
     .unwrap();
 
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements    | % Branches    | % Funcs       |
 |-------------|-----------------|-----------------|---------------|---------------|
 | src/Foo.sol | 100.00% (30/30) | 100.00% (40/40) | 100.00% (1/1) | 100.00% (7/7) |
 | Total       | 100.00% (30/30) | 100.00% (40/40) | 100.00% (1/1) | 100.00% (7/7) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_misc_coverage, |prj, cmd| {
@@ -1019,16 +998,14 @@ contract FooTest is DSTest {
     )
     .unwrap();
 
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File        | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------|-----------------|---------------|---------------|---------------|
 | src/Foo.sol | 100.00% (12/12) | 100.00% (9/9) | 100.00% (0/0) | 100.00% (4/4) |
 | Total       | 100.00% (12/12) | 100.00% (9/9) | 100.00% (0/0) | 100.00% (4/4) |
 
-"#]],
-    );
+"#]]);
 });
 
 // https://github.com/foundry-rs/foundry/issues/8605
@@ -1075,10 +1052,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 50% coverage for true branches.
-    cmd.arg("coverage")
-        .args(["--mt".to_string(), "testTrueCoverage".to_string()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--mt", "testTrueCoverage"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines      | % Statements | % Branches   | % Funcs       |
 |-------------------|--------------|--------------|--------------|---------------|
@@ -1090,7 +1064,7 @@ contract AContractTest is DSTest {
     // Assert 50% coverage for false branches.
     cmd.forge_fuse()
         .arg("coverage")
-        .args(["--mt".to_string(), "testFalseCoverage".to_string()])
+        .args(["--mt", "testFalseCoverage"])
         .assert_success()
         .stdout_eq(str![[r#"
 ...
@@ -1102,16 +1076,14 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% coverage (true/false branches properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
 | src/AContract.sol | 100.00% (5/5) | 100.00% (4/4) | 100.00% (4/4) | 100.00% (1/1) |
 | Total             | 100.00% (5/5) | 100.00% (4/4) | 100.00% (4/4) | 100.00% (1/1) |
 
-"#]],
-    );
+"#]]);
 });
 
 // https://github.com/foundry-rs/foundry/issues/8604
@@ -1164,10 +1136,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert 50% coverage for true branches.
-    cmd.arg("coverage")
-        .args(["--mt".to_string(), "testTrueCoverage".to_string()])
-        .assert_success()
-        .stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--mt", "testTrueCoverage"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines      | % Statements | % Branches   | % Funcs       |
 |-------------------|--------------|--------------|--------------|---------------|
@@ -1179,7 +1148,7 @@ contract AContractTest is DSTest {
     // Assert 50% coverage for false branches.
     cmd.forge_fuse()
         .arg("coverage")
-        .args(["--mt".to_string(), "testFalseCoverage".to_string()])
+        .args(["--mt", "testFalseCoverage"])
         .assert_success()
         .stdout_eq(str![[r#"
 ...
@@ -1191,16 +1160,14 @@ contract AContractTest is DSTest {
 "#]]);
 
     // Assert 100% coverage (true/false branches properly covered).
-    cmd.forge_fuse().arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.forge_fuse().arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
 | src/AContract.sol | 100.00% (5/5) | 100.00% (5/5) | 100.00% (2/2) | 100.00% (1/1) |
 | Total             | 100.00% (5/5) | 100.00% (5/5) | 100.00% (2/2) | 100.00% (1/1) |
 
-"#]],
-    );
+"#]]);
 });
 
 forgetest!(test_identical_bytecodes, |prj, cmd| {
@@ -1262,7 +1229,7 @@ contract AContractTest is DSTest {
     )
     .unwrap();
 
-    cmd.arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines         | % Statements  | % Branches    | % Funcs       |
 |-------------------|-----------------|---------------|---------------|---------------|
@@ -1312,7 +1279,7 @@ contract AContractTest is DSTest {
     )
     .unwrap();
 
-    cmd.arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|
@@ -1355,7 +1322,7 @@ contract AContractTest is DSTest {
     .unwrap();
 
     // Assert there's only one function (`increment`) reported.
-    cmd.arg("coverage").args(["--summary".to_string()]).assert_success().stdout_eq(str![[r#"
+    cmd.arg("coverage").args(["--summary"]).assert_success().stdout_eq(str![[r#"
 ...
 | File              | % Lines       | % Statements  | % Branches    | % Funcs       |
 |-------------------|---------------|---------------|---------------|---------------|

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rand.workspace = true
 snapbox = { version = "0.6", features = ["json", "regex"] }
+tempfile.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -11,7 +11,7 @@ use foundry_compilers::{
 use foundry_config::Config;
 use parking_lot::Mutex;
 use regex::Regex;
-use snapbox::{assert_data_eq, cmd::OutputAssert, str, IntoData};
+use snapbox::{assert_data_eq, cmd::OutputAssert, Data, IntoData};
 use std::{
     env,
     ffi::OsStr,
@@ -905,7 +905,7 @@ impl TestCommand {
     /// Runs the command and asserts that it **failed** nothing was printed to stdout.
     #[track_caller]
     pub fn assert_empty_stdout(&mut self) {
-        self.assert_success().stdout_eq(str![[r#""#]]);
+        self.assert_success().stdout_eq(Data::new());
     }
 
     /// Runs the command and asserts that it failed.
@@ -923,7 +923,23 @@ impl TestCommand {
     /// Runs the command and asserts that it **failed** nothing was printed to stderr.
     #[track_caller]
     pub fn assert_empty_stderr(&mut self) {
-        self.assert_failure().stderr_eq(str![[r#""#]]);
+        self.assert_failure().stderr_eq(Data::new());
+    }
+
+    /// Runs the command with a temporary file argument and asserts that the contents of the file
+    /// match the given data.
+    #[track_caller]
+    pub fn assert_file(&mut self, data: impl IntoData) {
+        self.assert_file_with(|this, path| _ = this.arg(path).assert_success(), data);
+    }
+
+    /// Creates a temporary file, passes it to `f`, then asserts that the contents of the file match
+    /// the given data.
+    #[track_caller]
+    pub fn assert_file_with(&mut self, f: impl FnOnce(&mut Self, &Path), data: impl IntoData) {
+        let file = tempfile::NamedTempFile::new().expect("couldn't create temporary file");
+        f(self, file.path());
+        assert_data_eq!(Data::read_from(file.path(), None), data);
     }
 
     /// Does not apply [`snapbox`] redactions to the command output.

--- a/crates/test-utils/src/util.rs
+++ b/crates/test-utils/src/util.rs
@@ -902,7 +902,7 @@ impl TestCommand {
         assert_data_eq!(actual, expected);
     }
 
-    /// Runs the command and asserts that it **failed** nothing was printed to stdout.
+    /// Runs the command and asserts that it **succeeded** nothing was printed to stdout.
     #[track_caller]
     pub fn assert_empty_stdout(&mut self) {
         self.assert_success().stdout_eq(Data::new());


### PR DESCRIPTION
`fallback`, `receive`, and `constructor` have an empty `name` in the AST. Use the `kind` as the name instead.