### PR TITLE
chore(`cast`): add `4byte-calldata` alias

### DIFF
--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -650,8 +650,8 @@ pub enum CastSubcommand {
     },
 
     /// Decode ABI-encoded calldata using https://openchain.xyz.
-    #[command(name = "4byte-decode", visible_aliases = &["4d", "4bd"])]
-    FourByteDecode {
+    #[command(name = "4byte-calldata", aliases = &["4byte-decode", "4d", "4bd"], visible_aliases = &["4bc", "4c"])]
+    FourByteCalldata {
         /// The ABI-encoded calldata.
         calldata: Option<String>,
     },

--- a/crates/cast/bin/args.rs
+++ b/crates/cast/bin/args.rs
@@ -650,7 +650,7 @@ pub enum CastSubcommand {
     },
 
     /// Decode ABI-encoded calldata using https://openchain.xyz.
-    #[command(name = "4byte-calldata", aliases = &["4byte-decode", "4d", "4bd"], visible_aliases = &["4bc", "4c"])]
+    #[command(name = "4byte-calldata", aliases = &["4byte-decode", "4d", "4bd"], visible_aliases = &["4c", "4bc"])]
     FourByteCalldata {
         /// The ABI-encoded calldata.
         calldata: Option<String>,

--- a/crates/cast/bin/main.rs
+++ b/crates/cast/bin/main.rs
@@ -518,7 +518,7 @@ async fn main_args(args: CastArgs) -> Result<()> {
                 sh_println!("{sig}")?
             }
         }
-        CastSubcommand::FourByteDecode { calldata } => {
+        CastSubcommand::FourByteCalldata { calldata } => {
             let calldata = stdin::unwrap_line(calldata)?;
             let sigs = decode_calldata(&calldata).await?;
             sigs.iter().enumerate().for_each(|(i, sig)| {

--- a/crates/cast/tests/cli/selectors.rs
+++ b/crates/cast/tests/cli/selectors.rs
@@ -25,7 +25,15 @@ Error: Invalid selector 0xa9059c: expected 10 characters (including 0x prefix).
 "#]]);
 });
 
-casttest!(fourbyte_decode, |_prj, cmd| {
+casttest!(fourbyte_calldata, |_prj, cmd| {
+    cmd.args(["4byte-calldata", "0xa9059cbb0000000000000000000000000a2ac0c368dc8ec680a0c98c907656bd970675950000000000000000000000000000000000000000000000000000000767954a79"]).assert_success().stdout_eq(str![[r#"
+1) "transfer(address,uint256)"
+0x0A2AC0c368Dc8eC680a0c98C907656BD97067595
+31802608249 [3.18e10]
+
+"#]]);
+
+    // Test for 4byte-decode alias
     cmd.args(["4byte-decode", "0xa9059cbb0000000000000000000000000a2ac0c368dc8ec680a0c98c907656bd970675950000000000000000000000000000000000000000000000000000000767954a79"]).assert_success().stdout_eq(str![[r#"
 1) "transfer(address,uint256)"
 0x0A2AC0c368Dc8eC680a0c98C907656BD97067595

--- a/crates/cast/tests/cli/selectors.rs
+++ b/crates/cast/tests/cli/selectors.rs
@@ -32,8 +32,9 @@ casttest!(fourbyte_calldata, |_prj, cmd| {
 31802608249 [3.18e10]
 
 "#]]);
+});
 
-    // Test for 4byte-decode alias
+casttest!(fourbyte_calldata_alias, |_prj, cmd| {
     cmd.args(["4byte-decode", "0xa9059cbb0000000000000000000000000a2ac0c368dc8ec680a0c98c907656bd970675950000000000000000000000000000000000000000000000000000000767954a79"]).assert_success().stdout_eq(str![[r#"
 1) "transfer(address,uint256)"
 0x0A2AC0c368Dc8eC680a0c98C907656BD97067595


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Related: https://github.com/foundry-rs/foundry/issues/9926#issuecomment-2672039964

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Change `4byte-decode` to `4byte-calldata` (`4c`, `4bc`) in non breaking way in line with `4byte-event`.  `4byte-decode` and its shorthands (`4d`, `4bd`) are hidden aliases

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

Manually tested + updated test to cover hidden alias
Related book PR: https://github.com/foundry-rs/book/pull/1456