### PR TITLE
fix: do not remove `snapshots` directory before running the test suite

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1059,12 +1059,6 @@ impl Config {
         remove_test_dir(&self.fuzz.failure_persist_dir);
         remove_test_dir(&self.invariant.failure_persist_dir);
 
-        // Remove snapshot directory.
-        let snapshot_dir = project.root().join(&self.snapshots);
-        if snapshot_dir.exists() {
-            let _ = fs::remove_dir_all(&snapshot_dir);
-        }
-
         Ok(())
     }
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -301,17 +301,6 @@ impl TestArgs {
         // Create test options from general project settings and compiler output.
         let project_root = &project.paths.root;
 
-        // Remove the snapshots directory if it exists.
-        // This is to ensure that we don't have any stale snapshots.
-        // If `FORGE_SNAPSHOT_CHECK` is set, we don't remove the snapshots directory as it is
-        // required for comparison.
-        if std::env::var_os("FORGE_SNAPSHOT_CHECK").is_none() {
-            let snapshot_dir = project_root.join(&config.snapshots);
-            if snapshot_dir.exists() {
-                let _ = fs::remove_dir_all(project_root.join(&config.snapshots));
-            }
-        }
-
         let should_debug = self.debug;
         let should_draw = self.flamegraph || self.flamechart;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/9477

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Given the feedback we've received on the default behavior of removing the `snapshots` directory this PR proposes to remove the removal all together.

The effect is that we no longer automatically clean up for the user if they have made a change in the following:

- A change in the test name
- A change in the custom group name

These files will now be `stained`. It is the responsibility of the user to clean this up.

`forge clean` will no longer remove the `snapshots` directory.