### PR TITLE
fix: pin to `macos-13-large` for release flow to support old SDK versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
-          - runner: macos-latest-large
+          - runner: macos-13-large
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64
             platform: darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
             svm_target_platform: linux-aarch64
             platform: linux
             arch: arm64
+          # This is pinned to `macos-13-large` to support old SDK versions.
+          # If the runner is deprecated it should be pinned to the oldest available version of the runner.
           - runner: macos-13-large
             target: x86_64-apple-darwin
             svm_target_platform: macosx-amd64


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Addresses: https://github.com/foundry-rs/foundry/pull/9869#issuecomment-2653632006 by pinning to `macos-13-large`

cc @DaniPopes 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Pins to `macos-13-large`  to support old SDK versions

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes