### PR TITLE
fix(`evm`):  P256Verify address

### DIFF
--- a/crates/evm/core/src/precompiles.rs
+++ b/crates/evm/core/src/precompiles.rs
@@ -49,10 +49,10 @@ pub const PRECOMPILES: &[Address] = &[
     ODYSSEY_P256_ADDRESS,
 ];
 
-/// [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212) secp256r1 precompile address on Odyssey.
+/// [EIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) secp256r1 precompile address on Odyssey.
 ///
 /// <https://github.com/ithacaxyz/odyssey/blob/482f4547631ae5c64ebea6a4b4ef93184a4abfee/crates/node/src/evm.rs#L35-L35>
-pub const ODYSSEY_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
+pub const ODYSSEY_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000014");
 
 /// Wrapper around revm P256 precompile, matching EIP-7212 spec.
 ///

--- a/crates/evm/core/src/precompiles.rs
+++ b/crates/evm/core/src/precompiles.rs
@@ -52,7 +52,7 @@ pub const PRECOMPILES: &[Address] = &[
 /// [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212) secp256r1 precompile address on Odyssey.
 ///
 /// <https://github.com/ithacaxyz/odyssey/blob/482f4547631ae5c64ebea6a4b4ef93184a4abfee/crates/node/src/evm.rs#L35-L35>
-pub const ODYSSEY_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000014");
+pub const ODYSSEY_P256_ADDRESS: Address = address!("0000000000000000000000000000000000000100");
 
 /// Wrapper around revm P256 precompile, matching EIP-7212 spec.
 ///

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloy_consensus::BlockHeader;
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::AnyTxEnvelope;
-use alloy_primitives::{address, Address, Selector, TxKind, B256, U256};
+use alloy_primitives::{Address, Selector, TxKind, B256, U256};
 use alloy_provider::{network::BlockResponse, Network};
 use alloy_rpc_types::{Transaction, TransactionRequest};
 use foundry_common::is_impersonated_tx;

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -18,6 +18,7 @@ use revm::{
         return_ok, CallInputs, CallOutcome, CallScheme, CallValue, CreateInputs, CreateOutcome,
         Gas, InstructionResult, InterpreterResult,
     },
+    precompile::secp256r1::P256VERIFY,
     primitives::{CreateScheme, EVMError, HandlerCfg, SpecId, KECCAK_EMPTY},
     FrameOrResult, FrameResult,
 };
@@ -301,10 +302,7 @@ pub fn odyssey_handler_register<EXT, DB: revm::Database>(handler: &mut EvmHandle
     handler.pre_execution.load_precompiles = Arc::new(move || {
         let mut loaded_precompiles = prev();
 
-        // For backwards compatibility, inject precompile at address 0x14.
-        let backwards_compat_p256 =
-            (address!("0000000000000000000000000000000000000014"), ODYSSEY_P256.1);
-        loaded_precompiles.extend([ODYSSEY_P256, backwards_compat_p256.into()]);
+        loaded_precompiles.extend([ODYSSEY_P256, P256VERIFY]);
 
         loaded_precompiles
     });

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloy_consensus::BlockHeader;
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::AnyTxEnvelope;
-use alloy_primitives::{Address, Selector, TxKind, B256, U256};
+use alloy_primitives::{address, Address, Selector, TxKind, B256, U256};
 use alloy_provider::{network::BlockResponse, Network};
 use alloy_rpc_types::{Transaction, TransactionRequest};
 use foundry_common::is_impersonated_tx;
@@ -301,7 +301,10 @@ pub fn odyssey_handler_register<EXT, DB: revm::Database>(handler: &mut EvmHandle
     handler.pre_execution.load_precompiles = Arc::new(move || {
         let mut loaded_precompiles = prev();
 
-        loaded_precompiles.extend([ODYSSEY_P256]);
+        // For backwards compatibility, inject precompile at address 0x14.
+        let backwards_compat_p256 =
+            (address!("0000000000000000000000000000000000000014"), ODYSSEY_P256.1);
+        loaded_precompiles.extend([ODYSSEY_P256, backwards_compat_p256.into()]);
 
         loaded_precompiles
     });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently the `P256Verify` is injected at the wrong address i.e `0x14`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Inject it at `0x100` according to the spec: https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md#specification. 
Maintains backward compatibility by also injecting it at 0x14. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
