### PR TITLE
chore: ignore solady CI failure in win

### DIFF
--- a/crates/forge/tests/cli/ext_integration.rs
+++ b/crates/forge/tests/cli/ext_integration.rs
@@ -59,7 +59,10 @@ fn sablier_v2_core() {
 }
 
 // <https://github.com/Vectorized/solady>
+// Fails on windows because "/*Transient*" does not skip transient contracts
+// (should be "*/*Transient*").
 #[test]
+#[cfg_attr(windows, ignore = "Windows cannot skip transient pattern")]
 fn solady() {
     ExtTester::new("Vectorized", "solady", "de9aee59648862bb98affd578248d1e75c7073ad").run();
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- on win solady fails to build due to `"tload" instruction is only available for Cancun-compatible VMs (you are currently compiling for "paris").` https://github.com/foundry-rs/foundry/actions/runs/13068792712/job/36465786880#step:12:70
- this happens since we bumped git commit and skip is defined as `skip = ["/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]` https://github.com/Vectorized/solady/blob/main/foundry.toml
- on win `"/*Transient*"` is not picked up, changing to `"*/*Transient*"` works
- will follow up with checking why this happens on win only / or solady PR to fix pattern
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
