### PR TITLE
fix(anvil): ipc append a newline

### DIFF
--- a/crates/anvil/server/src/ipc.rs
+++ b/crates/anvil/server/src/ipc.rs
@@ -2,7 +2,7 @@
 
 use crate::{error::RequestError, pubsub::PubSubConnection, PubSubRpcHandler};
 use anvil_rpc::request::Request;
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use futures::{ready, Sink, Stream, StreamExt};
 use interprocess::local_socket::{self as ls, tokio::prelude::*};
 use std::{
@@ -172,7 +172,7 @@ impl tokio_util::codec::Encoder<String> for JsonRpcCodec {
     fn encode(&mut self, msg: String, buf: &mut BytesMut) -> io::Result<()> {
         buf.extend_from_slice(msg.as_bytes());
         // Add newline character
-        buf.extend_from_slice(b"\n");
+        buf.put_u8(b'\n');
         Ok(())
     }
 }

--- a/crates/anvil/server/src/ipc.rs
+++ b/crates/anvil/server/src/ipc.rs
@@ -171,6 +171,8 @@ impl tokio_util::codec::Encoder<String> for JsonRpcCodec {
 
     fn encode(&mut self, msg: String, buf: &mut BytesMut) -> io::Result<()> {
         buf.extend_from_slice(msg.as_bytes());
+        // Add newline character
+        buf.extend_from_slice(b"\n");
         Ok(())
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Fix https://github.com/foundry-rs/foundry/issues/9203

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As reth will append a `\n` at the end of the stream: 

```rust
impl Default for Separator {
    fn default() -> Self {
        Self::Byte(b'\n')
    }
}

impl tokio_util::codec::Encoder<String> for StreamCodec {
    type Error = io::Error;

    fn encode(&mut self, msg: String, buf: &mut BytesMut) -> io::Result<()> {
        let mut payload = msg.into_bytes();
        if let Separator::Byte(separator) = self.outgoing_separator {
            payload.push(separator);
        }
        buf.extend_from_slice(&payload);
        Ok(())
    }
}
```

https://github.com/paradigmxyz/reth/blob/343bee568fa8f496a07e8849cb5dad726ba15f41/crates/rpc/ipc/src/stream_codec.rs#L44-L48

https://github.com/paradigmxyz/reth/blob/343bee568fa8f496a07e8849cb5dad726ba15f41/crates/rpc/ipc/src/stream_codec.rs#L128-L139

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
