### PR TITLE
fix: correctly set `gas_limit` reported by Anvil

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1173,6 +1173,8 @@ latest block number: {latest_block}"
         };
 
         let gas_limit = self.fork_gas_limit(&block);
+        self.gas_limit = Some(gas_limit);
+
         env.block = BlockEnv {
             number: U256::from(fork_block_number),
             timestamp: U256::from(block.header.timestamp),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Optimistically marking as resolved: https://github.com/foundry-rs/foundry/issues/7068

Related: https://github.com/foundry-rs/foundry/issues/9752

Originally part of https://github.com/foundry-rs/foundry/pull/9753, split out due to some nuances in that PR that need to be untangled further

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Fixes `gas_limit` as reported by Anvil

When forking Sonic, has 1 billion gas limit: `anvil --fork-url https://rpc.soniclabs.com`

Previously reported:

```
Gas Limit
==================

30000000
```

Fixed:

```
Gas Limit
==================

1000000000
```