### PR TITLE
feat(anvil): implement `anvil_rollback`

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    eth::subscription::SubscriptionId,
-    types::{ReorgOptions, RollbackOptions},
-};
+use crate::{eth::subscription::SubscriptionId, types::ReorgOptions};
 use alloy_primitives::{Address, Bytes, TxHash, B256, B64, U256};
 use alloy_rpc_types::{
     anvil::{Forking, MineOptions},
@@ -782,7 +779,7 @@ pub enum EthRequest {
 
     /// Rollback the chain
     #[cfg_attr(feature = "serde", serde(rename = "anvil_rollback",))]
-    Rollback(RollbackOptions),
+    Rollback(Option<u64>),
 
     /// Wallet
     #[cfg_attr(feature = "serde", serde(rename = "wallet_getCapabilities", with = "empty_params"))]

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,4 +1,7 @@
-use crate::{eth::subscription::SubscriptionId, types::ReorgOptions};
+use crate::{
+    eth::subscription::SubscriptionId,
+    types::{ReorgOptions, RollbackOptions},
+};
 use alloy_primitives::{Address, Bytes, TxHash, B256, B64, U256};
 use alloy_rpc_types::{
     anvil::{Forking, MineOptions},
@@ -776,6 +779,10 @@ pub enum EthRequest {
     /// Reorg the chain
     #[cfg_attr(feature = "serde", serde(rename = "anvil_reorg",))]
     Reorg(ReorgOptions),
+
+    /// Rollback the chain
+    #[cfg_attr(feature = "serde", serde(rename = "anvil_rollback",))]
+    Rollback(RollbackOptions),
 
     /// Wallet
     #[cfg_attr(feature = "serde", serde(rename = "wallet_getCapabilities", with = "empty_params"))]

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -38,13 +38,6 @@ pub struct ReorgOptions {
     pub tx_block_pairs: Vec<(TransactionData, u64)>,
 }
 
-/// Represents the options used in `anvil_rollback`
-#[derive(Debug, Clone, Deserialize)]
-pub struct RollbackOptions {
-    // The depth of the rollback
-    pub depth: u64,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum TransactionData {

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -38,6 +38,13 @@ pub struct ReorgOptions {
     pub tx_block_pairs: Vec<(TransactionData, u64)>,
 }
 
+/// Represents the options used in `anvil_rollback`
+#[derive(Debug, Clone, Deserialize)]
+pub struct RollbackOptions {
+    // The depth of the rollback
+    pub depth: u64,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum TransactionData {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -72,7 +72,7 @@ use anvil_core::{
         wallet::{WalletCapabilities, WalletError},
         EthRequest,
     },
-    types::{ReorgOptions, RollbackOptions, TransactionData, Work},
+    types::{ReorgOptions, TransactionData, Work},
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
 use foundry_common::provider::ProviderBuilder;
@@ -456,9 +456,7 @@ impl EthApi {
             EthRequest::Reorg(reorg_options) => {
                 self.anvil_reorg(reorg_options).await.to_rpc_result()
             }
-            EthRequest::Rollback(rollback_options) => {
-                self.anvil_rollback(rollback_options).await.to_rpc_result()
-            }
+            EthRequest::Rollback(depth) => self.anvil_rollback(depth).await.to_rpc_result(),
             EthRequest::WalletGetCapabilities(()) => self.get_capabilities().to_rpc_result(),
             EthRequest::WalletSendTransaction(tx) => {
                 self.wallet_send_transaction(*tx).await.to_rpc_result()
@@ -2080,9 +2078,9 @@ impl EthApi {
     /// chain height, i.e. can't rollback past the genesis block.
     ///
     /// Handler for RPC call: `anvil_rollback`
-    pub async fn anvil_rollback(&self, options: RollbackOptions) -> Result<()> {
+    pub async fn anvil_rollback(&self, depth: Option<u64>) -> Result<()> {
         node_info!("anvil_rollback");
-        let depth = options.depth;
+        let depth = depth.unwrap_or(1);
 
         // Check reorg depth doesn't exceed current chain height
         let current_height = self.backend.best_number();

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2631,49 +2631,7 @@ impl Backend {
         tx_pairs: HashMap<u64, Vec<Arc<PoolTransaction>>>,
         common_block: Block,
     ) -> Result<(), BlockchainError> {
-        // Get the database at the common block
-        let common_state = {
-            let mut state = self.states.write();
-            let state_db = state
-                .get(&common_block.header.hash_slow())
-                .ok_or(BlockchainError::DataUnavailable)?;
-            let db_full = state_db.maybe_as_full_db().ok_or(BlockchainError::DataUnavailable)?;
-            db_full.clone()
-        };
-
-        {
-            // Set state to common state
-            self.db.write().await.clear();
-            for (address, acc) in common_state {
-                for (key, value) in acc.storage {
-                    self.db.write().await.set_storage_at(address, key.into(), value.into())?;
-                }
-                self.db.write().await.insert_account(address, acc.info);
-            }
-        }
-
-        {
-            // Unwind the storage back to the common ancestor
-            self.blockchain
-                .storage
-                .write()
-                .unwind_to(common_block.header.number, common_block.header.hash_slow());
-
-            // Set environment back to common block
-            let mut env = self.env.write();
-            env.block = BlockEnv {
-                number: U256::from(common_block.header.number),
-                timestamp: U256::from(common_block.header.timestamp),
-                gas_limit: U256::from(common_block.header.gas_limit),
-                difficulty: common_block.header.difficulty,
-                prevrandao: Some(common_block.header.mix_hash),
-                coinbase: env.block.coinbase,
-                basefee: env.block.basefee,
-                ..env.block.clone()
-            };
-            self.time.reset(env.block.timestamp.to::<u64>());
-        }
-
+        self.rollback(common_block).await?;
         // Create the new reorged chain, filling the blocks with transactions if supplied
         for i in 0..depth {
             let to_be_mined = tx_pairs.get(&i).cloned().unwrap_or_else(Vec::new);
@@ -2724,19 +2682,14 @@ impl Backend {
 
             // Set environment back to common block
             let mut env = self.env.write();
-            env.block = BlockEnv {
-                number: U256::from(common_block.header.number),
-                timestamp: U256::from(common_block.header.timestamp),
-                gas_limit: U256::from(common_block.header.gas_limit),
-                difficulty: common_block.header.difficulty,
-                prevrandao: Some(common_block.header.mix_hash),
-                coinbase: env.block.coinbase,
-                basefee: env.block.basefee,
-                ..env.block.clone()
-            };
+            env.block.number = U256::from(common_block.header.number);
+            env.block.timestamp = U256::from(common_block.header.timestamp);
+            env.block.gas_limit = U256::from(common_block.header.gas_limit);
+            env.block.difficulty = common_block.header.difficulty;
+            env.block.prevrandao = Some(common_block.header.mix_hash);
+
             self.time.reset(env.block.timestamp.to::<u64>());
         }
-
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

Adds `anvil_rollback` RPC method. This method allows users to undo blocks that already been produced.
The existing `anvil_reorg` doesn't allow you to actually remove blocks, only to re-org in place. 

## Solution

The code is  similar to `anvil_reorg`, we simply skip the mining step.