### PR TITLE
fix: account for impersonated tx in configure_tx_env

### DIFF
--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -10,7 +10,7 @@ use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
     utils::{handle_traces, init_progress, TraceResult},
 };
-use foundry_common::{is_impersonated_tx, is_known_system_sender, shell, SYSTEM_TRANSACTION_TYPE};
+use foundry_common::{is_known_system_sender, shell, SYSTEM_TRANSACTION_TYPE};
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_config::{
     figment::{
@@ -212,12 +212,6 @@ impl RunArgs {
 
                     configure_tx_env(&mut env, &tx.inner);
 
-                    if is_impersonated_tx(&tx.inner.inner) {
-                        // If the transaction is impersonated, we need to set the caller to the from
-                        // address Ref: https://github.com/foundry-rs/foundry/issues/9541
-                        env.tx.caller = tx.from;
-                    }
-
                     if let Some(to) = Transaction::to(tx) {
                         trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
                         executor.transact_with_env(env.clone()).wrap_err_with(|| {
@@ -256,12 +250,6 @@ impl RunArgs {
             executor.set_trace_printer(self.trace_printer);
 
             configure_tx_env(&mut env, &tx.inner);
-
-            if is_impersonated_tx(&tx.inner.inner) {
-                // If the transaction is impersonated, we need to set the caller to the from address
-                // Ref: https://github.com/foundry-rs/foundry/issues/9541
-                env.tx.caller = tx.from;
-            }
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1281,7 +1281,7 @@ impl DatabaseExt for Backend {
         self.commit(journaled_state.state.clone());
 
         let res = {
-            configure_tx_req_env(&mut env, tx)?;
+            configure_tx_req_env(&mut env, tx, None)?;
             let env = self.env_with_handler_cfg(env);
 
             let mut db = self.clone();

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -89,7 +89,7 @@ pub fn get_function<'a>(
 }
 
 /// Configures the env for the given RPC transaction.
-/// Accounts for an impersonated transaction by reseting the `env.tx.caller` field to `tx.from`.
+/// Accounts for an impersonated transaction by resetting the `env.tx.caller` field to `tx.from`.
 pub fn configure_tx_env(env: &mut revm::primitives::Env, tx: &Transaction<AnyTxEnvelope>) {
     let impersonated_from = is_impersonated_tx(&tx.inner).then_some(tx.from);
     if let AnyTxEnvelope::Ethereum(tx) = &tx.inner {
@@ -99,7 +99,7 @@ pub fn configure_tx_env(env: &mut revm::primitives::Env, tx: &Transaction<AnyTxE
 
 /// Configures the env for the given RPC transaction request.
 /// `impersonated_from` is the address of the impersonated account. This helps account for an
-/// impersonated transaction by reseting the `env.tx.caller` field to `impersonated_from`.
+/// impersonated transaction by resetting the `env.tx.caller` field to `impersonated_from`.
 pub fn configure_tx_req_env(
     env: &mut revm::primitives::Env,
     tx: &TransactionRequest,

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -261,7 +261,7 @@ impl VerifyBytecodeArgs {
 
             // configure_tx_rq_env(&mut env, &gen_tx);
 
-            configure_tx_req_env(&mut env, &gen_tx_req)
+            configure_tx_req_env(&mut env, &gen_tx_req, None)
                 .wrap_err("Failed to configure tx request env")?;
 
             // Seed deployer account with funds
@@ -478,7 +478,7 @@ impl VerifyBytecodeArgs {
             }
 
             // configure_req__env(&mut env, &transaction.inner);
-            configure_tx_req_env(&mut env, &transaction)
+            configure_tx_req_env(&mut env, &transaction, None)
                 .wrap_err("Failed to configure tx request env")?;
 
             let fork_address = crate::utils::deploy_contract(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

impersonated_txs should be accounted for in `configure_tx_env` 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Handle impersonated txs while configuring env and reset `env.tx.caller`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
