### PR TITLE
fix(forge) vm.broadcastRawTransaction decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,6 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rlp",
  "alloy-rpc-types",
  "alloy-signer",
  "alloy-signer-local",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -39,7 +39,6 @@ alloy-signer-local = { workspace = true, features = [
 parking_lot.workspace = true
 alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-network.workspace = true
-alloy-rlp.workspace = true
 
 base64.workspace = true
 dialoguer = "0.11"

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use alloy_consensus::TxEnvelope;
 use alloy_genesis::{Genesis, GenesisAccount};
-use alloy_primitives::{map::HashMap, Address, Bytes, B256, U256};
-use alloy_rlp::Decodable;
+use alloy_network::eip2718::Decodable2718;
+use alloy_primitives::{hex, map::HashMap, Address, Bytes, B256, U256};
 use alloy_sol_types::SolValue;
 use foundry_common::fs::{read_json_file, write_json_file};
 use foundry_evm_core::{
@@ -776,7 +776,9 @@ impl Cheatcode for getStateDiffJsonCall {
 
 impl Cheatcode for broadcastRawTransactionCall {
     fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
-        let tx = TxEnvelope::decode(&mut self.data.as_ref())
+        let data = self.data.as_ref();
+        let tx_hex = hex::decode(data)?;
+        let tx = TxEnvelope::decode_2718(&mut tx_hex.as_slice())
             .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
 
         ccx.ecx.db.transact_from_tx(


### PR DESCRIPTION
## Motivation

Hi. I've been trying to use `vm.broadcastRawTransaction` cheatcode to use an RLP signed transaction in a test. I've generated raw transaction data using:

`cast tx 0x123... --raw` 

But trying to use it with `vm.broadcastRawTransaction` currently raises this error:

`[FAIL: vm.broadcastRawTransaction: failed to decode RLP-encoded transaction: unexpected tx type]`

I've tried to decode the same payload with `cast decode-transaction` and it correctly decode it.

## Solution

This PR changes implementation of `vm.broadcastRawTransaction` cheatcode, to use the same decode logic as `cast decode-transaction`. I've confirmed this change allows to use `vm.broadcastRawTransaction` in a forge test, with raw RLP signed transaction. 

