### PR TITLE
feat: bump `alpine=3.21` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM alpine:3.20 as build-environment
+FROM alpine:3.21 as build-environment
 
 ARG TARGETARCH
 WORKDIR /opt
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry --mount=type=cache,target=/r
     && strip out/chisel \
     && strip out/anvil;
 
-FROM alpine:3.20 as foundry-client
+FROM alpine:3.21 as foundry-client
 
 RUN apk add --no-cache linux-headers git gcompat libstdc++
 


### PR DESCRIPTION
Closes #9906 

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
Update alpine version to the most recent one (`3.21`).

## Solution
Update `Dockerfile`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes