### PR TITLE
fix(isolate): do not mark cold accounts with arbitrary storage

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -868,6 +868,13 @@ impl Inspector<&mut dyn DatabaseExt> for InspectorStackRefMut<'_> {
                     let JournaledState { state, warm_preloaded_addresses, .. } =
                         &mut ecx.journaled_state;
                     for (addr, acc_mut) in state {
+                        // Do not mark accounts and storage cold accounts with arbitrary storage.
+                        if let Some(cheatcodes) = &self.cheatcodes {
+                            if cheatcodes.has_arbitrary_storage(addr) {
+                                continue;
+                            }
+                        }
+
                         if !warm_preloaded_addresses.contains(addr) {
                             acc_mut.mark_cold();
                         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- test isolate CI is failing for arbitraryStorage cheatcodes since we now mark them as cold, see https://github.com/foundry-rs/foundry/pull/9940#issuecomment-2677158730
- CI passing https://github.com/foundry-rs/foundry/actions/runs/13499915297
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- do not mark as cold if address with arbitrary storage
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes