### PR TITLE
feat(doc): add support for @custom:variant documentation for enums

### DIFF
--- a/crates/doc/src/parser/comment.rs
+++ b/crates/doc/src/parser/comment.rs
@@ -21,6 +21,7 @@ pub enum CommentTag {
     /// Copies all missing tags from the base function (must be followed by the contract name)
     Inheritdoc,
     /// Custom tag, semantics is application-defined
+    Variant,
     Custom(String),
 }
 
@@ -41,6 +42,7 @@ impl CommentTag {
                 let custom_tag = trimmed.trim_start_matches("custom:").trim();
                 match custom_tag {
                     "param" => Self::Param,
+                    "variant" => Self::Variant,
                     _ => Self::Custom(custom_tag.to_owned()),
                 }
             }

--- a/crates/doc/src/writer/as_doc.rs
+++ b/crates/doc/src/writer/as_doc.rs
@@ -231,7 +231,6 @@ impl AsDoc for Document {
                                 writer.write_heading(&item.name.safe_unwrap().name)?;
                                 writer.write_section(comments, code)?;
 
-                                // Extraire les descriptions des variants
                                 let variants: Vec<_> = comments
                                 .include_tag(CommentTag::Variant)
                                 .iter()
@@ -297,7 +296,6 @@ impl AsDoc for Document {
                         writer.writeln_doc(&item.comments)?;
                         writer.write_code(&item.code)?;
 
-                        // Extraire les descriptions des variants
                         let variants: Vec<_> = item.comments
                             .include_tag(CommentTag::Variant)
                             .iter()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Currently, Solidity doesn't support `@param` documentation for enum variants,
resulting in incomplete documentation when using `forge doc`. This change addresses
the issue by allowing developers to document each enum variant individually using a
new `@custom:variant` tag.

## Solution

This PR updates the documentation parser to recognize the `@custom:variant` tag in
`crates/doc/src/parser/comment.rs` and modifies the documentation writer in
`crates/doc/src/writer/as_doc.rs` to include the variant descriptions in the generated
documentation. This enhancement enables more granular and clear documentation for enums,
thereby improving the developer experience.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes