### PR TITLE
feat: add option to store keystore file with custom account name

### DIFF
--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -259,9 +259,9 @@ impl WalletSubcommands {
                     for i in 0..number {
                         let account_name_ref = account_name.as_deref().map(|name| match number {
                             1 => name.to_string(),
-                            _ => format!("{}_{}", name, i + 1)
+                            _ => format!("{}_{}", name, i + 1),
                         });
-                        
+
                         let (wallet, uuid) = PrivateKeySigner::new_keystore(
                             &path,
                             &mut rng,

--- a/crates/cast/bin/cmd/wallet/mod.rs
+++ b/crates/cast/bin/cmd/wallet/mod.rs
@@ -34,6 +34,11 @@ pub enum WalletSubcommands {
         /// If provided, then keypair will be written to an encrypted JSON keystore.
         path: Option<String>,
 
+        /// Account name for the keystore file. If provided, the keystore file
+        /// will be named using this account name.
+        #[arg(value_name = "ACCOUNT_NAME")]
+        account_name: Option<String>,
+
         /// Triggers a hidden password prompt for the JSON keystore.
         ///
         /// Deprecated: prompting for a hidden password is now the default.
@@ -226,7 +231,7 @@ pub enum WalletSubcommands {
 impl WalletSubcommands {
     pub async fn run(self) -> Result<()> {
         match self {
-            Self::New { path, unsafe_password, number, .. } => {
+            Self::New { path, account_name, unsafe_password, number, .. } => {
                 let mut rng = thread_rng();
 
                 let mut json_values = if shell::is_json() { Some(vec![]) } else { None };
@@ -251,24 +256,29 @@ impl WalletSubcommands {
                         rpassword::prompt_password("Enter secret: ")?
                     };
 
-                    for _ in 0..number {
+                    for i in 0..number {
+                        let account_name_ref = account_name.as_deref().map(|name| match number {
+                            1 => name.to_string(),
+                            _ => format!("{}_{}", name, i + 1)
+                        });
+                        
                         let (wallet, uuid) = PrivateKeySigner::new_keystore(
                             &path,
                             &mut rng,
                             password.clone(),
-                            None,
+                            account_name_ref.as_deref(),
                         )?;
+                        let identifier = account_name_ref.as_deref().unwrap_or(&uuid);
 
                         if let Some(json) = json_values.as_mut() {
                             json.push(json!({
                                 "address": wallet.address().to_checksum(None),
-                                "path": format!("{}", path.join(uuid).display()),
-                            }
-                            ));
+                                "path": format!("{}", path.join(identifier).display()),
+                            }));
                         } else {
                             sh_println!(
                                 "Created new encrypted keystore file: {}",
-                                path.join(uuid).display()
+                                path.join(identifier).display()
                             )?;
                             sh_println!("Address: {}", wallet.address().to_checksum(None))?;
                         }

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -158,7 +158,7 @@ casttest!(finds_block, |_prj, cmd| {
 
 // tests that we can create a new wallet with keystore
 casttest!(new_wallet_keystore_with_password, |_prj, cmd| {
-    cmd.args(["wallet", "new", ".", "--unsafe-password", "test"]).assert_success().stdout_eq(str![
+    cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test"]).assert_success().stdout_eq(str![
         [r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -158,13 +158,13 @@ casttest!(finds_block, |_prj, cmd| {
 
 // tests that we can create a new wallet with keystore
 casttest!(new_wallet_keystore_with_password, |_prj, cmd| {
-    cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test"]).assert_success().stdout_eq(str![
-        [r#"
+    cmd.args(["wallet", "new", ".", "test-account", "--unsafe-password", "test"])
+        .assert_success()
+        .stdout_eq(str![[r#"
 Created new encrypted keystore file: [..]
 [ADDRESS]
 
-"#]
-    ]);
+"#]]);
 });
 
 // tests that we can get the address of a keystore file


### PR DESCRIPTION
Closes: #9911 

Adds an account name option to `cast wallet new`, allowing the keystore file to be named using the provided string (optionally). If multiple wallets are generated, it appends `_{wallet_num}` to the provided name account name, e.g., `account_1`, `account_2`, etc.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes