### PR TITLE
Update incorrect documentation in the READ.me

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -159,7 +159,7 @@ use_literal_content = false
 # use ipfs method to generate the metadata hash, solc's default.
 # To not include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, use "none"
 bytecode_hash = "ipfs"
-# Whether to append the metadata hash to the bytecode
+# Whether to append the CBOR-encoded metadata file.
 cbor_metadata = true
 # How to treat revert (and require) reason strings.
 # Possible values are: "default", "strip", "debug" and "verboseDebug".


### PR DESCRIPTION
## Motivation

I think this comment is incorrect. Based off my reading of [this solidity page](https://docs.soliditylang.org/en/latest/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode), it seems that this flag prevents the appending of the CBOR encoded file to the bytecode

## Solution

changing the comment
