### PR TITLE
chore: clearer error message when function signature does not contain…

### DIFF
--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -43,7 +43,7 @@ pub async fn parse_function_args<T: Transport + Clone, P: Provider<T, AnyNetwork
     let args = resolve_name_args(&args, provider).await;
 
     if let Ok(data) = hex::decode(sig) {
-        return Ok((data, None))
+        return Ok((data, None));
     }
 
     let func = if sig.contains('(') {
@@ -51,7 +51,7 @@ pub async fn parse_function_args<T: Transport + Clone, P: Provider<T, AnyNetwork
         get_func(sig)?
     } else {
         let etherscan_api_key = etherscan_api_key.ok_or_eyre(
-            "If you wish to fetch function data from EtherScan, please provide an API key.",
+            "Function signature does not contain parentheses. If you wish to fetch function data from EtherScan, please provide an API key.",
         )?;
         let to = to.ok_or_eyre("A 'to' address must be provided to fetch function data.")?;
         get_func_etherscan(sig, to, &args, chain, etherscan_api_key).await?


### PR DESCRIPTION
… parentheses

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When I wrongly input a function signature without parentheses:
```bash
./target/debug/cast call 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D 'deposit'
```
The error message is a bit of confusing:
```
Error: If you wish to fetch function data from EtherScan, please provide an API key.
```
And cost me some time the figure out what's the point.

A clearer error message is needed.

## Solution

Change the message into:

```bash
Function signature does not contain parentheses. If you wish to fetch function data from EtherScan, please provide an API key.
```
