### PR TITLE
feat(`cast source`): support alternative explorers

### DIFF
--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -921,9 +921,9 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Get the source code of a contract from Etherscan.
+    /// Get the source code of a contract from a block explorer.
     #[command(visible_aliases = &["et", "src"])]
-    EtherscanSource {
+    Source {
         /// The contract's address.
         address: String,
 
@@ -937,6 +937,15 @@ pub enum CastSubcommand {
 
         #[command(flatten)]
         etherscan: EtherscanOpts,
+
+        /// Alternative explorer api url to use that adheres to the etherscan api. If not provided,
+        /// defaults to etherscan.
+        #[arg(long, env = "EXPLORER_API_URL")]
+        explorer_api_url: Option<String>,
+
+        /// Alternative explorer browser url.
+        #[arg(long, env = "EXPLORER_URL")]
+        explorer_url: Option<String>,
     },
 
     /// Wallet management utilities.

--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -938,12 +938,12 @@ pub enum CastSubcommand {
         #[command(flatten)]
         etherscan: EtherscanOpts,
 
-        /// Alternative explorer api url to use that adheres to the etherscan api. If not provided,
-        /// defaults to etherscan.
+        /// Alternative explorer API URL to use that adheres to the Etherscan API. If not provided,
+        /// defaults to Etherscan.
         #[arg(long, env = "EXPLORER_API_URL")]
         explorer_api_url: Option<String>,
 
-        /// Alternative explorer browser url.
+        /// Alternative explorer browser URL.
         #[arg(long, env = "EXPLORER_URL")]
         explorer_url: Option<String>,
     },

--- a/crates/cast/bin/cmd/bind.rs
+++ b/crates/cast/bin/cmd/bind.rs
@@ -57,7 +57,7 @@ impl BindArgs {
     pub async fn run(self) -> Result<()> {
         Err(eyre::eyre!(
             "`cast bind` has been removed.\n\
-             Please use `cast source` to create a Forge project from a block-explorer source\n\
+             Please use `cast source` to create a Forge project from a block explorer source\n\
              and `forge bind` to generate the bindings to it instead."
         ))
     }

--- a/crates/cast/bin/cmd/bind.rs
+++ b/crates/cast/bin/cmd/bind.rs
@@ -57,7 +57,7 @@ impl BindArgs {
     pub async fn run(self) -> Result<()> {
         Err(eyre::eyre!(
             "`cast bind` has been removed.\n\
-             Please use `cast etherscan-source` to create a Forge project from an Etherscan source\n\
+             Please use `cast source` to create a Forge project from a block-explorer source\n\
              and `forge bind` to generate the bindings to it instead."
         ))
     }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -630,20 +630,50 @@ async fn main_args(args: CastArgs) -> Result<()> {
             "{}",
             SimpleCast::right_shift(&value, &bits, base_in.as_deref(), &base_out)?
         )?,
-        CastSubcommand::EtherscanSource { address, directory, etherscan, flatten } => {
+        CastSubcommand::Source {
+            address,
+            directory,
+            explorer_api_url,
+            explorer_url,
+            etherscan,
+            flatten,
+        } => {
             let config = etherscan.load_config()?;
-            let chain = config.chain.unwrap_or_default();
-            let api_key = config.get_etherscan_api_key(Some(chain)).unwrap_or_default();
+            let chain = etherscan.chain.unwrap_or_default();
+            let api_key = config.get_etherscan_api_key(Some(chain));
             match (directory, flatten) {
                 (Some(dir), false) => {
-                    SimpleCast::expand_etherscan_source_to_directory(chain, address, api_key, dir)
-                        .await?
+                    SimpleCast::expand_etherscan_source_to_directory(
+                        chain,
+                        address,
+                        api_key,
+                        dir,
+                        explorer_api_url,
+                        explorer_url,
+                    )
+                    .await?
                 }
-                (None, false) => {
-                    sh_println!("{}", SimpleCast::etherscan_source(chain, address, api_key).await?)?
-                }
+                (None, false) => sh_println!(
+                    "{}",
+                    SimpleCast::etherscan_source(
+                        chain,
+                        address,
+                        api_key,
+                        explorer_api_url,
+                        explorer_url
+                    )
+                    .await?
+                )?,
                 (dir, true) => {
-                    SimpleCast::etherscan_source_flatten(chain, address, api_key, dir).await?;
+                    SimpleCast::etherscan_source_flatten(
+                        chain,
+                        address,
+                        api_key,
+                        dir,
+                        explorer_api_url,
+                        explorer_url,
+                    )
+                    .await?;
                 }
             }
         }

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -639,7 +639,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             flatten,
         } => {
             let config = etherscan.load_config()?;
-            let chain = etherscan.chain.unwrap_or_default();
+            let chain = config.chain.unwrap_or_default();
             let api_key = config.get_etherscan_api_key(Some(chain));
             match (directory, flatten) {
                 (Some(dir), false) => {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -1937,7 +1937,9 @@ impl SimpleCast {
     ///     Cast::etherscan_source(
     ///         NamedChain::Mainnet.into(),
     ///         "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".to_string(),
-    ///         "<etherscan_api_key>".to_string()
+    ///         Some("<etherscan_api_key>".to_string()),
+    ///         None,
+    ///         None
     ///     )
     ///     .await
     ///     .unwrap()
@@ -1971,8 +1973,10 @@ impl SimpleCast {
     /// Cast::expand_etherscan_source_to_directory(
     ///     NamedChain::Mainnet.into(),
     ///     "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".to_string(),
-    ///     "<etherscan_api_key>".to_string(),
+    ///     Some("<etherscan_api_key>".to_string()),
     ///     PathBuf::from("output_dir"),
+    ///     None,
+    ///     None,
     /// )
     /// .await?;
     /// # Ok(())

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2086,3 +2086,28 @@ forgetest_async!(cast_run_impersonated_tx, |_prj, cmd| {
         .args(["run", &receipt.transaction_hash.to_string(), "--rpc-url", &http_endpoint])
         .assert_success();
 });
+
+// <https://github.com/foundry-rs/foundry/issues/4776>
+casttest!(fetch_src_blockscout, |_prj, cmd| {
+    let url = "https://eth.blockscout.com/api";
+
+    let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+
+    cmd.args([
+        "source",
+        &weth.to_string(),
+        "--chain-id",
+        "1",
+        "--explorer-api-url",
+        url,
+        "--flatten",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+...
+contract WETH9 {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+..."#]]);
+});

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2111,3 +2111,18 @@ contract WETH9 {
     uint8  public decimals = 18;
 ..."#]]);
 });
+
+casttest!(fetch_src_default, |_prj, cmd| {
+    let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    let etherscan_api_key = next_mainnet_etherscan_api_key();
+
+    cmd.args(["source", &weth.to_string(), "--flatten", "--etherscan-api-key", &etherscan_api_key])
+        .assert_success()
+        .stdout_eq(str![[r#"
+...
+contract WETH9 {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+..."#]]);
+});

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -81,7 +81,7 @@ fn test_verify_bytecode_with_ignore(
     let source_code = cmd
         .cast_fuse()
         .args([
-            "etherscan-source",
+            "source",
             addr,
             "--flatten",
             "--etherscan-api-key",

--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -25,7 +25,7 @@ fn test_verify_bytecode(
     // fetch and flatten source code
     let source_code = cmd
         .cast_fuse()
-        .args(["etherscan-source", addr, "--flatten", "--etherscan-api-key", &etherscan_key])
+        .args(["source", addr, "--flatten", "--etherscan-api-key", &etherscan_key])
         .assert_success()
         .get_output()
         .stdout_lossy();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Closes #4776 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Rename command from `cast etherscan-source` to `cast source`
- Add args `explorer_url: Option<String>` and `explorer_api_url: Option<String>` that can be used to specify alternative block explorers.
- Test

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
