### PR TITLE
chore: testFail* deprecation warning

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -474,7 +474,7 @@ impl<'a> FunctionRunner<'a> {
 
         let test_fail_warn_deprecation = |should_fail: bool| {
             if should_fail {
-                let _ = sh_warn!("`testFail*` has been deprecated. Consider changing {} to something along the lines of `test_Revert[If|When]_Condition` and expecting a revert.", func.name);
+                let _ = sh_warn!("`testFail*` has been deprecated and will be removed in the next release. Consider changing {} to something along the lines of `test_Revert[If|When]_Condition` and expecting a revert.", func.name);
             }
         };
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -416,8 +416,7 @@ impl<'a> ContractRunner<'a> {
 
         if !test_fail_deprecations.is_empty() {
             warnings.push(format!(
-                "`testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): {}.",
-                test_fail_deprecations
+                "`testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): {test_fail_deprecations}.",
             ));
         }
         SuiteResult::new(duration, test_results, warnings)

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -472,9 +472,21 @@ impl<'a> FunctionRunner<'a> {
             return self.result;
         }
 
+        let test_fail_warn_deprecation = |should_fail: bool| {
+            if should_fail {
+                let _ = sh_warn!("`testFail*` has been deprecated. Consider changing {} to something along the lines of `test_Revert[If|When]_Condition` and expecting a revert.", func.name);
+            }
+        };
+
         match kind {
-            TestFunctionKind::UnitTest { should_fail } => self.run_unit_test(func, should_fail),
-            TestFunctionKind::FuzzTest { should_fail } => self.run_fuzz_test(func, should_fail),
+            TestFunctionKind::UnitTest { should_fail } => {
+                test_fail_warn_deprecation(should_fail);
+                self.run_unit_test(func, should_fail)
+            }
+            TestFunctionKind::FuzzTest { should_fail } => {
+                test_fail_warn_deprecation(should_fail);
+                self.run_fuzz_test(func, should_fail)
+            }
             TestFunctionKind::InvariantTest => {
                 self.run_invariant_test(func, call_after_invariant, identified_contracts.unwrap())
             }

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2819,6 +2819,10 @@ forgetest!(test_fail_deprecation_warning, |prj, cmd| {
         function testFail_deprecated() public {
             revert("deprecated");
         }
+
+        function testFail_deprecated2() public {
+            revert("deprecated2");
+        }
     }
     "#,
     )
@@ -2827,6 +2831,6 @@ forgetest!(test_fail_deprecation_warning, |prj, cmd| {
     cmd.forge_fuse()
         .args(["test", "--mc", "WarnDeprecationTestFail"])
         .assert_success()
-        .stderr_eq(r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): testFail_deprecated.
+        .stderr_eq(r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): testFail_deprecated, testFail_deprecated2.
 "#);
 });

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2807,3 +2807,29 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]],
     );
 });
+
+forgetest!(test_fail_deprecation_warning, |prj, cmd| {
+    prj.insert_ds_test();
+
+    prj.add_source(
+        "WarnDeprecationTestFail.t.sol",
+        r#"
+    import "./test.sol";
+    contract WarnDeprecationTestFail is DSTest {
+        function testFail_deprecated() public {
+            revert("deprecated");
+        }
+    }
+    "#,
+    )
+    .unwrap();
+
+    cmd
+        .forge_fuse()
+        .args(["test", "--mc", "WarnDeprecationTestFail"])
+        .assert_success()
+        .stderr_eq(
+            r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing testFail_deprecated to something along the lines of `test_Revert[If|When]_Condition` and expecting a revert.
+"#,
+        );
+});

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2824,12 +2824,9 @@ forgetest!(test_fail_deprecation_warning, |prj, cmd| {
     )
     .unwrap();
 
-    cmd
-        .forge_fuse()
+    cmd.forge_fuse()
         .args(["test", "--mc", "WarnDeprecationTestFail"])
         .assert_success()
-        .stderr_eq(
-            r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing testFail_deprecated to something along the lines of `test_Revert[If|When]_Condition` and expecting a revert.
-"#,
-        );
+        .stderr_eq(r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): testFail_deprecated.
+"#);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref https://github.com/foundry-rs/foundry/pull/9574#discussion_r1892489392 for `0.3`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Warn if `testFail*` has been used. One warning per test suite

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
