### PR TITLE
feat(`cast age`): clarify block timestamp is UTC to allow for `date` compatibility

### DIFF
--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -289,7 +289,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
             let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             sh_println!(
-                "{}",
+                "{} UTC",
                 Cast::new(provider).age(block.unwrap_or(BlockId::Number(Latest))).await?
             )?
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes: https://github.com/foundry-rs/foundry/issues/9899

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Example:

```
cast age --rpc-url https://eth.merkle.io
```

Before: `Tue Feb 18 13:35:59 2025`
After: `Tue Feb 18 13:35:35 2025 UTC`

Before (as noted in ticket):

```
date +%s -d "`cast age 15537394 --rpc-url https://eth.merkle.io`"
1663216979
```

After (correct):

```
date +%s -d "`cast age 15537394 --rpc-url https://eth.merkle.io`"
1663224179
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes