### PR TITLE
fix(`config`): enable optimizer when `optimizer_runs` set in config

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -669,6 +669,12 @@ impl Config {
         add_profile(&Self::DEFAULT_PROFILE);
         add_profile(&config.profile);
 
+        // Ref: https://github.com/foundry-rs/foundry/issues/9665
+        // Enables the optimizer if the `optimizer_runs` has been set.
+        let optimizer = config.optimizer();
+        if optimizer.runs.is_some_and(|runs| runs > 0) && !config.optimizer {
+            config.optimizer = true;
+        }
         Ok(config)
     }
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -486,6 +486,17 @@ forgetest!(can_set_optimizer_runs, |prj, cmd| {
     assert_eq!(config.optimizer_runs, 300);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/9665>
+forgetest!(enable_optimizer_when_runs_set, |prj, cmd| {
+    // explicitly set optimizer runs
+    let config = Config { optimizer_runs: 1337, ..Default::default() };
+    assert!(!config.optimizer);
+    prj.write_config(config);
+
+    let config = cmd.config();
+    assert!(config.optimizer);
+});
+
 // test that gas_price can be set
 forgetest!(can_set_gas_price, |prj, cmd| {
     // explicitly set gas_price


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #9665 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Detect whether the `optimizer_runs` key has been set in the config and is nonzero. If yes, the set `config.optimizer = true`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
