### PR TITLE
fix: error handling with retries when waiting for receipt

### DIFF
--- a/crates/common/src/retry.rs
+++ b/crates/common/src/retry.rs
@@ -6,6 +6,8 @@ use std::{future::Future, time::Duration};
 /// Error type for Retry.
 #[derive(Debug, thiserror::Error)]
 pub enum RetryError<E = Report> {
+    /// Continues operation without decrementing retries.
+    Continue(E),
     /// Keeps retrying operation.
     Retry(E),
     /// Stops retrying operation immediately.
@@ -74,6 +76,12 @@ impl Retry {
     {
         loop {
             match callback().await {
+                Err(RetryError::Continue(e)) => {
+                    self.handle_continue(e);
+                    if !self.delay.is_zero() {
+                        tokio::time::sleep(self.delay).await;
+                    }
+                }
                 Err(RetryError::Retry(e)) if self.retries > 0 => {
                     self.handle_err(e);
                     if !self.delay.is_zero() {
@@ -89,6 +97,10 @@ impl Retry {
     fn handle_err(&mut self, err: Error) {
         debug_assert!(self.retries > 0);
         self.retries -= 1;
+        self.handle_continue(err);
+    }
+
+    fn handle_continue(&mut self, err: Error) {
         let _ = sh_warn!(
             "{msg}{delay} ({retries} tries remaining)",
             msg = crate::errors::display_chain(&err),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #9636 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- use `Retry` utility. add `Continue` variant to preserve number of retries (without decrementing)
- use `Continue` on watcher timeout err if tx is still known to the node (won't count as a retry). For all other errs use `Retry`
- tested with 100 txes on base sepolia
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
