### PR TITLE
chore(`config`): use solar for inline config parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,8 @@ dependencies = [
  "serde_regex",
  "similar-asserts",
  "solang-parser",
+ "solar-ast",
+ "solar-parse",
  "tempfile",
  "thiserror 2.0.9",
  "toml 0.8.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,7 +3998,6 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "similar-asserts",
- "solang-parser",
  "solar-ast",
  "solar-parse",
  "tempfile",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -22,6 +22,8 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 revm-primitives.workspace = true
 
 solang-parser.workspace = true
+solar-parse.workspace = true
+solar-ast.workspace = true
 
 dirs-next = "2"
 dunce.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,7 +21,6 @@ alloy-chains = { workspace = true, features = ["serde"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 revm-primitives.workspace = true
 
-solang-parser.workspace = true
 solar-parse.workspace = true
 solar-ast.workspace = true
 

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use serde_json::Value;
 use solang_parser::{helpers::CodeLocation, pt};
 use solar_ast::{
-    ast::{Arena, CommentKind, ItemKind},
+    ast::{Arena, CommentKind, Item, ItemKind},
     interface::{self, Session},
 };
 use solar_parse::Parser;
@@ -302,12 +302,30 @@ impl SolarParser {
             return;
         }
 
+        let handle_docs = |item: &Item<'_>| {
+            item.docs
+                .iter()
+                .filter(|d| d.symbol.as_str().contains(INLINE_CONFIG_PREFIX))
+                .map(|d| match d.kind {
+                    CommentKind::Line => d.symbol.as_str().trim().to_string(),
+                    CommentKind::Block => d
+                        .symbol
+                        .as_str()
+                        .lines()
+                        .map(|line| line.trim_start().trim_start_matches('*').trim())
+                        .filter(|line| line.contains(INLINE_CONFIG_PREFIX))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                })
+                .join("\n")
+        };
+
         // Instantiate solar session
         let sess = Session::builder()
             .with_silent_emitter(Some("Inline config parsing failed".to_string()))
             .build();
 
-        let res = sess.enter(|| -> interface::Result<()> {
+        let _ = sess.enter(|| -> interface::Result<()> {
             let arena = Arena::new();
 
             let mut parser = Parser::from_source_code(
@@ -319,50 +337,37 @@ impl SolarParser {
 
             let source_unit = parser.parse_file().map_err(|e| e.emit())?;
 
-            let mut prev_item_end = 0;
             for item in source_unit.items {
-                let ItemKind::Contract(ref c) = item.kind else {
-                    prev_item_end = item.span.hi().0;
-                    continue
-                };
+                let ItemKind::Contract(ref c) = item.kind else { continue };
 
                 if c.name.as_str() != contract_name {
-                    prev_item_end = item.span.hi().0;
                     continue
                 };
 
+                // Handle contract level doc comments
+                let docs = handle_docs(&item);
+                if !docs.is_empty() {
+                    natspecs.push(NatSpec {
+                        contract: contract_id.to_string(),
+                        function: None,
+                        line: "0:0:0".to_string(), // TODO
+                        docs,
+                    });
+                }
+
                 // Parse the doccomments for the item here.
-                let mut prev_end = item.span.lo().0;
                 for part in c.body.iter() {
                     let ItemKind::Function(ref f) = part.kind else { continue };
 
-                    let docs = part
-                        .docs
-                        .iter()
-                        .filter(|d| d.symbol.as_str().contains(INLINE_CONFIG_PREFIX))
-                        .map(|d| match d.kind {
-                            CommentKind::Line => d.symbol.as_str().trim().to_string(),
-                            CommentKind::Block => d
-                                .symbol
-                                .as_str()
-                                .lines()
-                                .map(|line| line.trim_start().trim_start_matches('*').trim())
-                                .filter(|line| line.contains(INLINE_CONFIG_PREFIX))
-                                .collect::<Vec<_>>()
-                                .join("\n"),
-                        })
-                        .join("\n");
-
-                    let natspec = NatSpec {
-                        contract: contract_id.to_string(),
-                        function: f.header.name.map(|f| f.to_string()),
-                        docs,
-                        line: "0:0:0".to_string(), // TODO
-                    };
-
-                    natspecs.push(natspec);
-
-                    // prev_end = f.span.hi().0;
+                    let docs = handle_docs(&part);
+                    if !docs.is_empty() {
+                        natspecs.push(NatSpec {
+                            contract: contract_id.to_string(),
+                            function: f.header.name.map(|f| f.to_string()),
+                            line: "0:0:0".to_string(), // TODO
+                            docs,
+                        });
+                    }
                 }
             }
 
@@ -624,10 +629,10 @@ contract FuzzInlineConf is DSTest {
     function testInlineConfFuzz2() {}
 }"#;
         let mut natspecs = vec![];
-        let solang = SolangParser::new();
+        let solar = SolarParser::new();
         let id = || "inline/FuzzInlineConf.t.sol:FuzzInlineConf".to_string();
         let default_line = || "0:0:0".to_string();
-        solang.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
+        solar.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
         assert_eq!(
             natspecs,
             [

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -471,7 +471,7 @@ function f2() {} /** forge-config: default.fuzz.runs = 800 */ function f3() {}
     }
 
     #[test]
-    fn parse_solang_2() {
+    fn parse_solar_2() {
         let src = r#"
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
@@ -489,10 +489,10 @@ contract FuzzInlineConf is DSTest {
 }
         "#;
         let mut natspecs = vec![];
-        let solang = SolangParser::new();
+        let solar = SolarParser::new();
         let id = || "inline/FuzzInlineConf.t.sol:FuzzInlineConf".to_string();
         let default_line = || "0:0:0".to_string();
-        solang.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
+        solar.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
         assert_eq!(
             natspecs,
             [

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -229,17 +229,22 @@ impl SolarParser {
         let handle_docs = |item: &Item<'_>| {
             item.docs
                 .iter()
-                .filter(|d| d.symbol.as_str().contains(INLINE_CONFIG_PREFIX))
-                .map(|d| match d.kind {
-                    CommentKind::Line => d.symbol.as_str().trim().to_string(),
-                    CommentKind::Block => d
-                        .symbol
-                        .as_str()
-                        .lines()
-                        .map(|line| line.trim_start().trim_start_matches('*').trim())
-                        .filter(|line| line.contains(INLINE_CONFIG_PREFIX))
-                        .collect::<Vec<_>>()
-                        .join("\n"),
+                .filter_map(|d| {
+                    if !d.symbol.as_str().contains(INLINE_CONFIG_PREFIX) {
+                        return None
+                    }
+                    match d.kind {
+                        CommentKind::Line => Some(d.symbol.as_str().trim().to_string()),
+                        CommentKind::Block => Some(
+                            d.symbol
+                                .as_str()
+                                .lines()
+                                .filter(|line| line.contains(INLINE_CONFIG_PREFIX))
+                                .map(|line| line.trim_start().trim_start_matches('*').trim())
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        ),
+                    }
                 })
                 .join("\n")
         };

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_solang() {
+    fn parse_solar() {
         let src = "
 contract C { /// forge-config: default.fuzz.runs = 600
 

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -561,7 +561,7 @@ contract FuzzInlineConf is DSTest {
     }
 
     #[test]
-    fn parse_solang_multiple_contracts_from_same_file() {
+    fn parse_solar_multiple_contracts_from_same_file() {
         let src = r#"
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
@@ -579,10 +579,10 @@ contract FuzzInlineConf2 is DSTest {
 }
         "#;
         let mut natspecs = vec![];
-        let solang = SolangParser::new();
+        let solar = SolarParser::new();
         let id = || "inline/FuzzInlineConf.t.sol:FuzzInlineConf".to_string();
         let default_line = || "0:0:0".to_string();
-        solang.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
+        solar.parse(&mut natspecs, src, &id(), "FuzzInlineConf");
         assert_eq!(
             natspecs,
             [NatSpec {
@@ -595,7 +595,7 @@ contract FuzzInlineConf2 is DSTest {
 
         let mut natspecs = vec![];
         let id = || "inline/FuzzInlineConf2.t.sol:FuzzInlineConf2".to_string();
-        solang.parse(&mut natspecs, src, &id(), "FuzzInlineConf2");
+        solar.parse(&mut natspecs, src, &id(), "FuzzInlineConf2");
         assert_eq!(
             natspecs,
             [NatSpec {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Ref: #9317 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace `SolangParser` with `SolarParser`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
