### PR TITLE
feat(`cheatcodes`): count assertion for `expectRevert`

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5174,7 +5174,7 @@
     {
       "func": {
         "id": "expectRevert_6",
-        "description": "Expects a `count` number of reverts from the upcoming calls with any revert data.",
+        "description": "Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.",
         "declaration": "function expectRevert(uint64 count) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5053,6 +5053,46 @@
     },
     {
       "func": {
+        "id": "expectRevert_10",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,address,uint64)",
+        "selector": "0xb0762d73",
+        "selectorBytes": [
+          176,
+          118,
+          45,
+          115
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_11",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,address,uint64)",
+        "selector": "0xd345fb1f",
+        "selectorBytes": [
+          211,
+          69,
+          251,
+          31
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "expectRevert_2",
         "description": "Expects an error on next call that exactly matches the revert data.",
         "declaration": "function expectRevert(bytes calldata revertData) external;",
@@ -5125,6 +5165,86 @@
           235,
           207,
           18
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_6",
+        "description": "Expects a `count` number of reverts from the upcoming calls with any revert data.",
+        "declaration": "function expectRevert(uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(uint64)",
+        "selector": "0x4ee38244",
+        "selectorBytes": [
+          78,
+          227,
+          130,
+          68
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_7",
+        "description": "Expects a `count` number of reverts from the upcoming calls that match the revert data.",
+        "declaration": "function expectRevert(bytes4 revertData, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes4,uint64)",
+        "selector": "0xe45ca72d",
+        "selectorBytes": [
+          228,
+          92,
+          167,
+          45
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_8",
+        "description": "Expects a `count` number of reverts from the upcoming calls that exactly match the revert data.",
+        "declaration": "function expectRevert(bytes calldata revertData, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(bytes,uint64)",
+        "selector": "0x4994c273",
+        "selectorBytes": [
+          73,
+          148,
+          194,
+          115
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
+        "id": "expectRevert_9",
+        "description": "Expects a `count` number of reverts from the upcoming calls from the reverter address.",
+        "declaration": "function expectRevert(address reverter, uint64 count) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "expectRevert(address,uint64)",
+        "selector": "0x1ff5f952",
+        "selectorBytes": [
+          31,
+          245,
+          249,
+          82
         ]
       },
       "group": "testing",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1019,6 +1019,30 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData, address reverter) external;
 
+    /// Expects a `count` number of reverts from the upcoming calls with any revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls that match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls that exactly match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(address reverter, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
+
+    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    #[cheatcode(group = Testing, safety = Unsafe)]
+    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
+
     /// Expects an error on next call that starts with the revert data.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectPartialRevert(bytes4 revertData) external;

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1019,7 +1019,7 @@ interface Vm {
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(bytes calldata revertData, address reverter) external;
 
-    /// Expects a `count` number of reverts from the upcoming calls with any revert data.
+    /// Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.
     #[cheatcode(group = Testing, safety = Unsafe)]
     function expectRevert(uint64 count) external;
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -771,11 +771,6 @@ where {
                             self.expected_revert = Some(expected_revert.clone());
                         }
 
-                        // tracing::info!(
-                        //     "create::end:: expected count {}, actual count {}",
-                        //     expected_revert.count,
-                        //     expected_revert.actual_count
-                        // );
                         outcome.result.result = InstructionResult::Return;
                         outcome.result.output = retdata;
                         outcome.address = address;

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1314,6 +1314,14 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
                 expected_revert.reverted_by.is_none()
             {
                 expected_revert.reverted_by = Some(call.target_address);
+            } else if outcome.result.is_revert() &&
+                expected_revert.reverter.is_some() &&
+                expected_revert.reverted_by.is_some() &&
+                expected_revert.count > 1
+            {
+                // If we're expecting more than one revert, we need to reset the reverted_by address
+                // to latest reverter.
+                expected_revert.reverted_by = Some(call.target_address);
             }
 
             if ecx.journaled_state.depth() <= expected_revert.depth {
@@ -1352,11 +1360,11 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
                             if expected_revert.actual_count < expected_revert.count {
                                 self.expected_revert = Some(expected_revert.clone());
                             }
-                            // tracing::info!(
-                            //     "call::end:: expected count {}, actual count {}",
-                            //     expected_revert.count,
-                            //     expected_revert.actual_count
-                            // );
+                            tracing::info!(
+                                "call::end:: expected count {}, actual count {}",
+                                expected_revert.count,
+                                expected_revert.actual_count
+                            );
                             outcome.result.result = InstructionResult::Return;
                             outcome.result.output = retdata;
                             outcome

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1355,11 +1355,6 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
                             if expected_revert.actual_count < expected_revert.count {
                                 self.expected_revert = Some(expected_revert.clone());
                             }
-                            tracing::info!(
-                                "call::end:: expected count {}, actual count {}",
-                                expected_revert.count,
-                                expected_revert.actual_count
-                            );
                             outcome.result.result = InstructionResult::Return;
                             outcome.result.output = retdata;
                             outcome

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -754,11 +754,11 @@ where {
             if ecx.journaled_state.depth() <= expected_revert.depth &&
                 matches!(expected_revert.kind, ExpectedRevertKind::Default)
             {
-                let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
+                let mut expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                 return match expect::handle_expect_revert(
                     false,
                     true,
-                    &expected_revert,
+                    &mut expected_revert,
                     outcome.result.result,
                     outcome.result.output.clone(),
                     &self.config.available_artifacts,
@@ -1315,11 +1315,13 @@ impl Inspector<&mut dyn DatabaseExt> for Cheatcodes {
                 };
 
                 if needs_processing {
-                    let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
+                    // Only `remove` the expected revert from state if `expected_revert.count` ==
+                    // `expected_revert.actual_count`
+                    let mut expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
                     return match expect::handle_expect_revert(
                         cheatcode_call,
                         false,
-                        &expected_revert,
+                        &mut expected_revert,
                         outcome.result.result,
                         outcome.result.output.clone(),
                         &self.config.available_artifacts,

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -89,6 +89,8 @@ pub struct ExpectedRevert {
     pub reverted_by: Option<Address>,
     /// Number of times this revert is expected.
     pub count: u64,
+    /// Actual number of times this revert has been seen.
+    pub actual_count: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -773,6 +775,7 @@ fn expect_revert(
         reverter,
         reverted_by: None,
         count,
+        actual_count: 0,
     });
     Ok(Default::default())
 }
@@ -780,7 +783,7 @@ fn expect_revert(
 pub(crate) fn handle_expect_revert(
     is_cheatcode: bool,
     is_create: bool,
-    expected_revert: &ExpectedRevert,
+    expected_revert: &mut ExpectedRevert,
     status: InstructionResult,
     retdata: Bytes,
     known_contracts: &Option<ContractsByArtifact>,

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -834,10 +834,9 @@ pub(crate) fn handle_expect_revert(
                         "expected 0 reverts with reason: {}, but got one",
                         &stringify(expected_reason)
                     ))
-                } else {
-                    // Return succes if the revert is not the expected one.
-                    return Ok(success_return());
                 }
+
+                return Ok(success_return())
             }
 
             bail!(msg);

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -840,25 +840,19 @@ pub(crate) fn handle_expect_revert(
         };
 
         match (reason_match, reverter_match) {
-            (Some(true), Some(true)) => {
-                Err(fmt_err!(
-                    "expected 0 reverts with reason: {}, from address: {}, but got one",
-                    &stringify(expected_reason.unwrap_or_default()),
-                    expected_revert.reverter.unwrap()
-                ))
-            }
-            (Some(true), None) => {
-                Err(fmt_err!(
-                    "expected 0 reverts with reason: {}, but got one",
-                    &stringify(expected_reason.unwrap_or_default())
-                ))
-            }
-            (None, Some(true)) => {
-                Err(fmt_err!(
-                    "expected 0 reverts from address: {}, but got one",
-                    expected_revert.reverter.unwrap()
-                ))
-            }
+            (Some(true), Some(true)) => Err(fmt_err!(
+                "expected 0 reverts with reason: {}, from address: {}, but got one",
+                &stringify(expected_reason.unwrap_or_default()),
+                expected_revert.reverter.unwrap()
+            )),
+            (Some(true), None) => Err(fmt_err!(
+                "expected 0 reverts with reason: {}, but got one",
+                &stringify(expected_reason.unwrap_or_default())
+            )),
+            (None, Some(true)) => Err(fmt_err!(
+                "expected 0 reverts from address: {}, but got one",
+                expected_revert.reverter.unwrap()
+            )),
             _ => Ok(success_return()),
         }
     } else {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -839,6 +839,17 @@ pub(crate) fn handle_expect_revert(
                 return Ok(success_return())
             }
 
+            if let Some(expected_reverter) = expected_revert.reverter {
+                if expected_reverter == expected_revert.reverted_by.unwrap_or_default() {
+                    return Err(fmt_err!(
+                        "expected 0 reverts from address: {}, but got one",
+                        expected_reverter
+                    ))
+                }
+
+                return Ok(success_return())
+            }
+
             bail!(msg);
         }
         _ => {

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -87,6 +87,8 @@ pub struct ExpectedRevert {
     pub reverter: Option<Address>,
     /// Actual reverter of the call.
     pub reverted_by: Option<Address>,
+    /// Number of times this revert is expected.
+    pub count: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -295,7 +297,7 @@ impl Cheatcode for expectEmitAnonymous_3Call {
 impl Cheatcode for expectRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self {} = self;
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None)
+        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, 1)
     }
 }
 
@@ -309,6 +311,7 @@ impl Cheatcode for expectRevert_1Call {
             false,
             false,
             None,
+            1,
         )
     }
 }
@@ -323,6 +326,7 @@ impl Cheatcode for expectRevert_2Call {
             false,
             false,
             None,
+            1,
         )
     }
 }
@@ -337,6 +341,7 @@ impl Cheatcode for expectRevert_3Call {
             false,
             false,
             Some(*reverter),
+            1,
         )
     }
 }
@@ -351,6 +356,7 @@ impl Cheatcode for expectRevert_4Call {
             false,
             false,
             Some(*reverter),
+            1,
         )
     }
 }
