### PR TITLE
fix(forge): allow `forge init --template` to work with `--no-commit`

### DIFF
--- a/crates/forge/bin/cmd/init.rs
+++ b/crates/forge/bin/cmd/init.rs
@@ -69,15 +69,18 @@ impl InitArgs {
             // fetch the template - always fetch shallow for templates since git history will be
             // collapsed. gitmodules will be initialized after the template is fetched
             git.fetch(true, &template, branch)?;
-            // reset git history to the head of the template
-            // first get the commit hash that was fetched
-            let commit_hash = git.commit_hash(true, "FETCH_HEAD")?;
-            // format a commit message for the new repo
-            let commit_msg = format!("chore: init from {template} at {commit_hash}");
-            // get the hash of the FETCH_HEAD with the new commit message
-            let new_commit_hash = git.commit_tree("FETCH_HEAD^{tree}", Some(commit_msg))?;
-            // reset head of this repo to be the head of the template repo
-            git.reset(true, new_commit_hash)?;
+
+            if !no_commit {
+                // reset git history to the head of the template
+                // first get the commit hash that was fetched
+                let commit_hash = git.commit_hash(true, "FETCH_HEAD")?;
+                // format a commit message for the new repo
+                let commit_msg = format!("chore: init from {template} at {commit_hash}");
+                // get the hash of the FETCH_HEAD with the new commit message
+                let new_commit_hash = git.commit_tree("FETCH_HEAD^{tree}", Some(commit_msg))?;
+                // reset head of this repo to be the head of the template repo
+                git.reset(true, new_commit_hash)?;
+            }
 
             // if shallow, just initialize submodules
             if shallow {

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -584,6 +584,31 @@ Error: git fetch exited with code 128
 "#]]);
 });
 
+// checks that `forge init --template [template] work with --no-commit
+forgetest!(can_init_template_with_no_commit, |prj, cmd| {
+    prj.wipe();
+    cmd.args(["init", "--template", "foundry-rs/forge-template", "--no-commit"])
+        .arg(prj.root())
+        .assert_success()
+        .stdout_eq(str![[r#"
+Initializing [..] from https://github.com/foundry-rs/forge-template...
+    Initialized forge project
+
+"#]]);
+
+    // show the latest commit message was not changed
+    let output = Command::new("git")
+        .args(["log", "-1", "--pretty=%s"]) // Get the latest commit message
+        .output()
+        .expect("Failed to execute git command");
+
+    let commit_message = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !commit_message.starts_with("chore: init from foundry-rs/forge-template"),
+        "Commit message should not start with 'chore: init from foundry-rs/forge-template'"
+    );
+});
+
 // checks that clone works
 forgetest!(can_clone, |prj, cmd| {
     prj.wipe();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

fixes: #4215 

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I am motivating by learning rust and using foundry as a means to do so.
I sought out some easy issues and landed on this comment: https://github.com/foundry-rs/foundry/issues/4215#issuecomment-2413695613 which should close that issue.

## Solution

Still allow the cloning of the repo but before making the commit, check to see the value `--no-commit` and adhere.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes