### PR TITLE
update Make link in docs

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,7 +5,7 @@ The Foundry project is organized as a regular [Cargo workspace][cargo-workspace]
 ## Installation requirements
 
 - [Rust](https://rustup.rs/)
-- Make
+- [Make](https://www.gnu.org/software/make/)
 
 We use `cargo-nextest` as test runner (both locally and in the [CI](#ci)):
 


### PR DESCRIPTION
This PR makes a small but useful update to the `docs/dev/README.md`:

- Updated the reference to **Make** by adding a direct link to the official [GNU Make](https://www.gnu.org/software/make/) website.

This ensures clarity for new contributors setting up the project.

### **Comment:**

Minor documentation improvement: added a proper link to **Make** in the installation requirements. Let me know if any changes are needed! 🚀