### PR TITLE
feat(invariant): on failures show original and current sequence len

### DIFF
--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -35,8 +35,8 @@ pub use inspector::Fuzzer;
 pub enum CounterExample {
     /// Call used as a counter example for fuzz tests.
     Single(BaseCounterExample),
-    /// Sequence of calls used as a counter example for invariant tests.
-    Sequence(Vec<BaseCounterExample>),
+    /// Original sequence size and sequence of calls used as a counter example for invariant tests.
+    Sequence(usize, Vec<BaseCounterExample>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -446,8 +446,14 @@ impl fmt::Display for TestResult {
                             CounterExample::Single(ex) => {
                                 write!(s, "; counterexample: {ex}]").unwrap();
                             }
-                            CounterExample::Sequence(sequence) => {
-                                s.push_str("]\n\t[Sequence]\n");
+                            CounterExample::Sequence(original, sequence) => {
+                                s.push_str(
+                                    format!(
+                                        "]\n\t[Sequence] (original: {original}, shrunk: {})\n",
+                                        sequence.len()
+                                    )
+                                    .as_str(),
+                                );
                                 for ex in sequence {
                                     writeln!(s, "\t\t{ex}").unwrap();
                                 }
@@ -593,7 +599,7 @@ impl TestResult {
         } else {
             Some(format!("{invariant_name} persisted failure revert"))
         };
-        self.counterexample = Some(CounterExample::Sequence(call_sequence));
+        self.counterexample = Some(CounterExample::Sequence(call_sequence.len(), call_sequence));
     }
 
     /// Returns the fail result for invariant test setup.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- suggested by @forkforkdog
- it is useful to show the original len of failed case vs the optimized counterexample len
- added info in failed test output
![image](https://github.com/user-attachments/assets/4ff12b19-109d-475c-94bb-1af633f338e0)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes