### PR TITLE
Update CI workflow template to unpin from `nightly` explicitly, relying on `foundry-toolchain` default

### DIFF
--- a/crates/forge/assets/workflowTemplate.yml
+++ b/crates/forge/assets/workflowTemplate.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         run: |

--- a/crates/forge/assets/workflowTemplate.yml
+++ b/crates/forge/assets/workflowTemplate.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
 
       - name: Show Forge version
         run: |


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`foundry-toolchain` will soon update users to default to `stable`, this PR removes explicit pinning to `nightly` in favor of the default of `foundry-toolchain` (now nightly, becoming stable).