### PR TITLE
fix(verify): cached artifacts by version

### DIFF
--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -324,6 +324,13 @@ impl VerifyArgs {
                     .get(&contract.name)
                     .and_then(|artifacts| {
                         let mut cached_artifacts = artifacts.get(&version);
+                        // If we try to verify with specific build version and no cached artifacts
+                        // found, then check if we have artifacts cached for same version but
+                        // without any build metadata.
+                        // This could happen when artifacts are built / cached
+                        // with a version like `0.8.20` but verify is using a compiler-version arg
+                        // as `0.8.20+commit.a1b79de6`.
+                        // See <https://github.com/foundry-rs/foundry/issues/9510>.
                         if cached_artifacts.is_none() && version.build != BuildMetadata::EMPTY {
                             version.build = BuildMetadata::EMPTY;
                             cached_artifacts = artifacts.get(&version);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #9510 

Similarly with https://github.com/foundry-rs/foundry/pull/9483
Try to retrieve artifacts from cache by version without build metadata too if cached artifacts and artifact not found by version arg.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
