### PR TITLE
feat: add support for binary_mappings and network_family configs

### DIFF
--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -49,6 +49,11 @@ fn main() {
 fn run() -> Result<()> {
     utils::load_dotenv();
 
+    if let Some(to) = utils::should_redirect_to() {
+        utils::redirect_execution(to)?;
+        return Ok(());
+    }
+
     let mut args = Anvil::parse();
     args.global.init()?;
     args.node.evm.resolve_rpc_alias();
@@ -70,7 +75,7 @@ fn run() -> Result<()> {
                 &mut std::io::stdout(),
             ),
         }
-        return Ok(())
+        return Ok(());
     }
 
     let _ = fdlimit::raise_fd_limit();

--- a/crates/anvil/src/anvil.rs
+++ b/crates/anvil/src/anvil.rs
@@ -49,9 +49,9 @@ fn main() {
 fn run() -> Result<()> {
     utils::load_dotenv();
 
-    if let Some(to) = utils::should_redirect_to() {
+    if let Some(to) = utils::should_redirect_to()? {
         utils::redirect_execution(to)?;
-        return Ok(());
+        return Ok(())
     }
 
     let mut args = Anvil::parse();
@@ -75,7 +75,7 @@ fn run() -> Result<()> {
                 &mut std::io::stdout(),
             ),
         }
-        return Ok(());
+        return Ok(())
     }
 
     let _ = fdlimit::raise_fd_limit();

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -52,6 +52,11 @@ fn run() -> Result<()> {
     utils::subscriber();
     utils::enable_paint();
 
+    if let Some(to) = utils::should_redirect_to() {
+        utils::redirect_execution(to)?;
+        return Ok(());
+    }
+
     let args = CastArgs::parse();
     args.global.init()?;
     main_args(args)

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -52,9 +52,9 @@ fn run() -> Result<()> {
     utils::subscriber();
     utils::enable_paint();
 
-    if let Some(to) = utils::should_redirect_to() {
+    if let Some(to) = utils::should_redirect_to()? {
         utils::redirect_execution(to)?;
-        return Ok(());
+        return Ok(())
     }
 
     let args = CastArgs::parse();

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -114,9 +114,9 @@ fn run() -> eyre::Result<()> {
     utils::subscriber();
     utils::load_dotenv();
 
-    if let Some(to) = utils::should_redirect_to() {
+    if let Some(to) = utils::should_redirect_to()? {
         utils::redirect_execution(to)?;
-        return Ok(());
+        return Ok(())
     }
 
     let args = Chisel::parse();
@@ -158,7 +158,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandFailed(e) => sh_err!("{e}")?,
                 _ => panic!("Unexpected result: Please report this bug."),
             }
-            return Ok(());
+            return Ok(())
         }
         Some(ChiselSubcommand::Load { id }) | Some(ChiselSubcommand::View { id }) => {
             // For both of these subcommands, we need to attempt to load the session from cache
@@ -166,7 +166,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandSuccess(_) => { /* Continue */ }
                 DispatchResult::CommandFailed(e) => {
                     sh_err!("{e}")?;
-                    return Ok(());
+                    return Ok(())
                 }
                 _ => panic!("Unexpected result! Please report this bug."),
             }
@@ -179,7 +179,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                     }
                     _ => panic!("Unexpected result! Please report this bug."),
                 }
-                return Ok(());
+                return Ok(())
             }
         }
         Some(ChiselSubcommand::ClearCache) => {
@@ -188,11 +188,11 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandFailed(e) => sh_err!("{e}")?,
                 _ => panic!("Unexpected result! Please report this bug."),
             }
-            return Ok(());
+            return Ok(())
         }
         Some(ChiselSubcommand::Eval { command }) => {
             dispatch_repl_line(&mut dispatcher, command).await?;
-            return Ok(());
+            return Ok(())
         }
         None => { /* No chisel subcommand present; Continue */ }
     }
