### PR TITLE
feat: add `vm.foundryVersionCmp` and `vm.foundryVersionAtLeast` cheatcodes

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -5474,6 +5474,46 @@
     },
     {
       "func": {
+        "id": "foundryVersionAtLeast",
+        "description": "Returns true if the current Foundry version is at least the given version.\nVersion string can be in the format `<cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>`.",
+        "declaration": "function foundryVersionAtLeast(string calldata version) external view returns (bool);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "foundryVersionAtLeast(string)",
+        "selector": "0x6248be1f",
+        "selectorBytes": [
+          98,
+          72,
+          190,
+          31
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "foundryVersionCmp",
+        "description": "Compares the current Foundry version with the given version string.\nVersion string can be in the format `<cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>`.\nReturns:\n-1 if current version is less than the given version\n0 if current version equals the given version\n1 if current version is greater than the given version",
+        "declaration": "function foundryVersionCmp(string calldata version) external view returns (int256);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "foundryVersionCmp(string)",
+        "selector": "0xca7b0a09",
+        "selectorBytes": [
+          202,
+          123,
+          10,
+          9
+        ]
+      },
+      "group": "testing",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "fsMetadata",
         "description": "Given a path, query the file system to get information about a file, directory, etc.",
         "declaration": "function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -1677,6 +1677,21 @@ interface Vm {
         string calldata error
     ) external pure;
 
+    /// Returns true if the current Foundry version is at least the given version.
+    /// Version string can be in the format `<cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>`.
+    #[cheatcode(group = Testing, safety = Safe)]
+    function foundryVersionAtLeast(string calldata version) external view returns (bool);
+
+    /// Compares the current Foundry version with the given version string.
+    /// Version string can be in the format `<cargo_version>-<tag>+<git_sha_short>.<unix_build_timestamp>.<profile>`.
+    /// Returns:
+    /// -1 if current version is less than the given version
+    /// 0 if current version equals the given version
+    /// 1 if current version is greater than the given version
+    #[cheatcode(group = Testing, safety = Safe)]
+    function foundryVersionCmp(string calldata version) external view returns (int256);
+
+
     // ======== OS and Filesystem ========
 
     // -------- Metadata --------

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -37,6 +37,8 @@ mod config;
 
 mod crypto;
 
+mod version;
+
 mod env;
 pub use env::set_execution_context;
 

--- a/crates/cheatcodes/src/version.rs
+++ b/crates/cheatcodes/src/version.rs
@@ -1,0 +1,40 @@
+use crate::{Cheatcode, Cheatcodes, Result, Vm::*};
+use alloy_sol_types::SolValue;
+use foundry_common::version::SEMVER_VERSION;
+use semver::Version;
+use std::cmp::Ordering;
+
+impl Cheatcode for foundryVersionCmpCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { version } = self;
+
+        let parsed_version = Version::parse(version)
+            .map_err(|e| fmt_err!("Invalid semver format '{}': {}", version, e))?;
+
+        let current_version = Version::parse(SEMVER_VERSION)
+            .map_err(|e| fmt_err!("Invalid current version: {}", e))?;
+        // Compare the current Foundry version (SEMVER_VERSION) against the parsed version.
+        // Note: returns -1 if current < provided, 0 if equal, 1 if current > provided.
+        let cmp_result = match current_version.cmp_precedence(&parsed_version) {
+            Ordering::Less => -1i32,
+            Ordering::Equal => 0i32,
+            Ordering::Greater => 1i32,
+        };
+        Ok(cmp_result.abi_encode())
+    }
+}
+
+impl Cheatcode for foundryVersionAtLeastCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { version } = self;
+
+        let parsed_version = Version::parse(version)
+            .map_err(|e| fmt_err!("Invalid semver format '{}': {}", version, e))?;
+
+        let current_version = Version::parse(SEMVER_VERSION)
+            .map_err(|e| fmt_err!("Invalid current version: {}", e))?;
+
+        let at_least = current_version.cmp_precedence(&parsed_version) != Ordering::Less;
+        Ok(at_least.abi_encode())
+    }
+}

--- a/testdata/cheats/Vm.sol
+++ b/testdata/cheats/Vm.sol
@@ -267,6 +267,8 @@ interface Vm {
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
     function fee(uint256 newBasefee) external;
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
+    function foundryVersionAtLeast(string calldata version) external view returns (bool);
+    function foundryVersionCmp(string calldata version) external view returns (int256);
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
     function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);
     function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);

--- a/testdata/default/cheats/GetFoundryVersion.t.sol
+++ b/testdata/default/cheats/GetFoundryVersion.t.sol
@@ -42,4 +42,28 @@ contract GetFoundryVersionTest is DSTest {
         // Validate build profile (e.g., "debug" or "release")
         require(bytes(buildType).length > 0, "Build type is empty");
     }
+
+    function testFoundryVersionCmp() public {
+        // Should return -1 if current version is less than argument
+        assertEq(vm.foundryVersionCmp("99.0.0-dev+b3d0002118.1737037945.debug"), -1);
+
+        // Should return 0 if versions are equal
+        string memory currentVersion = vm.getFoundryVersion();
+        assertEq(vm.foundryVersionCmp(currentVersion), 0);
+
+        // Should return 1 if current version is greater than argument
+        assertEq(vm.foundryVersionCmp("0.0.1-dev+b3d0002118.1737037945.debug"), 1);
+    }
+
+    function testFoundryVersionAtLeast() public {
+        // Should return false for future versions
+        assertEq(vm.foundryVersionAtLeast("99.0.0-dev+b3d0002118.1737037945.debug"), false);
+
+        // Should return true for current version
+        string memory currentVersion = vm.getFoundryVersion();
+        assertTrue(vm.foundryVersionAtLeast(currentVersion));
+
+        // Should return true for past versions
+        assertTrue(vm.foundryVersionAtLeast("0.2.0"));
+    }
 }


### PR DESCRIPTION
Closes #9725 

This PR adds `foundryVersionAtLeast` and `foundryVersionCmp` cheatcode both of which suggested here https://github.com/foundry-rs/foundry/issues/9725#issuecomment-2606812856, https://github.com/foundry-rs/foundry/pull/9683#discussion_r1919053389

I wasn't sure about where to put testcases so for now I added them in [`GetFoundryVersion.t.sol`](https://github.com/foundry-rs/foundry/compare/master...startup-dreamer:foundry:feat/version_cmp_cheatcodes?expand=1#diff-673cb213310087972912d3f2006005573dee47b59b57d462f1125b9abe4bb4d2).

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes