### PR TITLE
fix(`anvil`): impl `maybe_as_full_db` for `ForkedDatabase`

### DIFF
--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     revm::primitives::AccountInfo,
 };
-use alloy_primitives::{Address, B256, U256, U64};
+use alloy_primitives::{map::HashMap, Address, B256, U256, U64};
 use alloy_rpc_types::BlockId;
 use foundry_evm::{
     backend::{
@@ -14,7 +14,7 @@ use foundry_evm::{
     fork::database::ForkDbStateSnapshot,
     revm::{primitives::BlockEnv, Database},
 };
-use revm::DatabaseRef;
+use revm::{db::DbAccount, DatabaseRef};
 
 pub use foundry_evm::fork::database::ForkedDatabase;
 
@@ -92,6 +92,10 @@ impl MaybeFullDatabase for ForkedDatabase {
         self
     }
 
+    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+        Some(&self.database().accounts)
+    }
+
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
         let db = self.inner().db();
         let accounts = std::mem::take(&mut *db.accounts.write());
@@ -125,6 +129,10 @@ impl MaybeFullDatabase for ForkedDatabase {
 impl MaybeFullDatabase for ForkDbStateSnapshot {
     fn as_dyn(&self) -> &dyn DatabaseRef<Error = DatabaseError> {
         self
+    }
+
+    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+        Some(&self.local.accounts)
     }
 
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1484,12 +1484,13 @@ async fn test_fork_get_account() {
     let alice = accounts[0];
     let bob = accounts[1];
 
+    let init_block = provider.get_block_number().await.unwrap();
     let alice_bal = provider.get_balance(alice).await.unwrap();
     let alice_nonce = provider.get_transaction_count(alice).await.unwrap();
-    let alice_acc = provider.get_account(alice).await.unwrap();
+    let alice_acc_init = provider.get_account(alice).await.unwrap();
 
-    assert_eq!(alice_acc.balance, alice_bal);
-    assert_eq!(alice_acc.nonce, alice_nonce);
+    assert_eq!(alice_acc_init.balance, alice_bal);
+    assert_eq!(alice_acc_init.nonce, alice_nonce);
 
     let tx = TransactionRequest::default().from(alice).to(bob).value(U256::from(142));
 
@@ -1497,6 +1498,7 @@ async fn test_fork_get_account() {
     let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
 
     assert!(receipt.status());
+    assert_eq!(init_block + 1, receipt.block_number.unwrap());
 
     let alice_acc = provider.get_account(alice).await.unwrap();
 
@@ -1505,4 +1507,8 @@ async fn test_fork_get_account() {
         alice_bal - (U256::from(142) + U256::from(receipt.gas_used * receipt.effective_gas_price)),
     );
     assert_eq!(alice_acc.nonce, alice_nonce + 1);
+
+    let alice_acc_prev_block = provider.get_account(alice).number(init_block).await.unwrap();
+
+    assert_eq!(alice_acc_init, alice_acc_prev_block);
 }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1473,3 +1473,36 @@ async fn test_reset_dev_account_nonce() {
 
     assert!(receipt.status());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_get_account() {
+    let (_api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+
+    let accounts = handle.dev_accounts().collect::<Vec<_>>();
+
+    let alice = accounts[0];
+    let bob = accounts[1];
+
+    let alice_bal = provider.get_balance(alice).await.unwrap();
+    let alice_nonce = provider.get_transaction_count(alice).await.unwrap();
+    let alice_acc = provider.get_account(alice).await.unwrap();
+
+    assert_eq!(alice_acc.balance, alice_bal);
+    assert_eq!(alice_acc.nonce, alice_nonce);
+
+    let tx = TransactionRequest::default().from(alice).to(bob).value(U256::from(142));
+
+    let tx = WithOtherFields::new(tx);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+
+    assert!(receipt.status());
+
+    let alice_acc = provider.get_account(alice).await.unwrap();
+
+    assert_eq!(
+        alice_acc.balance,
+        alice_bal - (U256::from(142) + U256::from(receipt.gas_used * receipt.effective_gas_price)),
+    );
+    assert_eq!(alice_acc.nonce, alice_nonce + 1);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Re: https://t.me/foundry_rs/38080

Currently `maybe_as_full_db` isn't implemented for `ForkedDatabase` hence queries that run over a specific state in forked mode would fail with `Required data unavailable` 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Implement `maybe_as_full_db` for `ForkedDatabase`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
