### PR TITLE
chore(fmt): tx fields indent with the same whitespaces

### DIFF
--- a/crates/common/fmt/src/ui.rs
+++ b/crates/common/fmt/src/ui.rs
@@ -507,8 +507,8 @@ impl UIfmt for AnyTxEnvelope {
             Self::Unknown(tx) => {
                 format!(
                     "
-hash {}
-type {}
+hash                 {}
+type                 {}
 {}
                     ",
                     tx.hash.pretty(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Let the `hash` and `type` fields indent with the other fields

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
