### PR TITLE
fix(trace_filter): allow params to be object or array with len 1

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -321,7 +321,7 @@ pub enum EthRequest {
     TraceBlock(BlockNumber),
 
     // Return filtered traces over blocks
-    #[cfg_attr(feature = "serde", serde(rename = "trace_filter",))]
+    #[cfg_attr(feature = "serde", serde(rename = "trace_filter", with = "sequence"))]
     TraceFilter(TraceFilter),
 
     // Custom endpoints, they're not extracted to a separate type out of serde convenience


### PR DESCRIPTION
## Motivation

Currently, Anvil’s `trace_filter` only accepts an object, while Geth and Erigon support an object or an **array with one object** - the filter in both cases. This causes compatibility issues with tools that expect both formats to be valid - in my case `graph-node`, which utilizes the `rust-web3` crate, and always packages up params in an array.

For example, Anvil will only accept:

```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"trace_filter","params":{"fromBlock":"0x0","toBlock":"0x0"},"id":1}' \
-H "Content-Type: application/json" http://localhost:8545
```

But it **rejects**:

```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"trace_filter","params":[{"fromBlock":"0x0","toBlock":"0x0"}],"id":1}' \
-H "Content-Type: application/json" http://localhost:8545
```

with the error:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid type: map, expected an 8 byte hex string"}}
```

Since Geth and Erigon both accept either format, this makes Anvil inconsistent.

## Solution

This PR updates Anvil to support both formats by allowing `trace_filter` to deserialize from an **array containing a single object**.

With this change, Anvil will now accept:

- **Array of one object (new behavior, matching Geth/Erigon):**  

  ```json
  [{"fromBlock": "0x0", "toBlock": "0x0"}]
  ```