### PR TITLE
Update README.md

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -10,7 +10,7 @@ $ cargo test
 
 should be enough to get you started!
 
-To learn more about how foundry's tools works, see [./architecture.md](./architecture.md).
+To learn more about how foundry's tools work, see [./architecture.md](./architecture.md).
 It also explains the high-level layout of some aspects of the source code.
 To read more about how to use it, see [📖 Foundry Book][foundry-book]
 Note though, that the internal documentation is very incomplete.


### PR DESCRIPTION
Changes Made:
1. Old Text:
"To learn more about how foundry's tools works, see ./architecture.md."
2. New Text:
"To learn more about how foundry's tools work, see ./architecture.md."
Reason for Changes:
The change corrects a grammatical error in the sentence. The word "works" was changed to "work" to ensure subject-verb agreement. The subject "tools" is plural, so the verb should also be in its plural form, "work."