@@ -234,7 +234,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
             }
             Err(ReadlineError::Interrupted) => {
                 if interrupt {
-                    break;
+                    break
                 } else {
                     sh_println!("(To exit, press Ctrl+C again)")?;
                     interrupt = true;
@@ -243,7 +243,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
             Err(ReadlineError::Eof) => break,
             Err(err) => {
                 sh_err!("{err:?}")?;
-                break;
+                break
             }
         }
     }

--- a/crates/chisel/bin/main.rs
+++ b/crates/chisel/bin/main.rs
@@ -114,6 +114,11 @@ fn run() -> eyre::Result<()> {
     utils::subscriber();
     utils::load_dotenv();
 
+    if let Some(to) = utils::should_redirect_to() {
+        utils::redirect_execution(to)?;
+        return Ok(());
+    }
+
     let args = Chisel::parse();
     args.global.init()?;
     main_args(args)
@@ -153,7 +158,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandFailed(e) => sh_err!("{e}")?,
                 _ => panic!("Unexpected result: Please report this bug."),
             }
-            return Ok(())
+            return Ok(());
         }
         Some(ChiselSubcommand::Load { id }) | Some(ChiselSubcommand::View { id }) => {
             // For both of these subcommands, we need to attempt to load the session from cache
@@ -161,7 +166,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandSuccess(_) => { /* Continue */ }
                 DispatchResult::CommandFailed(e) => {
                     sh_err!("{e}")?;
-                    return Ok(())
+                    return Ok(());
                 }
                 _ => panic!("Unexpected result! Please report this bug."),
             }
@@ -174,7 +179,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                     }
                     _ => panic!("Unexpected result! Please report this bug."),
                 }
-                return Ok(())
+                return Ok(());
             }
         }
         Some(ChiselSubcommand::ClearCache) => {
@@ -183,11 +188,11 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
                 DispatchResult::CommandFailed(e) => sh_err!("{e}")?,
                 _ => panic!("Unexpected result! Please report this bug."),
             }
-            return Ok(())
+            return Ok(());
         }
         Some(ChiselSubcommand::Eval { command }) => {
             dispatch_repl_line(&mut dispatcher, command).await?;
-            return Ok(())
+            return Ok(());
         }
         None => { /* No chisel subcommand present; Continue */ }
     }