@@ -365,6 +371,7 @@ impl Cheatcode for expectRevert_5Call {
             false,
             false,
             Some(*reverter),
+            1,
         )
     }
 }
@@ -421,6 +428,7 @@ impl Cheatcode for expectPartialRevert_0Call {
             false,
             true,
             None,
+            1,
         )
     }
 }
@@ -435,13 +443,14 @@ impl Cheatcode for expectPartialRevert_1Call {
             false,
             true,
             Some(*reverter),
+            1,
         )
     }
 }
 
 impl Cheatcode for _expectCheatcodeRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
-        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false, None)
+        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), true, false, None, 1)
     }
 }
 
@@ -455,6 +464,7 @@ impl Cheatcode for _expectCheatcodeRevert_1Call {
             true,
             false,
             None,
+            1,
         )
     }
 }
@@ -469,6 +479,7 @@ impl Cheatcode for _expectCheatcodeRevert_2Call {
             true,
             false,
             None,
+            1,
         )
     }
 }
@@ -704,6 +715,7 @@ fn expect_revert(
     cheatcode: bool,
     partial_match: bool,
     reverter: Option<Address>,
+    count: u64,
 ) -> Result {
     ensure!(
         state.expected_revert.is_none(),
@@ -720,6 +732,7 @@ fn expect_revert(
         partial_match,
         reverter,
         reverted_by: None,
+        count,
     });
     Ok(Default::default())
 }

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -841,26 +841,26 @@ pub(crate) fn handle_expect_revert(
 
         match (reason_match, reverter_match) {
             (Some(true), Some(true)) => {
-                return Err(fmt_err!(
+                Err(fmt_err!(
                     "expected 0 reverts with reason: {}, from address: {}, but got one",
                     &stringify(expected_reason.unwrap_or_default()),
                     expected_revert.reverter.unwrap()
                 ))
             }
             (Some(true), None) => {
-                return Err(fmt_err!(
+                Err(fmt_err!(
                     "expected 0 reverts with reason: {}, but got one",
                     &stringify(expected_reason.unwrap_or_default())
                 ))
             }
             (None, Some(true)) => {
-                return Err(fmt_err!(
+                Err(fmt_err!(
                     "expected 0 reverts from address: {}, but got one",
                     expected_revert.reverter.unwrap()
                 ))
             }
-            _ => return Ok(success_return()),
-        };
+            _ => Ok(success_return()),
+        }
     } else {
         ensure!(!matches!(status, return_ok!()), "next call did not revert as expected");
 

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -796,6 +796,17 @@ pub(crate) fn handle_expect_revert(
         }
     };
 
+    // If count is 0, we expect the call NOT to revert
+    if expected_revert.count == 0 &&
+        expected_revert.reason.is_none() &&
+        expected_revert.reverter.is_none()
+    {
+        if matches!(status, return_ok!()) {
+            return Ok(success_return());
+        }
+        bail!("call reverted when it was expected not to revert");
+    }
+
     ensure!(!matches!(status, return_ok!()), "next call did not revert as expected");
 
     // If expected reverter address is set then check it matches the actual reverter.

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -379,42 +379,82 @@ impl Cheatcode for expectRevert_5Call {
 impl Cheatcode for expectRevert_6Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { count } = self;
-        todo!()
+        expect_revert(ccx.state, None, ccx.ecx.journaled_state.depth(), false, false, None, *count)
     }
 }
 
 impl Cheatcode for expectRevert_7Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData, count } = self;
-        todo!()
+        expect_revert(
+            ccx.state,
+            Some(revertData.as_ref()),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            None,
+            *count,
+        )
     }
 }
 
 impl Cheatcode for expectRevert_8Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData, count } = self;
