### PR TITLE
chore(cast): upgrade evmole to 0.6.1, use new style API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "evmole"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fcfb15a14bc209e2b3d2bd32291ec445b1e348d7d9d986aa61a09149350fd7"
+checksum = "f58e21c69e0ae62877b65241d25cae9e28477818482fab8c1101d15289725a46"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ alloy-chains = "0.1"
 alloy-rlp = "0.3"
 alloy-trie = "0.6.0"
 
-## op-alloy 
+## op-alloy
 op-alloy-rpc-types = "0.7.1"
 op-alloy-consensus = "0.7.1"
 
@@ -260,7 +260,7 @@ color-eyre = "0.6"
 comfy-table = "7"
 dunce = "1"
 evm-disassembler = "0.5"
-evmole = "0.5"
+evmole = "0.6"
 eyre = "0.6"
 figment = "0.10"
 futures = "0.3"


### PR DESCRIPTION
## Motivation

New version of evmole has been released, the old API has been deprecated.

## Solution

Upgraded to new version and migrated to new style API.
