### PR TITLE
chore(`foundryup`): default to stable if no specific version is passed in

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -244,7 +244,7 @@ The installer for Foundry.
 
 Update or revert to a specific Foundry version with ease.
 
-By default, the latest nightly version is installed from built binaries.
+By default, the latest stable version is installed from built binaries.
 
 USAGE:
     foundryup <OPTIONS>

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -89,7 +89,7 @@ main() {
 
   # Install by downloading binaries
   if [[ "$FOUNDRYUP_REPO" == "foundry-rs/foundry" && -z "$FOUNDRYUP_BRANCH" && -z "$FOUNDRYUP_COMMIT" ]]; then
-    FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-nightly}
+    FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION:-stable}
     FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
 
     # Normalize versions (handle channels, versions without v prefix


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As a preparation for major breaking changes `foundryup` should default to the latest `stable` release by default. This will allow users to not have to deal immediately with breaking changes introduced in the nightly builds.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Default to `stable` release.

Users are still able to install the latest `nightly` by running `foundryup --install nightly`.