@@ -229,7 +234,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
             }
             Err(ReadlineError::Interrupted) => {
                 if interrupt {
-                    break
+                    break;
                 } else {
                     sh_println!("(To exit, press Ctrl+C again)")?;
                     interrupt = true;
@@ -238,7 +243,7 @@ async fn main_args(args: Chisel) -> eyre::Result<()> {
             Err(ReadlineError::Eof) => break,
             Err(err) => {
                 sh_err!("{err:?}")?;
-                break
+                break;
             }
         }
     }

--- a/crates/cli/src/utils/bin_redirect.rs
+++ b/crates/cli/src/utils/bin_redirect.rs
@@ -1,20 +1,119 @@
-use std::path::PathBuf;
+use std::{io::IsTerminal, path::PathBuf};
+
+use eyre::{Context as _, ContextCompat as _};
+use foundry_common::{io::style::WARN, stdin::parse_line, Shell};
+use foundry_config::network_family::NetworkFamily;
 
 /// Loads config and checks if there is a binary remapping for the current binary.
 /// If there is a remapping, returns the path to the binary that should be executed.
 /// Returns `None` if the binary is not remapped _or_ if the current binary is not found in the
 /// config.
-pub fn should_redirect_to() -> Option<PathBuf> {
-    let current_exe = std::env::current_exe().ok()?;
-    let binary_name = current_exe.file_stem()?.to_str()?;
-    let config = foundry_config::Config::load();
-    config.binary_mappings().redirect_for(binary_name).cloned()
+///
+/// Required user consent for the redirect. If consent is not provided (either via
+/// config or prompt), will return an error.
+pub fn should_redirect_to() -> eyre::Result<Option<PathBuf>> {
+    let current_exe =
+        std::env::current_exe().context("Unable to query the current executable name")?;
+    let binary_name = current_exe
+        .file_stem()
+        .with_context(|| "Unable to parse executable file name")?
+        .to_str()
+        .context("Executable name is not UTF-8")?;
+    let config = foundry_config::Config::load()?;
+    let Some(redirect) = config.binary_mappings().redirect_for(binary_name).cloned() else {
+        trace!(
+            binary_name = ?binary_name,
+            redirects = ?config.binary_mappings(),
+            "No redirect is found",
+        );
+        return Ok(None)
+    };
+
+    // We cannot use shell macros, since they will implicitly initialize global shell.
+    let mut shell = Shell::default();
+
+    // Ensure that if redirect exists, user opted in to it.
+    let redirect = match config.allow_alternative_binaries {
+        Some(true) => {
+            // User opted in to alternative binaries.
+            Some(redirect)
+        }
+        Some(false) => {
+            // User opted out of alternative binaries.
+            shell.warn("A binary remapping was detected, but `allow_alternative_binaries` is set to false, which prohibits the redirects.")?;
+            eyre::bail!("Binary remapping is not allowed by the user.");
+        }
+        None => {
+            // Prompt user to allow alternative binary.
+            shell.warn("")?;
+            let mut lines = vec![
+                "A binary remapping was detected, but `allow_alternative_binaries` is not set in the config.".to_string(),
+                "You can set `allow_alternative_binaries` config to `true` to avoid this prompt.".to_string(),
+                "Foundry team is not responsible for the safety of the redirected binary.".to_string(),
+                format!("If you would allow it, the execution would be redirected to the following binary: {redirect:?}")
+            ];
+            append_attestation_docs(&mut lines, &config, &redirect);
+
+            print_box_message(&mut shell, &lines)?;
+
+            let std = std::io::stdin();
+            if !std.is_terminal() {
+                shell.error("std is not a terminal, cannot prompt user. Ignoring the redirect")?;
+                eyre::bail!("Binary remapping must be explicitly allowed");
+            }
+
+            shell.print_out("Do you want to allow the redirect? [y/N] ")?;
+            std::io::Write::flush(&mut std::io::stdout())?;
+
+            let response: String = parse_line()?;
+            if matches!(response.as_str(), "y" | "Y") {
+                Some(redirect)
+            } else {
+                eyre::bail!("User did not allow redirecting to another binary");
+            }
+        }
+    };
+    Ok(redirect)
+}
+
+/// Appends the lines that explain how to verify the binary attestation.
+fn append_attestation_docs(
+    lines: &mut Vec<String>,
+    config: &foundry_config::Config,
+    binary_name: &PathBuf,
+) {
+    if config.network_family == NetworkFamily::Zksync {
+        lines.extend_from_slice(&[
+            String::new(),
+            "Tip:".to_string(),
+            "ZKsync network family is selected in the config.".to_string(),
+            "To verify the authenticity of the binary, you can use the following command (Linux/MacOS):".to_string(),
+            format!("$ gh attestation verify --owner matter-labs $(which {binary_name:?})"),
+        ])
+    }
+}
+
+fn print_box_message(shell: &mut Shell, lines: &[String]) -> eyre::Result<()> {
+    // Print messages via `shell.print` rounding them with an ascii box.
+    let max_len = lines.iter().map(String::len).max().unwrap_or(0);
+    let top = format!("+{:-<1$}+\n", "", max_len + 2);
+    shell.write_stdout(&top, &WARN)?;
+    for line in lines {
+        shell.write_stdout("| ", &WARN)?;
+        shell.print_out(format!("{line:<max_len$}"))?;
+        shell.write_stdout(" |\n", &WARN)?;
+    }
+    shell.write_stdout(&top, &WARN)?;
+    Ok(())
 }
 
 /// Launches the `to` binary with the same arguments as the current binary.
 /// E.g. if user runs `forge build --arg1 --arg2`, and `to` is `/path/to/custom/forge`, then
 /// this function will run `/path/to/custom/forge build --arg1 --arg2`.
 pub fn redirect_execution(to: PathBuf) -> eyre::Result<()> {
+    // We cannot use shell macros, since they will implicitly initialize global shell.
+    let mut shell = Shell::default();
+    shell.warn(format!("Redirecting execution to: {to:?}"))?;
     let args = std::env::args().skip(1).collect::<Vec<_>>();
     let status = std::process::Command::new(to)
         .args(args)

--- a/crates/cli/src/utils/bin_redirect.rs
+++ b/crates/cli/src/utils/bin_redirect.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+/// Loads config and checks if there is a binary remapping for the current binary.
+/// If there is a remapping, returns the path to the binary that should be executed.
+/// Returns `None` if the binary is not remapped _or_ if the current binary is not found in the
+/// config.
+pub fn should_redirect_to() -> Option<PathBuf> {
+    let current_exe = std::env::current_exe().ok()?;
+    let binary_name = current_exe.file_stem()?.to_str()?;
+    let config = foundry_config::Config::load();
+    config.binary_mappings().redirect_for(binary_name).cloned()
+}
+
+/// Launches the `to` binary with the same arguments as the current binary.
+/// E.g. if user runs `forge build --arg1 --arg2`, and `to` is `/path/to/custom/forge`, then
+/// this function will run `/path/to/custom/forge build --arg1 --arg2`.
+pub fn redirect_execution(to: PathBuf) -> eyre::Result<()> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let status = std::process::Command::new(to)
+        .args(args)
+        .status()
+        .map_err(|e| eyre::eyre!("Failed to run command: {}", e))?;
+    if !status.success() {
+        eyre::bail!("Command failed with status: {}", status);
+    }
+    Ok(())
+}

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -27,6 +27,9 @@ pub use suggestions::*;
 mod abi;
 pub use abi::*;
 
+mod bin_redirect;
+pub use bin_redirect::*;
+
 // reexport all `foundry_config::utils`
 #[doc(hidden)]
 pub use foundry_config::utils::*;

--- a/crates/config/src/binary_mappings.rs
+++ b/crates/config/src/binary_mappings.rs
@@ -1,0 +1,109 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+/// Binaries that can be remapped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BinaryName {
+    Forge,
+    Anvil,
+    Cast,
+    Chisel,
+}
+
+impl TryFrom<&str> for BinaryName {
+    type Error = eyre::Error;
+
+    fn try_from(value: &str) -> eyre::Result<Self> {
+        match value {
+            "forge" => Ok(Self::Forge),
+            "anvil" => Ok(Self::Anvil),
+            "cast" => Ok(Self::Cast),
+            "chisel" => Ok(Self::Chisel),
+            _ => eyre::bail!("Invalid binary name: {value}"),
+        }
+    }
+}
+
+/// Contains the config for binary remappings,
+/// e.g. ability to redirect any of the foundry binaries to some other binary.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinaryMappings {
+    /// The mappings from binary name to the path of the binary.
+    #[serde(flatten)]
+    pub mappings: HashMap<BinaryName, PathBuf>,
+}
+
+impl BinaryMappings {
+    /// Tells if the binary name is remapped to some other binary.
+    /// This function will return `None` if the binary name cannot be parsed or if
+    /// the binary name is not remapped.
+    pub fn redirect_for(&self, binary_name: &str) -> Option<&PathBuf> {
+        // Sanitize the path so that it
+        let binary_name = Path::new(binary_name).file_stem()?.to_str()?;
+        let binary_name = BinaryName::try_from(binary_name).ok()?;
+        self.mappings.get(&binary_name)
+    }
+}
+
+impl<T> From<T> for BinaryMappings
+where
+    T: Into<HashMap<BinaryName, PathBuf>>,
+{
+    fn from(mappings: T) -> Self {
+        Self { mappings: mappings.into() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_names() {
+        assert_eq!(BinaryName::try_from("forge").unwrap(), BinaryName::Forge);
+        assert_eq!(BinaryName::try_from("anvil").unwrap(), BinaryName::Anvil);
+        assert_eq!(BinaryName::try_from("cast").unwrap(), BinaryName::Cast);
+        assert_eq!(BinaryName::try_from("chisel").unwrap(), BinaryName::Chisel);
+    }
+
+    #[test]
+    fn binary_names_serde() {
+        let test_vector = [
+            (BinaryName::Forge, r#""forge""#),
+            (BinaryName::Anvil, r#""anvil""#),
+            (BinaryName::Cast, r#""cast""#),
+            (BinaryName::Chisel, r#""chisel""#),
+        ];
+
+        for (binary_name, expected) in test_vector.iter() {
+            let serialized = serde_json::to_string(binary_name).unwrap();
+            assert_eq!(serialized, *expected);
+
+            let deserialized: BinaryName = serde_json::from_str(expected).unwrap();
+            assert_eq!(deserialized, *binary_name);
+        }
+    }
+
+    #[test]
+    fn redirect_to() {
+        let mappings = BinaryMappings::from([
+            (BinaryName::Forge, PathBuf::from("forge-zksync")),
+            (BinaryName::Anvil, PathBuf::from("anvil-zksync")),
+            (BinaryName::Cast, PathBuf::from("cast-zksync")),
+            (BinaryName::Chisel, PathBuf::from("chisel-zksync")),
+        ]);
+
+        assert_eq!(mappings.redirect_for("forge"), Some(&PathBuf::from("forge-zksync")));
+        assert_eq!(mappings.redirect_for("anvil"), Some(&PathBuf::from("anvil-zksync")));
+        assert_eq!(mappings.redirect_for("cast"), Some(&PathBuf::from("cast-zksync")));
+        assert_eq!(mappings.redirect_for("chisel"), Some(&PathBuf::from("chisel-zksync")));
+        assert_eq!(mappings.redirect_for("invalid"), None);
+        assert_eq!(mappings.redirect_for("/usr/bin/forge"), Some(&PathBuf::from("forge-zksync")));
+        assert_eq!(mappings.redirect_for("anvil.exe"), Some(&PathBuf::from("anvil-zksync")));
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -38,6 +38,7 @@ use foundry_compilers::{
     ArtifactOutput, ConfigurableArtifacts, Graph, Project, ProjectPathsConfig,
     RestrictionsWithVersion, VyperLanguage,
 };
+use network_family::NetworkFamily;
 use regex::Regex;
 use revm_primitives::{map::AddressHashMap, FixedBytes, SpecId};
 use semver::Version;
@@ -123,6 +124,11 @@ use bind_json::BindJsonConfig;
 
 mod compilation;
 use compilation::{CompilationRestrictions, SettingsOverrides};
+
+mod binary_mappings;
+use binary_mappings::BinaryMappings;
+
+mod network_family;
 
 /// Foundry configuration
 ///
@@ -515,6 +521,17 @@ pub struct Config {
     /// Restrictions on compilation of certain files.
     #[serde(default)]
     pub compilation_restrictions: Vec<CompilationRestrictions>,
+
+    /// Configuration for alternative versions of foundry tools to be used.
+    #[serde(default)]
+    pub binary_mappings: Option<BinaryMappings>,
+
+    /// Network family configuration.
+    /// If specified, network family can be used to change certain defaults (such as
+    /// binary mappings). Note, however, that network family only changes _defaults_,
+    /// so if the configuration is explicitly provided, it takes precedence.
+    #[serde(default)]
+    pub network_family: NetworkFamily,
 
     /// PRIVATE: This structure may grow, As such, constructing this structure should
     /// _always_ be done using a public constructor or update syntax:
@@ -2023,6 +2040,11 @@ impl Config {
         }
     }
 
+    /// Returns the binary mappings.
+    pub fn binary_mappings(&self) -> BinaryMappings {
+        self.binary_mappings.clone().unwrap_or_else(|| self.network_family.binary_mappings())
+    }
+
     /// The path provided to this function should point to a cached chain folder.
     fn get_cached_blocks(chain_path: &Path) -> eyre::Result<Vec<(String, u64)>> {
         let mut blocks = vec![];
@@ -2413,6 +2435,8 @@ impl Default for Config {
             additional_compiler_profiles: Default::default(),
             compilation_restrictions: Default::default(),
             eof: false,
+            binary_mappings: Default::default(),
+            network_family: NetworkFamily::Ethereum,
             _non_exhaustive: (),
         }
     }
@@ -4890,6 +4914,70 @@ mod tests {
                     remappings_location: RemappingsLocation::Txt,
                     recursive_deps: true,
                 })
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_binary_mappings() {
+        figment::Jail::expect_with(|jail| {
+            // No mappings by default.
+            let config = Config::load();
+            assert_eq!(config.binary_mappings(), BinaryMappings::default());
+
+            // Load specified mappings.
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                binary_mappings = { "forge" = "forge-zksync", "anvil" = "anvil-zksync" }
+            "#,
+            )?;
+            let config = Config::load();
+            assert_eq!(
+                config.binary_mappings(),
+                BinaryMappings::from([
+                    (binary_mappings::BinaryName::Forge, PathBuf::from("forge-zksync")),
+                    (binary_mappings::BinaryName::Anvil, PathBuf::from("anvil-zksync"))
+                ])
+            );
+
+            // Override via network family.
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                network_family = "zksync"
+            "#,
+            )?;
+            let config = Config::load();
+            assert_eq!(
+                config.binary_mappings(),
+                BinaryMappings::from([
+                    (binary_mappings::BinaryName::Forge, PathBuf::from("forge-zksync")),
+                    (binary_mappings::BinaryName::Cast, PathBuf::from("cast-zksync")),
+                    (binary_mappings::BinaryName::Anvil, PathBuf::from("anvil-zksync"))
+                ])
+            );
+
+            // Config precedence.
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                binary_mappings = { "forge" = "something-custom", "anvil" = "something-else" }
+                network_family = "zksync"
+            "#,
+            )?;
+            let config = Config::load();
+            assert_eq!(
+                config.binary_mappings(),
+                BinaryMappings::from([
+                    (binary_mappings::BinaryName::Forge, PathBuf::from("something-custom")),
+                    (binary_mappings::BinaryName::Anvil, PathBuf::from("something-else"))
+                ])
             );
 
             Ok(())

--- a/crates/config/src/network_family.rs
+++ b/crates/config/src/network_family.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::binary_mappings::{BinaryMappings, BinaryName};
+
+#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkFamily {
+    #[default]
+    Ethereum,
+    Zksync,
+}
+
+impl NetworkFamily {
+    pub fn binary_mappings(self) -> BinaryMappings {
+        match self {
+            Self::Ethereum => BinaryMappings::default(),
+            Self::Zksync => Self::zksync_mappings(),
+        }
+    }
+
+    fn zksync_mappings() -> BinaryMappings {
+        BinaryMappings::from([
+            (BinaryName::Forge, "forge-zksync".into()),
+            (BinaryName::Anvil, "anvil-zksync".into()),
+            (BinaryName::Cast, "cast-zksync".into()),
+            // Chisel is not currently supported on ZKsync.
+        ])
+    }
+}

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -34,6 +34,11 @@ fn run() -> Result<()> {
     utils::subscriber();
     utils::enable_paint();
 
+    if let Some(to) = utils::should_redirect_to() {
+        utils::redirect_execution(to)?;
+        return Ok(());
+    }
+
     let args = Forge::parse();
     args.global.init()?;
     init_execution_context(&args.cmd);

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -34,9 +34,9 @@ fn run() -> Result<()> {
     utils::subscriber();
     utils::enable_paint();
 
-    if let Some(to) = utils::should_redirect_to() {
+    if let Some(to) = utils::should_redirect_to()? {
         utils::redirect_execution(to)?;
-        return Ok(());
+        return Ok(())
     }
 
     let args = Forge::parse();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -163,6 +163,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         compilation_restrictions: Default::default(),
         eof: false,
         binary_mappings: Default::default(),
+        allow_alternative_binaries: None,
         network_family: Default::default(),
         _non_exhaustive: (),
     };
@@ -1003,8 +1004,8 @@ ignored_warnings_from = []
 deny_warnings = false
 test_failures_file = "cache/test-failures"
 show_progress = false
+additional_compiler_profiles = []
 eof = false
-transaction_timeout = 120
 ffi = false
 allow_internal_expect_revert = false
 always_use_create_2_factory = false
@@ -1033,16 +1034,17 @@ bytecode_hash = "ipfs"
 cbor_metadata = true
 sparse_mode = false
 build_info = false
+network_family = "ethereum"
 compilation_restrictions = []
-additional_compiler_profiles = []
-assertions_revert = true
+legacy_assertions = false
 isolate = false
 disable_block_gas_limit = false
-odyssey = false
+transaction_timeout = 120
 unchecked_cheatcode_artifacts = false
 create2_library_salt = "0x0000000000000000000000000000000000000000000000000000000000000000"
 create2_deployer = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
-legacy_assertions = false
+odyssey = false
+assertions_revert = true
 
 [[profile.default.fs_permissions]]
 access = "read"
@@ -1295,7 +1297,10 @@ exclude = []
   "transaction_timeout": 120,
   "eof": false,
   "additional_compiler_profiles": [],
-  "compilation_restrictions": []
+  "compilation_restrictions": [],
+  "binary_mappings": null,
+  "allow_alternative_binaries": null,
+  "network_family": "ethereum"
 }
 
 "#]]);

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -162,6 +162,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         additional_compiler_profiles: Default::default(),
         compilation_restrictions: Default::default(),
         eof: false,
+        binary_mappings: Default::default(),
+        network_family: Default::default(),
         _non_exhaustive: (),
     };
     prj.write_config(input.clone());


### PR DESCRIPTION
## Motivation

Fixes #9227

This PR makes it possible to use foundry profiles to redirect execution to alternative foundry implementations (e.g. `forge` to `forge-zksync` or `anvil` to `anvil-zksync`) in an extendible way.

## Demo


https://github.com/user-attachments/assets/d4d899d3-c420-49fa-8f52-fc2a9a07ddbb



## Solution

> [!NOTE]
> Update: Now changes are made to be strict opt-in. User must set `allow_alternative_binaries` config variable to `true`, otherwise they'll be prompted to allow execution manually. Strict opt-out by setting it to `false` is also possible.

We introduce two new configuration options:
- `binary_mappings`: this setting allows you to specify where the execution should be redirected to. In essense, it's a map from enum with keys `["anvil", "cast", "chisel", "forge"]` to arbitrary paths.
- `network_family`: an enum which currently has two options (`ethereum` and `zksync`) that allows overriding default configuration. Right now the only thing it does is override `binary_mappings` to ZKsync-specific values.

In combination, it makes it possible to define a profile for zksync, e.g.:

```toml
[profile.zksync]
network_family = "zksync"
```

and it would redirect commands to the [foundry-zksync](https://github.com/matter-labs/foundry-zksync).

This way there is no need for foundry-zksync to override foundry binaries, as well as there is no need for users to change their scripts if they work with both upstream foundry and zksync foundry (which they would have to if we named binaries differently).