### PR TITLE
fix(cast): try decoding custom errors when execution reverted in cast send

### DIFF
--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -28,7 +28,7 @@ pub enum SenderKind<'a> {
     /// An address without signer. Used for read-only calls and transactions sent through unlocked
     /// accounts.
     Address(Address),
-    /// A refersnce to a signer.
+    /// A reference to a signer.
     Signer(&'a WalletSigner),
     /// An owned signer.
     OwnedSigner(WalletSigner),
@@ -370,7 +370,7 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
                 Ok(())
             }
             Err(err) => {
-                if let TransportError::ErrorResp(ref payload) = err {
+                if let TransportError::ErrorResp(payload) = &err {
                     // If execution reverted with code 3 during provider gas estimation then try
                     // to decode custom errors and append it to the error message.
                     if payload.code == 3 {

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -1,4 +1,5 @@
 use alloy_consensus::{SidecarBuilder, SimpleCoder};
+use alloy_dyn_abi::ErrorExt;
 use alloy_json_abi::Function;
 use alloy_network::{
     AnyNetwork, TransactionBuilder, TransactionBuilder4844, TransactionBuilder7702,
@@ -8,14 +9,17 @@ use alloy_provider::Provider;
 use alloy_rpc_types::{AccessList, Authorization, TransactionInput, TransactionRequest};
 use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
+use alloy_transport::TransportError;
+use cast::traces::identifier::SignaturesIdentifier;
 use eyre::Result;
 use foundry_cli::{
     opts::{CliAuthorizationList, TransactionOpts},
     utils::{self, parse_function_args},
 };
-use foundry_common::ens::NameOrAddress;
+use foundry_common::{ens::NameOrAddress, fmt::format_tokens};
 use foundry_config::{Chain, Config};
 use foundry_wallets::{WalletOpts, WalletSigner};
+use serde_json::value::RawValue;
 
 /// Different sender kinds used by [`CastTxBuilder`].
 pub enum SenderKind<'a> {
@@ -350,10 +354,34 @@ impl<P: Provider<AnyNetwork>> CastTxBuilder<P, InputState> {
         }
 
         if self.tx.gas.is_none() {
-            self.tx.gas = Some(self.provider.estimate_gas(&self.tx).await?);
+            self.estimate_gas().await?;
         }
 
         Ok((self.tx, self.state.func))
+    }
+
+    /// Estimate tx gas from provider call. Tries to decode custom error if execution reverted.
+    async fn estimate_gas(&mut self) -> Result<()> {
+        match self.provider.estimate_gas(&self.tx).await {
+            Ok(estimated) => {
+                self.tx.gas = Some(estimated);
+                Ok(())
+            }
+            Err(err) => {
+                if let TransportError::ErrorResp(ref payload) = err {
+                    // If execution reverted with code 3 during provider gas estimation then try
+                    // to decode custom errors and append it to the error message.
+                    if payload.code == 3 {
+                        if let Some(data) = &payload.data {
+                            if let Ok(Some(decoded_error)) = decode_execution_revert(data).await {
+                                eyre::bail!("Failed to estimate gas: {}: {}", err, decoded_error)
+                            }
+                        }
+                    }
+                }
+                eyre::bail!("Failed to estimate gas: {}", err)
+            }
+        }
     }
 
     /// Parses the passed --auth value and sets the authorization list on the transaction.
@@ -400,4 +428,33 @@ where
 
         Ok(self)
     }
+}
+
+/// Helper function that tries to decode custom error name and inputs from error payload data.
+async fn decode_execution_revert(data: &RawValue) -> Result<Option<String>> {
+    if let Some(err_data) = data.to_string().replace("\"", "").strip_prefix("0x") {
+        let selector = err_data.get(..8).unwrap_or_default();
+        if let Some(known_error) = SignaturesIdentifier::new(Config::foundry_cache_dir(), false)?
+            .write()
+            .await
+            .identify_error(&hex::decode(selector)?)
+            .await
+        {
+            let mut decoded_error = known_error.name.clone();
+            if !known_error.inputs.is_empty() {
+                decoded_error.push('(');
+                let error = known_error.decode_error(&hex::decode(err_data)?)?;
+                let mut tokens = format_tokens(&error.body).peekable();
+                while let Some(token) = &tokens.next() {
+                    decoded_error.push_str(token);
+                    if tokens.peek().is_some() {
+                        decoded_error.push_str(", ");
+                    }
+                }
+                decoded_error.push(')');
+            }
+            return Ok(Some(decoded_error))
+        }
+    }
+    Ok(None)
 }

--- a/crates/cast/bin/tx.rs
+++ b/crates/cast/bin/tx.rs
@@ -434,10 +434,8 @@ where
 
 /// Helper function that tries to decode custom error name and inputs from error payload data.
 async fn decode_execution_revert(data: &RawValue) -> Result<Option<String>> {
-    if let Some(err_data) =
-        serde_json::from_str::<String>(data.get()).unwrap_or_default().strip_prefix("0x")
-    {
-        let selector = err_data.get(..8).unwrap_or_default();
+    if let Some(err_data) = serde_json::from_str::<String>(data.get())?.strip_prefix("0x") {
+        let selector = err_data.get(..8).unwrap();
         if let Some(known_error) = SignaturesIdentifier::new(Config::foundry_cache_dir(), false)?
             .write()
             .await
@@ -447,7 +445,7 @@ async fn decode_execution_revert(data: &RawValue) -> Result<Option<String>> {
             let mut decoded_error = known_error.name.clone();
             if !known_error.inputs.is_empty() {
                 if let Ok(error) = known_error.decode_error(&hex::decode(err_data)?) {
-                    write!(decoded_error, "({})", format_tokens(&error.body).format(", ")).unwrap();
+                    write!(decoded_error, "({})", format_tokens(&error.body).format(", "))?;
                 }
             }
             return Ok(Some(decoded_error))


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- closes #9789 
- opened for visibility and initial feedback
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- try decode custom error with SignaturesIdentifier if code 3 and append to output e.g.
```
Error: server returned an error response: error code 3: execution reverted: custom error 0x6786ad34: ..., data: "...": AddressInsufficientBalance(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, 1000)
```