### PR TITLE
fix(`cli`): handle id and named chain_id's correctly

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1958,7 +1958,7 @@ Transaction successfully executed.
 
 // https://github.com/foundry-rs/foundry/issues/9476
 forgetest_async!(cast_call_custom_chain_id, |_prj, cmd| {
-    let chain_id = 5555u64;
+    let chain_id = 55555u64;
     let (_api, handle) = anvil::spawn(NodeConfig::test().with_chain_id(Some(chain_id))).await;
 
     let http_endpoint = handle.http_endpoint();

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1955,3 +1955,22 @@ Transaction successfully executed.
 
 "#]]);
 });
+
+// https://github.com/foundry-rs/foundry/issues/9476
+forgetest_async!(cast_call_custom_chain_id, |_prj, cmd| {
+    let chain_id = 5555u64;
+    let (_api, handle) = anvil::spawn(NodeConfig::test().with_chain_id(Some(chain_id))).await;
+
+    let http_endpoint = handle.http_endpoint();
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &http_endpoint,
+            "--chain",
+            &chain_id.to_string(),
+        ])
+        .assert_success();
+});

--- a/crates/cli/src/opts/ethereum.rs
+++ b/crates/cli/src/opts/ethereum.rs
@@ -1,4 +1,5 @@
 use crate::opts::ChainValueParser;
+use alloy_chains::ChainKind;
 use clap::Parser;
 use eyre::Result;
 use foundry_config::{
@@ -154,7 +155,11 @@ impl EtherscanOpts {
             dict.insert("etherscan_api_key".into(), key.into());
         }
         if let Some(chain) = self.chain {
-            dict.insert("chain_id".into(), chain.to_string().into());
+            if let ChainKind::Id(id) = chain.kind() {
+                dict.insert("chain_id".into(), (*id).into());
+            } else {
+                dict.insert("chain_id".into(), chain.to_string().into());
+            }
         }
         dict
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9476 

Currently, when inserting the passed `chain` into figment dict we don't differentiate between `ChainKind::Id` and `ChainKind::NamedChain`, even though they hold different types underneath; `u64` and `String` respectively.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Insert `Chain` into dict according to `Id` or `NamedChain`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
