### PR TITLE
fix: add support for inline `isolate` configuration

### DIFF
--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -293,14 +293,15 @@ pub struct TestRunnerConfig {
 }
 
 impl TestRunnerConfig {
-    /// Reconfigures all fields using the given `inline_config`.
-    pub fn reconfigure_with(&mut self, inline_config: Arc<Config>) {
-        debug_assert!(!Arc::ptr_eq(&self.config, &inline_config));
+    /// Reconfigures all fields using the given `config`.
+    /// This is for example used to override the configuration with inline config.
+    pub fn reconfigure_with(&mut self, config: Arc<Config>) {
+        debug_assert!(!Arc::ptr_eq(&self.config, &config));
 
-        self.spec_id = inline_config.evm_spec_id();
-        self.sender = inline_config.sender;
-        self.odyssey = inline_config.odyssey;
-        self.isolation = inline_config.isolate;
+        self.spec_id = config.evm_spec_id();
+        self.sender = config.sender;
+        self.odyssey = config.odyssey;
+        self.isolation = config.isolate;
 
         // Specific to Forge, not present in config.
         // TODO: self.evm_opts
@@ -309,7 +310,7 @@ impl TestRunnerConfig {
         // self.debug = N/A;
         // self.decode_internal = N/A;
 
-        self.config = inline_config;
+        self.config = config;
     }
 
     /// Configures the given executor with this configuration.

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -294,20 +294,19 @@ pub struct TestRunnerConfig {
 
 impl TestRunnerConfig {
     /// Reconfigures all fields using the given `config`.
-    pub fn reconfigure_with(&mut self, config: Arc<Config>) {
-        debug_assert!(!Arc::ptr_eq(&self.config, &config));
+    pub fn reconfigure_with(&mut self, inline_config: Arc<Config>) {
+        debug_assert!(!Arc::ptr_eq(&self.config, &inline_config));
 
         // TODO: self.evm_opts
         // TODO: self.env
-        self.spec_id = config.evm_spec_id();
-        self.sender = config.sender;
+        self.isolation = inline_config.isolate;
+        self.spec_id = inline_config.evm_spec_id();
+        self.sender = inline_config.sender;
         // self.coverage = N/A;
         // self.debug = N/A;
         // self.decode_internal = N/A;
-        // self.isolation = N/A;
-        self.odyssey = config.odyssey;
-
-        self.config = config;
+        self.odyssey = inline_config.odyssey;
+        self.config = inline_config;
     }
 
     /// Configures the given executor with this configuration.

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -293,19 +293,22 @@ pub struct TestRunnerConfig {
 }
 
 impl TestRunnerConfig {
-    /// Reconfigures all fields using the given `config`.
+    /// Reconfigures all fields using the given `inline_config`.
     pub fn reconfigure_with(&mut self, inline_config: Arc<Config>) {
         debug_assert!(!Arc::ptr_eq(&self.config, &inline_config));
 
-        // TODO: self.evm_opts
-        // TODO: self.env
-        self.isolation = inline_config.isolate;
         self.spec_id = inline_config.evm_spec_id();
         self.sender = inline_config.sender;
+        self.odyssey = inline_config.odyssey;
+        self.isolation = inline_config.isolate;
+
+        // Specific to Forge, not present in config.
+        // TODO: self.evm_opts
+        // TODO: self.env
         // self.coverage = N/A;
         // self.debug = N/A;
         // self.decode_internal = N/A;
-        self.odyssey = inline_config.odyssey;
+
         self.config = inline_config;
     }
 

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -230,13 +230,13 @@ forgetest_init!(config_inline_isolate, |prj, cmd| {
             /// forge-config: default.isolate = true
             function test_isolate() public {
                 vm.startSnapshotGas("testIsolatedFunction");
-                dummy.setNumber(42);
+                dummy.setNumber(1);
                 vm.stopSnapshotGas();
             }
 
             function test_non_isolate() public {
                 vm.startSnapshotGas("testNonIsolatedFunction");
-                dummy.setNumber(42);
+                dummy.setNumber(2);
                 vm.stopSnapshotGas();
             }
         }
@@ -251,7 +251,7 @@ forgetest_init!(config_inline_isolate, |prj, cmd| {
 
             function test_non_isolate() public {
                 vm.startSnapshotGas("testIsolatedContract");
-                dummy.setNumber(42);
+                dummy.setNumber(3);
                 vm.stopSnapshotGas();
             }
         }
@@ -318,6 +318,15 @@ Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
         read_snapshot(&prj.root().join("snapshots/FunctionConfig.json"));
     let contract_config: ContractConfig =
         read_snapshot(&prj.root().join("snapshots/ContractConfig.json"));
+
+    // FunctionConfig {
+    //     test_isolated_function: 48926,
+    //     test_non_isolated_function: 27722,
+    // }
+
+    // ContractConfig {
+    //     test_isolated_contract: 48926,
+    // }
 
     assert!(function_config.test_isolated_function > function_config.test_non_isolated_function);
     assert_eq!(function_config.test_isolated_function, contract_config.test_isolated_contract);

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -1,3 +1,7 @@
+use std::{fs, path::Path};
+
+use serde::{Deserialize, Deserializer};
+
 forgetest!(runs, |prj, cmd| {
     prj.add_test(
         "inline.sol",
@@ -201,7 +205,125 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 "#]]);
 });
 
-forgetest_init!(evm_version, |prj, cmd| {
+forgetest_init!(config_inline_isolate, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_test(
+        "inline.sol",
+        r#"
+        import {Test} from "forge-std/Test.sol";
+
+        contract Dummy {
+            uint256 public number;
+
+            function setNumber(uint256 newNumber) public {
+                number = newNumber;
+            }
+        }
+
+        contract FunctionConfig is Test {
+            Dummy dummy;
+
+            function setUp() public {
+                dummy = new Dummy();
+            }
+
+            /// forge-config: default.isolate = true
+            function test_isolate() public {
+                vm.startSnapshotGas("testIsolatedFunction");
+                dummy.setNumber(42);
+                vm.stopSnapshotGas();
+            }
+
+            function test_non_isolate() public {
+                vm.startSnapshotGas("testNonIsolatedFunction");
+                dummy.setNumber(42);
+                vm.stopSnapshotGas();
+            }
+        }
+
+        /// forge-config: default.isolate = true
+        contract ContractConfig is Test {
+            Dummy dummy;
+
+            function setUp() public {
+                dummy = new Dummy();
+            }
+
+            function test_non_isolate() public {
+                vm.startSnapshotGas("testIsolatedContract");
+                dummy.setNumber(42);
+                vm.stopSnapshotGas();
+            }
+        }
+    "#,
+    )
+    .unwrap();
+
+    cmd.args(["test", "-j1"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/inline.sol:ContractConfig
+[PASS] test_non_isolate() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 2 tests for test/inline.sol:FunctionConfig
+[PASS] test_isolate() ([GAS])
+[PASS] test_non_isolate() ([GAS])
+Suite result: ok. 2 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
+
+"#]]);
+
+    assert!(prj.root().join("snapshots/FunctionConfig.json").exists());
+    assert!(prj.root().join("snapshots/ContractConfig.json").exists());
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct FunctionConfig {
+        #[serde(deserialize_with = "string_to_u64")]
+        test_isolated_function: u64,
+
+        #[serde(deserialize_with = "string_to_u64")]
+        test_non_isolated_function: u64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ContractConfig {
+        #[serde(deserialize_with = "string_to_u64")]
+        test_isolated_contract: u64,
+    }
+
+    fn string_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: serde_json::Value = Deserialize::deserialize(deserializer)?;
+        match s {
+            serde_json::Value::String(s) => s.parse::<u64>().map_err(serde::de::Error::custom),
+            serde_json::Value::Number(n) if n.is_u64() => Ok(n.as_u64().unwrap()),
+            _ => Err(serde::de::Error::custom("Expected a string or number")),
+        }
+    }
+
+    fn read_snapshot<T: for<'de> Deserialize<'de>>(path: &Path) -> T {
+        let content = fs::read_to_string(path).expect("Failed to read file");
+        serde_json::from_str(&content).expect("Failed to parse snapshot")
+    }
+
+    let function_config: FunctionConfig =
+        read_snapshot(&prj.root().join("snapshots/FunctionConfig.json"));
+    let contract_config: ContractConfig =
+        read_snapshot(&prj.root().join("snapshots/ContractConfig.json"));
+
+    assert!(function_config.test_isolated_function > function_config.test_non_isolated_function);
+    assert_eq!(function_config.test_isolated_function, contract_config.test_isolated_contract);
+});
+
+forgetest_init!(config_inline_evm_version, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(
         "inline.sol",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Previously `/// forge-config: default.isolate = true` did not work as expected as it was not implemented

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implements it, clean up / clarify + add test

## PR Checklist

Added test that tests whether gas isolation is enabled without hardcoding gas

Like `config_inline_evm_version` it uses `forgetest_init!`, arguably this could be better done w/ `forgetest` directly but out of scope in this ticket.

I noticed we haven't documented the isolate mode well in the Foundry book, added a follow-up ticket for me here: https://github.com/foundry-rs/book/issues/1454

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes