### PR TITLE
fix(`forge`): disable artifacts for coverage

### DIFF
--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -150,7 +150,7 @@ impl CoverageArgs {
         let mut warning =
             "optimizer settings have been disabled for accurate coverage reports".to_string();
         if !self.ir_minimum {
-            warning += ", if you encounter \"stack too deep\" errors, consider using `--ir-minimum` which enables viaIR with mimimum optimization resolving most of the errors";
+            warning += ", if you encounter \"stack too deep\" errors, consider using `--ir-minimum` which enables viaIR with minimum optimization resolving most of the errors";
         }
 
         sh_warn!("{warning}")?;

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -107,15 +107,7 @@ impl CoverageArgs {
     /// Builds the project.
     fn build(&self, config: &Config) -> Result<(Project, ProjectCompileOutput)> {
         // Set up the project
-        let mut project = config.create_project(false, false)?;
-
-        // Set a different artifacts path for coverage. `out/coverage`.
-        // This is done to avoid overwriting the artifacts of the main build that maybe built with
-        // different optimizer settings or --via-ir. Optimizer settings are disabled for
-        // coverage builds.
-        let coverage_artifacts_path = project.artifacts_path().join("coverage");
-        project.paths.artifacts = coverage_artifacts_path.clone();
-        project.paths.build_infos = coverage_artifacts_path.join("build-info");
+        let mut project = config.create_project(false, true)?;
 
         if self.ir_minimum {
             // print warning message

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1746,28 +1746,10 @@ contract AContractTest is DSTest {
 ...
 "#]]);
 
-    let coverage_artifacts = prj.artifacts().join("coverage");
-    assert!(coverage_artifacts.is_dir() && coverage_artifacts.exists());
+    // no artifacts are to be written
+    let artifacts = prj.artifacts();
 
-    let build_info = coverage_artifacts.join("build-info");
+    let files = files_with_ext(artifacts, "json").collect::<Vec<_>>();
 
-    assert!(build_info.is_dir() && build_info.exists());
-    let files = files_with_ext(&coverage_artifacts, "json")
-        .map(|f| f.file_name().unwrap().to_string_lossy().into_owned())
-        .collect::<Vec<_>>();
-
-    assert!(files.len() == 4);
-    let expected_artifacts = ["AContract.json", "AContractTest.json", "DSTest.json"];
-    expected_artifacts.iter().for_each(|artifact| {
-        assert!(files.contains(&artifact.to_string()));
-    });
-
-    // Should recompile
-    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[
-        r#"[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
-Compiler run successful!
-...
-"#
-    ]]);
+    assert!(files.is_empty());
 });

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1757,7 +1757,7 @@ contract AContractTest is DSTest {
         .collect::<Vec<_>>();
 
     assert!(files.len() == 4);
-    let expected_artifacts = vec!["AContract.json", "AContractTest.json", "DSTest.json"];
+    let expected_artifacts = ["AContract.json", "AContractTest.json", "DSTest.json"];
     expected_artifacts.iter().for_each(|artifact| {
         assert!(files.contains(&artifact.to_string()));
     });

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1692,7 +1692,7 @@ fn assert_lcov(cmd: &mut TestCommand, data: impl IntoData) {
     cmd.args(["--report=lcov", "--report-file"]).assert_file(data.into_data());
 }
 
-forgetest!(diff_artifact_dir, |prj, cmd| {
+forgetest!(no_artifacts_written, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source(
         "AContract.sol",
@@ -1747,9 +1747,7 @@ contract AContractTest is DSTest {
 "#]]);
 
     // no artifacts are to be written
-    let artifacts = prj.artifacts();
-
-    let files = files_with_ext(artifacts, "json").collect::<Vec<_>>();
+    let files = files_with_ext(prj.artifacts(), "json").collect::<Vec<_>>();
 
     assert!(files.is_empty());
 });

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1,4 +1,4 @@
-use foundry_common::fs;
+use foundry_common::fs::{self, files_with_ext};
 use foundry_test_utils::{
     snapbox::{Data, IntoData},
     TestCommand, TestProject,
@@ -1691,3 +1691,83 @@ contract AContract {
 fn assert_lcov(cmd: &mut TestCommand, data: impl IntoData) {
     cmd.args(["--report=lcov", "--report-file"]).assert_file(data.into_data());
 }
+
+forgetest!(diff_artifact_dir, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    int public i;
+
+    function init() public {
+        i = 0;
+    }
+
+    function foo() public {
+        i = 1;
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import {AContract} from "./AContract.sol";
+
+contract AContractTest is DSTest {
+    AContract a;
+
+    function setUp() public {
+        a = new AContract();
+        a.init();
+    }
+
+    function testFoo() public {
+        a.foo();
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
+...
+╭-------------------+---------------+---------------+---------------+---------------╮
+| File              | % Lines       | % Statements  | % Branches    | % Funcs       |
++===================================================================================+
+| src/AContract.sol | 100.00% (4/4) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
+|-------------------+---------------+---------------+---------------+---------------|
+| Total             | 100.00% (4/4) | 100.00% (2/2) | 100.00% (0/0) | 100.00% (2/2) |
+╰-------------------+---------------+---------------+---------------+---------------╯
+...
+"#]]);
+
+    let coverage_artifacts = prj.artifacts().join("coverage");
+    assert!(coverage_artifacts.is_dir() && coverage_artifacts.exists());
+
+    let build_info = coverage_artifacts.join("build-info");
+
+    assert!(build_info.is_dir() && build_info.exists());
+    let files = files_with_ext(&coverage_artifacts, "json")
+        .map(|f| f.file_name().unwrap().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    assert!(files.len() == 4);
+    let expected_artifacts = vec!["AContract.json", "AContractTest.json", "DSTest.json"];
+    expected_artifacts.iter().for_each(|artifact| {
+        assert!(files.contains(&artifact.to_string()));
+    });
+
+    // Should recompile
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[
+        r#"[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+...
+"#
+    ]]);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #8840 

Saves coverage artifacts and build-info to a separate directory `out/coverage` and `out/coverage/build-info` respectively. This prevents users from mistakenly deploying unoptimized contracts, see: https://github.com/foundry-rs/foundry/issues/8840#issuecomment-2390792012

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Artifacts generated by `forge coverage` are written to `out/coverage`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
