### PR TITLE
fix: map 7623 to gas too high

### DIFF
--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -281,6 +281,9 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
             InvalidTransaction::CallGasCostMoreThanGasLimit => {
                 Self::GasTooHigh(ErrDetail { detail: String::from("CallGasCostMoreThanGasLimit") })
             }
+            InvalidTransaction::GasFloorMoreThanGasLimit => {
+                Self::GasTooHigh(ErrDetail { detail: String::from("CallGasCostMoreThanGasLimit") })
+            }
             InvalidTransaction::RejectCallerWithCode => Self::SenderNoEOA,
             InvalidTransaction::LackOfFundForMaxFee { .. } => Self::InsufficientFunds,
             InvalidTransaction::OverflowPaymentInTransaction => Self::GasUintOverflow,
@@ -305,7 +308,6 @@ impl From<revm::primitives::InvalidTransaction> for InvalidTransactionError {
             InvalidTransaction::OptimismError(_) |
             InvalidTransaction::EofCrateShouldHaveToAddress |
             InvalidTransaction::EmptyAuthorizationList => Self::Revm(err),
-            InvalidTransaction::GasFloorMoreThanGasLimit => Self::Revm(err),
         }
     }
 }


### PR DESCRIPTION
this is a new error introduced with 7623 in prague that we need to treat as gas too high in ethestimate which happens if the calldata cost exceeds the gas limit 

the error naming here is super inconsistent so it's debatable whether this is gas to low or gas to high, map this is treated as "out of gas"