### PR TITLE
feat(chisel): determine proper path to Vm.sol based on proj remappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vergen",
+ "walkdir",
  "yansi",
 ]
 

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -64,6 +64,7 @@ time = { version = "0.3", features = ["formatting"] }
 tokio = { workspace = true, features = ["full"] }
 yansi.workspace = true
 tracing.workspace = true
+walkdir.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }

--- a/crates/chisel/src/session_source.rs
+++ b/crates/chisel/src/session_source.rs
@@ -17,6 +17,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use solang_parser::{diagnostics::Diagnostic, pt};
 use std::{fs, path::PathBuf};
+use walkdir::WalkDir;
 use yansi::Paint;
 
 /// The minimum Solidity version of the `Vm` interface.
@@ -466,15 +467,26 @@ contract {contract_name} is Script {{
     pub fn to_repl_source(&self) -> String {
         let Version { major, minor, patch, .. } = self.solc.version;
         let Self { contract_name, global_code, top_level_code, run_code, config, .. } = self;
-
-        let (vm_import, vm_constant) = if !config.no_vm {
-            (
-                "import {Vm} from \"forge-std/Vm.sol\";\n",
-                "Vm internal constant vm = Vm(address(uint160(uint256(keccak256(\"hevm cheat code\")))));\n"
-            )
-        } else {
-            ("", "")
-        };
+        let (mut vm_import, mut vm_constant) = (String::new(), String::new());
+        if !config.no_vm {
+            // Check if there's any `forge-std` remapping and determine proper path to it by
+            // searching remapping path.
+            if let Some(remapping) = config
+                .foundry_config
+                .remappings
+                .iter()
+                .find(|remapping| remapping.name == "forge-std/")
+            {
+                if let Some(vm_path) = WalkDir::new(&remapping.path.path)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .find(|e| e.file_name() == "Vm.sol")
+                {
+                    vm_import = format!("import {{Vm}} from \"{}\";\n", vm_path.path().display());
+                    vm_constant = "Vm internal constant vm = Vm(address(uint160(uint256(keccak256(\"hevm cheat code\")))));\n".to_string();
+                }
+            }
+        }
 
         format!(
             r#"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #9647 

- check if in foundry project / any forge-std remapping and search proper path to Vm.sol
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
