### PR TITLE
fix: mark metis as different gas calc

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -175,7 +175,8 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                     NamedChain::Moonbase |
                     NamedChain::Moonbeam |
                     NamedChain::MoonbeamDev |
-                    NamedChain::Moonriver
+                    NamedChain::Moonriver |
+                    NamedChain::Metis
             );
     }
     false


### PR DESCRIPTION
should close #9832