### PR TITLE
fix: read rpc config when using fork cheatcodes

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -186,9 +186,9 @@ impl CheatsConfig {
     ///  - Returns an error if `url_or_alias` is not an alias but does not start with a `http` or
     ///    `ws` `scheme` and is not a path to an existing file
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
-        match self.rpc_endpoints.get(url_or_alias) {
-            Some(rpc_endpoint) => Ok(rpc_endpoint.clone()),
-            None => {
+        let maybe_rpc_endpoint = self.rpc_endpoints.get(url_or_alias);
+
+        if maybe_rpc_endpoint.is_none() {
                 // check if it's a URL or a path to an existing file to an ipc socket
                 if url_or_alias.starts_with("http") ||
                     url_or_alias.starts_with("ws") ||
@@ -196,11 +196,17 @@ impl CheatsConfig {
                     Path::new(url_or_alias).exists()
                 {
                     let url = RpcEndpointUrl::Env(url_or_alias.to_string());
-                    Ok(RpcEndpoint::new(url).resolve())
+                    return Ok(RpcEndpoint::new(url).resolve())
                 } else {
-                    Err(fmt_err!("invalid rpc url: {url_or_alias}"))
+                    return Err(fmt_err!("invalid rpc url: {url_or_alias}"))
                 }
+        } else {
+            let mut endpoint = maybe_rpc_endpoint.unwrap().clone();
+            if endpoint.is_unresolved() {
+                // try resolve again, by checking if env vars are now set
+                endpoint = endpoint.try_resolve();
             }
+            return Ok(endpoint)
         }
     }
     /// Returns all the RPC urls and their alias.

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -187,7 +187,6 @@ impl CheatsConfig {
     ///    `ws` `scheme` and is not a path to an existing file
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         if let Some(endpoint) = self.rpc_endpoints.get(url_or_alias) {
-            // try resolve again, by checking if env vars are now set
             Ok(endpoint.clone().try_resolve())
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -187,12 +187,8 @@ impl CheatsConfig {
     ///    `ws` `scheme` and is not a path to an existing file
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         if let Some(endpoint) = self.rpc_endpoints.get(url_or_alias) {
-            let mut endpoint = endpoint.clone();
-            if endpoint.is_unresolved() {
-                // try resolve again, by checking if env vars are now set
-                endpoint = endpoint.try_resolve();
-            }
-            Ok(endpoint)
+            // try resolve again, by checking if env vars are now set
+            Ok(endpoint.clone().try_resolve())
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket
             if url_or_alias.starts_with("http") ||

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -192,7 +192,7 @@ impl CheatsConfig {
                 // try resolve again, by checking if env vars are now set
                 endpoint = endpoint.try_resolve();
             }
-            return Ok(endpoint)
+            Ok(endpoint)
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket
             if url_or_alias.starts_with("http") ||
@@ -201,9 +201,9 @@ impl CheatsConfig {
                 Path::new(url_or_alias).exists()
             {
                 let url = RpcEndpointUrl::Env(url_or_alias.to_string());
-                return Ok(RpcEndpoint::new(url).resolve())
+                Ok(RpcEndpoint::new(url).resolve())
             } else {
-                return Err(fmt_err!("invalid rpc url: {url_or_alias}"))
+                Err(fmt_err!("invalid rpc url: {url_or_alias}"))
             }
         }
     }

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -5,7 +5,7 @@ use foundry_common::{fs::normalize_path, ContractsByArtifact};
 use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
 use foundry_config::{
     cache::StorageCachingConfig, fs_permissions::FsAccessKind, Config, FsPermissions,
-    ResolvedRpcEndpoints,
+    ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl
 };
 use foundry_evm_core::opts::EvmOpts;
 use semver::Version;
@@ -185,13 +185,9 @@ impl CheatsConfig {
     ///  - Returns an error if `url_or_alias` is a known alias but references an unresolved env var.
     ///  - Returns an error if `url_or_alias` is not an alias but does not start with a `http` or
     ///    `ws` `scheme` and is not a path to an existing file
-    pub fn rpc_url(&self, url_or_alias: &str) -> Result<String> {
+    pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         match self.rpc_endpoints.get(url_or_alias) {
-            Some(Ok(url)) => Ok(url.clone()),
-            Some(Err(err)) => {
-                // try resolve again, by checking if env vars are now set
-                err.try_resolve().map_err(Into::into)
-            }
+            Some(rpc_endpoint) => Ok(rpc_endpoint.clone()),
             None => {
                 // check if it's a URL or a path to an existing file to an ipc socket
                 if url_or_alias.starts_with("http") ||
@@ -199,19 +195,19 @@ impl CheatsConfig {
                     // check for existing ipc file
                     Path::new(url_or_alias).exists()
                 {
-                    Ok(url_or_alias.into())
+                    let url = RpcEndpointUrl::Env(url_or_alias.to_string());
+                    Ok(RpcEndpoint::new(url).resolve())
                 } else {
                     Err(fmt_err!("invalid rpc url: {url_or_alias}"))
                 }
             }
         }
     }
-
     /// Returns all the RPC urls and their alias.
     pub fn rpc_urls(&self) -> Result<Vec<Rpc>> {
         let mut urls = Vec::with_capacity(self.rpc_endpoints.len());
         for alias in self.rpc_endpoints.keys() {
-            let url = self.rpc_url(alias)?;
+            let url = self.rpc_endpoint(alias)?.url()?;
             urls.push(Rpc { key: alias.clone(), url });
         }
         Ok(urls)

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -5,7 +5,7 @@ use foundry_common::{fs::normalize_path, ContractsByArtifact};
 use foundry_compilers::{utils::canonicalize, ProjectPathsConfig};
 use foundry_config::{
     cache::StorageCachingConfig, fs_permissions::FsAccessKind, Config, FsPermissions,
-    ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl
+    ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl,
 };
 use foundry_evm_core::opts::EvmOpts;
 use semver::Version;

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -332,6 +332,9 @@ fn create_fork_request(
     evm_opts.fork_block_number = block;
     evm_opts.fork_retries = rpc_endpoint.config.retries;
     evm_opts.fork_retry_backoff = rpc_endpoint.config.retry_backoff;
+    if let Some(Ok(auth)) = rpc_endpoint.auth {
+        evm_opts.fork_headers = Some(vec![format!("Authorization: {auth}")]);
+    }
     let fork = CreateFork {
         enable_caching: !ccx.state.config.no_storage_caching &&
             ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -226,7 +226,7 @@ impl Cheatcode for rpc_0Call {
 impl Cheatcode for rpc_1Call {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { urlOrAlias, method, params } = self;
-        let url = state.config.rpc_url(urlOrAlias)?;
+        let url = state.config.rpc_endpoint(urlOrAlias)?.url()?;
         rpc_call(&url, method, params)
     }
 }
@@ -326,9 +326,12 @@ fn create_fork_request(
 ) -> Result<CreateFork> {
     persist_caller(ccx);
 
-    let url = ccx.state.config.rpc_url(url_or_alias)?;
+    let rpc_endpoint = ccx.state.config.rpc_endpoint(url_or_alias)?;
+    let url = rpc_endpoint.url()?;
     let mut evm_opts = ccx.state.config.evm_opts.clone();
     evm_opts.fork_block_number = block;
+    evm_opts.fork_retries = rpc_endpoint.config.retries;
+    evm_opts.fork_retry_backoff = rpc_endpoint.config.retry_backoff;
     let fork = CreateFork {
         enable_caching: !ccx.state.config.no_storage_caching &&
             ccx.state.config.rpc_storage_caching.enable_for_endpoint(&url),

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -42,7 +42,8 @@ impl Cheatcode for getFoundryVersionCall {
 impl Cheatcode for rpcUrlCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { rpcAlias } = self;
-        state.config.rpc_url(rpcAlias).map(|url| url.abi_encode())
+        let url = state.config.rpc_endpoint(&rpcAlias)?.url()?.abi_encode();
+        Ok(url)
     }
 }
 

--- a/crates/cheatcodes/src/test.rs
+++ b/crates/cheatcodes/src/test.rs
@@ -42,7 +42,7 @@ impl Cheatcode for getFoundryVersionCall {
 impl Cheatcode for rpcUrlCall {
     fn apply(&self, state: &mut Cheatcodes) -> Result {
         let Self { rpcAlias } = self;
-        let url = state.config.rpc_endpoint(&rpcAlias)?.url()?.abi_encode();
+        let url = state.config.rpc_endpoint(rpcAlias)?.url()?.abi_encode();
         Ok(url)
     }
 }

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloy_json_abi::{InternalType, JsonAbi};
 use alloy_primitives::{hex, Address};
 use forge_fmt::FormatterConfig;
-use foundry_config::{Config, RpcEndpoint};
+use foundry_config::{Config, RpcEndpointUrl};
 use foundry_evm::{
     decode::decode_console_logs,
     traces::{
@@ -357,9 +357,9 @@ impl ChiselDispatcher {
                 {
                     endpoint.clone()
                 } else {
-                    RpcEndpoint::Env(arg.to_string()).into()
+                    RpcEndpointUrl::Env(arg.to_string()).into()
                 };
-                let fork_url = match endpoint.resolve() {
+                let fork_url = match endpoint.resolve().url() {
                     Ok(fork_url) => fork_url,
                     Err(e) => {
                         return DispatchResult::CommandFailed(Self::make_error(format!(

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -241,6 +241,12 @@ impl ProviderBuilder {
         self
     }
 
+    /// Sets http headers. If `None`, defaults to the already-set value.
+    pub fn maybe_headers(mut self, headers: Option<Vec<String>>) -> Self {
+        self.headers = headers.unwrap_or(self.headers);
+        self
+    }
+
     /// Constructs the `RetryProvider` taking all configs into account.
     pub fn build(self) -> Result<RetryProvider> {
         let Self {

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -12,7 +12,7 @@ use std::{
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RpcEndpoints {
-    endpoints: BTreeMap<String, RpcEndpointConfig>,
+    endpoints: BTreeMap<String, RpcEndpoint>,
 }
 
 impl RpcEndpoints {
@@ -25,7 +25,7 @@ impl RpcEndpoints {
                 .into_iter()
                 .map(|(name, e)| match e.into() {
                     RpcEndpointType::String(url) => {
-                        (name.into(), RpcEndpointConfig { endpoint: url, ..Default::default() })
+                        (name.into(), RpcEndpoint::new(url))
                     }
                     RpcEndpointType::Config(config) => (name.into(), config),
                 })
@@ -38,7 +38,7 @@ impl RpcEndpoints {
         self.endpoints.is_empty()
     }
 
-    /// Returns all (alias -> url) pairs
+    /// Returns all (alias -> rpc_endpoint) pairs
     pub fn resolved(self) -> ResolvedRpcEndpoints {
         ResolvedRpcEndpoints {
             endpoints: self
@@ -47,20 +47,12 @@ impl RpcEndpoints {
                 .into_iter()
                 .map(|(name, e)| (name, e.resolve()))
                 .collect(),
-            auths: self
-                .endpoints
-                .into_iter()
-                .map(|(name, e)| match e.auth {
-                    Some(auth) => (name, auth.resolve().map(Some)),
-                    None => (name, Ok(None)),
-                })
-                .collect(),
         }
     }
 }
 
 impl Deref for RpcEndpoints {
-    type Target = BTreeMap<String, RpcEndpointConfig>;
+    type Target = BTreeMap<String, RpcEndpoint>;
 
     fn deref(&self) -> &Self::Target {
         &self.endpoints
@@ -72,14 +64,14 @@ impl Deref for RpcEndpoints {
 #[serde(untagged)]
 pub enum RpcEndpointType {
     /// Raw Endpoint url string
-    String(RpcEndpoint),
+    String(RpcEndpointUrl),
     /// Config object
-    Config(RpcEndpointConfig),
+    Config(RpcEndpoint),
 }
 
 impl RpcEndpointType {
     /// Returns the string variant
-    pub fn as_endpoint_string(&self) -> Option<&RpcEndpoint> {
+    pub fn as_endpoint_string(&self) -> Option<&RpcEndpointUrl> {
         match self {
             Self::String(url) => Some(url),
             Self::Config(_) => None,
@@ -87,7 +79,7 @@ impl RpcEndpointType {
     }
 
     /// Returns the config variant
-    pub fn as_endpoint_config(&self) -> Option<&RpcEndpointConfig> {
+    pub fn as_endpoint_config(&self) -> Option<&RpcEndpoint> {
         match self {
             Self::Config(config) => Some(config),
             Self::String(_) => None,
@@ -134,7 +126,7 @@ impl TryFrom<RpcEndpointType> for String {
 /// value of the env var itself.
 /// In other words, this type does not resolve env vars when it's being deserialized
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RpcEndpoint {
+pub enum RpcEndpointUrl {
     /// A raw Url (ws, http)
     Url(String),
     /// An endpoint that contains at least one `${ENV_VAR}` placeholder
@@ -143,7 +135,7 @@ pub enum RpcEndpoint {
     Env(String),
 }
 
-impl RpcEndpoint {
+impl RpcEndpointUrl {
     /// Returns the url variant
     pub fn as_url(&self) -> Option<&str> {
         match self {
@@ -173,7 +165,7 @@ impl RpcEndpoint {
     }
 }
 
-impl fmt::Display for RpcEndpoint {
+impl fmt::Display for RpcEndpointUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Url(url) => url.fmt(f),
@@ -182,15 +174,15 @@ impl fmt::Display for RpcEndpoint {
     }
 }
 
-impl TryFrom<RpcEndpoint> for String {
+impl TryFrom<RpcEndpointUrl> for String {
     type Error = UnresolvedEnvVarError;
 
-    fn try_from(value: RpcEndpoint) -> Result<Self, Self::Error> {
+    fn try_from(value: RpcEndpointUrl) -> Result<Self, Self::Error> {
         value.resolve()
     }
 }
 
-impl Serialize for RpcEndpoint {
+impl Serialize for RpcEndpointUrl {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -199,7 +191,7 @@ impl Serialize for RpcEndpoint {
     }
 }
 
-impl<'de> Deserialize<'de> for RpcEndpoint {
+impl<'de> Deserialize<'de> for RpcEndpointUrl {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -211,14 +203,14 @@ impl<'de> Deserialize<'de> for RpcEndpoint {
     }
 }
 
-impl From<RpcEndpoint> for RpcEndpointType {
-    fn from(endpoint: RpcEndpoint) -> Self {
+impl From<RpcEndpointUrl> for RpcEndpointType {
+    fn from(endpoint: RpcEndpointUrl) -> Self {
         Self::String(endpoint)
     }
 }
 
-impl From<RpcEndpoint> for RpcEndpointConfig {
-    fn from(endpoint: RpcEndpoint) -> Self {
+impl From<RpcEndpointUrl> for RpcEndpoint {
+    fn from(endpoint: RpcEndpointUrl) -> Self {
         Self { endpoint, ..Default::default() }
     }
 }
@@ -275,12 +267,9 @@ impl<'de> Deserialize<'de> for RpcAuth {
     }
 }
 
-/// Rpc endpoint configuration variant
+// Rpc endpoint configuration
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RpcEndpointConfig {
-    /// endpoint url or env
-    pub endpoint: RpcEndpoint,
-
     /// The number of retries.
     pub retries: Option<u32>,
 
@@ -291,23 +280,11 @@ pub struct RpcEndpointConfig {
     ///
     /// See also <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
     pub compute_units_per_second: Option<u64>,
-
-    /// Token to be used as authentication
-    pub auth: Option<RpcAuth>,
-}
-
-impl RpcEndpointConfig {
-    /// Returns the url this type holds, see [`RpcEndpoint::resolve`]
-    pub fn resolve(self) -> Result<String, UnresolvedEnvVarError> {
-        self.endpoint.resolve()
-    }
 }
 
 impl fmt::Display for RpcEndpointConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { endpoint, retries, retry_backoff, compute_units_per_second, auth } = self;
-
-        write!(f, "{endpoint}")?;
+        let Self { retries, retry_backoff, compute_units_per_second } = self;
 
         if let Some(retries) = retries {
             write!(f, ", retries={retries}")?;
@@ -321,38 +298,81 @@ impl fmt::Display for RpcEndpointConfig {
             write!(f, ", compute_units_per_second={compute_units_per_second}")?;
         }
 
-        if let Some(auth) = auth {
-            write!(f, ", auth={auth}")?;
-        }
-
         Ok(())
     }
 }
 
-impl Serialize for RpcEndpointConfig {
+impl Default for RpcEndpointConfig {
+    fn default() -> Self {
+        Self { retries: None, retry_backoff: None, compute_units_per_second: None }
+    }
+}
+
+/// Rpc endpoint configuration variant
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcEndpoint {
+    /// endpoint url or env
+    pub endpoint: RpcEndpointUrl,
+
+    /// Token to be used as authentication
+    pub auth: Option<RpcAuth>,
+
+    /// additional configuration
+    pub config: RpcEndpointConfig,
+}
+
+impl RpcEndpoint {
+    pub fn new(endpoint: RpcEndpointUrl) -> Self {
+        Self { endpoint, ..Default::default() }
+    }
+
+    /// Resolves environment variables in fields into their raw values
+    pub fn resolve(self) -> ResolvedRpcEndpoint {
+        ResolvedRpcEndpoint {
+            endpoint: self.endpoint.resolve(),
+            auth: self.auth.map(|auth| auth.resolve()),
+            config: self.config,
+        }
+    }
+}
+
+impl fmt::Display for RpcEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { endpoint, auth, config } = self;
+        write!(f, "{endpoint}")?;
+        write!(f, "{config}")?;
+        if let Some(auth) = auth {
+            write!(f, ", auth={auth}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for RpcEndpoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        if self.retries.is_none() &&
-            self.retry_backoff.is_none() &&
-            self.compute_units_per_second.is_none()
+        if self.config.retries.is_none() &&
+            self.config.retry_backoff.is_none() &&
+            self.config.compute_units_per_second.is_none() &&
+            self.auth.is_none()
         {
             // serialize as endpoint if there's no additional config
             self.endpoint.serialize(serializer)
         } else {
             let mut map = serializer.serialize_map(Some(4))?;
             map.serialize_entry("endpoint", &self.endpoint)?;
-            map.serialize_entry("retries", &self.retries)?;
-            map.serialize_entry("retry_backoff", &self.retry_backoff)?;
-            map.serialize_entry("compute_units_per_second", &self.compute_units_per_second)?;
+            map.serialize_entry("retries", &self.config.retries)?;
+            map.serialize_entry("retry_backoff", &self.config.retry_backoff)?;
+            map.serialize_entry("compute_units_per_second", &self.config.compute_units_per_second)?;
             map.serialize_entry("auth", &self.auth)?;
             map.end()
         }
     }
 }
 
-impl<'de> Deserialize<'de> for RpcEndpointConfig {
+impl<'de> Deserialize<'de> for RpcEndpoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -368,7 +388,7 @@ impl<'de> Deserialize<'de> for RpcEndpointConfig {
         #[derive(Deserialize)]
         struct RpcEndpointConfigInner {
             #[serde(alias = "url")]
-            endpoint: RpcEndpoint,
+            endpoint: RpcEndpointUrl,
             retries: Option<u32>,
             retry_backoff: Option<u64>,
             compute_units_per_second: Option<u64>,
@@ -383,46 +403,62 @@ impl<'de> Deserialize<'de> for RpcEndpointConfig {
             auth,
         } = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
 
-        Ok(Self { endpoint, retries, retry_backoff, compute_units_per_second, auth })
+        Ok(Self { endpoint, auth, config: RpcEndpointConfig { retries, retry_backoff, compute_units_per_second } })
     }
 }
 
-impl From<RpcEndpointConfig> for RpcEndpointType {
-    fn from(config: RpcEndpointConfig) -> Self {
+impl From<RpcEndpoint> for RpcEndpointType {
+    fn from(config: RpcEndpoint) -> Self {
         Self::Config(config)
     }
 }
 
-impl Default for RpcEndpointConfig {
+impl Default for RpcEndpoint {
     fn default() -> Self {
         Self {
-            endpoint: RpcEndpoint::Url("http://localhost:8545".to_string()),
-            retries: None,
-            retry_backoff: None,
-            compute_units_per_second: None,
+            endpoint: RpcEndpointUrl::Url("http://localhost:8545".to_string()),
+            config: RpcEndpointConfig::default(),
             auth: None,
         }
     }
 }
 
-/// Container type for _resolved_ endpoints, see [`RpcEndpoint::resolve`].
+/// Rpc endpoint with environment variables resolved to values, see [`RpcEndpoint::resolve`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedRpcEndpoint {
+    pub endpoint: Result<String, UnresolvedEnvVarError>,
+    pub auth: Option<Result<String, UnresolvedEnvVarError>>,
+    pub config: RpcEndpointConfig,
+}
+
+impl ResolvedRpcEndpoint {
+    /// Returns the url this type holds, see [`RpcEndpoint::resolve`]
+    pub fn url(&self) -> Result<String, UnresolvedEnvVarError> {
+        self.endpoint.clone()
+    }
+
+    pub fn is_unresolved(&self) -> bool {
+        let endpoint_err = self.endpoint.is_err();
+        let auth_err = self.auth.as_ref().map(|auth| auth.is_err()).unwrap_or(false);
+        endpoint_err || auth_err
+    }
+}
+
+/// Container type for _resolved_ endpoints.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResolvedRpcEndpoints {
-    /// contains all named endpoints and their URL or an error if we failed to resolve the env var
-    /// alias
-    endpoints: BTreeMap<String, Result<String, UnresolvedEnvVarError>>,
-    auths: BTreeMap<String, Result<Option<String>, UnresolvedEnvVarError>>,
+    endpoints: BTreeMap<String, ResolvedRpcEndpoint>,
 }
 
 impl ResolvedRpcEndpoints {
     /// Returns true if there's an endpoint that couldn't be resolved
     pub fn has_unresolved(&self) -> bool {
-        self.endpoints.values().any(|val| val.is_err())
+        self.endpoints.values().any(|e| e.is_unresolved())
     }
 }
 
 impl Deref for ResolvedRpcEndpoints {
-    type Target = BTreeMap<String, Result<String, UnresolvedEnvVarError>>;
+    type Target = BTreeMap<String, ResolvedRpcEndpoint>;
 
     fn deref(&self) -> &Self::Target {
         &self.endpoints
@@ -434,6 +470,7 @@ impl DerefMut for ResolvedRpcEndpoints {
         &mut self.endpoints
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -448,27 +485,31 @@ mod tests {
             "compute_units_per_second": 100,
             "auth": "Bearer 123"
         }"#;
-        let config: RpcEndpointConfig = serde_json::from_str(s).unwrap();
+        let config: RpcEndpoint = serde_json::from_str(s).unwrap();
         assert_eq!(
             config,
-            RpcEndpointConfig {
-                endpoint: RpcEndpoint::Url("http://localhost:8545".to_string()),
-                retries: Some(5),
-                retry_backoff: Some(250),
-                compute_units_per_second: Some(100),
+            RpcEndpoint {
+                endpoint: RpcEndpointUrl::Url("http://localhost:8545".to_string()),
+                config: RpcEndpointConfig {
+                    retries: Some(5),
+                    retry_backoff: Some(250),
+                    compute_units_per_second: Some(100),
+                },
                 auth: Some(RpcAuth::Raw("Bearer 123".to_string())),
             }
         );
 
         let s = "\"http://localhost:8545\"";
-        let config: RpcEndpointConfig = serde_json::from_str(s).unwrap();
+        let config: RpcEndpoint = serde_json::from_str(s).unwrap();
         assert_eq!(
             config,
-            RpcEndpointConfig {
-                endpoint: RpcEndpoint::Url("http://localhost:8545".to_string()),
-                retries: None,
-                retry_backoff: None,
-                compute_units_per_second: None,
+            RpcEndpoint {
+                endpoint: RpcEndpointUrl::Url("http://localhost:8545".to_string()),
+                config: RpcEndpointConfig {
+                    retries: None,
+                    retry_backoff: None,
+                    compute_units_per_second: None,
+                },
                 auth: None,
             }
         );

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -39,11 +39,7 @@ impl RpcEndpoints {
     /// Returns all (alias -> rpc_endpoint) pairs
     pub fn resolved(self) -> ResolvedRpcEndpoints {
         ResolvedRpcEndpoints {
-            endpoints: self
-                .endpoints
-                .into_iter()
-                .map(|(name, e)| (name, e.resolve()))
-                .collect(),
+            endpoints: self.endpoints.into_iter().map(|(name, e)| (name, e.resolve())).collect(),
         }
     }
 }

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -436,18 +436,17 @@ impl ResolvedRpcEndpoint {
     }
 
     // Attempts to resolve unresolved environment variables into a new instance
-    pub fn try_resolve(self) -> Self {
+    pub fn try_resolve(mut self) -> Self {
         if !self.is_unresolved() {
             return self
         }
-        let mut new_endpoint = self.clone();
         if let Err(err) = self.endpoint {
-            new_endpoint.endpoint = err.try_resolve()
+            self.endpoint = err.try_resolve()
         }
-        if let Some(Err(err)) = &new_endpoint.auth {
-            new_endpoint.auth = Some(err.try_resolve())
+        if let Some(Err(err)) = self.auth {
+            self.auth = Some(err.try_resolve())
         }
-        new_endpoint
+        self
     }
 }
 

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -43,7 +43,6 @@ impl RpcEndpoints {
         ResolvedRpcEndpoints {
             endpoints: self
                 .endpoints
-                .clone()
                 .into_iter()
                 .map(|(name, e)| (name, e.resolve()))
                 .collect(),
@@ -268,7 +267,7 @@ impl<'de> Deserialize<'de> for RpcAuth {
 }
 
 // Rpc endpoint configuration
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RpcEndpointConfig {
     /// The number of retries.
     pub retries: Option<u32>,
@@ -299,12 +298,6 @@ impl fmt::Display for RpcEndpointConfig {
         }
 
         Ok(())
-    }
-}
-
-impl Default for RpcEndpointConfig {
-    fn default() -> Self {
-        Self { retries: None, retry_backoff: None, compute_units_per_second: None }
     }
 }
 
@@ -453,12 +446,10 @@ impl ResolvedRpcEndpoint {
         if let Err(err) = self.endpoint {
             new_endpoint.endpoint = err.try_resolve()
         }
-        if let Some(auth) = &new_endpoint.auth {
-            if let Err(err) = auth {
-                new_endpoint.auth = Some(err.try_resolve())
-            }
+        if let Some(Err(err)) = &new_endpoint.auth {
+            new_endpoint.auth = Some(err.try_resolve())
         }
-        return new_endpoint
+        new_endpoint
     }
 }
 

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -24,9 +24,7 @@ impl RpcEndpoints {
             endpoints: endpoints
                 .into_iter()
                 .map(|(name, e)| match e.into() {
-                    RpcEndpointType::String(url) => {
-                        (name.into(), RpcEndpoint::new(url))
-                    }
+                    RpcEndpointType::String(url) => (name.into(), RpcEndpoint::new(url)),
                     RpcEndpointType::Config(config) => (name.into(), config),
                 })
                 .collect(),
@@ -396,7 +394,11 @@ impl<'de> Deserialize<'de> for RpcEndpoint {
             auth,
         } = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
 
-        Ok(Self { endpoint, auth, config: RpcEndpointConfig { retries, retry_backoff, compute_units_per_second } })
+        Ok(Self {
+            endpoint,
+            auth,
+            config: RpcEndpointConfig { retries, retry_backoff, compute_units_per_second },
+        })
     }
 }
 
@@ -479,7 +481,6 @@ impl DerefMut for ResolvedRpcEndpoints {
         &mut self.endpoints
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -58,7 +58,7 @@ pub mod utils;
 pub use utils::*;
 
 mod endpoints;
-pub use endpoints::{ResolvedRpcEndpoints, RpcEndpoint, RpcEndpoints};
+pub use endpoints::{ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpointUrl, RpcEndpoints, RpcEndpoint};
 
 mod etherscan;
 use etherscan::{
@@ -1295,7 +1295,7 @@ impl Config {
     ) -> Option<Result<Cow<'_, str>, UnresolvedEnvVarError>> {
         let mut endpoints = self.rpc_endpoints.clone().resolved();
         if let Some(endpoint) = endpoints.remove(maybe_alias) {
-            return Some(endpoint.map(Cow::Owned));
+            return Some(endpoint.url().map(Cow::Owned));
         }
 
         if let Ok(Some(endpoint)) = mesc::get_endpoint_by_query(maybe_alias, Some("foundry")) {
@@ -2533,10 +2533,10 @@ mod tests {
     use super::*;
     use crate::{
         cache::{CachedChains, CachedEndpoints},
-        endpoints::{RpcEndpointConfig, RpcEndpointType},
+        endpoints::{RpcEndpoint, RpcEndpointType},
         etherscan::ResolvedEtherscanConfigs,
     };
-    use endpoints::RpcAuth;
+    use endpoints::{RpcAuth, RpcEndpointConfig};
     use figment::error::Kind::InvalidType;
     use foundry_compilers::artifacts::{
         vyper::VyperOptimizationMode, ModelCheckerEngine, YulDetails,
@@ -3206,17 +3206,19 @@ mod tests {
                 RpcEndpoints::new([
                     (
                         "optimism",
-                        RpcEndpointType::String(RpcEndpoint::Url(
+                        RpcEndpointType::String(RpcEndpointUrl::Url(
                             "https://example.com/".to_string()
                         ))
                     ),
                     (
                         "mainnet",
-                        RpcEndpointType::Config(RpcEndpointConfig {
-                            endpoint: RpcEndpoint::Env("${_CONFIG_MAINNET}".to_string()),
-                            retries: Some(3),
-                            retry_backoff: Some(1000),
-                            compute_units_per_second: Some(1000),
+                        RpcEndpointType::Config(RpcEndpoint {
+                            endpoint: RpcEndpointUrl::Env("${_CONFIG_MAINNET}".to_string()),
+                            config: RpcEndpointConfig {
+                                retries: Some(3),
+                                retry_backoff: Some(1000),
+                                compute_units_per_second: Some(1000),
+                            },
                             auth: None,
                         })
                     ),
@@ -3227,10 +3229,23 @@ mod tests {
             let resolved = config.rpc_endpoints.resolved();
             assert_eq!(
                 RpcEndpoints::new([
-                    ("optimism", RpcEndpoint::Url("https://example.com/".to_string())),
+                    (
+                        "optimism",
+                        RpcEndpointType::String(RpcEndpointUrl::Url(
+                            "https://example.com/".to_string()
+                        ))
+                    ),
                     (
                         "mainnet",
-                        RpcEndpoint::Url("https://eth-mainnet.alchemyapi.io/v2/123455".to_string())
+                        RpcEndpointType::Config(RpcEndpoint {
+                            endpoint: RpcEndpointUrl::Env("${_CONFIG_MAINNET}".to_string()),
+                            config: RpcEndpointConfig {
+                                retries: Some(3),
+                                retry_backoff: Some(1000),
+                                compute_units_per_second: Some(1000),
+                            },
+                            auth: None,
+                        })
                     ),
                 ])
                 .resolved(),
@@ -3263,17 +3278,19 @@ mod tests {
                 RpcEndpoints::new([
                     (
                         "optimism",
-                        RpcEndpointType::String(RpcEndpoint::Url(
+                        RpcEndpointType::String(RpcEndpointUrl::Url(
                             "https://example.com/".to_string()
                         ))
                     ),
                     (
                         "mainnet",
-                        RpcEndpointType::Config(RpcEndpointConfig {
-                            endpoint: RpcEndpoint::Env("${_CONFIG_MAINNET}".to_string()),
-                            retries: Some(3),
-                            retry_backoff: Some(1000),
-                            compute_units_per_second: Some(1000),
+                        RpcEndpointType::Config(RpcEndpoint {
+                            endpoint: RpcEndpointUrl::Env("${_CONFIG_MAINNET}".to_string()),
+                            config: RpcEndpointConfig {
+                                retries: Some(3),
+                                retry_backoff: Some(1000),
+                                compute_units_per_second: Some(1000)
+                            },
                             auth: Some(RpcAuth::Env("Bearer ${_CONFIG_AUTH}".to_string())),
                         })
                     ),
@@ -3285,19 +3302,21 @@ mod tests {
                 RpcEndpoints::new([
                     (
                         "optimism",
-                        RpcEndpointType::String(RpcEndpoint::Url(
+                        RpcEndpointType::String(RpcEndpointUrl::Url(
                             "https://example.com/".to_string()
                         ))
                     ),
                     (
                         "mainnet",
-                        RpcEndpointType::Config(RpcEndpointConfig {
-                            endpoint: RpcEndpoint::Url(
+                        RpcEndpointType::Config(RpcEndpoint {
+                            endpoint: RpcEndpointUrl::Url(
                                 "https://eth-mainnet.alchemyapi.io/v2/123455".to_string()
                             ),
-                            retries: Some(3),
-                            retry_backoff: Some(1000),
-                            compute_units_per_second: Some(1000),
+                            config: RpcEndpointConfig {
+                                retries: Some(3),
+                                retry_backoff: Some(1000),
+                                compute_units_per_second: Some(1000)
+                            },
                             auth: Some(RpcAuth::Raw("Bearer 123456".to_string())),
                         })
                     ),
@@ -3343,18 +3362,18 @@ mod tests {
             assert_eq!(
                 endpoints,
                 RpcEndpoints::new([
-                    ("optimism", RpcEndpoint::Url("https://example.com/".to_string())),
+                    ("optimism", RpcEndpointUrl::Url("https://example.com/".to_string())),
                     (
                         "mainnet",
-                        RpcEndpoint::Url("https://eth-mainnet.alchemyapi.io/v2/123455".to_string())
+                        RpcEndpointUrl::Url("https://eth-mainnet.alchemyapi.io/v2/123455".to_string())
                     ),
                     (
                         "mainnet_2",
-                        RpcEndpoint::Url("https://eth-mainnet.alchemyapi.io/v2/123456".to_string())
+                        RpcEndpointUrl::Url("https://eth-mainnet.alchemyapi.io/v2/123456".to_string())
                     ),
                     (
                         "mainnet_3",
-                        RpcEndpoint::Url(
+                        RpcEndpointUrl::Url(
                             "https://eth-mainnet.alchemyapi.io/v2/123456/98765".to_string()
                         )
                     ),
@@ -3530,17 +3549,17 @@ mod tests {
                     revert_strings: Some(RevertStrings::Strip),
                     allow_paths: vec![PathBuf::from("allow"), PathBuf::from("paths")],
                     rpc_endpoints: RpcEndpoints::new([
-                        ("optimism", RpcEndpoint::Url("https://example.com/".to_string())),
-                        ("mainnet", RpcEndpoint::Env("${RPC_MAINNET}".to_string())),
+                        ("optimism", RpcEndpointUrl::Url("https://example.com/".to_string())),
+                        ("mainnet", RpcEndpointUrl::Env("${RPC_MAINNET}".to_string())),
                         (
                             "mainnet_2",
-                            RpcEndpoint::Env(
+                            RpcEndpointUrl::Env(
                                 "https://eth-mainnet.alchemyapi.io/v2/${API_KEY}".to_string()
                             )
                         ),
                         (
                             "mainnet_3",
-                            RpcEndpoint::Env(
+                            RpcEndpointUrl::Env(
                                 "https://eth-mainnet.alchemyapi.io/v2/${API_KEY}/${ANOTHER_KEY}"
                                     .to_string()
                             )
@@ -3664,11 +3683,11 @@ mod tests {
             assert_eq!(
                 config.rpc_endpoints,
                 RpcEndpoints::new([
-                    ("optimism", RpcEndpoint::Url("https://example.com/".to_string())),
-                    ("mainnet", RpcEndpoint::Env("${RPC_MAINNET}".to_string())),
+                    ("optimism", RpcEndpointUrl::Url("https://example.com/".to_string())),
+                    ("mainnet", RpcEndpointUrl::Env("${RPC_MAINNET}".to_string())),
                     (
                         "mainnet_2",
-                        RpcEndpoint::Env(
+                        RpcEndpointUrl::Env(
                             "https://eth-mainnet.alchemyapi.io/v2/${API_KEY}".to_string()
                         )
                     ),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -58,7 +58,9 @@ pub mod utils;
 pub use utils::*;
 
 mod endpoints;
-pub use endpoints::{ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpointUrl, RpcEndpoints, RpcEndpoint};
+pub use endpoints::{
+    ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl, RpcEndpoints,
+};
 
 mod etherscan;
 use etherscan::{
@@ -3365,11 +3367,15 @@ mod tests {
                     ("optimism", RpcEndpointUrl::Url("https://example.com/".to_string())),
                     (
                         "mainnet",
-                        RpcEndpointUrl::Url("https://eth-mainnet.alchemyapi.io/v2/123455".to_string())
+                        RpcEndpointUrl::Url(
+                            "https://eth-mainnet.alchemyapi.io/v2/123455".to_string()
+                        )
                     ),
                     (
                         "mainnet_2",
-                        RpcEndpointUrl::Url("https://eth-mainnet.alchemyapi.io/v2/123456".to_string())
+                        RpcEndpointUrl::Url(
+                            "https://eth-mainnet.alchemyapi.io/v2/123456".to_string()
+                        )
                     ),
                     (
                         "mainnet_3",

--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -514,6 +514,7 @@ async fn create_fork(mut fork: CreateFork) -> eyre::Result<(ForkId, CreatedFork,
         ProviderBuilder::new(fork.url.as_str())
             .maybe_max_retry(fork.evm_opts.fork_retries)
             .maybe_initial_backoff(fork.evm_opts.fork_retry_backoff)
+            .maybe_headers(fork.evm_opts.fork_headers.clone())
             .compute_units_per_second(fork.evm_opts.get_compute_units_per_second())
             .build()?,
     );

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -29,6 +29,9 @@ pub struct EvmOpts {
     /// Initial retry backoff.
     pub fork_retry_backoff: Option<u64>,
 
+    /// Headers to use with `fork_url`
+    pub fork_headers: Option<Vec<String>>,
+
     /// The available compute units per second.
     ///
     /// See also <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
@@ -80,6 +83,7 @@ impl Default for EvmOpts {
             fork_block_number: None,
             fork_retries: None,
             fork_retry_backoff: None,
+            fork_headers: None,
             compute_units_per_second: None,
             no_rpc_rate_limit: false,
             no_storage_caching: false,

--- a/crates/forge/tests/it/test_helpers.rs
+++ b/crates/forge/tests/it/test_helpers.rs
@@ -11,7 +11,7 @@ use foundry_compilers::{
 };
 use foundry_config::{
     fs_permissions::PathPermission, Config, FsPermissions, FuzzConfig, FuzzDictionaryConfig,
-    InvariantConfig, RpcEndpoint, RpcEndpoints,
+    InvariantConfig, RpcEndpointUrl, RpcEndpoints,
 };
 use foundry_evm::{constants::CALLER, opts::EvmOpts};
 use foundry_test_utils::{fd_lock, init_tracing, rpc::next_rpc_endpoint};
@@ -339,15 +339,15 @@ pub fn manifest_root() -> &'static Path {
 /// the RPC endpoints used during tests
 pub fn rpc_endpoints() -> RpcEndpoints {
     RpcEndpoints::new([
-        ("mainnet", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Mainnet))),
-        ("mainnet2", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Mainnet))),
-        ("sepolia", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Sepolia))),
-        ("optimism", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Optimism))),
-        ("arbitrum", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Arbitrum))),
-        ("polygon", RpcEndpoint::Url(next_rpc_endpoint(NamedChain::Polygon))),
-        ("avaxTestnet", RpcEndpoint::Url("https://api.avax-test.network/ext/bc/C/rpc".into())),
-        ("moonbeam", RpcEndpoint::Url("https://moonbeam-rpc.publicnode.com".into())),
-        ("rpcEnvAlias", RpcEndpoint::Env("${RPC_ENV_ALIAS}".into())),
+        ("mainnet", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Mainnet))),
+        ("mainnet2", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Mainnet))),
+        ("sepolia", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Sepolia))),
+        ("optimism", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Optimism))),
+        ("arbitrum", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Arbitrum))),
+        ("polygon", RpcEndpointUrl::Url(next_rpc_endpoint(NamedChain::Polygon))),
+        ("avaxTestnet", RpcEndpointUrl::Url("https://api.avax-test.network/ext/bc/C/rpc".into())),
+        ("moonbeam", RpcEndpointUrl::Url("https://moonbeam-rpc.publicnode.com".into())),
+        ("rpcEnvAlias", RpcEndpointUrl::Env("${RPC_ENV_ALIAS}".into())),
     ])
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9162 - Set retry config (backoff, max retries) from rpc configuration when a fork is created using cheatcodes

## Solution

Idea - https://github.com/foundry-rs/foundry/issues/9162#issuecomment-2535586933

Implementation:

Use two structs `RpcEndpoint` and `ResolvedRpcEndpoint` that both contain the same data, with the exception that environment variables are resolved to their values in `ResolvedRpcEndpoint`.

Extract shared fields out into a common struct field `RpcEndpointConfig` that doesn't need environment variable resolution.