### PR TITLE
fix: set debug none for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ split-debuginfo = "unpacked"
 [profile.release]
 opt-level = 3
 lto = "thin"
-debug = "line-tables-only"
+debug = "none"
 strip = "debuginfo"
 panic = "abort"
 codegen-units = 16


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #9662 

relates to a rustc bug w/  `--profile maxperf` and `lto = "fat"` for 1.84.0 only (stable)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
