### PR TITLE
Fix rewrite of User-Agent header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "async-trait",
+ "axum",
  "clap",
  "comfy-table",
  "dunce",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -73,4 +73,4 @@ terminal_size.workspace = true
 foundry-macros.workspace = true
 similar-asserts.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-axum = {workspace = true}
+axum = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -73,3 +73,4 @@ terminal_size.workspace = true
 foundry-macros.workspace = true
 similar-asserts.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+axum = {workspace = true}

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -344,16 +344,15 @@ mod tests {
         let shutdown_notify_clone = Arc::clone(&shutdown_notify);
         let listener = tokio::net::TcpListener::bind("0.0.0.0:1337").await.unwrap();
 
-        let handler = axum::routing::get(|actual_headers: HeaderMap| {
+        let http_handler = axum::routing::get(|actual_headers: HeaderMap| {
             let user_agent = HeaderName::from_str("User-Agent").unwrap();
-            assert!(actual_headers.contains_key(user_agent.clone()));
             assert_eq!(actual_headers[user_agent], HeaderValue::from_str("test-agent").unwrap());
 
             async { "" }
         });
 
         let server_task = tokio::spawn(async move {
-            axum::serve(listener, handler.into_make_service())
+            axum::serve(listener, http_handler.into_make_service())
                 .with_graceful_shutdown(async move {
                     shutdown_notify_clone.notified().await;
                 })
@@ -362,18 +361,13 @@ mod tests {
         });
 
         let transport = RuntimeTransportBuilder::new(Url::parse("http://127.0.0.1:1337").unwrap())
-            .with_headers(vec![
-                "User-Agent: test-agent".to_string(),
-                "Some-Header: some-header".to_string(),
-            ])
+            .with_headers(vec!["User-Agent: test-agent".to_string()])
             .build();
-
         let inner = transport.connect_http().await.unwrap();
 
         match inner {
             InnerTransport::Http(http) => {
-                let client = http.client();
-                let _ = client.get("http://127.0.0.1:1337").send().await.unwrap();
+                let _ = http.client().get("http://127.0.0.1:1337").send().await.unwrap();
 
                 // assert inside http_handler
             }
@@ -382,7 +376,6 @@ mod tests {
 
         // Signal the server to shut down
         shutdown_notify.notify_one();
-
         // Wait for the server to shut down
         server_task.await.unwrap();
     }

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -333,7 +333,6 @@ fn url_to_file_path(url: &Url) -> Result<PathBuf, ()> {
     url.to_file_path()
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,9 +346,7 @@ mod tests {
 
         let handler = axum::routing::get(|actual_headers: HeaderMap| {
             let user_agent = HeaderName::from_str("User-Agent").unwrap();
-            assert!(
-                actual_headers.contains_key(user_agent.clone()),
-            );
+            assert!(actual_headers.contains_key(user_agent.clone()),);
             assert_eq!(actual_headers[user_agent], HeaderValue::from_str("test-agent").unwrap());
 
             async { "" }

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -346,7 +346,7 @@ mod tests {
 
         let handler = axum::routing::get(|actual_headers: HeaderMap| {
             let user_agent = HeaderName::from_str("User-Agent").unwrap();
-            assert!(actual_headers.contains_key(user_agent.clone()),);
+            assert!(actual_headers.contains_key(user_agent.clone()));
             assert_eq!(actual_headers[user_agent], HeaderValue::from_str("test-agent").unwrap());
 
             async { "" }

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -176,7 +176,7 @@ impl RuntimeTransport {
             );
         }
 
-        if !headers.iter().any(|(k, _v)| k.as_str().starts_with("User-Agent:")) {
+        if !headers.iter().any(|(k, _v)| k.as_str().starts_with("user-agent")) {
             headers.insert(
                 reqwest::header::USER_AGENT,
                 HeaderValue::from_str(DEFAULT_USER_AGENT)

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_user_agent_header() {
-        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = Url::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
 
         let http_handler = axum::routing::get(|actual_headers: HeaderMap| {

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -176,7 +176,7 @@ impl RuntimeTransport {
             );
         }
 
-        if !headers.iter().any(|(k, _v)| k.as_str().starts_with("user-agent")) {
+        if !headers.iter().any(|(k, _v)| k.eq(&reqwest::header::USER_AGENT)) {
             headers.insert(
                 reqwest::header::USER_AGENT,
                 HeaderValue::from_str(DEFAULT_USER_AGENT)


### PR DESCRIPTION

## Motivation

For now passed `User-Agent` header is rewritten to `foundry/version`, but it should not

## Solution

Fix header existence check condition (`HeaderName` is lowercased and do not contains `:`)
