### PR TITLE
fix(cheatcode): envOr use default for empty strings

### DIFF
--- a/crates/cheatcodes/src/env.rs
+++ b/crates/cheatcodes/src/env.rs
@@ -175,7 +175,11 @@ impl Cheatcode for envOr_4Call {
 impl Cheatcode for envOr_5Call {
     fn apply(&self, _state: &mut Cheatcodes) -> Result {
         let Self { name, defaultValue } = self;
-        env_default(name, defaultValue, &DynSolType::String)
+        let value = match env::var(name) {
+            Ok(env_var) if !env_var.is_empty() => env_var,
+            _ => defaultValue.to_string(),
+        };
+        Ok(value.abi_encode())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
closes #7408 

- use default if string env var empty when `vm.envOr(string)`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
