### PR TITLE
feat(`forge`): inspect - default to pretty output

### DIFF
--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -31,7 +31,7 @@ pub struct InspectArgs {
     pub field: ContractArtifactField,
 
     /// Pretty print the selected field, if supported.
-    #[arg(long, default_value = "true")]
+    #[arg(long)]
     pub pretty: bool,
 
     /// All build arguments are supported
@@ -195,7 +195,7 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>) -> Result<()
         Cell::new("Contract"),
     ];
 
-    print_table(headers, |mut table| {
+    print_table(headers, |table| {
         for slot in &storage_layout.storage {
             let storage_type = storage_layout.types.get(&slot.storage_type);
             table.add_row([
@@ -207,7 +207,6 @@ pub fn print_storage_layout(storage_layout: Option<&StorageLayout>) -> Result<()
                 &slot.contract,
             ]);
         }
-        table
     })
 }
 
@@ -222,11 +221,10 @@ fn print_method_identifiers(method_identifiers: &Option<BTreeMap<String, String>
 
     let headers = vec![Cell::new("Method"), Cell::new("Identifier")];
 
-    print_table(headers, |mut table| {
+    print_table(headers, |table| {
         for (method, identifier) in method_identifiers {
             table.add_row([method, identifier]);
         }
-        table
     })
 }
 
@@ -240,21 +238,18 @@ fn print_errors_events(map: &Map<String, Value>, is_err: bool) -> Result<()> {
     } else {
         vec![Cell::new("Event"), Cell::new("Topic")]
     };
-    print_table(headers, |mut table| {
+    print_table(headers, |table| {
         for (method, selector) in map {
             table.add_row([method, selector.as_str().unwrap()]);
         }
-        table
     })
 }
 
-fn print_table(headers: Vec<Cell>, add_rows: impl Fn(Table) -> Table) -> Result<()> {
+fn print_table(headers: Vec<Cell>, add_rows: impl FnOnce(&mut Table)) -> Result<()> {
     let mut table = Table::new();
     table.apply_modifier(UTF8_ROUND_CORNERS);
     table.set_header(headers);
-
-    let table = add_rows(table);
-
+    add_rows(&mut table);
     sh_println!("\n{table}\n")?;
     Ok(())
 }

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -17,6 +17,7 @@ use foundry_compilers::{
     utils::canonicalize,
 };
 use regex::Regex;
+use serde_json::{Map, Value};
 use std::{collections::BTreeMap, fmt, sync::LazyLock};
 
 /// CLI arguments for `forge inspect`.
@@ -151,11 +152,7 @@ impl InspectArgs {
                         );
                     }
                 }
-                if is_json {
-                    print_json(&out)?;
-                } else {
-                    todo!("table version")
-                }
+                print_errors(&out)?;
             }
             ContractArtifactField::Events => {
                 let mut out = serde_json::Map::new();
@@ -237,6 +234,21 @@ fn print_method_identifiers(method_identifiers: &Option<BTreeMap<String, String>
     print_table(headers, |mut table| {
         for (method, identifier) in method_identifiers {
             table.add_row([method, identifier]);
+        }
+        table
+    })
+}
+
+fn print_errors(errors: &Map<String, Value>) -> Result<()> {
+    if shell::is_json() {
+        return print_json(errors);
+    }
+
+    let headers = vec![Cell::new("Error"), Cell::new("Selector")];
+
+    print_table(headers, |mut table| {
+        for (method, selector) in errors {
+            table.add_row([method, selector.as_str().unwrap()]);
         }
         table
     })

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -79,7 +79,6 @@ impl InspectArgs {
             eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
         })?;
 
-        let is_json = shell::is_json();
         // Match on ContractArtifactFields and pretty-print
         match field {
             ContractArtifactField::Abi => {
@@ -87,7 +86,7 @@ impl InspectArgs {
                     .abi
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
-                if !is_json {
+                if !shell::is_json() {
                     let source = foundry_cli::utils::abi_to_solidity(abi, &contract.name)?;
                     sh_println!("{source}")?;
                 } else {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -1,4 +1,4 @@
-use alloy_json_abi::{InternalType, JsonAbi, Param};
+use alloy_json_abi::{EventParam, InternalType, JsonAbi, Param};
 use alloy_primitives::{hex, keccak256, Address};
 use clap::Parser;
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, Cell, Table};
@@ -147,10 +147,10 @@ impl InspectArgs {
 fn parse_errors(abi: &JsonAbi) -> Map<String, Value> {
     let mut out = serde_json::Map::new();
     for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
-        let types = er.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
+        let types = get_ty_sig(&er.inputs);
         let sig = format!("{:x}", er.selector());
         let sig_trimmed = &sig[0..8];
-        out.insert(format!("{}({})", er.name, types.join(",")), sig_trimmed.to_string().into());
+        out.insert(format!("{}({})", er.name, types), sig_trimmed.to_string().into());
     }
     out
 }
@@ -158,107 +158,111 @@ fn parse_errors(abi: &JsonAbi) -> Map<String, Value> {
 fn parse_events(abi: &JsonAbi) -> Map<String, Value> {
     let mut out = serde_json::Map::new();
     for ev in abi.events.iter().flat_map(|(_, events)| events) {
-        let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
+        let types = parse_event_params(&ev.inputs);
         let topic = hex::encode(keccak256(ev.signature()));
-        out.insert(format!("{}({})", ev.name, types.join(",")), format!("0x{topic}").into());
+        out.insert(format!("{}({})", ev.name, types), format!("0x{topic}").into());
     }
     out
 }
 
+fn parse_event_params(ev_params: &Vec<EventParam>) -> String {
+    ev_params
+        .iter()
+        .map(|p| {
+            if let Some(ty) = p.internal_type() {
+                return internal_ty(ty)
+            }
+            p.ty.clone()
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 fn print_abi(abi: &JsonAbi) -> Result<()> {
-    if !shell::is_json() {
-        let headers = vec![Cell::new("Type"), Cell::new("Signature"), Cell::new("Selector")];
-        print_table(headers, |table| {
-            let contract_ty = |c: &Option<String>, ty: &String| {
-                c.clone().map_or(ty.clone(), |c| format!("{c}.{ty}"))
-            };
-
-            let internal_ty = |ty: &InternalType| match ty {
-                InternalType::AddressPayable(addr) => addr.clone(),
-                InternalType::Contract(contract) => contract.clone(),
-                InternalType::Enum { contract, ty } => contract_ty(contract, ty),
-                InternalType::Struct { contract, ty } => contract_ty(contract, ty),
-                InternalType::Other { contract, ty } => contract_ty(contract, ty),
-            };
-
-            let get_ty_sig = |inputs: &Vec<Param>| {
-                inputs
-                    .iter()
-                    .map(|p| {
-                        if let Some(ty) = p.internal_type() {
-                            return internal_ty(ty);
-                        }
-                        p.ty.clone()
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",")
-            };
-            // Print events
-            for ev in abi.events.iter().flat_map(|(_, events)| events) {
-                let types = ev
-                    .inputs
-                    .iter()
-                    .map(|p| {
-                        if let Some(ty) = p.internal_type() {
-                            return internal_ty(ty)
-                        }
-                        p.ty.clone()
-                    })
-                    .collect::<Vec<_>>();
-                let selector = ev.selector().to_string();
-                table.add_row(["event", &format!("{}({})", ev.name, types.join(",")), &selector]);
-            }
-
-            // Print errors
-            for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
-                let selector = er.selector().to_string();
-                table.add_row([
-                    "error",
-                    &format!("{}({})", er.name, get_ty_sig(&er.inputs)),
-                    &selector,
-                ]);
-            }
-
-            // Print functions
-            for func in abi.functions.iter().flat_map(|(_, f)| f) {
-                let selector = func.selector().to_string();
-                let state_mut = func.state_mutability.as_json_str();
-                let func_sig = if !func.outputs.is_empty() {
-                    format!(
-                        "{}({}) {state_mut} returns ({})",
-                        func.name,
-                        get_ty_sig(&func.inputs),
-                        get_ty_sig(&func.outputs)
-                    )
-                } else {
-                    format!("{}({}) {state_mut}", func.name, get_ty_sig(&func.inputs))
-                };
-                table.add_row(["function", &func_sig, &selector]);
-            }
-
-            if let Some(constructor) = abi.constructor() {
-                let state_mut = constructor.state_mutability.as_json_str();
-                table.add_row([
-                    "constructor",
-                    &format!("constructor({}) {state_mut}", get_ty_sig(&constructor.inputs)),
-                    "",
-                ]);
-            }
-
-            if let Some(fallback) = &abi.fallback {
-                let state_mut = fallback.state_mutability.as_json_str();
-                table.add_row(["fallback", &format!("fallback() {state_mut}"), ""]);
-            }
-
-            if let Some(receive) = &abi.receive {
-                let state_mut = receive.state_mutability.as_json_str();
-                table.add_row(["receive", &format!("receive() {state_mut}"), ""]);
-            }
-        })?;
-    } else {
-        print_json(abi)?;
+    if shell::is_json() {
+        return print_json(abi)
     }
-    Ok(())
+
+    let headers = vec![Cell::new("Type"), Cell::new("Signature"), Cell::new("Selector")];
+    print_table(headers, |table| {
+        // Print events
+        for ev in abi.events.iter().flat_map(|(_, events)| events) {
+            let types = parse_event_params(&ev.inputs);
+            let selector = ev.selector().to_string();
+            table.add_row(["event", &format!("{}({})", ev.name, types), &selector]);
+        }
+
+        // Print errors
+        for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
+            let selector = er.selector().to_string();
+            table.add_row([
+                "error",
+                &format!("{}({})", er.name, get_ty_sig(&er.inputs)),
+                &selector,
+            ]);
+        }
+
+        // Print functions
+        for func in abi.functions.iter().flat_map(|(_, f)| f) {
+            let selector = func.selector().to_string();
+            let state_mut = func.state_mutability.as_json_str();
+            let func_sig = if !func.outputs.is_empty() {
+                format!(
+                    "{}({}) {state_mut} returns ({})",
+                    func.name,
+                    get_ty_sig(&func.inputs),
+                    get_ty_sig(&func.outputs)
+                )
+            } else {
+                format!("{}({}) {state_mut}", func.name, get_ty_sig(&func.inputs))
+            };
+            table.add_row(["function", &func_sig, &selector]);
+        }
+
+        if let Some(constructor) = abi.constructor() {
+            let state_mut = constructor.state_mutability.as_json_str();
+            table.add_row([
+                "constructor",
+                &format!("constructor({}) {state_mut}", get_ty_sig(&constructor.inputs)),
+                "",
+            ]);
+        }
+
+        if let Some(fallback) = &abi.fallback {
+            let state_mut = fallback.state_mutability.as_json_str();
+            table.add_row(["fallback", &format!("fallback() {state_mut}"), ""]);
+        }
+
+        if let Some(receive) = &abi.receive {
+            let state_mut = receive.state_mutability.as_json_str();
+            table.add_row(["receive", &format!("receive() {state_mut}"), ""]);
+        }
+    })
+}
+
+fn get_ty_sig(inputs: &Vec<Param>) -> String {
+    inputs
+        .iter()
+        .map(|p| {
+            if let Some(ty) = p.internal_type() {
+                return internal_ty(ty);
+            }
+            p.ty.clone()
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn internal_ty(ty: &InternalType) -> String {
+    let contract_ty =
+        |c: &Option<String>, ty: &String| c.clone().map_or(ty.clone(), |c| format!("{c}.{ty}"));
+    match ty {
+        InternalType::AddressPayable(addr) => addr.clone(),
+        InternalType::Contract(contract) => contract.clone(),
+        InternalType::Enum { contract, ty } => contract_ty(contract, ty),
+        InternalType::Struct { contract, ty } => contract_ty(contract, ty),
+        InternalType::Other { contract, ty } => contract_ty(contract, ty),
+    }
 }
 
 pub fn print_storage_layout(storage_layout: Option<&StorageLayout>) -> Result<()> {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -240,11 +240,12 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
                 table.add_row(["function", &func_sig, selector.as_str()]);
             }
 
-            if let Some(contructor) = abi.constructor() {
-                let state_mut = contructor.state_mutability.as_json_str();
+            if let Some(constructor) = abi.constructor() {
+                let state_mut = constructor.state_mutability.as_json_str();
                 table.add_row([
                     "constructor",
-                    format!("constructor({}) {state_mut}", get_ty_sig(&contructor.inputs)).as_str(),
+                    format!("constructor({}) {state_mut}", get_ty_sig(&constructor.inputs))
+                        .as_str(),
                     "",
                 ]);
             }

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -30,7 +30,7 @@ pub struct InspectArgs {
     pub field: ContractArtifactField,
 
     /// Pretty print the selected field, if supported.
-    #[arg(long)]
+    #[arg(long, default_value = "true")]
     pub pretty: bool,
 
     /// All build arguments are supported
@@ -78,6 +78,7 @@ impl InspectArgs {
             eyre::eyre!("Could not find artifact `{contract}` in the compiled artifacts")
         })?;
 
+        let is_json = shell::is_json();
         // Match on ContractArtifactFields and pretty-print
         match field {
             ContractArtifactField::Abi => {
@@ -85,7 +86,7 @@ impl InspectArgs {
                     .abi
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
-                if pretty {
+                if !is_json {
                     let source = foundry_cli::utils::abi_to_solidity(abi, &contract.name)?;
                     sh_println!("{source}")?;
                 } else {
@@ -105,10 +106,18 @@ impl InspectArgs {
                 print_json_str(&artifact.legacy_assembly, None)?;
             }
             ContractArtifactField::MethodIdentifiers => {
-                print_json(&artifact.method_identifiers)?;
+                if is_json {
+                    print_json(&artifact.method_identifiers)?;
+                } else {
+                    todo!("table version")
+                }
             }
             ContractArtifactField::GasEstimates => {
-                print_json(&artifact.gas_estimates)?;
+                if is_json {
+                    print_json(&artifact.gas_estimates)?;
+                } else {
+                    todo!("prettier fmt")
+                }
             }
             ContractArtifactField::StorageLayout => {
                 print_storage_layout(artifact.storage_layout.as_ref())?;
@@ -146,7 +155,11 @@ impl InspectArgs {
                         );
                     }
                 }
-                print_json(&out)?;
+                if is_json {
+                    print_json(&out)?;
+                } else {
+                    todo!("table version")
+                }
             }
             ContractArtifactField::Events => {
                 let mut out = serde_json::Map::new();
@@ -162,7 +175,11 @@ impl InspectArgs {
                         );
                     }
                 }
-                print_json(&out)?;
+                if is_json {
+                    print_json(&out)?;
+                } else {
+                    todo!("table version")
+                }
             }
             ContractArtifactField::Eof => {
                 print_eof(artifact.deployed_bytecode.and_then(|b| b.bytecode))?;

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -165,7 +165,7 @@ fn parse_events(abi: &JsonAbi) -> Map<String, Value> {
     out
 }
 
-fn parse_event_params(ev_params: &Vec<EventParam>) -> String {
+fn parse_event_params(ev_params: &[EventParam]) -> String {
     ev_params
         .iter()
         .map(|p| {
@@ -240,7 +240,7 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
     })
 }
 
-fn get_ty_sig(inputs: &Vec<Param>) -> String {
+fn get_ty_sig(inputs: &[Param]) -> String {
     inputs
         .iter()
         .map(|p| {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -1,3 +1,4 @@
+use alloy_json_abi::{InternalType, JsonAbi, Param};
 use alloy_primitives::{hex, keccak256, Address};
 use clap::Parser;
 use comfy_table::{modifiers::UTF8_ROUND_CORNERS, Cell, Table};
@@ -82,12 +83,7 @@ impl InspectArgs {
                     .abi
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("Failed to fetch lossless ABI"))?;
-                if !shell::is_json() {
-                    let source = foundry_cli::utils::abi_to_solidity(abi, &contract.name)?;
-                    sh_println!("{source}")?;
-                } else {
-                    print_json(abi)?;
-                }
+                print_abi(abi)?;
             }
             ContractArtifactField::Bytecode => {
                 print_json_str(&artifact.bytecode, Some("object"))?;
@@ -129,36 +125,11 @@ impl InspectArgs {
                 print_json_str(&artifact.ewasm, None)?;
             }
             ContractArtifactField::Errors => {
-                let mut out = serde_json::Map::new();
-                if let Some(abi) = &artifact.abi {
-                    let abi = &abi;
-                    // Print the signature of all errors.
-                    for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
-                        let types = er.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
-                        let sig = format!("{:x}", er.selector());
-                        let sig_trimmed = &sig[0..8];
-                        out.insert(
-                            format!("{}({})", er.name, types.join(",")),
-                            sig_trimmed.to_string().into(),
-                        );
-                    }
-                }
+                let out = artifact.abi.as_ref().map_or(Map::new(), parse_errors);
                 print_errors_events(&out, true)?;
             }
             ContractArtifactField::Events => {
-                let mut out = serde_json::Map::new();
-                if let Some(abi) = &artifact.abi {
-                    let abi = &abi;
-                    // Print the topic of all events including anonymous.
-                    for ev in abi.events.iter().flat_map(|(_, events)| events) {
-                        let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
-                        let topic = hex::encode(keccak256(ev.signature()));
-                        out.insert(
-                            format!("{}({})", ev.name, types.join(",")),
-                            format!("0x{topic}").into(),
-                        );
-                    }
-                }
+                let out = artifact.abi.as_ref().map_or(Map::new(), parse_events);
                 print_errors_events(&out, false)?;
             }
             ContractArtifactField::Eof => {
@@ -171,6 +142,127 @@ impl InspectArgs {
 
         Ok(())
     }
+}
+
+fn parse_errors(abi: &JsonAbi) -> Map<String, Value> {
+    let mut out = serde_json::Map::new();
+    for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
+        let types = er.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
+        let sig = format!("{:x}", er.selector());
+        let sig_trimmed = &sig[0..8];
+        out.insert(format!("{}({})", er.name, types.join(",")), sig_trimmed.to_string().into());
+    }
+    out
+}
+
+fn parse_events(abi: &JsonAbi) -> Map<String, Value> {
+    let mut out = serde_json::Map::new();
+    for ev in abi.events.iter().flat_map(|(_, events)| events) {
+        let types = ev.inputs.iter().map(|p| p.ty.clone()).collect::<Vec<_>>();
+        let topic = hex::encode(keccak256(ev.signature()));
+        out.insert(format!("{}({})", ev.name, types.join(",")), format!("0x{topic}").into());
+    }
+    out
+}
+
+fn print_abi(abi: &JsonAbi) -> Result<()> {
+    if !shell::is_json() {
+        let headers = vec![Cell::new("Type"), Cell::new("Signature"), Cell::new("Selector")];
+        print_table(headers, |table| {
+            let contract_ty = |c: &Option<String>, ty: &String| {
+                c.clone().map_or(ty.clone(), |c| format!("{}.{}", c, ty))
+            };
+
+            let internal_ty = |ty: &InternalType| match ty {
+                InternalType::AddressPayable(addr) => addr.clone(),
+                InternalType::Contract(contract) => contract.clone(),
+                InternalType::Enum { contract, ty } => contract_ty(contract, ty),
+                InternalType::Struct { contract, ty } => contract_ty(contract, ty),
+                InternalType::Other { contract, ty } => contract_ty(contract, ty),
+            };
+
+            let get_ty_sig = |inputs: &Vec<Param>| {
+                inputs
+                    .iter()
+                    .map(|p| {
+                        if let Some(ty) = p.internal_type() {
+                            return internal_ty(ty);
+                        }
+                        p.ty.clone()
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
+            };
+            // Print events
+            for ev in abi.events.iter().flat_map(|(_, events)| events) {
+                let types = ev
+                    .inputs
+                    .iter()
+                    .map(|p| {
+                        if let Some(ty) = p.internal_type() {
+                            return internal_ty(ty)
+                        }
+                        p.ty.clone()
+                    })
+                    .collect::<Vec<_>>();
+                let selector = ev.selector().to_string();
+                table.add_row([
+                    "event",
+                    format!("{}({})", ev.name, types.join(",")).as_str(),
+                    selector.as_str(),
+                ]);
+            }
+
+            // Print errors
+            for er in abi.errors.iter().flat_map(|(_, errors)| errors) {
+                let selector = er.selector().to_string();
+                table.add_row([
+                    "error",
+                    format!("{}({})", er.name, get_ty_sig(&er.inputs)).as_str(),
+                    selector.as_str(),
+                ]);
+            }
+
+            // Print functions
+            for func in abi.functions.iter().flat_map(|(_, f)| f) {
+                let selector = func.selector().to_string();
+                let state_mut = func.state_mutability.as_json_str();
+                let func_sig = if func.outputs.len() > 0 {
+                    format!(
+                        "{}({}) {state_mut} returns ({})",
+                        func.name,
+                        get_ty_sig(&func.inputs),
+                        get_ty_sig(&func.outputs)
+                    )
+                } else {
+                    format!("{}({}) {state_mut}", func.name, get_ty_sig(&func.inputs))
+                };
+                table.add_row(["function", &func_sig, selector.as_str()]);
+            }
+
+            if let Some(contructor) = abi.constructor() {
+                let state_mut = contructor.state_mutability.as_json_str();
+                table.add_row([
+                    "constructor",
+                    format!("constructor({}) {state_mut}", get_ty_sig(&contructor.inputs)).as_str(),
+                    "",
+                ]);
+            }
+
+            if let Some(fallback) = &abi.fallback {
+                let state_mut = fallback.state_mutability.as_json_str();
+                table.add_row(["fallback", format!("fallback() {state_mut}",).as_str(), ""]);
+            }
+
+            if let Some(receive) = &abi.receive {
+                let state_mut = receive.state_mutability.as_json_str();
+                table.add_row(["receive", format!("receive() {state_mut}",).as_str(), ""]);
+            }
+        })?;
+    } else {
+        print_json(abi)?;
+    }
+    Ok(())
 }
 
 pub fn print_storage_layout(storage_layout: Option<&StorageLayout>) -> Result<()> {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -170,7 +170,7 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
         let headers = vec![Cell::new("Type"), Cell::new("Signature"), Cell::new("Selector")];
         print_table(headers, |table| {
             let contract_ty = |c: &Option<String>, ty: &String| {
-                c.clone().map_or(ty.clone(), |c| format!("{}.{}", c, ty))
+                c.clone().map_or(ty.clone(), |c| format!("{c}.{ty}"))
             };
 
             let internal_ty = |ty: &InternalType| match ty {
@@ -206,11 +206,7 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
                     })
                     .collect::<Vec<_>>();
                 let selector = ev.selector().to_string();
-                table.add_row([
-                    "event",
-                    format!("{}({})", ev.name, types.join(",")).as_str(),
-                    selector.as_str(),
-                ]);
+                table.add_row(["event", &format!("{}({})", ev.name, types.join(",")), &selector]);
             }
 
             // Print errors
@@ -218,8 +214,8 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
                 let selector = er.selector().to_string();
                 table.add_row([
                     "error",
-                    format!("{}({})", er.name, get_ty_sig(&er.inputs)).as_str(),
-                    selector.as_str(),
+                    &format!("{}({})", er.name, get_ty_sig(&er.inputs)),
+                    &selector,
                 ]);
             }
 
@@ -227,7 +223,7 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
             for func in abi.functions.iter().flat_map(|(_, f)| f) {
                 let selector = func.selector().to_string();
                 let state_mut = func.state_mutability.as_json_str();
-                let func_sig = if func.outputs.len() > 0 {
+                let func_sig = if !func.outputs.is_empty() {
                     format!(
                         "{}({}) {state_mut} returns ({})",
                         func.name,
@@ -237,27 +233,26 @@ fn print_abi(abi: &JsonAbi) -> Result<()> {
                 } else {
                     format!("{}({}) {state_mut}", func.name, get_ty_sig(&func.inputs))
                 };
-                table.add_row(["function", &func_sig, selector.as_str()]);
+                table.add_row(["function", &func_sig, &selector]);
             }
 
             if let Some(constructor) = abi.constructor() {
                 let state_mut = constructor.state_mutability.as_json_str();
                 table.add_row([
                     "constructor",
-                    format!("constructor({}) {state_mut}", get_ty_sig(&constructor.inputs))
-                        .as_str(),
+                    &format!("constructor({}) {state_mut}", get_ty_sig(&constructor.inputs)),
                     "",
                 ]);
             }
 
             if let Some(fallback) = &abi.fallback {
                 let state_mut = fallback.state_mutability.as_json_str();
-                table.add_row(["fallback", format!("fallback() {state_mut}",).as_str(), ""]);
+                table.add_row(["fallback", &format!("fallback() {state_mut}"), ""]);
             }
 
             if let Some(receive) = &abi.receive {
                 let state_mut = receive.state_mutability.as_json_str();
-                table.add_row(["receive", format!("receive() {state_mut}",).as_str(), ""]);
+                table.add_row(["receive", &format!("receive() {state_mut}"), ""]);
             }
         })?;
     } else {

--- a/crates/forge/bin/cmd/inspect.rs
+++ b/crates/forge/bin/cmd/inspect.rs
@@ -30,10 +30,6 @@ pub struct InspectArgs {
     #[arg(value_enum)]
     pub field: ContractArtifactField,
 
-    /// Pretty print the selected field, if supported.
-    #[arg(long)]
-    pub pretty: bool,
-
     /// All build arguments are supported
     #[command(flatten)]
     build: BuildOpts,
@@ -41,7 +37,7 @@ pub struct InspectArgs {
 
 impl InspectArgs {
     pub fn run(self) -> Result<()> {
-        let Self { contract, field, build, pretty: _ } = self;
+        let Self { contract, field, build } = self;
 
         trace!(target: "forge", ?field, ?contract, "running forge inspect");
 
@@ -118,10 +114,10 @@ impl InspectArgs {
                 print_json(&artifact.devdoc)?;
             }
             ContractArtifactField::Ir => {
-                print_yul(artifact.ir.as_deref(), self.pretty)?;
+                print_yul(artifact.ir.as_deref())?;
             }
             ContractArtifactField::IrOptimized => {
-                print_yul(artifact.ir_optimized.as_deref(), self.pretty)?;
+                print_yul(artifact.ir_optimized.as_deref())?;
             }
             ContractArtifactField::Metadata => {
                 print_json(&artifact.metadata)?;
@@ -448,7 +444,7 @@ fn print_json_str(obj: &impl serde::Serialize, key: Option<&str>) -> Result<()> 
     Ok(())
 }
 
-fn print_yul(yul: Option<&str>, pretty: bool) -> Result<()> {
+fn print_yul(yul: Option<&str>) -> Result<()> {
     let Some(yul) = yul else {
         eyre::bail!("Could not get IR output");
     };
@@ -456,11 +452,7 @@ fn print_yul(yul: Option<&str>, pretty: bool) -> Result<()> {
     static YUL_COMMENTS: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"(///.*\n\s*)|(\s*/\*\*.*\*/)").unwrap());
 
-    if pretty {
-        sh_println!("{}", YUL_COMMENTS.replace_all(yul, ""))?;
-    } else {
-        sh_println!("{yul}")?;
-    }
+    sh_println!("{}", YUL_COMMENTS.replace_all(yul, ""))?;
 
     Ok(())
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3230,14 +3230,18 @@ Compiler run successful!
         .stdout_eq(str![[r#""{...}""#]].is_json());
 });
 
-// <https://github.com/foundry-rs/foundry/issues/6816>
 forgetest_init!(can_inspect_counter_pretty, |prj, cmd| {
     cmd.args(["inspect", "src/Counter.sol:Counter", "abi"]).assert_success().stdout_eq(str![[r#"
-interface Counter {
-    function increment() external;
-    function number() external view returns (uint256);
-    function setNumber(uint256 newNumber) external;
-}
+
+╭----------+---------------------------------+------------╮
+| Type     | Signature                       | Selector   |
++=========================================================+
+| function | increment() nonpayable          | 0xd09de08a |
+|----------+---------------------------------+------------|
+| function | number() view returns (uint256) | 0x8381f58a |
+|----------+---------------------------------+------------|
+| function | setNumber(uint256) nonpayable   | 0x3fb5c1cb |
+╰----------+---------------------------------+------------╯
 
 
 "#]]);

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3232,8 +3232,7 @@ Compiler run successful!
 
 // <https://github.com/foundry-rs/foundry/issues/6816>
 forgetest_init!(can_inspect_counter_pretty, |prj, cmd| {
-    cmd.args(["inspect", "src/Counter.sol:Counter", "abi", "--pretty"]).assert_success().stdout_eq(
-        str![[r#"
+    cmd.args(["inspect", "src/Counter.sol:Counter", "abi"]).assert_success().stdout_eq(str![[r#"
 interface Counter {
     function increment() external;
     function number() external view returns (uint256);
@@ -3241,8 +3240,7 @@ interface Counter {
 }
 
 
-"#]],
-    );
+"#]]);
 });
 
 // checks that `clean` also works with the "out" value set in Config

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3247,6 +3247,104 @@ forgetest_init!(can_inspect_counter_pretty, |prj, cmd| {
 "#]]);
 });
 
+forgetest!(inspect_counter_with_events_errs, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r#"
+    contract Counter {
+    uint256 public number;
+    uint64 public count;
+    struct MyStruct {
+        uint64 count;
+    }
+    struct ErrWithMsg {
+        string message;
+    }
+
+    event Incremented(uint256 newValue);
+    event Decremented(uint256 newValue);
+
+    error NumberIsZero();
+    error CustomErr(ErrWithMsg e);
+
+    constructor(uint256 _number) {
+        number = _number;
+    }
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() external {
+        number++;
+    }
+
+    function decrement() public payable {
+        if (number == 0) {
+            return;
+        }
+        number--;
+    }
+
+    function square() public {
+        number = number * number;
+    }
+
+    fallback() external payable {
+        ErrWithMsg memory err = ErrWithMsg("Fallback function is not allowed");
+        revert CustomErr(err);
+    }
+
+    receive() external payable {
+        count++;
+    }
+
+    function setStruct(MyStruct memory s, uint32 b) public {
+        count = s.count;
+    }
+}
+    "#,
+    )
+    .unwrap();
+
+    cmd.args(["inspect", "Counter", "abi"]).assert_success().stdout_eq(str![[r#"
+
+╭-------------+-----------------------------------------------+--------------------------------------------------------------------╮
+| Type        | Signature                                     | Selector                                                           |
++==================================================================================================================================+
+| event       | Decremented(uint256)                          | 0xc9118d86370931e39644ee137c931308fa3774f6c90ab057f0c3febf427ef94a |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| event       | Incremented(uint256)                          | 0x20d8a6f5a693f9d1d627a598e8820f7a55ee74c183aa8f1a30e8d4e8dd9a8d84 |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| error       | CustomErr(Counter.ErrWithMsg)                 | 0x0625625a                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| error       | NumberIsZero()                                | 0xde5d32ac                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | count() view returns (uint64)                 | 0x06661abd                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | decrement() payable                           | 0x2baeceb7                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | increment() nonpayable                        | 0xd09de08a                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | number() view returns (uint256)               | 0x8381f58a                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | setNumber(uint256) nonpayable                 | 0x3fb5c1cb                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | setStruct(Counter.MyStruct,uint32) nonpayable | 0x08ef7366                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| function    | square() nonpayable                           | 0xd742cb01                                                         |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| constructor | constructor(uint256) nonpayable               |                                                                    |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| fallback    | fallback() payable                            |                                                                    |
+|-------------+-----------------------------------------------+--------------------------------------------------------------------|
+| receive     | receive() payable                             |                                                                    |
+╰-------------+-----------------------------------------------+--------------------------------------------------------------------╯
+
+
+"#]]);
+});
+
 // checks that `clean` also works with the "out" value set in Config
 forgetest_init!(gas_report_include_tests, |prj, cmd| {
     prj.write_config(Config {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3247,10 +3247,7 @@ forgetest_init!(can_inspect_counter_pretty, |prj, cmd| {
 "#]]);
 });
 
-forgetest!(inspect_counter_with_events_errs, |prj, cmd| {
-    prj.add_source(
-        "Counter.sol",
-        r#"
+const CUSTOM_COUNTER: &str = r#"
     contract Counter {
     uint256 public number;
     uint64 public count;
@@ -3303,9 +3300,9 @@ forgetest!(inspect_counter_with_events_errs, |prj, cmd| {
         count = s.count;
     }
 }
-    "#,
-    )
-    .unwrap();
+    "#;
+forgetest!(inspect_custom_counter_abi, |prj, cmd| {
+    prj.add_source("Counter.sol", CUSTOM_COUNTER).unwrap();
 
     cmd.args(["inspect", "Counter", "abi"]).assert_success().stdout_eq(str![[r#"
 
@@ -3340,6 +3337,67 @@ forgetest!(inspect_counter_with_events_errs, |prj, cmd| {
 |-------------+-----------------------------------------------+--------------------------------------------------------------------|
 | receive     | receive() payable                             |                                                                    |
 ╰-------------+-----------------------------------------------+--------------------------------------------------------------------╯
+
+
+"#]]);
+});
+
+forgetest!(inspect_custom_counter_events, |prj, cmd| {
+    prj.add_source("Counter.sol", CUSTOM_COUNTER).unwrap();
+
+    cmd.args(["inspect", "Counter", "events"]).assert_success().stdout_eq(str![[r#"
+
+╭----------------------+--------------------------------------------------------------------╮
+| Event                | Topic                                                              |
++===========================================================================================+
+| Decremented(uint256) | 0xc9118d86370931e39644ee137c931308fa3774f6c90ab057f0c3febf427ef94a |
+|----------------------+--------------------------------------------------------------------|
+| Incremented(uint256) | 0x20d8a6f5a693f9d1d627a598e8820f7a55ee74c183aa8f1a30e8d4e8dd9a8d84 |
+╰----------------------+--------------------------------------------------------------------╯
+
+
+"#]]);
+});
+
+forgetest!(inspect_custom_counter_errors, |prj, cmd| {
+    prj.add_source("Counter.sol", CUSTOM_COUNTER).unwrap();
+
+    cmd.args(["inspect", "Counter", "errors"]).assert_success().stdout_eq(str![[r#"
+
+╭-------------------------------+----------╮
+| Error                         | Selector |
++==========================================+
+| CustomErr(Counter.ErrWithMsg) | 0625625a |
+|-------------------------------+----------|
+| NumberIsZero()                | de5d32ac |
+╰-------------------------------+----------╯
+
+
+"#]]);
+});
+
+forgetest!(inspect_custom_counter_method_identifiers, |prj, cmd| {
+    prj.add_source("Counter.sol", CUSTOM_COUNTER).unwrap();
+
+    cmd.args(["inspect", "Counter", "method-identifiers"]).assert_success().stdout_eq(str![[r#"
+
+╭----------------------------+------------╮
+| Method                     | Identifier |
++=========================================+
+| count()                    | 06661abd   |
+|----------------------------+------------|
+| decrement()                | 2baeceb7   |
+|----------------------------+------------|
+| increment()                | d09de08a   |
+|----------------------------+------------|
+| number()                   | 8381f58a   |
+|----------------------------+------------|
+| setNumber(uint256)         | 3fb5c1cb   |
+|----------------------------+------------|
+| setStruct((uint64),uint32) | 08ef7366   |
+|----------------------------+------------|
+| square()                   | d742cb01   |
+╰----------------------------+------------╯
 
 
 "#]]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #5165 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Removes the `--pretty` flag and makes that behavior the default. 
- Generate table layout for `abi`, `method-identifiers`, `errors`, and `events` by default, json can be obtained using the `--json`. 
- For artifacts fields that are not table-friendly, generate `json` by default. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
