### PR TITLE
fix(`cast`): reset `env.tx.caller` for impersonated txs

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::Transaction;
+use alloy_consensus::{Transaction, Typed2718};
 use alloy_network::TransactionResponse;
 use alloy_primitives::U256;
 use alloy_provider::Provider;
@@ -10,7 +10,7 @@ use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{handle_traces, init_progress, TraceResult},
 };
-use foundry_common::{is_known_system_sender, shell, SYSTEM_TRANSACTION_TYPE};
+use foundry_common::{is_known_system_sender, shell, tx_is_impersonated, SYSTEM_TRANSACTION_TYPE};
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{
     figment::{
@@ -250,6 +250,19 @@ impl RunArgs {
             executor.set_trace_printer(self.trace_printer);
 
             configure_tx_env(&mut env, &tx.inner);
+
+            let is_impersonated = match tx.inner.inner {
+                alloy_network::AnyTxEnvelope::Ethereum(ref envelope) => {
+                    tx_is_impersonated(envelope.signature(), envelope.ty())
+                }
+                _ => false,
+            };
+
+            if is_impersonated {
+                // If the transaction is impersonated, we need to set the caller to the from address
+                // Ref: https://github.com/foundry-rs/foundry/issues/9541
+                env.tx.caller = tx.from;
+            }
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::{Transaction, Typed2718};
+use alloy_consensus::Transaction;
 use alloy_network::TransactionResponse;
 use alloy_primitives::U256;
 use alloy_provider::Provider;
@@ -10,7 +10,7 @@ use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{handle_traces, init_progress, TraceResult},
 };
-use foundry_common::{is_known_system_sender, shell, tx_is_impersonated, SYSTEM_TRANSACTION_TYPE};
+use foundry_common::{is_impersonated_tx, is_known_system_sender, shell, SYSTEM_TRANSACTION_TYPE};
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{
     figment::{
@@ -212,14 +212,7 @@ impl RunArgs {
 
                     configure_tx_env(&mut env, &tx.inner);
 
-                    let is_impersonated = match tx.inner.inner {
-                        alloy_network::AnyTxEnvelope::Ethereum(ref envelope) => {
-                            tx_is_impersonated(envelope.signature(), envelope.ty())
-                        }
-                        _ => false,
-                    };
-
-                    if is_impersonated {
+                    if is_impersonated_tx(&tx.inner.inner) {
                         // If the transaction is impersonated, we need to set the caller to the from
                         // address Ref: https://github.com/foundry-rs/foundry/issues/9541
                         env.tx.caller = tx.from;
@@ -264,14 +257,7 @@ impl RunArgs {
 
             configure_tx_env(&mut env, &tx.inner);
 
-            let is_impersonated = match tx.inner.inner {
-                alloy_network::AnyTxEnvelope::Ethereum(ref envelope) => {
-                    tx_is_impersonated(envelope.signature(), envelope.ty())
-                }
-                _ => false,
-            };
-
-            if is_impersonated {
+            if is_impersonated_tx(&tx.inner.inner) {
                 // If the transaction is impersonated, we need to set the caller to the from address
                 // Ref: https://github.com/foundry-rs/foundry/issues/9541
                 env.tx.caller = tx.from;

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1,5 +1,7 @@
 //! Commonly used constants.
 
+use alloy_consensus::Typed2718;
+use alloy_network::AnyTxEnvelope;
 use alloy_primitives::{address, Address, PrimitiveSignature, B256};
 use std::time::Duration;
 
@@ -53,7 +55,14 @@ pub fn is_known_system_sender(sender: Address) -> bool {
     [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS].contains(&sender)
 }
 
-pub fn tx_is_impersonated(sig: &PrimitiveSignature, ty: u8) -> bool {
+pub fn is_impersonated_tx(tx: &AnyTxEnvelope) -> bool {
+    if let AnyTxEnvelope::Ethereum(tx) = tx {
+        return is_impersonated_sig(tx.signature(), tx.ty());
+    }
+    false
+}
+
+pub fn is_impersonated_sig(sig: &PrimitiveSignature, ty: u8) -> bool {
     let impersonated_sig = PrimitiveSignature::from_scalars_and_parity(
         B256::with_last_byte(1),
         B256::with_last_byte(1),

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1,6 +1,6 @@
 //! Commonly used constants.
 
-use alloy_primitives::{address, Address};
+use alloy_primitives::{address, Address, PrimitiveSignature, B256};
 use std::time::Duration;
 
 /// The dev chain-id, inherited from hardhat
@@ -51,6 +51,18 @@ pub const DEFAULT_USER_AGENT: &str = concat!("foundry/", env!("CARGO_PKG_VERSION
 #[inline]
 pub fn is_known_system_sender(sender: Address) -> bool {
     [ARBITRUM_SENDER, OPTIMISM_SYSTEM_ADDRESS].contains(&sender)
+}
+
+pub fn tx_is_impersonated(sig: &PrimitiveSignature, ty: u8) -> bool {
+    let impersonated_sig = PrimitiveSignature::from_scalars_and_parity(
+        B256::with_last_byte(1),
+        B256::with_last_byte(1),
+        false,
+    );
+    if ty != SYSTEM_TRANSACTION_TYPE && sig == &impersonated_sig {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9541 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Reset `env.tx.caller` to `tx.from` for impersonated txs

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
