### PR TITLE
add comment to `-r` option about default value

### DIFF
--- a/crates/cli/src/opts/ethereum.rs
+++ b/crates/cli/src/opts/ethereum.rs
@@ -18,7 +18,7 @@ const FLASHBOTS_URL: &str = "https://rpc.flashbots.net/fast";
 
 #[derive(Clone, Debug, Default, Parser)]
 pub struct RpcOpts {
-    /// The RPC endpoint.
+    /// The RPC endpoint, default value is http://localhost:8545.
     #[arg(short = 'r', long = "rpc-url", env = "ETH_RPC_URL")]
     pub url: Option<String>,
 


### PR DESCRIPTION
This PR adds a comment to the `-r` option about default value, otherwise users may wonder how `cast send` like below works:

```bash
cast send 0xf16FE8a2BA6bfaACf11c8bbf16E5Ccc2f718474b --value 10000000000000000000000 --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
```