### PR TITLE
feat: add mathjax support to forge doc mdbook config

### DIFF
--- a/crates/doc/static/book.toml
+++ b/crates/doc/static/book.toml
@@ -6,6 +6,7 @@ src = "src"
 no-section-label = true
 additional-js = ["solidity.min.js"]
 additional-css = ["book.css"]
+mathjax-support = true
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
## Motivation

Crypto is a math heavy field, and adding math in documentation should be easy. Latex is the de-facto standard mechanism for writing math.

## Solution

Add mathjax support to the mdbook config for forge doc. See https://rust-lang.github.io/mdBook/format/mathjax.html for examples and reasoning.

An alternative solution is to add an extra key to the foundry `[doc]` section, but I see no reason to _not_ have this enabled by default, and this PR is _far_ easier.


## PR Checklist

Happy to add these as needed. I don't think any of them apply.

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes