### PR TITLE
fix(invariant): handle simple contract names in metrics table

### DIFF
--- a/crates/forge/bin/cmd/test/mod.rs
+++ b/crates/forge/bin/cmd/test/mod.rs
@@ -56,7 +56,7 @@ mod summary;
 pub use filter::FilterArgs;
 use forge::{result::TestKind, traces::render_trace_arena_inner};
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
-use summary::{print_invariant_metrics, TestSummaryReport};
+use summary::{format_invariant_metrics_table, TestSummaryReport};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, build, evm);
@@ -569,7 +569,9 @@ impl TestArgs {
 
                     // Display invariant metrics if invariant kind.
                     if let TestKind::Invariant { metrics, .. } = &result.kind {
-                        print_invariant_metrics(metrics);
+                        if !metrics.is_empty() {
+                            let _ = sh_println!("\n{}\n", format_invariant_metrics_table(metrics));
+                        }
                     }
 
                     // We only display logs at level 2 and above


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- invariant metrics are usually recorded with key containing full path to contracts (e.g. `src/universal/Proxy.sol:Proxy.changeAdmin`)
- there are scenarios where contract name does not contain artifact path (therefore metrics are recorded with keys as `SystemConfig.setGasLimit`) - see https://github.com/ethereum-optimism/optimism/blob/opcm-up/upgrade-asr/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol#L22 Current logic handles only contracts with full path and does not display any metric in this case:

![image](https://github.com/user-attachments/assets/b28f192c-b43d-4e03-beba-e67303eba0c0)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- handle metrics keys without artifact path
- refactor  `print_invariant_metrics` fn to `format_invariant_metrics_table`
- add test

![image](https://github.com/user-attachments/assets/23032682-f232-4d8e-8217-b47db3ac1db7)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
