### PR TITLE
chore(deps): bump svm 0.5.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8595,9 +8595,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svm-rs"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e9bc6b09b8a7a919128f8c029ae4048d83f814af557e948115273c75864acf"
+checksum = "2079b44b2dc358e0aa611988e806f92a0d1f174206566de745a4a422a8009c65"
 dependencies = [
  "const-hex",
  "dirs 5.0.1",
@@ -8615,9 +8615,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d0964cd9dfcbf8bd21057c1a4aa293fefab208306461989ce723dd9c51e71e"
+checksum = "9379e64a7d61f2a288e97c4b7d80a5cdcc893f24a83b6ec0ec18ffd36d58c6e2"
 dependencies = [
  "build_const",
  "const-hex",


### PR DESCRIPTION
Fixes https://github.com/foundry-rs/foundry/issues/9682. See https://github.com/alloy-rs/svm-rs/pull/150.