### PR TITLE
fix: respect `disable_block_gas_limit` config key

### DIFF
--- a/crates/common/src/evm.rs
+++ b/crates/common/src/evm.rs
@@ -267,6 +267,7 @@ pub struct EnvArgs {
 
     /// Whether to disable the block gas limit checks.
     #[arg(long, visible_alias = "no-gas-limit")]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub disable_block_gas_limit: bool,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We need this so that it doesn't override the config value if not provided

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
