### PR TITLE
chore: fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
-          - runner: macos-12-large
+          - runner: macos-latest-large
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64
             platform: darwin
@@ -278,7 +278,7 @@ jobs:
   issue:
     name: Open an issue
     runs-on: ubuntu-latest
-    needs: [prepare, release-docker, release, cleanup]
+    needs: [ prepare, release-docker, release, cleanup ]
     if: failure()
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

>This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

`macos-12-large` has been deprecated and now unavailable as a runner causing releases to partially fail:

- https://github.com/foundry-rs/foundry/actions/runs/13253147519
- https://github.com/foundry-rs/foundry/actions/runs/13275161837

Closes: https://github.com/foundry-rs/foundry/issues/9867

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

According to https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#about-macos-larger-runners the `Intel` architecture should be available on `macos-latest-large`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes