### PR TITLE
chore: remove rustls/openssl features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_COLOR: always
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
   PROFILE: maxperf
-  STABLE_VERSION: 'v0.3.0'
+  STABLE_VERSION: "v0.3.0"
 
 jobs:
   prepare:
@@ -148,7 +148,7 @@ jobs:
         run: |
           set -eo pipefail
           flags=(--target $TARGET --profile $PROFILE --bins 
-            --no-default-features --features rustls,aws-kms,cli,asm-keccak)
+            --no-default-features --features aws-kms,cli,asm-keccak)
 
           # `jemalloc` is not fully supported on MSVC or aarch64 Linux.
           if [[ "$TARGET" != *msvc* && "$TARGET" != "aarch64-unknown-linux-gnu" ]]; then
@@ -278,7 +278,7 @@ jobs:
   issue:
     name: Open an issue
     runs-on: ubuntu-latest
-    needs: [ prepare, release-docker, release, cleanup ]
+    needs: [prepare, release-docker, release, cleanup]
     if: failure()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,10 +113,6 @@ jobs:
 
   deny:
     uses: ithacaxyz/ci/.github/workflows/deny.yml@main
-    with:
-      # Clear out arguments to not pass `--all-features` to `cargo deny`.
-      # Many crates have an `openssl` feature which enables banned dependencies.
-      deny-flags: ""
 
   ci-success:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,21 +3316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "forge"
 version = "1.0.0"
 dependencies = [
@@ -5004,22 +4989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5969,23 +5938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6319,48 +6271,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
-dependencies = [
- "bitflags 2.8.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -7319,14 +7233,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7340,7 +7252,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-socks",
  "tokio-util",
@@ -8931,16 +8842,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,10 @@ proptest = "1"
 rand = "0.8"
 rayon = "1"
 regex = { version = "1", default-features = false }
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "rustls-tls-native-roots",
+] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ CARGO_TARGET_DIR ?= target
 # List of features to use when building. Can be overridden via the environment.
 # No jemalloc on Windows
 ifeq ($(OS),Windows_NT)
-    FEATURES ?= rustls aws-kms cli asm-keccak
+    FEATURES ?= aws-kms cli asm-keccak
 else
-    FEATURES ?= jemalloc rustls aws-kms cli asm-keccak
+    FEATURES ?= jemalloc aws-kms cli asm-keccak
 endif
 
 ##@ Help

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -93,9 +93,7 @@ async-trait.workspace = true
 divan.workspace = true
 
 [features]
-default = ["rustls", "jemalloc"]
-rustls = ["foundry-cli/rustls", "foundry-wallets/rustls"]
-openssl = ["foundry-cli/openssl"]
+default = ["jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["dep:tikv-jemallocator"]
 aws-kms = ["foundry-wallets/aws-kms", "dep:aws-sdk-kms"]

--- a/crates/chisel/Cargo.toml
+++ b/crates/chisel/Cargo.toml
@@ -65,8 +65,6 @@ serial_test = "3"
 tracing-subscriber.workspace = true
 
 [features]
-default = ["rustls", "jemalloc"]
-rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
-openssl = ["foundry-compilers/openssl", "reqwest/default-tls"]
+default = ["jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["dep:tikv-jemallocator"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -54,8 +54,4 @@ tracing-tracy = { version = "0.11", optional = true }
 tempfile.workspace = true
 
 [features]
-default = ["rustls"]
-rustls = ["foundry-wallets/rustls"]
-openssl = ["foundry-compilers/openssl"]
-
 tracy = ["dep:tracing-tracy"]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -71,11 +71,7 @@ terminal_size.workspace = true
 
 [build-dependencies]
 chrono.workspace = true
-vergen = { workspace = true, features = [
-    "build",
-    "git",
-    "gitcl",
-] }
+vergen = { workspace = true, features = ["build", "git", "gitcl"] }
 
 [dev-dependencies]
 foundry-macros.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -55,6 +55,4 @@ figment = { workspace = true, features = ["test"] }
 tempfile.workspace = true
 
 [features]
-default = ["rustls"]
-rustls = ["reqwest/rustls-tls-native-roots"]
 isolate-by-default = []

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -123,14 +123,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 alloy-signer-local.workspace = true
 
 [features]
-default = ["rustls", "jemalloc"]
-rustls = [
-    "foundry-cli/rustls",
-    "foundry-wallets/rustls",
-    "reqwest/rustls-tls",
-    "reqwest/rustls-tls-native-roots",
-]
-openssl = ["foundry-cli/openssl", "reqwest/default-tls"]
+default = ["jemalloc"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 jemalloc = ["dep:tikv-jemallocator"]
 aws-kms = ["foundry-wallets/aws-kms"]

--- a/crates/wallets/Cargo.toml
+++ b/crates/wallets/Cargo.toml
@@ -27,7 +27,7 @@ alloy-dyn-abi.workspace = true
 
 # aws-kms
 alloy-signer-aws = { workspace = true, features = ["eip712"], optional = true }
-aws-config = { version = "1", optional = true }                                 # default-features are necessary
+aws-config = { version = "1", default-features = true, optional = true }
 aws-sdk-kms = { version = "1", default-features = false, optional = true }
 
 # gcp-kms
@@ -51,7 +51,5 @@ eth-keystore = "0.5.0"
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-default = ["rustls"]
-rustls = ["aws-sdk-kms?/rustls"]
 aws-kms = ["dep:alloy-signer-aws", "dep:aws-config", "dep:aws-sdk-kms"]
 gcp-kms = ["dep:alloy-signer-gcp", "dep:gcloud-sdk"]

--- a/deny.toml
+++ b/deny.toml
@@ -7,10 +7,6 @@ yanked = "warn"
 ignore = [
     # proc-macro-error is unmaintained
     "RUSTSEC-2024-0370",
-    # instant is unmaintained
-    "RUSTSEC-2024-0384",
-    # derivative is unmaintained
-    "RUSTSEC-2024-0388",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -47,7 +43,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "OpenSSL",
     "Unlicense",
     "WTFPL",


### PR DESCRIPTION
I don't think these were ever used. We always use rustls, so remove these features and always enable rustls.