### PR TITLE
fix(docker): revert to use ubuntu:22.04 as base image

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,16 +1,19 @@
 # This image is meant to enable cross-architecture builds.
 # It assumes the foundry binaries have already been compiled for `$TARGETPLATFORM` and are
 # locatable in `./dist/bin/$TARGETARCH`
-FROM alpine:3.20
+FROM ubuntu:22.04
 
 # Filled by docker buildx
 ARG TARGETARCH
 
-RUN apk add --no-cache git
+RUN apt update && apt install -y git
 
 COPY ./dist/bin/$TARGETARCH/* /usr/local/bin/
 
-RUN adduser -Du 1000 foundry
+RUN groupadd -g 1000 foundry && \
+    useradd -m -u 1000 -g foundry foundry
+
+USER foundry
 
 ENTRYPOINT ["/bin/sh", "-c"]
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- regression in docker images introduced by https://github.com/foundry-rs/foundry/pull/9775
- commands fail with `/bin/sh: forge: not found` / `/bin/sh: anvil: not found`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- roll back to ubuntu (was changed in https://github.com/foundry-rs/foundry/commit/f3548cb4d06b5eec81f2482e9fc3c16e58f7efe5)
- install git and create foundry user, set default foundry user

Tested forge commands from image built from `fix-docker` branch as:
- create new project `forge init hello-world && cd hello-world`
- forge install:
```sh
docker run --rm -it \
    -v "$(pwd)":/workspace \
    -w /workspace \
    -u 1000:1000 \
    ghcr.io/foundry-rs/foundry:fix-docker \
    -c "forge install"
```
- forge clean and build:
```sh
docker run --rm -it \
    -v "$(pwd)":/workspace \
    -w /workspace \
    -u 1000:1000 \
    ghcr.io/foundry-rs/foundry:fix-docker \
    -c "forge clean && forge build"
```
 
Tested `docker-compose up anvil` from `docker-compose.yml`
```yml
services:
  anvil:
    image: ghcr.io/foundry-rs/foundry:fix-docker
    container_name: anvil
    environment:
      ANVIL_IP_ADDR: "0.0.0.0"
    working_dir: /anvil
    ports:
    - "8545:8545"
    command: anvil
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
