### PR TITLE
fix(ens): don't resolve addr if doesn't contain .

### DIFF
--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -350,7 +350,7 @@ mod tests {
     #[test]
     fn parse_storage_etherscan_api_key() {
         let args =
-            StorageArgs::parse_from(["foundry-cli", "addr", "--etherscan-api-key", "dummykey"]);
+            StorageArgs::parse_from(["foundry-cli", "addr.eth", "--etherscan-api-key", "dummykey"]);
         assert_eq!(args.etherscan.key(), Some("dummykey".to_string()));
 
         std::env::set_var("ETHERSCAN_API_KEY", "FXY");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
When I'm querying the balance of my account, but by mistake missing the last char, the cast return as below:

```
cast balance  0xFacbDEcF714f55d65ABF5be2054a8127880405c`missing one char`
Error: Failed to get resolver from the ENS registry: buffer overrun while deserializing
```

this error seems a little misleading, so let's check if the address contains a `.` or not, then to resolve the ens.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
