### PR TITLE
fix: use custom build profile in --version

### DIFF
--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -40,8 +40,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Set formatted version strings
     let pkg_version = env::var("CARGO_PKG_VERSION")?;
 
-    // Append the profile to the version string, defaulting to "debug".
-    let profile = env::var("PROFILE").unwrap_or_else(|_| String::from("debug"));
+    // Append the profile to the version string
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
 
     // Set the build timestamp.
     let build_timestamp = env::var("VERGEN_BUILD_TIMESTAMP")?;


### PR DESCRIPTION
## Motivation

`PROFILE` only captures release or debug / dev, however we have custom profiles that should show up here

## Solution

This uses the `OUT_DIR` which can capture custom build profiles 