### PR TITLE
chore: bump version to 0.3.1 to make it easier to identify non-stable builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -2002,7 +2002,7 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2097,7 +2097,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chisel"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3309,7 +3309,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "forge-doc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "ariadne",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script-sequence"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "forge-sol-macro-gen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-expander",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "forge-verify"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "Inflector",
  "alloy-chains",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "crossterm",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "alloy-dyn-abi",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-traces"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-test-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-wallets"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 # Remember to update clippy.toml as well
 rust-version = "1.83"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Make it easier for users to identify that they are running a non-stable version

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Bumps to `0.3.1`

Not sure if we should also bump to `0.3.1` here cc @grandizzy 

https://github.com/foundry-rs/foundry/blob/37398592bbf638f7edea16f7bbb957f5c5f748eb/foundryup/foundryup#L4-L7
