### PR TITLE
fix: propagate color config to TraceWriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934ff8719effd2023a48cf63e69536c1c3ced9d3895068f6f5cc9a4ff845e59b"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +919,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-svg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3607949e9f6de49ea4bafe12f5e4fd73613ebf24795e48587302a8cc0e4bb35"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-lossy",
+ "html-escape",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4750,6 +4772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8255,6 +8286,7 @@ checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
 dependencies = [
  "anstream",
  "anstyle",
+ "anstyle-svg",
  "normalize-line-endings",
  "regex",
  "serde",
@@ -9447,6 +9479,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/common/src/io/shell.rs
+++ b/crates/common/src/io/shell.rs
@@ -18,6 +18,11 @@ use std::{
     },
 };
 
+/// Returns the current color choice.
+pub fn color_choice() -> ColorChoice {
+    Shell::get().color_choice()
+}
+
 /// Returns the currently set verbosity level.
 pub fn verbosity() -> Verbosity {
     Shell::get().verbosity()

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -201,10 +201,20 @@ pub fn render_trace_arena_inner(
     }
 
     let mut w = TraceWriter::new(Vec::<u8>::new())
+        .color_cheatcodes(true)
+        .use_colors(convert_color_choice(shell::color_choice()))
         .write_bytecodes(with_bytecodes)
         .with_storage_changes(with_storage_changes);
     w.write_arena(&arena.resolve_arena()).expect("Failed to write traces");
     String::from_utf8(w.into_writer()).expect("trace writer wrote invalid UTF-8")
+}
+
+fn convert_color_choice(choice: shell::ColorChoice) -> revm_inspectors::ColorChoice {
+    match choice {
+        shell::ColorChoice::Auto => revm_inspectors::ColorChoice::Auto,
+        shell::ColorChoice::Always => revm_inspectors::ColorChoice::Always,
+        shell::ColorChoice::Never => revm_inspectors::ColorChoice::Never,
+    }
 }
 
 /// Specifies the kind of trace.

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -2829,3 +2829,10 @@ forgetest!(test_fail_deprecation_warning, |prj, cmd| {
         .stderr_eq(r#"Warning: `testFail*` has been deprecated and will be removed in the next release. Consider changing to test_Revert[If|When]_Condition and expecting a revert. Found deprecated testFail* function(s): testFail_deprecated, testFail_deprecated2.
 "#);
 });
+
+#[cfg(not(feature = "isolate-by-default"))]
+forgetest_init!(colored_traces, |prj, cmd| {
+    cmd.args(["test", "--mt", "test_Increment", "--color", "always", "-vvvvv"])
+        .assert_success()
+        .stdout_eq(file!["../fixtures/colored_traces.svg": TermSvg]);
+});

--- a/crates/forge/tests/fixtures/colored_traces.svg
+++ b/crates/forge/tests/fixtures/colored_traces.svg
@@ -1,0 +1,82 @@
+<svg width="852px" height="542px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-blue { fill: #0000AA }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>No files changed, compilation skipped</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>Ran 1 test for test/Counter.t.sol:CounterTest</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>[PASS] test_Increment() ([GAS])</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>Traces:</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  [137242] </tspan><tspan class="fg-green">CounterTest</tspan><tspan>::</tspan><tspan class="fg-green">setUp</tspan><tspan>()</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    ├─ [96345] </tspan><tspan class="fg-yellow">→ new</tspan><tspan> Counter@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>    │   └─ </tspan><tspan class="fg-green">← [Return] </tspan><tspan>481 bytes of code</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>    ├─ [2592] </tspan><tspan class="fg-green">Counter</tspan><tspan>::</tspan><tspan class="fg-green">setNumber</tspan><tspan>(0)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>    │   └─ </tspan><tspan class="fg-green">← [Stop] </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>    └─ </tspan><tspan class="fg-green">← [Stop] </tspan>
+</tspan>
+    <tspan x="10px" y="226px">
+</tspan>
+    <tspan x="10px" y="244px"><tspan>  [31851] </tspan><tspan class="fg-green">CounterTest</tspan><tspan>::</tspan><tspan class="fg-green">test_Increment</tspan><tspan>()</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>    ├─ [22418] </tspan><tspan class="fg-green">Counter</tspan><tspan>::</tspan><tspan class="fg-green">increment</tspan><tspan>()</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>    │   ├─  storage changes:</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>    │   │   @ 0: 0 → 1</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan>    │   └─ </tspan><tspan class="fg-green">← [Stop] </tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>    ├─ [424] </tspan><tspan class="fg-green">Counter</tspan><tspan>::</tspan><tspan class="fg-green">number</tspan><tspan>()</tspan><tspan class="fg-yellow"> [staticcall]</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>    │   └─ </tspan><tspan class="fg-green">← [Return] </tspan><tspan>1</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>    ├─ [0] </tspan><tspan class="fg-blue">VM</tspan><tspan>::</tspan><tspan class="fg-blue">assertEq</tspan><tspan>(1, 1)</tspan><tspan class="fg-yellow"> [staticcall]</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>    │   └─ </tspan><tspan class="fg-blue">← [Return] </tspan>
+</tspan>
+    <tspan x="10px" y="406px"><tspan>    ├─  storage changes:</tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>    │   @ 0: 0 → 1</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>    └─ </tspan><tspan class="fg-green">← [Stop] </tspan>
+</tspan>
+    <tspan x="10px" y="460px">
+</tspan>
+    <tspan x="10px" y="478px"><tspan>Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]</tspan>
+</tspan>
+    <tspan x="10px" y="496px">
+</tspan>
+    <tspan x="10px" y="514px"><tspan>Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)</tspan>
+</tspan>
+    <tspan x="10px" y="532px">
+</tspan>
+  </text>
+
+</svg>

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -30,7 +30,7 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rand.workspace = true
-snapbox = { version = "0.6", features = ["json", "regex"] }
+snapbox = { version = "0.6", features = ["json", "regex", "term-svg"] }
 tempfile.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
So that --color=always works with traces.