### PR TITLE
fix(--isolate): avoid remappings lookups

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -698,7 +698,10 @@ impl InspectorStackRefMut<'_> {
     /// it.
     fn with_stack<O>(&mut self, f: impl FnOnce(&mut InspectorStack) -> O) -> O {
         let mut stack = InspectorStack {
-            cheatcodes: self.cheatcodes.as_deref_mut().map(std::mem::take),
+            cheatcodes: self
+                .cheatcodes
+                .as_deref_mut()
+                .map(|cheats| core::mem::replace(cheats, Cheatcodes::new(cheats.config.clone()))),
             inner: std::mem::take(self.inner),
         };
 

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -1,7 +1,3 @@
-use std::{fs, path::Path};
-
-use serde::{Deserialize, Deserializer};
-
 forgetest!(runs, |prj, cmd| {
     prj.add_test(
         "inline.sol",
@@ -207,6 +203,9 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 
 #[cfg(not(feature = "isolate-by-default"))]
 forgetest_init!(config_inline_isolate, |prj, cmd| {
+    use serde::{Deserialize, Deserializer};
+    use std::{fs, path::Path};
+
     prj.wipe_contracts();
     prj.add_test(
         "inline.sol",

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -205,6 +205,7 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 "#]]);
 });
 
+#[cfg(not(feature = "isolate-by-default"))]
 forgetest_init!(config_inline_isolate, |prj, cmd| {
     prj.wipe_contracts();
     prj.add_test(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

On every `with_stack` call we are invoking `mem::take` on `&mut Cheatcodes` which results in invocation of `CheatsConfig::default()` https://github.com/foundry-rs/foundry/blob/c609884bdb13b9846fe9ddc5f08d99cf30c53695/crates/evm/evm/src/inspectors/stack.rs#L701
https://github.com/foundry-rs/foundry/blob/c609884bdb13b9846fe9ddc5f08d99cf30c53695/crates/cheatcodes/src/inspector.rs#L498-L502

Which then invokes `ProjectPathsConfigBuilder` resulting in remappings resolution happening on every call and significantly degrading performance https://github.com/foundry-rs/foundry/blob/c609884bdb13b9846fe9ddc5f08d99cf30c53695/crates/cheatcodes/src/config.rs#L217


## Solution

Solution is to reuse the `CheatsConfig` we already have as its `Arc`'ed and we don't really care about this temporary value.

This improves `forge test --isolate` (and `--gas-report`) performance by ~100x

Additionally fixed a test which is right now causing `test-isolate` CI job to fail

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes