### PR TITLE
Fix typos in documentation and code comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ To use the latest pinned nightly locally, use the following command:
 foundryup --version nightly-e15e33a07c0920189fc336391f538c3dad53da73
 ````
 
-To use the latest pinned nightly on your CI, modify your Foundry installation step to use an specific version:
+To use the latest pinned nightly on your CI, modify your Foundry installation step to use a specific version:
 
 ```
 - name: Install Foundry

--- a/crates/anvil/src/server/error.rs
+++ b/crates/anvil/src/server/error.rs
@@ -1,7 +1,7 @@
 /// Result alias
 pub type NodeResult<T> = Result<T, NodeError>;
 
-/// An error that can occur when launching a anvil instance
+/// An error that can occur when launching an anvil instance
 #[derive(Debug, thiserror::Error)]
 pub enum NodeError {
     #[error(transparent)]

--- a/crates/fmt/src/comments.rs
+++ b/crates/fmt/src/comments.rs
@@ -406,7 +406,7 @@ impl Iterator for CommentStateCharIndices<'_> {
 
 impl std::iter::FusedIterator for CommentStateCharIndices<'_> {}
 
-/// An Iterator over characters in a string slice which are not a apart of comments
+/// An Iterator over characters in a string slice which are not an apart of comments
 pub struct NonCommentChars<'a>(CommentStateCharIndices<'a>);
 
 impl Iterator for NonCommentChars<'_> {


### PR DESCRIPTION
This pull request fixes typos in documentation and code comments across multiple files. The following changes were made:

- `CHANGELOG.md`: Corrected "an specific version" to "a specific version."
- `crates/anvil/src/server/error.rs`: Fixed "a anvil instance" to "an anvil instance."
- `crates/fmt/src/comments.rs`: Updated "a apart" to "an apart."

These changes improve the clarity and professionalism of the documentation and comments.

## Motivation:
Clear and accurate documentation and comments are essential for maintaining code quality and improving readability for contributors.

## Solution:
Typos were identified and corrected in the affected files without introducing any functional changes to the codebase.

## Checklist:
- [x] I have reviewed and corrected typos in the specified files.
- [x] Documentation and comments now follow proper grammar rules.
- [x] Changes do not affect any functionality of the code.
- [x] Tests (if required) have been reviewed for compatibility with the updated comments.
