### PR TITLE
refactor: properly handle config load errors

### DIFF
--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -587,9 +587,10 @@ pub struct AnvilEvmArgs {
 impl AnvilEvmArgs {
     pub fn resolve_rpc_alias(&mut self) {
         if let Some(fork_url) = &self.fork_url {
-            let config = Config::load_with_providers(FigmentProviders::Anvil);
-            if let Some(Ok(url)) = config.get_rpc_url_with_alias(&fork_url.url) {
-                self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
+            if let Ok(config) = Config::load_with_providers(FigmentProviders::Anvil) {
+                if let Some(Ok(url)) = config.get_rpc_url_with_alias(&fork_url.url) {
+                    self.fork_url = Some(ForkUrl { url: url.to_string(), block: fork_url.block });
+                }
             }
         }
     }

--- a/crates/cast/bin/cmd/access_list.rs
+++ b/crates/cast/bin/cmd/access_list.rs
@@ -5,10 +5,9 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils,
+    utils::{self, LoadConfig},
 };
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Config;
 use std::str::FromStr;
 
 /// CLI arguments for `cast access-list`.
@@ -46,7 +45,7 @@ impl AccessListArgs {
     pub async fn run(self) -> Result<()> {
         let Self { to, sig, args, tx, eth, block } = self;
 
-        let config = Config::from(&eth);
+        let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 

--- a/crates/cast/bin/cmd/artifact.rs
+++ b/crates/cast/bin/cmd/artifact.rs
@@ -5,10 +5,9 @@ use eyre::Result;
 use foundry_block_explorers::Client;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
-    utils,
+    utils::{self, LoadConfig},
 };
 use foundry_common::fs;
-use foundry_config::Config;
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -51,7 +50,7 @@ impl ArtifactArgs {
         let Self { contract, etherscan, rpc, output: output_location, abi_path } = self;
 
         let mut etherscan = etherscan;
-        let config = Config::from(&rpc);
+        let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
         let api_key = etherscan.key().unwrap_or_default();
         let chain = provider.get_chain_id().await?;

--- a/crates/cast/bin/cmd/call.rs
+++ b/crates/cast/bin/cmd/call.rs
@@ -119,7 +119,7 @@ impl CallArgs {
     pub async fn run(self) -> Result<()> {
         let figment = Into::<Figment>::into(&self.eth).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;
-        let mut config = Config::try_from(figment)?.sanitized();
+        let mut config = Config::from_provider(figment)?.sanitized();
 
         let Self {
             to,

--- a/crates/cast/bin/cmd/constructor_args.rs
+++ b/crates/cast/bin/cmd/constructor_args.rs
@@ -1,3 +1,7 @@
+use super::{
+    creation_code::fetch_creation_code,
+    interface::{fetch_abi_from_etherscan, load_abi_from_file},
+};
 use alloy_dyn_abi::DynSolType;
 use alloy_primitives::{Address, Bytes};
 use alloy_provider::Provider;
@@ -6,13 +10,7 @@ use eyre::{eyre, OptionExt, Result};
 use foundry_block_explorers::Client;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
-    utils,
-};
-use foundry_config::Config;
-
-use super::{
-    creation_code::fetch_creation_code,
-    interface::{fetch_abi_from_etherscan, load_abi_from_file},
+    utils::{self, LoadConfig},
 };
 
 /// CLI arguments for `cast creation-args`.
@@ -35,10 +33,9 @@ pub struct ConstructorArgsArgs {
 
 impl ConstructorArgsArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { contract, etherscan, rpc, abi_path } = self;
+        let Self { contract, mut etherscan, rpc, abi_path } = self;
 
-        let mut etherscan = etherscan;
-        let config = Config::from(&rpc);
+        let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
         let api_key = etherscan.key().unwrap_or_default();
         let chain = provider.get_chain_id().await?;

--- a/crates/cast/bin/cmd/creation_code.rs
+++ b/crates/cast/bin/cmd/creation_code.rs
@@ -1,3 +1,4 @@
+use super::interface::{fetch_abi_from_etherscan, load_abi_from_file};
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, Bytes};
 use alloy_provider::{ext::TraceApi, Provider};
@@ -8,12 +9,9 @@ use eyre::{eyre, OptionExt, Result};
 use foundry_block_explorers::Client;
 use foundry_cli::{
     opts::{EtherscanOpts, RpcOpts},
-    utils,
+    utils::{self, LoadConfig},
 };
 use foundry_common::provider::RetryProvider;
-use foundry_config::Config;
-
-use super::interface::{fetch_abi_from_etherscan, load_abi_from_file};
 
 /// CLI arguments for `cast creation-code`.
 #[derive(Parser)]
@@ -47,11 +45,10 @@ pub struct CreationCodeArgs {
 
 impl CreationCodeArgs {
     pub async fn run(self) -> Result<()> {
-        let Self { contract, etherscan, rpc, disassemble, without_args, only_args, abi_path } =
+        let Self { contract, mut etherscan, rpc, disassemble, without_args, only_args, abi_path } =
             self;
 
-        let mut etherscan = etherscan;
-        let config = Config::from(&rpc);
+        let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
         let api_key = etherscan.key().unwrap_or_default();
         let chain = provider.get_chain_id().await?;

--- a/crates/cast/bin/cmd/estimate.rs
+++ b/crates/cast/bin/cmd/estimate.rs
@@ -6,10 +6,9 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::{self, parse_ether_value},
+    utils::{self, parse_ether_value, LoadConfig},
 };
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Config;
 use std::str::FromStr;
 
 /// CLI arguments for `cast estimate`.
@@ -69,7 +68,7 @@ impl EstimateArgs {
     pub async fn run(self) -> Result<()> {
         let Self { to, mut sig, mut args, mut tx, block, eth, command } = self;
 
-        let config = Config::from(&eth);
+        let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
         let sender = SenderKind::from_wallet_opts(eth.wallet).await?;
 

--- a/crates/cast/bin/cmd/find_block.rs
+++ b/crates/cast/bin/cmd/find_block.rs
@@ -2,8 +2,10 @@ use alloy_provider::Provider;
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
-use foundry_cli::{opts::RpcOpts, utils};
-use foundry_config::Config;
+use foundry_cli::{
+    opts::RpcOpts,
+    utils::{self, LoadConfig},
+};
 use futures::join;
 
 /// CLI arguments for `cast find-block`.
@@ -21,7 +23,7 @@ impl FindBlockArgs {
         let Self { timestamp, rpc } = self;
 
         let ts_target = timestamp;
-        let config = Config::from(&rpc);
+        let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
 
         let last_block_num = provider.get_block_number().await?;

--- a/crates/cast/bin/cmd/interface.rs
+++ b/crates/cast/bin/cmd/interface.rs
@@ -3,10 +3,10 @@ use alloy_primitives::Address;
 use clap::Parser;
 use eyre::{Context, Result};
 use foundry_block_explorers::Client;
-use foundry_cli::opts::EtherscanOpts;
+use foundry_cli::{opts::EtherscanOpts, utils::LoadConfig};
 use foundry_common::{compile::ProjectCompiler, fs, shell};
 use foundry_compilers::{info::ContractInfo, utils::canonicalize};
-use foundry_config::{load_config_with_root, try_find_project_root, Config};
+use foundry_config::load_config;
 use itertools::Itertools;
 use serde_json::Value;
 use std::{
@@ -114,8 +114,7 @@ pub fn load_abi_from_file(path: &str, name: Option<String>) -> Result<Vec<(JsonA
 
 /// Load the ABI from the artifact of a locally compiled contract.
 fn load_abi_from_artifact(path_or_contract: &str) -> Result<Vec<(JsonAbi, String)>> {
-    let root = try_find_project_root(None)?;
-    let config = load_config_with_root(Some(&root));
+    let config = load_config()?;
     let project = config.project()?;
     let compiler = ProjectCompiler::new().quiet(true);
 
@@ -139,7 +138,7 @@ pub async fn fetch_abi_from_etherscan(
     address: Address,
     etherscan: &EtherscanOpts,
 ) -> Result<Vec<(JsonAbi, String)>> {
-    let config = Config::from(etherscan);
+    let config = etherscan.load_config()?;
     let chain = config.chain.unwrap_or_default();
     let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
     let client = Client::new(chain, api_key)?;

--- a/crates/cast/bin/cmd/logs.rs
+++ b/crates/cast/bin/cmd/logs.rs
@@ -6,9 +6,8 @@ use alloy_rpc_types::{BlockId, BlockNumberOrTag, Filter, FilterBlockOption, Filt
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
-use foundry_cli::{opts::EthereumOpts, utils};
+use foundry_cli::{opts::EthereumOpts, utils, utils::LoadConfig};
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Config;
 use itertools::Itertools;
 use std::{io, str::FromStr};
 
@@ -58,7 +57,7 @@ impl LogsArgs {
         let Self { from_block, to_block, address, sig_or_topic, topics_or_args, subscribe, eth } =
             self;
 
-        let config = Config::from(&eth);
+        let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
 
         let cast = Cast::new(&provider);

--- a/crates/cast/bin/cmd/mktx.rs
+++ b/crates/cast/bin/cmd/mktx.rs
@@ -6,10 +6,9 @@ use clap::Parser;
 use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
-    utils::get_provider,
+    utils::{get_provider, LoadConfig},
 };
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Config;
 use std::{path::PathBuf, str::FromStr};
 
 /// CLI arguments for `cast mktx`.
@@ -82,7 +81,7 @@ impl MakeTxArgs {
             None
         };
 
-        let config = Config::from(&eth);
+        let config = eth.load_config()?;
 
         // Retrieve the signer, and bail if it can't be constructed.
         let signer = eth.wallet.signer().await?;

--- a/crates/cast/bin/cmd/mod.rs
+++ b/crates/cast/bin/cmd/mod.rs
@@ -1,4 +1,4 @@
-//! Subcommands for cast
+//! `cast` subcommands.
 //!
 //! All subcommands should respect the `foundry_config::Config`.
 //! If a subcommand accepts values that are supported by the `Config`, then the subcommand should

--- a/crates/cast/bin/cmd/rpc.rs
+++ b/crates/cast/bin/cmd/rpc.rs
@@ -1,8 +1,7 @@
 use cast::Cast;
 use clap::Parser;
 use eyre::Result;
-use foundry_cli::{opts::RpcOpts, utils};
-use foundry_config::Config;
+use foundry_cli::{opts::RpcOpts, utils, utils::LoadConfig};
 use itertools::Itertools;
 
 /// CLI arguments for `cast rpc`.
@@ -37,7 +36,7 @@ impl RpcArgs {
     pub async fn run(self) -> Result<()> {
         let Self { raw, method, params, rpc } = self;
 
-        let config = Config::from(&rpc);
+        let config = rpc.load_config()?;
         let provider = utils::get_provider(&config)?;
 
         let params = if raw {

--- a/crates/cast/bin/cmd/run.rs
+++ b/crates/cast/bin/cmd/run.rs
@@ -103,7 +103,7 @@ impl RunArgs {
     pub async fn run(self) -> Result<()> {
         let figment = Into::<Figment>::into(&self.rpc).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;
-        let mut config = Config::try_from(figment)?.sanitized();
+        let mut config = Config::from_provider(figment)?.sanitized();
 
         let compute_units_per_second =
             if self.no_rate_limit { Some(u64::MAX) } else { self.compute_units_per_second };

--- a/crates/cast/bin/cmd/send.rs
+++ b/crates/cast/bin/cmd/send.rs
@@ -11,9 +11,9 @@ use eyre::Result;
 use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
     utils,
+    utils::LoadConfig,
 };
 use foundry_common::ens::NameOrAddress;
-use foundry_config::Config;
 use std::{path::PathBuf, str::FromStr};
 
 /// CLI arguments for `cast send`.
@@ -115,7 +115,7 @@ impl SendTxArgs {
             None
         };
 
-        let config = Config::from(&eth);
+        let config = eth.load_config()?;
         let provider = utils::get_provider(&config)?;
 
         let builder = CastTxBuilder::new(&provider, tx, &config)

--- a/crates/cast/bin/cmd/storage.rs
+++ b/crates/cast/bin/cmd/storage.rs
@@ -12,6 +12,7 @@ use foundry_block_explorers::Client;
 use foundry_cli::{
     opts::{BuildOpts, EtherscanOpts, RpcOpts},
     utils,
+    utils::LoadConfig,
 };
 use foundry_common::{
     abi::find_source,
@@ -85,7 +86,7 @@ impl figment::Provider for StorageArgs {
 
 impl StorageArgs {
     pub async fn run(self) -> Result<()> {
-        let config = Config::from(&self);
+        let config = self.load_config()?;
 
         let Self { address, slot, block, build, .. } = self;
         let provider = utils::get_provider(&config)?;
@@ -354,7 +355,7 @@ mod tests {
         assert_eq!(args.etherscan.key(), Some("dummykey".to_string()));
 
         std::env::set_var("ETHERSCAN_API_KEY", "FXY");
-        let config = Config::from(&args);
+        let config = args.load_config().unwrap();
         std::env::remove_var("ETHERSCAN_API_KEY");
         assert_eq!(config.etherscan_api_key, Some("dummykey".to_string()));
 

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -10,7 +10,7 @@ use alloy_signer_local::{
 use cast::revm::primitives::Authorization;
 use clap::Parser;
 use eyre::{Context, Result};
-use foundry_cli::{opts::RpcOpts, utils};
+use foundry_cli::{opts::RpcOpts, utils, utils::LoadConfig};
 use foundry_common::{fs, sh_println, shell};
 use foundry_config::Config;
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
@@ -369,7 +369,7 @@ impl WalletSubcommands {
             }
             Self::SignAuth { rpc, nonce, chain, wallet, address } => {
                 let wallet = wallet.signer().await?;
-                let provider = utils::get_provider(&Config::from(&rpc))?;
+                let provider = utils::get_provider(&rpc.load_config()?)?;
                 let nonce = if let Some(nonce) = nonce {
                     nonce
                 } else {

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -9,7 +9,7 @@ use cast::{Cast, SimpleCast};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use eyre::Result;
-use foundry_cli::{handler, utils};
+use foundry_cli::{handler, utils, utils::LoadConfig};
 use foundry_common::{
     abi::{get_error, get_event},
     ens::{namehash, ProviderEnsExt},
@@ -287,7 +287,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         // Blockchain & RPC queries
         CastSubcommand::AccessList(cmd) => cmd.run().await?,
         CastSubcommand::Age { block, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!(
                 "{}",
@@ -295,7 +295,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             )?
         }
         CastSubcommand::Balance { block, who, ether, rpc, erc20 } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let account_addr = who.resolve(&provider).await?;
 
@@ -316,7 +316,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             }
         }
         CastSubcommand::BaseFee { block, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!(
                 "{}",
@@ -324,7 +324,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             )?
         }
         CastSubcommand::Block { block, full, field, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!(
                 "{}",
@@ -334,7 +334,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             )?
         }
         CastSubcommand::BlockNumber { rpc, block } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let number = match block {
                 Some(id) => {
@@ -350,34 +350,34 @@ async fn main_args(args: CastArgs) -> Result<()> {
             sh_println!("{number}")?
         }
         CastSubcommand::Chain { rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!("{}", Cast::new(provider).chain().await?)?
         }
         CastSubcommand::ChainId { rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!("{}", Cast::new(provider).chain_id().await?)?
         }
         CastSubcommand::Client { rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!("{}", provider.get_client_version().await?)?
         }
         CastSubcommand::Code { block, who, disassemble, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).code(who, block, disassemble).await?)?
         }
         CastSubcommand::Codesize { block, who, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).codesize(who, block).await?)?
         }
         CastSubcommand::ComputeAddress { address, nonce, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
 
             let address = stdin::unwrap_line(address)?;
@@ -413,7 +413,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         }
         CastSubcommand::FindBlock(cmd) => cmd.run().await?,
         CastSubcommand::GasPrice { rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!("{}", Cast::new(provider).gas_price().await?)?;
         }
@@ -426,37 +426,37 @@ async fn main_args(args: CastArgs) -> Result<()> {
             sh_println!("{}", foundry_common::erc7201(&id))?;
         }
         CastSubcommand::Implementation { block, beacon, who, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).implementation(who, beacon, block).await?)?;
         }
         CastSubcommand::Admin { block, who, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).admin(who, block).await?)?;
         }
         CastSubcommand::Nonce { block, who, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).nonce(who, block).await?)?;
         }
         CastSubcommand::Codehash { block, who, slots, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).codehash(who, slots, block).await?)?;
         }
         CastSubcommand::StorageRoot { block, who, slots, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let who = who.resolve(&provider).await?;
             sh_println!("{}", Cast::new(provider).storage_root(who, slots, block).await?)?;
         }
         CastSubcommand::Proof { address, slots, rpc, block } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let address = address.resolve(&provider).await?;
             let value = provider
@@ -473,7 +473,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::Estimate(cmd) => cmd.run().await?,
         CastSubcommand::MakeTx(cmd) => cmd.run().await?,
         CastSubcommand::PublishTx { raw_tx, cast_async, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let cast = Cast::new(&provider);
             let pending_tx = cast.publish(raw_tx).await?;
@@ -487,7 +487,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             }
         }
         CastSubcommand::Receipt { tx_hash, field, cast_async, confirmations, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!(
                 "{}",
@@ -499,7 +499,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
         CastSubcommand::Run(cmd) => cmd.run().await?,
         CastSubcommand::SendTx(cmd) => cmd.run().await?,
         CastSubcommand::Tx { tx_hash, field, raw, rpc } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
 
             // Can use either --raw or specify raw as a field
@@ -565,7 +565,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             sh_println!("{}", namehash(&name))?
         }
         CastSubcommand::LookupAddress { who, rpc, verify } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
 
             let who = stdin::unwrap_line(who)?;
@@ -580,7 +580,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             sh_println!("{name}")?
         }
         CastSubcommand::ResolveName { who, rpc, verify } => {
-            let config = Config::from(&rpc);
+            let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
 
             let who = stdin::unwrap_line(who)?;
@@ -631,7 +631,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             SimpleCast::right_shift(&value, &bits, base_in.as_deref(), &base_out)?
         )?,
         CastSubcommand::EtherscanSource { address, directory, etherscan, flatten } => {
-            let config = Config::from(&etherscan);
+            let config = etherscan.load_config()?;
             let chain = config.chain.unwrap_or_default();
             let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
             match (directory, flatten) {

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -152,7 +152,7 @@ impl BuildOpts {
     /// `find_project_root` and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]).
     pub fn project(&self) -> Result<Project<MultiCompiler>> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         Ok(config.project()?)
     }
 
@@ -193,19 +193,6 @@ impl<'a> From<&'a BuildOpts> for Figment {
         };
 
         figment
-    }
-}
-
-impl<'a> From<&'a BuildOpts> for Config {
-    fn from(args: &'a BuildOpts) -> Self {
-        let figment: Figment = args.into();
-        let mut config = Self::from_provider(figment).sanitized();
-        // if `--config-path` is set we need to adjust the config's root path to the actual root
-        // path for the project, otherwise it will the parent dir of the `--config-path`
-        if args.project_paths.config_path.is_some() {
-            config.root = args.project_paths.project_root();
-        }
-        config
     }
 }
 

--- a/crates/cli/src/opts/build/paths.rs
+++ b/crates/cli/src/opts/build/paths.rs
@@ -71,8 +71,11 @@ impl ProjectPathOpts {
     /// # Panics
     ///
     /// Panics if the project root directory cannot be found. See [`find_project_root`].
+    #[track_caller]
     pub fn project_root(&self) -> PathBuf {
-        self.root.clone().unwrap_or_else(|| find_project_root(None))
+        self.root
+            .clone()
+            .unwrap_or_else(|| find_project_root(None).expect("could not determine project root"))
     }
 
     /// Returns the remappings to add to the config

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -193,7 +193,7 @@ pub fn load_dotenv() {
     // we only want the .env file of the cwd and project root
     // `find_project_root` calls `current_dir` internally so both paths are either both `Ok` or
     // both `Err`
-    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), try_find_project_root(None)) {
+    if let (Ok(cwd), Ok(prj_root)) = (std::env::current_dir(), find_project_root(None)) {
         load(&prj_root);
         if cwd != prj_root {
             // prj root and cwd can be identical

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -161,7 +161,7 @@ impl ProjectCompiler {
     ///
     /// ```ignore
     /// use foundry_common::compile::ProjectCompiler;
-    /// let config = foundry_config::Config::load();
+    /// let config = foundry_config::Config::load().unwrap();
     /// let prj = config.project().unwrap();
     /// ProjectCompiler::new().compile_with(|| Ok(prj.compile()?)).unwrap();
     /// ```

--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -300,7 +300,7 @@ mod tests {
             env: EnvArgs { chain: Some(NamedChain::Mainnet.into()), ..Default::default() },
             ..Default::default()
         };
-        let config = Config::from_provider(Config::figment().merge(args));
+        let config = Config::from_provider(Config::figment().merge(args)).unwrap();
         assert_eq!(config.chain, Some(NamedChain::Mainnet.into()));
 
         let env = EnvArgs::parse_from(["foundry-common", "--chain-id", "goerli"]);
@@ -313,7 +313,7 @@ mod tests {
             env: EnvArgs { chain: Some(NamedChain::Mainnet.into()), ..Default::default() },
             ..Default::default()
         };
-        let config = Config::from_provider(Config::figment().merge(args));
+        let config = Config::from_provider(Config::figment().merge(args)).unwrap();
         assert_eq!(config.memory_limit, Config::default().memory_limit);
 
         let env = EnvArgs::parse_from(["foundry-common", "--memory-limit", "100"]);
@@ -328,7 +328,7 @@ mod tests {
         let env = EnvArgs::parse_from(["foundry-common", "--chain-id", "mainnet"]);
         assert_eq!(env.chain, Some(Chain::mainnet()));
         let args = EvmArgs { env, ..Default::default() };
-        let config = Config::from_provider(Config::figment().merge(args));
+        let config = Config::from_provider(Config::figment().merge(args)).unwrap();
         assert_eq!(config.chain, Some(Chain::mainnet()));
     }
 }

--- a/crates/common/src/term.rs
+++ b/crates/common/src/term.rs
@@ -165,7 +165,11 @@ impl Reporter for SpinnerReporter {
                 dirty_files
                     .iter()
                     .map(|path| {
-                        let trimmed_path = path.strip_prefix(&project_root).unwrap_or(path);
+                        let trimmed_path = if let Ok(project_root) = &project_root {
+                            path.strip_prefix(project_root).unwrap_or(path)
+                        } else {
+                            path
+                        };
                         format!("- {}", trimmed_path.display())
                     })
                     .sorted()

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -3,11 +3,9 @@ use alloy_primitives::map::HashSet;
 use figment::providers::{Format, Toml};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{error::Error, fmt, str::FromStr};
-/// The message shown upon panic if the config could not be extracted from the figment
-pub const FAILED_TO_EXTRACT_CONFIG_PANIC_MSG: &str = "failed to extract foundry config:";
 
 /// Represents a failed attempt to extract `Config` from a `Figment`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct ExtractConfigError {
     /// error thrown when extracting the `Config`
     pub(crate) error: figment::Error,
@@ -40,11 +38,17 @@ impl fmt::Display for ExtractConfigError {
                 unique_errors.push(err);
             }
         }
-        writeln!(f, "{FAILED_TO_EXTRACT_CONFIG_PANIC_MSG}")?;
+        writeln!(f, "failed to extract foundry config:")?;
         for err in unique_errors {
             writeln!(f, "{err}")?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for ExtractConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -581,53 +581,26 @@ impl Config {
     /// Docker image with eof-enabled solc binary
     pub const EOF_SOLC_IMAGE: &'static str = "ghcr.io/paradigmxyz/forge-eof@sha256:46f868ce5264e1190881a3a335d41d7f42d6f26ed20b0c823609c715e38d603f";
 
-    /// Returns the current `Config`
+    /// Loads the `Config` from the current directory.
     ///
     /// See [`figment`](Self::figment) for more details.
-    #[track_caller]
-    pub fn load() -> Self {
+    pub fn load() -> Result<Self, ExtractConfigError> {
         Self::from_provider(Self::figment())
     }
 
-    /// Returns the current `Config` with the given `providers` preset
+    /// Loads the `Config` with the given `providers` preset.
     ///
     /// See [`figment`](Self::figment) for more details.
-    #[track_caller]
-    pub fn load_with_providers(providers: FigmentProviders) -> Self {
+    pub fn load_with_providers(providers: FigmentProviders) -> Result<Self, ExtractConfigError> {
         Self::from_provider(Self::default().to_figment(providers))
     }
 
-    /// Returns the current `Config`
+    /// Loads the `Config` from the given root directory.
     ///
     /// See [`figment_with_root`](Self::figment_with_root) for more details.
     #[track_caller]
-    pub fn load_with_root(root: impl AsRef<Path>) -> Self {
+    pub fn load_with_root(root: impl AsRef<Path>) -> Result<Self, ExtractConfigError> {
         Self::from_provider(Self::figment_with_root(root.as_ref()))
-    }
-
-    /// Extract a `Config` from `provider`, panicking if extraction fails.
-    ///
-    /// # Panics
-    ///
-    /// If extraction fails, prints an error message indicating the failure and
-    /// panics. For a version that doesn't panic, use [`Config::try_from()`].
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use figment::providers::{Env, Format, Toml};
-    /// use foundry_config::Config;
-    ///
-    /// // Use foundry's default `Figment`, but allow values from `other.toml`
-    /// // to supersede its values.
-    /// let figment = Config::figment().merge(Toml::file("other.toml").nested());
-    ///
-    /// let config = Config::from_provider(figment);
-    /// ```
-    #[track_caller]
-    pub fn from_provider<T: Provider>(provider: T) -> Self {
-        trace!("load config with provider: {:?}", provider.metadata());
-        Self::try_from(provider).unwrap_or_else(|err| panic!("{}", err))
     }
 
     /// Attempts to extract a `Config` from `provider`, returning the result.
@@ -642,13 +615,21 @@ impl Config {
     /// // to supersede its values.
     /// let figment = Config::figment().merge(Toml::file("other.toml").nested());
     ///
-    /// let config = Config::try_from(figment);
+    /// let config = Config::from_provider(figment);
     /// ```
-    pub fn try_from<T: Provider>(provider: T) -> Result<Self, ExtractConfigError> {
-        Self::try_from_figment(Figment::from(provider))
+    #[doc(alias = "try_from")]
+    pub fn from_provider<T: Provider>(provider: T) -> Result<Self, ExtractConfigError> {
+        trace!("load config with provider: {:?}", provider.metadata());
+        Self::from_figment(Figment::from(provider))
     }
 
-    fn try_from_figment(figment: Figment) -> Result<Self, ExtractConfigError> {
+    #[doc(hidden)]
+    #[deprecated(note = "use `Config::from_provider` instead")]
+    pub fn try_from<T: Provider>(provider: T) -> Result<Self, ExtractConfigError> {
+        Self::from_provider(provider)
+    }
+
+    fn from_figment(figment: Figment) -> Result<Self, ExtractConfigError> {
         let mut config = figment.extract::<Self>().map_err(ExtractConfigError::new)?;
         config.profile = figment.profile().clone();
 
@@ -1641,6 +1622,16 @@ impl Config {
         Self::with_root(root.as_ref()).into()
     }
 
+    #[doc(hidden)]
+    #[track_caller]
+    pub fn figment_with_root_opt(root: Option<&Path>) -> Figment {
+        let root = match root {
+            Some(root) => root,
+            None => &find_project_root(None).expect("could not determine project root"),
+        };
+        Self::figment_with_root(root)
+    }
+
     /// Creates a new Config that adds additional context extracted from the provided root.
     ///
     /// # Example
@@ -1718,7 +1709,7 @@ impl Config {
     where
         F: FnOnce(&Self, &mut toml_edit::DocumentMut) -> bool,
     {
-        let config = Self::load_with_root(root).sanitized();
+        let config = Self::load_with_root(root)?.sanitized();
         config.update(|doc| f(&config, doc))
     }
 
@@ -2616,7 +2607,7 @@ mod tests {
     #[test]
     fn test_install_dir() {
         figment::Jail::expect_with(|jail| {
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.install_lib_dir(), PathBuf::from("lib"));
             jail.create_file(
                 "foundry.toml",
@@ -2625,7 +2616,7 @@ mod tests {
                 libs = ['node_modules', 'lib']
             ",
             )?;
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.install_lib_dir(), PathBuf::from("lib"));
 
             jail.create_file(
@@ -2635,7 +2626,7 @@ mod tests {
                 libs = ['custom', 'node_modules', 'lib']
             ",
             )?;
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.install_lib_dir(), PathBuf::from("custom"));
 
             Ok(())
@@ -2674,7 +2665,7 @@ mod tests {
             ",
             )?;
 
-            let config = crate::Config::load();
+            let config = crate::Config::load().unwrap();
             let expected: &[figment::Profile] = &["ci".into(), "default".into(), "local".into()];
             assert_eq!(config.profiles, expected);
 
@@ -2686,9 +2677,9 @@ mod tests {
     fn test_default_round_trip() {
         figment::Jail::expect_with(|_| {
             let original = Config::figment();
-            let roundtrip = Figment::from(Config::from_provider(&original));
+            let roundtrip = Figment::from(Config::from_provider(&original).unwrap());
             for figment in &[original, roundtrip] {
-                let config = Config::from_provider(figment);
+                let config = Config::from_provider(figment).unwrap();
                 assert_eq!(config, Config::default().normalized_optimizer_settings());
             }
             Ok(())
@@ -2701,7 +2692,7 @@ mod tests {
             jail.set_env("FOUNDRY_FFI", "true");
             jail.set_env("FFI", "true");
             jail.set_env("DAPP_FFI", "true");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert!(!config.ffi);
 
             Ok(())
@@ -2729,7 +2720,7 @@ mod tests {
             ",
             )?;
             jail.set_env("FOUNDRY_PROFILE", "local");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.libs, vec![PathBuf::from("modules")]);
 
             Ok(())
@@ -2749,15 +2740,15 @@ mod tests {
     #[test]
     fn test_default_libs() {
         figment::Jail::expect_with(|jail| {
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.libs, vec![PathBuf::from("lib")]);
 
             fs::create_dir_all(jail.directory().join("node_modules")).unwrap();
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.libs, vec![PathBuf::from("node_modules")]);
 
             fs::create_dir_all(jail.directory().join("lib")).unwrap();
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.libs, vec![PathBuf::from("lib"), PathBuf::from("node_modules")]);
 
             Ok(())
@@ -2780,12 +2771,12 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.src, PathBuf::from("defaultsrc"));
             assert_eq!(config.libs, vec![PathBuf::from("lib"), PathBuf::from("node_modules")]);
 
             jail.set_env("FOUNDRY_PROFILE", "custom");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.src, PathBuf::from("customsrc"));
             assert_eq!(config.test, PathBuf::from("defaulttest"));
             assert_eq!(config.libs, vec![PathBuf::from("lib"), PathBuf::from("node_modules")]);
@@ -2805,7 +2796,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             let paths_config = config.project_paths::<Solc>();
             assert_eq!(paths_config.tests, PathBuf::from(r"mytest"));
             Ok(())
@@ -2824,7 +2815,7 @@ mod tests {
                 cache = true
             "#,
             )?;
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert!(config.remappings.is_empty());
 
             jail.create_file(
@@ -2835,7 +2826,7 @@ mod tests {
             ",
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.remappings,
                 vec![
@@ -2845,7 +2836,7 @@ mod tests {
             );
 
             jail.set_env("DAPP_REMAPPINGS", "ds-test=lib/ds-test/\nother/=lib/other/");
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_eq!(
                 config.remappings,
@@ -2875,7 +2866,7 @@ mod tests {
                 cache = true
             "#,
             )?;
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert!(config.remappings.is_empty());
 
             jail.create_file(
@@ -2886,7 +2877,7 @@ mod tests {
             ",
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.remappings,
                 vec![
@@ -2896,7 +2887,7 @@ mod tests {
             );
 
             jail.set_env("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/src/\nenv-lib/=lib/env-lib/");
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             // Remappings should now be:
             // - ds-test from environment (lib/ds-test/src/)
@@ -2936,11 +2927,11 @@ mod tests {
             "#,
             )?;
 
-            let mut config = Config::load();
+            let mut config = Config::load().unwrap();
             config.libs.push("libs".into());
             config.update_libs().unwrap();
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.libs, vec![PathBuf::from("node_modules"), PathBuf::from("libs"),]);
             Ok(())
         });
@@ -2960,7 +2951,7 @@ mod tests {
                 ),
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config,
                 Config {
@@ -2985,7 +2976,7 @@ mod tests {
             "#,
             )?;
 
-            let _config = Config::load();
+            let _config = Config::load().unwrap();
 
             Ok(())
         });
@@ -2997,7 +2988,7 @@ mod tests {
         figment::Jail::expect_with(|jail| {
             jail.set_env("FOUNDRY_CONFIG", "this config does not exist");
 
-            let _config = Config::load();
+            let _config = Config::load().unwrap();
 
             Ok(())
         });
@@ -3018,7 +3009,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert!(config
                 .get_etherscan_config_with_chain(Some(NamedChain::BinanceSmartChain.into()))
                 .is_err());
@@ -3065,7 +3056,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert!(config.etherscan.clone().resolved().has_unresolved());
 
@@ -3118,7 +3109,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             let etherscan = config.get_etherscan_config().unwrap().unwrap();
             assert_eq!(etherscan.chain, Some(NamedChain::Sepolia.into()));
             assert_eq!(etherscan.key, "FX42Z3BBJJEWXWGYV2X1CIPRSCN");
@@ -3141,7 +3132,7 @@ mod tests {
             )?;
             jail.set_env("_CONFIG_MAINNET", "https://eth-mainnet.alchemyapi.io/v2/123455");
 
-            let mut config = Config::load();
+            let mut config = Config::load().unwrap();
             assert_eq!("http://localhost:8545", config.get_rpc_url_or_localhost_http().unwrap());
 
             config.eth_rpc_url = Some("mainnet".to_string());
@@ -3170,7 +3161,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!("http://localhost:8545", config.get_rpc_url_or_localhost_http().unwrap());
 
             Ok(())
@@ -3188,13 +3179,13 @@ mod tests {
                 polygonMumbai = "https://polygon-mumbai.g.alchemy.com/v2/${_RESOLVE_RPC_ALIAS}"
             "#,
             )?;
-            let mut config = Config::load();
+            let mut config = Config::load().unwrap();
             config.eth_rpc_url = Some("polygonMumbai".to_string());
             assert!(config.get_rpc_url().unwrap().is_err());
 
             jail.set_env("_RESOLVE_RPC_ALIAS", "123455");
 
-            let mut config = Config::load();
+            let mut config = Config::load().unwrap();
             config.eth_rpc_url = Some("polygonMumbai".to_string());
             assert_eq!(
                 "https://polygon-mumbai.g.alchemy.com/v2/123455",
@@ -3222,7 +3213,7 @@ mod tests {
             jail.set_env("TEST_RESOLVE_RPC_ALIAS_ARB_ONE", "123455");
             jail.set_env("TEST_RESOLVE_RPC_ALIAS_ARBISCAN", "123455");
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             let config = config.get_etherscan_config_with_chain(Some(NamedChain::Arbitrum.into()));
             assert!(config.is_err());
@@ -3245,7 +3236,7 @@ mod tests {
             )?;
             jail.set_env("_CONFIG_MAINNET", "https://eth-mainnet.alchemyapi.io/v2/123455");
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 RpcEndpoints::new([
                     (
@@ -3313,7 +3304,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             jail.set_env("_CONFIG_AUTH", "123456");
             jail.set_env("_CONFIG_MAINNET", "https://eth-mainnet.alchemyapi.io/v2/123455");
@@ -3389,7 +3380,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_eq!(config.get_rpc_url().unwrap().unwrap(), "https://example.com/");
 
@@ -3448,7 +3439,7 @@ mod tests {
             "#,
             )?;
 
-            let mut config = Config::load();
+            let mut config = Config::load().unwrap();
 
             let optimism = config.get_etherscan_api_key(Some(NamedChain::Optimism.into()));
             assert_eq!(optimism, Some("https://etherscan-optimism.com/".to_string()));
@@ -3475,7 +3466,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             let mumbai = config
                 .get_etherscan_config_with_chain(Some(NamedChain::PolygonMumbai.into()))
@@ -3500,7 +3491,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             let mumbai = config
                 .get_etherscan_config_with_chain(Some(NamedChain::PolygonMumbai.into()))
@@ -3530,7 +3521,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             let mumbai = config.get_etherscan_config_with_chain(None).unwrap().unwrap();
             assert_eq!(mumbai.key, "https://etherscan-mumbai.com/".to_string());
@@ -3572,7 +3563,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config,
                 Config {
@@ -3634,7 +3625,7 @@ mod tests {
             ",
             )?;
 
-            let config = Config::load_with_root(jail.directory());
+            let config = Config::load_with_root(jail.directory()).unwrap();
             assert_eq!(
                 config.remappings,
                 vec![Remapping::from_str("nested/=lib/nested/").unwrap().into()]
@@ -3719,7 +3710,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load_with_root(jail.directory());
+            let config = Config::load_with_root(jail.directory()).unwrap();
 
             assert_eq!(config.ignored_file_paths, vec![PathBuf::from("something")]);
             assert_eq!(config.fuzz.seed, Some(U256::from(1000)));
@@ -3757,7 +3748,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Version(Version::new(0, 8, 12))));
 
             jail.create_file(
@@ -3768,7 +3759,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Version(Version::new(0, 8, 12))));
 
             jail.create_file(
@@ -3779,11 +3770,11 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Local("path/to/local/solc".into())));
 
             jail.set_env("FOUNDRY_SOLC_VERSION", "0.6.6");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Version(Version::new(0, 6, 6))));
             Ok(())
         });
@@ -3802,7 +3793,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Version(Version::new(0, 8, 12))));
 
             Ok(())
@@ -3817,7 +3808,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.solc, Some(SolcReq::Version(Version::new(0, 8, 20))));
 
             Ok(())
@@ -3840,7 +3831,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config,
                 Config {
@@ -3870,7 +3861,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_eq!(
                 config.extra_output,
@@ -3895,7 +3886,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config,
                 Config {
@@ -3907,7 +3898,7 @@ mod tests {
             );
 
             jail.set_env("FOUNDRY_SRC", r"other-src");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config,
                 Config {
@@ -3942,7 +3933,7 @@ mod tests {
                 src = "other-src"
             "#,
             )?;
-            let loaded = Config::load();
+            let loaded = Config::load().unwrap();
             assert_eq!(loaded.evm_version, EvmVersion::Berlin);
             let base = loaded.into_basic();
             let default = Config::default();
@@ -3983,7 +3974,7 @@ mod tests {
                 dictionary_weight = 101
             ",
             )?;
-            let _config = Config::load();
+            let _config = Config::load().unwrap();
             Ok(())
         });
     }
@@ -4011,7 +4002,7 @@ mod tests {
             )?;
 
             let invariant_default = InvariantConfig::default();
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_ne!(config.invariant.runs, config.fuzz.runs);
             assert_eq!(config.invariant.runs, 420);
@@ -4035,7 +4026,7 @@ mod tests {
             );
 
             jail.set_env("FOUNDRY_PROFILE", "ci");
-            let ci_config = Config::load();
+            let ci_config = Config::load().unwrap();
             assert_eq!(ci_config.fuzz.runs, 1);
             assert_eq!(ci_config.invariant.runs, 400);
             assert_eq!(ci_config.fuzz.dictionary.dictionary_weight, 5);
@@ -4068,12 +4059,12 @@ mod tests {
             ",
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.fuzz.runs, 100);
             assert_eq!(config.invariant.runs, 120);
 
             jail.set_env("FOUNDRY_PROFILE", "ci");
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.fuzz.runs, 420);
             assert_eq!(config.invariant.runs, 500);
 
@@ -4093,7 +4084,7 @@ mod tests {
             jail.set_env("DAPP_BUILD_OPTIMIZE_RUNS", 999);
             jail.set_env("DAPP_BUILD_OPTIMIZE", 0);
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_eq!(config.block_number, 1337);
             assert_eq!(config.sender, addr);
@@ -4114,7 +4105,7 @@ mod tests {
                 "DAPP_LIBRARIES",
                 "[src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6]",
             );
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.libraries,
                 vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
@@ -4125,7 +4116,7 @@ mod tests {
                 "DAPP_LIBRARIES",
                 "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
             );
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.libraries,
                 vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
@@ -4136,7 +4127,7 @@ mod tests {
                 "DAPP_LIBRARIES",
                 "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6,src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
             );
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.libraries,
                 vec![
@@ -4167,7 +4158,7 @@ mod tests {
                     ]
             ",
             )?;
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             let libs = config.parsed_libraries().unwrap().libs;
 
@@ -4221,7 +4212,7 @@ mod tests {
             let basic = default.clone().into_basic();
             jail.create_file("foundry.toml", &basic.to_string_pretty().unwrap())?;
 
-            let mut other = Config::load();
+            let mut other = Config::load().unwrap();
             clear_warning(&mut other);
             assert_eq!(default, other);
 
@@ -4229,7 +4220,7 @@ mod tests {
             assert_eq!(basic, other);
 
             jail.create_file("foundry.toml", &default.to_string_pretty().unwrap())?;
-            let mut other = Config::load();
+            let mut other = Config::load().unwrap();
             clear_warning(&mut other);
             assert_eq!(default, other);
 
@@ -4247,7 +4238,7 @@ mod tests {
                 fs_permissions = [{ access = "read-write", path = "./"}]
             "#,
             )?;
-            let loaded = Config::load();
+            let loaded = Config::load().unwrap();
 
             assert_eq!(
                 loaded.fs_permissions,
@@ -4261,7 +4252,7 @@ mod tests {
                 fs_permissions = [{ access = "none", path = "./"}]
             "#,
             )?;
-            let loaded = Config::load();
+            let loaded = Config::load().unwrap();
             assert_eq!(loaded.fs_permissions, FsPermissions::new(vec![PathPermission::none("./")]));
 
             Ok(())
@@ -4284,7 +4275,7 @@ mod tests {
                 stackAllocation = true
             ",
             )?;
-            let mut loaded = Config::load();
+            let mut loaded = Config::load().unwrap();
             clear_warning(&mut loaded);
             assert_eq!(
                 loaded.optimizer_details,
@@ -4301,7 +4292,7 @@ mod tests {
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
 
-            let mut reloaded = Config::load();
+            let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);
             assert_eq!(loaded, reloaded);
 
@@ -4324,7 +4315,7 @@ mod tests {
                 timeout = 10000
             ",
             )?;
-            let mut loaded = Config::load();
+            let mut loaded = Config::load().unwrap();
             clear_warning(&mut loaded);
             assert_eq!(
                 loaded.model_checker,
@@ -4351,7 +4342,7 @@ mod tests {
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
 
-            let mut reloaded = Config::load();
+            let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);
             assert_eq!(loaded, reloaded);
 
@@ -4374,7 +4365,7 @@ mod tests {
                 timeout = 10000
             ",
             )?;
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
 
             // NOTE(onbjerg): We have to canonicalize the path here using dunce because figment will
             // canonicalize the jail path using the standard library. The standard library *always*
@@ -4426,7 +4417,7 @@ mod tests {
                 bracket_spacing = true
             ",
             )?;
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert_eq!(
                 loaded.fmt,
                 FormatterConfig {
@@ -4453,7 +4444,7 @@ mod tests {
             ",
             )?;
 
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert_eq!(
                 loaded.invariant,
                 InvariantConfig {
@@ -4486,7 +4477,7 @@ mod tests {
             jail.set_env("FOUNDRY_FUZZ_DICTIONARY_WEIGHT", "99");
             jail.set_env("FOUNDRY_INVARIANT_DEPTH", "5");
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.fmt.line_length, 95);
             assert_eq!(config.fuzz.dictionary.dictionary_weight, 99);
             assert_eq!(config.invariant.depth, 5);
@@ -4531,7 +4522,7 @@ mod tests {
                 out = 'my-out'
             ",
             )?;
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert_eq!(loaded.src.file_name().unwrap(), "my-src");
             assert_eq!(loaded.out.file_name().unwrap(), "my-out");
             assert_eq!(
@@ -4556,11 +4547,11 @@ mod tests {
             ",
             )?;
             jail.set_env("ETHERSCAN_API_KEY", "");
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert!(loaded.etherscan_api_key.is_none());
 
             jail.set_env("ETHERSCAN_API_KEY", "DUMMY");
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert_eq!(loaded.etherscan_api_key, Some("DUMMY".into()));
 
             Ok(())
@@ -4582,7 +4573,7 @@ mod tests {
             let figment = Config::figment_with_root(jail.directory())
                 .merge(("etherscan_api_key", "USER_KEY"));
 
-            let loaded = Config::from_provider(figment);
+            let loaded = Config::from_provider(figment).unwrap();
             assert_eq!(loaded.etherscan_api_key, Some("USER_KEY".into()));
 
             Ok(())
@@ -4600,7 +4591,7 @@ mod tests {
             ",
             )?;
 
-            let loaded = Config::load().sanitized();
+            let loaded = Config::load().unwrap().sanitized();
             assert_eq!(loaded.evm_version, EvmVersion::London);
             Ok(())
         });
@@ -4656,7 +4647,6 @@ mod tests {
         }
 
         let _figment: Figment = From::from(&MyArgs::default());
-        let _config: Config = From::from(&MyArgs::default());
 
         #[derive(Default)]
         struct Outer {
@@ -4667,7 +4657,6 @@ mod tests {
         impl_figment_convert!(Outer, start, other, another);
 
         let _figment: Figment = From::from(&Outer::default());
-        let _config: Config = From::from(&Outer::default());
     }
 
     #[test]
@@ -4760,7 +4749,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.ignored_error_codes,
                 vec![
@@ -4785,7 +4774,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.ignored_file_paths, vec![Path::new("something").to_path_buf()]);
 
             Ok(())
@@ -4803,7 +4792,7 @@ mod tests {
             ",
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(config.optimizer_details, Some(OptimizerDetails::default()));
 
             Ok(())
@@ -4822,7 +4811,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.labels,
                 AddressHashMap::from_iter(vec![
@@ -4854,7 +4843,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
             assert_eq!(
                 config.vyper,
                 VyperConfig {
@@ -4884,7 +4873,7 @@ mod tests {
             "#,
             )?;
 
-            let config = Config::load();
+            let config = Config::load().unwrap();
 
             assert_eq!(
                 config.soldeer,

--- a/crates/config/src/macros.rs
+++ b/crates/config/src/macros.rs
@@ -40,7 +40,6 @@
 /// }
 ///
 /// let figment: Figment = From::from(&MyArgs::default());
-/// let config: Config = From::from(&MyArgs::default());
 ///
 ///  // Use `impl_figment` on a type that has several nested `Provider` as fields but is _not_ a `Provider` itself
 ///
@@ -53,23 +52,13 @@
 /// impl_figment_convert!(Outer, start, second, third);
 ///
 /// let figment: Figment = From::from(&Outer::default());
-/// let config: Config = From::from(&Outer::default());
 /// ```
 #[macro_export]
 macro_rules! impl_figment_convert {
     ($name:ty) => {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
             fn from(args: &'a $name) -> Self {
-                let root = args.root.clone()
-                    .unwrap_or_else(|| $crate::find_project_root(None));
-                $crate::Config::figment_with_root(&root).merge(args)
-            }
-        }
-
-        impl<'a> From<&'a $name> for $crate::Config {
-            fn from(args: &'a $name) -> Self {
-                let figment: $crate::figment::Figment = args.into();
-                $crate::Config::from_provider(figment).sanitized()
+                $crate::Config::figment_with_root_opt(args.root.as_deref()).merge(args)
             }
         }
     };
@@ -83,13 +72,6 @@ macro_rules! impl_figment_convert {
                 figment
             }
         }
-
-        impl<'a> From<&'a $name> for $crate::Config {
-            fn from(args: &'a $name) -> Self {
-                let figment: $crate::figment::Figment = args.into();
-                $crate::Config::from_provider(figment).sanitized()
-            }
-        }
     };
     ($name:ty, self, $start:ident $(, $more:ident)*) => {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
@@ -100,13 +82,6 @@ macro_rules! impl_figment_convert {
                 )*
                 figment = figment.merge(args);
                 figment
-            }
-        }
-
-        impl<'a> From<&'a $name> for $crate::Config {
-            fn from(args: &'a $name) -> Self {
-                let figment: $crate::figment::Figment = args.into();
-                $crate::Config::from_provider(figment).sanitized()
             }
         }
     };
@@ -173,13 +148,6 @@ macro_rules! merge_impl_figment_convert {
                 figment
             }
         }
-
-        impl<'a> From<&'a $name> for $crate::Config {
-            fn from(args: &'a $name) -> Self {
-                let figment: $crate::figment::Figment = args.into();
-                $crate::Config::from_provider(figment).sanitized()
-            }
-        }
     };
 }
 
@@ -193,16 +161,11 @@ macro_rules! impl_figment_convert_cast {
     ($name:ty) => {
         impl<'a> From<&'a $name> for $crate::figment::Figment {
             fn from(args: &'a $name) -> Self {
-                $crate::Config::with_root(&$crate::find_project_root(None))
+                let root =
+                    $crate::find_project_root(None).expect("could not determine project root");
+                $crate::Config::with_root(&root)
                     .to_figment($crate::FigmentProviders::Cast)
                     .merge(args)
-            }
-        }
-
-        impl<'a> From<&'a $name> for $crate::Config {
-            fn from(args: &'a $name) -> Self {
-                let figment: $crate::figment::Figment = args.into();
-                $crate::Config::from_provider(figment).sanitized()
             }
         }
     };

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -238,7 +238,8 @@ impl RemappingsProvider<'_> {
             })
             .flat_map(|lib: PathBuf| {
                 // load config, of the nested lib if it exists
-                let config = Config::load_with_root(&lib).sanitized();
+                let Ok(config) = Config::load_with_root(&lib) else { return vec![] };
+                let config = config.sanitized();
 
                 // if the configured _src_ directory is set to something that
                 // [Remapping::find_many()] doesn't classify as a src directory (src, contracts,

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -15,23 +15,20 @@ use std::{
     str::FromStr,
 };
 
-/// Loads the config for the current project workspace
-pub fn load_config() -> Config {
+// TODO: Why do these exist separately from `Config::load`?
+
+/// Loads the config for the current project workspace.
+pub fn load_config() -> eyre::Result<Config> {
     load_config_with_root(None)
 }
 
 /// Loads the config for the current project workspace or the provided root path.
-///
-/// # Panics
-///
-/// Panics if the project root cannot be found. See [`find_project_root`].
-#[track_caller]
-pub fn load_config_with_root(root: Option<&Path>) -> Config {
+pub fn load_config_with_root(root: Option<&Path>) -> eyre::Result<Config> {
     let root = match root {
         Some(root) => root,
-        None => &find_project_root(None),
+        None => &find_project_root(None)?,
     };
-    Config::load_with_root(root).sanitized()
+    Ok(Config::load_with_root(root)?.sanitized())
 }
 
 /// Returns the path of the top-level directory of the working git tree.
@@ -59,20 +56,10 @@ pub fn find_git_root(relative_to: &Path) -> io::Result<Option<PathBuf>> {
 ///
 /// Returns `repo` or `cwd` if no `foundry.toml` is found in the tree.
 ///
-/// # Panics
-///
-/// Panics if:
+/// Returns an error if:
 /// - `cwd` is `Some` and is not a valid directory;
 /// - `cwd` is `None` and the [`std::env::current_dir`] call fails.
-#[track_caller]
-pub fn find_project_root(cwd: Option<&Path>) -> PathBuf {
-    try_find_project_root(cwd).expect("Could not find project root")
-}
-
-/// Returns the root path to set for the project root.
-///
-/// Same as [`find_project_root`], but returns an error instead of panicking.
-pub fn try_find_project_root(cwd: Option<&Path>) -> io::Result<PathBuf> {
+pub fn find_project_root(cwd: Option<&Path>) -> io::Result<PathBuf> {
     let cwd = match cwd {
         Some(path) => path,
         None => &std::env::current_dir()?,

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -106,7 +106,7 @@ impl BindArgs {
             let _ = ProjectCompiler::new().compile(&project)?;
         }
 
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let artifacts = config.out;
         let bindings_root = self.bindings.clone().unwrap_or_else(|| artifacts.join("bindings"));
 

--- a/crates/forge/bin/cmd/bind_json.rs
+++ b/crates/forge/bin/cmd/bind_json.rs
@@ -65,7 +65,7 @@ impl BindJsonArgs {
     /// After that we'll still have enough information for bindings but compilation should succeed
     /// in most of the cases.
     fn preprocess(self) -> Result<PreprocessedState> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let project = config.create_project(false, true)?;
 
         let target_path = config.root.join(self.out.as_ref().unwrap_or(&config.bind_json.out));

--- a/crates/forge/bin/cmd/build.rs
+++ b/crates/forge/bin/cmd/build.rs
@@ -34,7 +34,7 @@ foundry_config::merge_impl_figment_convert!(BuildArgs, build);
 /// use foundry_cli::cmd::forge::build::BuildArgs;
 /// use foundry_config::Config;
 /// # fn t(args: BuildArgs) {
-/// let config = Config::from(&args);
+/// let config = (&args).load_config()?;
 /// # }
 /// ```
 ///
@@ -77,11 +77,11 @@ pub struct BuildArgs {
 
 impl BuildArgs {
     pub fn run(self) -> Result<ProjectCompileOutput> {
-        let mut config = self.try_load_config_emit_warnings()?;
+        let mut config = self.load_config()?;
 
         if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
             // need to re-configure here to also catch additional remappings
-            config = self.load_config();
+            config = self.load_config()?;
         }
 
         let project = config.project()?;
@@ -136,9 +136,9 @@ impl BuildArgs {
         // Use the path arguments or if none where provided the `src`, `test` and `script`
         // directories as well as the `foundry.toml` configuration file.
         self.watch.watchexec_config(|| {
-            let config = Config::from(self);
+            let config = self.load_config()?;
             let foundry_toml: PathBuf = config.root.join(Config::FILE_NAME);
-            [config.src, config.test, config.script, foundry_toml]
+            Ok([config.src, config.test, config.script, foundry_toml])
         })
     }
 }

--- a/crates/forge/bin/cmd/clone.rs
+++ b/crates/forge/bin/cmd/clone.rs
@@ -7,7 +7,10 @@ use foundry_block_explorers::{
     errors::EtherscanError,
     Client,
 };
-use foundry_cli::{opts::EtherscanOpts, utils::Git};
+use foundry_cli::{
+    opts::EtherscanOpts,
+    utils::{Git, LoadConfig},
+};
 use foundry_common::{compile::ProjectCompiler, fs};
 use foundry_compilers::{
     artifacts::{
@@ -96,7 +99,7 @@ impl CloneArgs {
             self;
 
         // step 0. get the chain and api key from the config
-        let config = Config::from(&etherscan);
+        let config = etherscan.load_config()?;
         let chain = config.chain.unwrap_or_default();
         let etherscan_api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
         let client = Client::new(chain, etherscan_api_key.clone())?;
@@ -547,7 +550,7 @@ fn dump_sources(meta: &Metadata, root: &PathBuf, no_reorg: bool) -> Result<Vec<R
 
 /// Compile the project in the root directory, and return the compilation result.
 pub fn compile_project(root: &Path) -> Result<ProjectCompileOutput> {
-    let mut config = Config::load_with_root(root).sanitized();
+    let mut config = Config::load_with_root(root)?.sanitized();
     config.extra_output.push(ContractOutputSelection::StorageLayout);
     let project = config.project()?;
     let compiler = ProjectCompiler::new();

--- a/crates/forge/bin/cmd/compiler.rs
+++ b/crates/forge/bin/cmd/compiler.rs
@@ -59,7 +59,7 @@ impl ResolveArgs {
         let Self { root, skip } = self;
 
         let root = root.unwrap_or_else(|| PathBuf::from("."));
-        let config = Config::load_with_root(&root);
+        let config = Config::load_with_root(&root)?;
         let project = config.project()?;
 
         let graph = Graph::resolve(&project.paths)?;

--- a/crates/forge/bin/cmd/config.rs
+++ b/crates/forge/bin/cmd/config.rs
@@ -36,7 +36,7 @@ impl ConfigArgs {
         }
 
         let config = self
-            .try_load_config_unsanitized_emit_warnings()?
+            .load_config_unsanitized()?
             .normalized_optimizer_settings()
             // we explicitly normalize the version, so mimic the behavior when invoking solc
             .normalized_evm_version();

--- a/crates/forge/bin/cmd/coverage.rs
+++ b/crates/forge/bin/cmd/coverage.rs
@@ -82,12 +82,12 @@ pub struct CoverageArgs {
 
 impl CoverageArgs {
     pub async fn run(self) -> Result<()> {
-        let (mut config, evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
+        let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
         // install missing dependencies
         if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
             // need to re-configure here to also catch additional remappings
-            config = self.load_config();
+            config = self.load_config()?;
         }
 
         // Set fuzz seed so coverage reports are deterministic

--- a/crates/forge/bin/cmd/create.rs
+++ b/crates/forge/bin/cmd/create.rs
@@ -103,12 +103,12 @@ pub struct CreateArgs {
 impl CreateArgs {
     /// Executes the command to create a contract
     pub async fn run(mut self) -> Result<()> {
-        let mut config = self.try_load_config_emit_warnings()?;
+        let mut config = self.load_config()?;
 
         // Install missing dependencies.
         if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
             // need to re-configure here to also catch additional remappings
-            config = self.load_config();
+            config = self.load_config()?;
         }
 
         // Find Project & Compile
@@ -248,7 +248,7 @@ impl CreateArgs {
 
         // Check config for Etherscan API Keys to avoid preflight check failing if no
         // ETHERSCAN_API_KEY value set.
-        let config = verify.load_config_emit_warnings();
+        let config = verify.load_config()?;
         verify.etherscan.key =
             config.get_etherscan_config_with_chain(Some(chain.into()))?.map(|c| c.key);
 

--- a/crates/forge/bin/cmd/doc/mod.rs
+++ b/crates/forge/bin/cmd/doc/mod.rs
@@ -6,7 +6,7 @@ use forge_doc::{
 };
 use foundry_cli::opts::GH_REPO_PREFIX_REGEX;
 use foundry_common::compile::ProjectCompiler;
-use foundry_config::{find_project_root, load_config_with_root, Config};
+use foundry_config::{load_config_with_root, Config};
 use std::{path::PathBuf, process::Command};
 
 mod server;
@@ -139,10 +139,6 @@ impl DocArgs {
     }
 
     pub fn config(&self) -> Result<Config> {
-        let root = match &self.root {
-            Some(root) => root,
-            None => &find_project_root(None),
-        };
-        Ok(load_config_with_root(Some(root)))
+        load_config_with_root(self.root.as_deref())
     }
 }

--- a/crates/forge/bin/cmd/eip712.rs
+++ b/crates/forge/bin/cmd/eip712.rs
@@ -24,7 +24,7 @@ pub struct Eip712Args {
 
 impl Eip712Args {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let mut project = config.create_project(false, true)?;
         let target_path = dunce::canonicalize(self.target_path)?;
         project.update_output_selection(|selection| {

--- a/crates/forge/bin/cmd/flatten.rs
+++ b/crates/forge/bin/cmd/flatten.rs
@@ -40,7 +40,7 @@ impl FlattenArgs {
 
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
         let build = BuildOpts { project_paths, ..Default::default() };
-        let config = build.try_load_config_emit_warnings()?;
+        let config = build.load_config()?;
         let project = config.create_project(false, true)?;
 
         let target_path = dunce::canonicalize(target_path)?;

--- a/crates/forge/bin/cmd/fmt.rs
+++ b/crates/forge/bin/cmd/fmt.rs
@@ -45,7 +45,7 @@ impl_figment_convert_basic!(FmtArgs);
 
 impl FmtArgs {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
 
         // Expand ignore globs and canonicalize from the get go
         let ignored = expand_globs(&config.root, config.fmt.ignore.iter())?

--- a/crates/forge/bin/cmd/geiger.rs
+++ b/crates/forge/bin/cmd/geiger.rs
@@ -91,7 +91,7 @@ impl GeigerArgs {
             sh_warn!("`--full` is deprecated as reports are not generated anymore\n")?;
         }
 
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let sources = self.sources(&config).wrap_err("Failed to resolve files")?;
 
         if config.ffi {

--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -130,7 +130,7 @@ impl InitArgs {
 
             // write foundry.toml, if it doesn't exist already
             let dest = root.join(Config::FILE_NAME);
-            let mut config = Config::load_with_root(&root);
+            let mut config = Config::load_with_root(&root)?;
             if !dest.exists() {
                 fs::write(dest, config.clone().into_basic().to_string_pretty()?)?;
             }

--- a/crates/forge/bin/cmd/install.rs
+++ b/crates/forge/bin/cmd/install.rs
@@ -58,7 +58,7 @@ impl_figment_convert_basic!(InstallArgs);
 
 impl InstallArgs {
     pub fn run(self) -> Result<()> {
-        let mut config = self.try_load_config_emit_warnings()?;
+        let mut config = self.load_config()?;
         self.opts.install(&mut config, self.dependencies)
     }
 }

--- a/crates/forge/bin/cmd/mod.rs
+++ b/crates/forge/bin/cmd/mod.rs
@@ -1,43 +1,9 @@
-//! Subcommands for forge
+//! `forge` subcommands.
 //!
 //! All subcommands should respect the `foundry_config::Config`.
 //! If a subcommand accepts values that are supported by the `Config`, then the subcommand should
 //! implement `figment::Provider` which allows the subcommand to override the config's defaults, see
 //! [`foundry_config::Config`].
-//!
-//! See [`BuildArgs`] for a reference implementation.
-//! And [`DebugArgs`] for how to merge `Providers`.
-//!
-//! # Example
-//!
-//! create a `clap` subcommand into a `figment::Provider` and integrate it in the
-//! `foundry_config::Config`:
-//!
-//! ```
-//! use clap::Parser;
-//! use forge::executor::opts::EvmOpts;
-//! use foundry_cli::cmd::forge::build::BuildArgs;
-//! use foundry_common::evm::EvmArgs;
-//! use foundry_config::{figment::Figment, *};
-//!
-//! // A new clap subcommand that accepts both `EvmArgs` and `BuildArgs`
-//! #[derive(Clone, Debug, Parser)]
-//! pub struct MyArgs {
-//!     #[command(flatten)]
-//!     evm: EvmArgs,
-//!     #[command(flatten)]
-//!     build: BuildArgs,
-//! }
-//!
-//! // add `Figment` and `Config` converters
-//! foundry_config::impl_figment_convert!(MyArgs, opts, evm_opts);
-//! let args = MyArgs::parse_from(["build"]);
-//!
-//! let figment: Figment = From::from(&args);
-//! let evm_opts = figment.extract::<EvmOpts>().unwrap();
-//!
-//! let config: Config = From::from(&args);
-//! ```
 
 pub mod bind;
 pub mod bind_json;

--- a/crates/forge/bin/cmd/remappings.rs
+++ b/crates/forge/bin/cmd/remappings.rs
@@ -21,7 +21,7 @@ impl_figment_convert_basic!(RemappingArgs);
 
 impl RemappingArgs {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
 
         if self.pretty {
             let mut groups = BTreeMap::<_, Vec<_>>::new();

--- a/crates/forge/bin/cmd/remove.rs
+++ b/crates/forge/bin/cmd/remove.rs
@@ -29,7 +29,7 @@ impl_figment_convert_basic!(RemoveArgs);
 
 impl RemoveArgs {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let (root, paths) = super::update::dependencies_paths(&self.dependencies, &config)?;
         let git_modules = root.join(".git/modules");
 

--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -268,7 +268,7 @@ impl TestArgs {
     /// Returns the test results for all matching tests.
     pub async fn execute_tests(mut self) -> Result<TestOutcome> {
         // Merge all configs.
-        let (mut config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
+        let (mut config, mut evm_opts) = self.load_config_and_evm_opts()?;
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
         if self.gas_report {
@@ -282,7 +282,7 @@ impl TestArgs {
         // Install missing dependencies.
         if install::install_missing_dependencies(&mut config) && config.auto_detect_remappings {
             // need to re-configure here to also catch additional remappings
-            config = self.load_config();
+            config = self.load_config()?;
         }
 
         // Set up the project.
@@ -803,8 +803,8 @@ impl TestArgs {
     /// bootstrap a new [`watchexe::Watchexec`] loop.
     pub(crate) fn watchexec_config(&self) -> Result<watchexec::Config> {
         self.watch.watchexec_config(|| {
-            let config = Config::from(self);
-            [config.src, config.test]
+            let config = self.load_config()?;
+            Ok([config.src, config.test])
         })
     }
 }

--- a/crates/forge/bin/cmd/tree.rs
+++ b/crates/forge/bin/cmd/tree.rs
@@ -27,7 +27,7 @@ foundry_config::impl_figment_convert!(TreeArgs, project_paths);
 
 impl TreeArgs {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let graph = Graph::<SolData>::resolve(&config.project_paths())?;
         let opts = TreeOptions { charset: self.charset, no_dedupe: self.no_dedupe };
         graph.print_with_options(opts);

--- a/crates/forge/bin/cmd/update.rs
+++ b/crates/forge/bin/cmd/update.rs
@@ -32,7 +32,7 @@ impl_figment_convert_basic!(UpdateArgs);
 
 impl UpdateArgs {
     pub fn run(self) -> Result<()> {
-        let config = self.try_load_config_emit_warnings()?;
+        let config = self.load_config()?;
         let (root, paths) = dependencies_paths(&self.dependencies, &config)?;
         // fetch the latest changes for each submodule (recursively if flag is set)
         let git = Git::new(&root);

--- a/crates/forge/bin/main.rs
+++ b/crates/forge/bin/main.rs
@@ -92,7 +92,7 @@ fn run() -> Result<()> {
             Ok(())
         }
         ForgeSubcommand::Clean { root } => {
-            let config = utils::load_config_with_root(root.as_deref());
+            let config = utils::load_config_with_root(root.as_deref())?;
             let project = config.project()?;
             config.cleanup(&project)?;
             Ok(())

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -171,7 +171,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
 // tests config gets printed to std out
 forgetest!(can_show_config, |prj, cmd| {
     let expected =
-        Config::load_with_root(prj.root()).to_string_pretty().unwrap().trim().to_string();
+        Config::load_with_root(prj.root()).unwrap().to_string_pretty().unwrap().trim().to_string();
     let output = cmd.arg("config").assert_success().get_output().stdout_lossy().trim().to_string();
     assert_eq!(expected, output);
 });
@@ -185,7 +185,7 @@ forgetest_init!(can_override_config, |prj, cmd| {
     let foundry_toml = prj.root().join(Config::FILE_NAME);
     assert!(foundry_toml.exists());
 
-    let profile = Config::load_with_root(prj.root());
+    let profile = Config::load_with_root(prj.root()).unwrap();
     // ensure that the auto-generated internal remapping for forge-std's ds-test exists
     assert_eq!(profile.remappings.len(), 1);
     assert_eq!("forge-std/=lib/forge-std/src/", profile.remappings[0].to_string());
@@ -205,7 +205,7 @@ forgetest_init!(can_override_config, |prj, cmd| {
     // remappings work
     let remappings_txt =
         prj.create_file("remappings.txt", "ds-test/=lib/forge-std/lib/ds-test/from-file/");
-    let config = forge_utils::load_config_with_root(Some(prj.root()));
+    let config = forge_utils::load_config_with_root(Some(prj.root())).unwrap();
     assert_eq!(
         format!(
             "ds-test/={}/",
@@ -251,7 +251,7 @@ forgetest_init!(can_parse_remappings_correctly, |prj, cmd| {
     let foundry_toml = prj.root().join(Config::FILE_NAME);
     assert!(foundry_toml.exists());
 
-    let profile = Config::load_with_root(prj.root());
+    let profile = Config::load_with_root(prj.root()).unwrap();
     // ensure that the auto-generated internal remapping for forge-std's ds-test exists
     assert_eq!(profile.remappings.len(), 1);
     let r = &profile.remappings[0];
@@ -275,13 +275,13 @@ Installing solmate in [..] (url: Some("https://github.com/transmissions11/solmat
     };
 
     install(&mut cmd, "transmissions11/solmate");
-    let profile = Config::load_with_root(prj.root());
+    let profile = Config::load_with_root(prj.root()).unwrap();
     // remappings work
     let remappings_txt = prj.create_file(
         "remappings.txt",
         "solmate/=lib/solmate/src/\nsolmate-contracts/=lib/solmate/src/",
     );
-    let config = forge_utils::load_config_with_root(Some(prj.root()));
+    let config = forge_utils::load_config_with_root(Some(prj.root())).unwrap();
     // trailing slashes are removed on windows `to_slash_lossy`
     let path = prj.root().join("lib/solmate/src/").to_slash_lossy().into_owned();
     #[cfg(windows)]
@@ -316,7 +316,7 @@ forgetest_init!(can_detect_config_vals, |prj, _cmd| {
     assert!(!config.auto_detect_solc);
     assert_eq!(config.eth_rpc_url, Some(url.to_string()));
 
-    let mut config = Config::load_with_root(prj.root());
+    let mut config = Config::load_with_root(prj.root()).unwrap();
     config.eth_rpc_url = Some("http://127.0.0.1:8545".to_string());
     config.auto_detect_solc = false;
     // write to `foundry.toml`
@@ -868,7 +868,7 @@ contract MyScript is BaseScript {
 
     let nested = prj.paths().libraries[0].join("another-dep");
     pretty_err(&nested, fs::create_dir_all(&nested));
-    let mut lib_config = Config::load_with_root(&nested);
+    let mut lib_config = Config::load_with_root(&nested).unwrap();
     lib_config.remappings = vec![
         Remapping::from_str("test/=test/").unwrap().into(),
         Remapping::from_str("script/=script/").unwrap().into(),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -222,7 +222,7 @@ impl ScriptArgs {
     pub async fn preprocess(self) -> Result<PreprocessedState> {
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
 
-        let (config, mut evm_opts) = self.load_config_and_evm_opts_emit_warnings()?;
+        let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
 
         if let Some(sender) = self.maybe_load_private_key()? {
             evm_opts.sender = sender;
@@ -689,7 +689,7 @@ mod tests {
             "--etherscan-api-key",
             "goerli",
         ]);
-        let config = args.load_config();
+        let config = args.load_config().unwrap();
         assert_eq!(config.etherscan_api_key, Some("goerli".to_string()));
     }
 
@@ -754,7 +754,7 @@ mod tests {
             root.as_os_str().to_str().unwrap(),
         ]);
 
-        let config = args.load_config();
+        let config = args.load_config().unwrap();
         let mumbai = config.get_etherscan_api_key(Some(NamedChain::PolygonMumbai.into()));
         assert_eq!(mumbai, Some("https://etherscan-mumbai.com/".to_string()));
     }

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -121,7 +121,7 @@ impl VerifyBytecodeArgs {
     /// bytecode.
     pub async fn run(mut self) -> Result<()> {
         // Setup
-        let config = self.load_config_emit_warnings();
+        let config = self.load_config()?;
         let provider = utils::get_provider(&config)?;
 
         // If chain is not set, we try to get it from the RPC.

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -147,7 +147,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
 
     /// Executes the command to check verification status on Etherscan
     async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
-        let config = args.try_load_config_emit_warnings()?;
+        let config = args.load_config()?;
         let etherscan = self.client(
             args.etherscan.chain.unwrap_or_default(),
             args.verifier.verifier_url.as_deref(),
@@ -215,7 +215,7 @@ impl EtherscanVerificationProvider {
         args: &VerifyArgs,
         context: &VerificationContext,
     ) -> Result<(Client, VerifyContract)> {
-        let config = args.try_load_config_emit_warnings()?;
+        let config = args.load_config()?;
         let etherscan = self.client(
             args.etherscan.chain.unwrap_or_default(),
             args.verifier.verifier_url.as_deref(),
@@ -483,7 +483,7 @@ mod tests {
             root.as_os_str().to_str().unwrap(),
         ]);
 
-        let config = args.load_config();
+        let config = args.load_config().unwrap();
 
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan
@@ -510,7 +510,7 @@ mod tests {
             root.as_os_str().to_str().unwrap(),
         ]);
 
-        let config = args.load_config();
+        let config = args.load_config().unwrap();
 
         let etherscan = EtherscanVerificationProvider::default();
         let client = etherscan

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -187,7 +187,7 @@ impl figment::Provider for VerifyArgs {
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
     pub async fn run(mut self) -> Result<()> {
-        let config = self.load_config_emit_warnings();
+        let config = self.load_config()?;
 
         if self.guess_constructor_args && config.get_rpc_url().is_none() {
             eyre::bail!(
@@ -262,7 +262,7 @@ impl VerifyArgs {
     /// Resolves [VerificationContext] object either from entered contract name or by trying to
     /// match bytecode located at given address.
     pub async fn resolve_context(&self) -> Result<VerificationContext> {
-        let mut config = self.load_config_emit_warnings();
+        let mut config = self.load_config()?;
         config.libraries.extend(self.libraries.clone());
 
         let project = config.project()?;


### PR DESCRIPTION
- remove panicking methods
- default to emitting warnings, with opt out
- use LoadConfig trait where possible, removing `From<&T> for Config`