### PR TITLE
fix(`script`): use fork_block_number for init sender nonce

### DIFF
--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -57,7 +57,7 @@ pub async fn next_nonce(
     let provider = try_get_http_provider(provider_url)
         .wrap_err_with(|| format!("bad fork_url provider: {provider_url}"))?;
 
-    let block_id = block_number.map_or(BlockId::latest(), |bn| BlockId::number(bn));
+    let block_id = block_number.map_or(BlockId::latest(), BlockId::number);
     Ok(provider.get_transaction_count(caller).block_id(block_id).await?)
 }
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -550,7 +550,7 @@ pub struct ScriptConfig {
 impl ScriptConfig {
     pub async fn new(config: Config, evm_opts: EvmOpts) -> Result<Self> {
         let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
-            next_nonce(evm_opts.sender, fork_url).await?
+            next_nonce(evm_opts.sender, fork_url, evm_opts.fork_block_number).await?
         } else {
             // dapptools compatibility
             1
@@ -561,7 +561,7 @@ impl ScriptConfig {
 
     pub async fn update_sender(&mut self, sender: Address) -> Result<()> {
         self.sender_nonce = if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
-            next_nonce(sender, fork_url).await?
+            next_nonce(sender, fork_url, None).await?
         } else {
             // dapptools compatibility
             1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9661 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Use `evm_opts.fork_block_number` while fetching the sender nonce that is to be set in `ScriptConfig`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