-        todo!()
+        expect_revert(
+            ccx.state,
+            Some(revertData),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            None,
+            *count,
+        )
     }
 }
 
 impl Cheatcode for expectRevert_9Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { reverter, count } = self;
-        todo!()
+        expect_revert(
+            ccx.state,
+            None,
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+            *count,
+        )
     }
 }
 
 impl Cheatcode for expectRevert_10Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData, reverter, count } = self;
-        todo!()
+        expect_revert(
+            ccx.state,
+            Some(revertData.as_ref()),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+            *count,
+        )
     }
 }
 
 impl Cheatcode for expectRevert_11Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData, reverter, count } = self;
-        todo!()
+        expect_revert(
+            ccx.state,
+            Some(revertData),
+            ccx.ecx.journaled_state.depth(),
+            false,
+            false,
+            Some(*reverter),
+            *count,
+        )
     }
 }
 

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -369,6 +369,48 @@ impl Cheatcode for expectRevert_5Call {
     }
 }
 
+impl Cheatcode for expectRevert_6Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { count } = self;
+        todo!()
+    }
+}
+
+impl Cheatcode for expectRevert_7Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { revertData, count } = self;
+        todo!()
+    }
+}
+
+impl Cheatcode for expectRevert_8Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { revertData, count } = self;
+        todo!()
+    }
+}
+
+impl Cheatcode for expectRevert_9Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { reverter, count } = self;
+        todo!()
+    }
+}
+
+impl Cheatcode for expectRevert_10Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { revertData, reverter, count } = self;
+        todo!()
+    }
+}
+
+impl Cheatcode for expectRevert_11Call {
+    fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
+        let Self { revertData, reverter, count } = self;
+        todo!()
+    }
+}
+
 impl Cheatcode for expectPartialRevert_0Call {
     fn apply_stateful(&self, ccx: &mut CheatsCtxt) -> Result {
         let Self { revertData } = self;

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -246,10 +246,16 @@ interface Vm {
     function expectPartialRevert(bytes4 revertData, address reverter) external;
     function expectRevert() external;
     function expectRevert(bytes4 revertData) external;
+    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
+    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
     function expectRevert(bytes calldata revertData) external;
     function expectRevert(address reverter) external;
     function expectRevert(bytes4 revertData, address reverter) external;
     function expectRevert(bytes calldata revertData, address reverter) external;
+    function expectRevert(uint64 count) external;
+    function expectRevert(bytes4 revertData, uint64 count) external;
+    function expectRevert(bytes calldata revertData, uint64 count) external;
+    function expectRevert(address reverter, uint64 count) external;
     function expectSafeMemory(uint64 min, uint64 max) external;
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
     function fee(uint256 newBasefee) external;

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -175,10 +175,7 @@ contract ExpectRevertTest is DSTest {
 
         Dummy dummy = new Dummy();
         vm.expectRevert();
-        reverter.callThenRevert(
-            dummy,
-            "revert message 4 i ran out of synonims for also"
-        );
+        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
 
         vm.expectRevert();
         reverter.revertWithoutReason();
@@ -329,22 +326,13 @@ contract ExpectRevertWithReverterTest is DSTest {
         vm.expectPartialRevert(CContractError.selector, address(cContract));
         aContract.callAndRevertInCContractThroughBContract();
         // Test expect revert with exact data match and reverter at second subcall.
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                CContractError.selector,
-                "Reverted by CContract"
-            ),
-            address(cContract)
-        );
+        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
         aContract.callAndRevertInCContract();
     }
 
     function testExpectRevertsWithReverterInConstructor() public {
         // Test expect revert with reverter when constructor reverts.
-        vm.expectRevert(
-            abi.encodePacked("Reverted by DContract"),
-            address(cContract)
-        );
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
         cContract.createDContract();
 
         vm.expectRevert(address(bContract));
@@ -495,5 +483,26 @@ contract ExpectRevertCount is DSTest {
 
         vm.expectRevert("called a function and then reverted", count);
         reverter.callThenNoRevert(dummy);
+    }
+}
+
+contract ExpectRevertCountWithReverter is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testRevertCountWithReverter() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testFailRevertCountWithReverter() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        Reverter reverter2 = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter2.revertWithMessage("revert");
     }
 }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -171,7 +171,10 @@ contract ExpectRevertTest is DSTest {
 
         Dummy dummy = new Dummy();
         vm.expectRevert();
-        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
+        reverter.callThenRevert(
+            dummy,
+            "revert message 4 i ran out of synonims for also"
+        );
 
         vm.expectRevert();
         reverter.revertWithoutReason();
@@ -322,13 +325,22 @@ contract ExpectRevertWithReverterTest is DSTest {
         vm.expectPartialRevert(CContractError.selector, address(cContract));
         aContract.callAndRevertInCContractThroughBContract();
         // Test expect revert with exact data match and reverter at second subcall.
-        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CContractError.selector,
+                "Reverted by CContract"
+            ),
+            address(cContract)
+        );
         aContract.callAndRevertInCContract();
     }
 
     function testExpectRevertsWithReverterInConstructor() public {
         // Test expect revert with reverter when constructor reverts.
-        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
+        vm.expectRevert(
+            abi.encodePacked("Reverted by DContract"),
+            address(cContract)
+        );
         cContract.createDContract();
 
         vm.expectRevert(address(bContract));
@@ -377,5 +389,28 @@ contract ExpectRevertCount is DSTest {
         Reverter reverter = new Reverter();
         vm.expectRevert(count);
         reverter.doNotRevert();
+    }
+
+    function testFailNoRevert() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(count);
+        reverter.revertWithMessage("revert");
+    }
+
+    function testRevertCountSpecific() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testFailReverCountSpecifc() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("second-revert");
     }
 }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -175,7 +175,10 @@ contract ExpectRevertTest is DSTest {
 
         Dummy dummy = new Dummy();
         vm.expectRevert();
-        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
+        reverter.callThenRevert(
+            dummy,
+            "revert message 4 i ran out of synonims for also"
+        );
 
         vm.expectRevert();
         reverter.revertWithoutReason();
@@ -326,13 +329,22 @@ contract ExpectRevertWithReverterTest is DSTest {
         vm.expectPartialRevert(CContractError.selector, address(cContract));
         aContract.callAndRevertInCContractThroughBContract();
         // Test expect revert with exact data match and reverter at second subcall.
-        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                CContractError.selector,
+                "Reverted by CContract"
+            ),
+            address(cContract)
+        );
         aContract.callAndRevertInCContract();
     }
 
     function testExpectRevertsWithReverterInConstructor() public {
         // Test expect revert with reverter when constructor reverts.
-        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
+        vm.expectRevert(
+            abi.encodePacked("Reverted by DContract"),
+            address(cContract)
+        );
         cContract.createDContract();
 
         vm.expectRevert(address(bContract));
@@ -504,5 +516,27 @@ contract ExpectRevertCountWithReverter is DSTest {
         vm.expectRevert(address(reverter), count);
         reverter.revertWithMessage("revert");
         reverter2.revertWithMessage("revert");
+    }
+
+    function testNoRevertWithReverter() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.doNotRevert();
+    }
+
+    function testNoRevertWithWrongReverter() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        Reverter reverter2 = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter2.revertWithMessage("revert"); // revert from wrong reverter
+    }
+
+    function testFailNoRevertWithReverter() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(address(reverter), count);
+        reverter.revertWithMessage("revert");
     }
 }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -374,6 +374,9 @@ contract ExpectRevertCount is DSTest {
         reverter.revertWithMessage("revert");
         reverter.revertWithMessage("revert2");
         reverter.revertWithMessage("revert3");
+
+        vm.expectRevert("revert");
+        reverter.revertWithMessage("revert");
     }
 
     function testFailRevertCountAny() public {
@@ -412,5 +415,26 @@ contract ExpectRevertCount is DSTest {
         vm.expectRevert("revert", count);
         reverter.revertWithMessage("revert");
         reverter.revertWithMessage("second-revert");
+    }
+
+    function testNoRevertSpecific() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.doNotRevert();
+    }
+
+    function testFailNoRevertSpecific() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert");
+    }
+
+    function testNoRevertSpecificButDiffRevert() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", count);
+        reverter.revertWithMessage("revert2");
     }
 }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -188,7 +188,7 @@ contract ExpectRevertTest is DSTest {
     }
 
     function testexpectCheatcodeRevert() public {
-        vm._expectCheatcodeRevert("JSON value at \".a\" is not an object");
+        vm._expectCheatcodeRevert('JSON value at ".a" is not an object');
         vm.parseJsonKeys('{"a": "b"}', ".a");
     }
 
