### PR TITLE
feat: add `--alloy-rev` and fix `forge bind` re-run on built project

### DIFF
--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -83,11 +83,11 @@ pub struct BindArgs {
     #[arg(long, hide = true)]
     alloy: bool,
 
-    /// Specify the alloy version.
+    /// Specify the Alloy version on Crates.
     #[arg(long)]
     alloy_version: Option<String>,
 
-    /// Specify the alloy revision.
+    /// Specify the Alloy revision on GitHub.
     #[arg(long, conflicts_with = "alloy_version")]
     alloy_rev: Option<String>,
 

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -163,6 +163,11 @@ impl BindArgs {
                     return None;
                 }
 
+                // Ignore the `target` directory in case the user has built the project.
+                if path.iter().any(|comp| comp == "target") {
+                    return None;
+                }
+
                 // We don't want `.metadata.json` files.
                 let stem = path.file_stem()?.to_str()?;
                 if stem.ends_with(".metadata") {

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -87,6 +87,10 @@ pub struct BindArgs {
     #[arg(long)]
     alloy_version: Option<String>,
 
+    /// Specify the alloy revision.
+    #[arg(long, conflicts_with = "alloy_version")]
+    alloy_rev: Option<String>,
+
     /// Generate bindings for the `ethers` library, instead of `alloy` (removed).
     #[arg(long, hide = true)]
     ethers: bool,
@@ -207,6 +211,7 @@ impl BindArgs {
             !self.skip_cargo_toml,
             self.module,
             self.alloy_version.clone(),
+            self.alloy_rev.clone(),
         )?;
         sh_println!("OK.")?;
         Ok(())
@@ -225,6 +230,7 @@ impl BindArgs {
                 bindings_root,
                 self.single_file,
                 self.alloy_version.clone(),
+                self.alloy_rev.clone(),
             )?;
         } else {
             trace!(single_file = self.single_file, "generating module");

--- a/crates/forge/bin/cmd/bind.rs
+++ b/crates/forge/bin/cmd/bind.rs
@@ -83,15 +83,15 @@ pub struct BindArgs {
     #[arg(long, hide = true)]
     alloy: bool,
 
-    /// Specify the Alloy version on Crates.
+    /// Specify the `alloy` version on Crates.
     #[arg(long)]
     alloy_version: Option<String>,
 
-    /// Specify the Alloy revision on GitHub.
+    /// Specify the `alloy` revision on GitHub.
     #[arg(long, conflicts_with = "alloy_version")]
     alloy_rev: Option<String>,
 
-    /// Generate bindings for the `ethers` library, instead of `alloy` (removed).
+    /// Generate bindings for the `ethers` library (removed), instead of `alloy`.
     #[arg(long, hide = true)]
     ethers: bool,
 

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -108,6 +108,7 @@ impl MultiSolMacroGen {
         bindings_path: &Path,
         single_file: bool,
         alloy_version: Option<String>,
+        alloy_rev: Option<String>,
     ) -> Result<()> {
         self.generate_bindings()?;
 
@@ -129,7 +130,11 @@ edition = "2021"
 
         let alloy_dep = if let Some(alloy_version) = alloy_version {
             format!(
-                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_version}", features = ["sol-types", "contract"] }}"#
+                r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#
+            )
+        } else if let Some(alloy_rev) = alloy_rev {
+            format!(
+                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#
             )
         } else {
             r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
@@ -235,9 +240,10 @@ edition = "2021"
         check_cargo_toml: bool,
         is_mod: bool,
         alloy_version: Option<String>,
+        alloy_rev: Option<String>,
     ) -> Result<()> {
         if check_cargo_toml {
-            self.check_cargo_toml(name, version, crate_path, alloy_version)?;
+            self.check_cargo_toml(name, version, crate_path, alloy_version, alloy_rev)?;
         }
 
         let mut super_contents = String::new();
@@ -304,6 +310,7 @@ edition = "2021"
         version: &str,
         crate_path: &Path,
         alloy_version: Option<String>,
+        alloy_rev: Option<String>,
     ) -> Result<()> {
         eyre::ensure!(crate_path.is_dir(), "Crate path must be a directory");
 
@@ -315,9 +322,11 @@ edition = "2021"
 
         let name_check = format!("name = \"{name}\"");
         let version_check = format!("version = \"{version}\"");
-        let alloy_dep_check = if let Some(version) = alloy_version {
+        let alloy_dep_check = if let Some(alloy_version) = alloy_version {
+            format!(r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#,)
+        } else if let Some(alloy_rev) = alloy_rev {
             format!(
-                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{version}", features = ["sol-types", "contract"] }}"#,
+                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#,
             )
         } else {
             r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -323,7 +323,9 @@ edition = "2021"
         let name_check = format!("name = \"{name}\"");
         let version_check = format!("version = \"{version}\"");
         let alloy_dep_check = if let Some(alloy_version) = alloy_version {
-            format!(r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#,)
+            format!(
+                r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#,
+            )
         } else if let Some(alloy_rev) = alloy_rev {
             format!(
                 r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#,

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -127,7 +127,7 @@ edition = "2021"
 [dependencies]
 "#
         );
-        
+
         let alloy_dep = Self::get_alloy_dep(alloy_version, alloy_rev);
         write!(toml_contents, "{alloy_dep}")?;
 
@@ -327,7 +327,7 @@ edition = "2021"
 
     /// Returns the `alloy` dependency string for the Cargo.toml file.
     /// If `alloy_version` is provided, it will use that version from crates.io.
-    /// If `alloy_rev` is provided, it will use that revision from the `alloy-rs/alloy` GitHub repository.
+    /// If `alloy_rev` is provided, it will use that revision from the GitHub repository.
     fn get_alloy_dep(alloy_version: Option<String>, alloy_rev: Option<String>) -> String {
         if let Some(alloy_version) = alloy_version {
             format!(

--- a/crates/sol-macro-gen/src/sol_macro_gen.rs
+++ b/crates/sol-macro-gen/src/sol_macro_gen.rs
@@ -127,18 +127,8 @@ edition = "2021"
 [dependencies]
 "#
         );
-
-        let alloy_dep = if let Some(alloy_version) = alloy_version {
-            format!(
-                r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#
-            )
-        } else if let Some(alloy_rev) = alloy_rev {
-            format!(
-                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#
-            )
-        } else {
-            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
-        };
+        
+        let alloy_dep = Self::get_alloy_dep(alloy_version, alloy_rev);
         write!(toml_contents, "{alloy_dep}")?;
 
         fs::write(cargo_toml_path, toml_contents).wrap_err("Failed to write Cargo.toml")?;
@@ -322,17 +312,7 @@ edition = "2021"
 
         let name_check = format!("name = \"{name}\"");
         let version_check = format!("version = \"{version}\"");
-        let alloy_dep_check = if let Some(alloy_version) = alloy_version {
-            format!(
-                r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#,
-            )
-        } else if let Some(alloy_rev) = alloy_rev {
-            format!(
-                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#,
-            )
-        } else {
-            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
-        };
+        let alloy_dep_check = Self::get_alloy_dep(alloy_version, alloy_rev);
         let toml_consistent = cargo_toml_contents.contains(&name_check) &&
             cargo_toml_contents.contains(&version_check) &&
             cargo_toml_contents.contains(&alloy_dep_check);
@@ -343,6 +323,23 @@ edition = "2021"
         );
 
         Ok(())
+    }
+
+    /// Returns the `alloy` dependency string for the Cargo.toml file.
+    /// If `alloy_version` is provided, it will use that version from crates.io.
+    /// If `alloy_rev` is provided, it will use that revision from the `alloy-rs/alloy` GitHub repository.
+    fn get_alloy_dep(alloy_version: Option<String>, alloy_rev: Option<String>) -> String {
+        if let Some(alloy_version) = alloy_version {
+            format!(
+                r#"alloy = {{ version = "{alloy_version}", features = ["sol-types", "contract"] }}"#,
+            )
+        } else if let Some(alloy_rev) = alloy_rev {
+            format!(
+                r#"alloy = {{ git = "https://github.com/alloy-rs/alloy", rev = "{alloy_rev}", features = ["sol-types", "contract"] }}"#,
+            )
+        } else {
+            r#"alloy = { git = "https://github.com/alloy-rs/alloy", features = ["sol-types", "contract"] }"#.to_string()
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/9844

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fixes:

When a user previously would run `cargo build` in the `out/bindings/` directory and re-run `forge bind` it would panic with:

```
The application panicked (crashed).
Message:  Ident is not allowed to be empty; use Option<Ident>
Location: crates/sol-macro-gen/src/sol_macro_gen.rs:36

This is a bug. Consider reporting it at https://github.com/foundry-rs/foundry

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: proc_macro2::fallback::validate_ident::h9f587f7b233989e3
      at <unknown source file>:<unknown line>
   9: forge_sol_macro_gen::sol_macro_gen::SolMacroGen::get_sol_input::h533d8cfab70c8dcc
      at <unknown source file>:<unknown line>
  10: forge_sol_macro_gen::sol_macro_gen::MultiSolMacroGen::generate_bindings::he1a61b9e709472bf
      at <unknown source file>:<unknown line>
  11: forge::cmd::bind::BindArgs::run::hbd97091f69e18f6c
      at <unknown source file>:<unknown line>
  12: forge::main::h5432d3818d4aa99f
      at <unknown source file>:<unknown line>
  13: std::sys::backtrace::__rust_begin_short_backtrace::h92514999f571db08
      at <unknown source file>:<unknown line>
  14: main<unknown>
      at <unknown source file>:<unknown line>
  15: __libc_start_call_main<unknown>
      at ./csu/../sysdeps/nptl/libc_start_call_main.h:58
  16: __libc_start_main_impl<unknown>
      at ./csu/../csu/libc-start.c:360
  17: _start<unknown>
      at <unknown source file>:<unknown line>
```

This is fixed by filtering the `target` directory which includes files like `target/debug/.fingerprint/shlex-ee1bfdecfc2a170a/lib-shlex.json` out

Features:

Add `--alloy-rev`, marked as conflicting with `--alloy-version`, updated `--alloy-version` to use crates.io whereas rev uses git

```
$ forge bind --alloy-version "0.11.0"
```

yields

```
[package]
name = "foundry-contracts"
version = "0.1.0"
edition = "2021"

[dependencies]
alloy = { version = "0.11.0", features = ["sol-types", "contract"] }
```

```
$ forge bind --alloy-rev "v0.11.0"
```

yields

```
[package]
name = "foundry-contracts"
version = "0.1.0"
edition = "2021"

[dependencies]
alloy = { git = "https://github.com/alloy-rs/alloy", rev = "v0.11.0", features = ["sol-types", "contract"] }
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes

Marked as breaking change as the behavior of `--alloy-version` has changed to use Crates rather than Github

The book doesn't have documentation on `forge bind` beyond the reference which will be automatically updated