### PR TITLE
fix(verify): use configured `solc_version` (if any) to identify artifact

### DIFF
--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -275,13 +275,13 @@ impl VerifyArgs {
 
             let cache = project.read_cache_file().ok();
 
-            let version = if let Some(ref version) = self.compiler_version {
-                version.trim_start_matches('v').parse()?
-            } else if let Some(ref solc) = config.solc {
+            let version = if let Some(ref solc) = config.solc {
                 match solc {
                     SolcReq::Version(version) => version.to_owned(),
                     SolcReq::Local(solc) => Solc::new(solc)?.version,
                 }
+            } else if let Some(ref version) = self.compiler_version {
+                version.trim_start_matches('v').parse()?
             } else if let Some(entry) =
                 cache.as_ref().and_then(|cache| cache.files.get(&contract_path).cloned())
             {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
reproducible with https://github.com/superform-xyz/SuperVaults/tree/testProdDeployment by running `sh ./script/utils/verify_contracts.sh` after a `forge build` (works OK if no cache / `forge clean` issued before)
- fails with `Error: No matching artifact found for SuperVault` because artifact was compiled with version within `foundry.toml` (`solc_version = "0.8.23"`, artifacts added in cache with `{Version { major: 0, minor: 8, patch: 23 }` key) but we first detect version from solc (which is `v0.8.23+commit.f704f362` so parsed as `Version { major: 0, minor: 8, patch: 23, build: BuildMetadata("commit.f704f362") }` cannot identify cached artifact)
https://github.com/foundry-rs/foundry/blob/2c9719ed2fdc99c3fd75ed6f62bb298e2f080b88/crates/verify/src/verify.rs#L278-L284

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- use configured solc version if any, and then try to figure version out from compiler version