### PR TITLE
fix/feat(coverage): add --lcov-version

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -23,7 +23,7 @@ use foundry_compilers::{
 };
 use foundry_config::{Config, SolcReq};
 use rayon::prelude::*;
-use semver::Version;
+use semver::{Version, VersionReq};
 use std::{
     io,
     path::{Path, PathBuf},
@@ -41,6 +41,18 @@ pub struct CoverageArgs {
     /// This flag can be used multiple times.
     #[arg(long, value_enum, default_value = "summary")]
     report: Vec<CoverageReportKind>,
+
+    /// The version of the LCOV "tracefile" format to use.
+    ///
+    /// Format: `MAJOR[.MINOR]`.
+    ///
+    /// Main differences:
+    /// - `1.x`: The original v1 format.
+    /// - `2.0`: Adds support for "line end" numbers for functions. LCOV 2.1 and onwards may emit
+    ///   an error if this option is not provided.
+    /// - `2.2`: Changes the format of functions.
+    #[arg(long, default_value = "1.16", value_parser = parse_lcov_version)]
+    lcov_version: Version,
 
     /// Enable viaIR with minimum optimization
     ///
@@ -295,7 +307,7 @@ impl CoverageArgs {
                     let path =
                         root.join(self.report_file.as_deref().unwrap_or("lcov.info".as_ref()));
                     let mut file = io::BufWriter::new(fs::create_file(path)?);
-                    LcovReporter::new(&mut file).report(&report)
+                    LcovReporter::new(&mut file, self.lcov_version.clone()).report(&report)
                 }
                 CoverageReportKind::Bytecode => {
                     let destdir = root.join("bytecode-coverage");
@@ -402,5 +414,33 @@ impl BytecodeData {
             &source_analysis.items,
             items_by_source_id,
         )
+    }
+}
+
+fn parse_lcov_version(s: &str) -> Result<Version, String> {
+    let vr = VersionReq::parse(&format!("={s}")).map_err(|e| e.to_string())?;
+    let [c] = &vr.comparators[..] else {
+        return Err("invalid version".to_string());
+    };
+    if c.op != semver::Op::Exact {
+        return Err("invalid version".to_string());
+    }
+    if !c.pre.is_empty() {
+        return Err("pre-releases are not supported".to_string());
+    }
+    Ok(Version::new(c.major, c.minor.unwrap_or(0), c.patch.unwrap_or(0)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lcov_version() {
+        assert_eq!(parse_lcov_version("0").unwrap(), Version::new(0, 0, 0));
+        assert_eq!(parse_lcov_version("1").unwrap(), Version::new(1, 0, 0));
+        assert_eq!(parse_lcov_version("1.0").unwrap(), Version::new(1, 0, 0));
+        assert_eq!(parse_lcov_version("1.1").unwrap(), Version::new(1, 1, 0));
+        assert_eq!(parse_lcov_version("1.11").unwrap(), Version::new(1, 11, 0));
     }
 }

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -32,8 +32,52 @@ Wrote LCOV report.
 
     let lcov = prj.root().join("lcov.info");
     assert!(lcov.exists(), "lcov.info was not created");
-    assert_data_eq!(
-        Data::read_from(&lcov, None),
+    let default_lcov = str![[r#"
+TN:
+SF:script/Counter.s.sol
+DA:10,0
+FN:10,CounterScript.setUp
+FNDA:0,CounterScript.setUp
+DA:12,0
+FN:12,CounterScript.run
+FNDA:0,CounterScript.run
+DA:13,0
+DA:15,0
+DA:17,0
+FNF:2
+FNH:0
+LF:5
+LH:0
+BRF:0
+BRH:0
+end_of_record
+TN:
+SF:src/Counter.sol
+DA:7,258
+FN:7,Counter.setNumber
+FNDA:258,Counter.setNumber
+DA:8,258
+DA:11,1
+FN:11,Counter.increment
+FNDA:1,Counter.increment
+DA:12,1
+FNF:2
+FNH:2
+LF:4
+LH:4
+BRF:0
+BRH:0
+end_of_record
+
+"#]];
+    assert_data_eq!(Data::read_from(&lcov, None), default_lcov.clone());
+    assert_lcov(
+        cmd.forge_fuse().args(["coverage", "--report=lcov", "--lcov-version=1"]),
+        default_lcov,
+    );
+
+    assert_lcov(
+        cmd.forge_fuse().args(["coverage", "--report=lcov", "--lcov-version=2"]),
         str![[r#"
 TN:
 SF:script/Counter.s.sol
@@ -71,7 +115,49 @@ BRF:0
 BRH:0
 end_of_record
 
-"#]]
+"#]],
+    );
+
+    assert_lcov(
+        cmd.forge_fuse().args(["coverage", "--report=lcov", "--lcov-version=2.2"]),
+        str![[r#"
+TN:
+SF:script/Counter.s.sol
+DA:10,0
+FNL:0,10,10
+FNA:0,0,CounterScript.setUp
+DA:12,0
+FNL:1,12,18
+FNA:1,0,CounterScript.run
+DA:13,0
+DA:15,0
+DA:17,0
+FNF:2
+FNH:0
+LF:5
+LH:0
+BRF:0
+BRH:0
+end_of_record
+TN:
+SF:src/Counter.sol
+DA:7,258
+FNL:2,7,9
+FNA:2,258,Counter.setNumber
+DA:8,258
+DA:11,1
+FNL:3,11,13
+FNA:3,1,Counter.increment
+DA:12,1
+FNF:2
+FNH:2
+LF:4
+LH:4
+BRF:0
+BRH:0
+end_of_record
+
+"#]],
     );
 }
 
@@ -432,7 +518,7 @@ contract AContractTest is DSTest {
 TN:
 SF:src/AContract.sol
 DA:7,1
-FN:7,9,AContract.foo
+FN:7,AContract.foo
 FNDA:1,AContract.foo
 DA:8,1
 FNF:1
@@ -1397,7 +1483,7 @@ contract AContractTest is DSTest {
 TN:
 SF:src/AContract.sol
 DA:9,1
-FN:9,9,AContract.increment
+FN:9,AContract.increment
 FNDA:1,AContract.increment
 FNF:1
 FNH:1
@@ -1466,11 +1552,11 @@ contract AContractTest is DSTest {
 TN:
 SF:src/AContract.sol
 DA:7,1
-FN:7,9,AContract.constructor
+FN:7,AContract.constructor
 FNDA:1,AContract.constructor
 DA:8,1
 DA:11,1
-FN:11,13,AContract.receive
+FN:11,AContract.receive
 FNDA:1,AContract.receive
 DA:12,1
 FNF:2
@@ -1530,5 +1616,5 @@ contract AContract {
 
 #[track_caller]
 fn assert_lcov(cmd: &mut TestCommand, data: impl IntoData) {
-    cmd.args(["--report=lcov", "--report-file"]).assert_file(data);
+    cmd.args(["--report=lcov", "--report-file"]).assert_file(data.into_data());
 }


### PR DESCRIPTION
In https://github.com/foundry-rs/foundry/pull/9438, it turns out that the `end_line` is a breaking change as it was added in 2.0, whereas I interpreted the documentation that the "old" format referred to pre-2.0.

Adds `--lcov-version major[.minor]` to `forge coverage`. Defaults to "1" for backwards compatibility. See the flag's documentation for differences between versions.

The original version issue (https://github.com/foundry-rs/foundry/issues/8281) is still fixed even with `--version 1` because the error was "missing corresponding lines" (DA), which are now always added with https://github.com/foundry-rs/foundry/pull/9438.

Fixes https://github.com/foundry-rs/foundry/issues/9461.