@@ -349,5 +349,33 @@ contract ExpectRevertWithReverterTest is DSTest {
         vm.expectRevert(address(aContract));
         aContract.doNotRevert();
         aContract.callAndRevert();
+    }
+}
+
+contract ExpectRevertCount is DSTest {
+    Vm constant vm = Vm(HEVM_ADDRESS);
+
+    function testRevertCountAny() public {
+        uint64 count = 3;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert2");
+        reverter.revertWithMessage("revert3");
+    }
+
+    function testFailRevertCountAny() public {
+        uint64 count = 3;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert2");
+    }
+
+    function testNoRevert() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert(count);
+        reverter.doNotRevert();
     }
 }

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -175,10 +175,7 @@ contract ExpectRevertTest is DSTest {
 
         Dummy dummy = new Dummy();
         vm.expectRevert();
-        reverter.callThenRevert(
-            dummy,
-            "revert message 4 i ran out of synonims for also"
-        );
+        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
 
         vm.expectRevert();
         reverter.revertWithoutReason();
@@ -329,22 +326,13 @@ contract ExpectRevertWithReverterTest is DSTest {
         vm.expectPartialRevert(CContractError.selector, address(cContract));
         aContract.callAndRevertInCContractThroughBContract();
         // Test expect revert with exact data match and reverter at second subcall.
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                CContractError.selector,
-                "Reverted by CContract"
-            ),
-            address(cContract)
-        );
+        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
         aContract.callAndRevertInCContract();
     }
 
     function testExpectRevertsWithReverterInConstructor() public {
         // Test expect revert with reverter when constructor reverts.
-        vm.expectRevert(
-            abi.encodePacked("Reverted by DContract"),
-            address(cContract)
-        );
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
         cContract.createDContract();
 
         vm.expectRevert(address(bContract));
@@ -538,5 +526,40 @@ contract ExpectRevertCountWithReverter is DSTest {
         Reverter reverter = new Reverter();
         vm.expectRevert(address(reverter), count);
         reverter.revertWithMessage("revert");
+    }
+
+    function testReverterCountWithData() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function testFailReverterCountWithWrongData() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter.revertWithMessage("wrong revert");
+    }
+
+    function testFailWrongReverterCountWithData() public {
+        uint64 count = 2;
+        Reverter reverter = new Reverter();
+        Reverter reverter2 = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert");
+        reverter2.revertWithMessage("revert");
+    }
+
+    function testNoReverterCountWithData() public {
+        uint64 count = 0;
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.doNotRevert();
+
+        vm.expectRevert("revert", address(reverter), count);
+        reverter.revertWithMessage("revert2");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #509 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Implement `expectRevert` overloads with the `count` arg. Negative assertions can be made by setting `count` to `0`

```solidity
    /// Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.
    function expectRevert(uint64 count) external;

    /// Expects a `count` number of reverts from the upcoming calls that match the revert data.
    function expectRevert(bytes4 revertData, uint64 count) external;

    /// Expects a `count` number of reverts from the upcoming calls that exactly match the revert data.
    function expectRevert(bytes calldata revertData, uint64 count) external;

    /// Expects a `count` number of reverts from the upcoming calls from the reverter address.
    function expectRevert(address reverter, uint64 count) external;

    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;

    /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
